### PR TITLE
Update ugorji + etcd + go-etcd dependencies

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -237,8 +237,8 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-etcd/etcd",
-			"Comment": "v2.0.0-34-gde3514f",
-			"Rev": "de3514f25635bbfb024fdaf2a8d5f67378492675"
+			"Comment": "v2.0.0-38-g003851b",
+			"Rev": "003851be7bb0694fe3cc457a49529a19388ee7cf"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/http",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -117,123 +117,123 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/client",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/discovery",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/error",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/etcdserver",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/crc",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/fileutil",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/httputil",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/idutil",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/ioutil",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/netutil",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/pathutil",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/pbutil",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/runtime",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/timeutil",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/transport",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/types",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/wait",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/raft",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/rafthttp",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/snap",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/storage",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/store",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/version",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/wal",
-			"Comment": "v2.2.1-1-g4dc835c",
-			"Rev": "4dc835c718bbdbb9a1c36ef5cdf1921a423cbf70"
+			"Comment": "v2.2.2-1-g09b81ba",
+			"Rev": "09b81bad15e96e05dafd0494a8c165a13718c350"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-etcd/etcd",
@@ -382,7 +382,6 @@
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
-			"Comment": "0.2.1-728-g1399676",
 			"Rev": "1399676f53e6ccf46e0bf00751b21bed329bc60e"
 		},
 		{

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -708,7 +708,7 @@
 		},
 		{
 			"ImportPath": "github.com/ugorji/go/codec",
-			"Rev": "8a2a3a8c488c3ebd98f422a965260278267a0551"
+			"Rev": "f1f1a805ed361a0e078bb537e4ea78cd37dcf065"
 		},
 		{
 			"ImportPath": "github.com/vaughan0/go-ini",

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/keys.generated.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/keys.generated.go
@@ -15,10 +15,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81819         = 1
-	codecSelferC_RAW1819          = 0
+	// ----- content types ----
+	codecSelferC_UTF81819 = 1
+	codecSelferC_RAW1819  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1819 = 10
 	codecSelferValueTypeMap1819   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1819    = 2
+	codecSelfer_containerMapValue1819  = 3
+	codecSelfer_containerMapEnd1819    = 4
+	codecSelfer_containerArrayElem1819 = 6
+	codecSelfer_containerArrayEnd1819  = 7
 )
 
 var (
@@ -29,10 +37,10 @@ var (
 type codecSelfer1819 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -58,18 +66,21 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [3]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2 int = 3
+				yynn2 = 3
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				yym4 := z.EncBinary()
 				_ = yym4
 				if false {
@@ -77,7 +88,9 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81819, string(x.Action))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1819)
 				r.EncodeString(codecSelferC_UTF81819, string("action"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1819)
 				yym5 := z.EncBinary()
 				_ = yym5
 				if false {
@@ -86,13 +99,16 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				if x.Node == nil {
 					r.EncodeNil()
 				} else {
 					x.Node.CodecEncodeSelf(e)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1819)
 				r.EncodeString(codecSelferC_UTF81819, string("node"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1819)
 				if x.Node == nil {
 					r.EncodeNil()
 				} else {
@@ -100,21 +116,26 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				if x.PrevNode == nil {
 					r.EncodeNil()
 				} else {
 					x.PrevNode.CodecEncodeSelf(e)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1819)
 				r.EncodeString(codecSelferC_UTF81819, string("prevNode"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1819)
 				if x.PrevNode == nil {
 					r.EncodeNil()
 				} else {
 					x.PrevNode.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1819)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1819)
 			}
 		}
 	}
@@ -129,17 +150,18 @@ func (x *Response) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1819) {
+		yyct9 := r.ContainerType()
+		if yyct9 == codecSelferValueTypeMap1819 {
 			yyl9 := r.ReadMapStart()
 			if yyl9 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1819)
 			} else {
 				x.codecDecodeSelfFromMap(yyl9, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1819) {
+		} else if yyct9 == codecSelferValueTypeArray1819 {
 			yyl9 := r.ReadArrayStart()
 			if yyl9 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 			} else {
 				x.codecDecodeSelfFromArray(yyl9, d)
 			}
@@ -166,8 +188,10 @@ func (x *Response) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1819)
 		yys10Slc = r.DecodeBytes(yys10Slc, true, true)
 		yys10 := string(yys10Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1819)
 		switch yys10 {
 		case "action":
 			if r.TryDecodeAsNil() {
@@ -201,9 +225,7 @@ func (x *Response) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys10)
 		} // end switch yys10
 	} // end for yyj10
-	if !yyhl10 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1819)
 }
 
 func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -220,9 +242,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb14 = r.CheckBreak()
 	}
 	if yyb14 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		x.Action = ""
 	} else {
@@ -235,9 +258,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb14 = r.CheckBreak()
 	}
 	if yyb14 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		if x.Node != nil {
 			x.Node = nil
@@ -255,9 +279,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb14 = r.CheckBreak()
 	}
 	if yyb14 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		if x.PrevNode != nil {
 			x.PrevNode = nil
@@ -278,9 +303,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb14 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 		z.DecStructFieldNotFound(yyj14-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 }
 
 func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -303,18 +329,21 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq19[1] = x.Dir != false
 			yyq19[6] = x.Expiration != nil
 			yyq19[7] = x.TTL != 0
+			var yynn19 int
 			if yyr19 || yy2arr19 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn19 int = 5
+				yynn19 = 5
 				for _, b := range yyq19 {
 					if b {
 						yynn19++
 					}
 				}
 				r.EncodeMapStart(yynn19)
+				yynn19 = 0
 			}
 			if yyr19 || yy2arr19 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				yym21 := z.EncBinary()
 				_ = yym21
 				if false {
@@ -322,7 +351,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81819, string(x.Key))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1819)
 				r.EncodeString(codecSelferC_UTF81819, string("key"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1819)
 				yym22 := z.EncBinary()
 				_ = yym22
 				if false {
@@ -331,6 +362,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr19 || yy2arr19 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				if yyq19[1] {
 					yym24 := z.EncBinary()
 					_ = yym24
@@ -343,7 +375,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq19[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1819)
 					r.EncodeString(codecSelferC_UTF81819, string("dir"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1819)
 					yym25 := z.EncBinary()
 					_ = yym25
 					if false {
@@ -353,6 +387,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr19 || yy2arr19 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				yym27 := z.EncBinary()
 				_ = yym27
 				if false {
@@ -360,7 +395,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81819, string(x.Value))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1819)
 				r.EncodeString(codecSelferC_UTF81819, string("value"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1819)
 				yym28 := z.EncBinary()
 				_ = yym28
 				if false {
@@ -369,13 +406,16 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr19 || yy2arr19 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				if x.Nodes == nil {
 					r.EncodeNil()
 				} else {
 					x.Nodes.CodecEncodeSelf(e)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1819)
 				r.EncodeString(codecSelferC_UTF81819, string("nodes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1819)
 				if x.Nodes == nil {
 					r.EncodeNil()
 				} else {
@@ -383,6 +423,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr19 || yy2arr19 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				yym31 := z.EncBinary()
 				_ = yym31
 				if false {
@@ -390,7 +431,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeUint(uint64(x.CreatedIndex))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1819)
 				r.EncodeString(codecSelferC_UTF81819, string("createdIndex"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1819)
 				yym32 := z.EncBinary()
 				_ = yym32
 				if false {
@@ -399,6 +442,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr19 || yy2arr19 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				yym34 := z.EncBinary()
 				_ = yym34
 				if false {
@@ -406,7 +450,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeUint(uint64(x.ModifiedIndex))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1819)
 				r.EncodeString(codecSelferC_UTF81819, string("modifiedIndex"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1819)
 				yym35 := z.EncBinary()
 				_ = yym35
 				if false {
@@ -415,6 +461,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr19 || yy2arr19 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				if yyq19[6] {
 					if x.Expiration == nil {
 						r.EncodeNil()
@@ -438,7 +485,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq19[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1819)
 					r.EncodeString(codecSelferC_UTF81819, string("expiration"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1819)
 					if x.Expiration == nil {
 						r.EncodeNil()
 					} else {
@@ -459,6 +508,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr19 || yy2arr19 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 				if yyq19[7] {
 					yym42 := z.EncBinary()
 					_ = yym42
@@ -471,7 +521,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq19[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1819)
 					r.EncodeString(codecSelferC_UTF81819, string("ttl"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1819)
 					yym43 := z.EncBinary()
 					_ = yym43
 					if false {
@@ -480,8 +532,10 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep19 {
-				r.EncodeEnd()
+			if yyr19 || yy2arr19 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1819)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1819)
 			}
 		}
 	}
@@ -496,17 +550,18 @@ func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1819) {
+		yyct45 := r.ContainerType()
+		if yyct45 == codecSelferValueTypeMap1819 {
 			yyl45 := r.ReadMapStart()
 			if yyl45 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1819)
 			} else {
 				x.codecDecodeSelfFromMap(yyl45, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1819) {
+		} else if yyct45 == codecSelferValueTypeArray1819 {
 			yyl45 := r.ReadArrayStart()
 			if yyl45 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 			} else {
 				x.codecDecodeSelfFromArray(yyl45, d)
 			}
@@ -533,8 +588,10 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1819)
 		yys46Slc = r.DecodeBytes(yys46Slc, true, true)
 		yys46 := string(yys46Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1819)
 		switch yys46 {
 		case "key":
 			if r.TryDecodeAsNil() {
@@ -606,9 +663,7 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys46)
 		} // end switch yys46
 	} // end for yyj46
-	if !yyhl46 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1819)
 }
 
 func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -625,9 +680,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb57 = r.CheckBreak()
 	}
 	if yyb57 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		x.Key = ""
 	} else {
@@ -640,9 +696,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb57 = r.CheckBreak()
 	}
 	if yyb57 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		x.Dir = false
 	} else {
@@ -655,9 +712,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb57 = r.CheckBreak()
 	}
 	if yyb57 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		x.Value = ""
 	} else {
@@ -670,9 +728,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb57 = r.CheckBreak()
 	}
 	if yyb57 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		x.Nodes = nil
 	} else {
@@ -686,9 +745,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb57 = r.CheckBreak()
 	}
 	if yyb57 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		x.CreatedIndex = 0
 	} else {
@@ -701,9 +761,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb57 = r.CheckBreak()
 	}
 	if yyb57 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		x.ModifiedIndex = 0
 	} else {
@@ -716,9 +777,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb57 = r.CheckBreak()
 	}
 	if yyb57 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		if x.Expiration != nil {
 			x.Expiration = nil
@@ -748,9 +810,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb57 = r.CheckBreak()
 	}
 	if yyb57 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 	if r.TryDecodeAsNil() {
 		x.TTL = 0
 	} else {
@@ -766,9 +829,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb57 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1819)
 		z.DecStructFieldNotFound(yyj57-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1819)
 }
 
 func (x Nodes) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -807,13 +871,14 @@ func (x codecSelfer1819) encNodes(v Nodes, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv70 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1819)
 		if yyv70 == nil {
 			r.EncodeNil()
 		} else {
 			yyv70.CodecEncodeSelf(e)
 		}
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1819)
 }
 
 func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
@@ -823,39 +888,44 @@ func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
 
 	yyv71 := *v
 	yyh71, yyl71 := z.DecSliceHelperStart()
-
-	var yyrr71, yyrl71 int
-	var yyc71, yyrt71 bool
-	_, _, _ = yyc71, yyrt71, yyrl71
-	yyrr71 = yyl71
-
-	if yyv71 == nil {
-		if yyrl71, yyrt71 = z.DecInferLen(yyl71, z.DecBasicHandle().MaxInitLen, 8); yyrt71 {
-			yyrr71 = yyrl71
-		}
-		yyv71 = make(Nodes, yyrl71)
-		yyc71 = true
-	}
-
+	var yyc71 bool
 	if yyl71 == 0 {
-		if len(yyv71) != 0 {
+		if yyv71 == nil {
+			yyv71 = []*Node{}
+			yyc71 = true
+		} else if len(yyv71) != 0 {
 			yyv71 = yyv71[:0]
 			yyc71 = true
 		}
 	} else if yyl71 > 0 {
-
+		var yyrr71, yyrl71 int
+		var yyrt71 bool
 		if yyl71 > cap(yyv71) {
-			yyrl71, yyrt71 = z.DecInferLen(yyl71, z.DecBasicHandle().MaxInitLen, 8)
-			yyv71 = make([]*Node, yyrl71)
-			yyc71 = true
 
+			yyrg71 := len(yyv71) > 0
+			yyv271 := yyv71
+			yyrl71, yyrt71 = z.DecInferLen(yyl71, z.DecBasicHandle().MaxInitLen, 8)
+			if yyrt71 {
+				if yyrl71 <= cap(yyv71) {
+					yyv71 = yyv71[:yyrl71]
+				} else {
+					yyv71 = make([]*Node, yyrl71)
+				}
+			} else {
+				yyv71 = make([]*Node, yyrl71)
+			}
+			yyc71 = true
 			yyrr71 = len(yyv71)
+			if yyrg71 {
+				copy(yyv71, yyv271)
+			}
 		} else if yyl71 != len(yyv71) {
 			yyv71 = yyv71[:yyl71]
 			yyc71 = true
 		}
 		yyj71 := 0
 		for ; yyj71 < yyrr71; yyj71++ {
+			yyh71.ElemContainerState(yyj71)
 			if r.TryDecodeAsNil() {
 				if yyv71[yyj71] != nil {
 					*yyv71[yyj71] = Node{}
@@ -872,6 +942,7 @@ func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
 		if yyrt71 {
 			for ; yyj71 < yyl71; yyj71++ {
 				yyv71 = append(yyv71, nil)
+				yyh71.ElemContainerState(yyj71)
 				if r.TryDecodeAsNil() {
 					if yyv71[yyj71] != nil {
 						*yyv71[yyj71] = Node{}
@@ -888,12 +959,14 @@ func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj71 := 0; !r.CheckBreak(); yyj71++ {
+		yyj71 := 0
+		for ; !r.CheckBreak(); yyj71++ {
+
 			if yyj71 >= len(yyv71) {
 				yyv71 = append(yyv71, nil) // var yyz71 *Node
 				yyc71 = true
 			}
-
+			yyh71.ElemContainerState(yyj71)
 			if yyj71 < len(yyv71) {
 				if r.TryDecodeAsNil() {
 					if yyv71[yyj71] != nil {
@@ -912,10 +985,16 @@ func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh71.End()
+		if yyj71 < len(yyv71) {
+			yyv71 = yyv71[:yyj71]
+			yyc71 = true
+		} else if yyj71 == 0 && yyv71 == nil {
+			yyv71 = []*Node{}
+			yyc71 = true
+		}
 	}
+	yyh71.End()
 	if yyc71 {
 		*v = yyv71
 	}
-
 }

--- a/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/auth/auth.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/auth/auth.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	etcderr "github.com/coreos/etcd/error"
@@ -52,8 +53,8 @@ var rootRole = Role{
 	Role: RootRoleName,
 	Permissions: Permissions{
 		KV: RWPermission{
-			Read:  []string{"*"},
-			Write: []string{"*"},
+			Read:  []string{"/*"},
+			Write: []string{"/*"},
 		},
 	},
 }
@@ -62,8 +63,8 @@ var guestRole = Role{
 	Role: GuestRoleName,
 	Permissions: Permissions{
 		KV: RWPermission{
-			Read:  []string{"*"},
-			Write: []string{"*"},
+			Read:  []string{"/*"},
+			Write: []string{"/*"},
 		},
 	},
 }
@@ -93,7 +94,9 @@ type store struct {
 	server      doer
 	timeout     time.Duration
 	ensuredOnce bool
-	enabled     *bool
+
+	mu      sync.Mutex // protect enabled
+	enabled *bool
 }
 
 type User struct {
@@ -377,6 +380,9 @@ func (s *store) UpdateRole(role Role) (Role, error) {
 }
 
 func (s *store) AuthEnabled() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	return s.detectAuth()
 }
 
@@ -384,6 +390,10 @@ func (s *store) EnableAuth() error {
 	if s.AuthEnabled() {
 		return authErr(http.StatusConflict, "already enabled")
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	_, err := s.GetUser("root")
 	if err != nil {
 		return authErr(http.StatusConflict, "No root user available, please create one")
@@ -412,6 +422,10 @@ func (s *store) DisableAuth() error {
 	if !s.AuthEnabled() {
 		return authErr(http.StatusConflict, "already disabled")
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	err := s.disableAuth()
 	if err == nil {
 		b := false

--- a/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/cluster.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/cluster.go
@@ -220,6 +220,9 @@ func (c *cluster) SetID(id types.ID) { c.id = id }
 func (c *cluster) SetStore(st store.Store) { c.store = st }
 
 func (c *cluster) Recover() {
+	c.Lock()
+	defer c.Unlock()
+
 	c.members, c.removed = membersFromStore(c.store)
 	c.version = clusterVersionFromStore(c.store)
 	MustDetectDowngrade(c.version)

--- a/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/errors.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/errors.go
@@ -16,6 +16,7 @@ package etcdserver
 
 import (
 	"errors"
+	"fmt"
 
 	etcdErr "github.com/coreos/etcd/error"
 )
@@ -36,4 +37,13 @@ var (
 func isKeyNotFound(err error) bool {
 	e, ok := err.(*etcdErr.Error)
 	return ok && e.ErrorCode == etcdErr.EcodeKeyNotFound
+}
+
+type DiscoveryError struct {
+	Op  string
+	Err error
+}
+
+func (e DiscoveryError) Error() string {
+	return fmt.Sprintf("failed to %s discovery cluster (%v)", e.Op, e.Err)
 }

--- a/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/server.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/server.go
@@ -238,7 +238,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		if cfg.ShouldDiscover() {
 			str, err := discovery.JoinCluster(cfg.DiscoveryURL, cfg.DiscoveryProxy, m.ID, cfg.InitialPeerURLsMap.String())
 			if err != nil {
-				return nil, err
+				return nil, &DiscoveryError{Op: "join", Err: err}
 			}
 			urlsmap, err := types.NewURLsMap(str)
 			if err != nil {

--- a/Godeps/_workspace/src/github.com/coreos/etcd/rafthttp/transport.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/rafthttp/transport.go
@@ -151,7 +151,10 @@ func (t *transport) Send(msgs []raftpb.Message) {
 			t.maybeUpdatePeersTerm(m.Term)
 		}
 
+		t.mu.RLock()
 		p, ok := t.peers[to]
+		t.mu.RUnlock()
+
 		if ok {
 			if m.Type == raftpb.MsgApp {
 				t.serverStats.SendAppendReq(m.Size())

--- a/Godeps/_workspace/src/github.com/coreos/etcd/version/version.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/version/version.go
@@ -27,7 +27,7 @@ import (
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "2.1.0"
-	Version           = "2.2.1+git"
+	Version           = "2.2.2+git"
 
 	// Git SHA Value will be set during build
 	GitSHA = "Not provided (use ./build instead of go build)"

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/response.generated.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/response.generated.go
@@ -16,24 +16,32 @@ import (
 )
 
 const (
-	codecSelferC_UTF86669         = 1
-	codecSelferC_RAW6669          = 0
-	codecSelverValueTypeArray6669 = 10
-	codecSelverValueTypeMap6669   = 9
+	// ----- content types ----
+	codecSelferC_UTF81978 = 1
+	codecSelferC_RAW1978  = 0
+	// ----- value types used ----
+	codecSelferValueTypeArray1978 = 10
+	codecSelferValueTypeMap1978   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1978    = 2
+	codecSelfer_containerMapValue1978  = 3
+	codecSelfer_containerMapEnd1978    = 4
+	codecSelfer_containerArrayElem1978 = 6
+	codecSelfer_containerArrayEnd1978  = 7
 )
 
 var (
-	codecSelferBitsize6669                         = uint8(reflect.TypeOf(uint(0)).Bits())
-	codecSelferOnlyMapOrArrayEncodeToStructErr6669 = errors.New(`only encoded map or array can be decoded into a struct`)
+	codecSelferBitsize1978                         = uint8(reflect.TypeOf(uint(0)).Bits())
+	codecSelferOnlyMapOrArrayEncodeToStructErr1978 = errors.New(`only encoded map or array can be decoded into a struct`)
 )
 
-type codecSelfer6669 struct{}
+type codecSelfer1978 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -44,7 +52,7 @@ func init() {
 }
 
 func (x responseType) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	yym1 := z.EncBinary()
@@ -57,7 +65,7 @@ func (x responseType) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *responseType) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	yym2 := z.DecBinary()
@@ -65,12 +73,12 @@ func (x *responseType) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		*((*int)(x)) = int(r.DecodeInt(codecSelferBitsize6669))
+		*((*int)(x)) = int(r.DecodeInt(codecSelferBitsize1978))
 	}
 }
 
 func (x *RawResponse) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
@@ -86,18 +94,21 @@ func (x *RawResponse) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq4 [3]bool
 			_, _, _ = yysep4, yyq4, yy2arr4
 			const yyr4 bool = false
+			var yynn4 int
 			if yyr4 || yy2arr4 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn4 int = 3
+				yynn4 = 3
 				for _, b := range yyq4 {
 					if b {
 						yynn4++
 					}
 				}
 				r.EncodeMapStart(yynn4)
+				yynn4 = 0
 			}
 			if yyr4 || yy2arr4 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				yym6 := z.EncBinary()
 				_ = yym6
 				if false {
@@ -105,7 +116,9 @@ func (x *RawResponse) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.StatusCode))
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF86669, string("StatusCode"))
+				z.EncSendContainerState(codecSelfer_containerMapKey1978)
+				r.EncodeString(codecSelferC_UTF81978, string("StatusCode"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1978)
 				yym7 := z.EncBinary()
 				_ = yym7
 				if false {
@@ -114,6 +127,7 @@ func (x *RawResponse) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr4 || yy2arr4 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if x.Body == nil {
 					r.EncodeNil()
 				} else {
@@ -121,11 +135,13 @@ func (x *RawResponse) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym9
 					if false {
 					} else {
-						r.EncodeStringBytes(codecSelferC_RAW6669, []byte(x.Body))
+						r.EncodeStringBytes(codecSelferC_RAW1978, []byte(x.Body))
 					}
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF86669, string("Body"))
+				z.EncSendContainerState(codecSelfer_containerMapKey1978)
+				r.EncodeString(codecSelferC_UTF81978, string("Body"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1978)
 				if x.Body == nil {
 					r.EncodeNil()
 				} else {
@@ -133,11 +149,12 @@ func (x *RawResponse) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym10
 					if false {
 					} else {
-						r.EncodeStringBytes(codecSelferC_RAW6669, []byte(x.Body))
+						r.EncodeStringBytes(codecSelferC_RAW1978, []byte(x.Body))
 					}
 				}
 			}
 			if yyr4 || yy2arr4 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if x.Header == nil {
 					r.EncodeNil()
 				} else {
@@ -150,7 +167,9 @@ func (x *RawResponse) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF86669, string("Header"))
+				z.EncSendContainerState(codecSelfer_containerMapKey1978)
+				r.EncodeString(codecSelferC_UTF81978, string("Header"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1978)
 				if x.Header == nil {
 					r.EncodeNil()
 				} else {
@@ -163,15 +182,17 @@ func (x *RawResponse) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep4 {
-				r.EncodeEnd()
+			if yyr4 || yy2arr4 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1978)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1978)
 			}
 		}
 	}
 }
 
 func (x *RawResponse) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	yym14 := z.DecBinary()
@@ -179,28 +200,29 @@ func (x *RawResponse) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelverValueTypeMap6669) {
+		yyct15 := r.ContainerType()
+		if yyct15 == codecSelferValueTypeMap1978 {
 			yyl15 := r.ReadMapStart()
 			if yyl15 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1978)
 			} else {
 				x.codecDecodeSelfFromMap(yyl15, d)
 			}
-		} else if r.IsContainerType(codecSelverValueTypeArray6669) {
+		} else if yyct15 == codecSelferValueTypeArray1978 {
 			yyl15 := r.ReadArrayStart()
 			if yyl15 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 			} else {
 				x.codecDecodeSelfFromArray(yyl15, d)
 			}
 		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr6669)
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1978)
 		}
 	}
 }
 
 func (x *RawResponse) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yys16Slc = z.DecScratchBuffer() // default slice to decode into
@@ -216,14 +238,16 @@ func (x *RawResponse) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1978)
 		yys16Slc = r.DecodeBytes(yys16Slc, true, true)
 		yys16 := string(yys16Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1978)
 		switch yys16 {
 		case "StatusCode":
 			if r.TryDecodeAsNil() {
 				x.StatusCode = 0
 			} else {
-				x.StatusCode = int(r.DecodeInt(codecSelferBitsize6669))
+				x.StatusCode = int(r.DecodeInt(codecSelferBitsize1978))
 			}
 		case "Body":
 			if r.TryDecodeAsNil() {
@@ -254,13 +278,11 @@ func (x *RawResponse) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys16)
 		} // end switch yys16
 	} // end for yyj16
-	if !yyhl16 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1978)
 }
 
 func (x *RawResponse) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yyj22 int
@@ -273,13 +295,14 @@ func (x *RawResponse) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb22 = r.CheckBreak()
 	}
 	if yyb22 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.StatusCode = 0
 	} else {
-		x.StatusCode = int(r.DecodeInt(codecSelferBitsize6669))
+		x.StatusCode = int(r.DecodeInt(codecSelferBitsize1978))
 	}
 	yyj22++
 	if yyhl22 {
@@ -288,9 +311,10 @@ func (x *RawResponse) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb22 = r.CheckBreak()
 	}
 	if yyb22 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.Body = nil
 	} else {
@@ -309,9 +333,10 @@ func (x *RawResponse) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb22 = r.CheckBreak()
 	}
 	if yyb22 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.Header = nil
 	} else {
@@ -334,13 +359,14 @@ func (x *RawResponse) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb22 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 		z.DecStructFieldNotFound(yyj22-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 }
 
 func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
@@ -357,41 +383,49 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep29, yyq29, yy2arr29
 			const yyr29 bool = false
 			yyq29[2] = x.PrevNode != nil
+			var yynn29 int
 			if yyr29 || yy2arr29 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn29 int = 5
+				yynn29 = 5
 				for _, b := range yyq29 {
 					if b {
 						yynn29++
 					}
 				}
 				r.EncodeMapStart(yynn29)
+				yynn29 = 0
 			}
 			if yyr29 || yy2arr29 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				yym31 := z.EncBinary()
 				_ = yym31
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF86669, string(x.Action))
+					r.EncodeString(codecSelferC_UTF81978, string(x.Action))
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF86669, string("action"))
+				z.EncSendContainerState(codecSelfer_containerMapKey1978)
+				r.EncodeString(codecSelferC_UTF81978, string("action"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1978)
 				yym32 := z.EncBinary()
 				_ = yym32
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF86669, string(x.Action))
+					r.EncodeString(codecSelferC_UTF81978, string(x.Action))
 				}
 			}
 			if yyr29 || yy2arr29 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if x.Node == nil {
 					r.EncodeNil()
 				} else {
 					x.Node.CodecEncodeSelf(e)
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF86669, string("node"))
+				z.EncSendContainerState(codecSelfer_containerMapKey1978)
+				r.EncodeString(codecSelferC_UTF81978, string("node"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1978)
 				if x.Node == nil {
 					r.EncodeNil()
 				} else {
@@ -399,6 +433,7 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr29 || yy2arr29 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if yyq29[2] {
 					if x.PrevNode == nil {
 						r.EncodeNil()
@@ -410,7 +445,9 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq29[2] {
-					r.EncodeString(codecSelferC_UTF86669, string("prevNode"))
+					z.EncSendContainerState(codecSelfer_containerMapKey1978)
+					r.EncodeString(codecSelferC_UTF81978, string("prevNode"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1978)
 					if x.PrevNode == nil {
 						r.EncodeNil()
 					} else {
@@ -419,6 +456,7 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr29 || yy2arr29 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				yym36 := z.EncBinary()
 				_ = yym36
 				if false {
@@ -426,7 +464,9 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeUint(uint64(x.EtcdIndex))
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF86669, string("etcdIndex"))
+				z.EncSendContainerState(codecSelfer_containerMapKey1978)
+				r.EncodeString(codecSelferC_UTF81978, string("etcdIndex"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1978)
 				yym37 := z.EncBinary()
 				_ = yym37
 				if false {
@@ -435,6 +475,7 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr29 || yy2arr29 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				yym39 := z.EncBinary()
 				_ = yym39
 				if false {
@@ -442,7 +483,9 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeUint(uint64(x.RaftIndex))
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF86669, string("raftIndex"))
+				z.EncSendContainerState(codecSelfer_containerMapKey1978)
+				r.EncodeString(codecSelferC_UTF81978, string("raftIndex"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1978)
 				yym40 := z.EncBinary()
 				_ = yym40
 				if false {
@@ -451,6 +494,7 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr29 || yy2arr29 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				yym42 := z.EncBinary()
 				_ = yym42
 				if false {
@@ -458,7 +502,9 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeUint(uint64(x.RaftTerm))
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF86669, string("raftTerm"))
+				z.EncSendContainerState(codecSelfer_containerMapKey1978)
+				r.EncodeString(codecSelferC_UTF81978, string("raftTerm"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1978)
 				yym43 := z.EncBinary()
 				_ = yym43
 				if false {
@@ -466,15 +512,17 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeUint(uint64(x.RaftTerm))
 				}
 			}
-			if yysep29 {
-				r.EncodeEnd()
+			if yyr29 || yy2arr29 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1978)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1978)
 			}
 		}
 	}
 }
 
 func (x *Response) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	yym44 := z.DecBinary()
@@ -482,28 +530,29 @@ func (x *Response) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelverValueTypeMap6669) {
+		yyct45 := r.ContainerType()
+		if yyct45 == codecSelferValueTypeMap1978 {
 			yyl45 := r.ReadMapStart()
 			if yyl45 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1978)
 			} else {
 				x.codecDecodeSelfFromMap(yyl45, d)
 			}
-		} else if r.IsContainerType(codecSelverValueTypeArray6669) {
+		} else if yyct45 == codecSelferValueTypeArray1978 {
 			yyl45 := r.ReadArrayStart()
 			if yyl45 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 			} else {
 				x.codecDecodeSelfFromArray(yyl45, d)
 			}
 		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr6669)
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1978)
 		}
 	}
 }
 
 func (x *Response) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yys46Slc = z.DecScratchBuffer() // default slice to decode into
@@ -519,8 +568,10 @@ func (x *Response) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1978)
 		yys46Slc = r.DecodeBytes(yys46Slc, true, true)
 		yys46 := string(yys46Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1978)
 		switch yys46 {
 		case "action":
 			if r.TryDecodeAsNil() {
@@ -572,13 +623,11 @@ func (x *Response) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys46)
 		} // end switch yys46
 	} // end for yyj46
-	if !yyhl46 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1978)
 }
 
 func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yyj53 int
@@ -591,9 +640,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb53 = r.CheckBreak()
 	}
 	if yyb53 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.Action = ""
 	} else {
@@ -606,9 +656,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb53 = r.CheckBreak()
 	}
 	if yyb53 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		if x.Node != nil {
 			x.Node = nil
@@ -626,9 +677,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb53 = r.CheckBreak()
 	}
 	if yyb53 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		if x.PrevNode != nil {
 			x.PrevNode = nil
@@ -646,9 +698,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb53 = r.CheckBreak()
 	}
 	if yyb53 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.EtcdIndex = 0
 	} else {
@@ -661,9 +714,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb53 = r.CheckBreak()
 	}
 	if yyb53 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.RaftIndex = 0
 	} else {
@@ -676,9 +730,10 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb53 = r.CheckBreak()
 	}
 	if yyb53 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.RaftTerm = 0
 	} else {
@@ -694,13 +749,14 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb53 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 		z.DecStructFieldNotFound(yyj53-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 }
 
 func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
@@ -723,56 +779,65 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq61[5] = len(x.Nodes) != 0
 			yyq61[6] = x.ModifiedIndex != 0
 			yyq61[7] = x.CreatedIndex != 0
+			var yynn61 int
 			if yyr61 || yy2arr61 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn61 int = 1
+				yynn61 = 1
 				for _, b := range yyq61 {
 					if b {
 						yynn61++
 					}
 				}
 				r.EncodeMapStart(yynn61)
+				yynn61 = 0
 			}
 			if yyr61 || yy2arr61 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				yym63 := z.EncBinary()
 				_ = yym63
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF86669, string(x.Key))
+					r.EncodeString(codecSelferC_UTF81978, string(x.Key))
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF86669, string("key"))
+				z.EncSendContainerState(codecSelfer_containerMapKey1978)
+				r.EncodeString(codecSelferC_UTF81978, string("key"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1978)
 				yym64 := z.EncBinary()
 				_ = yym64
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF86669, string(x.Key))
+					r.EncodeString(codecSelferC_UTF81978, string(x.Key))
 				}
 			}
 			if yyr61 || yy2arr61 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if yyq61[1] {
 					yym66 := z.EncBinary()
 					_ = yym66
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF86669, string(x.Value))
+						r.EncodeString(codecSelferC_UTF81978, string(x.Value))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF86669, "")
+					r.EncodeString(codecSelferC_UTF81978, "")
 				}
 			} else {
 				if yyq61[1] {
-					r.EncodeString(codecSelferC_UTF86669, string("value"))
+					z.EncSendContainerState(codecSelfer_containerMapKey1978)
+					r.EncodeString(codecSelferC_UTF81978, string("value"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1978)
 					yym67 := z.EncBinary()
 					_ = yym67
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF86669, string(x.Value))
+						r.EncodeString(codecSelferC_UTF81978, string(x.Value))
 					}
 				}
 			}
 			if yyr61 || yy2arr61 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if yyq61[2] {
 					yym69 := z.EncBinary()
 					_ = yym69
@@ -785,7 +850,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq61[2] {
-					r.EncodeString(codecSelferC_UTF86669, string("dir"))
+					z.EncSendContainerState(codecSelfer_containerMapKey1978)
+					r.EncodeString(codecSelferC_UTF81978, string("dir"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1978)
 					yym70 := z.EncBinary()
 					_ = yym70
 					if false {
@@ -795,6 +862,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr61 || yy2arr61 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if yyq61[3] {
 					if x.Expiration == nil {
 						r.EncodeNil()
@@ -818,7 +886,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq61[3] {
-					r.EncodeString(codecSelferC_UTF86669, string("expiration"))
+					z.EncSendContainerState(codecSelfer_containerMapKey1978)
+					r.EncodeString(codecSelferC_UTF81978, string("expiration"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1978)
 					if x.Expiration == nil {
 						r.EncodeNil()
 					} else {
@@ -839,6 +909,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr61 || yy2arr61 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if yyq61[4] {
 					yym77 := z.EncBinary()
 					_ = yym77
@@ -851,7 +922,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq61[4] {
-					r.EncodeString(codecSelferC_UTF86669, string("ttl"))
+					z.EncSendContainerState(codecSelfer_containerMapKey1978)
+					r.EncodeString(codecSelferC_UTF81978, string("ttl"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1978)
 					yym78 := z.EncBinary()
 					_ = yym78
 					if false {
@@ -861,6 +934,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr61 || yy2arr61 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if yyq61[5] {
 					if x.Nodes == nil {
 						r.EncodeNil()
@@ -872,7 +946,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq61[5] {
-					r.EncodeString(codecSelferC_UTF86669, string("nodes"))
+					z.EncSendContainerState(codecSelfer_containerMapKey1978)
+					r.EncodeString(codecSelferC_UTF81978, string("nodes"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1978)
 					if x.Nodes == nil {
 						r.EncodeNil()
 					} else {
@@ -881,6 +957,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr61 || yy2arr61 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if yyq61[6] {
 					yym81 := z.EncBinary()
 					_ = yym81
@@ -893,7 +970,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq61[6] {
-					r.EncodeString(codecSelferC_UTF86669, string("modifiedIndex"))
+					z.EncSendContainerState(codecSelfer_containerMapKey1978)
+					r.EncodeString(codecSelferC_UTF81978, string("modifiedIndex"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1978)
 					yym82 := z.EncBinary()
 					_ = yym82
 					if false {
@@ -903,6 +982,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr61 || yy2arr61 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 				if yyq61[7] {
 					yym84 := z.EncBinary()
 					_ = yym84
@@ -915,7 +995,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq61[7] {
-					r.EncodeString(codecSelferC_UTF86669, string("createdIndex"))
+					z.EncSendContainerState(codecSelfer_containerMapKey1978)
+					r.EncodeString(codecSelferC_UTF81978, string("createdIndex"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1978)
 					yym85 := z.EncBinary()
 					_ = yym85
 					if false {
@@ -924,15 +1006,17 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep61 {
-				r.EncodeEnd()
+			if yyr61 || yy2arr61 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1978)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1978)
 			}
 		}
 	}
 }
 
 func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	yym86 := z.DecBinary()
@@ -940,28 +1024,29 @@ func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelverValueTypeMap6669) {
+		yyct87 := r.ContainerType()
+		if yyct87 == codecSelferValueTypeMap1978 {
 			yyl87 := r.ReadMapStart()
 			if yyl87 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1978)
 			} else {
 				x.codecDecodeSelfFromMap(yyl87, d)
 			}
-		} else if r.IsContainerType(codecSelverValueTypeArray6669) {
+		} else if yyct87 == codecSelferValueTypeArray1978 {
 			yyl87 := r.ReadArrayStart()
 			if yyl87 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 			} else {
 				x.codecDecodeSelfFromArray(yyl87, d)
 			}
 		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr6669)
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1978)
 		}
 	}
 }
 
 func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yys88Slc = z.DecScratchBuffer() // default slice to decode into
@@ -977,8 +1062,10 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1978)
 		yys88Slc = r.DecodeBytes(yys88Slc, true, true)
 		yys88 := string(yys88Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1978)
 		switch yys88 {
 		case "key":
 			if r.TryDecodeAsNil() {
@@ -1050,13 +1137,11 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys88)
 		} // end switch yys88
 	} // end for yyj88
-	if !yyhl88 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1978)
 }
 
 func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yyj99 int
@@ -1069,9 +1154,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb99 = r.CheckBreak()
 	}
 	if yyb99 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.Key = ""
 	} else {
@@ -1084,9 +1170,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb99 = r.CheckBreak()
 	}
 	if yyb99 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.Value = ""
 	} else {
@@ -1099,9 +1186,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb99 = r.CheckBreak()
 	}
 	if yyb99 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.Dir = false
 	} else {
@@ -1114,9 +1202,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb99 = r.CheckBreak()
 	}
 	if yyb99 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		if x.Expiration != nil {
 			x.Expiration = nil
@@ -1146,9 +1235,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb99 = r.CheckBreak()
 	}
 	if yyb99 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.TTL = 0
 	} else {
@@ -1161,9 +1251,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb99 = r.CheckBreak()
 	}
 	if yyb99 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.Nodes = nil
 	} else {
@@ -1177,9 +1268,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb99 = r.CheckBreak()
 	}
 	if yyb99 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.ModifiedIndex = 0
 	} else {
@@ -1192,9 +1284,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb99 = r.CheckBreak()
 	}
 	if yyb99 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 	if r.TryDecodeAsNil() {
 		x.CreatedIndex = 0
 	} else {
@@ -1210,13 +1303,14 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb99 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1978)
 		z.DecStructFieldNotFound(yyj99-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1978)
 }
 
 func (x Nodes) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
@@ -1233,7 +1327,7 @@ func (x Nodes) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *Nodes) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer6669
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	yym111 := z.DecBinary()
@@ -1245,18 +1339,20 @@ func (x *Nodes) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x codecSelfer6669) enchttp_Header(v pkg1_http.Header, e *codec1978.Encoder) {
-	var h codecSelfer6669
+func (x codecSelfer1978) enchttp_Header(v pkg1_http.Header, e *codec1978.Encoder) {
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
 	for yyk112, yyv112 := range v {
+		z.EncSendContainerState(codecSelfer_containerMapKey1978)
 		yym113 := z.EncBinary()
 		_ = yym113
 		if false {
 		} else {
-			r.EncodeString(codecSelferC_UTF86669, string(yyk112))
+			r.EncodeString(codecSelferC_UTF81978, string(yyk112))
 		}
+		z.EncSendContainerState(codecSelfer_containerMapValue1978)
 		if yyv112 == nil {
 			r.EncodeNil()
 		} else {
@@ -1268,34 +1364,43 @@ func (x codecSelfer6669) enchttp_Header(v pkg1_http.Header, e *codec1978.Encoder
 			}
 		}
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerMapEnd1978)
 }
 
-func (x codecSelfer6669) dechttp_Header(v *pkg1_http.Header, d *codec1978.Decoder) {
-	var h codecSelfer6669
+func (x codecSelfer1978) dechttp_Header(v *pkg1_http.Header, d *codec1978.Decoder) {
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
 	yyv115 := *v
 	yyl115 := r.ReadMapStart()
+	yybh115 := z.DecBasicHandle()
 	if yyv115 == nil {
-		if yyl115 > 0 {
-			yyv115 = make(map[string][]string, yyl115)
-		} else {
-			yyv115 = make(map[string][]string) // supports indefinite-length, etc
-		}
+		yyrl115, _ := z.DecInferLen(yyl115, yybh115.MaxInitLen, 40)
+		yyv115 = make(map[string][]string, yyrl115)
 		*v = yyv115
+	}
+	var yymk115 string
+	var yymv115 []string
+	var yymg115 bool
+	if yybh115.MapValueReset {
+		yymg115 = true
 	}
 	if yyl115 > 0 {
 		for yyj115 := 0; yyj115 < yyl115; yyj115++ {
-			var yymk115 string
+			z.DecSendContainerState(codecSelfer_containerMapKey1978)
 			if r.TryDecodeAsNil() {
 				yymk115 = ""
 			} else {
 				yymk115 = string(r.DecodeString())
 			}
 
-			yymv115 := yyv115[yymk115]
+			if yymg115 {
+				yymv115 = yyv115[yymk115]
+			} else {
+				yymv115 = nil
+			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1978)
 			if r.TryDecodeAsNil() {
 				yymv115 = nil
 			} else {
@@ -1314,14 +1419,19 @@ func (x codecSelfer6669) dechttp_Header(v *pkg1_http.Header, d *codec1978.Decode
 		}
 	} else if yyl115 < 0 {
 		for yyj115 := 0; !r.CheckBreak(); yyj115++ {
-			var yymk115 string
+			z.DecSendContainerState(codecSelfer_containerMapKey1978)
 			if r.TryDecodeAsNil() {
 				yymk115 = ""
 			} else {
 				yymk115 = string(r.DecodeString())
 			}
 
-			yymv115 := yyv115[yymk115]
+			if yymg115 {
+				yymv115 = yyv115[yymk115]
+			} else {
+				yymv115 = nil
+			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1978)
 			if r.TryDecodeAsNil() {
 				yymv115 = nil
 			} else {
@@ -1338,63 +1448,71 @@ func (x codecSelfer6669) dechttp_Header(v *pkg1_http.Header, d *codec1978.Decode
 				yyv115[yymk115] = yymv115
 			}
 		}
-		r.ReadEnd()
 	} // else len==0: TODO: Should we clear map entries?
+	z.DecSendContainerState(codecSelfer_containerMapEnd1978)
 }
 
-func (x codecSelfer6669) encNodes(v Nodes, e *codec1978.Encoder) {
-	var h codecSelfer6669
+func (x codecSelfer1978) encNodes(v Nodes, e *codec1978.Encoder) {
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv122 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1978)
 		if yyv122 == nil {
 			r.EncodeNil()
 		} else {
 			yyv122.CodecEncodeSelf(e)
 		}
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1978)
 }
 
-func (x codecSelfer6669) decNodes(v *Nodes, d *codec1978.Decoder) {
-	var h codecSelfer6669
+func (x codecSelfer1978) decNodes(v *Nodes, d *codec1978.Decoder) {
+	var h codecSelfer1978
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
 	yyv123 := *v
 	yyh123, yyl123 := z.DecSliceHelperStart()
-
 	var yyc123 bool
-	_ = yyc123
-
-	if yyv123 == nil {
-		if yyl123 <= 0 {
-			yyv123 = make(Nodes, 0)
-		} else {
-			yyv123 = make(Nodes, yyl123)
-		}
-		yyc123 = true
-	}
-
 	if yyl123 == 0 {
-		if len(yyv123) != 0 {
+		if yyv123 == nil {
+			yyv123 = []*Node{}
+			yyc123 = true
+		} else if len(yyv123) != 0 {
 			yyv123 = yyv123[:0]
 			yyc123 = true
 		}
 	} else if yyl123 > 0 {
-
-		yyn123 := yyl123
+		var yyrr123, yyrl123 int
+		var yyrt123 bool
 		if yyl123 > cap(yyv123) {
-			yyv123 = make([]*Node, yyl123, yyl123)
-			yyc123 = true
 
+			yyrg123 := len(yyv123) > 0
+			yyv2123 := yyv123
+			yyrl123, yyrt123 = z.DecInferLen(yyl123, z.DecBasicHandle().MaxInitLen, 8)
+			if yyrt123 {
+				if yyrl123 <= cap(yyv123) {
+					yyv123 = yyv123[:yyrl123]
+				} else {
+					yyv123 = make([]*Node, yyrl123)
+				}
+			} else {
+				yyv123 = make([]*Node, yyrl123)
+			}
+			yyc123 = true
+			yyrr123 = len(yyv123)
+			if yyrg123 {
+				copy(yyv123, yyv2123)
+			}
 		} else if yyl123 != len(yyv123) {
 			yyv123 = yyv123[:yyl123]
 			yyc123 = true
 		}
 		yyj123 := 0
-		for ; yyj123 < yyn123; yyj123++ {
+		for ; yyj123 < yyrr123; yyj123++ {
+			yyh123.ElemContainerState(yyj123)
 			if r.TryDecodeAsNil() {
 				if yyv123[yyj123] != nil {
 					*yyv123[yyj123] = Node{}
@@ -1408,15 +1526,10 @@ func (x codecSelfer6669) decNodes(v *Nodes, d *codec1978.Decoder) {
 			}
 
 		}
-
-	} else {
-		for yyj123 := 0; !r.CheckBreak(); yyj123++ {
-			if yyj123 >= len(yyv123) {
-				yyv123 = append(yyv123, nil) // var yyz123 *Node
-				yyc123 = true
-			}
-
-			if yyj123 < len(yyv123) {
+		if yyrt123 {
+			for ; yyj123 < yyl123; yyj123++ {
+				yyv123 = append(yyv123, nil)
+				yyh123.ElemContainerState(yyj123)
 				if r.TryDecodeAsNil() {
 					if yyv123[yyj123] != nil {
 						*yyv123[yyj123] = Node{}
@@ -1429,15 +1542,46 @@ func (x codecSelfer6669) decNodes(v *Nodes, d *codec1978.Decoder) {
 					yyw125.CodecDecodeSelf(d)
 				}
 
+			}
+		}
+
+	} else {
+		yyj123 := 0
+		for ; !r.CheckBreak(); yyj123++ {
+
+			if yyj123 >= len(yyv123) {
+				yyv123 = append(yyv123, nil) // var yyz123 *Node
+				yyc123 = true
+			}
+			yyh123.ElemContainerState(yyj123)
+			if yyj123 < len(yyv123) {
+				if r.TryDecodeAsNil() {
+					if yyv123[yyj123] != nil {
+						*yyv123[yyj123] = Node{}
+					}
+				} else {
+					if yyv123[yyj123] == nil {
+						yyv123[yyj123] = new(Node)
+					}
+					yyw126 := yyv123[yyj123]
+					yyw126.CodecDecodeSelf(d)
+				}
+
 			} else {
 				z.DecSwallow()
 			}
 
 		}
-		yyh123.End()
+		if yyj123 < len(yyv123) {
+			yyv123 = yyv123[:yyj123]
+			yyc123 = true
+		} else if yyj123 == 0 && yyv123 == nil {
+			yyv123 = []*Node{}
+			yyc123 = true
+		}
 	}
+	yyh123.End()
 	if yyc123 {
 		*v = yyv123
 	}
-
 }

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/response.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/response.go
@@ -1,6 +1,6 @@
 package etcd
 
-//go:generate codecgen -o response.generated.go response.go
+//go:generate codecgen -d 1978 -o response.generated.go response.go
 
 import (
 	"net/http"

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/decode.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/decode.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"time"
 )
 
 // Some tagging information for error messages.
@@ -48,16 +49,23 @@ type decDriver interface {
 	// this will check if the next token is a break.
 	CheckBreak() bool
 	TryDecodeAsNil() bool
-	// check if a container type: vt is one of: Bytes, String, Nil, Slice or Map.
-	// if vt param == valueTypeNil, and nil is seen in stream, consume the nil.
-	IsContainerType(vt valueType) bool
+	// vt is one of: Bytes, String, Nil, Slice or Map. Return unSet if not known.
+	ContainerType() (vt valueType)
 	IsBuiltinType(rt uintptr) bool
 	DecodeBuiltin(rt uintptr, v interface{})
-	//decodeNaked: Numbers are decoded as int64, uint64, float64 only (no smaller sized number types).
-	//for extensions, decodeNaked must completely decode them as a *RawExt.
-	//extensions should also use readx to decode them, for efficiency.
-	//kInterface will extract the detached byte slice if it has to pass it outside its realm.
-	DecodeNaked() (v interface{}, vt valueType, decodeFurther bool)
+
+	// DecodeNaked will decode primitives (number, bool, string, []byte) and RawExt.
+	// For maps and arrays, it will not do the decoding in-band, but will signal
+	// the decoder, so that is done later, by setting the decNaked.valueType field.
+	//
+	// Note: Numbers are decoded as int64, uint64, float64 only (no smaller sized number types).
+	// for extensions, DecodeNaked must read the tag and the []byte if it exists.
+	// if the []byte is not read, then kInterfaceNaked will treat it as a Handle
+	// that stores the subsequent value in-band, and complete reading the RawExt.
+	//
+	// extensions should also use readx to decode them, for efficiency.
+	// kInterface will extract the detached byte slice if it has to pass it outside its realm.
+	DecodeNaked()
 	DecodeInt(bitsize uint8) (i int64)
 	DecodeUint(bitsize uint8) (ui uint64)
 	DecodeFloat(chkOverflow32 bool) (f float64)
@@ -78,13 +86,15 @@ type decDriver interface {
 	// decodeExt(verifyTag bool, tag byte) (xtag byte, xbs []byte)
 	ReadMapStart() int
 	ReadArrayStart() int
-	// ReadEnd registers the end of a map or array.
-	ReadEnd()
+
+	reset()
+	uncacheRead()
 }
 
 type decNoSeparator struct{}
 
-func (_ decNoSeparator) ReadEnd() {}
+func (_ decNoSeparator) ReadEnd()     {}
+func (_ decNoSeparator) uncacheRead() {}
 
 type DecodeOptions struct {
 	// MapType specifies type to use during schema-less decoding of a map in the stream.
@@ -326,6 +336,13 @@ type bytesDecReader struct {
 	t int    // track start
 }
 
+func (z *bytesDecReader) reset(in []byte) {
+	z.b = in
+	z.a = len(in)
+	z.c = 0
+	z.t = 0
+}
+
 func (z *bytesDecReader) numread() int {
 	return z.c
 }
@@ -460,12 +477,8 @@ func (f *decFnInfo) textUnmarshal(rv reflect.Value) {
 func (f *decFnInfo) jsonUnmarshal(rv reflect.Value) {
 	tm := f.getValueForUnmarshalInterface(rv, f.ti.junmIndir).(jsonUnmarshaler)
 	// bs := f.d.d.DecodeBytes(f.d.b[:], true, true)
-	// grab the bytes to be read, as UnmarshalJSON wants the full JSON to unmarshal it itself.
-	f.d.r.track()
-	f.d.swallow()
-	bs := f.d.r.stopTrack()
-	// fmt.Printf(">>>>>> REFLECTION JSON: %s\n", bs)
-	fnerr := tm.UnmarshalJSON(bs)
+	// grab the bytes to be read, as UnmarshalJSON needs the full JSON so as to unmarshal it itself.
+	fnerr := tm.UnmarshalJSON(f.d.nextValueBytes())
 	if fnerr != nil {
 		panic(fnerr)
 	}
@@ -549,63 +562,96 @@ func (f *decFnInfo) kInterfaceNaked() (rvn reflect.Value) {
 	// nil interface:
 	// use some hieristics to decode it appropriately
 	// based on the detected next value in the stream.
-	v, vt, decodeFurther := f.d.d.DecodeNaked()
-	if vt == valueTypeNil {
+	d := f.d
+	d.d.DecodeNaked()
+	n := &d.n
+	if n.v == valueTypeNil {
 		return
 	}
 	// We cannot decode non-nil stream value into nil interface with methods (e.g. io.Reader).
-	if num := f.ti.rt.NumMethod(); num > 0 {
-		f.d.errorf("cannot decode non-nil codec value into nil %v (%v methods)", f.ti.rt, num)
+	// if num := f.ti.rt.NumMethod(); num > 0 {
+	if f.ti.numMeth > 0 {
+		d.errorf("cannot decode non-nil codec value into nil %v (%v methods)", f.ti.rt, f.ti.numMeth)
 		return
 	}
-	var useRvn bool
-	switch vt {
+	// var useRvn bool
+	switch n.v {
 	case valueTypeMap:
-		if f.d.h.MapType == nil {
-			var m2 map[interface{}]interface{}
-			v = &m2
+		// if d.h.MapType == nil || d.h.MapType == mapIntfIntfTyp {
+		// } else if d.h.MapType == mapStrIntfTyp { // for json performance
+		// }
+		if d.mtid == 0 || d.mtid == mapIntfIntfTypId {
+			l := len(n.ms)
+			n.ms = append(n.ms, nil)
+			d.decode(&n.ms[l])
+			rvn = reflect.ValueOf(&n.ms[l]).Elem()
+			n.ms = n.ms[:l]
+		} else if d.mtid == mapStrIntfTypId { // for json performance
+			l := len(n.ns)
+			n.ns = append(n.ns, nil)
+			d.decode(&n.ns[l])
+			rvn = reflect.ValueOf(&n.ns[l]).Elem()
+			n.ns = n.ns[:l]
 		} else {
-			rvn = reflect.New(f.d.h.MapType).Elem()
-			useRvn = true
+			rvn = reflect.New(d.h.MapType).Elem()
+			d.decodeValue(rvn, nil)
 		}
 	case valueTypeArray:
-		if f.d.h.SliceType == nil {
-			var m2 []interface{}
-			v = &m2
+		// if d.h.SliceType == nil || d.h.SliceType == intfSliceTyp {
+		if d.stid == 0 || d.stid == intfSliceTypId {
+			l := len(n.ss)
+			n.ss = append(n.ss, nil)
+			d.decode(&n.ss[l])
+			rvn = reflect.ValueOf(&n.ss[l]).Elem()
+			n.ss = n.ss[:l]
 		} else {
-			rvn = reflect.New(f.d.h.SliceType).Elem()
-			useRvn = true
+			rvn = reflect.New(d.h.SliceType).Elem()
+			d.decodeValue(rvn, nil)
 		}
 	case valueTypeExt:
-		re := v.(*RawExt)
-		bfn := f.d.h.getExtForTag(re.Tag)
+		var v interface{}
+		tag, bytes := n.u, n.l // calling decode below might taint the values
+		if bytes == nil {
+			l := len(n.is)
+			n.is = append(n.is, nil)
+			v2 := &n.is[l]
+			n.is = n.is[:l]
+			d.decode(v2)
+			v = *v2
+		}
+		bfn := d.h.getExtForTag(tag)
 		if bfn == nil {
-			re.Data = detachZeroCopyBytes(f.d.bytes, nil, re.Data)
-			rvn = reflect.ValueOf(*re)
+			var re RawExt
+			re.Tag = tag
+			re.Data = detachZeroCopyBytes(d.bytes, nil, bytes)
+			rvn = reflect.ValueOf(re)
 		} else {
 			rvnA := reflect.New(bfn.rt)
 			rvn = rvnA.Elem()
-			if re.Data != nil {
-				bfn.ext.ReadExt(rvnA.Interface(), re.Data)
+			if bytes != nil {
+				bfn.ext.ReadExt(rvnA.Interface(), bytes)
 			} else {
-				bfn.ext.UpdateExt(rvnA.Interface(), re.Value)
+				bfn.ext.UpdateExt(rvnA.Interface(), v)
 			}
 		}
-		return
-	}
-	if decodeFurther {
-		if useRvn {
-			f.d.decodeValue(rvn, nil)
-		} else if v != nil {
-			// this v is a pointer, so we need to dereference it when done
-			f.d.decode(v)
-			rvn = reflect.ValueOf(v).Elem()
-			useRvn = true
-		}
-	}
-
-	if !useRvn && v != nil {
-		rvn = reflect.ValueOf(v)
+	case valueTypeNil:
+		// no-op
+	case valueTypeInt:
+		rvn = reflect.ValueOf(&n.i).Elem()
+	case valueTypeUint:
+		rvn = reflect.ValueOf(&n.u).Elem()
+	case valueTypeFloat:
+		rvn = reflect.ValueOf(&n.f).Elem()
+	case valueTypeBool:
+		rvn = reflect.ValueOf(&n.b).Elem()
+	case valueTypeString, valueTypeSymbol:
+		rvn = reflect.ValueOf(&n.s).Elem()
+	case valueTypeBytes:
+		rvn = reflect.ValueOf(&n.l).Elem()
+	case valueTypeTimestamp:
+		rvn = reflect.ValueOf(&n.t).Elem()
+	default:
+		panic(fmt.Errorf("kInterfaceNaked: unexpected valueType: %d", n.v))
 	}
 	return
 }
@@ -655,10 +701,14 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 	fti := f.ti
 	d := f.d
 	dd := d.d
-	if dd.IsContainerType(valueTypeMap) {
+	cr := d.cr
+	ctyp := dd.ContainerType()
+	if ctyp == valueTypeMap {
 		containerLen := dd.ReadMapStart()
 		if containerLen == 0 {
-			dd.ReadEnd()
+			if cr != nil {
+				cr.sendContainerState(containerMapEnd)
+			}
 			return
 		}
 		tisfi := fti.sfi
@@ -666,8 +716,14 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 		if hasLen {
 			for j := 0; j < containerLen; j++ {
 				// rvkencname := dd.DecodeString()
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
 				rvkencname := stringView(dd.DecodeBytes(f.d.b[:], true, true))
 				// rvksi := ti.getForEncName(rvkencname)
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
 				if k := fti.indexForEncName(rvkencname); k > -1 {
 					si := tisfi[k]
 					if dd.TryDecodeAsNil() {
@@ -682,8 +738,14 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 		} else {
 			for j := 0; !dd.CheckBreak(); j++ {
 				// rvkencname := dd.DecodeString()
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
 				rvkencname := stringView(dd.DecodeBytes(f.d.b[:], true, true))
 				// rvksi := ti.getForEncName(rvkencname)
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
 				if k := fti.indexForEncName(rvkencname); k > -1 {
 					si := tisfi[k]
 					if dd.TryDecodeAsNil() {
@@ -695,12 +757,16 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 					d.structFieldNotFound(-1, rvkencname)
 				}
 			}
-			dd.ReadEnd()
 		}
-	} else if dd.IsContainerType(valueTypeArray) {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+	} else if ctyp == valueTypeArray {
 		containerLen := dd.ReadArrayStart()
 		if containerLen == 0 {
-			dd.ReadEnd()
+			if cr != nil {
+				cr.sendContainerState(containerArrayEnd)
+			}
 			return
 		}
 		// Not much gain from doing it two ways for array.
@@ -714,6 +780,9 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 			} else if dd.CheckBreak() {
 				break
 			}
+			if cr != nil {
+				cr.sendContainerState(containerArrayElem)
+			}
 			if dd.TryDecodeAsNil() {
 				si.setToZeroValue(rv)
 			} else {
@@ -723,10 +792,15 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 		if containerLen > len(fti.sfip) {
 			// read remaining values and throw away
 			for j := len(fti.sfip); j < containerLen; j++ {
+				if cr != nil {
+					cr.sendContainerState(containerArrayElem)
+				}
 				d.structFieldNotFound(j, "")
 			}
 		}
-		dd.ReadEnd()
+		if cr != nil {
+			cr.sendContainerState(containerArrayEnd)
+		}
 	} else {
 		f.d.error(onlyMapOrArrayCanDecodeIntoStructErr)
 		return
@@ -740,59 +814,50 @@ func (f *decFnInfo) kSlice(rv reflect.Value) {
 	d := f.d
 	dd := d.d
 	rtelem0 := ti.rt.Elem()
-
-	if dd.IsContainerType(valueTypeBytes) || dd.IsContainerType(valueTypeString) {
-		if ti.rtid == uint8SliceTypId || rtelem0.Kind() == reflect.Uint8 {
-			if f.seq == seqTypeChan {
-				bs2 := dd.DecodeBytes(nil, false, true)
-				ch := rv.Interface().(chan<- byte)
-				for _, b := range bs2 {
-					ch <- b
-				}
-			} else {
-				rvbs := rv.Bytes()
-				bs2 := dd.DecodeBytes(rvbs, false, false)
-				if rvbs == nil && bs2 != nil || rvbs != nil && bs2 == nil || len(bs2) != len(rvbs) {
-					if rv.CanSet() {
-						rv.SetBytes(bs2)
-					} else {
-						copy(rvbs, bs2)
-					}
+	ctyp := dd.ContainerType()
+	if ctyp == valueTypeBytes || ctyp == valueTypeString {
+		// you can only decode bytes or string in the stream into a slice or array of bytes
+		if !(ti.rtid == uint8SliceTypId || rtelem0.Kind() == reflect.Uint8) {
+			f.d.errorf("bytes or string in the stream must be decoded into a slice or array of bytes, not %v", ti.rt)
+		}
+		if f.seq == seqTypeChan {
+			bs2 := dd.DecodeBytes(nil, false, true)
+			ch := rv.Interface().(chan<- byte)
+			for _, b := range bs2 {
+				ch <- b
+			}
+		} else {
+			rvbs := rv.Bytes()
+			bs2 := dd.DecodeBytes(rvbs, false, false)
+			if rvbs == nil && bs2 != nil || rvbs != nil && bs2 == nil || len(bs2) != len(rvbs) {
+				if rv.CanSet() {
+					rv.SetBytes(bs2)
+				} else {
+					copy(rvbs, bs2)
 				}
 			}
-			return
 		}
+		return
 	}
 
 	// array := f.seq == seqTypeChan
 
-	slh, containerLenS := d.decSliceHelperStart()
+	slh, containerLenS := d.decSliceHelperStart() // only expects valueType(Array|Map)
 
-	var rvlen, numToRead int
-	var truncated bool // says that the len of the sequence is not same as the expected number of elements.
-
-	numToRead = containerLenS // if truncated, reset numToRead
-
-	// an array can never return a nil slice. so no need to check f.array here.
-	if rv.IsNil() {
-		// either chan or slice
-		if rvlen, truncated = decInferLen(containerLenS, f.d.h.MaxInitLen, int(rtelem0.Size())); truncated {
-			numToRead = rvlen
-		}
-		if f.seq == seqTypeSlice {
-			rv.Set(reflect.MakeSlice(ti.rt, rvlen, rvlen))
-		} else if f.seq == seqTypeChan {
-			rv.Set(reflect.MakeChan(ti.rt, rvlen))
-		}
-	} else {
-		rvlen = rv.Len()
-	}
-
+	// // an array can never return a nil slice. so no need to check f.array here.
 	if containerLenS == 0 {
-		if f.seq == seqTypeSlice && rvlen != 0 {
-			rv.SetLen(0)
+		if f.seq == seqTypeSlice {
+			if rv.IsNil() {
+				rv.Set(reflect.MakeSlice(ti.rt, 0, 0))
+			} else {
+				rv.SetLen(0)
+			}
+		} else if f.seq == seqTypeChan {
+			if rv.IsNil() {
+				rv.Set(reflect.MakeChan(ti.rt, 0))
+			}
 		}
-		// dd.ReadEnd()
+		slh.End()
 		return
 	}
 
@@ -806,30 +871,48 @@ func (f *decFnInfo) kSlice(rv reflect.Value) {
 	rv0 = rv
 	rvChanged := false
 
-	rvcap := rv.Cap()
-
 	// for j := 0; j < containerLenS; j++ {
-
-	if containerLenS >= 0 { // hasLen
+	var rvlen int
+	if containerLenS > 0 { // hasLen
 		if f.seq == seqTypeChan {
+			if rv.IsNil() {
+				rvlen, _ = decInferLen(containerLenS, f.d.h.MaxInitLen, int(rtelem0.Size()))
+				rv.Set(reflect.MakeChan(ti.rt, rvlen))
+			}
 			// handle chan specially:
 			for j := 0; j < containerLenS; j++ {
 				rv9 = reflect.New(rtelem0).Elem()
+				slh.ElemContainerState(j)
 				d.decodeValue(rv9, fn)
 				rv.Send(rv9)
 			}
 		} else { // slice or array
+			var truncated bool         // says len of sequence is not same as expected number of elements
+			numToRead := containerLenS // if truncated, reset numToRead
+
+			rvcap := rv.Cap()
+			rvlen = rv.Len()
 			if containerLenS > rvcap {
 				if f.seq == seqTypeArray {
 					d.arrayCannotExpand(rvlen, containerLenS)
 				} else {
 					oldRvlenGtZero := rvlen > 0
 					rvlen, truncated = decInferLen(containerLenS, f.d.h.MaxInitLen, int(rtelem0.Size()))
-					rv = reflect.MakeSlice(ti.rt, rvlen, rvlen)
-					if oldRvlenGtZero && !isImmutableKind(rtelem0.Kind()) {
+					if truncated {
+						if rvlen <= rvcap {
+							rv.SetLen(rvlen)
+						} else {
+							rv = reflect.MakeSlice(ti.rt, rvlen, rvlen)
+							rvChanged = true
+						}
+					} else {
+						rv = reflect.MakeSlice(ti.rt, rvlen, rvlen)
+						rvChanged = true
+					}
+					if rvChanged && oldRvlenGtZero && !isImmutableKind(rtelem0.Kind()) {
 						reflect.Copy(rv, rv0) // only copy up to length NOT cap i.e. rv0.Slice(0, rvcap)
 					}
-					rvChanged = true
+					rvcap = rvlen
 				}
 				numToRead = rvlen
 			} else if containerLenS != rvlen {
@@ -841,6 +924,7 @@ func (f *decFnInfo) kSlice(rv reflect.Value) {
 			j := 0
 			// we read up to the numToRead
 			for ; j < numToRead; j++ {
+				slh.ElemContainerState(j)
 				d.decodeValue(rv.Index(j), fn)
 			}
 
@@ -849,6 +933,7 @@ func (f *decFnInfo) kSlice(rv reflect.Value) {
 
 			if f.seq == seqTypeArray {
 				for ; j < containerLenS; j++ {
+					slh.ElemContainerState(j)
 					d.swallow()
 				}
 			} else if truncated { // slice was truncated, as chan NOT in this block
@@ -858,44 +943,59 @@ func (f *decFnInfo) kSlice(rv reflect.Value) {
 					if resetSliceElemToZeroValue {
 						rv9.Set(reflect.Zero(rtelem0))
 					}
+					slh.ElemContainerState(j)
 					d.decodeValue(rv9, fn)
 				}
 			}
 		}
 	} else {
-		for j := 0; !dd.CheckBreak(); j++ {
-			var decodeIntoBlank bool
-			// if indefinite, etc, then expand the slice if necessary
-			if j >= rvlen {
-				if f.seq == seqTypeArray {
-					d.arrayCannotExpand(rvlen, j+1)
-					decodeIntoBlank = true
-				} else if f.seq == seqTypeSlice {
-					// rv = reflect.Append(rv, reflect.Zero(rtelem0)) // uses append logic, plus varargs
-					rv = expandSliceValue(rv, 1)
-					rv9 = rv.Index(j)
-					// rv.Index(rv.Len() - 1).Set(reflect.Zero(rtelem0))
-					if resetSliceElemToZeroValue {
-						rv9.Set(reflect.Zero(rtelem0))
-					}
-					rvlen++
-					rvChanged = true
-				}
-			} else if f.seq != seqTypeChan { // slice or array
-				rv9 = rv.Index(j)
-			}
+		rvlen = rv.Len()
+		j := 0
+		for ; !dd.CheckBreak(); j++ {
 			if f.seq == seqTypeChan {
+				slh.ElemContainerState(j)
 				rv9 = reflect.New(rtelem0).Elem()
 				d.decodeValue(rv9, fn)
 				rv.Send(rv9)
-			} else if decodeIntoBlank {
-				d.swallow()
-			} else { // seqTypeSlice
-				d.decodeValue(rv9, fn)
+			} else {
+				// if indefinite, etc, then expand the slice if necessary
+				var decodeIntoBlank bool
+				if j >= rvlen {
+					if f.seq == seqTypeArray {
+						d.arrayCannotExpand(rvlen, j+1)
+						decodeIntoBlank = true
+					} else { // if f.seq == seqTypeSlice
+						// rv = reflect.Append(rv, reflect.Zero(rtelem0)) // uses append logic, plus varargs
+						rv = expandSliceValue(rv, 1)
+						rv9 = rv.Index(j)
+						// rv.Index(rv.Len() - 1).Set(reflect.Zero(rtelem0))
+						if resetSliceElemToZeroValue {
+							rv9.Set(reflect.Zero(rtelem0))
+						}
+						rvlen++
+						rvChanged = true
+					}
+				} else { // slice or array
+					rv9 = rv.Index(j)
+				}
+				slh.ElemContainerState(j)
+				if decodeIntoBlank {
+					d.swallow()
+				} else { // seqTypeSlice
+					d.decodeValue(rv9, fn)
+				}
 			}
 		}
-		slh.End()
+		if f.seq == seqTypeSlice {
+			if j < rvlen {
+				rv.SetLen(j)
+			} else if j == 0 && rv.IsNil() {
+				rv = reflect.MakeSlice(ti.rt, 0, 0)
+				rvChanged = true
+			}
+		}
 	}
+	slh.End()
 
 	if rvChanged {
 		rv0.Set(rv)
@@ -911,20 +1011,22 @@ func (f *decFnInfo) kMap(rv reflect.Value) {
 	d := f.d
 	dd := d.d
 	containerLen := dd.ReadMapStart()
-
+	cr := d.cr
 	ti := f.ti
 	if rv.IsNil() {
 		rv.Set(reflect.MakeMap(ti.rt))
 	}
 
 	if containerLen == 0 {
-		// It is not length-prefix style container. They have no End marker.
-		// dd.ReadMapEnd()
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
 		return
 	}
 
 	ktype, vtype := ti.rt.Key(), ti.rt.Elem()
 	ktypeId := reflect.ValueOf(ktype).Pointer()
+	vtypeKind := vtype.Kind()
 	var keyFn, valFn *decFn
 	var xtyp reflect.Type
 	for xtyp = ktype; xtyp.Kind() == reflect.Ptr; xtyp = xtyp.Elem() {
@@ -933,13 +1035,12 @@ func (f *decFnInfo) kMap(rv reflect.Value) {
 	for xtyp = vtype; xtyp.Kind() == reflect.Ptr; xtyp = xtyp.Elem() {
 	}
 	valFn = d.getDecFn(xtyp, true, true)
-	var mapGet bool
+	var mapGet, mapSet bool
 	if !f.d.h.MapValueReset {
 		// if pointer, mapGet = true
 		// if interface, mapGet = true if !DecodeNakedAlways (else false)
 		// if builtin, mapGet = false
 		// else mapGet = true
-		vtypeKind := vtype.Kind()
 		if vtypeKind == reflect.Ptr {
 			mapGet = true
 		} else if vtypeKind == reflect.Interface {
@@ -951,12 +1052,15 @@ func (f *decFnInfo) kMap(rv reflect.Value) {
 		}
 	}
 
-	var rvk, rvv reflect.Value
+	var rvk, rvv, rvz reflect.Value
 
 	// for j := 0; j < containerLen; j++ {
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
 			rvk = reflect.New(ktype).Elem()
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			d.decodeValue(rvk, keyFn)
 
 			// special case if a byte array.
@@ -966,20 +1070,43 @@ func (f *decFnInfo) kMap(rv reflect.Value) {
 					rvk = reflect.ValueOf(d.string(rvk.Bytes()))
 				}
 			}
+			mapSet = true // set to false if u do a get, and its a pointer, and exists
 			if mapGet {
 				rvv = rv.MapIndex(rvk)
-				if !rvv.IsValid() {
-					rvv = reflect.New(vtype).Elem()
+				if rvv.IsValid() {
+					if vtypeKind == reflect.Ptr {
+						mapSet = false
+					}
+				} else {
+					if rvz.IsValid() {
+						rvz.Set(reflect.Zero(vtype))
+					} else {
+						rvz = reflect.New(vtype).Elem()
+					}
+					rvv = rvz
 				}
 			} else {
-				rvv = reflect.New(vtype).Elem()
+				if rvz.IsValid() {
+					rvz.Set(reflect.Zero(vtype))
+				} else {
+					rvz = reflect.New(vtype).Elem()
+				}
+				rvv = rvz
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			d.decodeValue(rvv, valFn)
-			rv.SetMapIndex(rvk, rvv)
+			if mapSet {
+				rv.SetMapIndex(rvk, rvv)
+			}
 		}
 	} else {
 		for j := 0; !dd.CheckBreak(); j++ {
 			rvk = reflect.New(ktype).Elem()
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			d.decodeValue(rvk, keyFn)
 
 			// special case if a byte array.
@@ -989,24 +1116,105 @@ func (f *decFnInfo) kMap(rv reflect.Value) {
 					rvk = reflect.ValueOf(d.string(rvk.Bytes()))
 				}
 			}
+			mapSet = true // set to false if u do a get, and its a pointer, and exists
 			if mapGet {
 				rvv = rv.MapIndex(rvk)
-				if !rvv.IsValid() {
-					rvv = reflect.New(vtype).Elem()
+				if rvv.IsValid() {
+					if vtypeKind == reflect.Ptr {
+						mapSet = false
+					}
+				} else {
+					if rvz.IsValid() {
+						rvz.Set(reflect.Zero(vtype))
+					} else {
+						rvz = reflect.New(vtype).Elem()
+					}
+					rvv = rvz
 				}
 			} else {
-				rvv = reflect.New(vtype).Elem()
+				if rvz.IsValid() {
+					rvz.Set(reflect.Zero(vtype))
+				} else {
+					rvz = reflect.New(vtype).Elem()
+				}
+				rvv = rvz
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			d.decodeValue(rvv, valFn)
-			rv.SetMapIndex(rvk, rvv)
+			if mapSet {
+				rv.SetMapIndex(rvk, rvv)
+			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 }
 
 type decRtidFn struct {
 	rtid uintptr
 	fn   decFn
+}
+
+// decNaked is used to keep track of the primitives decoded.
+// Without it, we would have to decode each primitive and wrap it
+// in an interface{}, causing an allocation.
+// In this model, the primitives are decoded in a "pseudo-atomic" fashion,
+// so we can rest assured that no other decoding happens while these
+// primitives are being decoded.
+//
+// maps and arrays are not handled by this mechanism.
+// However, RawExt is, and we accomodate for extensions that decode
+// RawExt from DecodeNaked, but need to decode the value subsequently.
+// kInterfaceNaked and swallow, which call DecodeNaked, handle this caveat.
+//
+// However, decNaked also keeps some arrays of default maps and slices
+// used in DecodeNaked. This way, we can get a pointer to it
+// without causing a new heap allocation.
+//
+// kInterfaceNaked will ensure that there is no allocation for the common
+// uses.
+type decNaked struct {
+	// r RawExt // used for RawExt, uint, []byte.
+	u uint64
+	i int64
+	f float64
+	l []byte
+	s string
+	t time.Time
+	b bool
+	v valueType
+
+	// stacks for reducing allocation
+	is []interface{}
+	ms []map[interface{}]interface{}
+	ns []map[string]interface{}
+	ss [][]interface{}
+	// rs []RawExt
+
+	// keep arrays at the bottom? Chance is that they are not used much.
+	ia [4]interface{}
+	ma [4]map[interface{}]interface{}
+	na [4]map[string]interface{}
+	sa [4][]interface{}
+	// ra [2]RawExt
+}
+
+func (n *decNaked) reset() {
+	if n.ss != nil {
+		n.ss = n.ss[:0]
+	}
+	if n.is != nil {
+		n.is = n.is[:0]
+	}
+	if n.ms != nil {
+		n.ms = n.ms[:0]
+	}
+	if n.ns != nil {
+		n.ns = n.ns[:0]
+	}
 }
 
 // A Decoder reads and decodes an object from an input stream in the codec format.
@@ -1019,32 +1227,84 @@ type Decoder struct {
 	// as the handler MAY need to do some coordination.
 	r decReader
 	// sa [initCollectionCap]decRtidFn
-	s []decRtidFn
-	h *BasicHandle
+	h  *BasicHandle
+	hh Handle
 
-	rb    bytesDecReader
-	hh    Handle
 	be    bool // is binary encoding
 	bytes bool // is bytes reader
 	js    bool // is json handle
 
+	rb bytesDecReader
 	ri ioDecReader
-	f  map[uintptr]*decFn
-	is map[string]string // used for interning strings
+	cr containerStateRecv
+
+	s []decRtidFn
+	f map[uintptr]*decFn
 
 	// _  uintptr // for alignment purposes, so next one starts from a cache line
 
-	b [scratchByteArrayLen]byte
+	// cache the mapTypeId and sliceTypeId for faster comparisons
+	mtid uintptr
+	stid uintptr
+
+	n  decNaked
+	b  [scratchByteArrayLen]byte
+	is map[string]string // used for interning strings
 }
 
 // NewDecoder returns a Decoder for decoding a stream of bytes from an io.Reader.
 //
 // For efficiency, Users are encouraged to pass in a memory buffered reader
 // (eg bufio.Reader, bytes.Buffer).
-func NewDecoder(r io.Reader, h Handle) (d *Decoder) {
-	d = &Decoder{hh: h, h: h.getBasicHandle(), be: h.isBinary()}
-	// d.s = d.sa[:0]
+func NewDecoder(r io.Reader, h Handle) *Decoder {
+	d := newDecoder(h)
+	d.Reset(r)
+	return d
+}
+
+// NewDecoderBytes returns a Decoder which efficiently decodes directly
+// from a byte slice with zero copying.
+func NewDecoderBytes(in []byte, h Handle) *Decoder {
+	d := newDecoder(h)
+	d.ResetBytes(in)
+	return d
+}
+
+func newDecoder(h Handle) *Decoder {
+	d := &Decoder{hh: h, h: h.getBasicHandle(), be: h.isBinary()}
+	n := &d.n
+	// n.rs = n.ra[:0]
+	n.ms = n.ma[:0]
+	n.is = n.ia[:0]
+	n.ns = n.na[:0]
+	n.ss = n.sa[:0]
+	_, d.js = h.(*JsonHandle)
+	if d.h.InternString {
+		d.is = make(map[string]string, 32)
+	}
+	d.d = h.newDecDriver(d)
+	d.cr, _ = d.d.(containerStateRecv)
+	// d.d = h.newDecDriver(decReaderT{true, &d.rb, &d.ri})
+	return d
+}
+
+func (d *Decoder) resetCommon() {
+	d.n.reset()
+	d.d.reset()
+	// reset all things which were cached from the Handle,
+	// but could be changed.
+	d.mtid, d.stid = 0, 0
+	if d.h.MapType != nil {
+		d.mtid = reflect.ValueOf(d.h.MapType).Pointer()
+	}
+	if d.h.SliceType != nil {
+		d.stid = reflect.ValueOf(d.h.SliceType).Pointer()
+	}
+}
+
+func (d *Decoder) Reset(r io.Reader) {
 	d.ri.x = &d.b
+	// d.s = d.sa[:0]
 	d.ri.bs.r = r
 	var ok bool
 	d.ri.br, ok = r.(decReaderByteScanner)
@@ -1052,30 +1312,21 @@ func NewDecoder(r io.Reader, h Handle) (d *Decoder) {
 		d.ri.br = &d.ri.bs
 	}
 	d.r = &d.ri
-	if d.h.InternString {
-		d.is = make(map[string]string, 32)
-	}
-	_, d.js = h.(*JsonHandle)
-	d.d = h.newDecDriver(d)
-	return
+	d.resetCommon()
 }
 
-// NewDecoderBytes returns a Decoder which efficiently decodes directly
-// from a byte slice with zero copying.
-func NewDecoderBytes(in []byte, h Handle) (d *Decoder) {
-	d = &Decoder{hh: h, h: h.getBasicHandle(), be: h.isBinary(), bytes: true}
+func (d *Decoder) ResetBytes(in []byte) {
 	// d.s = d.sa[:0]
-	d.rb.b = in
-	d.rb.a = len(in)
+	d.rb.reset(in)
 	d.r = &d.rb
-	if d.h.InternString {
-		d.is = make(map[string]string, 32)
-	}
-	_, d.js = h.(*JsonHandle)
-	d.d = h.newDecDriver(d)
-	// d.d = h.newDecDriver(decReaderT{true, &d.rb, &d.ri})
-	return
+	d.resetCommon()
 }
+
+// func (d *Decoder) sendContainerState(c containerState) {
+// 	if d.cr != nil {
+// 		d.cr.sendContainerState(c)
+// 	}
+// }
 
 // Decode decodes the stream from reader and stores the result in the
 // value pointed to by v. v cannot be a nil pointer. v can also be
@@ -1142,9 +1393,12 @@ func (d *Decoder) swallowViaHammer() {
 func (d *Decoder) swallow() {
 	// smarter decode that just swallows the content
 	dd := d.d
-	switch {
-	case dd.TryDecodeAsNil():
-	case dd.IsContainerType(valueTypeMap):
+	if dd.TryDecodeAsNil() {
+		return
+	}
+	cr := d.cr
+	switch dd.ContainerType() {
+	case valueTypeMap:
 		containerLen := dd.ReadMapStart()
 		clenGtEqualZero := containerLen >= 0
 		for j := 0; ; j++ {
@@ -1155,11 +1409,19 @@ func (d *Decoder) swallow() {
 			} else if dd.CheckBreak() {
 				break
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			d.swallow()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			d.swallow()
 		}
-		dd.ReadEnd()
-	case dd.IsContainerType(valueTypeArray):
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+	case valueTypeArray:
 		containerLenS := dd.ReadArrayStart()
 		clenGtEqualZero := containerLenS >= 0
 		for j := 0; ; j++ {
@@ -1170,17 +1432,30 @@ func (d *Decoder) swallow() {
 			} else if dd.CheckBreak() {
 				break
 			}
+			if cr != nil {
+				cr.sendContainerState(containerArrayElem)
+			}
 			d.swallow()
 		}
-		dd.ReadEnd()
-	case dd.IsContainerType(valueTypeBytes):
+		if cr != nil {
+			cr.sendContainerState(containerArrayEnd)
+		}
+	case valueTypeBytes:
 		dd.DecodeBytes(d.b[:], false, true)
-	case dd.IsContainerType(valueTypeString):
+	case valueTypeString:
 		dd.DecodeBytes(d.b[:], true, true)
 		// dd.DecodeStringAsBytes(d.b[:])
 	default:
 		// these are all primitives, which we can get from decodeNaked
+		// if RawExt using Value, complete the processing.
 		dd.DecodeNaked()
+		if n := &d.n; n.v == valueTypeExt && n.l == nil {
+			l := len(n.is)
+			n.is = append(n.is, nil)
+			v2 := &n.is[l]
+			n.is = n.is[:l]
+			d.decode(v2)
+		}
 	}
 }
 
@@ -1230,14 +1505,20 @@ func (d *Decoder) decode(iv interface{}) {
 		case *[]uint8:
 			*v = nil
 		case reflect.Value:
-			d.chkPtrValue(v)
+			if v.Kind() != reflect.Ptr || v.IsNil() {
+				d.errNotValidPtrValue(v)
+			}
+			// d.chkPtrValue(v)
 			v = v.Elem()
 			if v.IsValid() {
 				v.Set(reflect.Zero(v.Type()))
 			}
 		default:
 			rv := reflect.ValueOf(iv)
-			d.chkPtrValue(rv)
+			if rv.Kind() != reflect.Ptr || rv.IsNil() {
+				d.errNotValidPtrValue(rv)
+			}
+			// d.chkPtrValue(rv)
 			rv = rv.Elem()
 			if rv.IsValid() {
 				rv.Set(reflect.Zero(rv.Type()))
@@ -1255,7 +1536,10 @@ func (d *Decoder) decode(iv interface{}) {
 		v.CodecDecodeSelf(d)
 
 	case reflect.Value:
-		d.chkPtrValue(v)
+		if v.Kind() != reflect.Ptr || v.IsNil() {
+			d.errNotValidPtrValue(v)
+		}
+		// d.chkPtrValue(v)
 		d.decodeValueNotNil(v.Elem(), nil)
 
 	case *string:
@@ -1325,7 +1609,10 @@ func (d *Decoder) preDecodeValue(rv reflect.Value, tryNil bool) (rv2 reflect.Val
 func (d *Decoder) decodeI(iv interface{}, checkPtr, tryNil, checkFastpath, checkCodecSelfer bool) {
 	rv := reflect.ValueOf(iv)
 	if checkPtr {
-		d.chkPtrValue(rv)
+		if rv.Kind() != reflect.Ptr || rv.IsNil() {
+			d.errNotValidPtrValue(rv)
+		}
+		// d.chkPtrValue(rv)
 	}
 	rv, proceed := d.preDecodeValue(rv, tryNil)
 	if proceed {
@@ -1529,6 +1816,10 @@ func (d *Decoder) chkPtrValue(rv reflect.Value) {
 	if rv.Kind() == reflect.Ptr && !rv.IsNil() {
 		return
 	}
+	d.errNotValidPtrValue(rv)
+}
+
+func (d *Decoder) errNotValidPtrValue(rv reflect.Value) {
 	if !rv.IsValid() {
 		d.error(cannotDecodeIntoNilErr)
 		return
@@ -1571,31 +1862,65 @@ func (d *Decoder) intern(s string) {
 	}
 }
 
+func (d *Decoder) nextValueBytes() []byte {
+	d.d.uncacheRead()
+	d.r.track()
+	d.swallow()
+	return d.r.stopTrack()
+}
+
 // --------------------------------------------------
 
 // decSliceHelper assists when decoding into a slice, from a map or an array in the stream.
 // A slice can be set from a map or array in stream. This supports the MapBySlice interface.
 type decSliceHelper struct {
-	dd decDriver
-	ct valueType
+	d *Decoder
+	// ct valueType
+	array bool
 }
 
 func (d *Decoder) decSliceHelperStart() (x decSliceHelper, clen int) {
-	x.dd = d.d
-	if x.dd.IsContainerType(valueTypeArray) {
-		x.ct = valueTypeArray
-		clen = x.dd.ReadArrayStart()
-	} else if x.dd.IsContainerType(valueTypeMap) {
-		x.ct = valueTypeMap
-		clen = x.dd.ReadMapStart() * 2
+	dd := d.d
+	ctyp := dd.ContainerType()
+	if ctyp == valueTypeArray {
+		x.array = true
+		clen = dd.ReadArrayStart()
+	} else if ctyp == valueTypeMap {
+		clen = dd.ReadMapStart() * 2
 	} else {
-		d.errorf("only encoded map or array can be decoded into a slice")
+		d.errorf("only encoded map or array can be decoded into a slice (%d)", ctyp)
 	}
+	// x.ct = ctyp
+	x.d = d
 	return
 }
 
 func (x decSliceHelper) End() {
-	x.dd.ReadEnd()
+	cr := x.d.cr
+	if cr == nil {
+		return
+	}
+	if x.array {
+		cr.sendContainerState(containerArrayEnd)
+	} else {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (x decSliceHelper) ElemContainerState(index int) {
+	cr := x.d.cr
+	if cr == nil {
+		return
+	}
+	if x.array {
+		cr.sendContainerState(containerArrayElem)
+	} else {
+		if index%2 == 0 {
+			cr.sendContainerState(containerMapKey)
+		} else {
+			cr.sendContainerState(containerMapValue)
+		}
+	}
 }
 
 func decByteSlice(r decReader, clen int, bs []byte) (bsOut []byte) {

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.generated.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.generated.go
@@ -1,4 +1,4 @@
-// //+build ignore
+// +build !notfastpath
 
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
@@ -373,6 +373,9 @@ func init() {
 
 // -- -- fast path type switch
 func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool {
+	if !fastpathEnabled {
+		return false
+	}
 	switch v := iv.(type) {
 
 	case []interface{}:
@@ -1731,12 +1734,16 @@ func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool {
 		fastpathTV.EncMapBoolBoolV(*v, fastpathCheckNilTrue, e)
 
 	default:
+		_ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
 		return false
 	}
 	return true
 }
 
 func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool {
+	if !fastpathEnabled {
+		return false
+	}
 	switch v := iv.(type) {
 
 	case []interface{}:
@@ -1815,12 +1822,16 @@ func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool {
 		fastpathTV.EncSliceBoolV(*v, fastpathCheckNilTrue, e)
 
 	default:
+		_ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
 		return false
 	}
 	return true
 }
 
 func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool {
+	if !fastpathEnabled {
+		return false
+	}
 	switch v := iv.(type) {
 
 	case map[interface{}]interface{}:
@@ -3117,15 +3128,21 @@ func (f *encFnInfo) fastpathEncSliceIntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceIntfV(v []interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		e.encode(v2)
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceStringR(rv reflect.Value) {
@@ -3133,15 +3150,21 @@ func (f *encFnInfo) fastpathEncSliceStringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceStringV(v []string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeString(c_UTF8, v2)
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceFloat32R(rv reflect.Value) {
@@ -3149,15 +3172,21 @@ func (f *encFnInfo) fastpathEncSliceFloat32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceFloat32V(v []float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeFloat32(v2)
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceFloat64R(rv reflect.Value) {
@@ -3165,15 +3194,21 @@ func (f *encFnInfo) fastpathEncSliceFloat64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceFloat64V(v []float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeFloat64(v2)
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceUintR(rv reflect.Value) {
@@ -3181,15 +3216,21 @@ func (f *encFnInfo) fastpathEncSliceUintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceUintV(v []uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeUint(uint64(v2))
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceUint16R(rv reflect.Value) {
@@ -3197,15 +3238,21 @@ func (f *encFnInfo) fastpathEncSliceUint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceUint16V(v []uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeUint(uint64(v2))
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceUint32R(rv reflect.Value) {
@@ -3213,15 +3260,21 @@ func (f *encFnInfo) fastpathEncSliceUint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceUint32V(v []uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeUint(uint64(v2))
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceUint64R(rv reflect.Value) {
@@ -3229,15 +3282,21 @@ func (f *encFnInfo) fastpathEncSliceUint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceUint64V(v []uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeUint(uint64(v2))
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceUintptrR(rv reflect.Value) {
@@ -3245,15 +3304,21 @@ func (f *encFnInfo) fastpathEncSliceUintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceUintptrV(v []uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		e.encode(v2)
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceIntR(rv reflect.Value) {
@@ -3261,15 +3326,21 @@ func (f *encFnInfo) fastpathEncSliceIntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceIntV(v []int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeInt(int64(v2))
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceInt8R(rv reflect.Value) {
@@ -3277,15 +3348,21 @@ func (f *encFnInfo) fastpathEncSliceInt8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceInt8V(v []int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeInt(int64(v2))
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceInt16R(rv reflect.Value) {
@@ -3293,15 +3370,21 @@ func (f *encFnInfo) fastpathEncSliceInt16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceInt16V(v []int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeInt(int64(v2))
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceInt32R(rv reflect.Value) {
@@ -3309,15 +3392,21 @@ func (f *encFnInfo) fastpathEncSliceInt32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceInt32V(v []int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeInt(int64(v2))
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceInt64R(rv reflect.Value) {
@@ -3325,15 +3414,21 @@ func (f *encFnInfo) fastpathEncSliceInt64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceInt64V(v []int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeInt(int64(v2))
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncSliceBoolR(rv reflect.Value) {
@@ -3341,15 +3436,21 @@ func (f *encFnInfo) fastpathEncSliceBoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncSliceBoolV(v []bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
 		ee.EncodeBool(v2)
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfIntfR(rv reflect.Value) {
@@ -3357,6 +3458,7 @@ func (f *encFnInfo) fastpathEncMapIntfIntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfIntfV(v map[interface{}]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3378,16 +3480,30 @@ func (_ fastpathT) EncMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfStringR(rv reflect.Value) {
@@ -3395,6 +3511,7 @@ func (f *encFnInfo) fastpathEncMapIntfStringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfStringV(v map[interface{}]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3416,16 +3533,30 @@ func (_ fastpathT) EncMapIntfStringV(v map[interface{}]string, checkNil bool, e 
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUintR(rv reflect.Value) {
@@ -3433,6 +3564,7 @@ func (f *encFnInfo) fastpathEncMapIntfUintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfUintV(v map[interface{}]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3454,16 +3586,30 @@ func (_ fastpathT) EncMapIntfUintV(v map[interface{}]uint, checkNil bool, e *Enc
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUint8R(rv reflect.Value) {
@@ -3471,6 +3617,7 @@ func (f *encFnInfo) fastpathEncMapIntfUint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfUint8V(v map[interface{}]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3492,16 +3639,30 @@ func (_ fastpathT) EncMapIntfUint8V(v map[interface{}]uint8, checkNil bool, e *E
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUint16R(rv reflect.Value) {
@@ -3509,6 +3670,7 @@ func (f *encFnInfo) fastpathEncMapIntfUint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfUint16V(v map[interface{}]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3530,16 +3692,30 @@ func (_ fastpathT) EncMapIntfUint16V(v map[interface{}]uint16, checkNil bool, e 
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUint32R(rv reflect.Value) {
@@ -3547,6 +3723,7 @@ func (f *encFnInfo) fastpathEncMapIntfUint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfUint32V(v map[interface{}]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3568,16 +3745,30 @@ func (_ fastpathT) EncMapIntfUint32V(v map[interface{}]uint32, checkNil bool, e 
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUint64R(rv reflect.Value) {
@@ -3585,6 +3776,7 @@ func (f *encFnInfo) fastpathEncMapIntfUint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfUint64V(v map[interface{}]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3606,16 +3798,30 @@ func (_ fastpathT) EncMapIntfUint64V(v map[interface{}]uint64, checkNil bool, e 
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUintptrR(rv reflect.Value) {
@@ -3623,6 +3829,7 @@ func (f *encFnInfo) fastpathEncMapIntfUintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3644,16 +3851,30 @@ func (_ fastpathT) EncMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, 
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfIntR(rv reflect.Value) {
@@ -3661,6 +3882,7 @@ func (f *encFnInfo) fastpathEncMapIntfIntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfIntV(v map[interface{}]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3682,16 +3904,30 @@ func (_ fastpathT) EncMapIntfIntV(v map[interface{}]int, checkNil bool, e *Encod
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfInt8R(rv reflect.Value) {
@@ -3699,6 +3935,7 @@ func (f *encFnInfo) fastpathEncMapIntfInt8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfInt8V(v map[interface{}]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3720,16 +3957,30 @@ func (_ fastpathT) EncMapIntfInt8V(v map[interface{}]int8, checkNil bool, e *Enc
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfInt16R(rv reflect.Value) {
@@ -3737,6 +3988,7 @@ func (f *encFnInfo) fastpathEncMapIntfInt16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfInt16V(v map[interface{}]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3758,16 +4010,30 @@ func (_ fastpathT) EncMapIntfInt16V(v map[interface{}]int16, checkNil bool, e *E
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfInt32R(rv reflect.Value) {
@@ -3775,6 +4041,7 @@ func (f *encFnInfo) fastpathEncMapIntfInt32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfInt32V(v map[interface{}]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3796,16 +4063,30 @@ func (_ fastpathT) EncMapIntfInt32V(v map[interface{}]int32, checkNil bool, e *E
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfInt64R(rv reflect.Value) {
@@ -3813,6 +4094,7 @@ func (f *encFnInfo) fastpathEncMapIntfInt64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfInt64V(v map[interface{}]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3834,16 +4116,30 @@ func (_ fastpathT) EncMapIntfInt64V(v map[interface{}]int64, checkNil bool, e *E
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfFloat32R(rv reflect.Value) {
@@ -3851,6 +4147,7 @@ func (f *encFnInfo) fastpathEncMapIntfFloat32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfFloat32V(v map[interface{}]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3872,16 +4169,30 @@ func (_ fastpathT) EncMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfFloat64R(rv reflect.Value) {
@@ -3889,6 +4200,7 @@ func (f *encFnInfo) fastpathEncMapIntfFloat64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfFloat64V(v map[interface{}]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3910,16 +4222,30 @@ func (_ fastpathT) EncMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntfBoolR(rv reflect.Value) {
@@ -3927,6 +4253,7 @@ func (f *encFnInfo) fastpathEncMapIntfBoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntfBoolV(v map[interface{}]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3948,16 +4275,30 @@ func (_ fastpathT) EncMapIntfBoolV(v map[interface{}]bool, checkNil bool, e *Enc
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[v2[j].i])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringIntfR(rv reflect.Value) {
@@ -3965,6 +4306,7 @@ func (f *encFnInfo) fastpathEncMapStringIntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringIntfV(v map[string]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -3980,24 +4322,38 @@ func (_ fastpathT) EncMapStringIntfV(v map[string]interface{}, checkNil bool, e 
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			e.encode(v[string(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringStringR(rv reflect.Value) {
@@ -4005,6 +4361,7 @@ func (f *encFnInfo) fastpathEncMapStringStringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringStringV(v map[string]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4020,24 +4377,38 @@ func (_ fastpathT) EncMapStringStringV(v map[string]string, checkNil bool, e *En
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeString(c_UTF8, v[string(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringUintR(rv reflect.Value) {
@@ -4045,6 +4416,7 @@ func (f *encFnInfo) fastpathEncMapStringUintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringUintV(v map[string]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4060,24 +4432,38 @@ func (_ fastpathT) EncMapStringUintV(v map[string]uint, checkNil bool, e *Encode
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeUint(uint64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringUint8R(rv reflect.Value) {
@@ -4085,6 +4471,7 @@ func (f *encFnInfo) fastpathEncMapStringUint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringUint8V(v map[string]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4100,24 +4487,38 @@ func (_ fastpathT) EncMapStringUint8V(v map[string]uint8, checkNil bool, e *Enco
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeUint(uint64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringUint16R(rv reflect.Value) {
@@ -4125,6 +4526,7 @@ func (f *encFnInfo) fastpathEncMapStringUint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringUint16V(v map[string]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4140,24 +4542,38 @@ func (_ fastpathT) EncMapStringUint16V(v map[string]uint16, checkNil bool, e *En
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeUint(uint64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringUint32R(rv reflect.Value) {
@@ -4165,6 +4581,7 @@ func (f *encFnInfo) fastpathEncMapStringUint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringUint32V(v map[string]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4180,24 +4597,38 @@ func (_ fastpathT) EncMapStringUint32V(v map[string]uint32, checkNil bool, e *En
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeUint(uint64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringUint64R(rv reflect.Value) {
@@ -4205,6 +4636,7 @@ func (f *encFnInfo) fastpathEncMapStringUint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringUint64V(v map[string]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4220,24 +4652,38 @@ func (_ fastpathT) EncMapStringUint64V(v map[string]uint64, checkNil bool, e *En
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeUint(uint64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringUintptrR(rv reflect.Value) {
@@ -4245,6 +4691,7 @@ func (f *encFnInfo) fastpathEncMapStringUintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringUintptrV(v map[string]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4260,24 +4707,38 @@ func (_ fastpathT) EncMapStringUintptrV(v map[string]uintptr, checkNil bool, e *
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			e.encode(v[string(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringIntR(rv reflect.Value) {
@@ -4285,6 +4746,7 @@ func (f *encFnInfo) fastpathEncMapStringIntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringIntV(v map[string]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4300,24 +4762,38 @@ func (_ fastpathT) EncMapStringIntV(v map[string]int, checkNil bool, e *Encoder)
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeInt(int64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringInt8R(rv reflect.Value) {
@@ -4325,6 +4801,7 @@ func (f *encFnInfo) fastpathEncMapStringInt8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringInt8V(v map[string]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4340,24 +4817,38 @@ func (_ fastpathT) EncMapStringInt8V(v map[string]int8, checkNil bool, e *Encode
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeInt(int64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringInt16R(rv reflect.Value) {
@@ -4365,6 +4856,7 @@ func (f *encFnInfo) fastpathEncMapStringInt16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringInt16V(v map[string]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4380,24 +4872,38 @@ func (_ fastpathT) EncMapStringInt16V(v map[string]int16, checkNil bool, e *Enco
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeInt(int64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringInt32R(rv reflect.Value) {
@@ -4405,6 +4911,7 @@ func (f *encFnInfo) fastpathEncMapStringInt32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringInt32V(v map[string]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4420,24 +4927,38 @@ func (_ fastpathT) EncMapStringInt32V(v map[string]int32, checkNil bool, e *Enco
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeInt(int64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringInt64R(rv reflect.Value) {
@@ -4445,6 +4966,7 @@ func (f *encFnInfo) fastpathEncMapStringInt64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringInt64V(v map[string]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4460,24 +4982,38 @@ func (_ fastpathT) EncMapStringInt64V(v map[string]int64, checkNil bool, e *Enco
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeInt(int64(v[string(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringFloat32R(rv reflect.Value) {
@@ -4485,6 +5021,7 @@ func (f *encFnInfo) fastpathEncMapStringFloat32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringFloat32V(v map[string]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4500,24 +5037,38 @@ func (_ fastpathT) EncMapStringFloat32V(v map[string]float32, checkNil bool, e *
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeFloat32(v[string(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringFloat64R(rv reflect.Value) {
@@ -4525,6 +5076,7 @@ func (f *encFnInfo) fastpathEncMapStringFloat64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringFloat64V(v map[string]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4540,24 +5092,38 @@ func (_ fastpathT) EncMapStringFloat64V(v map[string]float64, checkNil bool, e *
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeFloat64(v[string(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapStringBoolR(rv reflect.Value) {
@@ -4565,6 +5131,7 @@ func (f *encFnInfo) fastpathEncMapStringBoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapStringBoolV(v map[string]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4580,24 +5147,38 @@ func (_ fastpathT) EncMapStringBoolV(v map[string]bool, checkNil bool, e *Encode
 		}
 		sort.Sort(stringSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			ee.EncodeBool(v[string(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32IntfR(rv reflect.Value) {
@@ -4605,6 +5186,7 @@ func (f *encFnInfo) fastpathEncMapFloat32IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32IntfV(v map[float32]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4619,16 +5201,30 @@ func (_ fastpathT) EncMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[float32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32StringR(rv reflect.Value) {
@@ -4636,6 +5232,7 @@ func (f *encFnInfo) fastpathEncMapFloat32StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32StringV(v map[float32]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4650,16 +5247,30 @@ func (_ fastpathT) EncMapFloat32StringV(v map[float32]string, checkNil bool, e *
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[float32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32UintR(rv reflect.Value) {
@@ -4667,6 +5278,7 @@ func (f *encFnInfo) fastpathEncMapFloat32UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32UintV(v map[float32]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4681,16 +5293,30 @@ func (_ fastpathT) EncMapFloat32UintV(v map[float32]uint, checkNil bool, e *Enco
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Uint8R(rv reflect.Value) {
@@ -4698,6 +5324,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Uint8V(v map[float32]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4712,16 +5339,30 @@ func (_ fastpathT) EncMapFloat32Uint8V(v map[float32]uint8, checkNil bool, e *En
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Uint16R(rv reflect.Value) {
@@ -4729,6 +5370,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Uint16V(v map[float32]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4743,16 +5385,30 @@ func (_ fastpathT) EncMapFloat32Uint16V(v map[float32]uint16, checkNil bool, e *
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Uint32R(rv reflect.Value) {
@@ -4760,6 +5416,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Uint32V(v map[float32]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4774,16 +5431,30 @@ func (_ fastpathT) EncMapFloat32Uint32V(v map[float32]uint32, checkNil bool, e *
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Uint64R(rv reflect.Value) {
@@ -4791,6 +5462,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Uint64V(v map[float32]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4805,16 +5477,30 @@ func (_ fastpathT) EncMapFloat32Uint64V(v map[float32]uint64, checkNil bool, e *
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32UintptrR(rv reflect.Value) {
@@ -4822,6 +5508,7 @@ func (f *encFnInfo) fastpathEncMapFloat32UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4836,16 +5523,30 @@ func (_ fastpathT) EncMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, e
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[float32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32IntR(rv reflect.Value) {
@@ -4853,6 +5554,7 @@ func (f *encFnInfo) fastpathEncMapFloat32IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32IntV(v map[float32]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4867,16 +5569,30 @@ func (_ fastpathT) EncMapFloat32IntV(v map[float32]int, checkNil bool, e *Encode
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Int8R(rv reflect.Value) {
@@ -4884,6 +5600,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Int8V(v map[float32]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4898,16 +5615,30 @@ func (_ fastpathT) EncMapFloat32Int8V(v map[float32]int8, checkNil bool, e *Enco
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Int16R(rv reflect.Value) {
@@ -4915,6 +5646,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Int16V(v map[float32]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4929,16 +5661,30 @@ func (_ fastpathT) EncMapFloat32Int16V(v map[float32]int16, checkNil bool, e *En
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Int32R(rv reflect.Value) {
@@ -4946,6 +5692,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Int32V(v map[float32]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4960,16 +5707,30 @@ func (_ fastpathT) EncMapFloat32Int32V(v map[float32]int32, checkNil bool, e *En
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Int64R(rv reflect.Value) {
@@ -4977,6 +5738,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Int64V(v map[float32]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -4991,16 +5753,30 @@ func (_ fastpathT) EncMapFloat32Int64V(v map[float32]int64, checkNil bool, e *En
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Float32R(rv reflect.Value) {
@@ -5008,6 +5784,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Float32V(v map[float32]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5022,16 +5799,30 @@ func (_ fastpathT) EncMapFloat32Float32V(v map[float32]float32, checkNil bool, e
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[float32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Float64R(rv reflect.Value) {
@@ -5039,6 +5830,7 @@ func (f *encFnInfo) fastpathEncMapFloat32Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32Float64V(v map[float32]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5053,16 +5845,30 @@ func (_ fastpathT) EncMapFloat32Float64V(v map[float32]float64, checkNil bool, e
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[float32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32BoolR(rv reflect.Value) {
@@ -5070,6 +5876,7 @@ func (f *encFnInfo) fastpathEncMapFloat32BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat32BoolV(v map[float32]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5084,16 +5891,30 @@ func (_ fastpathT) EncMapFloat32BoolV(v map[float32]bool, checkNil bool, e *Enco
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[float32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64IntfR(rv reflect.Value) {
@@ -5101,6 +5922,7 @@ func (f *encFnInfo) fastpathEncMapFloat64IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64IntfV(v map[float64]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5115,16 +5937,30 @@ func (_ fastpathT) EncMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[float64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64StringR(rv reflect.Value) {
@@ -5132,6 +5968,7 @@ func (f *encFnInfo) fastpathEncMapFloat64StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64StringV(v map[float64]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5146,16 +5983,30 @@ func (_ fastpathT) EncMapFloat64StringV(v map[float64]string, checkNil bool, e *
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[float64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64UintR(rv reflect.Value) {
@@ -5163,6 +6014,7 @@ func (f *encFnInfo) fastpathEncMapFloat64UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64UintV(v map[float64]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5177,16 +6029,30 @@ func (_ fastpathT) EncMapFloat64UintV(v map[float64]uint, checkNil bool, e *Enco
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Uint8R(rv reflect.Value) {
@@ -5194,6 +6060,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Uint8V(v map[float64]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5208,16 +6075,30 @@ func (_ fastpathT) EncMapFloat64Uint8V(v map[float64]uint8, checkNil bool, e *En
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Uint16R(rv reflect.Value) {
@@ -5225,6 +6106,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Uint16V(v map[float64]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5239,16 +6121,30 @@ func (_ fastpathT) EncMapFloat64Uint16V(v map[float64]uint16, checkNil bool, e *
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Uint32R(rv reflect.Value) {
@@ -5256,6 +6152,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Uint32V(v map[float64]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5270,16 +6167,30 @@ func (_ fastpathT) EncMapFloat64Uint32V(v map[float64]uint32, checkNil bool, e *
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Uint64R(rv reflect.Value) {
@@ -5287,6 +6198,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Uint64V(v map[float64]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5301,16 +6213,30 @@ func (_ fastpathT) EncMapFloat64Uint64V(v map[float64]uint64, checkNil bool, e *
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64UintptrR(rv reflect.Value) {
@@ -5318,6 +6244,7 @@ func (f *encFnInfo) fastpathEncMapFloat64UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5332,16 +6259,30 @@ func (_ fastpathT) EncMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, e
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[float64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64IntR(rv reflect.Value) {
@@ -5349,6 +6290,7 @@ func (f *encFnInfo) fastpathEncMapFloat64IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64IntV(v map[float64]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5363,16 +6305,30 @@ func (_ fastpathT) EncMapFloat64IntV(v map[float64]int, checkNil bool, e *Encode
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Int8R(rv reflect.Value) {
@@ -5380,6 +6336,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Int8V(v map[float64]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5394,16 +6351,30 @@ func (_ fastpathT) EncMapFloat64Int8V(v map[float64]int8, checkNil bool, e *Enco
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Int16R(rv reflect.Value) {
@@ -5411,6 +6382,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Int16V(v map[float64]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5425,16 +6397,30 @@ func (_ fastpathT) EncMapFloat64Int16V(v map[float64]int16, checkNil bool, e *En
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Int32R(rv reflect.Value) {
@@ -5442,6 +6428,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Int32V(v map[float64]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5456,16 +6443,30 @@ func (_ fastpathT) EncMapFloat64Int32V(v map[float64]int32, checkNil bool, e *En
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Int64R(rv reflect.Value) {
@@ -5473,6 +6474,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Int64V(v map[float64]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5487,16 +6489,30 @@ func (_ fastpathT) EncMapFloat64Int64V(v map[float64]int64, checkNil bool, e *En
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[float64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Float32R(rv reflect.Value) {
@@ -5504,6 +6520,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Float32V(v map[float64]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5518,16 +6535,30 @@ func (_ fastpathT) EncMapFloat64Float32V(v map[float64]float32, checkNil bool, e
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[float64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Float64R(rv reflect.Value) {
@@ -5535,6 +6566,7 @@ func (f *encFnInfo) fastpathEncMapFloat64Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64Float64V(v map[float64]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5549,16 +6581,30 @@ func (_ fastpathT) EncMapFloat64Float64V(v map[float64]float64, checkNil bool, e
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[float64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64BoolR(rv reflect.Value) {
@@ -5566,6 +6612,7 @@ func (f *encFnInfo) fastpathEncMapFloat64BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapFloat64BoolV(v map[float64]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5580,16 +6627,30 @@ func (_ fastpathT) EncMapFloat64BoolV(v map[float64]bool, checkNil bool, e *Enco
 		}
 		sort.Sort(floatSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[float64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintIntfR(rv reflect.Value) {
@@ -5597,6 +6658,7 @@ func (f *encFnInfo) fastpathEncMapUintIntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintIntfV(v map[uint]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5611,16 +6673,30 @@ func (_ fastpathT) EncMapUintIntfV(v map[uint]interface{}, checkNil bool, e *Enc
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintStringR(rv reflect.Value) {
@@ -5628,6 +6704,7 @@ func (f *encFnInfo) fastpathEncMapUintStringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintStringV(v map[uint]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5642,16 +6719,30 @@ func (_ fastpathT) EncMapUintStringV(v map[uint]string, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[uint(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintUintR(rv reflect.Value) {
@@ -5659,6 +6750,7 @@ func (f *encFnInfo) fastpathEncMapUintUintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintUintV(v map[uint]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5673,16 +6765,30 @@ func (_ fastpathT) EncMapUintUintV(v map[uint]uint, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintUint8R(rv reflect.Value) {
@@ -5690,6 +6796,7 @@ func (f *encFnInfo) fastpathEncMapUintUint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintUint8V(v map[uint]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5704,16 +6811,30 @@ func (_ fastpathT) EncMapUintUint8V(v map[uint]uint8, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintUint16R(rv reflect.Value) {
@@ -5721,6 +6842,7 @@ func (f *encFnInfo) fastpathEncMapUintUint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintUint16V(v map[uint]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5735,16 +6857,30 @@ func (_ fastpathT) EncMapUintUint16V(v map[uint]uint16, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintUint32R(rv reflect.Value) {
@@ -5752,6 +6888,7 @@ func (f *encFnInfo) fastpathEncMapUintUint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintUint32V(v map[uint]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5766,16 +6903,30 @@ func (_ fastpathT) EncMapUintUint32V(v map[uint]uint32, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintUint64R(rv reflect.Value) {
@@ -5783,6 +6934,7 @@ func (f *encFnInfo) fastpathEncMapUintUint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintUint64V(v map[uint]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5797,16 +6949,30 @@ func (_ fastpathT) EncMapUintUint64V(v map[uint]uint64, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintUintptrR(rv reflect.Value) {
@@ -5814,6 +6980,7 @@ func (f *encFnInfo) fastpathEncMapUintUintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintUintptrV(v map[uint]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5828,16 +6995,30 @@ func (_ fastpathT) EncMapUintUintptrV(v map[uint]uintptr, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintIntR(rv reflect.Value) {
@@ -5845,6 +7026,7 @@ func (f *encFnInfo) fastpathEncMapUintIntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintIntV(v map[uint]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5859,16 +7041,30 @@ func (_ fastpathT) EncMapUintIntV(v map[uint]int, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintInt8R(rv reflect.Value) {
@@ -5876,6 +7072,7 @@ func (f *encFnInfo) fastpathEncMapUintInt8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintInt8V(v map[uint]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5890,16 +7087,30 @@ func (_ fastpathT) EncMapUintInt8V(v map[uint]int8, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintInt16R(rv reflect.Value) {
@@ -5907,6 +7118,7 @@ func (f *encFnInfo) fastpathEncMapUintInt16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintInt16V(v map[uint]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5921,16 +7133,30 @@ func (_ fastpathT) EncMapUintInt16V(v map[uint]int16, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintInt32R(rv reflect.Value) {
@@ -5938,6 +7164,7 @@ func (f *encFnInfo) fastpathEncMapUintInt32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintInt32V(v map[uint]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5952,16 +7179,30 @@ func (_ fastpathT) EncMapUintInt32V(v map[uint]int32, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintInt64R(rv reflect.Value) {
@@ -5969,6 +7210,7 @@ func (f *encFnInfo) fastpathEncMapUintInt64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintInt64V(v map[uint]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -5983,16 +7225,30 @@ func (_ fastpathT) EncMapUintInt64V(v map[uint]int64, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintFloat32R(rv reflect.Value) {
@@ -6000,6 +7256,7 @@ func (f *encFnInfo) fastpathEncMapUintFloat32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintFloat32V(v map[uint]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6014,16 +7271,30 @@ func (_ fastpathT) EncMapUintFloat32V(v map[uint]float32, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[uint(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintFloat64R(rv reflect.Value) {
@@ -6031,6 +7302,7 @@ func (f *encFnInfo) fastpathEncMapUintFloat64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintFloat64V(v map[uint]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6045,16 +7317,30 @@ func (_ fastpathT) EncMapUintFloat64V(v map[uint]float64, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[uint(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintBoolR(rv reflect.Value) {
@@ -6062,6 +7348,7 @@ func (f *encFnInfo) fastpathEncMapUintBoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintBoolV(v map[uint]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6076,16 +7363,30 @@ func (_ fastpathT) EncMapUintBoolV(v map[uint]bool, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[uint(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8IntfR(rv reflect.Value) {
@@ -6093,6 +7394,7 @@ func (f *encFnInfo) fastpathEncMapUint8IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8IntfV(v map[uint8]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6107,16 +7409,30 @@ func (_ fastpathT) EncMapUint8IntfV(v map[uint8]interface{}, checkNil bool, e *E
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8StringR(rv reflect.Value) {
@@ -6124,6 +7440,7 @@ func (f *encFnInfo) fastpathEncMapUint8StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8StringV(v map[uint8]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6138,16 +7455,30 @@ func (_ fastpathT) EncMapUint8StringV(v map[uint8]string, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[uint8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8UintR(rv reflect.Value) {
@@ -6155,6 +7486,7 @@ func (f *encFnInfo) fastpathEncMapUint8UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8UintV(v map[uint8]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6169,16 +7501,30 @@ func (_ fastpathT) EncMapUint8UintV(v map[uint8]uint, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Uint8R(rv reflect.Value) {
@@ -6186,6 +7532,7 @@ func (f *encFnInfo) fastpathEncMapUint8Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Uint8V(v map[uint8]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6200,16 +7547,30 @@ func (_ fastpathT) EncMapUint8Uint8V(v map[uint8]uint8, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Uint16R(rv reflect.Value) {
@@ -6217,6 +7578,7 @@ func (f *encFnInfo) fastpathEncMapUint8Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Uint16V(v map[uint8]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6231,16 +7593,30 @@ func (_ fastpathT) EncMapUint8Uint16V(v map[uint8]uint16, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Uint32R(rv reflect.Value) {
@@ -6248,6 +7624,7 @@ func (f *encFnInfo) fastpathEncMapUint8Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Uint32V(v map[uint8]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6262,16 +7639,30 @@ func (_ fastpathT) EncMapUint8Uint32V(v map[uint8]uint32, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Uint64R(rv reflect.Value) {
@@ -6279,6 +7670,7 @@ func (f *encFnInfo) fastpathEncMapUint8Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Uint64V(v map[uint8]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6293,16 +7685,30 @@ func (_ fastpathT) EncMapUint8Uint64V(v map[uint8]uint64, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8UintptrR(rv reflect.Value) {
@@ -6310,6 +7716,7 @@ func (f *encFnInfo) fastpathEncMapUint8UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6324,16 +7731,30 @@ func (_ fastpathT) EncMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8IntR(rv reflect.Value) {
@@ -6341,6 +7762,7 @@ func (f *encFnInfo) fastpathEncMapUint8IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8IntV(v map[uint8]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6355,16 +7777,30 @@ func (_ fastpathT) EncMapUint8IntV(v map[uint8]int, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Int8R(rv reflect.Value) {
@@ -6372,6 +7808,7 @@ func (f *encFnInfo) fastpathEncMapUint8Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Int8V(v map[uint8]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6386,16 +7823,30 @@ func (_ fastpathT) EncMapUint8Int8V(v map[uint8]int8, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Int16R(rv reflect.Value) {
@@ -6403,6 +7854,7 @@ func (f *encFnInfo) fastpathEncMapUint8Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Int16V(v map[uint8]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6417,16 +7869,30 @@ func (_ fastpathT) EncMapUint8Int16V(v map[uint8]int16, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Int32R(rv reflect.Value) {
@@ -6434,6 +7900,7 @@ func (f *encFnInfo) fastpathEncMapUint8Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Int32V(v map[uint8]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6448,16 +7915,30 @@ func (_ fastpathT) EncMapUint8Int32V(v map[uint8]int32, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Int64R(rv reflect.Value) {
@@ -6465,6 +7946,7 @@ func (f *encFnInfo) fastpathEncMapUint8Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Int64V(v map[uint8]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6479,16 +7961,30 @@ func (_ fastpathT) EncMapUint8Int64V(v map[uint8]int64, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Float32R(rv reflect.Value) {
@@ -6496,6 +7992,7 @@ func (f *encFnInfo) fastpathEncMapUint8Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Float32V(v map[uint8]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6510,16 +8007,30 @@ func (_ fastpathT) EncMapUint8Float32V(v map[uint8]float32, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[uint8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Float64R(rv reflect.Value) {
@@ -6527,6 +8038,7 @@ func (f *encFnInfo) fastpathEncMapUint8Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8Float64V(v map[uint8]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6541,16 +8053,30 @@ func (_ fastpathT) EncMapUint8Float64V(v map[uint8]float64, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[uint8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint8BoolR(rv reflect.Value) {
@@ -6558,6 +8084,7 @@ func (f *encFnInfo) fastpathEncMapUint8BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint8BoolV(v map[uint8]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6572,16 +8099,30 @@ func (_ fastpathT) EncMapUint8BoolV(v map[uint8]bool, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[uint8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16IntfR(rv reflect.Value) {
@@ -6589,6 +8130,7 @@ func (f *encFnInfo) fastpathEncMapUint16IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16IntfV(v map[uint16]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6603,16 +8145,30 @@ func (_ fastpathT) EncMapUint16IntfV(v map[uint16]interface{}, checkNil bool, e 
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16StringR(rv reflect.Value) {
@@ -6620,6 +8176,7 @@ func (f *encFnInfo) fastpathEncMapUint16StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16StringV(v map[uint16]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6634,16 +8191,30 @@ func (_ fastpathT) EncMapUint16StringV(v map[uint16]string, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[uint16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16UintR(rv reflect.Value) {
@@ -6651,6 +8222,7 @@ func (f *encFnInfo) fastpathEncMapUint16UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16UintV(v map[uint16]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6665,16 +8237,30 @@ func (_ fastpathT) EncMapUint16UintV(v map[uint16]uint, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Uint8R(rv reflect.Value) {
@@ -6682,6 +8268,7 @@ func (f *encFnInfo) fastpathEncMapUint16Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Uint8V(v map[uint16]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6696,16 +8283,30 @@ func (_ fastpathT) EncMapUint16Uint8V(v map[uint16]uint8, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Uint16R(rv reflect.Value) {
@@ -6713,6 +8314,7 @@ func (f *encFnInfo) fastpathEncMapUint16Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Uint16V(v map[uint16]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6727,16 +8329,30 @@ func (_ fastpathT) EncMapUint16Uint16V(v map[uint16]uint16, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Uint32R(rv reflect.Value) {
@@ -6744,6 +8360,7 @@ func (f *encFnInfo) fastpathEncMapUint16Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Uint32V(v map[uint16]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6758,16 +8375,30 @@ func (_ fastpathT) EncMapUint16Uint32V(v map[uint16]uint32, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Uint64R(rv reflect.Value) {
@@ -6775,6 +8406,7 @@ func (f *encFnInfo) fastpathEncMapUint16Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Uint64V(v map[uint16]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6789,16 +8421,30 @@ func (_ fastpathT) EncMapUint16Uint64V(v map[uint16]uint64, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16UintptrR(rv reflect.Value) {
@@ -6806,6 +8452,7 @@ func (f *encFnInfo) fastpathEncMapUint16UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6820,16 +8467,30 @@ func (_ fastpathT) EncMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16IntR(rv reflect.Value) {
@@ -6837,6 +8498,7 @@ func (f *encFnInfo) fastpathEncMapUint16IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16IntV(v map[uint16]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6851,16 +8513,30 @@ func (_ fastpathT) EncMapUint16IntV(v map[uint16]int, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Int8R(rv reflect.Value) {
@@ -6868,6 +8544,7 @@ func (f *encFnInfo) fastpathEncMapUint16Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Int8V(v map[uint16]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6882,16 +8559,30 @@ func (_ fastpathT) EncMapUint16Int8V(v map[uint16]int8, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Int16R(rv reflect.Value) {
@@ -6899,6 +8590,7 @@ func (f *encFnInfo) fastpathEncMapUint16Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Int16V(v map[uint16]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6913,16 +8605,30 @@ func (_ fastpathT) EncMapUint16Int16V(v map[uint16]int16, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Int32R(rv reflect.Value) {
@@ -6930,6 +8636,7 @@ func (f *encFnInfo) fastpathEncMapUint16Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Int32V(v map[uint16]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6944,16 +8651,30 @@ func (_ fastpathT) EncMapUint16Int32V(v map[uint16]int32, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Int64R(rv reflect.Value) {
@@ -6961,6 +8682,7 @@ func (f *encFnInfo) fastpathEncMapUint16Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Int64V(v map[uint16]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -6975,16 +8697,30 @@ func (_ fastpathT) EncMapUint16Int64V(v map[uint16]int64, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Float32R(rv reflect.Value) {
@@ -6992,6 +8728,7 @@ func (f *encFnInfo) fastpathEncMapUint16Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Float32V(v map[uint16]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7006,16 +8743,30 @@ func (_ fastpathT) EncMapUint16Float32V(v map[uint16]float32, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[uint16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Float64R(rv reflect.Value) {
@@ -7023,6 +8774,7 @@ func (f *encFnInfo) fastpathEncMapUint16Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16Float64V(v map[uint16]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7037,16 +8789,30 @@ func (_ fastpathT) EncMapUint16Float64V(v map[uint16]float64, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[uint16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint16BoolR(rv reflect.Value) {
@@ -7054,6 +8820,7 @@ func (f *encFnInfo) fastpathEncMapUint16BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint16BoolV(v map[uint16]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7068,16 +8835,30 @@ func (_ fastpathT) EncMapUint16BoolV(v map[uint16]bool, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[uint16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32IntfR(rv reflect.Value) {
@@ -7085,6 +8866,7 @@ func (f *encFnInfo) fastpathEncMapUint32IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32IntfV(v map[uint32]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7099,16 +8881,30 @@ func (_ fastpathT) EncMapUint32IntfV(v map[uint32]interface{}, checkNil bool, e 
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32StringR(rv reflect.Value) {
@@ -7116,6 +8912,7 @@ func (f *encFnInfo) fastpathEncMapUint32StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32StringV(v map[uint32]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7130,16 +8927,30 @@ func (_ fastpathT) EncMapUint32StringV(v map[uint32]string, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[uint32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32UintR(rv reflect.Value) {
@@ -7147,6 +8958,7 @@ func (f *encFnInfo) fastpathEncMapUint32UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32UintV(v map[uint32]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7161,16 +8973,30 @@ func (_ fastpathT) EncMapUint32UintV(v map[uint32]uint, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Uint8R(rv reflect.Value) {
@@ -7178,6 +9004,7 @@ func (f *encFnInfo) fastpathEncMapUint32Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Uint8V(v map[uint32]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7192,16 +9019,30 @@ func (_ fastpathT) EncMapUint32Uint8V(v map[uint32]uint8, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Uint16R(rv reflect.Value) {
@@ -7209,6 +9050,7 @@ func (f *encFnInfo) fastpathEncMapUint32Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Uint16V(v map[uint32]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7223,16 +9065,30 @@ func (_ fastpathT) EncMapUint32Uint16V(v map[uint32]uint16, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Uint32R(rv reflect.Value) {
@@ -7240,6 +9096,7 @@ func (f *encFnInfo) fastpathEncMapUint32Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Uint32V(v map[uint32]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7254,16 +9111,30 @@ func (_ fastpathT) EncMapUint32Uint32V(v map[uint32]uint32, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Uint64R(rv reflect.Value) {
@@ -7271,6 +9142,7 @@ func (f *encFnInfo) fastpathEncMapUint32Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Uint64V(v map[uint32]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7285,16 +9157,30 @@ func (_ fastpathT) EncMapUint32Uint64V(v map[uint32]uint64, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32UintptrR(rv reflect.Value) {
@@ -7302,6 +9188,7 @@ func (f *encFnInfo) fastpathEncMapUint32UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7316,16 +9203,30 @@ func (_ fastpathT) EncMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32IntR(rv reflect.Value) {
@@ -7333,6 +9234,7 @@ func (f *encFnInfo) fastpathEncMapUint32IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32IntV(v map[uint32]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7347,16 +9249,30 @@ func (_ fastpathT) EncMapUint32IntV(v map[uint32]int, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Int8R(rv reflect.Value) {
@@ -7364,6 +9280,7 @@ func (f *encFnInfo) fastpathEncMapUint32Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Int8V(v map[uint32]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7378,16 +9295,30 @@ func (_ fastpathT) EncMapUint32Int8V(v map[uint32]int8, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Int16R(rv reflect.Value) {
@@ -7395,6 +9326,7 @@ func (f *encFnInfo) fastpathEncMapUint32Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Int16V(v map[uint32]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7409,16 +9341,30 @@ func (_ fastpathT) EncMapUint32Int16V(v map[uint32]int16, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Int32R(rv reflect.Value) {
@@ -7426,6 +9372,7 @@ func (f *encFnInfo) fastpathEncMapUint32Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Int32V(v map[uint32]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7440,16 +9387,30 @@ func (_ fastpathT) EncMapUint32Int32V(v map[uint32]int32, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Int64R(rv reflect.Value) {
@@ -7457,6 +9418,7 @@ func (f *encFnInfo) fastpathEncMapUint32Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Int64V(v map[uint32]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7471,16 +9433,30 @@ func (_ fastpathT) EncMapUint32Int64V(v map[uint32]int64, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Float32R(rv reflect.Value) {
@@ -7488,6 +9464,7 @@ func (f *encFnInfo) fastpathEncMapUint32Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Float32V(v map[uint32]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7502,16 +9479,30 @@ func (_ fastpathT) EncMapUint32Float32V(v map[uint32]float32, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[uint32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Float64R(rv reflect.Value) {
@@ -7519,6 +9510,7 @@ func (f *encFnInfo) fastpathEncMapUint32Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32Float64V(v map[uint32]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7533,16 +9525,30 @@ func (_ fastpathT) EncMapUint32Float64V(v map[uint32]float64, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[uint32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint32BoolR(rv reflect.Value) {
@@ -7550,6 +9556,7 @@ func (f *encFnInfo) fastpathEncMapUint32BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint32BoolV(v map[uint32]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7564,16 +9571,30 @@ func (_ fastpathT) EncMapUint32BoolV(v map[uint32]bool, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[uint32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64IntfR(rv reflect.Value) {
@@ -7581,6 +9602,7 @@ func (f *encFnInfo) fastpathEncMapUint64IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64IntfV(v map[uint64]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7595,16 +9617,30 @@ func (_ fastpathT) EncMapUint64IntfV(v map[uint64]interface{}, checkNil bool, e 
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64StringR(rv reflect.Value) {
@@ -7612,6 +9648,7 @@ func (f *encFnInfo) fastpathEncMapUint64StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64StringV(v map[uint64]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7626,16 +9663,30 @@ func (_ fastpathT) EncMapUint64StringV(v map[uint64]string, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[uint64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64UintR(rv reflect.Value) {
@@ -7643,6 +9694,7 @@ func (f *encFnInfo) fastpathEncMapUint64UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64UintV(v map[uint64]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7657,16 +9709,30 @@ func (_ fastpathT) EncMapUint64UintV(v map[uint64]uint, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Uint8R(rv reflect.Value) {
@@ -7674,6 +9740,7 @@ func (f *encFnInfo) fastpathEncMapUint64Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Uint8V(v map[uint64]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7688,16 +9755,30 @@ func (_ fastpathT) EncMapUint64Uint8V(v map[uint64]uint8, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Uint16R(rv reflect.Value) {
@@ -7705,6 +9786,7 @@ func (f *encFnInfo) fastpathEncMapUint64Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Uint16V(v map[uint64]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7719,16 +9801,30 @@ func (_ fastpathT) EncMapUint64Uint16V(v map[uint64]uint16, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Uint32R(rv reflect.Value) {
@@ -7736,6 +9832,7 @@ func (f *encFnInfo) fastpathEncMapUint64Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Uint32V(v map[uint64]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7750,16 +9847,30 @@ func (_ fastpathT) EncMapUint64Uint32V(v map[uint64]uint32, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Uint64R(rv reflect.Value) {
@@ -7767,6 +9878,7 @@ func (f *encFnInfo) fastpathEncMapUint64Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Uint64V(v map[uint64]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7781,16 +9893,30 @@ func (_ fastpathT) EncMapUint64Uint64V(v map[uint64]uint64, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64UintptrR(rv reflect.Value) {
@@ -7798,6 +9924,7 @@ func (f *encFnInfo) fastpathEncMapUint64UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7812,16 +9939,30 @@ func (_ fastpathT) EncMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uint64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64IntR(rv reflect.Value) {
@@ -7829,6 +9970,7 @@ func (f *encFnInfo) fastpathEncMapUint64IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64IntV(v map[uint64]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7843,16 +9985,30 @@ func (_ fastpathT) EncMapUint64IntV(v map[uint64]int, checkNil bool, e *Encoder)
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Int8R(rv reflect.Value) {
@@ -7860,6 +10016,7 @@ func (f *encFnInfo) fastpathEncMapUint64Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Int8V(v map[uint64]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7874,16 +10031,30 @@ func (_ fastpathT) EncMapUint64Int8V(v map[uint64]int8, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Int16R(rv reflect.Value) {
@@ -7891,6 +10062,7 @@ func (f *encFnInfo) fastpathEncMapUint64Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Int16V(v map[uint64]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7905,16 +10077,30 @@ func (_ fastpathT) EncMapUint64Int16V(v map[uint64]int16, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Int32R(rv reflect.Value) {
@@ -7922,6 +10108,7 @@ func (f *encFnInfo) fastpathEncMapUint64Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Int32V(v map[uint64]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7936,16 +10123,30 @@ func (_ fastpathT) EncMapUint64Int32V(v map[uint64]int32, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Int64R(rv reflect.Value) {
@@ -7953,6 +10154,7 @@ func (f *encFnInfo) fastpathEncMapUint64Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Int64V(v map[uint64]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7967,16 +10169,30 @@ func (_ fastpathT) EncMapUint64Int64V(v map[uint64]int64, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uint64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Float32R(rv reflect.Value) {
@@ -7984,6 +10200,7 @@ func (f *encFnInfo) fastpathEncMapUint64Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Float32V(v map[uint64]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -7998,16 +10215,30 @@ func (_ fastpathT) EncMapUint64Float32V(v map[uint64]float32, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[uint64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Float64R(rv reflect.Value) {
@@ -8015,6 +10246,7 @@ func (f *encFnInfo) fastpathEncMapUint64Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64Float64V(v map[uint64]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8029,16 +10261,30 @@ func (_ fastpathT) EncMapUint64Float64V(v map[uint64]float64, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[uint64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUint64BoolR(rv reflect.Value) {
@@ -8046,6 +10292,7 @@ func (f *encFnInfo) fastpathEncMapUint64BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUint64BoolV(v map[uint64]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8060,16 +10307,30 @@ func (_ fastpathT) EncMapUint64BoolV(v map[uint64]bool, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[uint64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrIntfR(rv reflect.Value) {
@@ -8077,6 +10338,7 @@ func (f *encFnInfo) fastpathEncMapUintptrIntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8091,16 +10353,30 @@ func (_ fastpathT) EncMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, 
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uintptr(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrStringR(rv reflect.Value) {
@@ -8108,6 +10384,7 @@ func (f *encFnInfo) fastpathEncMapUintptrStringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrStringV(v map[uintptr]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8122,16 +10399,30 @@ func (_ fastpathT) EncMapUintptrStringV(v map[uintptr]string, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[uintptr(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUintR(rv reflect.Value) {
@@ -8139,6 +10430,7 @@ func (f *encFnInfo) fastpathEncMapUintptrUintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrUintV(v map[uintptr]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8153,16 +10445,30 @@ func (_ fastpathT) EncMapUintptrUintV(v map[uintptr]uint, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUint8R(rv reflect.Value) {
@@ -8170,6 +10476,7 @@ func (f *encFnInfo) fastpathEncMapUintptrUint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8184,16 +10491,30 @@ func (_ fastpathT) EncMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUint16R(rv reflect.Value) {
@@ -8201,6 +10522,7 @@ func (f *encFnInfo) fastpathEncMapUintptrUint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8215,16 +10537,30 @@ func (_ fastpathT) EncMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUint32R(rv reflect.Value) {
@@ -8232,6 +10568,7 @@ func (f *encFnInfo) fastpathEncMapUintptrUint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8246,16 +10583,30 @@ func (_ fastpathT) EncMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUint64R(rv reflect.Value) {
@@ -8263,6 +10614,7 @@ func (f *encFnInfo) fastpathEncMapUintptrUint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8277,16 +10629,30 @@ func (_ fastpathT) EncMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, e *
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUintptrR(rv reflect.Value) {
@@ -8294,6 +10660,7 @@ func (f *encFnInfo) fastpathEncMapUintptrUintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8308,16 +10675,30 @@ func (_ fastpathT) EncMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, e
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[uintptr(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrIntR(rv reflect.Value) {
@@ -8325,6 +10706,7 @@ func (f *encFnInfo) fastpathEncMapUintptrIntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrIntV(v map[uintptr]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8339,16 +10721,30 @@ func (_ fastpathT) EncMapUintptrIntV(v map[uintptr]int, checkNil bool, e *Encode
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrInt8R(rv reflect.Value) {
@@ -8356,6 +10752,7 @@ func (f *encFnInfo) fastpathEncMapUintptrInt8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrInt8V(v map[uintptr]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8370,16 +10767,30 @@ func (_ fastpathT) EncMapUintptrInt8V(v map[uintptr]int8, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrInt16R(rv reflect.Value) {
@@ -8387,6 +10798,7 @@ func (f *encFnInfo) fastpathEncMapUintptrInt16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrInt16V(v map[uintptr]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8401,16 +10813,30 @@ func (_ fastpathT) EncMapUintptrInt16V(v map[uintptr]int16, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrInt32R(rv reflect.Value) {
@@ -8418,6 +10844,7 @@ func (f *encFnInfo) fastpathEncMapUintptrInt32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrInt32V(v map[uintptr]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8432,16 +10859,30 @@ func (_ fastpathT) EncMapUintptrInt32V(v map[uintptr]int32, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrInt64R(rv reflect.Value) {
@@ -8449,6 +10890,7 @@ func (f *encFnInfo) fastpathEncMapUintptrInt64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrInt64V(v map[uintptr]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8463,16 +10905,30 @@ func (_ fastpathT) EncMapUintptrInt64V(v map[uintptr]int64, checkNil bool, e *En
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[uintptr(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrFloat32R(rv reflect.Value) {
@@ -8480,6 +10936,7 @@ func (f *encFnInfo) fastpathEncMapUintptrFloat32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8494,16 +10951,30 @@ func (_ fastpathT) EncMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, e
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[uintptr(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrFloat64R(rv reflect.Value) {
@@ -8511,6 +10982,7 @@ func (f *encFnInfo) fastpathEncMapUintptrFloat64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8525,16 +10997,30 @@ func (_ fastpathT) EncMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, e
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[uintptr(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrBoolR(rv reflect.Value) {
@@ -8542,6 +11028,7 @@ func (f *encFnInfo) fastpathEncMapUintptrBoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapUintptrBoolV(v map[uintptr]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8556,16 +11043,30 @@ func (_ fastpathT) EncMapUintptrBoolV(v map[uintptr]bool, checkNil bool, e *Enco
 		}
 		sort.Sort(uintSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[uintptr(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntIntfR(rv reflect.Value) {
@@ -8573,6 +11074,7 @@ func (f *encFnInfo) fastpathEncMapIntIntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntIntfV(v map[int]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8587,16 +11089,30 @@ func (_ fastpathT) EncMapIntIntfV(v map[int]interface{}, checkNil bool, e *Encod
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntStringR(rv reflect.Value) {
@@ -8604,6 +11120,7 @@ func (f *encFnInfo) fastpathEncMapIntStringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntStringV(v map[int]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8618,16 +11135,30 @@ func (_ fastpathT) EncMapIntStringV(v map[int]string, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[int(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntUintR(rv reflect.Value) {
@@ -8635,6 +11166,7 @@ func (f *encFnInfo) fastpathEncMapIntUintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntUintV(v map[int]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8649,16 +11181,30 @@ func (_ fastpathT) EncMapIntUintV(v map[int]uint, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntUint8R(rv reflect.Value) {
@@ -8666,6 +11212,7 @@ func (f *encFnInfo) fastpathEncMapIntUint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntUint8V(v map[int]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8680,16 +11227,30 @@ func (_ fastpathT) EncMapIntUint8V(v map[int]uint8, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntUint16R(rv reflect.Value) {
@@ -8697,6 +11258,7 @@ func (f *encFnInfo) fastpathEncMapIntUint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntUint16V(v map[int]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8711,16 +11273,30 @@ func (_ fastpathT) EncMapIntUint16V(v map[int]uint16, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntUint32R(rv reflect.Value) {
@@ -8728,6 +11304,7 @@ func (f *encFnInfo) fastpathEncMapIntUint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntUint32V(v map[int]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8742,16 +11319,30 @@ func (_ fastpathT) EncMapIntUint32V(v map[int]uint32, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntUint64R(rv reflect.Value) {
@@ -8759,6 +11350,7 @@ func (f *encFnInfo) fastpathEncMapIntUint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntUint64V(v map[int]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8773,16 +11365,30 @@ func (_ fastpathT) EncMapIntUint64V(v map[int]uint64, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntUintptrR(rv reflect.Value) {
@@ -8790,6 +11396,7 @@ func (f *encFnInfo) fastpathEncMapIntUintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntUintptrV(v map[int]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8804,16 +11411,30 @@ func (_ fastpathT) EncMapIntUintptrV(v map[int]uintptr, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntIntR(rv reflect.Value) {
@@ -8821,6 +11442,7 @@ func (f *encFnInfo) fastpathEncMapIntIntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntIntV(v map[int]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8835,16 +11457,30 @@ func (_ fastpathT) EncMapIntIntV(v map[int]int, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntInt8R(rv reflect.Value) {
@@ -8852,6 +11488,7 @@ func (f *encFnInfo) fastpathEncMapIntInt8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntInt8V(v map[int]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8866,16 +11503,30 @@ func (_ fastpathT) EncMapIntInt8V(v map[int]int8, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntInt16R(rv reflect.Value) {
@@ -8883,6 +11534,7 @@ func (f *encFnInfo) fastpathEncMapIntInt16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntInt16V(v map[int]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8897,16 +11549,30 @@ func (_ fastpathT) EncMapIntInt16V(v map[int]int16, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntInt32R(rv reflect.Value) {
@@ -8914,6 +11580,7 @@ func (f *encFnInfo) fastpathEncMapIntInt32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntInt32V(v map[int]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8928,16 +11595,30 @@ func (_ fastpathT) EncMapIntInt32V(v map[int]int32, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntInt64R(rv reflect.Value) {
@@ -8945,6 +11626,7 @@ func (f *encFnInfo) fastpathEncMapIntInt64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntInt64V(v map[int]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8959,16 +11641,30 @@ func (_ fastpathT) EncMapIntInt64V(v map[int]int64, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntFloat32R(rv reflect.Value) {
@@ -8976,6 +11672,7 @@ func (f *encFnInfo) fastpathEncMapIntFloat32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntFloat32V(v map[int]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -8990,16 +11687,30 @@ func (_ fastpathT) EncMapIntFloat32V(v map[int]float32, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[int(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntFloat64R(rv reflect.Value) {
@@ -9007,6 +11718,7 @@ func (f *encFnInfo) fastpathEncMapIntFloat64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntFloat64V(v map[int]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9021,16 +11733,30 @@ func (_ fastpathT) EncMapIntFloat64V(v map[int]float64, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[int(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapIntBoolR(rv reflect.Value) {
@@ -9038,6 +11764,7 @@ func (f *encFnInfo) fastpathEncMapIntBoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapIntBoolV(v map[int]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9052,16 +11779,30 @@ func (_ fastpathT) EncMapIntBoolV(v map[int]bool, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[int(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8IntfR(rv reflect.Value) {
@@ -9069,6 +11810,7 @@ func (f *encFnInfo) fastpathEncMapInt8IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8IntfV(v map[int8]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9083,16 +11825,30 @@ func (_ fastpathT) EncMapInt8IntfV(v map[int8]interface{}, checkNil bool, e *Enc
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8StringR(rv reflect.Value) {
@@ -9100,6 +11856,7 @@ func (f *encFnInfo) fastpathEncMapInt8StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8StringV(v map[int8]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9114,16 +11871,30 @@ func (_ fastpathT) EncMapInt8StringV(v map[int8]string, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[int8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8UintR(rv reflect.Value) {
@@ -9131,6 +11902,7 @@ func (f *encFnInfo) fastpathEncMapInt8UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8UintV(v map[int8]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9145,16 +11917,30 @@ func (_ fastpathT) EncMapInt8UintV(v map[int8]uint, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Uint8R(rv reflect.Value) {
@@ -9162,6 +11948,7 @@ func (f *encFnInfo) fastpathEncMapInt8Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Uint8V(v map[int8]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9176,16 +11963,30 @@ func (_ fastpathT) EncMapInt8Uint8V(v map[int8]uint8, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Uint16R(rv reflect.Value) {
@@ -9193,6 +11994,7 @@ func (f *encFnInfo) fastpathEncMapInt8Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Uint16V(v map[int8]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9207,16 +12009,30 @@ func (_ fastpathT) EncMapInt8Uint16V(v map[int8]uint16, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Uint32R(rv reflect.Value) {
@@ -9224,6 +12040,7 @@ func (f *encFnInfo) fastpathEncMapInt8Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Uint32V(v map[int8]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9238,16 +12055,30 @@ func (_ fastpathT) EncMapInt8Uint32V(v map[int8]uint32, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Uint64R(rv reflect.Value) {
@@ -9255,6 +12086,7 @@ func (f *encFnInfo) fastpathEncMapInt8Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Uint64V(v map[int8]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9269,16 +12101,30 @@ func (_ fastpathT) EncMapInt8Uint64V(v map[int8]uint64, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8UintptrR(rv reflect.Value) {
@@ -9286,6 +12132,7 @@ func (f *encFnInfo) fastpathEncMapInt8UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8UintptrV(v map[int8]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9300,16 +12147,30 @@ func (_ fastpathT) EncMapInt8UintptrV(v map[int8]uintptr, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8IntR(rv reflect.Value) {
@@ -9317,6 +12178,7 @@ func (f *encFnInfo) fastpathEncMapInt8IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8IntV(v map[int8]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9331,16 +12193,30 @@ func (_ fastpathT) EncMapInt8IntV(v map[int8]int, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Int8R(rv reflect.Value) {
@@ -9348,6 +12224,7 @@ func (f *encFnInfo) fastpathEncMapInt8Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Int8V(v map[int8]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9362,16 +12239,30 @@ func (_ fastpathT) EncMapInt8Int8V(v map[int8]int8, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Int16R(rv reflect.Value) {
@@ -9379,6 +12270,7 @@ func (f *encFnInfo) fastpathEncMapInt8Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Int16V(v map[int8]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9393,16 +12285,30 @@ func (_ fastpathT) EncMapInt8Int16V(v map[int8]int16, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Int32R(rv reflect.Value) {
@@ -9410,6 +12316,7 @@ func (f *encFnInfo) fastpathEncMapInt8Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Int32V(v map[int8]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9424,16 +12331,30 @@ func (_ fastpathT) EncMapInt8Int32V(v map[int8]int32, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Int64R(rv reflect.Value) {
@@ -9441,6 +12362,7 @@ func (f *encFnInfo) fastpathEncMapInt8Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Int64V(v map[int8]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9455,16 +12377,30 @@ func (_ fastpathT) EncMapInt8Int64V(v map[int8]int64, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int8(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Float32R(rv reflect.Value) {
@@ -9472,6 +12408,7 @@ func (f *encFnInfo) fastpathEncMapInt8Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Float32V(v map[int8]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9486,16 +12423,30 @@ func (_ fastpathT) EncMapInt8Float32V(v map[int8]float32, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[int8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Float64R(rv reflect.Value) {
@@ -9503,6 +12454,7 @@ func (f *encFnInfo) fastpathEncMapInt8Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8Float64V(v map[int8]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9517,16 +12469,30 @@ func (_ fastpathT) EncMapInt8Float64V(v map[int8]float64, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[int8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt8BoolR(rv reflect.Value) {
@@ -9534,6 +12500,7 @@ func (f *encFnInfo) fastpathEncMapInt8BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt8BoolV(v map[int8]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9548,16 +12515,30 @@ func (_ fastpathT) EncMapInt8BoolV(v map[int8]bool, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[int8(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16IntfR(rv reflect.Value) {
@@ -9565,6 +12546,7 @@ func (f *encFnInfo) fastpathEncMapInt16IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16IntfV(v map[int16]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9579,16 +12561,30 @@ func (_ fastpathT) EncMapInt16IntfV(v map[int16]interface{}, checkNil bool, e *E
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16StringR(rv reflect.Value) {
@@ -9596,6 +12592,7 @@ func (f *encFnInfo) fastpathEncMapInt16StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16StringV(v map[int16]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9610,16 +12607,30 @@ func (_ fastpathT) EncMapInt16StringV(v map[int16]string, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[int16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16UintR(rv reflect.Value) {
@@ -9627,6 +12638,7 @@ func (f *encFnInfo) fastpathEncMapInt16UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16UintV(v map[int16]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9641,16 +12653,30 @@ func (_ fastpathT) EncMapInt16UintV(v map[int16]uint, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Uint8R(rv reflect.Value) {
@@ -9658,6 +12684,7 @@ func (f *encFnInfo) fastpathEncMapInt16Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Uint8V(v map[int16]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9672,16 +12699,30 @@ func (_ fastpathT) EncMapInt16Uint8V(v map[int16]uint8, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Uint16R(rv reflect.Value) {
@@ -9689,6 +12730,7 @@ func (f *encFnInfo) fastpathEncMapInt16Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Uint16V(v map[int16]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9703,16 +12745,30 @@ func (_ fastpathT) EncMapInt16Uint16V(v map[int16]uint16, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Uint32R(rv reflect.Value) {
@@ -9720,6 +12776,7 @@ func (f *encFnInfo) fastpathEncMapInt16Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Uint32V(v map[int16]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9734,16 +12791,30 @@ func (_ fastpathT) EncMapInt16Uint32V(v map[int16]uint32, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Uint64R(rv reflect.Value) {
@@ -9751,6 +12822,7 @@ func (f *encFnInfo) fastpathEncMapInt16Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Uint64V(v map[int16]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9765,16 +12837,30 @@ func (_ fastpathT) EncMapInt16Uint64V(v map[int16]uint64, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16UintptrR(rv reflect.Value) {
@@ -9782,6 +12868,7 @@ func (f *encFnInfo) fastpathEncMapInt16UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16UintptrV(v map[int16]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9796,16 +12883,30 @@ func (_ fastpathT) EncMapInt16UintptrV(v map[int16]uintptr, checkNil bool, e *En
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16IntR(rv reflect.Value) {
@@ -9813,6 +12914,7 @@ func (f *encFnInfo) fastpathEncMapInt16IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16IntV(v map[int16]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9827,16 +12929,30 @@ func (_ fastpathT) EncMapInt16IntV(v map[int16]int, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Int8R(rv reflect.Value) {
@@ -9844,6 +12960,7 @@ func (f *encFnInfo) fastpathEncMapInt16Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Int8V(v map[int16]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9858,16 +12975,30 @@ func (_ fastpathT) EncMapInt16Int8V(v map[int16]int8, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Int16R(rv reflect.Value) {
@@ -9875,6 +13006,7 @@ func (f *encFnInfo) fastpathEncMapInt16Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Int16V(v map[int16]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9889,16 +13021,30 @@ func (_ fastpathT) EncMapInt16Int16V(v map[int16]int16, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Int32R(rv reflect.Value) {
@@ -9906,6 +13052,7 @@ func (f *encFnInfo) fastpathEncMapInt16Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Int32V(v map[int16]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9920,16 +13067,30 @@ func (_ fastpathT) EncMapInt16Int32V(v map[int16]int32, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Int64R(rv reflect.Value) {
@@ -9937,6 +13098,7 @@ func (f *encFnInfo) fastpathEncMapInt16Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Int64V(v map[int16]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9951,16 +13113,30 @@ func (_ fastpathT) EncMapInt16Int64V(v map[int16]int64, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int16(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Float32R(rv reflect.Value) {
@@ -9968,6 +13144,7 @@ func (f *encFnInfo) fastpathEncMapInt16Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Float32V(v map[int16]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -9982,16 +13159,30 @@ func (_ fastpathT) EncMapInt16Float32V(v map[int16]float32, checkNil bool, e *En
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[int16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Float64R(rv reflect.Value) {
@@ -9999,6 +13190,7 @@ func (f *encFnInfo) fastpathEncMapInt16Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16Float64V(v map[int16]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10013,16 +13205,30 @@ func (_ fastpathT) EncMapInt16Float64V(v map[int16]float64, checkNil bool, e *En
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[int16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt16BoolR(rv reflect.Value) {
@@ -10030,6 +13236,7 @@ func (f *encFnInfo) fastpathEncMapInt16BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt16BoolV(v map[int16]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10044,16 +13251,30 @@ func (_ fastpathT) EncMapInt16BoolV(v map[int16]bool, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[int16(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32IntfR(rv reflect.Value) {
@@ -10061,6 +13282,7 @@ func (f *encFnInfo) fastpathEncMapInt32IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32IntfV(v map[int32]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10075,16 +13297,30 @@ func (_ fastpathT) EncMapInt32IntfV(v map[int32]interface{}, checkNil bool, e *E
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32StringR(rv reflect.Value) {
@@ -10092,6 +13328,7 @@ func (f *encFnInfo) fastpathEncMapInt32StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32StringV(v map[int32]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10106,16 +13343,30 @@ func (_ fastpathT) EncMapInt32StringV(v map[int32]string, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[int32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32UintR(rv reflect.Value) {
@@ -10123,6 +13374,7 @@ func (f *encFnInfo) fastpathEncMapInt32UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32UintV(v map[int32]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10137,16 +13389,30 @@ func (_ fastpathT) EncMapInt32UintV(v map[int32]uint, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Uint8R(rv reflect.Value) {
@@ -10154,6 +13420,7 @@ func (f *encFnInfo) fastpathEncMapInt32Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Uint8V(v map[int32]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10168,16 +13435,30 @@ func (_ fastpathT) EncMapInt32Uint8V(v map[int32]uint8, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Uint16R(rv reflect.Value) {
@@ -10185,6 +13466,7 @@ func (f *encFnInfo) fastpathEncMapInt32Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Uint16V(v map[int32]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10199,16 +13481,30 @@ func (_ fastpathT) EncMapInt32Uint16V(v map[int32]uint16, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Uint32R(rv reflect.Value) {
@@ -10216,6 +13512,7 @@ func (f *encFnInfo) fastpathEncMapInt32Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Uint32V(v map[int32]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10230,16 +13527,30 @@ func (_ fastpathT) EncMapInt32Uint32V(v map[int32]uint32, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Uint64R(rv reflect.Value) {
@@ -10247,6 +13558,7 @@ func (f *encFnInfo) fastpathEncMapInt32Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Uint64V(v map[int32]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10261,16 +13573,30 @@ func (_ fastpathT) EncMapInt32Uint64V(v map[int32]uint64, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32UintptrR(rv reflect.Value) {
@@ -10278,6 +13604,7 @@ func (f *encFnInfo) fastpathEncMapInt32UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32UintptrV(v map[int32]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10292,16 +13619,30 @@ func (_ fastpathT) EncMapInt32UintptrV(v map[int32]uintptr, checkNil bool, e *En
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32IntR(rv reflect.Value) {
@@ -10309,6 +13650,7 @@ func (f *encFnInfo) fastpathEncMapInt32IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32IntV(v map[int32]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10323,16 +13665,30 @@ func (_ fastpathT) EncMapInt32IntV(v map[int32]int, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Int8R(rv reflect.Value) {
@@ -10340,6 +13696,7 @@ func (f *encFnInfo) fastpathEncMapInt32Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Int8V(v map[int32]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10354,16 +13711,30 @@ func (_ fastpathT) EncMapInt32Int8V(v map[int32]int8, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Int16R(rv reflect.Value) {
@@ -10371,6 +13742,7 @@ func (f *encFnInfo) fastpathEncMapInt32Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Int16V(v map[int32]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10385,16 +13757,30 @@ func (_ fastpathT) EncMapInt32Int16V(v map[int32]int16, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Int32R(rv reflect.Value) {
@@ -10402,6 +13788,7 @@ func (f *encFnInfo) fastpathEncMapInt32Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Int32V(v map[int32]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10416,16 +13803,30 @@ func (_ fastpathT) EncMapInt32Int32V(v map[int32]int32, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Int64R(rv reflect.Value) {
@@ -10433,6 +13834,7 @@ func (f *encFnInfo) fastpathEncMapInt32Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Int64V(v map[int32]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10447,16 +13849,30 @@ func (_ fastpathT) EncMapInt32Int64V(v map[int32]int64, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int32(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Float32R(rv reflect.Value) {
@@ -10464,6 +13880,7 @@ func (f *encFnInfo) fastpathEncMapInt32Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Float32V(v map[int32]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10478,16 +13895,30 @@ func (_ fastpathT) EncMapInt32Float32V(v map[int32]float32, checkNil bool, e *En
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[int32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Float64R(rv reflect.Value) {
@@ -10495,6 +13926,7 @@ func (f *encFnInfo) fastpathEncMapInt32Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32Float64V(v map[int32]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10509,16 +13941,30 @@ func (_ fastpathT) EncMapInt32Float64V(v map[int32]float64, checkNil bool, e *En
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[int32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt32BoolR(rv reflect.Value) {
@@ -10526,6 +13972,7 @@ func (f *encFnInfo) fastpathEncMapInt32BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt32BoolV(v map[int32]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10540,16 +13987,30 @@ func (_ fastpathT) EncMapInt32BoolV(v map[int32]bool, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[int32(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64IntfR(rv reflect.Value) {
@@ -10557,6 +14018,7 @@ func (f *encFnInfo) fastpathEncMapInt64IntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64IntfV(v map[int64]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10571,16 +14033,30 @@ func (_ fastpathT) EncMapInt64IntfV(v map[int64]interface{}, checkNil bool, e *E
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64StringR(rv reflect.Value) {
@@ -10588,6 +14064,7 @@ func (f *encFnInfo) fastpathEncMapInt64StringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64StringV(v map[int64]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10602,16 +14079,30 @@ func (_ fastpathT) EncMapInt64StringV(v map[int64]string, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[int64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64UintR(rv reflect.Value) {
@@ -10619,6 +14110,7 @@ func (f *encFnInfo) fastpathEncMapInt64UintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64UintV(v map[int64]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10633,16 +14125,30 @@ func (_ fastpathT) EncMapInt64UintV(v map[int64]uint, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Uint8R(rv reflect.Value) {
@@ -10650,6 +14156,7 @@ func (f *encFnInfo) fastpathEncMapInt64Uint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Uint8V(v map[int64]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10664,16 +14171,30 @@ func (_ fastpathT) EncMapInt64Uint8V(v map[int64]uint8, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Uint16R(rv reflect.Value) {
@@ -10681,6 +14202,7 @@ func (f *encFnInfo) fastpathEncMapInt64Uint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Uint16V(v map[int64]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10695,16 +14217,30 @@ func (_ fastpathT) EncMapInt64Uint16V(v map[int64]uint16, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Uint32R(rv reflect.Value) {
@@ -10712,6 +14248,7 @@ func (f *encFnInfo) fastpathEncMapInt64Uint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Uint32V(v map[int64]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10726,16 +14263,30 @@ func (_ fastpathT) EncMapInt64Uint32V(v map[int64]uint32, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Uint64R(rv reflect.Value) {
@@ -10743,6 +14294,7 @@ func (f *encFnInfo) fastpathEncMapInt64Uint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Uint64V(v map[int64]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10757,16 +14309,30 @@ func (_ fastpathT) EncMapInt64Uint64V(v map[int64]uint64, checkNil bool, e *Enco
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64UintptrR(rv reflect.Value) {
@@ -10774,6 +14340,7 @@ func (f *encFnInfo) fastpathEncMapInt64UintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64UintptrV(v map[int64]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10788,16 +14355,30 @@ func (_ fastpathT) EncMapInt64UintptrV(v map[int64]uintptr, checkNil bool, e *En
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[int64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64IntR(rv reflect.Value) {
@@ -10805,6 +14386,7 @@ func (f *encFnInfo) fastpathEncMapInt64IntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64IntV(v map[int64]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10819,16 +14401,30 @@ func (_ fastpathT) EncMapInt64IntV(v map[int64]int, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Int8R(rv reflect.Value) {
@@ -10836,6 +14432,7 @@ func (f *encFnInfo) fastpathEncMapInt64Int8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Int8V(v map[int64]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10850,16 +14447,30 @@ func (_ fastpathT) EncMapInt64Int8V(v map[int64]int8, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Int16R(rv reflect.Value) {
@@ -10867,6 +14478,7 @@ func (f *encFnInfo) fastpathEncMapInt64Int16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Int16V(v map[int64]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10881,16 +14493,30 @@ func (_ fastpathT) EncMapInt64Int16V(v map[int64]int16, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Int32R(rv reflect.Value) {
@@ -10898,6 +14524,7 @@ func (f *encFnInfo) fastpathEncMapInt64Int32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Int32V(v map[int64]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10912,16 +14539,30 @@ func (_ fastpathT) EncMapInt64Int32V(v map[int64]int32, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Int64R(rv reflect.Value) {
@@ -10929,6 +14570,7 @@ func (f *encFnInfo) fastpathEncMapInt64Int64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Int64V(v map[int64]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10943,16 +14585,30 @@ func (_ fastpathT) EncMapInt64Int64V(v map[int64]int64, checkNil bool, e *Encode
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[int64(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Float32R(rv reflect.Value) {
@@ -10960,6 +14616,7 @@ func (f *encFnInfo) fastpathEncMapInt64Float32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Float32V(v map[int64]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -10974,16 +14631,30 @@ func (_ fastpathT) EncMapInt64Float32V(v map[int64]float32, checkNil bool, e *En
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[int64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Float64R(rv reflect.Value) {
@@ -10991,6 +14662,7 @@ func (f *encFnInfo) fastpathEncMapInt64Float64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64Float64V(v map[int64]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11005,16 +14677,30 @@ func (_ fastpathT) EncMapInt64Float64V(v map[int64]float64, checkNil bool, e *En
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[int64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapInt64BoolR(rv reflect.Value) {
@@ -11022,6 +14708,7 @@ func (f *encFnInfo) fastpathEncMapInt64BoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapInt64BoolV(v map[int64]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11036,16 +14723,30 @@ func (_ fastpathT) EncMapInt64BoolV(v map[int64]bool, checkNil bool, e *Encoder)
 		}
 		sort.Sort(intSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[int64(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolIntfR(rv reflect.Value) {
@@ -11053,6 +14754,7 @@ func (f *encFnInfo) fastpathEncMapBoolIntfR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolIntfV(v map[bool]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11067,16 +14769,30 @@ func (_ fastpathT) EncMapBoolIntfV(v map[bool]interface{}, checkNil bool, e *Enc
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[bool(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolStringR(rv reflect.Value) {
@@ -11084,6 +14800,7 @@ func (f *encFnInfo) fastpathEncMapBoolStringR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolStringV(v map[bool]string, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11098,16 +14815,30 @@ func (_ fastpathT) EncMapBoolStringV(v map[bool]string, checkNil bool, e *Encode
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v[bool(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeString(c_UTF8, v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUintR(rv reflect.Value) {
@@ -11115,6 +14846,7 @@ func (f *encFnInfo) fastpathEncMapBoolUintR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolUintV(v map[bool]uint, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11129,16 +14861,30 @@ func (_ fastpathT) EncMapBoolUintV(v map[bool]uint, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUint8R(rv reflect.Value) {
@@ -11146,6 +14892,7 @@ func (f *encFnInfo) fastpathEncMapBoolUint8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolUint8V(v map[bool]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11160,16 +14907,30 @@ func (_ fastpathT) EncMapBoolUint8V(v map[bool]uint8, checkNil bool, e *Encoder)
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUint16R(rv reflect.Value) {
@@ -11177,6 +14938,7 @@ func (f *encFnInfo) fastpathEncMapBoolUint16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolUint16V(v map[bool]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11191,16 +14953,30 @@ func (_ fastpathT) EncMapBoolUint16V(v map[bool]uint16, checkNil bool, e *Encode
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUint32R(rv reflect.Value) {
@@ -11208,6 +14984,7 @@ func (f *encFnInfo) fastpathEncMapBoolUint32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolUint32V(v map[bool]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11222,16 +14999,30 @@ func (_ fastpathT) EncMapBoolUint32V(v map[bool]uint32, checkNil bool, e *Encode
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUint64R(rv reflect.Value) {
@@ -11239,6 +15030,7 @@ func (f *encFnInfo) fastpathEncMapBoolUint64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolUint64V(v map[bool]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11253,16 +15045,30 @@ func (_ fastpathT) EncMapBoolUint64V(v map[bool]uint64, checkNil bool, e *Encode
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeUint(uint64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUintptrR(rv reflect.Value) {
@@ -11270,6 +15076,7 @@ func (f *encFnInfo) fastpathEncMapBoolUintptrR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolUintptrV(v map[bool]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11284,16 +15091,30 @@ func (_ fastpathT) EncMapBoolUintptrV(v map[bool]uintptr, checkNil bool, e *Enco
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v[bool(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			e.encode(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolIntR(rv reflect.Value) {
@@ -11301,6 +15122,7 @@ func (f *encFnInfo) fastpathEncMapBoolIntR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolIntV(v map[bool]int, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11315,16 +15137,30 @@ func (_ fastpathT) EncMapBoolIntV(v map[bool]int, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolInt8R(rv reflect.Value) {
@@ -11332,6 +15168,7 @@ func (f *encFnInfo) fastpathEncMapBoolInt8R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolInt8V(v map[bool]int8, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11346,16 +15183,30 @@ func (_ fastpathT) EncMapBoolInt8V(v map[bool]int8, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolInt16R(rv reflect.Value) {
@@ -11363,6 +15214,7 @@ func (f *encFnInfo) fastpathEncMapBoolInt16R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolInt16V(v map[bool]int16, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11377,16 +15229,30 @@ func (_ fastpathT) EncMapBoolInt16V(v map[bool]int16, checkNil bool, e *Encoder)
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolInt32R(rv reflect.Value) {
@@ -11394,6 +15260,7 @@ func (f *encFnInfo) fastpathEncMapBoolInt32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolInt32V(v map[bool]int32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11408,16 +15275,30 @@ func (_ fastpathT) EncMapBoolInt32V(v map[bool]int32, checkNil bool, e *Encoder)
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolInt64R(rv reflect.Value) {
@@ -11425,6 +15306,7 @@ func (f *encFnInfo) fastpathEncMapBoolInt64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolInt64V(v map[bool]int64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11439,16 +15321,30 @@ func (_ fastpathT) EncMapBoolInt64V(v map[bool]int64, checkNil bool, e *Encoder)
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v[bool(k2)]))
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeInt(int64(v2))
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolFloat32R(rv reflect.Value) {
@@ -11456,6 +15352,7 @@ func (f *encFnInfo) fastpathEncMapBoolFloat32R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolFloat32V(v map[bool]float32, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11470,16 +15367,30 @@ func (_ fastpathT) EncMapBoolFloat32V(v map[bool]float32, checkNil bool, e *Enco
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v[bool(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat32(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolFloat64R(rv reflect.Value) {
@@ -11487,6 +15398,7 @@ func (f *encFnInfo) fastpathEncMapBoolFloat64R(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolFloat64V(v map[bool]float64, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11501,16 +15413,30 @@ func (_ fastpathT) EncMapBoolFloat64V(v map[bool]float64, checkNil bool, e *Enco
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v[bool(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeFloat64(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 func (f *encFnInfo) fastpathEncMapBoolBoolR(rv reflect.Value) {
@@ -11518,6 +15444,7 @@ func (f *encFnInfo) fastpathEncMapBoolBoolR(rv reflect.Value) {
 }
 func (_ fastpathT) EncMapBoolBoolV(v map[bool]bool, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -11532,22 +15459,39 @@ func (_ fastpathT) EncMapBoolBoolV(v map[bool]bool, checkNil bool, e *Encoder) {
 		}
 		sort.Sort(boolSlice(v2))
 		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v[bool(k2)])
 		}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			ee.EncodeBool(v2)
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
 }
 
 // -- decode
 
 // -- -- fast path type switch
 func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
+	if !fastpathEnabled {
+		return false
+	}
 	switch v := iv.(type) {
 
 	case []interface{}:
@@ -13719,6 +17663,7 @@ func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
 		}
 
 	default:
+		_ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
 		return false
 	}
 	return true
@@ -13746,8 +17691,7 @@ func (f fastpathT) DecSliceIntfX(vp *[]interface{}, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
-	d *Decoder) (_ []interface{}, changed bool) {
+func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool, d *Decoder) (_ []interface{}, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -13758,59 +17702,83 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16); xtrunc {
-			x2read = xlen
-		}
-		v = make([]interface{}, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []interface{}{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]interface{}, xlen)
+					}
+				} else {
+					v = make([]interface{}, xlen)
 				}
-				v = make([]interface{}, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			d.decode(&v[j])
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, nil)
+				slh.ElemContainerState(j)
 				d.decode(&v[j])
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []interface{}{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]interface{}, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, nil)
@@ -13819,15 +17787,21 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				d.decode(&v[j])
 
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -13851,8 +17825,7 @@ func (f fastpathT) DecSliceStringX(vp *[]string, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool,
-	d *Decoder) (_ []string, changed bool) {
+func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool, d *Decoder) (_ []string, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -13863,59 +17836,83 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16); xtrunc {
-			x2read = xlen
-		}
-		v = make([]string, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []string{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]string, xlen)
+					}
+				} else {
+					v = make([]string, xlen)
 				}
-				v = make([]string, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = dd.DecodeString()
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, "")
+				slh.ElemContainerState(j)
 				v[j] = dd.DecodeString()
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []string{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]string, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, "")
@@ -13924,14 +17921,20 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = dd.DecodeString()
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -13955,8 +17958,7 @@ func (f fastpathT) DecSliceFloat32X(vp *[]float32, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool,
-	d *Decoder) (_ []float32, changed bool) {
+func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool, d *Decoder) (_ []float32, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -13967,59 +17969,83 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
-			x2read = xlen
-		}
-		v = make([]float32, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []float32{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]float32, xlen)
+					}
+				} else {
+					v = make([]float32, xlen)
 				}
-				v = make([]float32, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = float32(dd.DecodeFloat(true))
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = float32(dd.DecodeFloat(true))
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []float32{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]float32, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14028,14 +18054,20 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = float32(dd.DecodeFloat(true))
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14059,8 +18091,7 @@ func (f fastpathT) DecSliceFloat64X(vp *[]float64, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool,
-	d *Decoder) (_ []float64, changed bool) {
+func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool, d *Decoder) (_ []float64, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -14071,59 +18102,83 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-			x2read = xlen
-		}
-		v = make([]float64, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []float64{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]float64, xlen)
+					}
+				} else {
+					v = make([]float64, xlen)
 				}
-				v = make([]float64, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = dd.DecodeFloat(false)
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = dd.DecodeFloat(false)
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []float64{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]float64, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14132,14 +18187,20 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = dd.DecodeFloat(false)
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14163,8 +18224,7 @@ func (f fastpathT) DecSliceUintX(vp *[]uint, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool,
-	d *Decoder) (_ []uint, changed bool) {
+func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool, d *Decoder) (_ []uint, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -14175,59 +18235,83 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-			x2read = xlen
-		}
-		v = make([]uint, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []uint{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uint, xlen)
+					}
+				} else {
+					v = make([]uint, xlen)
 				}
-				v = make([]uint, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = uint(dd.DecodeUint(uintBitsize))
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = uint(dd.DecodeUint(uintBitsize))
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uint{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]uint, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14236,14 +18320,20 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = uint(dd.DecodeUint(uintBitsize))
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14267,8 +18357,7 @@ func (f fastpathT) DecSliceUint16X(vp *[]uint16, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool,
-	d *Decoder) (_ []uint16, changed bool) {
+func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool, d *Decoder) (_ []uint16, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -14279,59 +18368,83 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2); xtrunc {
-			x2read = xlen
-		}
-		v = make([]uint16, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []uint16{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uint16, xlen)
+					}
+				} else {
+					v = make([]uint16, xlen)
 				}
-				v = make([]uint16, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = uint16(dd.DecodeUint(16))
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = uint16(dd.DecodeUint(16))
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uint16{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]uint16, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14340,14 +18453,20 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = uint16(dd.DecodeUint(16))
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14371,8 +18490,7 @@ func (f fastpathT) DecSliceUint32X(vp *[]uint32, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool,
-	d *Decoder) (_ []uint32, changed bool) {
+func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool, d *Decoder) (_ []uint32, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -14383,59 +18501,83 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
-			x2read = xlen
-		}
-		v = make([]uint32, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []uint32{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uint32, xlen)
+					}
+				} else {
+					v = make([]uint32, xlen)
 				}
-				v = make([]uint32, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = uint32(dd.DecodeUint(32))
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = uint32(dd.DecodeUint(32))
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uint32{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]uint32, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14444,14 +18586,20 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = uint32(dd.DecodeUint(32))
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14475,8 +18623,7 @@ func (f fastpathT) DecSliceUint64X(vp *[]uint64, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool,
-	d *Decoder) (_ []uint64, changed bool) {
+func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool, d *Decoder) (_ []uint64, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -14487,59 +18634,83 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-			x2read = xlen
-		}
-		v = make([]uint64, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []uint64{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uint64, xlen)
+					}
+				} else {
+					v = make([]uint64, xlen)
 				}
-				v = make([]uint64, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = dd.DecodeUint(64)
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = dd.DecodeUint(64)
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uint64{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]uint64, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14548,14 +18719,20 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = dd.DecodeUint(64)
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14579,8 +18756,7 @@ func (f fastpathT) DecSliceUintptrX(vp *[]uintptr, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool,
-	d *Decoder) (_ []uintptr, changed bool) {
+func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool, d *Decoder) (_ []uintptr, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -14591,59 +18767,83 @@ func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-			x2read = xlen
-		}
-		v = make([]uintptr, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []uintptr{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uintptr, xlen)
+					}
+				} else {
+					v = make([]uintptr, xlen)
 				}
-				v = make([]uintptr, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = uintptr(dd.DecodeUint(uintBitsize))
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = uintptr(dd.DecodeUint(uintBitsize))
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uintptr{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]uintptr, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14652,14 +18852,20 @@ func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = uintptr(dd.DecodeUint(uintBitsize))
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14683,8 +18889,7 @@ func (f fastpathT) DecSliceIntX(vp *[]int, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool,
-	d *Decoder) (_ []int, changed bool) {
+func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool, d *Decoder) (_ []int, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -14695,59 +18900,83 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-			x2read = xlen
-		}
-		v = make([]int, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []int{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int, xlen)
+					}
+				} else {
+					v = make([]int, xlen)
 				}
-				v = make([]int, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = int(dd.DecodeInt(intBitsize))
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = int(dd.DecodeInt(intBitsize))
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]int, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14756,14 +18985,20 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = int(dd.DecodeInt(intBitsize))
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14787,8 +19022,7 @@ func (f fastpathT) DecSliceInt8X(vp *[]int8, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool,
-	d *Decoder) (_ []int8, changed bool) {
+func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool, d *Decoder) (_ []int8, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -14799,59 +19033,83 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1); xtrunc {
-			x2read = xlen
-		}
-		v = make([]int8, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []int8{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int8, xlen)
+					}
+				} else {
+					v = make([]int8, xlen)
 				}
-				v = make([]int8, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = int8(dd.DecodeInt(8))
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = int8(dd.DecodeInt(8))
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int8{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]int8, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14860,14 +19118,20 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = int8(dd.DecodeInt(8))
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14891,8 +19155,7 @@ func (f fastpathT) DecSliceInt16X(vp *[]int16, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool,
-	d *Decoder) (_ []int16, changed bool) {
+func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool, d *Decoder) (_ []int16, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -14903,59 +19166,83 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2); xtrunc {
-			x2read = xlen
-		}
-		v = make([]int16, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []int16{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int16, xlen)
+					}
+				} else {
+					v = make([]int16, xlen)
 				}
-				v = make([]int16, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = int16(dd.DecodeInt(16))
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = int16(dd.DecodeInt(16))
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int16{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]int16, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -14964,14 +19251,20 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = int16(dd.DecodeInt(16))
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -14995,8 +19288,7 @@ func (f fastpathT) DecSliceInt32X(vp *[]int32, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool,
-	d *Decoder) (_ []int32, changed bool) {
+func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool, d *Decoder) (_ []int32, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -15007,59 +19299,83 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
-			x2read = xlen
-		}
-		v = make([]int32, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []int32{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int32, xlen)
+					}
+				} else {
+					v = make([]int32, xlen)
 				}
-				v = make([]int32, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = int32(dd.DecodeInt(32))
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = int32(dd.DecodeInt(32))
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int32{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]int32, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -15068,14 +19384,20 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = int32(dd.DecodeInt(32))
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -15099,8 +19421,7 @@ func (f fastpathT) DecSliceInt64X(vp *[]int64, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool,
-	d *Decoder) (_ []int64, changed bool) {
+func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool, d *Decoder) (_ []int64, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -15111,59 +19432,83 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-			x2read = xlen
-		}
-		v = make([]int64, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []int64{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int64, xlen)
+					}
+				} else {
+					v = make([]int64, xlen)
 				}
-				v = make([]int64, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = dd.DecodeInt(64)
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, 0)
+				slh.ElemContainerState(j)
 				v[j] = dd.DecodeInt(64)
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int64{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]int64, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, 0)
@@ -15172,14 +19517,20 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = dd.DecodeInt(64)
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -15203,8 +19554,7 @@ func (f fastpathT) DecSliceBoolX(vp *[]bool, checkNil bool, d *Decoder) {
 		*vp = v
 	}
 }
-func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool,
-	d *Decoder) (_ []bool, changed bool) {
+func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool, d *Decoder) (_ []bool, changed bool) {
 	dd := d.d
 
 	if checkNil && dd.TryDecodeAsNil() {
@@ -15215,59 +19565,83 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-	x2read := containerLenS
-	var xtrunc bool
-	if canChange && v == nil {
-		var xlen int
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1); xtrunc {
-			x2read = xlen
-		}
-		v = make([]bool, xlen)
-		changed = true
-	}
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
+		if canChange {
+			if v == nil {
+				v = []bool{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
 			changed = true
 		}
-		return v, changed
+		slh.End()
+		return
 	}
 
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
 		if containerLenS > cap(v) {
 			if canChange {
 				var xlen int
-				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1); xtrunc {
-					x2read = xlen
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]bool, xlen)
+					}
+				} else {
+					v = make([]bool, xlen)
 				}
-				v = make([]bool, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
 		}
-
 		j := 0
 		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			v[j] = dd.DecodeBool()
 		}
 		if xtrunc {
 			for ; j < containerLenS; j++ {
 				v = append(v, false)
+				slh.ElemContainerState(j)
 				v[j] = dd.DecodeBool()
 			}
 		} else if !canChange {
 			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []bool{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]bool, 1, 4)
+			changed = true
+		}
 		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		for ; !breakFound; j++ {
 			if j >= len(v) {
 				if canChange {
 					v = append(v, false)
@@ -15276,14 +19650,20 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
+			slh.ElemContainerState(j)
 			if j < len(v) {
 				v[j] = dd.DecodeBool()
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End()
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End()
 	return v, changed
 }
 
@@ -15308,6 +19688,7 @@ func (f fastpathT) DecMapIntfIntfX(vp *map[interface{}]interface{}, checkNil boo
 func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15327,10 +19708,16 @@ func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			if mapGet {
 				mv = v[mk]
@@ -15344,10 +19731,16 @@ func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			if mapGet {
 				mv = v[mk]
@@ -15359,7 +19752,9 @@ func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15385,6 +19780,7 @@ func (f fastpathT) DecMapIntfStringX(vp *map[interface{}]string, checkNil bool, 
 func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15404,10 +19800,16 @@ func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, ca
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeString()
 			if v != nil {
@@ -15416,17 +19818,25 @@ func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15452,6 +19862,7 @@ func (f fastpathT) DecMapIntfUintX(vp *map[interface{}]uint, checkNil bool, d *D
 func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15471,10 +19882,16 @@ func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canCha
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
@@ -15483,17 +19900,25 @@ func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15519,6 +19944,7 @@ func (f fastpathT) DecMapIntfUint8X(vp *map[interface{}]uint8, checkNil bool, d 
 func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15538,10 +19964,16 @@ func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canC
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
@@ -15550,17 +19982,25 @@ func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15586,6 +20026,7 @@ func (f fastpathT) DecMapIntfUint16X(vp *map[interface{}]uint16, checkNil bool, 
 func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15605,10 +20046,16 @@ func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, ca
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
@@ -15617,17 +20064,25 @@ func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15653,6 +20108,7 @@ func (f fastpathT) DecMapIntfUint32X(vp *map[interface{}]uint32, checkNil bool, 
 func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15672,10 +20128,16 @@ func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, ca
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
@@ -15684,17 +20146,25 @@ func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15720,6 +20190,7 @@ func (f fastpathT) DecMapIntfUint64X(vp *map[interface{}]uint64, checkNil bool, 
 func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15739,10 +20210,16 @@ func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, ca
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
@@ -15751,17 +20228,25 @@ func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15787,6 +20272,7 @@ func (f fastpathT) DecMapIntfUintptrX(vp *map[interface{}]uintptr, checkNil bool
 func (_ fastpathT) DecMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15806,10 +20292,16 @@ func (_ fastpathT) DecMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, 
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
@@ -15818,17 +20310,25 @@ func (_ fastpathT) DecMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15854,6 +20354,7 @@ func (f fastpathT) DecMapIntfIntX(vp *map[interface{}]int, checkNil bool, d *Dec
 func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15873,10 +20374,16 @@ func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChang
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
@@ -15885,17 +20392,25 @@ func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChang
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15921,6 +20436,7 @@ func (f fastpathT) DecMapIntfInt8X(vp *map[interface{}]int8, checkNil bool, d *D
 func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -15940,10 +20456,16 @@ func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canCha
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
@@ -15952,17 +20474,25 @@ func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -15988,6 +20518,7 @@ func (f fastpathT) DecMapIntfInt16X(vp *map[interface{}]int16, checkNil bool, d 
 func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16007,10 +20538,16 @@ func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canC
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
@@ -16019,17 +20556,25 @@ func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16055,6 +20600,7 @@ func (f fastpathT) DecMapIntfInt32X(vp *map[interface{}]int32, checkNil bool, d 
 func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16074,10 +20620,16 @@ func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canC
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
@@ -16086,17 +20638,25 @@ func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16122,6 +20682,7 @@ func (f fastpathT) DecMapIntfInt64X(vp *map[interface{}]int64, checkNil bool, d 
 func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16141,10 +20702,16 @@ func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canC
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
@@ -16153,17 +20720,25 @@ func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16189,6 +20764,7 @@ func (f fastpathT) DecMapIntfFloat32X(vp *map[interface{}]float32, checkNil bool
 func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16208,10 +20784,16 @@ func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
@@ -16220,17 +20802,25 @@ func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16256,6 +20846,7 @@ func (f fastpathT) DecMapIntfFloat64X(vp *map[interface{}]float64, checkNil bool
 func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16275,10 +20866,16 @@ func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
@@ -16287,17 +20884,25 @@ func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16323,6 +20928,7 @@ func (f fastpathT) DecMapIntfBoolX(vp *map[interface{}]bool, checkNil bool, d *D
 func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16342,10 +20948,16 @@ func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canCha
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeBool()
 			if v != nil {
@@ -16354,17 +20966,25 @@ func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = nil
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
 			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16390,6 +21010,7 @@ func (f fastpathT) DecMapStringIntfX(vp *map[string]interface{}, checkNil bool, 
 func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16409,7 +21030,13 @@ func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, ca
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -16422,7 +21049,13 @@ func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -16433,7 +21066,9 @@ func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, ca
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16459,6 +21094,7 @@ func (f fastpathT) DecMapStringStringX(vp *map[string]string, checkNil bool, d *
 func (_ fastpathT) DecMapStringStringV(v map[string]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16478,7 +21114,13 @@ func (_ fastpathT) DecMapStringStringV(v map[string]string, checkNil bool, canCh
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -16486,13 +21128,21 @@ func (_ fastpathT) DecMapStringStringV(v map[string]string, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16518,6 +21168,7 @@ func (f fastpathT) DecMapStringUintX(vp *map[string]uint, checkNil bool, d *Deco
 func (_ fastpathT) DecMapStringUintV(v map[string]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16537,7 +21188,13 @@ func (_ fastpathT) DecMapStringUintV(v map[string]uint, checkNil bool, canChange
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -16545,13 +21202,21 @@ func (_ fastpathT) DecMapStringUintV(v map[string]uint, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16577,6 +21242,7 @@ func (f fastpathT) DecMapStringUint8X(vp *map[string]uint8, checkNil bool, d *De
 func (_ fastpathT) DecMapStringUint8V(v map[string]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16596,7 +21262,13 @@ func (_ fastpathT) DecMapStringUint8V(v map[string]uint8, checkNil bool, canChan
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -16604,13 +21276,21 @@ func (_ fastpathT) DecMapStringUint8V(v map[string]uint8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16636,6 +21316,7 @@ func (f fastpathT) DecMapStringUint16X(vp *map[string]uint16, checkNil bool, d *
 func (_ fastpathT) DecMapStringUint16V(v map[string]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16655,7 +21336,13 @@ func (_ fastpathT) DecMapStringUint16V(v map[string]uint16, checkNil bool, canCh
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -16663,13 +21350,21 @@ func (_ fastpathT) DecMapStringUint16V(v map[string]uint16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16695,6 +21390,7 @@ func (f fastpathT) DecMapStringUint32X(vp *map[string]uint32, checkNil bool, d *
 func (_ fastpathT) DecMapStringUint32V(v map[string]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16714,7 +21410,13 @@ func (_ fastpathT) DecMapStringUint32V(v map[string]uint32, checkNil bool, canCh
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -16722,13 +21424,21 @@ func (_ fastpathT) DecMapStringUint32V(v map[string]uint32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16754,6 +21464,7 @@ func (f fastpathT) DecMapStringUint64X(vp *map[string]uint64, checkNil bool, d *
 func (_ fastpathT) DecMapStringUint64V(v map[string]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16773,7 +21484,13 @@ func (_ fastpathT) DecMapStringUint64V(v map[string]uint64, checkNil bool, canCh
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -16781,13 +21498,21 @@ func (_ fastpathT) DecMapStringUint64V(v map[string]uint64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16813,6 +21538,7 @@ func (f fastpathT) DecMapStringUintptrX(vp *map[string]uintptr, checkNil bool, d
 func (_ fastpathT) DecMapStringUintptrV(v map[string]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16832,7 +21558,13 @@ func (_ fastpathT) DecMapStringUintptrV(v map[string]uintptr, checkNil bool, can
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -16840,13 +21572,21 @@ func (_ fastpathT) DecMapStringUintptrV(v map[string]uintptr, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16872,6 +21612,7 @@ func (f fastpathT) DecMapStringIntX(vp *map[string]int, checkNil bool, d *Decode
 func (_ fastpathT) DecMapStringIntV(v map[string]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16891,7 +21632,13 @@ func (_ fastpathT) DecMapStringIntV(v map[string]int, checkNil bool, canChange b
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -16899,13 +21646,21 @@ func (_ fastpathT) DecMapStringIntV(v map[string]int, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16931,6 +21686,7 @@ func (f fastpathT) DecMapStringInt8X(vp *map[string]int8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapStringInt8V(v map[string]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -16950,7 +21706,13 @@ func (_ fastpathT) DecMapStringInt8V(v map[string]int8, checkNil bool, canChange
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -16958,13 +21720,21 @@ func (_ fastpathT) DecMapStringInt8V(v map[string]int8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -16990,6 +21760,7 @@ func (f fastpathT) DecMapStringInt16X(vp *map[string]int16, checkNil bool, d *De
 func (_ fastpathT) DecMapStringInt16V(v map[string]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17009,7 +21780,13 @@ func (_ fastpathT) DecMapStringInt16V(v map[string]int16, checkNil bool, canChan
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -17017,13 +21794,21 @@ func (_ fastpathT) DecMapStringInt16V(v map[string]int16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17049,6 +21834,7 @@ func (f fastpathT) DecMapStringInt32X(vp *map[string]int32, checkNil bool, d *De
 func (_ fastpathT) DecMapStringInt32V(v map[string]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17068,7 +21854,13 @@ func (_ fastpathT) DecMapStringInt32V(v map[string]int32, checkNil bool, canChan
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -17076,13 +21868,21 @@ func (_ fastpathT) DecMapStringInt32V(v map[string]int32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17108,6 +21908,7 @@ func (f fastpathT) DecMapStringInt64X(vp *map[string]int64, checkNil bool, d *De
 func (_ fastpathT) DecMapStringInt64V(v map[string]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17127,7 +21928,13 @@ func (_ fastpathT) DecMapStringInt64V(v map[string]int64, checkNil bool, canChan
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -17135,13 +21942,21 @@ func (_ fastpathT) DecMapStringInt64V(v map[string]int64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17167,6 +21982,7 @@ func (f fastpathT) DecMapStringFloat32X(vp *map[string]float32, checkNil bool, d
 func (_ fastpathT) DecMapStringFloat32V(v map[string]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17186,7 +22002,13 @@ func (_ fastpathT) DecMapStringFloat32V(v map[string]float32, checkNil bool, can
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -17194,13 +22016,21 @@ func (_ fastpathT) DecMapStringFloat32V(v map[string]float32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17226,6 +22056,7 @@ func (f fastpathT) DecMapStringFloat64X(vp *map[string]float64, checkNil bool, d
 func (_ fastpathT) DecMapStringFloat64V(v map[string]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17245,7 +22076,13 @@ func (_ fastpathT) DecMapStringFloat64V(v map[string]float64, checkNil bool, can
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -17253,13 +22090,21 @@ func (_ fastpathT) DecMapStringFloat64V(v map[string]float64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17285,6 +22130,7 @@ func (f fastpathT) DecMapStringBoolX(vp *map[string]bool, checkNil bool, d *Deco
 func (_ fastpathT) DecMapStringBoolV(v map[string]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17304,7 +22150,13 @@ func (_ fastpathT) DecMapStringBoolV(v map[string]bool, checkNil bool, canChange
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -17312,13 +22164,21 @@ func (_ fastpathT) DecMapStringBoolV(v map[string]bool, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17344,6 +22204,7 @@ func (f fastpathT) DecMapFloat32IntfX(vp *map[float32]interface{}, checkNil bool
 func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17363,7 +22224,13 @@ func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -17376,7 +22243,13 @@ func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -17387,7 +22260,9 @@ func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17413,6 +22288,7 @@ func (f fastpathT) DecMapFloat32StringX(vp *map[float32]string, checkNil bool, d
 func (_ fastpathT) DecMapFloat32StringV(v map[float32]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17432,7 +22308,13 @@ func (_ fastpathT) DecMapFloat32StringV(v map[float32]string, checkNil bool, can
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -17440,13 +22322,21 @@ func (_ fastpathT) DecMapFloat32StringV(v map[float32]string, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17472,6 +22362,7 @@ func (f fastpathT) DecMapFloat32UintX(vp *map[float32]uint, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat32UintV(v map[float32]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17491,7 +22382,13 @@ func (_ fastpathT) DecMapFloat32UintV(v map[float32]uint, checkNil bool, canChan
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -17499,13 +22396,21 @@ func (_ fastpathT) DecMapFloat32UintV(v map[float32]uint, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17531,6 +22436,7 @@ func (f fastpathT) DecMapFloat32Uint8X(vp *map[float32]uint8, checkNil bool, d *
 func (_ fastpathT) DecMapFloat32Uint8V(v map[float32]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17550,7 +22456,13 @@ func (_ fastpathT) DecMapFloat32Uint8V(v map[float32]uint8, checkNil bool, canCh
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -17558,13 +22470,21 @@ func (_ fastpathT) DecMapFloat32Uint8V(v map[float32]uint8, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17590,6 +22510,7 @@ func (f fastpathT) DecMapFloat32Uint16X(vp *map[float32]uint16, checkNil bool, d
 func (_ fastpathT) DecMapFloat32Uint16V(v map[float32]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17609,7 +22530,13 @@ func (_ fastpathT) DecMapFloat32Uint16V(v map[float32]uint16, checkNil bool, can
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -17617,13 +22544,21 @@ func (_ fastpathT) DecMapFloat32Uint16V(v map[float32]uint16, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17649,6 +22584,7 @@ func (f fastpathT) DecMapFloat32Uint32X(vp *map[float32]uint32, checkNil bool, d
 func (_ fastpathT) DecMapFloat32Uint32V(v map[float32]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17668,7 +22604,13 @@ func (_ fastpathT) DecMapFloat32Uint32V(v map[float32]uint32, checkNil bool, can
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -17676,13 +22618,21 @@ func (_ fastpathT) DecMapFloat32Uint32V(v map[float32]uint32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17708,6 +22658,7 @@ func (f fastpathT) DecMapFloat32Uint64X(vp *map[float32]uint64, checkNil bool, d
 func (_ fastpathT) DecMapFloat32Uint64V(v map[float32]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17727,7 +22678,13 @@ func (_ fastpathT) DecMapFloat32Uint64V(v map[float32]uint64, checkNil bool, can
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -17735,13 +22692,21 @@ func (_ fastpathT) DecMapFloat32Uint64V(v map[float32]uint64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17767,6 +22732,7 @@ func (f fastpathT) DecMapFloat32UintptrX(vp *map[float32]uintptr, checkNil bool,
 func (_ fastpathT) DecMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17786,7 +22752,13 @@ func (_ fastpathT) DecMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, c
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -17794,13 +22766,21 @@ func (_ fastpathT) DecMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17826,6 +22806,7 @@ func (f fastpathT) DecMapFloat32IntX(vp *map[float32]int, checkNil bool, d *Deco
 func (_ fastpathT) DecMapFloat32IntV(v map[float32]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17845,7 +22826,13 @@ func (_ fastpathT) DecMapFloat32IntV(v map[float32]int, checkNil bool, canChange
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -17853,13 +22840,21 @@ func (_ fastpathT) DecMapFloat32IntV(v map[float32]int, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17885,6 +22880,7 @@ func (f fastpathT) DecMapFloat32Int8X(vp *map[float32]int8, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat32Int8V(v map[float32]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17904,7 +22900,13 @@ func (_ fastpathT) DecMapFloat32Int8V(v map[float32]int8, checkNil bool, canChan
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -17912,13 +22914,21 @@ func (_ fastpathT) DecMapFloat32Int8V(v map[float32]int8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -17944,6 +22954,7 @@ func (f fastpathT) DecMapFloat32Int16X(vp *map[float32]int16, checkNil bool, d *
 func (_ fastpathT) DecMapFloat32Int16V(v map[float32]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -17963,7 +22974,13 @@ func (_ fastpathT) DecMapFloat32Int16V(v map[float32]int16, checkNil bool, canCh
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -17971,13 +22988,21 @@ func (_ fastpathT) DecMapFloat32Int16V(v map[float32]int16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18003,6 +23028,7 @@ func (f fastpathT) DecMapFloat32Int32X(vp *map[float32]int32, checkNil bool, d *
 func (_ fastpathT) DecMapFloat32Int32V(v map[float32]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18022,7 +23048,13 @@ func (_ fastpathT) DecMapFloat32Int32V(v map[float32]int32, checkNil bool, canCh
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -18030,13 +23062,21 @@ func (_ fastpathT) DecMapFloat32Int32V(v map[float32]int32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18062,6 +23102,7 @@ func (f fastpathT) DecMapFloat32Int64X(vp *map[float32]int64, checkNil bool, d *
 func (_ fastpathT) DecMapFloat32Int64V(v map[float32]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18081,7 +23122,13 @@ func (_ fastpathT) DecMapFloat32Int64V(v map[float32]int64, checkNil bool, canCh
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -18089,13 +23136,21 @@ func (_ fastpathT) DecMapFloat32Int64V(v map[float32]int64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18121,6 +23176,7 @@ func (f fastpathT) DecMapFloat32Float32X(vp *map[float32]float32, checkNil bool,
 func (_ fastpathT) DecMapFloat32Float32V(v map[float32]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18140,7 +23196,13 @@ func (_ fastpathT) DecMapFloat32Float32V(v map[float32]float32, checkNil bool, c
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -18148,13 +23210,21 @@ func (_ fastpathT) DecMapFloat32Float32V(v map[float32]float32, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18180,6 +23250,7 @@ func (f fastpathT) DecMapFloat32Float64X(vp *map[float32]float64, checkNil bool,
 func (_ fastpathT) DecMapFloat32Float64V(v map[float32]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18199,7 +23270,13 @@ func (_ fastpathT) DecMapFloat32Float64V(v map[float32]float64, checkNil bool, c
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -18207,13 +23284,21 @@ func (_ fastpathT) DecMapFloat32Float64V(v map[float32]float64, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18239,6 +23324,7 @@ func (f fastpathT) DecMapFloat32BoolX(vp *map[float32]bool, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat32BoolV(v map[float32]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18258,7 +23344,13 @@ func (_ fastpathT) DecMapFloat32BoolV(v map[float32]bool, checkNil bool, canChan
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -18266,13 +23358,21 @@ func (_ fastpathT) DecMapFloat32BoolV(v map[float32]bool, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18298,6 +23398,7 @@ func (f fastpathT) DecMapFloat64IntfX(vp *map[float64]interface{}, checkNil bool
 func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18317,7 +23418,13 @@ func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -18330,7 +23437,13 @@ func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -18341,7 +23454,9 @@ func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18367,6 +23482,7 @@ func (f fastpathT) DecMapFloat64StringX(vp *map[float64]string, checkNil bool, d
 func (_ fastpathT) DecMapFloat64StringV(v map[float64]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18386,7 +23502,13 @@ func (_ fastpathT) DecMapFloat64StringV(v map[float64]string, checkNil bool, can
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -18394,13 +23516,21 @@ func (_ fastpathT) DecMapFloat64StringV(v map[float64]string, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18426,6 +23556,7 @@ func (f fastpathT) DecMapFloat64UintX(vp *map[float64]uint, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat64UintV(v map[float64]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18445,7 +23576,13 @@ func (_ fastpathT) DecMapFloat64UintV(v map[float64]uint, checkNil bool, canChan
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -18453,13 +23590,21 @@ func (_ fastpathT) DecMapFloat64UintV(v map[float64]uint, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18485,6 +23630,7 @@ func (f fastpathT) DecMapFloat64Uint8X(vp *map[float64]uint8, checkNil bool, d *
 func (_ fastpathT) DecMapFloat64Uint8V(v map[float64]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18504,7 +23650,13 @@ func (_ fastpathT) DecMapFloat64Uint8V(v map[float64]uint8, checkNil bool, canCh
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -18512,13 +23664,21 @@ func (_ fastpathT) DecMapFloat64Uint8V(v map[float64]uint8, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18544,6 +23704,7 @@ func (f fastpathT) DecMapFloat64Uint16X(vp *map[float64]uint16, checkNil bool, d
 func (_ fastpathT) DecMapFloat64Uint16V(v map[float64]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18563,7 +23724,13 @@ func (_ fastpathT) DecMapFloat64Uint16V(v map[float64]uint16, checkNil bool, can
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -18571,13 +23738,21 @@ func (_ fastpathT) DecMapFloat64Uint16V(v map[float64]uint16, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18603,6 +23778,7 @@ func (f fastpathT) DecMapFloat64Uint32X(vp *map[float64]uint32, checkNil bool, d
 func (_ fastpathT) DecMapFloat64Uint32V(v map[float64]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18622,7 +23798,13 @@ func (_ fastpathT) DecMapFloat64Uint32V(v map[float64]uint32, checkNil bool, can
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -18630,13 +23812,21 @@ func (_ fastpathT) DecMapFloat64Uint32V(v map[float64]uint32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18662,6 +23852,7 @@ func (f fastpathT) DecMapFloat64Uint64X(vp *map[float64]uint64, checkNil bool, d
 func (_ fastpathT) DecMapFloat64Uint64V(v map[float64]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18681,7 +23872,13 @@ func (_ fastpathT) DecMapFloat64Uint64V(v map[float64]uint64, checkNil bool, can
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -18689,13 +23886,21 @@ func (_ fastpathT) DecMapFloat64Uint64V(v map[float64]uint64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18721,6 +23926,7 @@ func (f fastpathT) DecMapFloat64UintptrX(vp *map[float64]uintptr, checkNil bool,
 func (_ fastpathT) DecMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18740,7 +23946,13 @@ func (_ fastpathT) DecMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, c
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -18748,13 +23960,21 @@ func (_ fastpathT) DecMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18780,6 +24000,7 @@ func (f fastpathT) DecMapFloat64IntX(vp *map[float64]int, checkNil bool, d *Deco
 func (_ fastpathT) DecMapFloat64IntV(v map[float64]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18799,7 +24020,13 @@ func (_ fastpathT) DecMapFloat64IntV(v map[float64]int, checkNil bool, canChange
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -18807,13 +24034,21 @@ func (_ fastpathT) DecMapFloat64IntV(v map[float64]int, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18839,6 +24074,7 @@ func (f fastpathT) DecMapFloat64Int8X(vp *map[float64]int8, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat64Int8V(v map[float64]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18858,7 +24094,13 @@ func (_ fastpathT) DecMapFloat64Int8V(v map[float64]int8, checkNil bool, canChan
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -18866,13 +24108,21 @@ func (_ fastpathT) DecMapFloat64Int8V(v map[float64]int8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18898,6 +24148,7 @@ func (f fastpathT) DecMapFloat64Int16X(vp *map[float64]int16, checkNil bool, d *
 func (_ fastpathT) DecMapFloat64Int16V(v map[float64]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18917,7 +24168,13 @@ func (_ fastpathT) DecMapFloat64Int16V(v map[float64]int16, checkNil bool, canCh
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -18925,13 +24182,21 @@ func (_ fastpathT) DecMapFloat64Int16V(v map[float64]int16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -18957,6 +24222,7 @@ func (f fastpathT) DecMapFloat64Int32X(vp *map[float64]int32, checkNil bool, d *
 func (_ fastpathT) DecMapFloat64Int32V(v map[float64]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -18976,7 +24242,13 @@ func (_ fastpathT) DecMapFloat64Int32V(v map[float64]int32, checkNil bool, canCh
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -18984,13 +24256,21 @@ func (_ fastpathT) DecMapFloat64Int32V(v map[float64]int32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19016,6 +24296,7 @@ func (f fastpathT) DecMapFloat64Int64X(vp *map[float64]int64, checkNil bool, d *
 func (_ fastpathT) DecMapFloat64Int64V(v map[float64]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19035,7 +24316,13 @@ func (_ fastpathT) DecMapFloat64Int64V(v map[float64]int64, checkNil bool, canCh
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -19043,13 +24330,21 @@ func (_ fastpathT) DecMapFloat64Int64V(v map[float64]int64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19075,6 +24370,7 @@ func (f fastpathT) DecMapFloat64Float32X(vp *map[float64]float32, checkNil bool,
 func (_ fastpathT) DecMapFloat64Float32V(v map[float64]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19094,7 +24390,13 @@ func (_ fastpathT) DecMapFloat64Float32V(v map[float64]float32, checkNil bool, c
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -19102,13 +24404,21 @@ func (_ fastpathT) DecMapFloat64Float32V(v map[float64]float32, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19134,6 +24444,7 @@ func (f fastpathT) DecMapFloat64Float64X(vp *map[float64]float64, checkNil bool,
 func (_ fastpathT) DecMapFloat64Float64V(v map[float64]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19153,7 +24464,13 @@ func (_ fastpathT) DecMapFloat64Float64V(v map[float64]float64, checkNil bool, c
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -19161,13 +24478,21 @@ func (_ fastpathT) DecMapFloat64Float64V(v map[float64]float64, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19193,6 +24518,7 @@ func (f fastpathT) DecMapFloat64BoolX(vp *map[float64]bool, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat64BoolV(v map[float64]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19212,7 +24538,13 @@ func (_ fastpathT) DecMapFloat64BoolV(v map[float64]bool, checkNil bool, canChan
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -19220,13 +24552,21 @@ func (_ fastpathT) DecMapFloat64BoolV(v map[float64]bool, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19252,6 +24592,7 @@ func (f fastpathT) DecMapUintIntfX(vp *map[uint]interface{}, checkNil bool, d *D
 func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19271,7 +24612,13 @@ func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canCha
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -19284,7 +24631,13 @@ func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -19295,7 +24648,9 @@ func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canCha
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19321,6 +24676,7 @@ func (f fastpathT) DecMapUintStringX(vp *map[uint]string, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUintStringV(v map[uint]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19340,7 +24696,13 @@ func (_ fastpathT) DecMapUintStringV(v map[uint]string, checkNil bool, canChange
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -19348,13 +24710,21 @@ func (_ fastpathT) DecMapUintStringV(v map[uint]string, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19380,6 +24750,7 @@ func (f fastpathT) DecMapUintUintX(vp *map[uint]uint, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapUintUintV(v map[uint]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19399,7 +24770,13 @@ func (_ fastpathT) DecMapUintUintV(v map[uint]uint, checkNil bool, canChange boo
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -19407,13 +24784,21 @@ func (_ fastpathT) DecMapUintUintV(v map[uint]uint, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19439,6 +24824,7 @@ func (f fastpathT) DecMapUintUint8X(vp *map[uint]uint8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUintUint8V(v map[uint]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19458,7 +24844,13 @@ func (_ fastpathT) DecMapUintUint8V(v map[uint]uint8, checkNil bool, canChange b
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -19466,13 +24858,21 @@ func (_ fastpathT) DecMapUintUint8V(v map[uint]uint8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19498,6 +24898,7 @@ func (f fastpathT) DecMapUintUint16X(vp *map[uint]uint16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUintUint16V(v map[uint]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19517,7 +24918,13 @@ func (_ fastpathT) DecMapUintUint16V(v map[uint]uint16, checkNil bool, canChange
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -19525,13 +24932,21 @@ func (_ fastpathT) DecMapUintUint16V(v map[uint]uint16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19557,6 +24972,7 @@ func (f fastpathT) DecMapUintUint32X(vp *map[uint]uint32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUintUint32V(v map[uint]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19576,7 +24992,13 @@ func (_ fastpathT) DecMapUintUint32V(v map[uint]uint32, checkNil bool, canChange
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -19584,13 +25006,21 @@ func (_ fastpathT) DecMapUintUint32V(v map[uint]uint32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19616,6 +25046,7 @@ func (f fastpathT) DecMapUintUint64X(vp *map[uint]uint64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUintUint64V(v map[uint]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19635,7 +25066,13 @@ func (_ fastpathT) DecMapUintUint64V(v map[uint]uint64, checkNil bool, canChange
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -19643,13 +25080,21 @@ func (_ fastpathT) DecMapUintUint64V(v map[uint]uint64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19675,6 +25120,7 @@ func (f fastpathT) DecMapUintUintptrX(vp *map[uint]uintptr, checkNil bool, d *De
 func (_ fastpathT) DecMapUintUintptrV(v map[uint]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19694,7 +25140,13 @@ func (_ fastpathT) DecMapUintUintptrV(v map[uint]uintptr, checkNil bool, canChan
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -19702,13 +25154,21 @@ func (_ fastpathT) DecMapUintUintptrV(v map[uint]uintptr, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19734,6 +25194,7 @@ func (f fastpathT) DecMapUintIntX(vp *map[uint]int, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapUintIntV(v map[uint]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19753,7 +25214,13 @@ func (_ fastpathT) DecMapUintIntV(v map[uint]int, checkNil bool, canChange bool,
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -19761,13 +25228,21 @@ func (_ fastpathT) DecMapUintIntV(v map[uint]int, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19793,6 +25268,7 @@ func (f fastpathT) DecMapUintInt8X(vp *map[uint]int8, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapUintInt8V(v map[uint]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19812,7 +25288,13 @@ func (_ fastpathT) DecMapUintInt8V(v map[uint]int8, checkNil bool, canChange boo
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -19820,13 +25302,21 @@ func (_ fastpathT) DecMapUintInt8V(v map[uint]int8, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19852,6 +25342,7 @@ func (f fastpathT) DecMapUintInt16X(vp *map[uint]int16, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUintInt16V(v map[uint]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19871,7 +25362,13 @@ func (_ fastpathT) DecMapUintInt16V(v map[uint]int16, checkNil bool, canChange b
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -19879,13 +25376,21 @@ func (_ fastpathT) DecMapUintInt16V(v map[uint]int16, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19911,6 +25416,7 @@ func (f fastpathT) DecMapUintInt32X(vp *map[uint]int32, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUintInt32V(v map[uint]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19930,7 +25436,13 @@ func (_ fastpathT) DecMapUintInt32V(v map[uint]int32, checkNil bool, canChange b
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -19938,13 +25450,21 @@ func (_ fastpathT) DecMapUintInt32V(v map[uint]int32, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -19970,6 +25490,7 @@ func (f fastpathT) DecMapUintInt64X(vp *map[uint]int64, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUintInt64V(v map[uint]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -19989,7 +25510,13 @@ func (_ fastpathT) DecMapUintInt64V(v map[uint]int64, checkNil bool, canChange b
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -19997,13 +25524,21 @@ func (_ fastpathT) DecMapUintInt64V(v map[uint]int64, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20029,6 +25564,7 @@ func (f fastpathT) DecMapUintFloat32X(vp *map[uint]float32, checkNil bool, d *De
 func (_ fastpathT) DecMapUintFloat32V(v map[uint]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20048,7 +25584,13 @@ func (_ fastpathT) DecMapUintFloat32V(v map[uint]float32, checkNil bool, canChan
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -20056,13 +25598,21 @@ func (_ fastpathT) DecMapUintFloat32V(v map[uint]float32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20088,6 +25638,7 @@ func (f fastpathT) DecMapUintFloat64X(vp *map[uint]float64, checkNil bool, d *De
 func (_ fastpathT) DecMapUintFloat64V(v map[uint]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20107,7 +25658,13 @@ func (_ fastpathT) DecMapUintFloat64V(v map[uint]float64, checkNil bool, canChan
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -20115,13 +25672,21 @@ func (_ fastpathT) DecMapUintFloat64V(v map[uint]float64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20147,6 +25712,7 @@ func (f fastpathT) DecMapUintBoolX(vp *map[uint]bool, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapUintBoolV(v map[uint]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20166,7 +25732,13 @@ func (_ fastpathT) DecMapUintBoolV(v map[uint]bool, checkNil bool, canChange boo
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -20174,13 +25746,21 @@ func (_ fastpathT) DecMapUintBoolV(v map[uint]bool, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20206,6 +25786,7 @@ func (f fastpathT) DecMapUint8IntfX(vp *map[uint8]interface{}, checkNil bool, d 
 func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20225,7 +25806,13 @@ func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canC
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -20238,7 +25825,13 @@ func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -20249,7 +25842,9 @@ func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canC
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20275,6 +25870,7 @@ func (f fastpathT) DecMapUint8StringX(vp *map[uint8]string, checkNil bool, d *De
 func (_ fastpathT) DecMapUint8StringV(v map[uint8]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20294,7 +25890,13 @@ func (_ fastpathT) DecMapUint8StringV(v map[uint8]string, checkNil bool, canChan
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -20302,13 +25904,21 @@ func (_ fastpathT) DecMapUint8StringV(v map[uint8]string, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20334,6 +25944,7 @@ func (f fastpathT) DecMapUint8UintX(vp *map[uint8]uint, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint8UintV(v map[uint8]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20353,7 +25964,13 @@ func (_ fastpathT) DecMapUint8UintV(v map[uint8]uint, checkNil bool, canChange b
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -20361,13 +25978,21 @@ func (_ fastpathT) DecMapUint8UintV(v map[uint8]uint, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20393,6 +26018,7 @@ func (f fastpathT) DecMapUint8Uint8X(vp *map[uint8]uint8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint8Uint8V(v map[uint8]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20412,7 +26038,13 @@ func (_ fastpathT) DecMapUint8Uint8V(v map[uint8]uint8, checkNil bool, canChange
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -20420,13 +26052,21 @@ func (_ fastpathT) DecMapUint8Uint8V(v map[uint8]uint8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20452,6 +26092,7 @@ func (f fastpathT) DecMapUint8Uint16X(vp *map[uint8]uint16, checkNil bool, d *De
 func (_ fastpathT) DecMapUint8Uint16V(v map[uint8]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20471,7 +26112,13 @@ func (_ fastpathT) DecMapUint8Uint16V(v map[uint8]uint16, checkNil bool, canChan
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -20479,13 +26126,21 @@ func (_ fastpathT) DecMapUint8Uint16V(v map[uint8]uint16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20511,6 +26166,7 @@ func (f fastpathT) DecMapUint8Uint32X(vp *map[uint8]uint32, checkNil bool, d *De
 func (_ fastpathT) DecMapUint8Uint32V(v map[uint8]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20530,7 +26186,13 @@ func (_ fastpathT) DecMapUint8Uint32V(v map[uint8]uint32, checkNil bool, canChan
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -20538,13 +26200,21 @@ func (_ fastpathT) DecMapUint8Uint32V(v map[uint8]uint32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20570,6 +26240,7 @@ func (f fastpathT) DecMapUint8Uint64X(vp *map[uint8]uint64, checkNil bool, d *De
 func (_ fastpathT) DecMapUint8Uint64V(v map[uint8]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20589,7 +26260,13 @@ func (_ fastpathT) DecMapUint8Uint64V(v map[uint8]uint64, checkNil bool, canChan
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -20597,13 +26274,21 @@ func (_ fastpathT) DecMapUint8Uint64V(v map[uint8]uint64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20629,6 +26314,7 @@ func (f fastpathT) DecMapUint8UintptrX(vp *map[uint8]uintptr, checkNil bool, d *
 func (_ fastpathT) DecMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20648,7 +26334,13 @@ func (_ fastpathT) DecMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, canCh
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -20656,13 +26348,21 @@ func (_ fastpathT) DecMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20688,6 +26388,7 @@ func (f fastpathT) DecMapUint8IntX(vp *map[uint8]int, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapUint8IntV(v map[uint8]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20707,7 +26408,13 @@ func (_ fastpathT) DecMapUint8IntV(v map[uint8]int, checkNil bool, canChange boo
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -20715,13 +26422,21 @@ func (_ fastpathT) DecMapUint8IntV(v map[uint8]int, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20747,6 +26462,7 @@ func (f fastpathT) DecMapUint8Int8X(vp *map[uint8]int8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint8Int8V(v map[uint8]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20766,7 +26482,13 @@ func (_ fastpathT) DecMapUint8Int8V(v map[uint8]int8, checkNil bool, canChange b
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -20774,13 +26496,21 @@ func (_ fastpathT) DecMapUint8Int8V(v map[uint8]int8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20806,6 +26536,7 @@ func (f fastpathT) DecMapUint8Int16X(vp *map[uint8]int16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint8Int16V(v map[uint8]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20825,7 +26556,13 @@ func (_ fastpathT) DecMapUint8Int16V(v map[uint8]int16, checkNil bool, canChange
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -20833,13 +26570,21 @@ func (_ fastpathT) DecMapUint8Int16V(v map[uint8]int16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20865,6 +26610,7 @@ func (f fastpathT) DecMapUint8Int32X(vp *map[uint8]int32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint8Int32V(v map[uint8]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20884,7 +26630,13 @@ func (_ fastpathT) DecMapUint8Int32V(v map[uint8]int32, checkNil bool, canChange
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -20892,13 +26644,21 @@ func (_ fastpathT) DecMapUint8Int32V(v map[uint8]int32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20924,6 +26684,7 @@ func (f fastpathT) DecMapUint8Int64X(vp *map[uint8]int64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint8Int64V(v map[uint8]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -20943,7 +26704,13 @@ func (_ fastpathT) DecMapUint8Int64V(v map[uint8]int64, checkNil bool, canChange
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -20951,13 +26718,21 @@ func (_ fastpathT) DecMapUint8Int64V(v map[uint8]int64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -20983,6 +26758,7 @@ func (f fastpathT) DecMapUint8Float32X(vp *map[uint8]float32, checkNil bool, d *
 func (_ fastpathT) DecMapUint8Float32V(v map[uint8]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21002,7 +26778,13 @@ func (_ fastpathT) DecMapUint8Float32V(v map[uint8]float32, checkNil bool, canCh
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -21010,13 +26792,21 @@ func (_ fastpathT) DecMapUint8Float32V(v map[uint8]float32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21042,6 +26832,7 @@ func (f fastpathT) DecMapUint8Float64X(vp *map[uint8]float64, checkNil bool, d *
 func (_ fastpathT) DecMapUint8Float64V(v map[uint8]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21061,7 +26852,13 @@ func (_ fastpathT) DecMapUint8Float64V(v map[uint8]float64, checkNil bool, canCh
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -21069,13 +26866,21 @@ func (_ fastpathT) DecMapUint8Float64V(v map[uint8]float64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21101,6 +26906,7 @@ func (f fastpathT) DecMapUint8BoolX(vp *map[uint8]bool, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint8BoolV(v map[uint8]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21120,7 +26926,13 @@ func (_ fastpathT) DecMapUint8BoolV(v map[uint8]bool, checkNil bool, canChange b
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -21128,13 +26940,21 @@ func (_ fastpathT) DecMapUint8BoolV(v map[uint8]bool, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21160,6 +26980,7 @@ func (f fastpathT) DecMapUint16IntfX(vp *map[uint16]interface{}, checkNil bool, 
 func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21179,7 +27000,13 @@ func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, ca
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -21192,7 +27019,13 @@ func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -21203,7 +27036,9 @@ func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, ca
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21229,6 +27064,7 @@ func (f fastpathT) DecMapUint16StringX(vp *map[uint16]string, checkNil bool, d *
 func (_ fastpathT) DecMapUint16StringV(v map[uint16]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21248,7 +27084,13 @@ func (_ fastpathT) DecMapUint16StringV(v map[uint16]string, checkNil bool, canCh
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -21256,13 +27098,21 @@ func (_ fastpathT) DecMapUint16StringV(v map[uint16]string, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21288,6 +27138,7 @@ func (f fastpathT) DecMapUint16UintX(vp *map[uint16]uint, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint16UintV(v map[uint16]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21307,7 +27158,13 @@ func (_ fastpathT) DecMapUint16UintV(v map[uint16]uint, checkNil bool, canChange
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -21315,13 +27172,21 @@ func (_ fastpathT) DecMapUint16UintV(v map[uint16]uint, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21347,6 +27212,7 @@ func (f fastpathT) DecMapUint16Uint8X(vp *map[uint16]uint8, checkNil bool, d *De
 func (_ fastpathT) DecMapUint16Uint8V(v map[uint16]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21366,7 +27232,13 @@ func (_ fastpathT) DecMapUint16Uint8V(v map[uint16]uint8, checkNil bool, canChan
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -21374,13 +27246,21 @@ func (_ fastpathT) DecMapUint16Uint8V(v map[uint16]uint8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21406,6 +27286,7 @@ func (f fastpathT) DecMapUint16Uint16X(vp *map[uint16]uint16, checkNil bool, d *
 func (_ fastpathT) DecMapUint16Uint16V(v map[uint16]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21425,7 +27306,13 @@ func (_ fastpathT) DecMapUint16Uint16V(v map[uint16]uint16, checkNil bool, canCh
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -21433,13 +27320,21 @@ func (_ fastpathT) DecMapUint16Uint16V(v map[uint16]uint16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21465,6 +27360,7 @@ func (f fastpathT) DecMapUint16Uint32X(vp *map[uint16]uint32, checkNil bool, d *
 func (_ fastpathT) DecMapUint16Uint32V(v map[uint16]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21484,7 +27380,13 @@ func (_ fastpathT) DecMapUint16Uint32V(v map[uint16]uint32, checkNil bool, canCh
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -21492,13 +27394,21 @@ func (_ fastpathT) DecMapUint16Uint32V(v map[uint16]uint32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21524,6 +27434,7 @@ func (f fastpathT) DecMapUint16Uint64X(vp *map[uint16]uint64, checkNil bool, d *
 func (_ fastpathT) DecMapUint16Uint64V(v map[uint16]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21543,7 +27454,13 @@ func (_ fastpathT) DecMapUint16Uint64V(v map[uint16]uint64, checkNil bool, canCh
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -21551,13 +27468,21 @@ func (_ fastpathT) DecMapUint16Uint64V(v map[uint16]uint64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21583,6 +27508,7 @@ func (f fastpathT) DecMapUint16UintptrX(vp *map[uint16]uintptr, checkNil bool, d
 func (_ fastpathT) DecMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21602,7 +27528,13 @@ func (_ fastpathT) DecMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, can
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -21610,13 +27542,21 @@ func (_ fastpathT) DecMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21642,6 +27582,7 @@ func (f fastpathT) DecMapUint16IntX(vp *map[uint16]int, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint16IntV(v map[uint16]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21661,7 +27602,13 @@ func (_ fastpathT) DecMapUint16IntV(v map[uint16]int, checkNil bool, canChange b
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -21669,13 +27616,21 @@ func (_ fastpathT) DecMapUint16IntV(v map[uint16]int, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21701,6 +27656,7 @@ func (f fastpathT) DecMapUint16Int8X(vp *map[uint16]int8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint16Int8V(v map[uint16]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21720,7 +27676,13 @@ func (_ fastpathT) DecMapUint16Int8V(v map[uint16]int8, checkNil bool, canChange
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -21728,13 +27690,21 @@ func (_ fastpathT) DecMapUint16Int8V(v map[uint16]int8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21760,6 +27730,7 @@ func (f fastpathT) DecMapUint16Int16X(vp *map[uint16]int16, checkNil bool, d *De
 func (_ fastpathT) DecMapUint16Int16V(v map[uint16]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21779,7 +27750,13 @@ func (_ fastpathT) DecMapUint16Int16V(v map[uint16]int16, checkNil bool, canChan
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -21787,13 +27764,21 @@ func (_ fastpathT) DecMapUint16Int16V(v map[uint16]int16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21819,6 +27804,7 @@ func (f fastpathT) DecMapUint16Int32X(vp *map[uint16]int32, checkNil bool, d *De
 func (_ fastpathT) DecMapUint16Int32V(v map[uint16]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21838,7 +27824,13 @@ func (_ fastpathT) DecMapUint16Int32V(v map[uint16]int32, checkNil bool, canChan
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -21846,13 +27838,21 @@ func (_ fastpathT) DecMapUint16Int32V(v map[uint16]int32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21878,6 +27878,7 @@ func (f fastpathT) DecMapUint16Int64X(vp *map[uint16]int64, checkNil bool, d *De
 func (_ fastpathT) DecMapUint16Int64V(v map[uint16]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21897,7 +27898,13 @@ func (_ fastpathT) DecMapUint16Int64V(v map[uint16]int64, checkNil bool, canChan
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -21905,13 +27912,21 @@ func (_ fastpathT) DecMapUint16Int64V(v map[uint16]int64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21937,6 +27952,7 @@ func (f fastpathT) DecMapUint16Float32X(vp *map[uint16]float32, checkNil bool, d
 func (_ fastpathT) DecMapUint16Float32V(v map[uint16]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -21956,7 +27972,13 @@ func (_ fastpathT) DecMapUint16Float32V(v map[uint16]float32, checkNil bool, can
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -21964,13 +27986,21 @@ func (_ fastpathT) DecMapUint16Float32V(v map[uint16]float32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -21996,6 +28026,7 @@ func (f fastpathT) DecMapUint16Float64X(vp *map[uint16]float64, checkNil bool, d
 func (_ fastpathT) DecMapUint16Float64V(v map[uint16]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22015,7 +28046,13 @@ func (_ fastpathT) DecMapUint16Float64V(v map[uint16]float64, checkNil bool, can
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -22023,13 +28060,21 @@ func (_ fastpathT) DecMapUint16Float64V(v map[uint16]float64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22055,6 +28100,7 @@ func (f fastpathT) DecMapUint16BoolX(vp *map[uint16]bool, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint16BoolV(v map[uint16]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22074,7 +28120,13 @@ func (_ fastpathT) DecMapUint16BoolV(v map[uint16]bool, checkNil bool, canChange
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -22082,13 +28134,21 @@ func (_ fastpathT) DecMapUint16BoolV(v map[uint16]bool, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22114,6 +28174,7 @@ func (f fastpathT) DecMapUint32IntfX(vp *map[uint32]interface{}, checkNil bool, 
 func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22133,7 +28194,13 @@ func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, ca
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -22146,7 +28213,13 @@ func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -22157,7 +28230,9 @@ func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, ca
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22183,6 +28258,7 @@ func (f fastpathT) DecMapUint32StringX(vp *map[uint32]string, checkNil bool, d *
 func (_ fastpathT) DecMapUint32StringV(v map[uint32]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22202,7 +28278,13 @@ func (_ fastpathT) DecMapUint32StringV(v map[uint32]string, checkNil bool, canCh
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -22210,13 +28292,21 @@ func (_ fastpathT) DecMapUint32StringV(v map[uint32]string, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22242,6 +28332,7 @@ func (f fastpathT) DecMapUint32UintX(vp *map[uint32]uint, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint32UintV(v map[uint32]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22261,7 +28352,13 @@ func (_ fastpathT) DecMapUint32UintV(v map[uint32]uint, checkNil bool, canChange
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -22269,13 +28366,21 @@ func (_ fastpathT) DecMapUint32UintV(v map[uint32]uint, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22301,6 +28406,7 @@ func (f fastpathT) DecMapUint32Uint8X(vp *map[uint32]uint8, checkNil bool, d *De
 func (_ fastpathT) DecMapUint32Uint8V(v map[uint32]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22320,7 +28426,13 @@ func (_ fastpathT) DecMapUint32Uint8V(v map[uint32]uint8, checkNil bool, canChan
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -22328,13 +28440,21 @@ func (_ fastpathT) DecMapUint32Uint8V(v map[uint32]uint8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22360,6 +28480,7 @@ func (f fastpathT) DecMapUint32Uint16X(vp *map[uint32]uint16, checkNil bool, d *
 func (_ fastpathT) DecMapUint32Uint16V(v map[uint32]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22379,7 +28500,13 @@ func (_ fastpathT) DecMapUint32Uint16V(v map[uint32]uint16, checkNil bool, canCh
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -22387,13 +28514,21 @@ func (_ fastpathT) DecMapUint32Uint16V(v map[uint32]uint16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22419,6 +28554,7 @@ func (f fastpathT) DecMapUint32Uint32X(vp *map[uint32]uint32, checkNil bool, d *
 func (_ fastpathT) DecMapUint32Uint32V(v map[uint32]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22438,7 +28574,13 @@ func (_ fastpathT) DecMapUint32Uint32V(v map[uint32]uint32, checkNil bool, canCh
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -22446,13 +28588,21 @@ func (_ fastpathT) DecMapUint32Uint32V(v map[uint32]uint32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22478,6 +28628,7 @@ func (f fastpathT) DecMapUint32Uint64X(vp *map[uint32]uint64, checkNil bool, d *
 func (_ fastpathT) DecMapUint32Uint64V(v map[uint32]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22497,7 +28648,13 @@ func (_ fastpathT) DecMapUint32Uint64V(v map[uint32]uint64, checkNil bool, canCh
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -22505,13 +28662,21 @@ func (_ fastpathT) DecMapUint32Uint64V(v map[uint32]uint64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22537,6 +28702,7 @@ func (f fastpathT) DecMapUint32UintptrX(vp *map[uint32]uintptr, checkNil bool, d
 func (_ fastpathT) DecMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22556,7 +28722,13 @@ func (_ fastpathT) DecMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, can
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -22564,13 +28736,21 @@ func (_ fastpathT) DecMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22596,6 +28776,7 @@ func (f fastpathT) DecMapUint32IntX(vp *map[uint32]int, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint32IntV(v map[uint32]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22615,7 +28796,13 @@ func (_ fastpathT) DecMapUint32IntV(v map[uint32]int, checkNil bool, canChange b
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -22623,13 +28810,21 @@ func (_ fastpathT) DecMapUint32IntV(v map[uint32]int, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22655,6 +28850,7 @@ func (f fastpathT) DecMapUint32Int8X(vp *map[uint32]int8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint32Int8V(v map[uint32]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22674,7 +28870,13 @@ func (_ fastpathT) DecMapUint32Int8V(v map[uint32]int8, checkNil bool, canChange
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -22682,13 +28884,21 @@ func (_ fastpathT) DecMapUint32Int8V(v map[uint32]int8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22714,6 +28924,7 @@ func (f fastpathT) DecMapUint32Int16X(vp *map[uint32]int16, checkNil bool, d *De
 func (_ fastpathT) DecMapUint32Int16V(v map[uint32]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22733,7 +28944,13 @@ func (_ fastpathT) DecMapUint32Int16V(v map[uint32]int16, checkNil bool, canChan
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -22741,13 +28958,21 @@ func (_ fastpathT) DecMapUint32Int16V(v map[uint32]int16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22773,6 +28998,7 @@ func (f fastpathT) DecMapUint32Int32X(vp *map[uint32]int32, checkNil bool, d *De
 func (_ fastpathT) DecMapUint32Int32V(v map[uint32]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22792,7 +29018,13 @@ func (_ fastpathT) DecMapUint32Int32V(v map[uint32]int32, checkNil bool, canChan
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -22800,13 +29032,21 @@ func (_ fastpathT) DecMapUint32Int32V(v map[uint32]int32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22832,6 +29072,7 @@ func (f fastpathT) DecMapUint32Int64X(vp *map[uint32]int64, checkNil bool, d *De
 func (_ fastpathT) DecMapUint32Int64V(v map[uint32]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22851,7 +29092,13 @@ func (_ fastpathT) DecMapUint32Int64V(v map[uint32]int64, checkNil bool, canChan
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -22859,13 +29106,21 @@ func (_ fastpathT) DecMapUint32Int64V(v map[uint32]int64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22891,6 +29146,7 @@ func (f fastpathT) DecMapUint32Float32X(vp *map[uint32]float32, checkNil bool, d
 func (_ fastpathT) DecMapUint32Float32V(v map[uint32]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22910,7 +29166,13 @@ func (_ fastpathT) DecMapUint32Float32V(v map[uint32]float32, checkNil bool, can
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -22918,13 +29180,21 @@ func (_ fastpathT) DecMapUint32Float32V(v map[uint32]float32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -22950,6 +29220,7 @@ func (f fastpathT) DecMapUint32Float64X(vp *map[uint32]float64, checkNil bool, d
 func (_ fastpathT) DecMapUint32Float64V(v map[uint32]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -22969,7 +29240,13 @@ func (_ fastpathT) DecMapUint32Float64V(v map[uint32]float64, checkNil bool, can
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -22977,13 +29254,21 @@ func (_ fastpathT) DecMapUint32Float64V(v map[uint32]float64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23009,6 +29294,7 @@ func (f fastpathT) DecMapUint32BoolX(vp *map[uint32]bool, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint32BoolV(v map[uint32]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23028,7 +29314,13 @@ func (_ fastpathT) DecMapUint32BoolV(v map[uint32]bool, checkNil bool, canChange
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -23036,13 +29328,21 @@ func (_ fastpathT) DecMapUint32BoolV(v map[uint32]bool, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23068,6 +29368,7 @@ func (f fastpathT) DecMapUint64IntfX(vp *map[uint64]interface{}, checkNil bool, 
 func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23087,7 +29388,13 @@ func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, ca
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -23100,7 +29407,13 @@ func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -23111,7 +29424,9 @@ func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, ca
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23137,6 +29452,7 @@ func (f fastpathT) DecMapUint64StringX(vp *map[uint64]string, checkNil bool, d *
 func (_ fastpathT) DecMapUint64StringV(v map[uint64]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23156,7 +29472,13 @@ func (_ fastpathT) DecMapUint64StringV(v map[uint64]string, checkNil bool, canCh
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -23164,13 +29486,21 @@ func (_ fastpathT) DecMapUint64StringV(v map[uint64]string, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23196,6 +29526,7 @@ func (f fastpathT) DecMapUint64UintX(vp *map[uint64]uint, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint64UintV(v map[uint64]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23215,7 +29546,13 @@ func (_ fastpathT) DecMapUint64UintV(v map[uint64]uint, checkNil bool, canChange
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -23223,13 +29560,21 @@ func (_ fastpathT) DecMapUint64UintV(v map[uint64]uint, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23255,6 +29600,7 @@ func (f fastpathT) DecMapUint64Uint8X(vp *map[uint64]uint8, checkNil bool, d *De
 func (_ fastpathT) DecMapUint64Uint8V(v map[uint64]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23274,7 +29620,13 @@ func (_ fastpathT) DecMapUint64Uint8V(v map[uint64]uint8, checkNil bool, canChan
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -23282,13 +29634,21 @@ func (_ fastpathT) DecMapUint64Uint8V(v map[uint64]uint8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23314,6 +29674,7 @@ func (f fastpathT) DecMapUint64Uint16X(vp *map[uint64]uint16, checkNil bool, d *
 func (_ fastpathT) DecMapUint64Uint16V(v map[uint64]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23333,7 +29694,13 @@ func (_ fastpathT) DecMapUint64Uint16V(v map[uint64]uint16, checkNil bool, canCh
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -23341,13 +29708,21 @@ func (_ fastpathT) DecMapUint64Uint16V(v map[uint64]uint16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23373,6 +29748,7 @@ func (f fastpathT) DecMapUint64Uint32X(vp *map[uint64]uint32, checkNil bool, d *
 func (_ fastpathT) DecMapUint64Uint32V(v map[uint64]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23392,7 +29768,13 @@ func (_ fastpathT) DecMapUint64Uint32V(v map[uint64]uint32, checkNil bool, canCh
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -23400,13 +29782,21 @@ func (_ fastpathT) DecMapUint64Uint32V(v map[uint64]uint32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23432,6 +29822,7 @@ func (f fastpathT) DecMapUint64Uint64X(vp *map[uint64]uint64, checkNil bool, d *
 func (_ fastpathT) DecMapUint64Uint64V(v map[uint64]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23451,7 +29842,13 @@ func (_ fastpathT) DecMapUint64Uint64V(v map[uint64]uint64, checkNil bool, canCh
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -23459,13 +29856,21 @@ func (_ fastpathT) DecMapUint64Uint64V(v map[uint64]uint64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23491,6 +29896,7 @@ func (f fastpathT) DecMapUint64UintptrX(vp *map[uint64]uintptr, checkNil bool, d
 func (_ fastpathT) DecMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23510,7 +29916,13 @@ func (_ fastpathT) DecMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, can
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -23518,13 +29930,21 @@ func (_ fastpathT) DecMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23550,6 +29970,7 @@ func (f fastpathT) DecMapUint64IntX(vp *map[uint64]int, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint64IntV(v map[uint64]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23569,7 +29990,13 @@ func (_ fastpathT) DecMapUint64IntV(v map[uint64]int, checkNil bool, canChange b
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -23577,13 +30004,21 @@ func (_ fastpathT) DecMapUint64IntV(v map[uint64]int, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23609,6 +30044,7 @@ func (f fastpathT) DecMapUint64Int8X(vp *map[uint64]int8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint64Int8V(v map[uint64]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23628,7 +30064,13 @@ func (_ fastpathT) DecMapUint64Int8V(v map[uint64]int8, checkNil bool, canChange
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -23636,13 +30078,21 @@ func (_ fastpathT) DecMapUint64Int8V(v map[uint64]int8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23668,6 +30118,7 @@ func (f fastpathT) DecMapUint64Int16X(vp *map[uint64]int16, checkNil bool, d *De
 func (_ fastpathT) DecMapUint64Int16V(v map[uint64]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23687,7 +30138,13 @@ func (_ fastpathT) DecMapUint64Int16V(v map[uint64]int16, checkNil bool, canChan
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -23695,13 +30152,21 @@ func (_ fastpathT) DecMapUint64Int16V(v map[uint64]int16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23727,6 +30192,7 @@ func (f fastpathT) DecMapUint64Int32X(vp *map[uint64]int32, checkNil bool, d *De
 func (_ fastpathT) DecMapUint64Int32V(v map[uint64]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23746,7 +30212,13 @@ func (_ fastpathT) DecMapUint64Int32V(v map[uint64]int32, checkNil bool, canChan
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -23754,13 +30226,21 @@ func (_ fastpathT) DecMapUint64Int32V(v map[uint64]int32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23786,6 +30266,7 @@ func (f fastpathT) DecMapUint64Int64X(vp *map[uint64]int64, checkNil bool, d *De
 func (_ fastpathT) DecMapUint64Int64V(v map[uint64]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23805,7 +30286,13 @@ func (_ fastpathT) DecMapUint64Int64V(v map[uint64]int64, checkNil bool, canChan
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -23813,13 +30300,21 @@ func (_ fastpathT) DecMapUint64Int64V(v map[uint64]int64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23845,6 +30340,7 @@ func (f fastpathT) DecMapUint64Float32X(vp *map[uint64]float32, checkNil bool, d
 func (_ fastpathT) DecMapUint64Float32V(v map[uint64]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23864,7 +30360,13 @@ func (_ fastpathT) DecMapUint64Float32V(v map[uint64]float32, checkNil bool, can
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -23872,13 +30374,21 @@ func (_ fastpathT) DecMapUint64Float32V(v map[uint64]float32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23904,6 +30414,7 @@ func (f fastpathT) DecMapUint64Float64X(vp *map[uint64]float64, checkNil bool, d
 func (_ fastpathT) DecMapUint64Float64V(v map[uint64]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23923,7 +30434,13 @@ func (_ fastpathT) DecMapUint64Float64V(v map[uint64]float64, checkNil bool, can
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -23931,13 +30448,21 @@ func (_ fastpathT) DecMapUint64Float64V(v map[uint64]float64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -23963,6 +30488,7 @@ func (f fastpathT) DecMapUint64BoolX(vp *map[uint64]bool, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint64BoolV(v map[uint64]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -23982,7 +30508,13 @@ func (_ fastpathT) DecMapUint64BoolV(v map[uint64]bool, checkNil bool, canChange
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -23990,13 +30522,21 @@ func (_ fastpathT) DecMapUint64BoolV(v map[uint64]bool, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24022,6 +30562,7 @@ func (f fastpathT) DecMapUintptrIntfX(vp *map[uintptr]interface{}, checkNil bool
 func (_ fastpathT) DecMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24041,7 +30582,13 @@ func (_ fastpathT) DecMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, 
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -24054,7 +30601,13 @@ func (_ fastpathT) DecMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -24065,7 +30618,9 @@ func (_ fastpathT) DecMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, 
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24091,6 +30646,7 @@ func (f fastpathT) DecMapUintptrStringX(vp *map[uintptr]string, checkNil bool, d
 func (_ fastpathT) DecMapUintptrStringV(v map[uintptr]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24110,7 +30666,13 @@ func (_ fastpathT) DecMapUintptrStringV(v map[uintptr]string, checkNil bool, can
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -24118,13 +30680,21 @@ func (_ fastpathT) DecMapUintptrStringV(v map[uintptr]string, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24150,6 +30720,7 @@ func (f fastpathT) DecMapUintptrUintX(vp *map[uintptr]uint, checkNil bool, d *De
 func (_ fastpathT) DecMapUintptrUintV(v map[uintptr]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24169,7 +30740,13 @@ func (_ fastpathT) DecMapUintptrUintV(v map[uintptr]uint, checkNil bool, canChan
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -24177,13 +30754,21 @@ func (_ fastpathT) DecMapUintptrUintV(v map[uintptr]uint, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24209,6 +30794,7 @@ func (f fastpathT) DecMapUintptrUint8X(vp *map[uintptr]uint8, checkNil bool, d *
 func (_ fastpathT) DecMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24228,7 +30814,13 @@ func (_ fastpathT) DecMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, canCh
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -24236,13 +30828,21 @@ func (_ fastpathT) DecMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24268,6 +30868,7 @@ func (f fastpathT) DecMapUintptrUint16X(vp *map[uintptr]uint16, checkNil bool, d
 func (_ fastpathT) DecMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24287,7 +30888,13 @@ func (_ fastpathT) DecMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, can
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -24295,13 +30902,21 @@ func (_ fastpathT) DecMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24327,6 +30942,7 @@ func (f fastpathT) DecMapUintptrUint32X(vp *map[uintptr]uint32, checkNil bool, d
 func (_ fastpathT) DecMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24346,7 +30962,13 @@ func (_ fastpathT) DecMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, can
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -24354,13 +30976,21 @@ func (_ fastpathT) DecMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24386,6 +31016,7 @@ func (f fastpathT) DecMapUintptrUint64X(vp *map[uintptr]uint64, checkNil bool, d
 func (_ fastpathT) DecMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24405,7 +31036,13 @@ func (_ fastpathT) DecMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, can
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -24413,13 +31050,21 @@ func (_ fastpathT) DecMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24445,6 +31090,7 @@ func (f fastpathT) DecMapUintptrUintptrX(vp *map[uintptr]uintptr, checkNil bool,
 func (_ fastpathT) DecMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24464,7 +31110,13 @@ func (_ fastpathT) DecMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, c
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -24472,13 +31124,21 @@ func (_ fastpathT) DecMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24504,6 +31164,7 @@ func (f fastpathT) DecMapUintptrIntX(vp *map[uintptr]int, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUintptrIntV(v map[uintptr]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24523,7 +31184,13 @@ func (_ fastpathT) DecMapUintptrIntV(v map[uintptr]int, checkNil bool, canChange
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -24531,13 +31198,21 @@ func (_ fastpathT) DecMapUintptrIntV(v map[uintptr]int, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24563,6 +31238,7 @@ func (f fastpathT) DecMapUintptrInt8X(vp *map[uintptr]int8, checkNil bool, d *De
 func (_ fastpathT) DecMapUintptrInt8V(v map[uintptr]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24582,7 +31258,13 @@ func (_ fastpathT) DecMapUintptrInt8V(v map[uintptr]int8, checkNil bool, canChan
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -24590,13 +31272,21 @@ func (_ fastpathT) DecMapUintptrInt8V(v map[uintptr]int8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24622,6 +31312,7 @@ func (f fastpathT) DecMapUintptrInt16X(vp *map[uintptr]int16, checkNil bool, d *
 func (_ fastpathT) DecMapUintptrInt16V(v map[uintptr]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24641,7 +31332,13 @@ func (_ fastpathT) DecMapUintptrInt16V(v map[uintptr]int16, checkNil bool, canCh
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -24649,13 +31346,21 @@ func (_ fastpathT) DecMapUintptrInt16V(v map[uintptr]int16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24681,6 +31386,7 @@ func (f fastpathT) DecMapUintptrInt32X(vp *map[uintptr]int32, checkNil bool, d *
 func (_ fastpathT) DecMapUintptrInt32V(v map[uintptr]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24700,7 +31406,13 @@ func (_ fastpathT) DecMapUintptrInt32V(v map[uintptr]int32, checkNil bool, canCh
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -24708,13 +31420,21 @@ func (_ fastpathT) DecMapUintptrInt32V(v map[uintptr]int32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24740,6 +31460,7 @@ func (f fastpathT) DecMapUintptrInt64X(vp *map[uintptr]int64, checkNil bool, d *
 func (_ fastpathT) DecMapUintptrInt64V(v map[uintptr]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24759,7 +31480,13 @@ func (_ fastpathT) DecMapUintptrInt64V(v map[uintptr]int64, checkNil bool, canCh
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -24767,13 +31494,21 @@ func (_ fastpathT) DecMapUintptrInt64V(v map[uintptr]int64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24799,6 +31534,7 @@ func (f fastpathT) DecMapUintptrFloat32X(vp *map[uintptr]float32, checkNil bool,
 func (_ fastpathT) DecMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24818,7 +31554,13 @@ func (_ fastpathT) DecMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, c
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -24826,13 +31568,21 @@ func (_ fastpathT) DecMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24858,6 +31608,7 @@ func (f fastpathT) DecMapUintptrFloat64X(vp *map[uintptr]float64, checkNil bool,
 func (_ fastpathT) DecMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24877,7 +31628,13 @@ func (_ fastpathT) DecMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, c
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -24885,13 +31642,21 @@ func (_ fastpathT) DecMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24917,6 +31682,7 @@ func (f fastpathT) DecMapUintptrBoolX(vp *map[uintptr]bool, checkNil bool, d *De
 func (_ fastpathT) DecMapUintptrBoolV(v map[uintptr]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uintptr]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24936,7 +31702,13 @@ func (_ fastpathT) DecMapUintptrBoolV(v map[uintptr]bool, checkNil bool, canChan
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -24944,13 +31716,21 @@ func (_ fastpathT) DecMapUintptrBoolV(v map[uintptr]bool, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -24976,6 +31756,7 @@ func (f fastpathT) DecMapIntIntfX(vp *map[int]interface{}, checkNil bool, d *Dec
 func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -24995,7 +31776,13 @@ func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChang
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -25008,7 +31795,13 @@ func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChang
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -25019,7 +31812,9 @@ func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChang
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25045,6 +31840,7 @@ func (f fastpathT) DecMapIntStringX(vp *map[int]string, checkNil bool, d *Decode
 func (_ fastpathT) DecMapIntStringV(v map[int]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25064,7 +31860,13 @@ func (_ fastpathT) DecMapIntStringV(v map[int]string, checkNil bool, canChange b
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -25072,13 +31874,21 @@ func (_ fastpathT) DecMapIntStringV(v map[int]string, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25104,6 +31914,7 @@ func (f fastpathT) DecMapIntUintX(vp *map[int]uint, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapIntUintV(v map[int]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25123,7 +31934,13 @@ func (_ fastpathT) DecMapIntUintV(v map[int]uint, checkNil bool, canChange bool,
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -25131,13 +31948,21 @@ func (_ fastpathT) DecMapIntUintV(v map[int]uint, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25163,6 +31988,7 @@ func (f fastpathT) DecMapIntUint8X(vp *map[int]uint8, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapIntUint8V(v map[int]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25182,7 +32008,13 @@ func (_ fastpathT) DecMapIntUint8V(v map[int]uint8, checkNil bool, canChange boo
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -25190,13 +32022,21 @@ func (_ fastpathT) DecMapIntUint8V(v map[int]uint8, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25222,6 +32062,7 @@ func (f fastpathT) DecMapIntUint16X(vp *map[int]uint16, checkNil bool, d *Decode
 func (_ fastpathT) DecMapIntUint16V(v map[int]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25241,7 +32082,13 @@ func (_ fastpathT) DecMapIntUint16V(v map[int]uint16, checkNil bool, canChange b
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -25249,13 +32096,21 @@ func (_ fastpathT) DecMapIntUint16V(v map[int]uint16, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25281,6 +32136,7 @@ func (f fastpathT) DecMapIntUint32X(vp *map[int]uint32, checkNil bool, d *Decode
 func (_ fastpathT) DecMapIntUint32V(v map[int]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25300,7 +32156,13 @@ func (_ fastpathT) DecMapIntUint32V(v map[int]uint32, checkNil bool, canChange b
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -25308,13 +32170,21 @@ func (_ fastpathT) DecMapIntUint32V(v map[int]uint32, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25340,6 +32210,7 @@ func (f fastpathT) DecMapIntUint64X(vp *map[int]uint64, checkNil bool, d *Decode
 func (_ fastpathT) DecMapIntUint64V(v map[int]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25359,7 +32230,13 @@ func (_ fastpathT) DecMapIntUint64V(v map[int]uint64, checkNil bool, canChange b
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -25367,13 +32244,21 @@ func (_ fastpathT) DecMapIntUint64V(v map[int]uint64, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25399,6 +32284,7 @@ func (f fastpathT) DecMapIntUintptrX(vp *map[int]uintptr, checkNil bool, d *Deco
 func (_ fastpathT) DecMapIntUintptrV(v map[int]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25418,7 +32304,13 @@ func (_ fastpathT) DecMapIntUintptrV(v map[int]uintptr, checkNil bool, canChange
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -25426,13 +32318,21 @@ func (_ fastpathT) DecMapIntUintptrV(v map[int]uintptr, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25458,6 +32358,7 @@ func (f fastpathT) DecMapIntIntX(vp *map[int]int, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapIntIntV(v map[int]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25477,7 +32378,13 @@ func (_ fastpathT) DecMapIntIntV(v map[int]int, checkNil bool, canChange bool,
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -25485,13 +32392,21 @@ func (_ fastpathT) DecMapIntIntV(v map[int]int, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25517,6 +32432,7 @@ func (f fastpathT) DecMapIntInt8X(vp *map[int]int8, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapIntInt8V(v map[int]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25536,7 +32452,13 @@ func (_ fastpathT) DecMapIntInt8V(v map[int]int8, checkNil bool, canChange bool,
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -25544,13 +32466,21 @@ func (_ fastpathT) DecMapIntInt8V(v map[int]int8, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25576,6 +32506,7 @@ func (f fastpathT) DecMapIntInt16X(vp *map[int]int16, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapIntInt16V(v map[int]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25595,7 +32526,13 @@ func (_ fastpathT) DecMapIntInt16V(v map[int]int16, checkNil bool, canChange boo
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -25603,13 +32540,21 @@ func (_ fastpathT) DecMapIntInt16V(v map[int]int16, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25635,6 +32580,7 @@ func (f fastpathT) DecMapIntInt32X(vp *map[int]int32, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapIntInt32V(v map[int]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25654,7 +32600,13 @@ func (_ fastpathT) DecMapIntInt32V(v map[int]int32, checkNil bool, canChange boo
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -25662,13 +32614,21 @@ func (_ fastpathT) DecMapIntInt32V(v map[int]int32, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25694,6 +32654,7 @@ func (f fastpathT) DecMapIntInt64X(vp *map[int]int64, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapIntInt64V(v map[int]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25713,7 +32674,13 @@ func (_ fastpathT) DecMapIntInt64V(v map[int]int64, checkNil bool, canChange boo
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -25721,13 +32688,21 @@ func (_ fastpathT) DecMapIntInt64V(v map[int]int64, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25753,6 +32728,7 @@ func (f fastpathT) DecMapIntFloat32X(vp *map[int]float32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapIntFloat32V(v map[int]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25772,7 +32748,13 @@ func (_ fastpathT) DecMapIntFloat32V(v map[int]float32, checkNil bool, canChange
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -25780,13 +32762,21 @@ func (_ fastpathT) DecMapIntFloat32V(v map[int]float32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25812,6 +32802,7 @@ func (f fastpathT) DecMapIntFloat64X(vp *map[int]float64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapIntFloat64V(v map[int]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25831,7 +32822,13 @@ func (_ fastpathT) DecMapIntFloat64V(v map[int]float64, checkNil bool, canChange
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -25839,13 +32836,21 @@ func (_ fastpathT) DecMapIntFloat64V(v map[int]float64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25871,6 +32876,7 @@ func (f fastpathT) DecMapIntBoolX(vp *map[int]bool, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapIntBoolV(v map[int]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25890,7 +32896,13 @@ func (_ fastpathT) DecMapIntBoolV(v map[int]bool, checkNil bool, canChange bool,
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -25898,13 +32910,21 @@ func (_ fastpathT) DecMapIntBoolV(v map[int]bool, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25930,6 +32950,7 @@ func (f fastpathT) DecMapInt8IntfX(vp *map[int8]interface{}, checkNil bool, d *D
 func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -25949,7 +32970,13 @@ func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canCha
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -25962,7 +32989,13 @@ func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -25973,7 +33006,9 @@ func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canCha
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -25999,6 +33034,7 @@ func (f fastpathT) DecMapInt8StringX(vp *map[int8]string, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt8StringV(v map[int8]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26018,7 +33054,13 @@ func (_ fastpathT) DecMapInt8StringV(v map[int8]string, checkNil bool, canChange
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -26026,13 +33068,21 @@ func (_ fastpathT) DecMapInt8StringV(v map[int8]string, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26058,6 +33108,7 @@ func (f fastpathT) DecMapInt8UintX(vp *map[int8]uint, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt8UintV(v map[int8]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26077,7 +33128,13 @@ func (_ fastpathT) DecMapInt8UintV(v map[int8]uint, checkNil bool, canChange boo
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -26085,13 +33142,21 @@ func (_ fastpathT) DecMapInt8UintV(v map[int8]uint, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26117,6 +33182,7 @@ func (f fastpathT) DecMapInt8Uint8X(vp *map[int8]uint8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt8Uint8V(v map[int8]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26136,7 +33202,13 @@ func (_ fastpathT) DecMapInt8Uint8V(v map[int8]uint8, checkNil bool, canChange b
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -26144,13 +33216,21 @@ func (_ fastpathT) DecMapInt8Uint8V(v map[int8]uint8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26176,6 +33256,7 @@ func (f fastpathT) DecMapInt8Uint16X(vp *map[int8]uint16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt8Uint16V(v map[int8]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26195,7 +33276,13 @@ func (_ fastpathT) DecMapInt8Uint16V(v map[int8]uint16, checkNil bool, canChange
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -26203,13 +33290,21 @@ func (_ fastpathT) DecMapInt8Uint16V(v map[int8]uint16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26235,6 +33330,7 @@ func (f fastpathT) DecMapInt8Uint32X(vp *map[int8]uint32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt8Uint32V(v map[int8]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26254,7 +33350,13 @@ func (_ fastpathT) DecMapInt8Uint32V(v map[int8]uint32, checkNil bool, canChange
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -26262,13 +33364,21 @@ func (_ fastpathT) DecMapInt8Uint32V(v map[int8]uint32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26294,6 +33404,7 @@ func (f fastpathT) DecMapInt8Uint64X(vp *map[int8]uint64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt8Uint64V(v map[int8]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26313,7 +33424,13 @@ func (_ fastpathT) DecMapInt8Uint64V(v map[int8]uint64, checkNil bool, canChange
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -26321,13 +33438,21 @@ func (_ fastpathT) DecMapInt8Uint64V(v map[int8]uint64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26353,6 +33478,7 @@ func (f fastpathT) DecMapInt8UintptrX(vp *map[int8]uintptr, checkNil bool, d *De
 func (_ fastpathT) DecMapInt8UintptrV(v map[int8]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26372,7 +33498,13 @@ func (_ fastpathT) DecMapInt8UintptrV(v map[int8]uintptr, checkNil bool, canChan
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -26380,13 +33512,21 @@ func (_ fastpathT) DecMapInt8UintptrV(v map[int8]uintptr, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26412,6 +33552,7 @@ func (f fastpathT) DecMapInt8IntX(vp *map[int8]int, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapInt8IntV(v map[int8]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26431,7 +33572,13 @@ func (_ fastpathT) DecMapInt8IntV(v map[int8]int, checkNil bool, canChange bool,
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -26439,13 +33586,21 @@ func (_ fastpathT) DecMapInt8IntV(v map[int8]int, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26471,6 +33626,7 @@ func (f fastpathT) DecMapInt8Int8X(vp *map[int8]int8, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt8Int8V(v map[int8]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26490,7 +33646,13 @@ func (_ fastpathT) DecMapInt8Int8V(v map[int8]int8, checkNil bool, canChange boo
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -26498,13 +33660,21 @@ func (_ fastpathT) DecMapInt8Int8V(v map[int8]int8, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26530,6 +33700,7 @@ func (f fastpathT) DecMapInt8Int16X(vp *map[int8]int16, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt8Int16V(v map[int8]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26549,7 +33720,13 @@ func (_ fastpathT) DecMapInt8Int16V(v map[int8]int16, checkNil bool, canChange b
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -26557,13 +33734,21 @@ func (_ fastpathT) DecMapInt8Int16V(v map[int8]int16, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26589,6 +33774,7 @@ func (f fastpathT) DecMapInt8Int32X(vp *map[int8]int32, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt8Int32V(v map[int8]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26608,7 +33794,13 @@ func (_ fastpathT) DecMapInt8Int32V(v map[int8]int32, checkNil bool, canChange b
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -26616,13 +33808,21 @@ func (_ fastpathT) DecMapInt8Int32V(v map[int8]int32, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26648,6 +33848,7 @@ func (f fastpathT) DecMapInt8Int64X(vp *map[int8]int64, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt8Int64V(v map[int8]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26667,7 +33868,13 @@ func (_ fastpathT) DecMapInt8Int64V(v map[int8]int64, checkNil bool, canChange b
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -26675,13 +33882,21 @@ func (_ fastpathT) DecMapInt8Int64V(v map[int8]int64, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26707,6 +33922,7 @@ func (f fastpathT) DecMapInt8Float32X(vp *map[int8]float32, checkNil bool, d *De
 func (_ fastpathT) DecMapInt8Float32V(v map[int8]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26726,7 +33942,13 @@ func (_ fastpathT) DecMapInt8Float32V(v map[int8]float32, checkNil bool, canChan
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -26734,13 +33956,21 @@ func (_ fastpathT) DecMapInt8Float32V(v map[int8]float32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26766,6 +33996,7 @@ func (f fastpathT) DecMapInt8Float64X(vp *map[int8]float64, checkNil bool, d *De
 func (_ fastpathT) DecMapInt8Float64V(v map[int8]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26785,7 +34016,13 @@ func (_ fastpathT) DecMapInt8Float64V(v map[int8]float64, checkNil bool, canChan
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -26793,13 +34030,21 @@ func (_ fastpathT) DecMapInt8Float64V(v map[int8]float64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26825,6 +34070,7 @@ func (f fastpathT) DecMapInt8BoolX(vp *map[int8]bool, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt8BoolV(v map[int8]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26844,7 +34090,13 @@ func (_ fastpathT) DecMapInt8BoolV(v map[int8]bool, checkNil bool, canChange boo
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -26852,13 +34104,21 @@ func (_ fastpathT) DecMapInt8BoolV(v map[int8]bool, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26884,6 +34144,7 @@ func (f fastpathT) DecMapInt16IntfX(vp *map[int16]interface{}, checkNil bool, d 
 func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26903,7 +34164,13 @@ func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canC
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -26916,7 +34183,13 @@ func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -26927,7 +34200,9 @@ func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canC
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -26953,6 +34228,7 @@ func (f fastpathT) DecMapInt16StringX(vp *map[int16]string, checkNil bool, d *De
 func (_ fastpathT) DecMapInt16StringV(v map[int16]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -26972,7 +34248,13 @@ func (_ fastpathT) DecMapInt16StringV(v map[int16]string, checkNil bool, canChan
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -26980,13 +34262,21 @@ func (_ fastpathT) DecMapInt16StringV(v map[int16]string, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27012,6 +34302,7 @@ func (f fastpathT) DecMapInt16UintX(vp *map[int16]uint, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt16UintV(v map[int16]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27031,7 +34322,13 @@ func (_ fastpathT) DecMapInt16UintV(v map[int16]uint, checkNil bool, canChange b
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -27039,13 +34336,21 @@ func (_ fastpathT) DecMapInt16UintV(v map[int16]uint, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27071,6 +34376,7 @@ func (f fastpathT) DecMapInt16Uint8X(vp *map[int16]uint8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt16Uint8V(v map[int16]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27090,7 +34396,13 @@ func (_ fastpathT) DecMapInt16Uint8V(v map[int16]uint8, checkNil bool, canChange
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -27098,13 +34410,21 @@ func (_ fastpathT) DecMapInt16Uint8V(v map[int16]uint8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27130,6 +34450,7 @@ func (f fastpathT) DecMapInt16Uint16X(vp *map[int16]uint16, checkNil bool, d *De
 func (_ fastpathT) DecMapInt16Uint16V(v map[int16]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27149,7 +34470,13 @@ func (_ fastpathT) DecMapInt16Uint16V(v map[int16]uint16, checkNil bool, canChan
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -27157,13 +34484,21 @@ func (_ fastpathT) DecMapInt16Uint16V(v map[int16]uint16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27189,6 +34524,7 @@ func (f fastpathT) DecMapInt16Uint32X(vp *map[int16]uint32, checkNil bool, d *De
 func (_ fastpathT) DecMapInt16Uint32V(v map[int16]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27208,7 +34544,13 @@ func (_ fastpathT) DecMapInt16Uint32V(v map[int16]uint32, checkNil bool, canChan
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -27216,13 +34558,21 @@ func (_ fastpathT) DecMapInt16Uint32V(v map[int16]uint32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27248,6 +34598,7 @@ func (f fastpathT) DecMapInt16Uint64X(vp *map[int16]uint64, checkNil bool, d *De
 func (_ fastpathT) DecMapInt16Uint64V(v map[int16]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27267,7 +34618,13 @@ func (_ fastpathT) DecMapInt16Uint64V(v map[int16]uint64, checkNil bool, canChan
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -27275,13 +34632,21 @@ func (_ fastpathT) DecMapInt16Uint64V(v map[int16]uint64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27307,6 +34672,7 @@ func (f fastpathT) DecMapInt16UintptrX(vp *map[int16]uintptr, checkNil bool, d *
 func (_ fastpathT) DecMapInt16UintptrV(v map[int16]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27326,7 +34692,13 @@ func (_ fastpathT) DecMapInt16UintptrV(v map[int16]uintptr, checkNil bool, canCh
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -27334,13 +34706,21 @@ func (_ fastpathT) DecMapInt16UintptrV(v map[int16]uintptr, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27366,6 +34746,7 @@ func (f fastpathT) DecMapInt16IntX(vp *map[int16]int, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt16IntV(v map[int16]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27385,7 +34766,13 @@ func (_ fastpathT) DecMapInt16IntV(v map[int16]int, checkNil bool, canChange boo
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -27393,13 +34780,21 @@ func (_ fastpathT) DecMapInt16IntV(v map[int16]int, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27425,6 +34820,7 @@ func (f fastpathT) DecMapInt16Int8X(vp *map[int16]int8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt16Int8V(v map[int16]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27444,7 +34840,13 @@ func (_ fastpathT) DecMapInt16Int8V(v map[int16]int8, checkNil bool, canChange b
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -27452,13 +34854,21 @@ func (_ fastpathT) DecMapInt16Int8V(v map[int16]int8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27484,6 +34894,7 @@ func (f fastpathT) DecMapInt16Int16X(vp *map[int16]int16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt16Int16V(v map[int16]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27503,7 +34914,13 @@ func (_ fastpathT) DecMapInt16Int16V(v map[int16]int16, checkNil bool, canChange
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -27511,13 +34928,21 @@ func (_ fastpathT) DecMapInt16Int16V(v map[int16]int16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27543,6 +34968,7 @@ func (f fastpathT) DecMapInt16Int32X(vp *map[int16]int32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt16Int32V(v map[int16]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27562,7 +34988,13 @@ func (_ fastpathT) DecMapInt16Int32V(v map[int16]int32, checkNil bool, canChange
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -27570,13 +35002,21 @@ func (_ fastpathT) DecMapInt16Int32V(v map[int16]int32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27602,6 +35042,7 @@ func (f fastpathT) DecMapInt16Int64X(vp *map[int16]int64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt16Int64V(v map[int16]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27621,7 +35062,13 @@ func (_ fastpathT) DecMapInt16Int64V(v map[int16]int64, checkNil bool, canChange
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -27629,13 +35076,21 @@ func (_ fastpathT) DecMapInt16Int64V(v map[int16]int64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27661,6 +35116,7 @@ func (f fastpathT) DecMapInt16Float32X(vp *map[int16]float32, checkNil bool, d *
 func (_ fastpathT) DecMapInt16Float32V(v map[int16]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27680,7 +35136,13 @@ func (_ fastpathT) DecMapInt16Float32V(v map[int16]float32, checkNil bool, canCh
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -27688,13 +35150,21 @@ func (_ fastpathT) DecMapInt16Float32V(v map[int16]float32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27720,6 +35190,7 @@ func (f fastpathT) DecMapInt16Float64X(vp *map[int16]float64, checkNil bool, d *
 func (_ fastpathT) DecMapInt16Float64V(v map[int16]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27739,7 +35210,13 @@ func (_ fastpathT) DecMapInt16Float64V(v map[int16]float64, checkNil bool, canCh
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -27747,13 +35224,21 @@ func (_ fastpathT) DecMapInt16Float64V(v map[int16]float64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27779,6 +35264,7 @@ func (f fastpathT) DecMapInt16BoolX(vp *map[int16]bool, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt16BoolV(v map[int16]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27798,7 +35284,13 @@ func (_ fastpathT) DecMapInt16BoolV(v map[int16]bool, checkNil bool, canChange b
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -27806,13 +35298,21 @@ func (_ fastpathT) DecMapInt16BoolV(v map[int16]bool, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27838,6 +35338,7 @@ func (f fastpathT) DecMapInt32IntfX(vp *map[int32]interface{}, checkNil bool, d 
 func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27857,7 +35358,13 @@ func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canC
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -27870,7 +35377,13 @@ func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -27881,7 +35394,9 @@ func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canC
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27907,6 +35422,7 @@ func (f fastpathT) DecMapInt32StringX(vp *map[int32]string, checkNil bool, d *De
 func (_ fastpathT) DecMapInt32StringV(v map[int32]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27926,7 +35442,13 @@ func (_ fastpathT) DecMapInt32StringV(v map[int32]string, checkNil bool, canChan
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -27934,13 +35456,21 @@ func (_ fastpathT) DecMapInt32StringV(v map[int32]string, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -27966,6 +35496,7 @@ func (f fastpathT) DecMapInt32UintX(vp *map[int32]uint, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt32UintV(v map[int32]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -27985,7 +35516,13 @@ func (_ fastpathT) DecMapInt32UintV(v map[int32]uint, checkNil bool, canChange b
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -27993,13 +35530,21 @@ func (_ fastpathT) DecMapInt32UintV(v map[int32]uint, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28025,6 +35570,7 @@ func (f fastpathT) DecMapInt32Uint8X(vp *map[int32]uint8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt32Uint8V(v map[int32]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28044,7 +35590,13 @@ func (_ fastpathT) DecMapInt32Uint8V(v map[int32]uint8, checkNil bool, canChange
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -28052,13 +35604,21 @@ func (_ fastpathT) DecMapInt32Uint8V(v map[int32]uint8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28084,6 +35644,7 @@ func (f fastpathT) DecMapInt32Uint16X(vp *map[int32]uint16, checkNil bool, d *De
 func (_ fastpathT) DecMapInt32Uint16V(v map[int32]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28103,7 +35664,13 @@ func (_ fastpathT) DecMapInt32Uint16V(v map[int32]uint16, checkNil bool, canChan
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -28111,13 +35678,21 @@ func (_ fastpathT) DecMapInt32Uint16V(v map[int32]uint16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28143,6 +35718,7 @@ func (f fastpathT) DecMapInt32Uint32X(vp *map[int32]uint32, checkNil bool, d *De
 func (_ fastpathT) DecMapInt32Uint32V(v map[int32]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28162,7 +35738,13 @@ func (_ fastpathT) DecMapInt32Uint32V(v map[int32]uint32, checkNil bool, canChan
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -28170,13 +35752,21 @@ func (_ fastpathT) DecMapInt32Uint32V(v map[int32]uint32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28202,6 +35792,7 @@ func (f fastpathT) DecMapInt32Uint64X(vp *map[int32]uint64, checkNil bool, d *De
 func (_ fastpathT) DecMapInt32Uint64V(v map[int32]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28221,7 +35812,13 @@ func (_ fastpathT) DecMapInt32Uint64V(v map[int32]uint64, checkNil bool, canChan
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -28229,13 +35826,21 @@ func (_ fastpathT) DecMapInt32Uint64V(v map[int32]uint64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28261,6 +35866,7 @@ func (f fastpathT) DecMapInt32UintptrX(vp *map[int32]uintptr, checkNil bool, d *
 func (_ fastpathT) DecMapInt32UintptrV(v map[int32]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28280,7 +35886,13 @@ func (_ fastpathT) DecMapInt32UintptrV(v map[int32]uintptr, checkNil bool, canCh
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -28288,13 +35900,21 @@ func (_ fastpathT) DecMapInt32UintptrV(v map[int32]uintptr, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28320,6 +35940,7 @@ func (f fastpathT) DecMapInt32IntX(vp *map[int32]int, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt32IntV(v map[int32]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28339,7 +35960,13 @@ func (_ fastpathT) DecMapInt32IntV(v map[int32]int, checkNil bool, canChange boo
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -28347,13 +35974,21 @@ func (_ fastpathT) DecMapInt32IntV(v map[int32]int, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28379,6 +36014,7 @@ func (f fastpathT) DecMapInt32Int8X(vp *map[int32]int8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt32Int8V(v map[int32]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28398,7 +36034,13 @@ func (_ fastpathT) DecMapInt32Int8V(v map[int32]int8, checkNil bool, canChange b
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -28406,13 +36048,21 @@ func (_ fastpathT) DecMapInt32Int8V(v map[int32]int8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28438,6 +36088,7 @@ func (f fastpathT) DecMapInt32Int16X(vp *map[int32]int16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt32Int16V(v map[int32]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28457,7 +36108,13 @@ func (_ fastpathT) DecMapInt32Int16V(v map[int32]int16, checkNil bool, canChange
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -28465,13 +36122,21 @@ func (_ fastpathT) DecMapInt32Int16V(v map[int32]int16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28497,6 +36162,7 @@ func (f fastpathT) DecMapInt32Int32X(vp *map[int32]int32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt32Int32V(v map[int32]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28516,7 +36182,13 @@ func (_ fastpathT) DecMapInt32Int32V(v map[int32]int32, checkNil bool, canChange
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -28524,13 +36196,21 @@ func (_ fastpathT) DecMapInt32Int32V(v map[int32]int32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28556,6 +36236,7 @@ func (f fastpathT) DecMapInt32Int64X(vp *map[int32]int64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt32Int64V(v map[int32]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28575,7 +36256,13 @@ func (_ fastpathT) DecMapInt32Int64V(v map[int32]int64, checkNil bool, canChange
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -28583,13 +36270,21 @@ func (_ fastpathT) DecMapInt32Int64V(v map[int32]int64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28615,6 +36310,7 @@ func (f fastpathT) DecMapInt32Float32X(vp *map[int32]float32, checkNil bool, d *
 func (_ fastpathT) DecMapInt32Float32V(v map[int32]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28634,7 +36330,13 @@ func (_ fastpathT) DecMapInt32Float32V(v map[int32]float32, checkNil bool, canCh
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -28642,13 +36344,21 @@ func (_ fastpathT) DecMapInt32Float32V(v map[int32]float32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28674,6 +36384,7 @@ func (f fastpathT) DecMapInt32Float64X(vp *map[int32]float64, checkNil bool, d *
 func (_ fastpathT) DecMapInt32Float64V(v map[int32]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28693,7 +36404,13 @@ func (_ fastpathT) DecMapInt32Float64V(v map[int32]float64, checkNil bool, canCh
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -28701,13 +36418,21 @@ func (_ fastpathT) DecMapInt32Float64V(v map[int32]float64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28733,6 +36458,7 @@ func (f fastpathT) DecMapInt32BoolX(vp *map[int32]bool, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt32BoolV(v map[int32]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28752,7 +36478,13 @@ func (_ fastpathT) DecMapInt32BoolV(v map[int32]bool, checkNil bool, canChange b
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -28760,13 +36492,21 @@ func (_ fastpathT) DecMapInt32BoolV(v map[int32]bool, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28792,6 +36532,7 @@ func (f fastpathT) DecMapInt64IntfX(vp *map[int64]interface{}, checkNil bool, d 
 func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28811,7 +36552,13 @@ func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canC
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -28824,7 +36571,13 @@ func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -28835,7 +36588,9 @@ func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canC
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28861,6 +36616,7 @@ func (f fastpathT) DecMapInt64StringX(vp *map[int64]string, checkNil bool, d *De
 func (_ fastpathT) DecMapInt64StringV(v map[int64]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28880,7 +36636,13 @@ func (_ fastpathT) DecMapInt64StringV(v map[int64]string, checkNil bool, canChan
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -28888,13 +36650,21 @@ func (_ fastpathT) DecMapInt64StringV(v map[int64]string, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28920,6 +36690,7 @@ func (f fastpathT) DecMapInt64UintX(vp *map[int64]uint, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt64UintV(v map[int64]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28939,7 +36710,13 @@ func (_ fastpathT) DecMapInt64UintV(v map[int64]uint, checkNil bool, canChange b
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -28947,13 +36724,21 @@ func (_ fastpathT) DecMapInt64UintV(v map[int64]uint, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -28979,6 +36764,7 @@ func (f fastpathT) DecMapInt64Uint8X(vp *map[int64]uint8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt64Uint8V(v map[int64]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -28998,7 +36784,13 @@ func (_ fastpathT) DecMapInt64Uint8V(v map[int64]uint8, checkNil bool, canChange
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -29006,13 +36798,21 @@ func (_ fastpathT) DecMapInt64Uint8V(v map[int64]uint8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29038,6 +36838,7 @@ func (f fastpathT) DecMapInt64Uint16X(vp *map[int64]uint16, checkNil bool, d *De
 func (_ fastpathT) DecMapInt64Uint16V(v map[int64]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29057,7 +36858,13 @@ func (_ fastpathT) DecMapInt64Uint16V(v map[int64]uint16, checkNil bool, canChan
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -29065,13 +36872,21 @@ func (_ fastpathT) DecMapInt64Uint16V(v map[int64]uint16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29097,6 +36912,7 @@ func (f fastpathT) DecMapInt64Uint32X(vp *map[int64]uint32, checkNil bool, d *De
 func (_ fastpathT) DecMapInt64Uint32V(v map[int64]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29116,7 +36932,13 @@ func (_ fastpathT) DecMapInt64Uint32V(v map[int64]uint32, checkNil bool, canChan
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -29124,13 +36946,21 @@ func (_ fastpathT) DecMapInt64Uint32V(v map[int64]uint32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29156,6 +36986,7 @@ func (f fastpathT) DecMapInt64Uint64X(vp *map[int64]uint64, checkNil bool, d *De
 func (_ fastpathT) DecMapInt64Uint64V(v map[int64]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29175,7 +37006,13 @@ func (_ fastpathT) DecMapInt64Uint64V(v map[int64]uint64, checkNil bool, canChan
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -29183,13 +37020,21 @@ func (_ fastpathT) DecMapInt64Uint64V(v map[int64]uint64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29215,6 +37060,7 @@ func (f fastpathT) DecMapInt64UintptrX(vp *map[int64]uintptr, checkNil bool, d *
 func (_ fastpathT) DecMapInt64UintptrV(v map[int64]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29234,7 +37080,13 @@ func (_ fastpathT) DecMapInt64UintptrV(v map[int64]uintptr, checkNil bool, canCh
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -29242,13 +37094,21 @@ func (_ fastpathT) DecMapInt64UintptrV(v map[int64]uintptr, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29274,6 +37134,7 @@ func (f fastpathT) DecMapInt64IntX(vp *map[int64]int, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt64IntV(v map[int64]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29293,7 +37154,13 @@ func (_ fastpathT) DecMapInt64IntV(v map[int64]int, checkNil bool, canChange boo
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -29301,13 +37168,21 @@ func (_ fastpathT) DecMapInt64IntV(v map[int64]int, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29333,6 +37208,7 @@ func (f fastpathT) DecMapInt64Int8X(vp *map[int64]int8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt64Int8V(v map[int64]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29352,7 +37228,13 @@ func (_ fastpathT) DecMapInt64Int8V(v map[int64]int8, checkNil bool, canChange b
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -29360,13 +37242,21 @@ func (_ fastpathT) DecMapInt64Int8V(v map[int64]int8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29392,6 +37282,7 @@ func (f fastpathT) DecMapInt64Int16X(vp *map[int64]int16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt64Int16V(v map[int64]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29411,7 +37302,13 @@ func (_ fastpathT) DecMapInt64Int16V(v map[int64]int16, checkNil bool, canChange
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -29419,13 +37316,21 @@ func (_ fastpathT) DecMapInt64Int16V(v map[int64]int16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29451,6 +37356,7 @@ func (f fastpathT) DecMapInt64Int32X(vp *map[int64]int32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt64Int32V(v map[int64]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29470,7 +37376,13 @@ func (_ fastpathT) DecMapInt64Int32V(v map[int64]int32, checkNil bool, canChange
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -29478,13 +37390,21 @@ func (_ fastpathT) DecMapInt64Int32V(v map[int64]int32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29510,6 +37430,7 @@ func (f fastpathT) DecMapInt64Int64X(vp *map[int64]int64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt64Int64V(v map[int64]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29529,7 +37450,13 @@ func (_ fastpathT) DecMapInt64Int64V(v map[int64]int64, checkNil bool, canChange
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -29537,13 +37464,21 @@ func (_ fastpathT) DecMapInt64Int64V(v map[int64]int64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29569,6 +37504,7 @@ func (f fastpathT) DecMapInt64Float32X(vp *map[int64]float32, checkNil bool, d *
 func (_ fastpathT) DecMapInt64Float32V(v map[int64]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29588,7 +37524,13 @@ func (_ fastpathT) DecMapInt64Float32V(v map[int64]float32, checkNil bool, canCh
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -29596,13 +37538,21 @@ func (_ fastpathT) DecMapInt64Float32V(v map[int64]float32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29628,6 +37578,7 @@ func (f fastpathT) DecMapInt64Float64X(vp *map[int64]float64, checkNil bool, d *
 func (_ fastpathT) DecMapInt64Float64V(v map[int64]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29647,7 +37598,13 @@ func (_ fastpathT) DecMapInt64Float64V(v map[int64]float64, checkNil bool, canCh
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -29655,13 +37612,21 @@ func (_ fastpathT) DecMapInt64Float64V(v map[int64]float64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29687,6 +37652,7 @@ func (f fastpathT) DecMapInt64BoolX(vp *map[int64]bool, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt64BoolV(v map[int64]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29706,7 +37672,13 @@ func (_ fastpathT) DecMapInt64BoolV(v map[int64]bool, checkNil bool, canChange b
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -29714,13 +37686,21 @@ func (_ fastpathT) DecMapInt64BoolV(v map[int64]bool, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29746,6 +37726,7 @@ func (f fastpathT) DecMapBoolIntfX(vp *map[bool]interface{}, checkNil bool, d *D
 func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]interface{}, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29765,7 +37746,13 @@ func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canCha
 	var mv interface{}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -29778,7 +37765,13 @@ func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			if mapGet {
 				mv = v[mk]
 			} else {
@@ -29789,7 +37782,9 @@ func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canCha
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29815,6 +37810,7 @@ func (f fastpathT) DecMapBoolStringX(vp *map[bool]string, checkNil bool, d *Deco
 func (_ fastpathT) DecMapBoolStringV(v map[bool]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]string, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29834,7 +37830,13 @@ func (_ fastpathT) DecMapBoolStringV(v map[bool]string, checkNil bool, canChange
 	var mv string
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
@@ -29842,13 +37844,21 @@ func (_ fastpathT) DecMapBoolStringV(v map[bool]string, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29874,6 +37884,7 @@ func (f fastpathT) DecMapBoolUintX(vp *map[bool]uint, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapBoolUintV(v map[bool]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29893,7 +37904,13 @@ func (_ fastpathT) DecMapBoolUintV(v map[bool]uint, checkNil bool, canChange boo
 	var mv uint
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -29901,13 +37918,21 @@ func (_ fastpathT) DecMapBoolUintV(v map[bool]uint, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29933,6 +37958,7 @@ func (f fastpathT) DecMapBoolUint8X(vp *map[bool]uint8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapBoolUint8V(v map[bool]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -29952,7 +37978,13 @@ func (_ fastpathT) DecMapBoolUint8V(v map[bool]uint8, checkNil bool, canChange b
 	var mv uint8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
@@ -29960,13 +37992,21 @@ func (_ fastpathT) DecMapBoolUint8V(v map[bool]uint8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -29992,6 +38032,7 @@ func (f fastpathT) DecMapBoolUint16X(vp *map[bool]uint16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapBoolUint16V(v map[bool]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30011,7 +38052,13 @@ func (_ fastpathT) DecMapBoolUint16V(v map[bool]uint16, checkNil bool, canChange
 	var mv uint16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
@@ -30019,13 +38066,21 @@ func (_ fastpathT) DecMapBoolUint16V(v map[bool]uint16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30051,6 +38106,7 @@ func (f fastpathT) DecMapBoolUint32X(vp *map[bool]uint32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapBoolUint32V(v map[bool]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30070,7 +38126,13 @@ func (_ fastpathT) DecMapBoolUint32V(v map[bool]uint32, checkNil bool, canChange
 	var mv uint32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
@@ -30078,13 +38140,21 @@ func (_ fastpathT) DecMapBoolUint32V(v map[bool]uint32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30110,6 +38180,7 @@ func (f fastpathT) DecMapBoolUint64X(vp *map[bool]uint64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapBoolUint64V(v map[bool]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30129,7 +38200,13 @@ func (_ fastpathT) DecMapBoolUint64V(v map[bool]uint64, checkNil bool, canChange
 	var mv uint64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
@@ -30137,13 +38214,21 @@ func (_ fastpathT) DecMapBoolUint64V(v map[bool]uint64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30169,6 +38254,7 @@ func (f fastpathT) DecMapBoolUintptrX(vp *map[bool]uintptr, checkNil bool, d *De
 func (_ fastpathT) DecMapBoolUintptrV(v map[bool]uintptr, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uintptr, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30188,7 +38274,13 @@ func (_ fastpathT) DecMapBoolUintptrV(v map[bool]uintptr, checkNil bool, canChan
 	var mv uintptr
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -30196,13 +38288,21 @@ func (_ fastpathT) DecMapBoolUintptrV(v map[bool]uintptr, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = uintptr(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30228,6 +38328,7 @@ func (f fastpathT) DecMapBoolIntX(vp *map[bool]int, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapBoolIntV(v map[bool]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30247,7 +38348,13 @@ func (_ fastpathT) DecMapBoolIntV(v map[bool]int, checkNil bool, canChange bool,
 	var mv int
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
@@ -30255,13 +38362,21 @@ func (_ fastpathT) DecMapBoolIntV(v map[bool]int, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30287,6 +38402,7 @@ func (f fastpathT) DecMapBoolInt8X(vp *map[bool]int8, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapBoolInt8V(v map[bool]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int8, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30306,7 +38422,13 @@ func (_ fastpathT) DecMapBoolInt8V(v map[bool]int8, checkNil bool, canChange boo
 	var mv int8
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
@@ -30314,13 +38436,21 @@ func (_ fastpathT) DecMapBoolInt8V(v map[bool]int8, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30346,6 +38476,7 @@ func (f fastpathT) DecMapBoolInt16X(vp *map[bool]int16, checkNil bool, d *Decode
 func (_ fastpathT) DecMapBoolInt16V(v map[bool]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int16, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30365,7 +38496,13 @@ func (_ fastpathT) DecMapBoolInt16V(v map[bool]int16, checkNil bool, canChange b
 	var mv int16
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
@@ -30373,13 +38510,21 @@ func (_ fastpathT) DecMapBoolInt16V(v map[bool]int16, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30405,6 +38550,7 @@ func (f fastpathT) DecMapBoolInt32X(vp *map[bool]int32, checkNil bool, d *Decode
 func (_ fastpathT) DecMapBoolInt32V(v map[bool]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30424,7 +38570,13 @@ func (_ fastpathT) DecMapBoolInt32V(v map[bool]int32, checkNil bool, canChange b
 	var mv int32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
@@ -30432,13 +38584,21 @@ func (_ fastpathT) DecMapBoolInt32V(v map[bool]int32, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30464,6 +38624,7 @@ func (f fastpathT) DecMapBoolInt64X(vp *map[bool]int64, checkNil bool, d *Decode
 func (_ fastpathT) DecMapBoolInt64V(v map[bool]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30483,7 +38644,13 @@ func (_ fastpathT) DecMapBoolInt64V(v map[bool]int64, checkNil bool, canChange b
 	var mv int64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
@@ -30491,13 +38658,21 @@ func (_ fastpathT) DecMapBoolInt64V(v map[bool]int64, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30523,6 +38698,7 @@ func (f fastpathT) DecMapBoolFloat32X(vp *map[bool]float32, checkNil bool, d *De
 func (_ fastpathT) DecMapBoolFloat32V(v map[bool]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]float32, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30542,7 +38718,13 @@ func (_ fastpathT) DecMapBoolFloat32V(v map[bool]float32, checkNil bool, canChan
 	var mv float32
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
@@ -30550,13 +38732,21 @@ func (_ fastpathT) DecMapBoolFloat32V(v map[bool]float32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30582,6 +38772,7 @@ func (f fastpathT) DecMapBoolFloat64X(vp *map[bool]float64, checkNil bool, d *De
 func (_ fastpathT) DecMapBoolFloat64V(v map[bool]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]float64, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30601,7 +38792,13 @@ func (_ fastpathT) DecMapBoolFloat64V(v map[bool]float64, checkNil bool, canChan
 	var mv float64
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
@@ -30609,13 +38806,21 @@ func (_ fastpathT) DecMapBoolFloat64V(v map[bool]float64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }
@@ -30641,6 +38846,7 @@ func (f fastpathT) DecMapBoolBoolX(vp *map[bool]bool, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapBoolBoolV(v map[bool]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]bool, changed bool) {
 	dd := d.d
+	cr := d.cr
 
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -30660,7 +38866,13 @@ func (_ fastpathT) DecMapBoolBoolV(v map[bool]bool, checkNil bool, canChange boo
 	var mv bool
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
@@ -30668,13 +38880,21 @@ func (_ fastpathT) DecMapBoolBoolV(v map[bool]bool, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
 			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
 	}
 	return v, changed
 }

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.go.tmpl
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.go.tmpl
@@ -1,4 +1,4 @@
-// //+build ignore
+// +build !notfastpath
 
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
@@ -106,6 +106,9 @@ func init() {
 
 // -- -- fast path type switch
 func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool {
+	if !fastpathEnabled {
+		return false
+	}
 	switch v := iv.(type) {
 {{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
 	case []{{ .Elem }}:{{else}}
@@ -116,13 +119,16 @@ func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool {
 		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(*v, fastpathCheckNilTrue, e)
 {{end}}{{end}}
 	default:
-		_ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
+        _ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
 		return false
 	}
 	return true
 }
 
 func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool {
+	if !fastpathEnabled {
+		return false
+	}
 	switch v := iv.(type) {
 {{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
 	case []{{ .Elem }}:
@@ -131,12 +137,16 @@ func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool {
 		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(*v, fastpathCheckNilTrue, e)
 {{end}}{{end}}{{end}}
 	default:
+        _ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
 		return false
 	}
 	return true
 }
 
 func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool {
+	if !fastpathEnabled {
+		return false
+	}
 	switch v := iv.(type) {
 {{range .Values}}{{if not .Primitive}}{{if .MapKey }}
 	case map[{{ .MapKey }}]{{ .Elem }}:
@@ -145,6 +155,7 @@ func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool {
 		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(*v, fastpathCheckNilTrue, e)
 {{end}}{{end}}{{end}}
 	default:
+        _ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
 		return false
 	}
 	return true
@@ -157,16 +168,18 @@ func (f *encFnInfo) {{ .MethodNamePfx "fastpathEnc" false }}R(rv reflect.Value) 
 	fastpathTV.{{ .MethodNamePfx "Enc" false }}V(rv.Interface().([]{{ .Elem }}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v []{{ .Elem }}, checkNil bool, e *Encoder) {
-	ee := e.e 
+	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
 	}
 	ee.EncodeArrayStart(len(v))
 	for _, v2 := range v {
+		if cr != nil { cr.sendContainerState(containerArrayElem) }
 		{{ encmd .Elem "v2"}}
 	}
-	ee.EncodeEnd()
+	if cr != nil { cr.sendContainerState(containerArrayEnd) }{{/* ee.EncodeEnd() */}}
 }
 
 {{end}}{{end}}{{end}}
@@ -178,6 +191,7 @@ func (f *encFnInfo) {{ .MethodNamePfx "fastpathEnc" false }}R(rv reflect.Value) 
 }
 func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v map[{{ .MapKey }}]{{ .Elem }}, checkNil bool, e *Encoder) {
 	ee := e.e
+	cr := e.cr
 	if checkNil && v == nil {
 		ee.EncodeNil()
 		return
@@ -201,7 +215,9 @@ func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v map[{{ .MapKey }}]{{ .Ele
 		}
 		sort.Sort(bytesISlice(v2))
 		for j := range v2 {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
 			e.asis(v2[j].v)
+			if cr != nil { cr.sendContainerState(containerMapValue) }
 			e.encode(v[v2[j].i])
 		} {{else}}{{ $x := sorttype .MapKey true}}v2 := make([]{{ $x }}, len(v))
 		var i int 
@@ -211,24 +227,28 @@ func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v map[{{ .MapKey }}]{{ .Ele
 		}
 		sort.Sort({{ sorttype .MapKey false}}(v2))
 		for _, k2 := range v2 {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
 			{{if eq .MapKey "string"}}if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}{{else}}{{ $y := printf "%s(k2)" .MapKey }}{{ encmd .MapKey $y }}{{end}}
+			if cr != nil { cr.sendContainerState(containerMapValue) }
 			{{ $y := printf "v[%s(k2)]" .MapKey }}{{ encmd .Elem $y }}
 		} {{end}}
 	} else {
 		for k2, v2 := range v {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
 			{{if eq .MapKey "string"}}if asSymbols {
 				ee.EncodeSymbol(k2)
 			} else {
 				ee.EncodeString(c_UTF8, k2)
 			}{{else}}{{ encmd .MapKey "k2"}}{{end}}
+			if cr != nil { cr.sendContainerState(containerMapValue) }
 			{{ encmd .Elem "v2"}}
 		}
 	}
-	ee.EncodeEnd()
+	if cr != nil { cr.sendContainerState(containerMapEnd) }{{/* ee.EncodeEnd() */}}
 }
 
 {{end}}{{end}}{{end}}
@@ -237,6 +257,9 @@ func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v map[{{ .MapKey }}]{{ .Ele
 
 // -- -- fast path type switch
 func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
+	if !fastpathEnabled {
+		return false
+	}
 	switch v := iv.(type) {
 {{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
 	case []{{ .Elem }}:{{else}}
@@ -250,6 +273,7 @@ func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
 		}
 {{end}}{{end}}
 	default:
+        _ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
 		return false
 	}
 	return true
@@ -283,8 +307,7 @@ func (f fastpathT) {{ .MethodNamePfx "Dec" false }}X(vp *[]{{ .Elem }}, checkNil
 		*vp = v 
 	}
 }
-func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil bool, canChange bool, 
-	d *Decoder) (_ []{{ .Elem }}, changed bool) {
+func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil bool, canChange bool, d *Decoder) (_ []{{ .Elem }}, changed bool) {
 	dd := d.d
 	{{/* // if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil() */}}
 	if checkNil && dd.TryDecodeAsNil() {
@@ -295,28 +318,22 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil b
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
-    x2read := containerLenS
-    var xtrunc bool 
-	if canChange && v == nil {
-		var xlen int 
-		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, {{ .Size }}); xtrunc {
-			x2read = xlen
-		}
-		v = make([]{{ .Elem }}, xlen)
-		changed = true
-	} 
 	if containerLenS == 0 {
-		if canChange && len(v) != 0 {
-			v = v[:0]
-			changed = true 
-		}{{/*
-			// slh.End() // dd.ReadArrayEnd()
-		*/}}
-		return v, changed 
+		if canChange {
+			if v == nil {
+				v = []{{ .Elem }}{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return
 	}
 	
-	{{/* // for j := 0; j < containerLenS; j++ { */}}
 	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool 
 		if containerLenS > cap(v) {
 			if canChange { {{/*
 				// fast-path is for "basic" immutable types, so no need to copy them over
@@ -324,37 +341,64 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil b
 				// copy(s, v[:cap(v)])
 				// v = s */}}
 				var xlen int 
-                if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, {{ .Size }}); xtrunc {
-					x2read = xlen
+                xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, {{ .Size }})
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]{{ .Elem }}, xlen)
+					}
+				} else {
+					v = make([]{{ .Elem }}, xlen)
 				}
-                v = make([]{{ .Elem }}, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				x2read = len(v)
 			}
+			x2read = len(v)
 		} else if containerLenS != len(v) {
-			v = v[:containerLenS]
-			changed = true
-		}
-		{{/* // all checks done. cannot go past len. */}}
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		} {{/* // all checks done. cannot go past len. */}}
 		j := 0
-		for ; j < x2read; j++ { 
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
 			{{ if eq .Elem "interface{}" }}d.decode(&v[j]){{ else }}v[j] = {{ decmd .Elem }}{{ end }}
 		}
 		if xtrunc { {{/* // means canChange=true, changed=true already. */}}
 			for ; j < containerLenS; j++ {
 				v = append(v, {{ zerocmd .Elem }})
+				slh.ElemContainerState(j)
 				{{ if eq .Elem "interface{}" }}d.decode(&v[j]){{ else }}v[j] = {{ decmd .Elem }}{{ end }}
 			}
 		} else if !canChange {
-			for ; j < containerLenS; j++ { 
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
 				d.swallow()
 			}
 		}
 	} else {
-		j := 0
-		for ; !dd.CheckBreak(); j++ {
+		breakFound := dd.CheckBreak() {{/* check break first, so we can initialize v with a capacity of 4 if necessary */}}
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []{{ .Elem }}{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return
+		}
+		if cap(v) == 0 {
+			v = make([]{{ .Elem }}, 1, 4)
+			changed = true
+		}
+		j := 0	
+		for ; !breakFound; j++ {
 			if j >= len(v) { 
 				if canChange {
 					v = append(v, {{ zerocmd .Elem }})
@@ -362,16 +406,22 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil b
 				} else {
 					d.arrayCannotExpand(len(v), j+1)
 				}
-			} 
+			}
+			slh.ElemContainerState(j)
 			if j < len(v) { {{/* // all checks done. cannot go past len. */}}
 				{{ if eq .Elem "interface{}" }}d.decode(&v[j])
 				{{ else }}v[j] = {{ decmd .Elem }}{{ end }}
 			} else {
 				d.swallow()
 			}
+			breakFound = dd.CheckBreak()
 		}
-		slh.End() 
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
 	}
+	slh.End() 
 	return v, changed 
 }
 
@@ -405,6 +455,7 @@ func (f fastpathT) {{ .MethodNamePfx "Dec" false }}X(vp *map[{{ .MapKey }}]{{ .E
 func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v map[{{ .MapKey }}]{{ .Elem }}, checkNil bool, canChange bool, 
 	d *Decoder) (_ map[{{ .MapKey }}]{{ .Elem }}, changed bool) {
 	dd := d.d
+	cr := d.cr
 	{{/* // if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil() */}}
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
@@ -424,11 +475,13 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v map[{{ .MapKey }}]{{ .Ele
 	var mv {{ .Elem }}
 	if containerLen > 0 {
 		for j := 0; j < containerLen; j++ {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
 			{{ if eq .MapKey "interface{}" }}mk = nil 
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv) {{/* // maps cannot have []byte as key. switch to string. */}}
 			}{{ else }}mk = {{ decmd .MapKey }}{{ end }}
+			if cr != nil { cr.sendContainerState(containerMapValue) }
 			{{ if eq .Elem "interface{}" }}if mapGet { mv = v[mk] } else { mv = nil }
 			d.decode(&mv){{ else }}mv = {{ decmd .Elem }}{{ end }}
 			if v != nil {
@@ -437,19 +490,21 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v map[{{ .MapKey }}]{{ .Ele
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
 			{{ if eq .MapKey "interface{}" }}mk = nil 
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
 				mk = d.string(bv) {{/* // maps cannot have []byte as key. switch to string. */}}
 			}{{ else }}mk = {{ decmd .MapKey }}{{ end }}
+			if cr != nil { cr.sendContainerState(containerMapValue) }
 			{{ if eq .Elem "interface{}" }}if mapGet { mv = v[mk] } else { mv = nil }
 			d.decode(&mv){{ else }}mv = {{ decmd .Elem }}{{ end }}
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadEnd()
 	}
+	if cr != nil { cr.sendContainerState(containerMapEnd) }
 	return v, changed
 }
 

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.not.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.not.go
@@ -1,0 +1,32 @@
+// +build notfastpath
+
+package codec
+
+import "reflect"
+
+// The generated fast-path code is very large, and adds a few seconds to the build time.
+// This causes test execution, execution of small tools which use codec, etc
+// to take a long time.
+//
+// To mitigate, we now support the notfastpath tag.
+// This tag disables fastpath during build, allowing for faster build, test execution,
+// short-program runs, etc.
+
+func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool      { return false }
+func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool      { return false }
+func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool { return false }
+func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool   { return false }
+
+type fastpathT struct{}
+type fastpathE struct {
+	rtid  uintptr
+	rt    reflect.Type
+	encfn func(*encFnInfo, reflect.Value)
+	decfn func(*decFnInfo, reflect.Value)
+}
+type fastpathA [0]fastpathE
+
+func (x fastpathA) index(rtid uintptr) int { return -1 }
+
+var fastpathAV fastpathA
+var fastpathTV fastpathT

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-dec-array.go.tmpl
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-dec-array.go.tmpl
@@ -1,86 +1,101 @@
-{{var "v"}} := {{ if not isArray}}*{{ end }}{{ .Varname }}
+{{var "v"}} := {{if not isArray}}*{{end}}{{ .Varname }}
 {{var "h"}}, {{var "l"}} := z.DecSliceHelperStart() {{/* // helper, containerLenS */}}
-
-var {{var "rr"}}, {{var "rl"}} int {{/* // num2read, length of slice/array/chan */}}
-var {{var "c"}}, {{var "rt"}} bool {{/* // changed, truncated */}}
-_, _, _ = {{var "c"}}, {{var "rt"}}, {{var "rl"}}
-{{var "rr"}} = {{var "l"}}
-{{/* rl is NOT used. Only used for getting DecInferLen. len(r) used directly in code */}}
-
-{{ if not isArray }}if {{var "v"}} == nil {
-	if {{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }}); {{var "rt"}} {
-		{{var "rr"}} = {{var "rl"}}
-	}
-	{{var "v"}} = make({{ .CTyp }}, {{var "rl"}})
-	{{var "c"}} = true 
-} 
-{{ end }}
-if {{var "l"}} == 0 { {{ if isSlice }}
-	if len({{var "v"}}) != 0 { 
-		{{var "v"}} = {{var "v"}}[:0] 
-		{{var "c"}} = true 
-	} {{ end }}
+var {{var "c"}} bool {{/* // changed */}}
+if {{var "l"}} == 0 {
+	{{if isSlice }}if {{var "v"}} == nil {
+		{{var "v"}} = []{{ .Typ }}{}
+		{{var "c"}} = true
+	} else if len({{var "v"}}) != 0 {
+		{{var "v"}} = {{var "v"}}[:0]
+		{{var "c"}} = true
+	} {{end}} {{if isChan }}if {{var "v"}} == nil {
+		{{var "v"}} = make({{ .CTyp }}, 0)
+		{{var "c"}} = true
+	} {{end}}
 } else if {{var "l"}} > 0 {
-	{{ if isChan }}
+	{{if isChan }}if {{var "v"}} == nil {
+		{{var "rl"}}, _ = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+		{{var "v"}} = make({{ .CTyp }}, {{var "rl"}})
+		{{var "c"}} = true
+	}
 	for {{var "r"}} := 0; {{var "r"}} < {{var "l"}}; {{var "r"}}++ {
+		{{var "h"}}.ElemContainerState({{var "r"}})
 		var {{var "t"}} {{ .Typ }}
 		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
-		{{var "v"}} <- {{var "t"}} 
-	{{ else }} 
-	if {{var "l"}} > cap({{var "v"}}) {
-		{{ if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "l"}})
-		{{ else }}{{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
-		{{ if .Immutable }}
-		{{var "v2"}} := {{var "v"}}
-		{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
-		if len({{var "v"}}) > 0 {
-			copy({{var "v"}}, {{var "v2"}}[:cap({{var "v2"}})])
-		}
-		{{ else }}{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
-		{{ end }}{{var "c"}} = true 
-		{{ end }}
-		{{var "rr"}} = len({{var "v"}})
-	} else if {{var "l"}} != len({{var "v"}}) {
-		{{ if isSlice }}{{var "v"}} = {{var "v"}}[:{{var "l"}}]
-		{{var "c"}} = true {{ end }}
+		{{var "v"}} <- {{var "t"}}
 	}
+	{{ else }}	var {{var "rr"}}, {{var "rl"}} int {{/* // num2read, length of slice/array/chan */}}
+	var {{var "rt"}} bool {{/* truncated */}}
+	if {{var "l"}} > cap({{var "v"}}) {
+		{{if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "l"}})
+		{{ else }}{{if not .Immutable }}
+		{{var "rg"}} := len({{var "v"}}) > 0
+		{{var "v2"}} := {{var "v"}} {{end}}
+		{{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+		if {{var "rt"}} {
+			if {{var "rl"}} <= cap({{var "v"}}) {
+				{{var "v"}} = {{var "v"}}[:{{var "rl"}}]
+			} else {
+				{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
+			}
+		} else {
+			{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
+		}
+		{{var "c"}} = true
+		{{var "rr"}} = len({{var "v"}}) {{if not .Immutable }}
+			if {{var "rg"}} { copy({{var "v"}}, {{var "v2"}}) } {{end}} {{end}}{{/* end not Immutable, isArray */}}
+	} {{if isSlice }} else if {{var "l"}} != len({{var "v"}}) {
+		{{var "v"}} = {{var "v"}}[:{{var "l"}}]
+		{{var "c"}} = true
+	} {{end}}	{{/* end isSlice:47 */}} 
 	{{var "j"}} := 0
 	for ; {{var "j"}} < {{var "rr"}} ; {{var "j"}}++ {
+		{{var "h"}}.ElemContainerState({{var "j"}})
 		{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
 	}
-	{{ if isArray }}for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+	{{if isArray }}for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+		{{var "h"}}.ElemContainerState({{var "j"}})
 		z.DecSwallow()
 	}
-	{{ else }}if {{var "rt"}} { {{/* means that it is mutable and slice */}}
+	{{ else }}if {{var "rt"}} {
 		for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
 			{{var "v"}} = append({{var "v"}}, {{ zero}})
+			{{var "h"}}.ElemContainerState({{var "j"}})
 			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
 		}
-	}
-	{{ end }}
-	{{ end }}{{/* closing 'if not chan' */}}
-} else {
-	for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
-		if {{var "j"}} >= len({{var "v"}}) {
-			{{ if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "j"}}+1)
-			{{ else if isSlice}}{{var "v"}} = append({{var "v"}}, {{zero}})// var {{var "z"}} {{ .Typ }}
-			{{var "c"}} = true {{ end }}
-		}
-		{{ if isChan}}
+	} {{end}} {{/* end isArray:56 */}}
+	{{end}} {{/* end isChan:16 */}}
+} else { {{/* len < 0 */}}
+	{{var "j"}} := 0
+	for ; !r.CheckBreak(); {{var "j"}}++ {
+		{{if isChan }}
+		{{var "h"}}.ElemContainerState({{var "j"}})
 		var {{var "t"}} {{ .Typ }}
 		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
 		{{var "v"}} <- {{var "t"}} 
 		{{ else }}
+		if {{var "j"}} >= len({{var "v"}}) {
+			{{if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "j"}}+1)
+			{{ else }}{{var "v"}} = append({{var "v"}}, {{zero}})// var {{var "z"}} {{ .Typ }}
+			{{var "c"}} = true {{end}}
+		}
+		{{var "h"}}.ElemContainerState({{var "j"}})
 		if {{var "j"}} < len({{var "v"}}) {
 			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
 		} else {
 			z.DecSwallow()
 		}
-		{{ end }}
+		{{end}}
 	}
-	{{var "h"}}.End()
+	{{if isSlice }}if {{var "j"}} < len({{var "v"}}) {
+		{{var "v"}} = {{var "v"}}[:{{var "j"}}]
+		{{var "c"}} = true
+	} else if {{var "j"}} == 0 && {{var "v"}} == nil {
+		{{var "v"}} = []{{ .Typ }}{}
+		{{var "c"}} = true
+	}{{end}}
 }
-{{ if not isArray }}if {{var "c"}} { 
+{{var "h"}}.End()
+{{if not isArray }}if {{var "c"}} { 
 	*{{ .Varname }} = {{var "v"}}
-}{{ end }}
-
+}{{end}}

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-dec-map.go.tmpl
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-dec-map.go.tmpl
@@ -8,7 +8,7 @@ if {{var "v"}} == nil {
 }
 var {{var "mk"}} {{ .KTyp }}
 var {{var "mv"}} {{ .Typ }}
-var {{var "mg"}} bool
+var {{var "mg"}} {{if decElemKindPtr}}, {{var "ms"}}, {{var "mok"}}{{end}} bool
 if {{var "bh"}}.MapValueReset {
 	{{if decElemKindPtr}}{{var "mg"}} = true
 	{{else if decElemKindIntf}}if !{{var "bh"}}.InterfaceReset { {{var "mg"}} = true }
@@ -16,31 +16,43 @@ if {{var "bh"}}.MapValueReset {
 	{{end}} }
 if {{var "l"}} > 0  {
 for {{var "j"}} := 0; {{var "j"}} < {{var "l"}}; {{var "j"}}++ {
+	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
 	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
 {{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
 		{{var "mk"}} = string({{var "bv"}})
-	}{{ end }}
+	}{{ end }}{{if decElemKindPtr}}
+	{{var "ms"}} = true{{end}}
 	if {{var "mg"}} {
-		{{var "mv"}} = {{var "v"}}[{{var "mk"}}]
+		{{if decElemKindPtr}}{{var "mv"}}, {{var "mok"}} = {{var "v"}}[{{var "mk"}}] 
+		if {{var "mok"}} {
+			{{var "ms"}} = false
+		} {{else}}{{var "mv"}} = {{var "v"}}[{{var "mk"}}] {{end}}
 	} {{if not decElemKindImmutable}}else { {{var "mv"}} = {{decElemZero}} }{{end}}
+	z.DecSendContainerState(codecSelfer_containerMapValue{{ .Sfx }})
 	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
-	if {{var "v"}} != nil {
+	if {{if decElemKindPtr}} {{var "ms"}} && {{end}} {{var "v"}} != nil {
 		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
 	}
 }
 } else if {{var "l"}} < 0  {
 for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
+	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
 	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
 {{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
 		{{var "mk"}} = string({{var "bv"}})
-	}{{ end }}
+	}{{ end }}{{if decElemKindPtr}}
+	{{var "ms"}} = true {{ end }}
 	if {{var "mg"}} {
-		{{var "mv"}} = {{var "v"}}[{{var "mk"}}]
+		{{if decElemKindPtr}}{{var "mv"}}, {{var "mok"}} = {{var "v"}}[{{var "mk"}}] 
+		if {{var "mok"}} {
+			{{var "ms"}} = false
+		} {{else}}{{var "mv"}} = {{var "v"}}[{{var "mk"}}] {{end}}
 	} {{if not decElemKindImmutable}}else { {{var "mv"}} = {{decElemZero}} }{{end}}
+	z.DecSendContainerState(codecSelfer_containerMapValue{{ .Sfx }})
 	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
-	if {{var "v"}} != nil {
+	if {{if decElemKindPtr}} {{var "ms"}} && {{end}} {{var "v"}} != nil {
 		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
 	}
 }
-r.ReadEnd()
 } // else len==0: TODO: Should we clear map entries?
+z.DecSendContainerState(codecSelfer_containerMapEnd{{ .Sfx }})

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-helper.generated.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-helper.generated.go
@@ -116,6 +116,15 @@ func (f genHelperEncoder) EncExt(v interface{}) (r bool) {
 }
 
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncSendContainerState(c containerState) {
+	if f.e.cr != nil {
+		f.e.cr.sendContainerState(c)
+	}
+}
+
+// ---------------- DECODER FOLLOWS -----------------
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
 func (f genHelperDecoder) DecBasicHandle() *BasicHandle {
 	return f.d.h
 }
@@ -167,11 +176,8 @@ func (f genHelperDecoder) DecTextUnmarshal(tm encoding.TextUnmarshaler) {
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
 func (f genHelperDecoder) DecJSONUnmarshal(tm jsonUnmarshaler) {
 	// bs := f.dd.DecodeBytes(f.d.b[:], true, true)
-	f.d.r.track()
-	f.d.swallow()
-	bs := f.d.r.stopTrack()
-	// fmt.Printf(">>>>>> CODECGEN JSON: %s\n", bs)
-	fnerr := tm.UnmarshalJSON(bs)
+	// grab the bytes to be read, as UnmarshalJSON needs the full JSON so as to unmarshal it itself.
+	fnerr := tm.UnmarshalJSON(f.d.nextValueBytes())
 	if fnerr != nil {
 		panic(fnerr)
 	}
@@ -217,4 +223,11 @@ func (f genHelperDecoder) DecExt(v interface{}) (r bool) {
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
 func (f genHelperDecoder) DecInferLen(clen, maxlen, unit int) (rvlen int, truncated bool) {
 	return decInferLen(clen, maxlen, unit)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecSendContainerState(c containerState) {
+	if f.d.cr != nil {
+		f.d.cr.sendContainerState(c)
+	}
 }

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-helper.go.tmpl
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-helper.go.tmpl
@@ -106,6 +106,14 @@ func (f genHelperEncoder) EncExt(v interface{}) (r bool) {
 	}
 	return false 
 }
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncSendContainerState(c containerState) {
+	if f.e.cr != nil {
+		f.e.cr.sendContainerState(c)
+	}
+}
+
+// ---------------- DECODER FOLLOWS -----------------
 
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
 func (f genHelperDecoder) DecBasicHandle() *BasicHandle {
@@ -150,11 +158,8 @@ func (f genHelperDecoder) DecTextUnmarshal(tm encoding.TextUnmarshaler) {
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
 func (f genHelperDecoder) DecJSONUnmarshal(tm jsonUnmarshaler) {
 	// bs := f.dd.DecodeBytes(f.d.b[:], true, true)
-	f.d.r.track()
-	f.d.swallow()
-	bs := f.d.r.stopTrack()
-	// fmt.Printf(">>>>>> CODECGEN JSON: %s\n", bs)
-	fnerr := tm.UnmarshalJSON(bs)
+	// grab the bytes to be read, as UnmarshalJSON needs the full JSON so as to unmarshal it itself.
+	fnerr := tm.UnmarshalJSON(f.d.nextValueBytes())
 	if fnerr != nil {
 		panic(fnerr)
 	}
@@ -194,6 +199,12 @@ func (f genHelperDecoder) DecExt(v interface{}) (r bool) {
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
 func (f genHelperDecoder) DecInferLen(clen, maxlen, unit int) (rvlen int, truncated bool) {
 	return decInferLen(clen, maxlen, unit)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecSendContainerState(c containerState) {
+	if f.d.cr != nil {
+		f.d.cr.sendContainerState(c)
+	}
 }
 
 {{/*

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/noop.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/noop.go
@@ -38,21 +38,26 @@ type noopHandle struct {
 }
 
 type noopDrv struct {
+	d    *Decoder
+	e    *Encoder
 	i    int
 	S    []string
 	B    [][]byte
 	mks  []bool    // stack. if map (true), else if array (false)
 	mk   bool      // top of stack. what container are we on? map or array?
-	ct   valueType // last request for IsContainerType.
-	cb   bool      // last response for IsContainerType.
+	ct   valueType // last response for IsContainerType.
+	cb   int       // counter for ContainerType
 	rand *rand.Rand
 }
 
 func (h *noopDrv) r(v int) int { return h.rand.Intn(v) }
 func (h *noopDrv) m(v int) int { h.i++; return h.i % v }
 
-func (h *noopDrv) newEncDriver(_ *Encoder) encDriver { return h }
-func (h *noopDrv) newDecDriver(_ *Decoder) decDriver { return h }
+func (h *noopDrv) newEncDriver(e *Encoder) encDriver { h.e = e; return h }
+func (h *noopDrv) newDecDriver(d *Decoder) decDriver { h.d = d; return h }
+
+func (h *noopDrv) reset()       {}
+func (h *noopDrv) uncacheRead() {}
 
 // --- encDriver
 
@@ -111,18 +116,48 @@ func (h *noopDrv) ReadEnd() { h.end() }
 func (h *noopDrv) ReadMapStart() int   { h.start(true); return h.m(10) }
 func (h *noopDrv) ReadArrayStart() int { h.start(false); return h.m(10) }
 
-func (h *noopDrv) IsContainerType(vt valueType) bool {
+func (h *noopDrv) ContainerType() (vt valueType) {
 	// return h.m(2) == 0
-	// handle kStruct
-	if h.ct == valueTypeMap && vt == valueTypeArray || h.ct == valueTypeArray && vt == valueTypeMap {
-		h.cb = !h.cb
-		h.ct = vt
-		return h.cb
-	}
-	// go in a loop and check it.
-	h.ct = vt
-	h.cb = h.m(7) == 0
-	return h.cb
+	// handle kStruct, which will bomb is it calls this and doesn't get back a map or array.
+	// consequently, if the return value is not map or array, reset it to one of them based on h.m(7) % 2
+	// for kstruct: at least one out of every 2 times, return one of valueTypeMap or Array (else kstruct bombs)
+	// however, every 10th time it is called, we just return something else.
+	var vals = [...]valueType{valueTypeArray, valueTypeMap}
+	//  ------------ TAKE ------------
+	// if h.cb%2 == 0 {
+	// 	if h.ct == valueTypeMap || h.ct == valueTypeArray {
+	// 	} else {
+	// 		h.ct = vals[h.m(2)]
+	// 	}
+	// } else if h.cb%5 == 0 {
+	// 	h.ct = valueType(h.m(8))
+	// } else {
+	// 	h.ct = vals[h.m(2)]
+	// }
+	//  ------------ TAKE ------------
+	// if h.cb%16 == 0 {
+	// 	h.ct = valueType(h.cb % 8)
+	// } else {
+	// 	h.ct = vals[h.cb%2]
+	// }
+	h.ct = vals[h.cb%2]
+	h.cb++
+	return h.ct
+
+	// if h.ct == valueTypeNil || h.ct == valueTypeString || h.ct == valueTypeBytes {
+	// 	return h.ct
+	// }
+	// return valueTypeUnset
+	// TODO: may need to tweak this so it works.
+	// if h.ct == valueTypeMap && vt == valueTypeArray || h.ct == valueTypeArray && vt == valueTypeMap {
+	// 	h.cb = !h.cb
+	// 	h.ct = vt
+	// 	return h.cb
+	// }
+	// // go in a loop and check it.
+	// h.ct = vt
+	// h.cb = h.m(7) == 0
+	// return h.cb
 }
 func (h *noopDrv) TryDecodeAsNil() bool {
 	if h.mk {
@@ -135,7 +170,7 @@ func (h *noopDrv) DecodeExt(rv interface{}, xtag uint64, ext Ext) uint64 {
 	return 0
 }
 
-func (h *noopDrv) DecodeNaked() (v interface{}, vt valueType, decodeFurther bool) {
+func (h *noopDrv) DecodeNaked() {
 	// use h.r (random) not h.m() because h.m() could cause the same value to be given.
 	var sk int
 	if h.mk {
@@ -144,32 +179,35 @@ func (h *noopDrv) DecodeNaked() (v interface{}, vt valueType, decodeFurther bool
 	} else {
 		sk = h.r(12)
 	}
+	n := &h.d.n
 	switch sk {
 	case 0:
-		vt = valueTypeNil
+		n.v = valueTypeNil
 	case 1:
-		vt, v = valueTypeBool, false
+		n.v, n.b = valueTypeBool, false
 	case 2:
-		vt, v = valueTypeBool, true
+		n.v, n.b = valueTypeBool, true
 	case 3:
-		vt, v = valueTypeInt, h.DecodeInt(64)
+		n.v, n.i = valueTypeInt, h.DecodeInt(64)
 	case 4:
-		vt, v = valueTypeUint, h.DecodeUint(64)
+		n.v, n.u = valueTypeUint, h.DecodeUint(64)
 	case 5:
-		vt, v = valueTypeFloat, h.DecodeFloat(true)
+		n.v, n.f = valueTypeFloat, h.DecodeFloat(true)
 	case 6:
-		vt, v = valueTypeFloat, h.DecodeFloat(false)
+		n.v, n.f = valueTypeFloat, h.DecodeFloat(false)
 	case 7:
-		vt, v = valueTypeString, h.DecodeString()
+		n.v, n.s = valueTypeString, h.DecodeString()
 	case 8:
-		vt, v = valueTypeBytes, h.B[h.m(len(h.B))]
+		n.v, n.l = valueTypeBytes, h.B[h.m(len(h.B))]
 	case 9:
-		vt, decodeFurther = valueTypeArray, true
+		n.v = valueTypeArray
 	case 10:
-		vt, decodeFurther = valueTypeMap, true
+		n.v = valueTypeMap
 	default:
-		vt, v = valueTypeExt, &RawExt{Tag: h.DecodeUint(64), Data: h.B[h.m(len(h.B))]}
+		n.v = valueTypeExt
+		n.u = h.DecodeUint(64)
+		n.l = h.B[h.m(len(h.B))]
 	}
-	h.ct = vt
+	h.ct = n.v
 	return
 }

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/prebuild.sh
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/prebuild.sh
@@ -49,7 +49,8 @@ _build() {
         # [ -e "safe${_gg}" ] && mv safe${_gg} safe${_gg}__${_zts}.bak
         # [ -e "unsafe${_gg}" ] && mv unsafe${_gg} unsafe${_gg}__${_zts}.bak
     else 
-        rm -f fast-path.generated.go gen.generated.go gen-helper.generated.go *safe.generated.go *_generated_test.go *.generated_ffjson_expose.go
+        rm -f fast-path.generated.go gen.generated.go gen-helper.generated.go \
+           *safe.generated.go *_generated_test.go *.generated_ffjson_expose.go
     fi
 
     cat > gen.generated.go <<EOF
@@ -75,27 +76,6 @@ EOF
 
     cat >> gen.generated.go <<EOF
 \`
-
-EOF
-    # All functions, variables which must exist are put in this file.
-    # This way, build works before we generate the right things.
-    cat > fast-path.generated.go <<EOF
-package codec 
-import "reflect"
-// func GenBytesToStringRO(b []byte) string { return string(b) }
-func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool { return false }
-func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool { return false }
-func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool { return false }
-func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool { return false }
-type fastpathE struct {
-	rtid uintptr
-	rt reflect.Type 
-	encfn func(*encFnInfo, reflect.Value)
-	decfn func(*decFnInfo, reflect.Value)
-}
-type fastpathA [0]fastpathE
-func (x fastpathA) index(rtid uintptr) int { return -1 }
-var fastpathAV fastpathA 
 
 EOF
 
@@ -137,7 +117,7 @@ run("gen-helper.go.tmpl", "gen-helper.generated.go", false)
 }
 
 EOF
-    go run gen-from-tmpl.generated.go && \
+    go run -tags=notfastpath gen-from-tmpl.generated.go && \
         rm -f gen-from-tmpl.*generated.go 
 }
 
@@ -152,15 +132,18 @@ _codegenerators() {
         # Consequently, we should start msgp and ffjson first, and also put a small time latency before
         # starting codecgen.
         # Without this, ffjson chokes on one of the temporary files from codecgen.
-        echo "ffjson ... " && \
-            ffjson -w values_ffjson${zsfx} $zfin &
-        zzzIdFF=$!
-        echo "msgp ... " && \
-            msgp -tests=false -pkg=codec -o=values_msgp${zsfx} -file=$zfin &
-        zzzIdMsgp=$!
-
-        sleep 1 # give ffjson and msgp some buffer time. see note above.
-
+        if [[ $zexternal == "1" ]]
+        then 
+            echo "ffjson ... " && \
+                ffjson -w values_ffjson${zsfx} $zfin &
+            zzzIdFF=$!
+            echo "msgp ... " && \
+                msgp -tests=false -o=values_msgp${zsfx} -file=$zfin &
+            zzzIdMsgp=$!
+            
+            sleep 1 # give ffjson and msgp some buffer time. see note above.
+        fi
+        
         echo "codecgen - !unsafe ... " && \
             codecgen -rt codecgen -t 'x,codecgen,!unsafe' -o values_codecgen${zsfx} -d 19780 $zfin &
         zzzIdC=$!
@@ -169,8 +152,11 @@ _codegenerators() {
         zzzIdCU=$!
         wait $zzzIdC $zzzIdCU $zzzIdMsgp $zzzIdFF && \
             # remove (M|Unm)arshalJSON implementations, so they don't conflict with encoding/json bench \
-            sed -i 's+ MarshalJSON(+ _MarshalJSON(+g' values_ffjson${zsfx} && \
-            sed -i 's+ UnmarshalJSON(+ _UnmarshalJSON(+g' values_ffjson${zsfx} && \
+            if [[ $zexternal == "1" ]]
+            then
+                sed -i 's+ MarshalJSON(+ _MarshalJSON(+g' values_ffjson${zsfx} && \
+                    sed -i 's+ UnmarshalJSON(+ _UnmarshalJSON(+g' values_ffjson${zsfx}
+            fi && \
             echo "generators done!" && \
             true
     fi 
@@ -179,11 +165,12 @@ _codegenerators() {
 # _init reads the arguments and sets up the flags
 _init() {
 OPTIND=1
-while getopts "fb" flag
+while getopts "fbx" flag
 do
     case "x$flag" in 
         'xf') zforce=1;;
         'xb') zbak=1;;
+        'xx') zexternal=1;;
         *) echo "prebuild.sh accepts [-fb] only"; return 1;;
     esac
 done

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/tests.sh
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/tests.sh
@@ -4,22 +4,29 @@
 # This helps ensure that nothing gets broken.
 
 _run() {
-    # 1. VARIATIONS: regular (t), canonical (c), IO R/W (i), binc-nosymbols (n), struct2array (s)
-    # 2. MODE: reflection (r), codecgen (x), codecgen+unsafe (u)
+    # 1. VARIATIONS: regular (t), canonical (c), IO R/W (i),
+    #                binc-nosymbols (n), struct2array (s), intern string (e),
+    # 2. MODE: reflection (r), external (x), codecgen (g), unsafe (u), notfastpath (f)
+    # 3. OPTIONS: verbose (v), reset (z), must (m),
     # 
-    # Typically, you would run a combination of one value from a and b.
+    # Use combinations of mode to get exactly what you want,
+    # and then pass the variations you need.
 
     ztags=""
+    zargs=""
     local OPTIND 
     OPTIND=1
-    while getopts "xurtcinsvg" flag
+    while getopts "xurtcinsvgzmef" flag
     do
         case "x$flag" in 
             'xr')  ;;
+            'xf') ztags="$ztags notfastpath" ;;
             'xg') ztags="$ztags codecgen" ;;
             'xx') ztags="$ztags x" ;;
             'xu') ztags="$ztags unsafe" ;;
-            'xv') zverbose="-tv" ;; 
+            'xv') zargs="$zargs -tv" ;;
+            'xz') zargs="$zargs -tr" ;;
+            'xm') zargs="$zargs -tm" ;;
             *) ;;
         esac
     done
@@ -28,14 +35,15 @@ _run() {
     # echo ">>>>>>> TAGS: $ztags"
     
     OPTIND=1
-    while getopts "xurtcinsvg" flag
+    while getopts "xurtcinsvgzmef" flag
     do
         case "x$flag" in 
-            'xt') printf ">>>>>>> REGULAR    : "; go test "-tags=$ztags" "$zverbose" ; sleep 2 ;;
-            'xc') printf ">>>>>>> CANONICAL  : "; go test "-tags=$ztags" "$zverbose" -tc; sleep 2 ;;
-            'xi') printf ">>>>>>> I/O        : "; go test "-tags=$ztags" "$zverbose" -ti; sleep 2 ;;
-            'xn') printf ">>>>>>> NO_SYMBOLS : "; go test "-tags=$ztags" "$zverbose" -tn; sleep 2 ;;
-            'xs') printf ">>>>>>> TO_ARRAY   : "; go test "-tags=$ztags" "$zverbose" -ts; sleep 2 ;;
+            'xt') printf ">>>>>>> REGULAR    : "; go test "-tags=$ztags" $zargs ; sleep 2 ;;
+            'xc') printf ">>>>>>> CANONICAL  : "; go test "-tags=$ztags" $zargs -tc; sleep 2 ;;
+            'xi') printf ">>>>>>> I/O        : "; go test "-tags=$ztags" $zargs -ti; sleep 2 ;;
+            'xn') printf ">>>>>>> NO_SYMBOLS : "; go test "-tags=$ztags" $zargs -tn; sleep 2 ;;
+            'xs') printf ">>>>>>> TO_ARRAY   : "; go test "-tags=$ztags" $zargs -ts; sleep 2 ;;
+            'xe') printf ">>>>>>> INTERN     : "; go test "-tags=$ztags" $zargs -te; sleep 2 ;;
             *) ;;
         esac
     done
@@ -46,11 +54,21 @@ _run() {
 
 # echo ">>>>>>> RUNNING VARIATIONS OF TESTS"    
 if [[ "x$@" = "x" ]]; then
-    # r, x, g, gu
-    _run "-rtcins"
-    _run "-xtcins"
-    _run "-gtcins"
-    _run "-gutcins"
+    # All: r, x, g, gu
+    _run "-rtcinsm"  # regular
+    _run "-rtcinsmz" # regular with reset
+    _run "-rtcinsmf" # regular with no fastpath (notfastpath)
+    _run "-xtcinsm" # external
+    _run "-gxtcinsm" # codecgen: requires external
+    _run "-gxutcinsm" # codecgen + unsafe
+elif [[ "x$@" = "x-Z" ]]; then
+    # Regular
+    _run "-rtcinsm"  # regular
+    _run "-rtcinsmz" # regular with reset
+elif [[ "x$@" = "x-F" ]]; then
+    # regular with notfastpath
+    _run "-rtcinsmf"  # regular
+    _run "-rtcinsmzf" # regular with reset
 else
     _run "$@"
 fi

--- a/hack/update-codecgen.sh
+++ b/hack/update-codecgen.sh
@@ -54,7 +54,7 @@ function depends {
   file=${generated_files[$1]//\.generated\.go/.go}
   deps=$(go list -f "{{.Deps}}" ${file} | tr "[" " " | tr "]" " ")
   inputfile=${generated_files[$2]//\.generated\.go/.go}
-  fullpath=$(cd "$(dirname "${inputfile}")" && pwd -P)
+  fullpath=$(readlink -f ${generated_files[$2]//\.generated\.go/.go})
   candidate=$(dirname "${fullpath}")
   result=false
   for dep in ${deps}; do

--- a/pkg/api/types.generated.go
+++ b/pkg/api/types.generated.go
@@ -39,10 +39,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -53,10 +61,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -102,18 +110,21 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2[9] = x.DeletionGracePeriodSeconds != nil
 			yyq2[10] = len(x.Labels) != 0
 			yyq2[11] = len(x.Annotations) != 0
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(12)
 			} else {
-				var yynn2 int = 0
+				yynn2 = 0
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -126,7 +137,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -136,6 +149,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
@@ -148,7 +162,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("generateName"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
@@ -158,6 +174,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[2] {
 					yym10 := z.EncBinary()
 					_ = yym10
@@ -170,7 +187,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym11 := z.EncBinary()
 					_ = yym11
 					if false {
@@ -180,6 +199,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[3] {
 					yym13 := z.EncBinary()
 					_ = yym13
@@ -192,7 +212,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selfLink"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym14 := z.EncBinary()
 					_ = yym14
 					if false {
@@ -202,6 +224,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[4] {
 					yym16 := z.EncBinary()
 					_ = yym16
@@ -215,7 +238,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("uid"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym17 := z.EncBinary()
 					_ = yym17
 					if false {
@@ -226,6 +251,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[5] {
 					yym19 := z.EncBinary()
 					_ = yym19
@@ -238,7 +264,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym20 := z.EncBinary()
 					_ = yym20
 					if false {
@@ -248,6 +276,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[6] {
 					yym22 := z.EncBinary()
 					_ = yym22
@@ -260,7 +289,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("generation"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym23 := z.EncBinary()
 					_ = yym23
 					if false {
@@ -270,6 +301,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[7] {
 					yy25 := &x.CreationTimestamp
 					yym26 := z.EncBinary()
@@ -288,7 +320,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("creationTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy27 := &x.CreationTimestamp
 					yym28 := z.EncBinary()
 					_ = yym28
@@ -304,6 +338,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[8] {
 					if x.DeletionTimestamp == nil {
 						r.EncodeNil()
@@ -325,7 +360,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("deletionTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DeletionTimestamp == nil {
 						r.EncodeNil()
 					} else {
@@ -344,6 +381,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[9] {
 					if x.DeletionGracePeriodSeconds == nil {
 						r.EncodeNil()
@@ -361,7 +399,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("deletionGracePeriodSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DeletionGracePeriodSeconds == nil {
 						r.EncodeNil()
 					} else {
@@ -376,6 +416,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[10] {
 					if x.Labels == nil {
 						r.EncodeNil()
@@ -392,7 +433,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("labels"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
@@ -406,6 +449,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[11] {
 					if x.Annotations == nil {
 						r.EncodeNil()
@@ -422,7 +466,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("annotations"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Annotations == nil {
 						r.EncodeNil()
 					} else {
@@ -435,8 +481,10 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -451,17 +499,18 @@ func (x *ObjectMeta) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct44 := r.ContainerType()
+		if yyct44 == codecSelferValueTypeMap1234 {
 			yyl44 := r.ReadMapStart()
 			if yyl44 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl44, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct44 == codecSelferValueTypeArray1234 {
 			yyl44 := r.ReadArrayStart()
 			if yyl44 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl44, d)
 			}
@@ -488,8 +537,10 @@ func (x *ObjectMeta) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys45Slc = r.DecodeBytes(yys45Slc, true, true)
 		yys45 := string(yys45Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys45 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -615,9 +666,7 @@ func (x *ObjectMeta) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys45)
 		} // end switch yys45
 	} // end for yyj45
-	if !yyhl45 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -634,9 +683,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -649,9 +699,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.GenerateName = ""
 	} else {
@@ -664,9 +715,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Namespace = ""
 	} else {
@@ -679,9 +731,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SelfLink = ""
 	} else {
@@ -694,9 +747,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.UID = ""
 	} else {
@@ -709,9 +763,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ResourceVersion = ""
 	} else {
@@ -724,9 +779,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Generation = 0
 	} else {
@@ -739,9 +795,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CreationTimestamp = pkg2_unversioned.Time{}
 	} else {
@@ -765,9 +822,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.DeletionTimestamp != nil {
 			x.DeletionTimestamp = nil
@@ -795,9 +853,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.DeletionGracePeriodSeconds != nil {
 			x.DeletionGracePeriodSeconds = nil
@@ -820,9 +879,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
@@ -841,9 +901,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Annotations = nil
 	} else {
@@ -865,9 +926,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb63 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj63-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -903,18 +965,21 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq82[14] = x.VolumeSource.Flocker != nil && x.Flocker != nil
 			yyq82[15] = x.VolumeSource.DownwardAPI != nil && x.DownwardAPI != nil
 			yyq82[16] = x.VolumeSource.FC != nil && x.FC != nil
+			var yynn82 int
 			if yyr82 || yy2arr82 {
 				r.EncodeArrayStart(17)
 			} else {
-				var yynn82 int = 1
+				yynn82 = 1
 				for _, b := range yyq82 {
 					if b {
 						yynn82++
 					}
 				}
 				r.EncodeMapStart(yynn82)
+				yynn82 = 0
 			}
 			if yyr82 || yy2arr82 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym84 := z.EncBinary()
 				_ = yym84
 				if false {
@@ -922,7 +987,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym85 := z.EncBinary()
 				_ = yym85
 				if false {
@@ -940,6 +1007,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn86 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[1] {
 						if x.HostPath == nil {
 							r.EncodeNil()
@@ -952,7 +1020,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn86 {
 						r.EncodeNil()
 					} else {
@@ -974,6 +1044,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn87 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[2] {
 						if x.EmptyDir == nil {
 							r.EncodeNil()
@@ -986,7 +1057,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("emptyDir"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn87 {
 						r.EncodeNil()
 					} else {
@@ -1008,6 +1081,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn88 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[3] {
 						if x.GCEPersistentDisk == nil {
 							r.EncodeNil()
@@ -1020,7 +1094,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn88 {
 						r.EncodeNil()
 					} else {
@@ -1042,6 +1118,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn89 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[4] {
 						if x.AWSElasticBlockStore == nil {
 							r.EncodeNil()
@@ -1054,7 +1131,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn89 {
 						r.EncodeNil()
 					} else {
@@ -1076,6 +1155,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn90 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[5] {
 						if x.GitRepo == nil {
 							r.EncodeNil()
@@ -1088,7 +1168,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gitRepo"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn90 {
 						r.EncodeNil()
 					} else {
@@ -1110,6 +1192,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn91 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[6] {
 						if x.Secret == nil {
 							r.EncodeNil()
@@ -1122,7 +1205,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secret"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn91 {
 						r.EncodeNil()
 					} else {
@@ -1144,6 +1229,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn92 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[7] {
 						if x.NFS == nil {
 							r.EncodeNil()
@@ -1156,7 +1242,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn92 {
 						r.EncodeNil()
 					} else {
@@ -1178,6 +1266,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn93 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[8] {
 						if x.ISCSI == nil {
 							r.EncodeNil()
@@ -1190,7 +1279,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn93 {
 						r.EncodeNil()
 					} else {
@@ -1212,6 +1303,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn94 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[9] {
 						if x.Glusterfs == nil {
 							r.EncodeNil()
@@ -1224,7 +1316,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn94 {
 						r.EncodeNil()
 					} else {
@@ -1246,6 +1340,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn95 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[10] {
 						if x.PersistentVolumeClaim == nil {
 							r.EncodeNil()
@@ -1258,7 +1353,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("persistentVolumeClaim"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn95 {
 						r.EncodeNil()
 					} else {
@@ -1280,6 +1377,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn96 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[11] {
 						if x.RBD == nil {
 							r.EncodeNil()
@@ -1292,7 +1390,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn96 {
 						r.EncodeNil()
 					} else {
@@ -1314,6 +1414,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn97 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[12] {
 						if x.Cinder == nil {
 							r.EncodeNil()
@@ -1326,7 +1427,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn97 {
 						r.EncodeNil()
 					} else {
@@ -1348,6 +1451,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn98 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[13] {
 						if x.CephFS == nil {
 							r.EncodeNil()
@@ -1360,7 +1464,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn98 {
 						r.EncodeNil()
 					} else {
@@ -1382,6 +1488,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn99 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[14] {
 						if x.Flocker == nil {
 							r.EncodeNil()
@@ -1394,7 +1501,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn99 {
 						r.EncodeNil()
 					} else {
@@ -1416,6 +1525,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn100 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[15] {
 						if x.DownwardAPI == nil {
 							r.EncodeNil()
@@ -1428,7 +1538,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[15] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("downwardAPI"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn100 {
 						r.EncodeNil()
 					} else {
@@ -1450,6 +1562,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn101 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[16] {
 						if x.FC == nil {
 							r.EncodeNil()
@@ -1462,7 +1575,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[16] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn101 {
 						r.EncodeNil()
 					} else {
@@ -1474,8 +1589,10 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep82 {
-				r.EncodeEnd()
+			if yyr82 || yy2arr82 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1490,17 +1607,18 @@ func (x *Volume) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct103 := r.ContainerType()
+		if yyct103 == codecSelferValueTypeMap1234 {
 			yyl103 := r.ReadMapStart()
 			if yyl103 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl103, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct103 == codecSelferValueTypeArray1234 {
 			yyl103 := r.ReadArrayStart()
 			if yyl103 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl103, d)
 			}
@@ -1527,8 +1645,10 @@ func (x *Volume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys104Slc = r.DecodeBytes(yys104Slc, true, true)
 		yys104 := string(yys104Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys104 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -1764,9 +1884,7 @@ func (x *Volume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys104)
 		} // end switch yys104
 	} // end for yyj104
-	if !yyhl104 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -1783,13 +1901,17 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
 		x.Name = string(r.DecodeString())
+	}
+	if x.VolumeSource.HostPath == nil {
+		x.VolumeSource.HostPath = new(HostPathVolumeSource)
 	}
 	yyj122++
 	if yyhl122 {
@@ -1798,9 +1920,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HostPath != nil {
 			x.HostPath = nil
@@ -1811,6 +1934,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.HostPath.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.EmptyDir == nil {
+		x.VolumeSource.EmptyDir = new(EmptyDirVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1818,9 +1944,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.EmptyDir != nil {
 			x.EmptyDir = nil
@@ -1831,6 +1958,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.EmptyDir.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.GCEPersistentDisk == nil {
+		x.VolumeSource.GCEPersistentDisk = new(GCEPersistentDiskVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1838,9 +1968,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GCEPersistentDisk != nil {
 			x.GCEPersistentDisk = nil
@@ -1851,6 +1982,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.GCEPersistentDisk.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.AWSElasticBlockStore == nil {
+		x.VolumeSource.AWSElasticBlockStore = new(AWSElasticBlockStoreVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1858,9 +1992,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.AWSElasticBlockStore != nil {
 			x.AWSElasticBlockStore = nil
@@ -1871,6 +2006,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.AWSElasticBlockStore.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.GitRepo == nil {
+		x.VolumeSource.GitRepo = new(GitRepoVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1878,9 +2016,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GitRepo != nil {
 			x.GitRepo = nil
@@ -1891,6 +2030,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.GitRepo.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.Secret == nil {
+		x.VolumeSource.Secret = new(SecretVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1898,9 +2040,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Secret != nil {
 			x.Secret = nil
@@ -1911,6 +2054,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Secret.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.NFS == nil {
+		x.VolumeSource.NFS = new(NFSVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1918,9 +2064,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.NFS != nil {
 			x.NFS = nil
@@ -1931,6 +2078,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.NFS.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.ISCSI == nil {
+		x.VolumeSource.ISCSI = new(ISCSIVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1938,9 +2088,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ISCSI != nil {
 			x.ISCSI = nil
@@ -1951,6 +2102,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.ISCSI.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.Glusterfs == nil {
+		x.VolumeSource.Glusterfs = new(GlusterfsVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1958,9 +2112,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Glusterfs != nil {
 			x.Glusterfs = nil
@@ -1971,6 +2126,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Glusterfs.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.PersistentVolumeClaim == nil {
+		x.VolumeSource.PersistentVolumeClaim = new(PersistentVolumeClaimVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1978,9 +2136,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.PersistentVolumeClaim != nil {
 			x.PersistentVolumeClaim = nil
@@ -1991,6 +2150,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.PersistentVolumeClaim.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.RBD == nil {
+		x.VolumeSource.RBD = new(RBDVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1998,9 +2160,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RBD != nil {
 			x.RBD = nil
@@ -2011,6 +2174,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.RBD.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.Cinder == nil {
+		x.VolumeSource.Cinder = new(CinderVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2018,9 +2184,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Cinder != nil {
 			x.Cinder = nil
@@ -2031,6 +2198,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Cinder.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.CephFS == nil {
+		x.VolumeSource.CephFS = new(CephFSVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2038,9 +2208,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CephFS != nil {
 			x.CephFS = nil
@@ -2051,6 +2222,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.CephFS.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.Flocker == nil {
+		x.VolumeSource.Flocker = new(FlockerVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2058,9 +2232,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Flocker != nil {
 			x.Flocker = nil
@@ -2071,6 +2246,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Flocker.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.DownwardAPI == nil {
+		x.VolumeSource.DownwardAPI = new(DownwardAPIVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2078,9 +2256,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.DownwardAPI != nil {
 			x.DownwardAPI = nil
@@ -2091,6 +2270,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.DownwardAPI.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.FC == nil {
+		x.VolumeSource.FC = new(FCVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2098,9 +2280,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FC != nil {
 			x.FC = nil
@@ -2121,9 +2304,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb122 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj122-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -2159,18 +2343,21 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq141[13] = x.Flocker != nil
 			yyq141[14] = x.DownwardAPI != nil
 			yyq141[15] = x.FC != nil
+			var yynn141 int
 			if yyr141 || yy2arr141 {
 				r.EncodeArrayStart(16)
 			} else {
-				var yynn141 int = 0
+				yynn141 = 0
 				for _, b := range yyq141 {
 					if b {
 						yynn141++
 					}
 				}
 				r.EncodeMapStart(yynn141)
+				yynn141 = 0
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[0] {
 					if x.HostPath == nil {
 						r.EncodeNil()
@@ -2182,7 +2369,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HostPath == nil {
 						r.EncodeNil()
 					} else {
@@ -2191,6 +2380,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[1] {
 					if x.EmptyDir == nil {
 						r.EncodeNil()
@@ -2202,7 +2392,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("emptyDir"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.EmptyDir == nil {
 						r.EncodeNil()
 					} else {
@@ -2211,6 +2403,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[2] {
 					if x.GCEPersistentDisk == nil {
 						r.EncodeNil()
@@ -2222,7 +2415,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.GCEPersistentDisk == nil {
 						r.EncodeNil()
 					} else {
@@ -2231,6 +2426,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[3] {
 					if x.AWSElasticBlockStore == nil {
 						r.EncodeNil()
@@ -2242,7 +2438,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AWSElasticBlockStore == nil {
 						r.EncodeNil()
 					} else {
@@ -2251,6 +2449,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[4] {
 					if x.GitRepo == nil {
 						r.EncodeNil()
@@ -2262,7 +2461,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gitRepo"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.GitRepo == nil {
 						r.EncodeNil()
 					} else {
@@ -2271,6 +2472,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[5] {
 					if x.Secret == nil {
 						r.EncodeNil()
@@ -2282,7 +2484,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secret"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Secret == nil {
 						r.EncodeNil()
 					} else {
@@ -2291,6 +2495,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[6] {
 					if x.NFS == nil {
 						r.EncodeNil()
@@ -2302,7 +2507,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.NFS == nil {
 						r.EncodeNil()
 					} else {
@@ -2311,6 +2518,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[7] {
 					if x.ISCSI == nil {
 						r.EncodeNil()
@@ -2322,7 +2530,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ISCSI == nil {
 						r.EncodeNil()
 					} else {
@@ -2331,6 +2541,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[8] {
 					if x.Glusterfs == nil {
 						r.EncodeNil()
@@ -2342,7 +2553,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Glusterfs == nil {
 						r.EncodeNil()
 					} else {
@@ -2351,6 +2564,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[9] {
 					if x.PersistentVolumeClaim == nil {
 						r.EncodeNil()
@@ -2362,7 +2576,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("persistentVolumeClaim"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.PersistentVolumeClaim == nil {
 						r.EncodeNil()
 					} else {
@@ -2371,6 +2587,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[10] {
 					if x.RBD == nil {
 						r.EncodeNil()
@@ -2382,7 +2599,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RBD == nil {
 						r.EncodeNil()
 					} else {
@@ -2391,6 +2610,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[11] {
 					if x.Cinder == nil {
 						r.EncodeNil()
@@ -2402,7 +2622,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Cinder == nil {
 						r.EncodeNil()
 					} else {
@@ -2411,6 +2633,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[12] {
 					if x.CephFS == nil {
 						r.EncodeNil()
@@ -2422,7 +2645,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CephFS == nil {
 						r.EncodeNil()
 					} else {
@@ -2431,6 +2656,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[13] {
 					if x.Flocker == nil {
 						r.EncodeNil()
@@ -2442,7 +2668,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Flocker == nil {
 						r.EncodeNil()
 					} else {
@@ -2451,6 +2679,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[14] {
 					if x.DownwardAPI == nil {
 						r.EncodeNil()
@@ -2462,7 +2691,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("downwardAPI"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DownwardAPI == nil {
 						r.EncodeNil()
 					} else {
@@ -2471,6 +2702,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[15] {
 					if x.FC == nil {
 						r.EncodeNil()
@@ -2482,7 +2714,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[15] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.FC == nil {
 						r.EncodeNil()
 					} else {
@@ -2490,8 +2724,10 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep141 {
-				r.EncodeEnd()
+			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -2506,17 +2742,18 @@ func (x *VolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct159 := r.ContainerType()
+		if yyct159 == codecSelferValueTypeMap1234 {
 			yyl159 := r.ReadMapStart()
 			if yyl159 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl159, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct159 == codecSelferValueTypeArray1234 {
 			yyl159 := r.ReadArrayStart()
 			if yyl159 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl159, d)
 			}
@@ -2543,8 +2780,10 @@ func (x *VolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys160Slc = r.DecodeBytes(yys160Slc, true, true)
 		yys160 := string(yys160Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys160 {
 		case "hostPath":
 			if r.TryDecodeAsNil() {
@@ -2726,9 +2965,7 @@ func (x *VolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys160)
 		} // end switch yys160
 	} // end for yyj160
-	if !yyhl160 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -2745,9 +2982,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HostPath != nil {
 			x.HostPath = nil
@@ -2765,9 +3003,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.EmptyDir != nil {
 			x.EmptyDir = nil
@@ -2785,9 +3024,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GCEPersistentDisk != nil {
 			x.GCEPersistentDisk = nil
@@ -2805,9 +3045,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.AWSElasticBlockStore != nil {
 			x.AWSElasticBlockStore = nil
@@ -2825,9 +3066,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GitRepo != nil {
 			x.GitRepo = nil
@@ -2845,9 +3087,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Secret != nil {
 			x.Secret = nil
@@ -2865,9 +3108,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.NFS != nil {
 			x.NFS = nil
@@ -2885,9 +3129,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ISCSI != nil {
 			x.ISCSI = nil
@@ -2905,9 +3150,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Glusterfs != nil {
 			x.Glusterfs = nil
@@ -2925,9 +3171,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.PersistentVolumeClaim != nil {
 			x.PersistentVolumeClaim = nil
@@ -2945,9 +3192,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RBD != nil {
 			x.RBD = nil
@@ -2965,9 +3213,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Cinder != nil {
 			x.Cinder = nil
@@ -2985,9 +3234,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CephFS != nil {
 			x.CephFS = nil
@@ -3005,9 +3255,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Flocker != nil {
 			x.Flocker = nil
@@ -3025,9 +3276,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.DownwardAPI != nil {
 			x.DownwardAPI = nil
@@ -3045,9 +3297,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FC != nil {
 			x.FC = nil
@@ -3068,9 +3321,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb177 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj177-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3101,18 +3355,21 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq195[8] = x.CephFS != nil
 			yyq195[9] = x.FC != nil
 			yyq195[10] = x.Flocker != nil
+			var yynn195 int
 			if yyr195 || yy2arr195 {
 				r.EncodeArrayStart(11)
 			} else {
-				var yynn195 int = 0
+				yynn195 = 0
 				for _, b := range yyq195 {
 					if b {
 						yynn195++
 					}
 				}
 				r.EncodeMapStart(yynn195)
+				yynn195 = 0
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[0] {
 					if x.GCEPersistentDisk == nil {
 						r.EncodeNil()
@@ -3124,7 +3381,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.GCEPersistentDisk == nil {
 						r.EncodeNil()
 					} else {
@@ -3133,6 +3392,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[1] {
 					if x.AWSElasticBlockStore == nil {
 						r.EncodeNil()
@@ -3144,7 +3404,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AWSElasticBlockStore == nil {
 						r.EncodeNil()
 					} else {
@@ -3153,6 +3415,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[2] {
 					if x.HostPath == nil {
 						r.EncodeNil()
@@ -3164,7 +3427,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HostPath == nil {
 						r.EncodeNil()
 					} else {
@@ -3173,6 +3438,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[3] {
 					if x.Glusterfs == nil {
 						r.EncodeNil()
@@ -3184,7 +3450,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Glusterfs == nil {
 						r.EncodeNil()
 					} else {
@@ -3193,6 +3461,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[4] {
 					if x.NFS == nil {
 						r.EncodeNil()
@@ -3204,7 +3473,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.NFS == nil {
 						r.EncodeNil()
 					} else {
@@ -3213,6 +3484,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[5] {
 					if x.RBD == nil {
 						r.EncodeNil()
@@ -3224,7 +3496,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RBD == nil {
 						r.EncodeNil()
 					} else {
@@ -3233,6 +3507,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[6] {
 					if x.ISCSI == nil {
 						r.EncodeNil()
@@ -3244,7 +3519,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ISCSI == nil {
 						r.EncodeNil()
 					} else {
@@ -3253,6 +3530,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[7] {
 					if x.Cinder == nil {
 						r.EncodeNil()
@@ -3264,7 +3542,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Cinder == nil {
 						r.EncodeNil()
 					} else {
@@ -3273,6 +3553,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[8] {
 					if x.CephFS == nil {
 						r.EncodeNil()
@@ -3284,7 +3565,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CephFS == nil {
 						r.EncodeNil()
 					} else {
@@ -3293,6 +3576,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[9] {
 					if x.FC == nil {
 						r.EncodeNil()
@@ -3304,7 +3588,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.FC == nil {
 						r.EncodeNil()
 					} else {
@@ -3313,6 +3599,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[10] {
 					if x.Flocker == nil {
 						r.EncodeNil()
@@ -3324,7 +3611,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq195[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Flocker == nil {
 						r.EncodeNil()
 					} else {
@@ -3332,8 +3621,10 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep195 {
-				r.EncodeEnd()
+			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3348,17 +3639,18 @@ func (x *PersistentVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct208 := r.ContainerType()
+		if yyct208 == codecSelferValueTypeMap1234 {
 			yyl208 := r.ReadMapStart()
 			if yyl208 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl208, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct208 == codecSelferValueTypeArray1234 {
 			yyl208 := r.ReadArrayStart()
 			if yyl208 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl208, d)
 			}
@@ -3385,8 +3677,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys209Slc = r.DecodeBytes(yys209Slc, true, true)
 		yys209 := string(yys209Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys209 {
 		case "gcePersistentDisk":
 			if r.TryDecodeAsNil() {
@@ -3513,9 +3807,7 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys209)
 		} // end switch yys209
 	} // end for yyj209
-	if !yyhl209 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3532,9 +3824,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GCEPersistentDisk != nil {
 			x.GCEPersistentDisk = nil
@@ -3552,9 +3845,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.AWSElasticBlockStore != nil {
 			x.AWSElasticBlockStore = nil
@@ -3572,9 +3866,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HostPath != nil {
 			x.HostPath = nil
@@ -3592,9 +3887,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Glusterfs != nil {
 			x.Glusterfs = nil
@@ -3612,9 +3908,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.NFS != nil {
 			x.NFS = nil
@@ -3632,9 +3929,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RBD != nil {
 			x.RBD = nil
@@ -3652,9 +3950,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ISCSI != nil {
 			x.ISCSI = nil
@@ -3672,9 +3971,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Cinder != nil {
 			x.Cinder = nil
@@ -3692,9 +3992,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CephFS != nil {
 			x.CephFS = nil
@@ -3712,9 +4013,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FC != nil {
 			x.FC = nil
@@ -3732,9 +4034,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb221 = r.CheckBreak()
 	}
 	if yyb221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Flocker != nil {
 			x.Flocker = nil
@@ -3755,9 +4058,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb221 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj221-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3778,18 +4082,21 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 			_, _, _ = yysep234, yyq234, yy2arr234
 			const yyr234 bool = false
 			yyq234[1] = x.ReadOnly != false
+			var yynn234 int
 			if yyr234 || yy2arr234 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn234 int = 1
+				yynn234 = 1
 				for _, b := range yyq234 {
 					if b {
 						yynn234++
 					}
 				}
 				r.EncodeMapStart(yynn234)
+				yynn234 = 0
 			}
 			if yyr234 || yy2arr234 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym236 := z.EncBinary()
 				_ = yym236
 				if false {
@@ -3797,7 +4104,9 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClaimName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("claimName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym237 := z.EncBinary()
 				_ = yym237
 				if false {
@@ -3806,6 +4115,7 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 				}
 			}
 			if yyr234 || yy2arr234 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq234[1] {
 					yym239 := z.EncBinary()
 					_ = yym239
@@ -3818,7 +4128,9 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 				}
 			} else {
 				if yyq234[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym240 := z.EncBinary()
 					_ = yym240
 					if false {
@@ -3827,8 +4139,10 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 					}
 				}
 			}
-			if yysep234 {
-				r.EncodeEnd()
+			if yyr234 || yy2arr234 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3843,17 +4157,18 @@ func (x *PersistentVolumeClaimVolumeSource) CodecDecodeSelf(d *codec1978.Decoder
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct242 := r.ContainerType()
+		if yyct242 == codecSelferValueTypeMap1234 {
 			yyl242 := r.ReadMapStart()
 			if yyl242 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl242, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct242 == codecSelferValueTypeArray1234 {
 			yyl242 := r.ReadArrayStart()
 			if yyl242 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl242, d)
 			}
@@ -3880,8 +4195,10 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromMap(l int, d *cod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys243Slc = r.DecodeBytes(yys243Slc, true, true)
 		yys243 := string(yys243Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys243 {
 		case "claimName":
 			if r.TryDecodeAsNil() {
@@ -3899,9 +4216,7 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromMap(l int, d *cod
 			z.DecStructFieldNotFound(-1, yys243)
 		} // end switch yys243
 	} // end for yyj243
-	if !yyhl243 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3918,9 +4233,10 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromArray(l int, d *c
 		yyb246 = r.CheckBreak()
 	}
 	if yyb246 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ClaimName = ""
 	} else {
@@ -3933,9 +4249,10 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromArray(l int, d *c
 		yyb246 = r.CheckBreak()
 	}
 	if yyb246 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -3951,9 +4268,10 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromArray(l int, d *c
 		if yyb246 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj246-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3978,18 +4296,21 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq250[2] = true
 			yyq250[3] = true
 			yyq250[4] = true
+			var yynn250 int
 			if yyr250 || yy2arr250 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn250 int = 0
+				yynn250 = 0
 				for _, b := range yyq250 {
 					if b {
 						yynn250++
 					}
 				}
 				r.EncodeMapStart(yynn250)
+				yynn250 = 0
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[0] {
 					yym252 := z.EncBinary()
 					_ = yym252
@@ -4002,7 +4323,9 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym253 := z.EncBinary()
 					_ = yym253
 					if false {
@@ -4012,6 +4335,7 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[1] {
 					yym255 := z.EncBinary()
 					_ = yym255
@@ -4024,7 +4348,9 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym256 := z.EncBinary()
 					_ = yym256
 					if false {
@@ -4034,6 +4360,7 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[2] {
 					yy258 := &x.ObjectMeta
 					yy258.CodecEncodeSelf(e)
@@ -4042,12 +4369,15 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy259 := &x.ObjectMeta
 					yy259.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[3] {
 					yy261 := &x.Spec
 					yy261.CodecEncodeSelf(e)
@@ -4056,12 +4386,15 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy262 := &x.Spec
 					yy262.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[4] {
 					yy264 := &x.Status
 					yy264.CodecEncodeSelf(e)
@@ -4070,13 +4403,17 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy265 := &x.Status
 					yy265.CodecEncodeSelf(e)
 				}
 			}
-			if yysep250 {
-				r.EncodeEnd()
+			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4091,17 +4428,18 @@ func (x *PersistentVolume) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct267 := r.ContainerType()
+		if yyct267 == codecSelferValueTypeMap1234 {
 			yyl267 := r.ReadMapStart()
 			if yyl267 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl267, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct267 == codecSelferValueTypeArray1234 {
 			yyl267 := r.ReadArrayStart()
 			if yyl267 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl267, d)
 			}
@@ -4128,8 +4466,10 @@ func (x *PersistentVolume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys268Slc = r.DecodeBytes(yys268Slc, true, true)
 		yys268 := string(yys268Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys268 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -4168,9 +4508,7 @@ func (x *PersistentVolume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys268)
 		} // end switch yys268
 	} // end for yyj268
-	if !yyhl268 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -4187,9 +4525,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -4202,9 +4541,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -4217,9 +4557,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -4233,9 +4574,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = PersistentVolumeSpec{}
 	} else {
@@ -4249,9 +4591,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = PersistentVolumeStatus{}
 	} else {
@@ -4268,9 +4611,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if yyb274 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj274-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -4304,25 +4648,30 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq281[12] = len(x.AccessModes) != 0
 			yyq281[13] = x.ClaimRef != nil
 			yyq281[14] = x.PersistentVolumeReclaimPolicy != ""
+			var yynn281 int
 			if yyr281 || yy2arr281 {
 				r.EncodeArrayStart(15)
 			} else {
-				var yynn281 int = 1
+				yynn281 = 1
 				for _, b := range yyq281 {
 					if b {
 						yynn281++
 					}
 				}
 				r.EncodeMapStart(yynn281)
+				yynn281 = 0
 			}
 			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Capacity == nil {
 					r.EncodeNil()
 				} else {
 					x.Capacity.CodecEncodeSelf(e)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("capacity"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Capacity == nil {
 					r.EncodeNil()
 				} else {
@@ -4339,6 +4688,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn283 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[1] {
 						if x.GCEPersistentDisk == nil {
 							r.EncodeNil()
@@ -4351,7 +4701,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn283 {
 						r.EncodeNil()
 					} else {
@@ -4373,6 +4725,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn284 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[2] {
 						if x.AWSElasticBlockStore == nil {
 							r.EncodeNil()
@@ -4385,7 +4738,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn284 {
 						r.EncodeNil()
 					} else {
@@ -4407,6 +4762,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn285 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[3] {
 						if x.HostPath == nil {
 							r.EncodeNil()
@@ -4419,7 +4775,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn285 {
 						r.EncodeNil()
 					} else {
@@ -4441,6 +4799,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn286 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[4] {
 						if x.Glusterfs == nil {
 							r.EncodeNil()
@@ -4453,7 +4812,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn286 {
 						r.EncodeNil()
 					} else {
@@ -4475,6 +4836,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn287 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[5] {
 						if x.NFS == nil {
 							r.EncodeNil()
@@ -4487,7 +4849,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn287 {
 						r.EncodeNil()
 					} else {
@@ -4509,6 +4873,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn288 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[6] {
 						if x.RBD == nil {
 							r.EncodeNil()
@@ -4521,7 +4886,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn288 {
 						r.EncodeNil()
 					} else {
@@ -4543,6 +4910,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn289 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[7] {
 						if x.ISCSI == nil {
 							r.EncodeNil()
@@ -4555,7 +4923,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn289 {
 						r.EncodeNil()
 					} else {
@@ -4577,6 +4947,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn290 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[8] {
 						if x.Cinder == nil {
 							r.EncodeNil()
@@ -4589,7 +4960,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn290 {
 						r.EncodeNil()
 					} else {
@@ -4611,6 +4984,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn291 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[9] {
 						if x.CephFS == nil {
 							r.EncodeNil()
@@ -4623,7 +4997,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn291 {
 						r.EncodeNil()
 					} else {
@@ -4645,6 +5021,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn292 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[10] {
 						if x.FC == nil {
 							r.EncodeNil()
@@ -4657,7 +5034,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn292 {
 						r.EncodeNil()
 					} else {
@@ -4679,6 +5058,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn293 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[11] {
 						if x.Flocker == nil {
 							r.EncodeNil()
@@ -4691,7 +5071,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn293 {
 						r.EncodeNil()
 					} else {
@@ -4704,6 +5086,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq281[12] {
 					if x.AccessModes == nil {
 						r.EncodeNil()
@@ -4720,7 +5103,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("accessModes"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
@@ -4734,6 +5119,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq281[13] {
 					if x.ClaimRef == nil {
 						r.EncodeNil()
@@ -4745,7 +5131,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("claimRef"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ClaimRef == nil {
 						r.EncodeNil()
 					} else {
@@ -4754,6 +5142,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq281[14] {
 					x.PersistentVolumeReclaimPolicy.CodecEncodeSelf(e)
 				} else {
@@ -4761,12 +5150,16 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("persistentVolumeReclaimPolicy"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.PersistentVolumeReclaimPolicy.CodecEncodeSelf(e)
 				}
 			}
-			if yysep281 {
-				r.EncodeEnd()
+			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4781,17 +5174,18 @@ func (x *PersistentVolumeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct300 := r.ContainerType()
+		if yyct300 == codecSelferValueTypeMap1234 {
 			yyl300 := r.ReadMapStart()
 			if yyl300 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl300, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct300 == codecSelferValueTypeArray1234 {
 			yyl300 := r.ReadArrayStart()
 			if yyl300 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl300, d)
 			}
@@ -4818,8 +5212,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys301Slc = r.DecodeBytes(yys301Slc, true, true)
 		yys301 := string(yys301Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys301 {
 		case "capacity":
 			if r.TryDecodeAsNil() {
@@ -5015,9 +5411,7 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys301)
 		} // end switch yys301
 	} // end for yyj301
-	if !yyhl301 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5034,14 +5428,18 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
 		yyv319 := &x.Capacity
 		yyv319.CodecDecodeSelf(d)
+	}
+	if x.PersistentVolumeSource.GCEPersistentDisk == nil {
+		x.PersistentVolumeSource.GCEPersistentDisk = new(GCEPersistentDiskVolumeSource)
 	}
 	yyj318++
 	if yyhl318 {
@@ -5050,9 +5448,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GCEPersistentDisk != nil {
 			x.GCEPersistentDisk = nil
@@ -5063,6 +5462,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.GCEPersistentDisk.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.AWSElasticBlockStore == nil {
+		x.PersistentVolumeSource.AWSElasticBlockStore = new(AWSElasticBlockStoreVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5070,9 +5472,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.AWSElasticBlockStore != nil {
 			x.AWSElasticBlockStore = nil
@@ -5083,6 +5486,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.AWSElasticBlockStore.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.HostPath == nil {
+		x.PersistentVolumeSource.HostPath = new(HostPathVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5090,9 +5496,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HostPath != nil {
 			x.HostPath = nil
@@ -5103,6 +5510,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.HostPath.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.Glusterfs == nil {
+		x.PersistentVolumeSource.Glusterfs = new(GlusterfsVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5110,9 +5520,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Glusterfs != nil {
 			x.Glusterfs = nil
@@ -5123,6 +5534,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.Glusterfs.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.NFS == nil {
+		x.PersistentVolumeSource.NFS = new(NFSVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5130,9 +5544,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.NFS != nil {
 			x.NFS = nil
@@ -5143,6 +5558,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.NFS.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.RBD == nil {
+		x.PersistentVolumeSource.RBD = new(RBDVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5150,9 +5568,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RBD != nil {
 			x.RBD = nil
@@ -5163,6 +5582,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.RBD.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.ISCSI == nil {
+		x.PersistentVolumeSource.ISCSI = new(ISCSIVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5170,9 +5592,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ISCSI != nil {
 			x.ISCSI = nil
@@ -5183,6 +5606,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.ISCSI.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.Cinder == nil {
+		x.PersistentVolumeSource.Cinder = new(CinderVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5190,9 +5616,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Cinder != nil {
 			x.Cinder = nil
@@ -5203,6 +5630,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.Cinder.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.CephFS == nil {
+		x.PersistentVolumeSource.CephFS = new(CephFSVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5210,9 +5640,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CephFS != nil {
 			x.CephFS = nil
@@ -5223,6 +5654,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.CephFS.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.FC == nil {
+		x.PersistentVolumeSource.FC = new(FCVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5230,9 +5664,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FC != nil {
 			x.FC = nil
@@ -5243,6 +5678,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.FC.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.Flocker == nil {
+		x.PersistentVolumeSource.Flocker = new(FlockerVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5250,9 +5688,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Flocker != nil {
 			x.Flocker = nil
@@ -5270,9 +5709,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.AccessModes = nil
 	} else {
@@ -5291,9 +5731,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ClaimRef != nil {
 			x.ClaimRef = nil
@@ -5311,9 +5752,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PersistentVolumeReclaimPolicy = ""
 	} else {
@@ -5329,9 +5771,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb318 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj318-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PersistentVolumeReclaimPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5380,18 +5823,21 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq338[0] = x.Phase != ""
 			yyq338[1] = x.Message != ""
 			yyq338[2] = x.Reason != ""
+			var yynn338 int
 			if yyr338 || yy2arr338 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn338 int = 0
+				yynn338 = 0
 				for _, b := range yyq338 {
 					if b {
 						yynn338++
 					}
 				}
 				r.EncodeMapStart(yynn338)
+				yynn338 = 0
 			}
 			if yyr338 || yy2arr338 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq338[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -5399,11 +5845,14 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq338[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
 			if yyr338 || yy2arr338 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq338[1] {
 					yym341 := z.EncBinary()
 					_ = yym341
@@ -5416,7 +5865,9 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq338[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym342 := z.EncBinary()
 					_ = yym342
 					if false {
@@ -5426,6 +5877,7 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr338 || yy2arr338 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq338[2] {
 					yym344 := z.EncBinary()
 					_ = yym344
@@ -5438,7 +5890,9 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq338[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym345 := z.EncBinary()
 					_ = yym345
 					if false {
@@ -5447,8 +5901,10 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep338 {
-				r.EncodeEnd()
+			if yyr338 || yy2arr338 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5463,17 +5919,18 @@ func (x *PersistentVolumeStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct347 := r.ContainerType()
+		if yyct347 == codecSelferValueTypeMap1234 {
 			yyl347 := r.ReadMapStart()
 			if yyl347 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl347, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct347 == codecSelferValueTypeArray1234 {
 			yyl347 := r.ReadArrayStart()
 			if yyl347 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl347, d)
 			}
@@ -5500,8 +5957,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys348Slc = r.DecodeBytes(yys348Slc, true, true)
 		yys348 := string(yys348Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys348 {
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -5525,9 +5984,7 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys348)
 		} // end switch yys348
 	} // end for yyj348
-	if !yyhl348 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5544,9 +6001,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb352 = r.CheckBreak()
 	}
 	if yyb352 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -5559,9 +6017,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb352 = r.CheckBreak()
 	}
 	if yyb352 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -5574,9 +6033,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb352 = r.CheckBreak()
 	}
 	if yyb352 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -5592,9 +6052,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb352 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj352-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5617,18 +6078,21 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq357[0] = x.Kind != ""
 			yyq357[1] = x.APIVersion != ""
 			yyq357[2] = true
+			var yynn357 int
 			if yyr357 || yy2arr357 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn357 int = 1
+				yynn357 = 1
 				for _, b := range yyq357 {
 					if b {
 						yynn357++
 					}
 				}
 				r.EncodeMapStart(yynn357)
+				yynn357 = 0
 			}
 			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq357[0] {
 					yym359 := z.EncBinary()
 					_ = yym359
@@ -5641,7 +6105,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq357[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym360 := z.EncBinary()
 					_ = yym360
 					if false {
@@ -5651,6 +6117,7 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq357[1] {
 					yym362 := z.EncBinary()
 					_ = yym362
@@ -5663,7 +6130,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq357[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym363 := z.EncBinary()
 					_ = yym363
 					if false {
@@ -5673,6 +6142,7 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq357[2] {
 					yy365 := &x.ListMeta
 					yym366 := z.EncBinary()
@@ -5687,7 +6157,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq357[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy367 := &x.ListMeta
 					yym368 := z.EncBinary()
 					_ = yym368
@@ -5699,6 +6171,7 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -5710,7 +6183,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -5722,8 +6197,10 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep357 {
-				r.EncodeEnd()
+			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5738,17 +6215,18 @@ func (x *PersistentVolumeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct373 := r.ContainerType()
+		if yyct373 == codecSelferValueTypeMap1234 {
 			yyl373 := r.ReadMapStart()
 			if yyl373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl373, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct373 == codecSelferValueTypeArray1234 {
 			yyl373 := r.ReadArrayStart()
 			if yyl373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl373, d)
 			}
@@ -5775,8 +6253,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys374Slc = r.DecodeBytes(yys374Slc, true, true)
 		yys374 := string(yys374Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys374 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -5819,9 +6299,7 @@ func (x *PersistentVolumeList) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys374)
 		} // end switch yys374
 	} // end for yyj374
-	if !yyhl374 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5838,9 +6316,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb381 = r.CheckBreak()
 	}
 	if yyb381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -5853,9 +6332,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb381 = r.CheckBreak()
 	}
 	if yyb381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -5868,9 +6348,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb381 = r.CheckBreak()
 	}
 	if yyb381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -5890,9 +6371,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb381 = r.CheckBreak()
 	}
 	if yyb381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -5914,9 +6396,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb381 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj381-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5941,18 +6424,21 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq389[2] = true
 			yyq389[3] = true
 			yyq389[4] = true
+			var yynn389 int
 			if yyr389 || yy2arr389 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn389 int = 0
+				yynn389 = 0
 				for _, b := range yyq389 {
 					if b {
 						yynn389++
 					}
 				}
 				r.EncodeMapStart(yynn389)
+				yynn389 = 0
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[0] {
 					yym391 := z.EncBinary()
 					_ = yym391
@@ -5965,7 +6451,9 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym392 := z.EncBinary()
 					_ = yym392
 					if false {
@@ -5975,6 +6463,7 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[1] {
 					yym394 := z.EncBinary()
 					_ = yym394
@@ -5987,7 +6476,9 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym395 := z.EncBinary()
 					_ = yym395
 					if false {
@@ -5997,6 +6488,7 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[2] {
 					yy397 := &x.ObjectMeta
 					yy397.CodecEncodeSelf(e)
@@ -6005,12 +6497,15 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy398 := &x.ObjectMeta
 					yy398.CodecEncodeSelf(e)
 				}
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[3] {
 					yy400 := &x.Spec
 					yy400.CodecEncodeSelf(e)
@@ -6019,12 +6514,15 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy401 := &x.Spec
 					yy401.CodecEncodeSelf(e)
 				}
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[4] {
 					yy403 := &x.Status
 					yy403.CodecEncodeSelf(e)
@@ -6033,13 +6531,17 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy404 := &x.Status
 					yy404.CodecEncodeSelf(e)
 				}
 			}
-			if yysep389 {
-				r.EncodeEnd()
+			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6054,17 +6556,18 @@ func (x *PersistentVolumeClaim) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct406 := r.ContainerType()
+		if yyct406 == codecSelferValueTypeMap1234 {
 			yyl406 := r.ReadMapStart()
 			if yyl406 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl406, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct406 == codecSelferValueTypeArray1234 {
 			yyl406 := r.ReadArrayStart()
 			if yyl406 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl406, d)
 			}
@@ -6091,8 +6594,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys407Slc = r.DecodeBytes(yys407Slc, true, true)
 		yys407 := string(yys407Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys407 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -6131,9 +6636,7 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys407)
 		} // end switch yys407
 	} // end for yyj407
-	if !yyhl407 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6150,9 +6653,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -6165,9 +6669,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -6180,9 +6685,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -6196,9 +6702,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = PersistentVolumeClaimSpec{}
 	} else {
@@ -6212,9 +6719,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = PersistentVolumeClaimStatus{}
 	} else {
@@ -6231,9 +6739,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb413 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj413-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6256,18 +6765,21 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq420[0] = x.Kind != ""
 			yyq420[1] = x.APIVersion != ""
 			yyq420[2] = true
+			var yynn420 int
 			if yyr420 || yy2arr420 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn420 int = 1
+				yynn420 = 1
 				for _, b := range yyq420 {
 					if b {
 						yynn420++
 					}
 				}
 				r.EncodeMapStart(yynn420)
+				yynn420 = 0
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq420[0] {
 					yym422 := z.EncBinary()
 					_ = yym422
@@ -6280,7 +6792,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq420[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym423 := z.EncBinary()
 					_ = yym423
 					if false {
@@ -6290,6 +6804,7 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq420[1] {
 					yym425 := z.EncBinary()
 					_ = yym425
@@ -6302,7 +6817,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq420[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym426 := z.EncBinary()
 					_ = yym426
 					if false {
@@ -6312,6 +6829,7 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq420[2] {
 					yy428 := &x.ListMeta
 					yym429 := z.EncBinary()
@@ -6326,7 +6844,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq420[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy430 := &x.ListMeta
 					yym431 := z.EncBinary()
 					_ = yym431
@@ -6338,6 +6858,7 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6349,7 +6870,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6361,8 +6884,10 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep420 {
-				r.EncodeEnd()
+			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6377,17 +6902,18 @@ func (x *PersistentVolumeClaimList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct436 := r.ContainerType()
+		if yyct436 == codecSelferValueTypeMap1234 {
 			yyl436 := r.ReadMapStart()
 			if yyl436 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl436, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct436 == codecSelferValueTypeArray1234 {
 			yyl436 := r.ReadArrayStart()
 			if yyl436 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl436, d)
 			}
@@ -6414,8 +6940,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys437Slc = r.DecodeBytes(yys437Slc, true, true)
 		yys437 := string(yys437Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys437 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -6458,9 +6986,7 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromMap(l int, d *codec1978.D
 			z.DecStructFieldNotFound(-1, yys437)
 		} // end switch yys437
 	} // end for yyj437
-	if !yyhl437 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6477,9 +7003,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb444 = r.CheckBreak()
 	}
 	if yyb444 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -6492,9 +7019,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb444 = r.CheckBreak()
 	}
 	if yyb444 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -6507,9 +7035,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb444 = r.CheckBreak()
 	}
 	if yyb444 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -6529,9 +7058,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb444 = r.CheckBreak()
 	}
 	if yyb444 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -6553,9 +7083,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		if yyb444 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj444-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6578,18 +7109,21 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq452[0] = len(x.AccessModes) != 0
 			yyq452[1] = true
 			yyq452[2] = x.VolumeName != ""
+			var yynn452 int
 			if yyr452 || yy2arr452 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn452 int = 0
+				yynn452 = 0
 				for _, b := range yyq452 {
 					if b {
 						yynn452++
 					}
 				}
 				r.EncodeMapStart(yynn452)
+				yynn452 = 0
 			}
 			if yyr452 || yy2arr452 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq452[0] {
 					if x.AccessModes == nil {
 						r.EncodeNil()
@@ -6606,7 +7140,9 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq452[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("accessModes"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
@@ -6620,6 +7156,7 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr452 || yy2arr452 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq452[1] {
 					yy457 := &x.Resources
 					yy457.CodecEncodeSelf(e)
@@ -6628,12 +7165,15 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq452[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resources"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy458 := &x.Resources
 					yy458.CodecEncodeSelf(e)
 				}
 			}
 			if yyr452 || yy2arr452 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq452[2] {
 					yym460 := z.EncBinary()
 					_ = yym460
@@ -6646,7 +7186,9 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq452[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("volumeName"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym461 := z.EncBinary()
 					_ = yym461
 					if false {
@@ -6655,8 +7197,10 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep452 {
-				r.EncodeEnd()
+			if yyr452 || yy2arr452 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6671,17 +7215,18 @@ func (x *PersistentVolumeClaimSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct463 := r.ContainerType()
+		if yyct463 == codecSelferValueTypeMap1234 {
 			yyl463 := r.ReadMapStart()
 			if yyl463 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl463, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct463 == codecSelferValueTypeArray1234 {
 			yyl463 := r.ReadArrayStart()
 			if yyl463 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl463, d)
 			}
@@ -6708,8 +7253,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys464Slc = r.DecodeBytes(yys464Slc, true, true)
 		yys464 := string(yys464Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys464 {
 		case "accessModes":
 			if r.TryDecodeAsNil() {
@@ -6740,9 +7287,7 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 			z.DecStructFieldNotFound(-1, yys464)
 		} // end switch yys464
 	} // end for yyj464
-	if !yyhl464 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6759,9 +7304,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb469 = r.CheckBreak()
 	}
 	if yyb469 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.AccessModes = nil
 	} else {
@@ -6780,9 +7326,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb469 = r.CheckBreak()
 	}
 	if yyb469 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Resources = ResourceRequirements{}
 	} else {
@@ -6796,9 +7343,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb469 = r.CheckBreak()
 	}
 	if yyb469 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.VolumeName = ""
 	} else {
@@ -6814,9 +7362,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		if yyb469 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj469-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6839,18 +7388,21 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq475[0] = x.Phase != ""
 			yyq475[1] = len(x.AccessModes) != 0
 			yyq475[2] = len(x.Capacity) != 0
+			var yynn475 int
 			if yyr475 || yy2arr475 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn475 int = 0
+				yynn475 = 0
 				for _, b := range yyq475 {
 					if b {
 						yynn475++
 					}
 				}
 				r.EncodeMapStart(yynn475)
+				yynn475 = 0
 			}
 			if yyr475 || yy2arr475 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq475[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -6858,11 +7410,14 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq475[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
 			if yyr475 || yy2arr475 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq475[1] {
 					if x.AccessModes == nil {
 						r.EncodeNil()
@@ -6879,7 +7434,9 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq475[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("accessModes"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
@@ -6893,6 +7450,7 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr475 || yy2arr475 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq475[2] {
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -6904,7 +7462,9 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq475[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -6912,8 +7472,10 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep475 {
-				r.EncodeEnd()
+			if yyr475 || yy2arr475 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6928,17 +7490,18 @@ func (x *PersistentVolumeClaimStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct482 := r.ContainerType()
+		if yyct482 == codecSelferValueTypeMap1234 {
 			yyl482 := r.ReadMapStart()
 			if yyl482 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl482, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct482 == codecSelferValueTypeArray1234 {
 			yyl482 := r.ReadArrayStart()
 			if yyl482 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl482, d)
 			}
@@ -6965,8 +7528,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys483Slc = r.DecodeBytes(yys483Slc, true, true)
 		yys483 := string(yys483Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys483 {
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -6997,9 +7562,7 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromMap(l int, d *codec1978
 			z.DecStructFieldNotFound(-1, yys483)
 		} // end switch yys483
 	} // end for yyj483
-	if !yyhl483 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7016,9 +7579,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb488 = r.CheckBreak()
 	}
 	if yyb488 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -7031,9 +7595,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb488 = r.CheckBreak()
 	}
 	if yyb488 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.AccessModes = nil
 	} else {
@@ -7052,9 +7617,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb488 = r.CheckBreak()
 	}
 	if yyb488 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
@@ -7071,9 +7637,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec19
 		if yyb488 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj488-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PersistentVolumeAccessMode) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7171,18 +7738,21 @@ func (x *HostPathVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq500 [1]bool
 			_, _, _ = yysep500, yyq500, yy2arr500
 			const yyr500 bool = false
+			var yynn500 int
 			if yyr500 || yy2arr500 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn500 int = 1
+				yynn500 = 1
 				for _, b := range yyq500 {
 					if b {
 						yynn500++
 					}
 				}
 				r.EncodeMapStart(yynn500)
+				yynn500 = 0
 			}
 			if yyr500 || yy2arr500 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym502 := z.EncBinary()
 				_ = yym502
 				if false {
@@ -7190,7 +7760,9 @@ func (x *HostPathVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym503 := z.EncBinary()
 				_ = yym503
 				if false {
@@ -7198,8 +7770,10 @@ func (x *HostPathVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yysep500 {
-				r.EncodeEnd()
+			if yyr500 || yy2arr500 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7214,17 +7788,18 @@ func (x *HostPathVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct505 := r.ContainerType()
+		if yyct505 == codecSelferValueTypeMap1234 {
 			yyl505 := r.ReadMapStart()
 			if yyl505 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl505, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct505 == codecSelferValueTypeArray1234 {
 			yyl505 := r.ReadArrayStart()
 			if yyl505 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl505, d)
 			}
@@ -7251,8 +7826,10 @@ func (x *HostPathVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys506Slc = r.DecodeBytes(yys506Slc, true, true)
 		yys506 := string(yys506Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys506 {
 		case "path":
 			if r.TryDecodeAsNil() {
@@ -7264,9 +7841,7 @@ func (x *HostPathVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys506)
 		} // end switch yys506
 	} // end for yyj506
-	if !yyhl506 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HostPathVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7283,9 +7858,10 @@ func (x *HostPathVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb508 = r.CheckBreak()
 	}
 	if yyb508 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -7301,9 +7877,10 @@ func (x *HostPathVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb508 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj508-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EmptyDirVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7323,25 +7900,32 @@ func (x *EmptyDirVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq511 [1]bool
 			_, _, _ = yysep511, yyq511, yy2arr511
 			const yyr511 bool = false
+			var yynn511 int
 			if yyr511 || yy2arr511 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn511 int = 1
+				yynn511 = 1
 				for _, b := range yyq511 {
 					if b {
 						yynn511++
 					}
 				}
 				r.EncodeMapStart(yynn511)
+				yynn511 = 0
 			}
 			if yyr511 || yy2arr511 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Medium.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("medium"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Medium.CodecEncodeSelf(e)
 			}
-			if yysep511 {
-				r.EncodeEnd()
+			if yyr511 || yy2arr511 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7356,17 +7940,18 @@ func (x *EmptyDirVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct514 := r.ContainerType()
+		if yyct514 == codecSelferValueTypeMap1234 {
 			yyl514 := r.ReadMapStart()
 			if yyl514 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl514, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct514 == codecSelferValueTypeArray1234 {
 			yyl514 := r.ReadArrayStart()
 			if yyl514 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl514, d)
 			}
@@ -7393,8 +7978,10 @@ func (x *EmptyDirVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys515Slc = r.DecodeBytes(yys515Slc, true, true)
 		yys515 := string(yys515Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys515 {
 		case "medium":
 			if r.TryDecodeAsNil() {
@@ -7406,9 +7993,7 @@ func (x *EmptyDirVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys515)
 		} // end switch yys515
 	} // end for yyj515
-	if !yyhl515 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EmptyDirVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7425,9 +8010,10 @@ func (x *EmptyDirVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb517 = r.CheckBreak()
 	}
 	if yyb517 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Medium = ""
 	} else {
@@ -7443,9 +8029,10 @@ func (x *EmptyDirVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb517 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj517-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x StorageMedium) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7520,18 +8107,21 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq524[1] = x.FSType != ""
 			yyq524[2] = x.Partition != 0
 			yyq524[3] = x.ReadOnly != false
+			var yynn524 int
 			if yyr524 || yy2arr524 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn524 int = 1
+				yynn524 = 1
 				for _, b := range yyq524 {
 					if b {
 						yynn524++
 					}
 				}
 				r.EncodeMapStart(yynn524)
+				yynn524 = 0
 			}
 			if yyr524 || yy2arr524 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym526 := z.EncBinary()
 				_ = yym526
 				if false {
@@ -7539,7 +8129,9 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PDName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("pdName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym527 := z.EncBinary()
 				_ = yym527
 				if false {
@@ -7548,6 +8140,7 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr524 || yy2arr524 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq524[1] {
 					yym529 := z.EncBinary()
 					_ = yym529
@@ -7560,7 +8153,9 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq524[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym530 := z.EncBinary()
 					_ = yym530
 					if false {
@@ -7570,6 +8165,7 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr524 || yy2arr524 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq524[2] {
 					yym532 := z.EncBinary()
 					_ = yym532
@@ -7582,7 +8178,9 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq524[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("partition"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym533 := z.EncBinary()
 					_ = yym533
 					if false {
@@ -7592,6 +8190,7 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr524 || yy2arr524 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq524[3] {
 					yym535 := z.EncBinary()
 					_ = yym535
@@ -7604,7 +8203,9 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq524[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym536 := z.EncBinary()
 					_ = yym536
 					if false {
@@ -7613,8 +8214,10 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep524 {
-				r.EncodeEnd()
+			if yyr524 || yy2arr524 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7629,17 +8232,18 @@ func (x *GCEPersistentDiskVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct538 := r.ContainerType()
+		if yyct538 == codecSelferValueTypeMap1234 {
 			yyl538 := r.ReadMapStart()
 			if yyl538 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl538, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct538 == codecSelferValueTypeArray1234 {
 			yyl538 := r.ReadArrayStart()
 			if yyl538 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl538, d)
 			}
@@ -7666,8 +8270,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromMap(l int, d *codec19
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys539Slc = r.DecodeBytes(yys539Slc, true, true)
 		yys539 := string(yys539Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys539 {
 		case "pdName":
 			if r.TryDecodeAsNil() {
@@ -7697,9 +8303,7 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromMap(l int, d *codec19
 			z.DecStructFieldNotFound(-1, yys539)
 		} // end switch yys539
 	} // end for yyj539
-	if !yyhl539 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7716,9 +8320,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		yyb544 = r.CheckBreak()
 	}
 	if yyb544 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PDName = ""
 	} else {
@@ -7731,9 +8336,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		yyb544 = r.CheckBreak()
 	}
 	if yyb544 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -7746,9 +8352,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		yyb544 = r.CheckBreak()
 	}
 	if yyb544 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Partition = 0
 	} else {
@@ -7761,9 +8368,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		yyb544 = r.CheckBreak()
 	}
 	if yyb544 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -7779,9 +8387,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		if yyb544 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj544-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7806,18 +8415,21 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq550[2] = x.Lun != 0
 			yyq550[3] = x.FSType != ""
 			yyq550[4] = x.ReadOnly != false
+			var yynn550 int
 			if yyr550 || yy2arr550 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn550 int = 0
+				yynn550 = 0
 				for _, b := range yyq550 {
 					if b {
 						yynn550++
 					}
 				}
 				r.EncodeMapStart(yynn550)
+				yynn550 = 0
 			}
 			if yyr550 || yy2arr550 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq550[0] {
 					yym552 := z.EncBinary()
 					_ = yym552
@@ -7830,7 +8442,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq550[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("targetPortal"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym553 := z.EncBinary()
 					_ = yym553
 					if false {
@@ -7840,6 +8454,7 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr550 || yy2arr550 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq550[1] {
 					yym555 := z.EncBinary()
 					_ = yym555
@@ -7852,7 +8467,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq550[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("iqn"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym556 := z.EncBinary()
 					_ = yym556
 					if false {
@@ -7862,6 +8479,7 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr550 || yy2arr550 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq550[2] {
 					yym558 := z.EncBinary()
 					_ = yym558
@@ -7874,7 +8492,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq550[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lun"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym559 := z.EncBinary()
 					_ = yym559
 					if false {
@@ -7884,6 +8504,7 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr550 || yy2arr550 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq550[3] {
 					yym561 := z.EncBinary()
 					_ = yym561
@@ -7896,7 +8517,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq550[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym562 := z.EncBinary()
 					_ = yym562
 					if false {
@@ -7906,6 +8529,7 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr550 || yy2arr550 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq550[4] {
 					yym564 := z.EncBinary()
 					_ = yym564
@@ -7918,7 +8542,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq550[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym565 := z.EncBinary()
 					_ = yym565
 					if false {
@@ -7927,8 +8553,10 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep550 {
-				r.EncodeEnd()
+			if yyr550 || yy2arr550 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7943,17 +8571,18 @@ func (x *ISCSIVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct567 := r.ContainerType()
+		if yyct567 == codecSelferValueTypeMap1234 {
 			yyl567 := r.ReadMapStart()
 			if yyl567 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl567, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct567 == codecSelferValueTypeArray1234 {
 			yyl567 := r.ReadArrayStart()
 			if yyl567 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl567, d)
 			}
@@ -7980,8 +8609,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys568Slc = r.DecodeBytes(yys568Slc, true, true)
 		yys568 := string(yys568Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys568 {
 		case "targetPortal":
 			if r.TryDecodeAsNil() {
@@ -8017,9 +8648,7 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			z.DecStructFieldNotFound(-1, yys568)
 		} // end switch yys568
 	} // end for yyj568
-	if !yyhl568 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8036,9 +8665,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb574 = r.CheckBreak()
 	}
 	if yyb574 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetPortal = ""
 	} else {
@@ -8051,9 +8681,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb574 = r.CheckBreak()
 	}
 	if yyb574 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.IQN = ""
 	} else {
@@ -8066,9 +8697,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb574 = r.CheckBreak()
 	}
 	if yyb574 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Lun = 0
 	} else {
@@ -8081,9 +8713,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb574 = r.CheckBreak()
 	}
 	if yyb574 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -8096,9 +8729,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb574 = r.CheckBreak()
 	}
 	if yyb574 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -8114,9 +8748,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if yyb574 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj574-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8137,18 +8772,21 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep581, yyq581, yy2arr581
 			const yyr581 bool = false
 			yyq581[3] = x.ReadOnly != false
+			var yynn581 int
 			if yyr581 || yy2arr581 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn581 int = 3
+				yynn581 = 3
 				for _, b := range yyq581 {
 					if b {
 						yynn581++
 					}
 				}
 				r.EncodeMapStart(yynn581)
+				yynn581 = 0
 			}
 			if yyr581 || yy2arr581 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.TargetWWNs == nil {
 					r.EncodeNil()
 				} else {
@@ -8160,7 +8798,9 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("targetWWNs"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.TargetWWNs == nil {
 					r.EncodeNil()
 				} else {
@@ -8173,6 +8813,7 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr581 || yy2arr581 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Lun == nil {
 					r.EncodeNil()
 				} else {
@@ -8185,7 +8826,9 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lun"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Lun == nil {
 					r.EncodeNil()
 				} else {
@@ -8199,6 +8842,7 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr581 || yy2arr581 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym591 := z.EncBinary()
 				_ = yym591
 				if false {
@@ -8206,7 +8850,9 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FSType))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym592 := z.EncBinary()
 				_ = yym592
 				if false {
@@ -8215,6 +8861,7 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr581 || yy2arr581 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq581[3] {
 					yym594 := z.EncBinary()
 					_ = yym594
@@ -8227,7 +8874,9 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq581[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym595 := z.EncBinary()
 					_ = yym595
 					if false {
@@ -8236,8 +8885,10 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep581 {
-				r.EncodeEnd()
+			if yyr581 || yy2arr581 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8252,17 +8903,18 @@ func (x *FCVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct597 := r.ContainerType()
+		if yyct597 == codecSelferValueTypeMap1234 {
 			yyl597 := r.ReadMapStart()
 			if yyl597 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl597, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct597 == codecSelferValueTypeArray1234 {
 			yyl597 := r.ReadArrayStart()
 			if yyl597 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl597, d)
 			}
@@ -8289,8 +8941,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys598Slc = r.DecodeBytes(yys598Slc, true, true)
 		yys598 := string(yys598Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys598 {
 		case "targetWWNs":
 			if r.TryDecodeAsNil() {
@@ -8336,9 +8990,7 @@ func (x *FCVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys598)
 		} // end switch yys598
 	} // end for yyj598
-	if !yyhl598 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8355,9 +9007,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb605 = r.CheckBreak()
 	}
 	if yyb605 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetWWNs = nil
 	} else {
@@ -8376,9 +9029,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb605 = r.CheckBreak()
 	}
 	if yyb605 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Lun != nil {
 			x.Lun = nil
@@ -8401,9 +9055,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb605 = r.CheckBreak()
 	}
 	if yyb605 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -8416,9 +9071,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb605 = r.CheckBreak()
 	}
 	if yyb605 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -8434,9 +9090,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb605 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj605-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8459,18 +9116,21 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 			yyq613[1] = x.FSType != ""
 			yyq613[2] = x.Partition != 0
 			yyq613[3] = x.ReadOnly != false
+			var yynn613 int
 			if yyr613 || yy2arr613 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn613 int = 1
+				yynn613 = 1
 				for _, b := range yyq613 {
 					if b {
 						yynn613++
 					}
 				}
 				r.EncodeMapStart(yynn613)
+				yynn613 = 0
 			}
 			if yyr613 || yy2arr613 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym615 := z.EncBinary()
 				_ = yym615
 				if false {
@@ -8478,7 +9138,9 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 					r.EncodeString(codecSelferC_UTF81234, string(x.VolumeID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumeID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym616 := z.EncBinary()
 				_ = yym616
 				if false {
@@ -8487,6 +9149,7 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			}
 			if yyr613 || yy2arr613 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq613[1] {
 					yym618 := z.EncBinary()
 					_ = yym618
@@ -8499,7 +9162,9 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			} else {
 				if yyq613[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym619 := z.EncBinary()
 					_ = yym619
 					if false {
@@ -8509,6 +9174,7 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			}
 			if yyr613 || yy2arr613 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq613[2] {
 					yym621 := z.EncBinary()
 					_ = yym621
@@ -8521,7 +9187,9 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			} else {
 				if yyq613[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("partition"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym622 := z.EncBinary()
 					_ = yym622
 					if false {
@@ -8531,6 +9199,7 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			}
 			if yyr613 || yy2arr613 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq613[3] {
 					yym624 := z.EncBinary()
 					_ = yym624
@@ -8543,7 +9212,9 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			} else {
 				if yyq613[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym625 := z.EncBinary()
 					_ = yym625
 					if false {
@@ -8552,8 +9223,10 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 					}
 				}
 			}
-			if yysep613 {
-				r.EncodeEnd()
+			if yyr613 || yy2arr613 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8568,17 +9241,18 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecDecodeSelf(d *codec1978.Decoder)
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct627 := r.ContainerType()
+		if yyct627 == codecSelferValueTypeMap1234 {
 			yyl627 := r.ReadMapStart()
 			if yyl627 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl627, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct627 == codecSelferValueTypeArray1234 {
 			yyl627 := r.ReadArrayStart()
 			if yyl627 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl627, d)
 			}
@@ -8605,8 +9279,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromMap(l int, d *code
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys628Slc = r.DecodeBytes(yys628Slc, true, true)
 		yys628 := string(yys628Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys628 {
 		case "volumeID":
 			if r.TryDecodeAsNil() {
@@ -8636,9 +9312,7 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromMap(l int, d *code
 			z.DecStructFieldNotFound(-1, yys628)
 		} // end switch yys628
 	} // end for yyj628
-	if !yyhl628 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8655,9 +9329,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		yyb633 = r.CheckBreak()
 	}
 	if yyb633 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.VolumeID = ""
 	} else {
@@ -8670,9 +9345,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		yyb633 = r.CheckBreak()
 	}
 	if yyb633 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -8685,9 +9361,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		yyb633 = r.CheckBreak()
 	}
 	if yyb633 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Partition = 0
 	} else {
@@ -8700,9 +9377,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		yyb633 = r.CheckBreak()
 	}
 	if yyb633 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -8718,9 +9396,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		if yyb633 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj633-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8740,18 +9419,21 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq639 [2]bool
 			_, _, _ = yysep639, yyq639, yy2arr639
 			const yyr639 bool = false
+			var yynn639 int
 			if yyr639 || yy2arr639 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn639 int = 2
+				yynn639 = 2
 				for _, b := range yyq639 {
 					if b {
 						yynn639++
 					}
 				}
 				r.EncodeMapStart(yynn639)
+				yynn639 = 0
 			}
 			if yyr639 || yy2arr639 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym641 := z.EncBinary()
 				_ = yym641
 				if false {
@@ -8759,7 +9441,9 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Repository))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("repository"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym642 := z.EncBinary()
 				_ = yym642
 				if false {
@@ -8768,6 +9452,7 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr639 || yy2arr639 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym644 := z.EncBinary()
 				_ = yym644
 				if false {
@@ -8775,7 +9460,9 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Revision))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("revision"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym645 := z.EncBinary()
 				_ = yym645
 				if false {
@@ -8783,8 +9470,10 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Revision))
 				}
 			}
-			if yysep639 {
-				r.EncodeEnd()
+			if yyr639 || yy2arr639 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8799,17 +9488,18 @@ func (x *GitRepoVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct647 := r.ContainerType()
+		if yyct647 == codecSelferValueTypeMap1234 {
 			yyl647 := r.ReadMapStart()
 			if yyl647 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl647, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct647 == codecSelferValueTypeArray1234 {
 			yyl647 := r.ReadArrayStart()
 			if yyl647 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl647, d)
 			}
@@ -8836,8 +9526,10 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys648Slc = r.DecodeBytes(yys648Slc, true, true)
 		yys648 := string(yys648Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys648 {
 		case "repository":
 			if r.TryDecodeAsNil() {
@@ -8855,9 +9547,7 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys648)
 		} // end switch yys648
 	} // end for yyj648
-	if !yyhl648 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *GitRepoVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8874,9 +9564,10 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb651 = r.CheckBreak()
 	}
 	if yyb651 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Repository = ""
 	} else {
@@ -8889,9 +9580,10 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb651 = r.CheckBreak()
 	}
 	if yyb651 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Revision = ""
 	} else {
@@ -8907,9 +9599,10 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb651 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj651-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SecretVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8929,18 +9622,21 @@ func (x *SecretVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq655 [1]bool
 			_, _, _ = yysep655, yyq655, yy2arr655
 			const yyr655 bool = false
+			var yynn655 int
 			if yyr655 || yy2arr655 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn655 int = 1
+				yynn655 = 1
 				for _, b := range yyq655 {
 					if b {
 						yynn655++
 					}
 				}
 				r.EncodeMapStart(yynn655)
+				yynn655 = 0
 			}
 			if yyr655 || yy2arr655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym657 := z.EncBinary()
 				_ = yym657
 				if false {
@@ -8948,7 +9644,9 @@ func (x *SecretVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("secretName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym658 := z.EncBinary()
 				_ = yym658
 				if false {
@@ -8956,8 +9654,10 @@ func (x *SecretVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
 				}
 			}
-			if yysep655 {
-				r.EncodeEnd()
+			if yyr655 || yy2arr655 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8972,17 +9672,18 @@ func (x *SecretVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct660 := r.ContainerType()
+		if yyct660 == codecSelferValueTypeMap1234 {
 			yyl660 := r.ReadMapStart()
 			if yyl660 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl660, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct660 == codecSelferValueTypeArray1234 {
 			yyl660 := r.ReadArrayStart()
 			if yyl660 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl660, d)
 			}
@@ -9009,8 +9710,10 @@ func (x *SecretVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys661Slc = r.DecodeBytes(yys661Slc, true, true)
 		yys661 := string(yys661Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys661 {
 		case "secretName":
 			if r.TryDecodeAsNil() {
@@ -9022,9 +9725,7 @@ func (x *SecretVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys661)
 		} // end switch yys661
 	} // end for yyj661
-	if !yyhl661 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SecretVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9041,9 +9742,10 @@ func (x *SecretVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb663 = r.CheckBreak()
 	}
 	if yyb663 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SecretName = ""
 	} else {
@@ -9059,9 +9761,10 @@ func (x *SecretVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb663 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj663-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9082,18 +9785,21 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep666, yyq666, yy2arr666
 			const yyr666 bool = false
 			yyq666[2] = x.ReadOnly != false
+			var yynn666 int
 			if yyr666 || yy2arr666 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn666 int = 2
+				yynn666 = 2
 				for _, b := range yyq666 {
 					if b {
 						yynn666++
 					}
 				}
 				r.EncodeMapStart(yynn666)
+				yynn666 = 0
 			}
 			if yyr666 || yy2arr666 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym668 := z.EncBinary()
 				_ = yym668
 				if false {
@@ -9101,7 +9807,9 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Server))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("server"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym669 := z.EncBinary()
 				_ = yym669
 				if false {
@@ -9110,6 +9818,7 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr666 || yy2arr666 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym671 := z.EncBinary()
 				_ = yym671
 				if false {
@@ -9117,7 +9826,9 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym672 := z.EncBinary()
 				_ = yym672
 				if false {
@@ -9126,6 +9837,7 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr666 || yy2arr666 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq666[2] {
 					yym674 := z.EncBinary()
 					_ = yym674
@@ -9138,7 +9850,9 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq666[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym675 := z.EncBinary()
 					_ = yym675
 					if false {
@@ -9147,8 +9861,10 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep666 {
-				r.EncodeEnd()
+			if yyr666 || yy2arr666 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9163,17 +9879,18 @@ func (x *NFSVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct677 := r.ContainerType()
+		if yyct677 == codecSelferValueTypeMap1234 {
 			yyl677 := r.ReadMapStart()
 			if yyl677 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl677, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct677 == codecSelferValueTypeArray1234 {
 			yyl677 := r.ReadArrayStart()
 			if yyl677 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl677, d)
 			}
@@ -9200,8 +9917,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys678Slc = r.DecodeBytes(yys678Slc, true, true)
 		yys678 := string(yys678Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys678 {
 		case "server":
 			if r.TryDecodeAsNil() {
@@ -9225,9 +9944,7 @@ func (x *NFSVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys678)
 		} // end switch yys678
 	} // end for yyj678
-	if !yyhl678 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9244,9 +9961,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb682 = r.CheckBreak()
 	}
 	if yyb682 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Server = ""
 	} else {
@@ -9259,9 +9977,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb682 = r.CheckBreak()
 	}
 	if yyb682 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -9274,9 +9993,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb682 = r.CheckBreak()
 	}
 	if yyb682 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -9292,9 +10012,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb682 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj682-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9315,18 +10036,21 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep687, yyq687, yy2arr687
 			const yyr687 bool = false
 			yyq687[2] = x.ReadOnly != false
+			var yynn687 int
 			if yyr687 || yy2arr687 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn687 int = 2
+				yynn687 = 2
 				for _, b := range yyq687 {
 					if b {
 						yynn687++
 					}
 				}
 				r.EncodeMapStart(yynn687)
+				yynn687 = 0
 			}
 			if yyr687 || yy2arr687 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym689 := z.EncBinary()
 				_ = yym689
 				if false {
@@ -9334,7 +10058,9 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.EndpointsName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("endpoints"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym690 := z.EncBinary()
 				_ = yym690
 				if false {
@@ -9343,6 +10069,7 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr687 || yy2arr687 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym692 := z.EncBinary()
 				_ = yym692
 				if false {
@@ -9350,7 +10077,9 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym693 := z.EncBinary()
 				_ = yym693
 				if false {
@@ -9359,6 +10088,7 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr687 || yy2arr687 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq687[2] {
 					yym695 := z.EncBinary()
 					_ = yym695
@@ -9371,7 +10101,9 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq687[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym696 := z.EncBinary()
 					_ = yym696
 					if false {
@@ -9380,8 +10112,10 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep687 {
-				r.EncodeEnd()
+			if yyr687 || yy2arr687 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9396,17 +10130,18 @@ func (x *GlusterfsVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct698 := r.ContainerType()
+		if yyct698 == codecSelferValueTypeMap1234 {
 			yyl698 := r.ReadMapStart()
 			if yyl698 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl698, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct698 == codecSelferValueTypeArray1234 {
 			yyl698 := r.ReadArrayStart()
 			if yyl698 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl698, d)
 			}
@@ -9433,8 +10168,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys699Slc = r.DecodeBytes(yys699Slc, true, true)
 		yys699 := string(yys699Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys699 {
 		case "endpoints":
 			if r.TryDecodeAsNil() {
@@ -9458,9 +10195,7 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys699)
 		} // end switch yys699
 	} // end for yyj699
-	if !yyhl699 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9477,9 +10212,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb703 = r.CheckBreak()
 	}
 	if yyb703 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.EndpointsName = ""
 	} else {
@@ -9492,9 +10228,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb703 = r.CheckBreak()
 	}
 	if yyb703 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -9507,9 +10244,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb703 = r.CheckBreak()
 	}
 	if yyb703 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -9525,9 +10263,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb703 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj703-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9549,18 +10288,21 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr708 bool = false
 			yyq708[2] = x.FSType != ""
 			yyq708[7] = x.ReadOnly != false
+			var yynn708 int
 			if yyr708 || yy2arr708 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn708 int = 6
+				yynn708 = 6
 				for _, b := range yyq708 {
 					if b {
 						yynn708++
 					}
 				}
 				r.EncodeMapStart(yynn708)
+				yynn708 = 0
 			}
 			if yyr708 || yy2arr708 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.CephMonitors == nil {
 					r.EncodeNil()
 				} else {
@@ -9572,7 +10314,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("monitors"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.CephMonitors == nil {
 					r.EncodeNil()
 				} else {
@@ -9585,6 +10329,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr708 || yy2arr708 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym713 := z.EncBinary()
 				_ = yym713
 				if false {
@@ -9592,7 +10337,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RBDImage))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("image"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym714 := z.EncBinary()
 				_ = yym714
 				if false {
@@ -9601,6 +10348,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr708 || yy2arr708 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq708[2] {
 					yym716 := z.EncBinary()
 					_ = yym716
@@ -9613,7 +10361,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq708[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym717 := z.EncBinary()
 					_ = yym717
 					if false {
@@ -9623,6 +10373,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr708 || yy2arr708 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym719 := z.EncBinary()
 				_ = yym719
 				if false {
@@ -9630,7 +10381,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RBDPool))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("pool"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym720 := z.EncBinary()
 				_ = yym720
 				if false {
@@ -9639,6 +10392,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr708 || yy2arr708 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym722 := z.EncBinary()
 				_ = yym722
 				if false {
@@ -9646,7 +10400,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RadosUser))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("user"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym723 := z.EncBinary()
 				_ = yym723
 				if false {
@@ -9655,6 +10411,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr708 || yy2arr708 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym725 := z.EncBinary()
 				_ = yym725
 				if false {
@@ -9662,7 +10419,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Keyring))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("keyring"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym726 := z.EncBinary()
 				_ = yym726
 				if false {
@@ -9671,13 +10430,16 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr708 || yy2arr708 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.SecretRef == nil {
 					r.EncodeNil()
 				} else {
 					x.SecretRef.CodecEncodeSelf(e)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.SecretRef == nil {
 					r.EncodeNil()
 				} else {
@@ -9685,6 +10447,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr708 || yy2arr708 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq708[7] {
 					yym729 := z.EncBinary()
 					_ = yym729
@@ -9697,7 +10460,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq708[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym730 := z.EncBinary()
 					_ = yym730
 					if false {
@@ -9706,8 +10471,10 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep708 {
-				r.EncodeEnd()
+			if yyr708 || yy2arr708 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9722,17 +10489,18 @@ func (x *RBDVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct732 := r.ContainerType()
+		if yyct732 == codecSelferValueTypeMap1234 {
 			yyl732 := r.ReadMapStart()
 			if yyl732 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl732, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct732 == codecSelferValueTypeArray1234 {
 			yyl732 := r.ReadArrayStart()
 			if yyl732 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl732, d)
 			}
@@ -9759,8 +10527,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys733Slc = r.DecodeBytes(yys733Slc, true, true)
 		yys733 := string(yys733Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys733 {
 		case "monitors":
 			if r.TryDecodeAsNil() {
@@ -9825,9 +10595,7 @@ func (x *RBDVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys733)
 		} // end switch yys733
 	} // end for yyj733
-	if !yyhl733 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9844,9 +10612,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb743 = r.CheckBreak()
 	}
 	if yyb743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CephMonitors = nil
 	} else {
@@ -9865,9 +10634,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb743 = r.CheckBreak()
 	}
 	if yyb743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RBDImage = ""
 	} else {
@@ -9880,9 +10650,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb743 = r.CheckBreak()
 	}
 	if yyb743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -9895,9 +10666,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb743 = r.CheckBreak()
 	}
 	if yyb743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RBDPool = ""
 	} else {
@@ -9910,9 +10682,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb743 = r.CheckBreak()
 	}
 	if yyb743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RadosUser = ""
 	} else {
@@ -9925,9 +10698,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb743 = r.CheckBreak()
 	}
 	if yyb743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Keyring = ""
 	} else {
@@ -9940,9 +10714,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb743 = r.CheckBreak()
 	}
 	if yyb743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SecretRef != nil {
 			x.SecretRef = nil
@@ -9960,9 +10735,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb743 = r.CheckBreak()
 	}
 	if yyb743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -9978,9 +10754,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb743 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj743-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10002,18 +10779,21 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr754 bool = false
 			yyq754[1] = x.FSType != ""
 			yyq754[2] = x.ReadOnly != false
+			var yynn754 int
 			if yyr754 || yy2arr754 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn754 int = 1
+				yynn754 = 1
 				for _, b := range yyq754 {
 					if b {
 						yynn754++
 					}
 				}
 				r.EncodeMapStart(yynn754)
+				yynn754 = 0
 			}
 			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym756 := z.EncBinary()
 				_ = yym756
 				if false {
@@ -10021,7 +10801,9 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.VolumeID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumeID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym757 := z.EncBinary()
 				_ = yym757
 				if false {
@@ -10030,6 +10812,7 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq754[1] {
 					yym759 := z.EncBinary()
 					_ = yym759
@@ -10042,7 +10825,9 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq754[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym760 := z.EncBinary()
 					_ = yym760
 					if false {
@@ -10052,6 +10837,7 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq754[2] {
 					yym762 := z.EncBinary()
 					_ = yym762
@@ -10064,7 +10850,9 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq754[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym763 := z.EncBinary()
 					_ = yym763
 					if false {
@@ -10073,8 +10861,10 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep754 {
-				r.EncodeEnd()
+			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10089,17 +10879,18 @@ func (x *CinderVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct765 := r.ContainerType()
+		if yyct765 == codecSelferValueTypeMap1234 {
 			yyl765 := r.ReadMapStart()
 			if yyl765 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl765, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct765 == codecSelferValueTypeArray1234 {
 			yyl765 := r.ReadArrayStart()
 			if yyl765 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl765, d)
 			}
@@ -10126,8 +10917,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys766Slc = r.DecodeBytes(yys766Slc, true, true)
 		yys766 := string(yys766Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys766 {
 		case "volumeID":
 			if r.TryDecodeAsNil() {
@@ -10151,9 +10944,7 @@ func (x *CinderVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys766)
 		} // end switch yys766
 	} // end for yyj766
-	if !yyhl766 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10170,9 +10961,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb770 = r.CheckBreak()
 	}
 	if yyb770 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.VolumeID = ""
 	} else {
@@ -10185,9 +10977,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb770 = r.CheckBreak()
 	}
 	if yyb770 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -10200,9 +10993,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb770 = r.CheckBreak()
 	}
 	if yyb770 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -10218,9 +11012,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb770 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj770-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10244,18 +11039,21 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq775[2] = x.SecretFile != ""
 			yyq775[3] = x.SecretRef != nil
 			yyq775[4] = x.ReadOnly != false
+			var yynn775 int
 			if yyr775 || yy2arr775 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn775 int = 1
+				yynn775 = 1
 				for _, b := range yyq775 {
 					if b {
 						yynn775++
 					}
 				}
 				r.EncodeMapStart(yynn775)
+				yynn775 = 0
 			}
 			if yyr775 || yy2arr775 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Monitors == nil {
 					r.EncodeNil()
 				} else {
@@ -10267,7 +11065,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("monitors"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Monitors == nil {
 					r.EncodeNil()
 				} else {
@@ -10280,6 +11080,7 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr775 || yy2arr775 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq775[1] {
 					yym780 := z.EncBinary()
 					_ = yym780
@@ -10292,7 +11093,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq775[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("user"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym781 := z.EncBinary()
 					_ = yym781
 					if false {
@@ -10302,6 +11105,7 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr775 || yy2arr775 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq775[2] {
 					yym783 := z.EncBinary()
 					_ = yym783
@@ -10314,7 +11118,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq775[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secretFile"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym784 := z.EncBinary()
 					_ = yym784
 					if false {
@@ -10324,6 +11130,7 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr775 || yy2arr775 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq775[3] {
 					if x.SecretRef == nil {
 						r.EncodeNil()
@@ -10335,7 +11142,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq775[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SecretRef == nil {
 						r.EncodeNil()
 					} else {
@@ -10344,6 +11153,7 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr775 || yy2arr775 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq775[4] {
 					yym787 := z.EncBinary()
 					_ = yym787
@@ -10356,7 +11166,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq775[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym788 := z.EncBinary()
 					_ = yym788
 					if false {
@@ -10365,8 +11177,10 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep775 {
-				r.EncodeEnd()
+			if yyr775 || yy2arr775 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10381,17 +11195,18 @@ func (x *CephFSVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct790 := r.ContainerType()
+		if yyct790 == codecSelferValueTypeMap1234 {
 			yyl790 := r.ReadMapStart()
 			if yyl790 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl790, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct790 == codecSelferValueTypeArray1234 {
 			yyl790 := r.ReadArrayStart()
 			if yyl790 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl790, d)
 			}
@@ -10418,8 +11233,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys791Slc = r.DecodeBytes(yys791Slc, true, true)
 		yys791 := string(yys791Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys791 {
 		case "monitors":
 			if r.TryDecodeAsNil() {
@@ -10466,9 +11283,7 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys791)
 		} // end switch yys791
 	} // end for yyj791
-	if !yyhl791 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10485,9 +11300,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb798 = r.CheckBreak()
 	}
 	if yyb798 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Monitors = nil
 	} else {
@@ -10506,9 +11322,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb798 = r.CheckBreak()
 	}
 	if yyb798 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.User = ""
 	} else {
@@ -10521,9 +11338,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb798 = r.CheckBreak()
 	}
 	if yyb798 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SecretFile = ""
 	} else {
@@ -10536,9 +11354,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb798 = r.CheckBreak()
 	}
 	if yyb798 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SecretRef != nil {
 			x.SecretRef = nil
@@ -10556,9 +11375,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb798 = r.CheckBreak()
 	}
 	if yyb798 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -10574,9 +11394,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb798 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj798-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *FlockerVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10596,18 +11417,21 @@ func (x *FlockerVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq806 [1]bool
 			_, _, _ = yysep806, yyq806, yy2arr806
 			const yyr806 bool = false
+			var yynn806 int
 			if yyr806 || yy2arr806 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn806 int = 1
+				yynn806 = 1
 				for _, b := range yyq806 {
 					if b {
 						yynn806++
 					}
 				}
 				r.EncodeMapStart(yynn806)
+				yynn806 = 0
 			}
 			if yyr806 || yy2arr806 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym808 := z.EncBinary()
 				_ = yym808
 				if false {
@@ -10615,7 +11439,9 @@ func (x *FlockerVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.DatasetName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("datasetName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym809 := z.EncBinary()
 				_ = yym809
 				if false {
@@ -10623,8 +11449,10 @@ func (x *FlockerVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.DatasetName))
 				}
 			}
-			if yysep806 {
-				r.EncodeEnd()
+			if yyr806 || yy2arr806 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10639,17 +11467,18 @@ func (x *FlockerVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct811 := r.ContainerType()
+		if yyct811 == codecSelferValueTypeMap1234 {
 			yyl811 := r.ReadMapStart()
 			if yyl811 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl811, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct811 == codecSelferValueTypeArray1234 {
 			yyl811 := r.ReadArrayStart()
 			if yyl811 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl811, d)
 			}
@@ -10676,8 +11505,10 @@ func (x *FlockerVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys812Slc = r.DecodeBytes(yys812Slc, true, true)
 		yys812 := string(yys812Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys812 {
 		case "datasetName":
 			if r.TryDecodeAsNil() {
@@ -10689,9 +11520,7 @@ func (x *FlockerVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys812)
 		} // end switch yys812
 	} // end for yyj812
-	if !yyhl812 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *FlockerVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10708,9 +11537,10 @@ func (x *FlockerVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb814 = r.CheckBreak()
 	}
 	if yyb814 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DatasetName = ""
 	} else {
@@ -10726,9 +11556,10 @@ func (x *FlockerVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb814 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj814-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10749,18 +11580,21 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep817, yyq817, yy2arr817
 			const yyr817 bool = false
 			yyq817[0] = len(x.Items) != 0
+			var yynn817 int
 			if yyr817 || yy2arr817 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn817 int = 0
+				yynn817 = 0
 				for _, b := range yyq817 {
 					if b {
 						yynn817++
 					}
 				}
 				r.EncodeMapStart(yynn817)
+				yynn817 = 0
 			}
 			if yyr817 || yy2arr817 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq817[0] {
 					if x.Items == nil {
 						r.EncodeNil()
@@ -10777,7 +11611,9 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq817[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
@@ -10790,8 +11626,10 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep817 {
-				r.EncodeEnd()
+			if yyr817 || yy2arr817 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10806,17 +11644,18 @@ func (x *DownwardAPIVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct822 := r.ContainerType()
+		if yyct822 == codecSelferValueTypeMap1234 {
 			yyl822 := r.ReadMapStart()
 			if yyl822 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl822, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct822 == codecSelferValueTypeArray1234 {
 			yyl822 := r.ReadArrayStart()
 			if yyl822 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl822, d)
 			}
@@ -10843,8 +11682,10 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys823Slc = r.DecodeBytes(yys823Slc, true, true)
 		yys823 := string(yys823Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys823 {
 		case "items":
 			if r.TryDecodeAsNil() {
@@ -10862,9 +11703,7 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			z.DecStructFieldNotFound(-1, yys823)
 		} // end switch yys823
 	} // end for yyj823
-	if !yyhl823 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DownwardAPIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10881,9 +11720,10 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb826 = r.CheckBreak()
 	}
 	if yyb826 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -10905,9 +11745,10 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if yyb826 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj826-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10927,18 +11768,21 @@ func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq830 [2]bool
 			_, _, _ = yysep830, yyq830, yy2arr830
 			const yyr830 bool = false
+			var yynn830 int
 			if yyr830 || yy2arr830 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn830 int = 2
+				yynn830 = 2
 				for _, b := range yyq830 {
 					if b {
 						yynn830++
 					}
 				}
 				r.EncodeMapStart(yynn830)
+				yynn830 = 0
 			}
 			if yyr830 || yy2arr830 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym832 := z.EncBinary()
 				_ = yym832
 				if false {
@@ -10946,7 +11790,9 @@ func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym833 := z.EncBinary()
 				_ = yym833
 				if false {
@@ -10955,15 +11801,20 @@ func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr830 || yy2arr830 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy835 := &x.FieldRef
 				yy835.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fieldRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy836 := &x.FieldRef
 				yy836.CodecEncodeSelf(e)
 			}
-			if yysep830 {
-				r.EncodeEnd()
+			if yyr830 || yy2arr830 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10978,17 +11829,18 @@ func (x *DownwardAPIVolumeFile) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct838 := r.ContainerType()
+		if yyct838 == codecSelferValueTypeMap1234 {
 			yyl838 := r.ReadMapStart()
 			if yyl838 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl838, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct838 == codecSelferValueTypeArray1234 {
 			yyl838 := r.ReadArrayStart()
 			if yyl838 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl838, d)
 			}
@@ -11015,8 +11867,10 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys839Slc = r.DecodeBytes(yys839Slc, true, true)
 		yys839 := string(yys839Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys839 {
 		case "path":
 			if r.TryDecodeAsNil() {
@@ -11035,9 +11889,7 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys839)
 		} // end switch yys839
 	} // end for yyj839
-	if !yyhl839 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11054,9 +11906,10 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb842 = r.CheckBreak()
 	}
 	if yyb842 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -11069,9 +11922,10 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb842 = r.CheckBreak()
 	}
 	if yyb842 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FieldRef = ObjectFieldSelector{}
 	} else {
@@ -11088,9 +11942,10 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb842 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj842-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11114,18 +11969,21 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq846[1] = x.HostPort != 0
 			yyq846[3] = x.Protocol != ""
 			yyq846[4] = x.HostIP != ""
+			var yynn846 int
 			if yyr846 || yy2arr846 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn846 int = 1
+				yynn846 = 1
 				for _, b := range yyq846 {
 					if b {
 						yynn846++
 					}
 				}
 				r.EncodeMapStart(yynn846)
+				yynn846 = 0
 			}
 			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq846[0] {
 					yym848 := z.EncBinary()
 					_ = yym848
@@ -11138,7 +11996,9 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq846[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym849 := z.EncBinary()
 					_ = yym849
 					if false {
@@ -11148,6 +12008,7 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq846[1] {
 					yym851 := z.EncBinary()
 					_ = yym851
@@ -11160,7 +12021,9 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq846[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPort"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym852 := z.EncBinary()
 					_ = yym852
 					if false {
@@ -11170,6 +12033,7 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym854 := z.EncBinary()
 				_ = yym854
 				if false {
@@ -11177,7 +12041,9 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.ContainerPort))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("containerPort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym855 := z.EncBinary()
 				_ = yym855
 				if false {
@@ -11186,6 +12052,7 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq846[3] {
 					x.Protocol.CodecEncodeSelf(e)
 				} else {
@@ -11193,11 +12060,14 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq846[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("protocol"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Protocol.CodecEncodeSelf(e)
 				}
 			}
 			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq846[4] {
 					yym858 := z.EncBinary()
 					_ = yym858
@@ -11210,7 +12080,9 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq846[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym859 := z.EncBinary()
 					_ = yym859
 					if false {
@@ -11219,8 +12091,10 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep846 {
-				r.EncodeEnd()
+			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11235,17 +12109,18 @@ func (x *ContainerPort) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct861 := r.ContainerType()
+		if yyct861 == codecSelferValueTypeMap1234 {
 			yyl861 := r.ReadMapStart()
 			if yyl861 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl861, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct861 == codecSelferValueTypeArray1234 {
 			yyl861 := r.ReadArrayStart()
 			if yyl861 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl861, d)
 			}
@@ -11272,8 +12147,10 @@ func (x *ContainerPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys862Slc = r.DecodeBytes(yys862Slc, true, true)
 		yys862 := string(yys862Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys862 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -11309,9 +12186,7 @@ func (x *ContainerPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys862)
 		} // end switch yys862
 	} // end for yyj862
-	if !yyhl862 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11328,9 +12203,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb868 = r.CheckBreak()
 	}
 	if yyb868 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -11343,9 +12219,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb868 = r.CheckBreak()
 	}
 	if yyb868 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostPort = 0
 	} else {
@@ -11358,9 +12235,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb868 = r.CheckBreak()
 	}
 	if yyb868 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerPort = 0
 	} else {
@@ -11373,9 +12251,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb868 = r.CheckBreak()
 	}
 	if yyb868 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Protocol = ""
 	} else {
@@ -11388,9 +12267,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb868 = r.CheckBreak()
 	}
 	if yyb868 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostIP = ""
 	} else {
@@ -11406,9 +12286,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb868 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj868-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11429,18 +12310,21 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep875, yyq875, yy2arr875
 			const yyr875 bool = false
 			yyq875[1] = x.ReadOnly != false
+			var yynn875 int
 			if yyr875 || yy2arr875 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn875 int = 2
+				yynn875 = 2
 				for _, b := range yyq875 {
 					if b {
 						yynn875++
 					}
 				}
 				r.EncodeMapStart(yynn875)
+				yynn875 = 0
 			}
 			if yyr875 || yy2arr875 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym877 := z.EncBinary()
 				_ = yym877
 				if false {
@@ -11448,7 +12332,9 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym878 := z.EncBinary()
 				_ = yym878
 				if false {
@@ -11457,6 +12343,7 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr875 || yy2arr875 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq875[1] {
 					yym880 := z.EncBinary()
 					_ = yym880
@@ -11469,7 +12356,9 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq875[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym881 := z.EncBinary()
 					_ = yym881
 					if false {
@@ -11479,6 +12368,7 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr875 || yy2arr875 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym883 := z.EncBinary()
 				_ = yym883
 				if false {
@@ -11486,7 +12376,9 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MountPath))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("mountPath"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym884 := z.EncBinary()
 				_ = yym884
 				if false {
@@ -11494,8 +12386,10 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MountPath))
 				}
 			}
-			if yysep875 {
-				r.EncodeEnd()
+			if yyr875 || yy2arr875 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11510,17 +12404,18 @@ func (x *VolumeMount) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct886 := r.ContainerType()
+		if yyct886 == codecSelferValueTypeMap1234 {
 			yyl886 := r.ReadMapStart()
 			if yyl886 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl886, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct886 == codecSelferValueTypeArray1234 {
 			yyl886 := r.ReadArrayStart()
 			if yyl886 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl886, d)
 			}
@@ -11547,8 +12442,10 @@ func (x *VolumeMount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys887Slc = r.DecodeBytes(yys887Slc, true, true)
 		yys887 := string(yys887Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys887 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -11572,9 +12469,7 @@ func (x *VolumeMount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys887)
 		} // end switch yys887
 	} // end for yyj887
-	if !yyhl887 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11591,9 +12486,10 @@ func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb891 = r.CheckBreak()
 	}
 	if yyb891 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -11606,9 +12502,10 @@ func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb891 = r.CheckBreak()
 	}
 	if yyb891 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -11621,9 +12518,10 @@ func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb891 = r.CheckBreak()
 	}
 	if yyb891 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MountPath = ""
 	} else {
@@ -11639,9 +12537,10 @@ func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb891 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj891-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11663,18 +12562,21 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr896 bool = false
 			yyq896[1] = x.Value != ""
 			yyq896[2] = x.ValueFrom != nil
+			var yynn896 int
 			if yyr896 || yy2arr896 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn896 int = 1
+				yynn896 = 1
 				for _, b := range yyq896 {
 					if b {
 						yynn896++
 					}
 				}
 				r.EncodeMapStart(yynn896)
+				yynn896 = 0
 			}
 			if yyr896 || yy2arr896 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym898 := z.EncBinary()
 				_ = yym898
 				if false {
@@ -11682,7 +12584,9 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym899 := z.EncBinary()
 				_ = yym899
 				if false {
@@ -11691,6 +12595,7 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr896 || yy2arr896 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq896[1] {
 					yym901 := z.EncBinary()
 					_ = yym901
@@ -11703,7 +12608,9 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq896[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("value"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym902 := z.EncBinary()
 					_ = yym902
 					if false {
@@ -11713,6 +12620,7 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr896 || yy2arr896 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq896[2] {
 					if x.ValueFrom == nil {
 						r.EncodeNil()
@@ -11724,7 +12632,9 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq896[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("valueFrom"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ValueFrom == nil {
 						r.EncodeNil()
 					} else {
@@ -11732,8 +12642,10 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep896 {
-				r.EncodeEnd()
+			if yyr896 || yy2arr896 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11748,17 +12660,18 @@ func (x *EnvVar) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct905 := r.ContainerType()
+		if yyct905 == codecSelferValueTypeMap1234 {
 			yyl905 := r.ReadMapStart()
 			if yyl905 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl905, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct905 == codecSelferValueTypeArray1234 {
 			yyl905 := r.ReadArrayStart()
 			if yyl905 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl905, d)
 			}
@@ -11785,8 +12698,10 @@ func (x *EnvVar) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys906Slc = r.DecodeBytes(yys906Slc, true, true)
 		yys906 := string(yys906Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys906 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -11815,9 +12730,7 @@ func (x *EnvVar) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys906)
 		} // end switch yys906
 	} // end for yyj906
-	if !yyhl906 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11834,9 +12747,10 @@ func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb910 = r.CheckBreak()
 	}
 	if yyb910 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -11849,9 +12763,10 @@ func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb910 = r.CheckBreak()
 	}
 	if yyb910 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Value = ""
 	} else {
@@ -11864,9 +12779,10 @@ func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb910 = r.CheckBreak()
 	}
 	if yyb910 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ValueFrom != nil {
 			x.ValueFrom = nil
@@ -11887,9 +12803,10 @@ func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb910 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj910-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EnvVarSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11909,33 +12826,40 @@ func (x *EnvVarSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq915 [1]bool
 			_, _, _ = yysep915, yyq915, yy2arr915
 			const yyr915 bool = false
+			var yynn915 int
 			if yyr915 || yy2arr915 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn915 int = 1
+				yynn915 = 1
 				for _, b := range yyq915 {
 					if b {
 						yynn915++
 					}
 				}
 				r.EncodeMapStart(yynn915)
+				yynn915 = 0
 			}
 			if yyr915 || yy2arr915 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.FieldRef == nil {
 					r.EncodeNil()
 				} else {
 					x.FieldRef.CodecEncodeSelf(e)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fieldRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.FieldRef == nil {
 					r.EncodeNil()
 				} else {
 					x.FieldRef.CodecEncodeSelf(e)
 				}
 			}
-			if yysep915 {
-				r.EncodeEnd()
+			if yyr915 || yy2arr915 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11950,17 +12874,18 @@ func (x *EnvVarSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct918 := r.ContainerType()
+		if yyct918 == codecSelferValueTypeMap1234 {
 			yyl918 := r.ReadMapStart()
 			if yyl918 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl918, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct918 == codecSelferValueTypeArray1234 {
 			yyl918 := r.ReadArrayStart()
 			if yyl918 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl918, d)
 			}
@@ -11987,8 +12912,10 @@ func (x *EnvVarSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys919Slc = r.DecodeBytes(yys919Slc, true, true)
 		yys919 := string(yys919Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys919 {
 		case "fieldRef":
 			if r.TryDecodeAsNil() {
@@ -12005,9 +12932,7 @@ func (x *EnvVarSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys919)
 		} // end switch yys919
 	} // end for yyj919
-	if !yyhl919 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EnvVarSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12024,9 +12949,10 @@ func (x *EnvVarSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb921 = r.CheckBreak()
 	}
 	if yyb921 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FieldRef != nil {
 			x.FieldRef = nil
@@ -12047,9 +12973,10 @@ func (x *EnvVarSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb921 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj921-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12069,18 +12996,21 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq924 [2]bool
 			_, _, _ = yysep924, yyq924, yy2arr924
 			const yyr924 bool = false
+			var yynn924 int
 			if yyr924 || yy2arr924 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn924 int = 2
+				yynn924 = 2
 				for _, b := range yyq924 {
 					if b {
 						yynn924++
 					}
 				}
 				r.EncodeMapStart(yynn924)
+				yynn924 = 0
 			}
 			if yyr924 || yy2arr924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym926 := z.EncBinary()
 				_ = yym926
 				if false {
@@ -12088,7 +13018,9 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym927 := z.EncBinary()
 				_ = yym927
 				if false {
@@ -12097,6 +13029,7 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr924 || yy2arr924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym929 := z.EncBinary()
 				_ = yym929
 				if false {
@@ -12104,7 +13037,9 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fieldPath"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym930 := z.EncBinary()
 				_ = yym930
 				if false {
@@ -12112,8 +13047,10 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 				}
 			}
-			if yysep924 {
-				r.EncodeEnd()
+			if yyr924 || yy2arr924 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12128,17 +13065,18 @@ func (x *ObjectFieldSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct932 := r.ContainerType()
+		if yyct932 == codecSelferValueTypeMap1234 {
 			yyl932 := r.ReadMapStart()
 			if yyl932 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl932, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct932 == codecSelferValueTypeArray1234 {
 			yyl932 := r.ReadArrayStart()
 			if yyl932 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl932, d)
 			}
@@ -12165,8 +13103,10 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys933Slc = r.DecodeBytes(yys933Slc, true, true)
 		yys933 := string(yys933Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys933 {
 		case "apiVersion":
 			if r.TryDecodeAsNil() {
@@ -12184,9 +13124,7 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys933)
 		} // end switch yys933
 	} // end for yyj933
-	if !yyhl933 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ObjectFieldSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12203,9 +13141,10 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb936 = r.CheckBreak()
 	}
 	if yyb936 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -12218,9 +13157,10 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb936 = r.CheckBreak()
 	}
 	if yyb936 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FieldPath = ""
 	} else {
@@ -12236,9 +13176,10 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb936 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj936-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12262,18 +13203,21 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq940[1] = true
 			yyq940[2] = x.Host != ""
 			yyq940[3] = x.Scheme != ""
+			var yynn940 int
 			if yyr940 || yy2arr940 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn940 int = 0
+				yynn940 = 0
 				for _, b := range yyq940 {
 					if b {
 						yynn940++
 					}
 				}
 				r.EncodeMapStart(yynn940)
+				yynn940 = 0
 			}
 			if yyr940 || yy2arr940 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq940[0] {
 					yym942 := z.EncBinary()
 					_ = yym942
@@ -12286,7 +13230,9 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq940[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym943 := z.EncBinary()
 					_ = yym943
 					if false {
@@ -12296,6 +13242,7 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr940 || yy2arr940 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq940[1] {
 					yy945 := &x.Port
 					yym946 := z.EncBinary()
@@ -12312,7 +13259,9 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq940[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("port"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy947 := &x.Port
 					yym948 := z.EncBinary()
 					_ = yym948
@@ -12326,6 +13275,7 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr940 || yy2arr940 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq940[2] {
 					yym950 := z.EncBinary()
 					_ = yym950
@@ -12338,7 +13288,9 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq940[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym951 := z.EncBinary()
 					_ = yym951
 					if false {
@@ -12348,6 +13300,7 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr940 || yy2arr940 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq940[3] {
 					x.Scheme.CodecEncodeSelf(e)
 				} else {
@@ -12355,12 +13308,16 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq940[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("scheme"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Scheme.CodecEncodeSelf(e)
 				}
 			}
-			if yysep940 {
-				r.EncodeEnd()
+			if yyr940 || yy2arr940 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12375,17 +13332,18 @@ func (x *HTTPGetAction) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct954 := r.ContainerType()
+		if yyct954 == codecSelferValueTypeMap1234 {
 			yyl954 := r.ReadMapStart()
 			if yyl954 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl954, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct954 == codecSelferValueTypeArray1234 {
 			yyl954 := r.ReadArrayStart()
 			if yyl954 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl954, d)
 			}
@@ -12412,8 +13370,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys955Slc = r.DecodeBytes(yys955Slc, true, true)
 		yys955 := string(yys955Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys955 {
 		case "path":
 			if r.TryDecodeAsNil() {
@@ -12452,9 +13412,7 @@ func (x *HTTPGetAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys955)
 		} // end switch yys955
 	} // end for yyj955
-	if !yyhl955 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12471,9 +13429,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb961 = r.CheckBreak()
 	}
 	if yyb961 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -12486,9 +13445,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb961 = r.CheckBreak()
 	}
 	if yyb961 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = pkg5_intstr.IntOrString{}
 	} else {
@@ -12510,9 +13470,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb961 = r.CheckBreak()
 	}
 	if yyb961 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Host = ""
 	} else {
@@ -12525,9 +13486,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb961 = r.CheckBreak()
 	}
 	if yyb961 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Scheme = ""
 	} else {
@@ -12543,9 +13505,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb961 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj961-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x URIScheme) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12592,18 +13555,21 @@ func (x *TCPSocketAction) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep970, yyq970, yy2arr970
 			const yyr970 bool = false
 			yyq970[0] = true
+			var yynn970 int
 			if yyr970 || yy2arr970 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn970 int = 0
+				yynn970 = 0
 				for _, b := range yyq970 {
 					if b {
 						yynn970++
 					}
 				}
 				r.EncodeMapStart(yynn970)
+				yynn970 = 0
 			}
 			if yyr970 || yy2arr970 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq970[0] {
 					yy972 := &x.Port
 					yym973 := z.EncBinary()
@@ -12620,7 +13586,9 @@ func (x *TCPSocketAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq970[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("port"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy974 := &x.Port
 					yym975 := z.EncBinary()
 					_ = yym975
@@ -12633,8 +13601,10 @@ func (x *TCPSocketAction) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep970 {
-				r.EncodeEnd()
+			if yyr970 || yy2arr970 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12649,17 +13619,18 @@ func (x *TCPSocketAction) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct977 := r.ContainerType()
+		if yyct977 == codecSelferValueTypeMap1234 {
 			yyl977 := r.ReadMapStart()
 			if yyl977 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl977, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct977 == codecSelferValueTypeArray1234 {
 			yyl977 := r.ReadArrayStart()
 			if yyl977 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl977, d)
 			}
@@ -12686,8 +13657,10 @@ func (x *TCPSocketAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys978Slc = r.DecodeBytes(yys978Slc, true, true)
 		yys978 := string(yys978Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys978 {
 		case "port":
 			if r.TryDecodeAsNil() {
@@ -12708,9 +13681,7 @@ func (x *TCPSocketAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys978)
 		} // end switch yys978
 	} // end for yyj978
-	if !yyhl978 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *TCPSocketAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12727,9 +13698,10 @@ func (x *TCPSocketAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb981 = r.CheckBreak()
 	}
 	if yyb981 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = pkg5_intstr.IntOrString{}
 	} else {
@@ -12754,9 +13726,10 @@ func (x *TCPSocketAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb981 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj981-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ExecAction) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12777,18 +13750,21 @@ func (x *ExecAction) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep985, yyq985, yy2arr985
 			const yyr985 bool = false
 			yyq985[0] = len(x.Command) != 0
+			var yynn985 int
 			if yyr985 || yy2arr985 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn985 int = 0
+				yynn985 = 0
 				for _, b := range yyq985 {
 					if b {
 						yynn985++
 					}
 				}
 				r.EncodeMapStart(yynn985)
+				yynn985 = 0
 			}
 			if yyr985 || yy2arr985 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq985[0] {
 					if x.Command == nil {
 						r.EncodeNil()
@@ -12805,7 +13781,9 @@ func (x *ExecAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq985[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("command"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Command == nil {
 						r.EncodeNil()
 					} else {
@@ -12818,8 +13796,10 @@ func (x *ExecAction) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep985 {
-				r.EncodeEnd()
+			if yyr985 || yy2arr985 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12834,17 +13814,18 @@ func (x *ExecAction) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct990 := r.ContainerType()
+		if yyct990 == codecSelferValueTypeMap1234 {
 			yyl990 := r.ReadMapStart()
 			if yyl990 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl990, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct990 == codecSelferValueTypeArray1234 {
 			yyl990 := r.ReadArrayStart()
 			if yyl990 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl990, d)
 			}
@@ -12871,8 +13852,10 @@ func (x *ExecAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys991Slc = r.DecodeBytes(yys991Slc, true, true)
 		yys991 := string(yys991Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys991 {
 		case "command":
 			if r.TryDecodeAsNil() {
@@ -12890,9 +13873,7 @@ func (x *ExecAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys991)
 		} // end switch yys991
 	} // end for yyj991
-	if !yyhl991 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ExecAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12909,9 +13890,10 @@ func (x *ExecAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb994 = r.CheckBreak()
 	}
 	if yyb994 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
@@ -12933,9 +13915,10 @@ func (x *ExecAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb994 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj994-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12963,16 +13946,18 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq998[5] = x.PeriodSeconds != 0
 			yyq998[6] = x.SuccessThreshold != 0
 			yyq998[7] = x.FailureThreshold != 0
+			var yynn998 int
 			if yyr998 || yy2arr998 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn998 int = 0
+				yynn998 = 0
 				for _, b := range yyq998 {
 					if b {
 						yynn998++
 					}
 				}
 				r.EncodeMapStart(yynn998)
+				yynn998 = 0
 			}
 			var yyn999 bool
 			if x.Handler.Exec == nil {
@@ -12984,6 +13969,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn999 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq998[0] {
 						if x.Exec == nil {
 							r.EncodeNil()
@@ -12996,7 +13982,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq998[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("exec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn999 {
 						r.EncodeNil()
 					} else {
@@ -13018,6 +14006,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn1000 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq998[1] {
 						if x.HTTPGet == nil {
 							r.EncodeNil()
@@ -13030,7 +14019,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq998[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("httpGet"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn1000 {
 						r.EncodeNil()
 					} else {
@@ -13052,6 +14043,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn1001 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq998[2] {
 						if x.TCPSocket == nil {
 							r.EncodeNil()
@@ -13064,7 +14056,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq998[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tcpSocket"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn1001 {
 						r.EncodeNil()
 					} else {
@@ -13077,6 +14071,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq998[3] {
 					yym1003 := z.EncBinary()
 					_ = yym1003
@@ -13089,7 +14084,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq998[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("initialDelaySeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1004 := z.EncBinary()
 					_ = yym1004
 					if false {
@@ -13099,6 +14096,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq998[4] {
 					yym1006 := z.EncBinary()
 					_ = yym1006
@@ -13111,7 +14109,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq998[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1007 := z.EncBinary()
 					_ = yym1007
 					if false {
@@ -13121,6 +14121,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq998[5] {
 					yym1009 := z.EncBinary()
 					_ = yym1009
@@ -13133,7 +14134,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq998[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("periodSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1010 := z.EncBinary()
 					_ = yym1010
 					if false {
@@ -13143,6 +14146,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq998[6] {
 					yym1012 := z.EncBinary()
 					_ = yym1012
@@ -13155,7 +14159,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq998[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("successThreshold"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1013 := z.EncBinary()
 					_ = yym1013
 					if false {
@@ -13165,6 +14171,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq998[7] {
 					yym1015 := z.EncBinary()
 					_ = yym1015
@@ -13177,7 +14184,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq998[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("failureThreshold"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1016 := z.EncBinary()
 					_ = yym1016
 					if false {
@@ -13186,8 +14195,10 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep998 {
-				r.EncodeEnd()
+			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -13202,17 +14213,18 @@ func (x *Probe) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1018 := r.ContainerType()
+		if yyct1018 == codecSelferValueTypeMap1234 {
 			yyl1018 := r.ReadMapStart()
 			if yyl1018 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1018, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1018 == codecSelferValueTypeArray1234 {
 			yyl1018 := r.ReadArrayStart()
 			if yyl1018 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1018, d)
 			}
@@ -13239,8 +14251,10 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1019Slc = r.DecodeBytes(yys1019Slc, true, true)
 		yys1019 := string(yys1019Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1019 {
 		case "exec":
 			if x.Handler.Exec == nil {
@@ -13318,9 +14332,7 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1019)
 		} // end switch yys1019
 	} // end for yyj1019
-	if !yyhl1019 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -13330,6 +14342,9 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1028 int
 	var yyb1028 bool
 	var yyhl1028 bool = l >= 0
+	if x.Handler.Exec == nil {
+		x.Handler.Exec = new(ExecAction)
+	}
 	yyj1028++
 	if yyhl1028 {
 		yyb1028 = yyj1028 > l
@@ -13337,9 +14352,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1028 = r.CheckBreak()
 	}
 	if yyb1028 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Exec != nil {
 			x.Exec = nil
@@ -13350,6 +14366,9 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Exec.CodecDecodeSelf(d)
 	}
+	if x.Handler.HTTPGet == nil {
+		x.Handler.HTTPGet = new(HTTPGetAction)
+	}
 	yyj1028++
 	if yyhl1028 {
 		yyb1028 = yyj1028 > l
@@ -13357,9 +14376,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1028 = r.CheckBreak()
 	}
 	if yyb1028 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HTTPGet != nil {
 			x.HTTPGet = nil
@@ -13370,6 +14390,9 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.HTTPGet.CodecDecodeSelf(d)
 	}
+	if x.Handler.TCPSocket == nil {
+		x.Handler.TCPSocket = new(TCPSocketAction)
+	}
 	yyj1028++
 	if yyhl1028 {
 		yyb1028 = yyj1028 > l
@@ -13377,9 +14400,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1028 = r.CheckBreak()
 	}
 	if yyb1028 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TCPSocket != nil {
 			x.TCPSocket = nil
@@ -13397,9 +14421,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1028 = r.CheckBreak()
 	}
 	if yyb1028 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.InitialDelaySeconds = 0
 	} else {
@@ -13412,9 +14437,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1028 = r.CheckBreak()
 	}
 	if yyb1028 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TimeoutSeconds = 0
 	} else {
@@ -13427,9 +14453,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1028 = r.CheckBreak()
 	}
 	if yyb1028 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PeriodSeconds = 0
 	} else {
@@ -13442,9 +14469,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1028 = r.CheckBreak()
 	}
 	if yyb1028 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SuccessThreshold = 0
 	} else {
@@ -13457,9 +14485,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1028 = r.CheckBreak()
 	}
 	if yyb1028 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FailureThreshold = 0
 	} else {
@@ -13475,9 +14504,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1028 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1028-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PullPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -13551,18 +14581,21 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1042 bool = false
 			yyq1042[0] = len(x.Add) != 0
 			yyq1042[1] = len(x.Drop) != 0
+			var yynn1042 int
 			if yyr1042 || yy2arr1042 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1042 int = 0
+				yynn1042 = 0
 				for _, b := range yyq1042 {
 					if b {
 						yynn1042++
 					}
 				}
 				r.EncodeMapStart(yynn1042)
+				yynn1042 = 0
 			}
 			if yyr1042 || yy2arr1042 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1042[0] {
 					if x.Add == nil {
 						r.EncodeNil()
@@ -13579,7 +14612,9 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1042[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("add"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Add == nil {
 						r.EncodeNil()
 					} else {
@@ -13593,6 +14628,7 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1042 || yy2arr1042 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1042[1] {
 					if x.Drop == nil {
 						r.EncodeNil()
@@ -13609,7 +14645,9 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1042[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("drop"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Drop == nil {
 						r.EncodeNil()
 					} else {
@@ -13622,8 +14660,10 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1042 {
-				r.EncodeEnd()
+			if yyr1042 || yy2arr1042 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -13638,17 +14678,18 @@ func (x *Capabilities) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1050 := r.ContainerType()
+		if yyct1050 == codecSelferValueTypeMap1234 {
 			yyl1050 := r.ReadMapStart()
 			if yyl1050 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1050, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1050 == codecSelferValueTypeArray1234 {
 			yyl1050 := r.ReadArrayStart()
 			if yyl1050 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1050, d)
 			}
@@ -13675,8 +14716,10 @@ func (x *Capabilities) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1051Slc = r.DecodeBytes(yys1051Slc, true, true)
 		yys1051 := string(yys1051Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1051 {
 		case "add":
 			if r.TryDecodeAsNil() {
@@ -13706,9 +14749,7 @@ func (x *Capabilities) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1051)
 		} // end switch yys1051
 	} // end for yyj1051
-	if !yyhl1051 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Capabilities) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -13725,9 +14766,10 @@ func (x *Capabilities) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1056 = r.CheckBreak()
 	}
 	if yyb1056 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Add = nil
 	} else {
@@ -13746,9 +14788,10 @@ func (x *Capabilities) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1056 = r.CheckBreak()
 	}
 	if yyb1056 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Drop = nil
 	} else {
@@ -13770,9 +14813,10 @@ func (x *Capabilities) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1056 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1056-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -13794,18 +14838,21 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1062 bool = false
 			yyq1062[0] = len(x.Limits) != 0
 			yyq1062[1] = len(x.Requests) != 0
+			var yynn1062 int
 			if yyr1062 || yy2arr1062 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1062 int = 0
+				yynn1062 = 0
 				for _, b := range yyq1062 {
 					if b {
 						yynn1062++
 					}
 				}
 				r.EncodeMapStart(yynn1062)
+				yynn1062 = 0
 			}
 			if yyr1062 || yy2arr1062 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1062[0] {
 					if x.Limits == nil {
 						r.EncodeNil()
@@ -13817,7 +14864,9 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1062[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("limits"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Limits == nil {
 						r.EncodeNil()
 					} else {
@@ -13826,6 +14875,7 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1062 || yy2arr1062 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1062[1] {
 					if x.Requests == nil {
 						r.EncodeNil()
@@ -13837,7 +14887,9 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1062[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("requests"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Requests == nil {
 						r.EncodeNil()
 					} else {
@@ -13845,8 +14897,10 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1062 {
-				r.EncodeEnd()
+			if yyr1062 || yy2arr1062 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -13861,17 +14915,18 @@ func (x *ResourceRequirements) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1066 := r.ContainerType()
+		if yyct1066 == codecSelferValueTypeMap1234 {
 			yyl1066 := r.ReadMapStart()
 			if yyl1066 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1066, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1066 == codecSelferValueTypeArray1234 {
 			yyl1066 := r.ReadArrayStart()
 			if yyl1066 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1066, d)
 			}
@@ -13898,8 +14953,10 @@ func (x *ResourceRequirements) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1067Slc = r.DecodeBytes(yys1067Slc, true, true)
 		yys1067 := string(yys1067Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1067 {
 		case "limits":
 			if r.TryDecodeAsNil() {
@@ -13919,9 +14976,7 @@ func (x *ResourceRequirements) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys1067)
 		} // end switch yys1067
 	} // end for yyj1067
-	if !yyhl1067 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceRequirements) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -13938,9 +14993,10 @@ func (x *ResourceRequirements) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb1070 = r.CheckBreak()
 	}
 	if yyb1070 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Limits = nil
 	} else {
@@ -13954,9 +15010,10 @@ func (x *ResourceRequirements) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb1070 = r.CheckBreak()
 	}
 	if yyb1070 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Requests = nil
 	} else {
@@ -13973,9 +15030,10 @@ func (x *ResourceRequirements) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb1070 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1070-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -14010,18 +15068,21 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1074[15] = x.Stdin != false
 			yyq1074[16] = x.StdinOnce != false
 			yyq1074[17] = x.TTY != false
+			var yynn1074 int
 			if yyr1074 || yy2arr1074 {
 				r.EncodeArrayStart(18)
 			} else {
-				var yynn1074 int = 3
+				yynn1074 = 3
 				for _, b := range yyq1074 {
 					if b {
 						yynn1074++
 					}
 				}
 				r.EncodeMapStart(yynn1074)
+				yynn1074 = 0
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1076 := z.EncBinary()
 				_ = yym1076
 				if false {
@@ -14029,7 +15090,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1077 := z.EncBinary()
 				_ = yym1077
 				if false {
@@ -14038,6 +15101,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1079 := z.EncBinary()
 				_ = yym1079
 				if false {
@@ -14045,7 +15109,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Image))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("image"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1080 := z.EncBinary()
 				_ = yym1080
 				if false {
@@ -14054,6 +15120,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[2] {
 					if x.Command == nil {
 						r.EncodeNil()
@@ -14070,7 +15137,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("command"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Command == nil {
 						r.EncodeNil()
 					} else {
@@ -14084,6 +15153,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[3] {
 					if x.Args == nil {
 						r.EncodeNil()
@@ -14100,7 +15170,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("args"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Args == nil {
 						r.EncodeNil()
 					} else {
@@ -14114,6 +15186,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[4] {
 					yym1088 := z.EncBinary()
 					_ = yym1088
@@ -14126,7 +15199,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("workingDir"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1089 := z.EncBinary()
 					_ = yym1089
 					if false {
@@ -14136,6 +15211,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[5] {
 					if x.Ports == nil {
 						r.EncodeNil()
@@ -14152,7 +15228,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("ports"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Ports == nil {
 						r.EncodeNil()
 					} else {
@@ -14166,6 +15244,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[6] {
 					if x.Env == nil {
 						r.EncodeNil()
@@ -14182,7 +15261,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("env"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Env == nil {
 						r.EncodeNil()
 					} else {
@@ -14196,6 +15277,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[7] {
 					yy1097 := &x.Resources
 					yy1097.CodecEncodeSelf(e)
@@ -14204,12 +15286,15 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resources"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1098 := &x.Resources
 					yy1098.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[8] {
 					if x.VolumeMounts == nil {
 						r.EncodeNil()
@@ -14226,7 +15311,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("volumeMounts"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.VolumeMounts == nil {
 						r.EncodeNil()
 					} else {
@@ -14240,6 +15327,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[9] {
 					if x.LivenessProbe == nil {
 						r.EncodeNil()
@@ -14251,7 +15339,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("livenessProbe"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.LivenessProbe == nil {
 						r.EncodeNil()
 					} else {
@@ -14260,6 +15350,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[10] {
 					if x.ReadinessProbe == nil {
 						r.EncodeNil()
@@ -14271,7 +15362,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readinessProbe"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ReadinessProbe == nil {
 						r.EncodeNil()
 					} else {
@@ -14280,6 +15373,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[11] {
 					if x.Lifecycle == nil {
 						r.EncodeNil()
@@ -14291,7 +15385,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lifecycle"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Lifecycle == nil {
 						r.EncodeNil()
 					} else {
@@ -14300,6 +15396,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[12] {
 					yym1106 := z.EncBinary()
 					_ = yym1106
@@ -14312,7 +15409,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("terminationMessagePath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1107 := z.EncBinary()
 					_ = yym1107
 					if false {
@@ -14322,12 +15421,16 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.ImagePullPolicy.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("imagePullPolicy"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.ImagePullPolicy.CodecEncodeSelf(e)
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[14] {
 					if x.SecurityContext == nil {
 						r.EncodeNil()
@@ -14339,7 +15442,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("securityContext"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SecurityContext == nil {
 						r.EncodeNil()
 					} else {
@@ -14348,6 +15453,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[15] {
 					yym1111 := z.EncBinary()
 					_ = yym1111
@@ -14360,7 +15466,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[15] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1112 := z.EncBinary()
 					_ = yym1112
 					if false {
@@ -14370,6 +15478,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[16] {
 					yym1114 := z.EncBinary()
 					_ = yym1114
@@ -14382,7 +15491,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[16] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdinOnce"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1115 := z.EncBinary()
 					_ = yym1115
 					if false {
@@ -14392,6 +15503,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1074[17] {
 					yym1117 := z.EncBinary()
 					_ = yym1117
@@ -14404,7 +15516,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1074[17] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1118 := z.EncBinary()
 					_ = yym1118
 					if false {
@@ -14413,8 +15527,10 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1074 {
-				r.EncodeEnd()
+			if yyr1074 || yy2arr1074 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -14429,17 +15545,18 @@ func (x *Container) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1120 := r.ContainerType()
+		if yyct1120 == codecSelferValueTypeMap1234 {
 			yyl1120 := r.ReadMapStart()
 			if yyl1120 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1120, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1120 == codecSelferValueTypeArray1234 {
 			yyl1120 := r.ReadArrayStart()
 			if yyl1120 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1120, d)
 			}
@@ -14466,8 +15583,10 @@ func (x *Container) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1121Slc = r.DecodeBytes(yys1121Slc, true, true)
 		yys1121 := string(yys1121Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1121 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -14632,9 +15751,7 @@ func (x *Container) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1121)
 		} // end switch yys1121
 	} // end for yyj1121
-	if !yyhl1121 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -14651,9 +15768,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -14666,9 +15784,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Image = ""
 	} else {
@@ -14681,9 +15800,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
@@ -14702,9 +15822,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Args = nil
 	} else {
@@ -14723,9 +15844,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.WorkingDir = ""
 	} else {
@@ -14738,9 +15860,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
@@ -14759,9 +15882,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Env = nil
 	} else {
@@ -14780,9 +15904,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Resources = ResourceRequirements{}
 	} else {
@@ -14796,9 +15921,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.VolumeMounts = nil
 	} else {
@@ -14817,9 +15943,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.LivenessProbe != nil {
 			x.LivenessProbe = nil
@@ -14837,9 +15964,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ReadinessProbe != nil {
 			x.ReadinessProbe = nil
@@ -14857,9 +15985,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Lifecycle != nil {
 			x.Lifecycle = nil
@@ -14877,9 +16006,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TerminationMessagePath = ""
 	} else {
@@ -14892,9 +16022,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ImagePullPolicy = ""
 	} else {
@@ -14907,9 +16038,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SecurityContext != nil {
 			x.SecurityContext = nil
@@ -14927,9 +16059,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdin = false
 	} else {
@@ -14942,9 +16075,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.StdinOnce = false
 	} else {
@@ -14957,9 +16091,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1145 = r.CheckBreak()
 	}
 	if yyb1145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TTY = false
 	} else {
@@ -14975,9 +16110,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1145 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1145-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -15000,18 +16136,21 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1170[0] = x.Exec != nil
 			yyq1170[1] = x.HTTPGet != nil
 			yyq1170[2] = x.TCPSocket != nil
+			var yynn1170 int
 			if yyr1170 || yy2arr1170 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1170 int = 0
+				yynn1170 = 0
 				for _, b := range yyq1170 {
 					if b {
 						yynn1170++
 					}
 				}
 				r.EncodeMapStart(yynn1170)
+				yynn1170 = 0
 			}
 			if yyr1170 || yy2arr1170 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1170[0] {
 					if x.Exec == nil {
 						r.EncodeNil()
@@ -15023,7 +16162,9 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1170[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("exec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Exec == nil {
 						r.EncodeNil()
 					} else {
@@ -15032,6 +16173,7 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1170 || yy2arr1170 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1170[1] {
 					if x.HTTPGet == nil {
 						r.EncodeNil()
@@ -15043,7 +16185,9 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1170[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("httpGet"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HTTPGet == nil {
 						r.EncodeNil()
 					} else {
@@ -15052,6 +16196,7 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1170 || yy2arr1170 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1170[2] {
 					if x.TCPSocket == nil {
 						r.EncodeNil()
@@ -15063,7 +16208,9 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1170[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tcpSocket"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TCPSocket == nil {
 						r.EncodeNil()
 					} else {
@@ -15071,8 +16218,10 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1170 {
-				r.EncodeEnd()
+			if yyr1170 || yy2arr1170 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -15087,17 +16236,18 @@ func (x *Handler) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1175 := r.ContainerType()
+		if yyct1175 == codecSelferValueTypeMap1234 {
 			yyl1175 := r.ReadMapStart()
 			if yyl1175 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1175, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1175 == codecSelferValueTypeArray1234 {
 			yyl1175 := r.ReadArrayStart()
 			if yyl1175 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1175, d)
 			}
@@ -15124,8 +16274,10 @@ func (x *Handler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1176Slc = r.DecodeBytes(yys1176Slc, true, true)
 		yys1176 := string(yys1176Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1176 {
 		case "exec":
 			if r.TryDecodeAsNil() {
@@ -15164,9 +16316,7 @@ func (x *Handler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1176)
 		} // end switch yys1176
 	} // end for yyj1176
-	if !yyhl1176 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -15183,9 +16333,10 @@ func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1180 = r.CheckBreak()
 	}
 	if yyb1180 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Exec != nil {
 			x.Exec = nil
@@ -15203,9 +16354,10 @@ func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1180 = r.CheckBreak()
 	}
 	if yyb1180 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HTTPGet != nil {
 			x.HTTPGet = nil
@@ -15223,9 +16375,10 @@ func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1180 = r.CheckBreak()
 	}
 	if yyb1180 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TCPSocket != nil {
 			x.TCPSocket = nil
@@ -15246,9 +16399,10 @@ func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1180 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1180-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -15270,18 +16424,21 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1185 bool = false
 			yyq1185[0] = x.PostStart != nil
 			yyq1185[1] = x.PreStop != nil
+			var yynn1185 int
 			if yyr1185 || yy2arr1185 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1185 int = 0
+				yynn1185 = 0
 				for _, b := range yyq1185 {
 					if b {
 						yynn1185++
 					}
 				}
 				r.EncodeMapStart(yynn1185)
+				yynn1185 = 0
 			}
 			if yyr1185 || yy2arr1185 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1185[0] {
 					if x.PostStart == nil {
 						r.EncodeNil()
@@ -15293,7 +16450,9 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1185[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("postStart"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.PostStart == nil {
 						r.EncodeNil()
 					} else {
@@ -15302,6 +16461,7 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1185 || yy2arr1185 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1185[1] {
 					if x.PreStop == nil {
 						r.EncodeNil()
@@ -15313,7 +16473,9 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1185[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("preStop"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.PreStop == nil {
 						r.EncodeNil()
 					} else {
@@ -15321,8 +16483,10 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1185 {
-				r.EncodeEnd()
+			if yyr1185 || yy2arr1185 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -15337,17 +16501,18 @@ func (x *Lifecycle) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1189 := r.ContainerType()
+		if yyct1189 == codecSelferValueTypeMap1234 {
 			yyl1189 := r.ReadMapStart()
 			if yyl1189 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1189, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1189 == codecSelferValueTypeArray1234 {
 			yyl1189 := r.ReadArrayStart()
 			if yyl1189 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1189, d)
 			}
@@ -15374,8 +16539,10 @@ func (x *Lifecycle) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1190Slc = r.DecodeBytes(yys1190Slc, true, true)
 		yys1190 := string(yys1190Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1190 {
 		case "postStart":
 			if r.TryDecodeAsNil() {
@@ -15403,9 +16570,7 @@ func (x *Lifecycle) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1190)
 		} // end switch yys1190
 	} // end for yyj1190
-	if !yyhl1190 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Lifecycle) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -15422,9 +16587,10 @@ func (x *Lifecycle) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1193 = r.CheckBreak()
 	}
 	if yyb1193 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.PostStart != nil {
 			x.PostStart = nil
@@ -15442,9 +16608,10 @@ func (x *Lifecycle) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1193 = r.CheckBreak()
 	}
 	if yyb1193 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.PreStop != nil {
 			x.PreStop = nil
@@ -15465,9 +16632,10 @@ func (x *Lifecycle) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1193 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1193-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x ConditionStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -15515,18 +16683,21 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1199 bool = false
 			yyq1199[0] = x.Reason != ""
 			yyq1199[1] = x.Message != ""
+			var yynn1199 int
 			if yyr1199 || yy2arr1199 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1199 int = 0
+				yynn1199 = 0
 				for _, b := range yyq1199 {
 					if b {
 						yynn1199++
 					}
 				}
 				r.EncodeMapStart(yynn1199)
+				yynn1199 = 0
 			}
 			if yyr1199 || yy2arr1199 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1199[0] {
 					yym1201 := z.EncBinary()
 					_ = yym1201
@@ -15539,7 +16710,9 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1199[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1202 := z.EncBinary()
 					_ = yym1202
 					if false {
@@ -15549,6 +16722,7 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1199 || yy2arr1199 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1199[1] {
 					yym1204 := z.EncBinary()
 					_ = yym1204
@@ -15561,7 +16735,9 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1199[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1205 := z.EncBinary()
 					_ = yym1205
 					if false {
@@ -15570,8 +16746,10 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1199 {
-				r.EncodeEnd()
+			if yyr1199 || yy2arr1199 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -15586,17 +16764,18 @@ func (x *ContainerStateWaiting) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1207 := r.ContainerType()
+		if yyct1207 == codecSelferValueTypeMap1234 {
 			yyl1207 := r.ReadMapStart()
 			if yyl1207 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1207, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1207 == codecSelferValueTypeArray1234 {
 			yyl1207 := r.ReadArrayStart()
 			if yyl1207 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1207, d)
 			}
@@ -15623,8 +16802,10 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1208Slc = r.DecodeBytes(yys1208Slc, true, true)
 		yys1208 := string(yys1208Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1208 {
 		case "reason":
 			if r.TryDecodeAsNil() {
@@ -15642,9 +16823,7 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1208)
 		} // end switch yys1208
 	} // end for yyj1208
-	if !yyhl1208 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerStateWaiting) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -15661,9 +16840,10 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1211 = r.CheckBreak()
 	}
 	if yyb1211 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -15676,9 +16856,10 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1211 = r.CheckBreak()
 	}
 	if yyb1211 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -15694,9 +16875,10 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1211 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1211-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerStateRunning) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -15717,18 +16899,21 @@ func (x *ContainerStateRunning) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1215, yyq1215, yy2arr1215
 			const yyr1215 bool = false
 			yyq1215[0] = true
+			var yynn1215 int
 			if yyr1215 || yy2arr1215 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1215 int = 0
+				yynn1215 = 0
 				for _, b := range yyq1215 {
 					if b {
 						yynn1215++
 					}
 				}
 				r.EncodeMapStart(yynn1215)
+				yynn1215 = 0
 			}
 			if yyr1215 || yy2arr1215 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1215[0] {
 					yy1217 := &x.StartedAt
 					yym1218 := z.EncBinary()
@@ -15747,7 +16932,9 @@ func (x *ContainerStateRunning) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1215[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startedAt"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1219 := &x.StartedAt
 					yym1220 := z.EncBinary()
 					_ = yym1220
@@ -15762,8 +16949,10 @@ func (x *ContainerStateRunning) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1215 {
-				r.EncodeEnd()
+			if yyr1215 || yy2arr1215 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -15778,17 +16967,18 @@ func (x *ContainerStateRunning) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1222 := r.ContainerType()
+		if yyct1222 == codecSelferValueTypeMap1234 {
 			yyl1222 := r.ReadMapStart()
 			if yyl1222 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1222, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1222 == codecSelferValueTypeArray1234 {
 			yyl1222 := r.ReadArrayStart()
 			if yyl1222 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1222, d)
 			}
@@ -15815,8 +17005,10 @@ func (x *ContainerStateRunning) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1223Slc = r.DecodeBytes(yys1223Slc, true, true)
 		yys1223 := string(yys1223Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1223 {
 		case "startedAt":
 			if r.TryDecodeAsNil() {
@@ -15839,9 +17031,7 @@ func (x *ContainerStateRunning) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1223)
 		} // end switch yys1223
 	} // end for yyj1223
-	if !yyhl1223 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerStateRunning) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -15858,9 +17048,10 @@ func (x *ContainerStateRunning) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1226 = r.CheckBreak()
 	}
 	if yyb1226 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.StartedAt = pkg2_unversioned.Time{}
 	} else {
@@ -15887,9 +17078,10 @@ func (x *ContainerStateRunning) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1226 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1226-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -15915,18 +17107,21 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1230[4] = true
 			yyq1230[5] = true
 			yyq1230[6] = x.ContainerID != ""
+			var yynn1230 int
 			if yyr1230 || yy2arr1230 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn1230 int = 1
+				yynn1230 = 1
 				for _, b := range yyq1230 {
 					if b {
 						yynn1230++
 					}
 				}
 				r.EncodeMapStart(yynn1230)
+				yynn1230 = 0
 			}
 			if yyr1230 || yy2arr1230 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1232 := z.EncBinary()
 				_ = yym1232
 				if false {
@@ -15934,7 +17129,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.ExitCode))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("exitCode"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1233 := z.EncBinary()
 				_ = yym1233
 				if false {
@@ -15943,6 +17140,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1230 || yy2arr1230 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1230[1] {
 					yym1235 := z.EncBinary()
 					_ = yym1235
@@ -15955,7 +17153,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1230[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("signal"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1236 := z.EncBinary()
 					_ = yym1236
 					if false {
@@ -15965,6 +17165,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1230 || yy2arr1230 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1230[2] {
 					yym1238 := z.EncBinary()
 					_ = yym1238
@@ -15977,7 +17178,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1230[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1239 := z.EncBinary()
 					_ = yym1239
 					if false {
@@ -15987,6 +17190,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1230 || yy2arr1230 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1230[3] {
 					yym1241 := z.EncBinary()
 					_ = yym1241
@@ -15999,7 +17203,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1230[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1242 := z.EncBinary()
 					_ = yym1242
 					if false {
@@ -16009,6 +17215,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1230 || yy2arr1230 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1230[4] {
 					yy1244 := &x.StartedAt
 					yym1245 := z.EncBinary()
@@ -16027,7 +17234,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1230[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startedAt"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1246 := &x.StartedAt
 					yym1247 := z.EncBinary()
 					_ = yym1247
@@ -16043,6 +17252,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1230 || yy2arr1230 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1230[5] {
 					yy1249 := &x.FinishedAt
 					yym1250 := z.EncBinary()
@@ -16061,7 +17271,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1230[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("finishedAt"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1251 := &x.FinishedAt
 					yym1252 := z.EncBinary()
 					_ = yym1252
@@ -16077,6 +17289,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1230 || yy2arr1230 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1230[6] {
 					yym1254 := z.EncBinary()
 					_ = yym1254
@@ -16089,7 +17302,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1230[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("containerID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1255 := z.EncBinary()
 					_ = yym1255
 					if false {
@@ -16098,8 +17313,10 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1230 {
-				r.EncodeEnd()
+			if yyr1230 || yy2arr1230 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -16114,17 +17331,18 @@ func (x *ContainerStateTerminated) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1257 := r.ContainerType()
+		if yyct1257 == codecSelferValueTypeMap1234 {
 			yyl1257 := r.ReadMapStart()
 			if yyl1257 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1257, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1257 == codecSelferValueTypeArray1234 {
 			yyl1257 := r.ReadArrayStart()
 			if yyl1257 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1257, d)
 			}
@@ -16151,8 +17369,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromMap(l int, d *codec1978.De
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1258Slc = r.DecodeBytes(yys1258Slc, true, true)
 		yys1258 := string(yys1258Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1258 {
 		case "exitCode":
 			if r.TryDecodeAsNil() {
@@ -16222,9 +17442,7 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromMap(l int, d *codec1978.De
 			z.DecStructFieldNotFound(-1, yys1258)
 		} // end switch yys1258
 	} // end for yyj1258
-	if !yyhl1258 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -16241,9 +17459,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1268 = r.CheckBreak()
 	}
 	if yyb1268 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ExitCode = 0
 	} else {
@@ -16256,9 +17475,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1268 = r.CheckBreak()
 	}
 	if yyb1268 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Signal = 0
 	} else {
@@ -16271,9 +17491,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1268 = r.CheckBreak()
 	}
 	if yyb1268 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -16286,9 +17507,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1268 = r.CheckBreak()
 	}
 	if yyb1268 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -16301,9 +17523,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1268 = r.CheckBreak()
 	}
 	if yyb1268 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.StartedAt = pkg2_unversioned.Time{}
 	} else {
@@ -16327,9 +17550,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1268 = r.CheckBreak()
 	}
 	if yyb1268 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FinishedAt = pkg2_unversioned.Time{}
 	} else {
@@ -16353,9 +17577,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1268 = r.CheckBreak()
 	}
 	if yyb1268 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerID = ""
 	} else {
@@ -16371,9 +17596,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		if yyb1268 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1268-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -16396,18 +17622,21 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1279[0] = x.Waiting != nil
 			yyq1279[1] = x.Running != nil
 			yyq1279[2] = x.Terminated != nil
+			var yynn1279 int
 			if yyr1279 || yy2arr1279 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1279 int = 0
+				yynn1279 = 0
 				for _, b := range yyq1279 {
 					if b {
 						yynn1279++
 					}
 				}
 				r.EncodeMapStart(yynn1279)
+				yynn1279 = 0
 			}
 			if yyr1279 || yy2arr1279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1279[0] {
 					if x.Waiting == nil {
 						r.EncodeNil()
@@ -16419,7 +17648,9 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1279[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("waiting"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Waiting == nil {
 						r.EncodeNil()
 					} else {
@@ -16428,6 +17659,7 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1279 || yy2arr1279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1279[1] {
 					if x.Running == nil {
 						r.EncodeNil()
@@ -16439,7 +17671,9 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1279[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("running"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Running == nil {
 						r.EncodeNil()
 					} else {
@@ -16448,6 +17682,7 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1279 || yy2arr1279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1279[2] {
 					if x.Terminated == nil {
 						r.EncodeNil()
@@ -16459,7 +17694,9 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1279[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("terminated"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Terminated == nil {
 						r.EncodeNil()
 					} else {
@@ -16467,8 +17704,10 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1279 {
-				r.EncodeEnd()
+			if yyr1279 || yy2arr1279 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -16483,17 +17722,18 @@ func (x *ContainerState) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1284 := r.ContainerType()
+		if yyct1284 == codecSelferValueTypeMap1234 {
 			yyl1284 := r.ReadMapStart()
 			if yyl1284 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1284, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1284 == codecSelferValueTypeArray1234 {
 			yyl1284 := r.ReadArrayStart()
 			if yyl1284 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1284, d)
 			}
@@ -16520,8 +17760,10 @@ func (x *ContainerState) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1285Slc = r.DecodeBytes(yys1285Slc, true, true)
 		yys1285 := string(yys1285Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1285 {
 		case "waiting":
 			if r.TryDecodeAsNil() {
@@ -16560,9 +17802,7 @@ func (x *ContainerState) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1285)
 		} // end switch yys1285
 	} // end for yyj1285
-	if !yyhl1285 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -16579,9 +17819,10 @@ func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1289 = r.CheckBreak()
 	}
 	if yyb1289 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Waiting != nil {
 			x.Waiting = nil
@@ -16599,9 +17840,10 @@ func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1289 = r.CheckBreak()
 	}
 	if yyb1289 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Running != nil {
 			x.Running = nil
@@ -16619,9 +17861,10 @@ func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1289 = r.CheckBreak()
 	}
 	if yyb1289 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Terminated != nil {
 			x.Terminated = nil
@@ -16642,9 +17885,10 @@ func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1289 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1289-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -16667,18 +17911,21 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1294[1] = true
 			yyq1294[2] = true
 			yyq1294[7] = x.ContainerID != ""
+			var yynn1294 int
 			if yyr1294 || yy2arr1294 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1294 int = 5
+				yynn1294 = 5
 				for _, b := range yyq1294 {
 					if b {
 						yynn1294++
 					}
 				}
 				r.EncodeMapStart(yynn1294)
+				yynn1294 = 0
 			}
 			if yyr1294 || yy2arr1294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1296 := z.EncBinary()
 				_ = yym1296
 				if false {
@@ -16686,7 +17933,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1297 := z.EncBinary()
 				_ = yym1297
 				if false {
@@ -16695,6 +17944,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1294 || yy2arr1294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1294[1] {
 					yy1299 := &x.State
 					yy1299.CodecEncodeSelf(e)
@@ -16703,12 +17953,15 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1294[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("state"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1300 := &x.State
 					yy1300.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1294 || yy2arr1294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1294[2] {
 					yy1302 := &x.LastTerminationState
 					yy1302.CodecEncodeSelf(e)
@@ -16717,12 +17970,15 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1294[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastState"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1303 := &x.LastTerminationState
 					yy1303.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1294 || yy2arr1294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1305 := z.EncBinary()
 				_ = yym1305
 				if false {
@@ -16730,7 +17986,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.Ready))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("ready"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1306 := z.EncBinary()
 				_ = yym1306
 				if false {
@@ -16739,6 +17997,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1294 || yy2arr1294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1308 := z.EncBinary()
 				_ = yym1308
 				if false {
@@ -16746,7 +18005,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.RestartCount))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("restartCount"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1309 := z.EncBinary()
 				_ = yym1309
 				if false {
@@ -16755,6 +18016,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1294 || yy2arr1294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1311 := z.EncBinary()
 				_ = yym1311
 				if false {
@@ -16762,7 +18024,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Image))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("image"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1312 := z.EncBinary()
 				_ = yym1312
 				if false {
@@ -16771,6 +18035,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1294 || yy2arr1294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1314 := z.EncBinary()
 				_ = yym1314
 				if false {
@@ -16778,7 +18043,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ImageID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("imageID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1315 := z.EncBinary()
 				_ = yym1315
 				if false {
@@ -16787,6 +18054,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1294 || yy2arr1294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1294[7] {
 					yym1317 := z.EncBinary()
 					_ = yym1317
@@ -16799,7 +18067,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1294[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("containerID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1318 := z.EncBinary()
 					_ = yym1318
 					if false {
@@ -16808,8 +18078,10 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1294 {
-				r.EncodeEnd()
+			if yyr1294 || yy2arr1294 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -16824,17 +18096,18 @@ func (x *ContainerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1320 := r.ContainerType()
+		if yyct1320 == codecSelferValueTypeMap1234 {
 			yyl1320 := r.ReadMapStart()
 			if yyl1320 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1320, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1320 == codecSelferValueTypeArray1234 {
 			yyl1320 := r.ReadArrayStart()
 			if yyl1320 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1320, d)
 			}
@@ -16861,8 +18134,10 @@ func (x *ContainerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1321Slc = r.DecodeBytes(yys1321Slc, true, true)
 		yys1321 := string(yys1321Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1321 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -16918,9 +18193,7 @@ func (x *ContainerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1321)
 		} // end switch yys1321
 	} // end for yyj1321
-	if !yyhl1321 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -16937,9 +18210,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1330 = r.CheckBreak()
 	}
 	if yyb1330 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -16952,9 +18226,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1330 = r.CheckBreak()
 	}
 	if yyb1330 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.State = ContainerState{}
 	} else {
@@ -16968,9 +18243,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1330 = r.CheckBreak()
 	}
 	if yyb1330 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTerminationState = ContainerState{}
 	} else {
@@ -16984,9 +18260,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1330 = r.CheckBreak()
 	}
 	if yyb1330 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ready = false
 	} else {
@@ -16999,9 +18276,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1330 = r.CheckBreak()
 	}
 	if yyb1330 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RestartCount = 0
 	} else {
@@ -17014,9 +18292,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1330 = r.CheckBreak()
 	}
 	if yyb1330 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Image = ""
 	} else {
@@ -17029,9 +18308,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1330 = r.CheckBreak()
 	}
 	if yyb1330 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ImageID = ""
 	} else {
@@ -17044,9 +18324,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1330 = r.CheckBreak()
 	}
 	if yyb1330 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerID = ""
 	} else {
@@ -17062,9 +18343,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb1330 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1330-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PodPhase) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -17140,30 +18422,39 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1344[3] = true
 			yyq1344[4] = x.Reason != ""
 			yyq1344[5] = x.Message != ""
+			var yynn1344 int
 			if yyr1344 || yy2arr1344 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn1344 int = 2
+				yynn1344 = 2
 				for _, b := range yyq1344 {
 					if b {
 						yynn1344++
 					}
 				}
 				r.EncodeMapStart(yynn1344)
+				yynn1344 = 0
 			}
 			if yyr1344 || yy2arr1344 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr1344 || yy2arr1344 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Status.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Status.CodecEncodeSelf(e)
 			}
 			if yyr1344 || yy2arr1344 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1344[2] {
 					yy1348 := &x.LastProbeTime
 					yym1349 := z.EncBinary()
@@ -17182,7 +18473,9 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1344[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1350 := &x.LastProbeTime
 					yym1351 := z.EncBinary()
 					_ = yym1351
@@ -17198,6 +18491,7 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1344 || yy2arr1344 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1344[3] {
 					yy1353 := &x.LastTransitionTime
 					yym1354 := z.EncBinary()
@@ -17216,7 +18510,9 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1344[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1355 := &x.LastTransitionTime
 					yym1356 := z.EncBinary()
 					_ = yym1356
@@ -17232,6 +18528,7 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1344 || yy2arr1344 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1344[4] {
 					yym1358 := z.EncBinary()
 					_ = yym1358
@@ -17244,7 +18541,9 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1344[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1359 := z.EncBinary()
 					_ = yym1359
 					if false {
@@ -17254,6 +18553,7 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1344 || yy2arr1344 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1344[5] {
 					yym1361 := z.EncBinary()
 					_ = yym1361
@@ -17266,7 +18566,9 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1344[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1362 := z.EncBinary()
 					_ = yym1362
 					if false {
@@ -17275,8 +18577,10 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1344 {
-				r.EncodeEnd()
+			if yyr1344 || yy2arr1344 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -17291,17 +18595,18 @@ func (x *PodCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1364 := r.ContainerType()
+		if yyct1364 == codecSelferValueTypeMap1234 {
 			yyl1364 := r.ReadMapStart()
 			if yyl1364 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1364, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1364 == codecSelferValueTypeArray1234 {
 			yyl1364 := r.ReadArrayStart()
 			if yyl1364 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1364, d)
 			}
@@ -17328,8 +18633,10 @@ func (x *PodCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1365Slc = r.DecodeBytes(yys1365Slc, true, true)
 		yys1365 := string(yys1365Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1365 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -17393,9 +18700,7 @@ func (x *PodCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1365)
 		} // end switch yys1365
 	} // end for yyj1365
-	if !yyhl1365 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -17412,9 +18717,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1374 = r.CheckBreak()
 	}
 	if yyb1374 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -17427,9 +18733,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1374 = r.CheckBreak()
 	}
 	if yyb1374 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ""
 	} else {
@@ -17442,9 +18749,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1374 = r.CheckBreak()
 	}
 	if yyb1374 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg2_unversioned.Time{}
 	} else {
@@ -17468,9 +18776,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1374 = r.CheckBreak()
 	}
 	if yyb1374 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg2_unversioned.Time{}
 	} else {
@@ -17494,9 +18803,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1374 = r.CheckBreak()
 	}
 	if yyb1374 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -17509,9 +18819,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1374 = r.CheckBreak()
 	}
 	if yyb1374 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -17527,9 +18838,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1374 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1374-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x RestartPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -17578,18 +18890,21 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1386[0] = x.Kind != ""
 			yyq1386[1] = x.APIVersion != ""
 			yyq1386[2] = true
+			var yynn1386 int
 			if yyr1386 || yy2arr1386 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1386 int = 1
+				yynn1386 = 1
 				for _, b := range yyq1386 {
 					if b {
 						yynn1386++
 					}
 				}
 				r.EncodeMapStart(yynn1386)
+				yynn1386 = 0
 			}
 			if yyr1386 || yy2arr1386 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1386[0] {
 					yym1388 := z.EncBinary()
 					_ = yym1388
@@ -17602,7 +18917,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1386[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1389 := z.EncBinary()
 					_ = yym1389
 					if false {
@@ -17612,6 +18929,7 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1386 || yy2arr1386 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1386[1] {
 					yym1391 := z.EncBinary()
 					_ = yym1391
@@ -17624,7 +18942,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1386[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1392 := z.EncBinary()
 					_ = yym1392
 					if false {
@@ -17634,6 +18954,7 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1386 || yy2arr1386 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1386[2] {
 					yy1394 := &x.ListMeta
 					yym1395 := z.EncBinary()
@@ -17648,7 +18969,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1386[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1396 := &x.ListMeta
 					yym1397 := z.EncBinary()
 					_ = yym1397
@@ -17660,6 +18983,7 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1386 || yy2arr1386 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -17671,7 +18995,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -17683,8 +19009,10 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1386 {
-				r.EncodeEnd()
+			if yyr1386 || yy2arr1386 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -17699,17 +19027,18 @@ func (x *PodList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1402 := r.ContainerType()
+		if yyct1402 == codecSelferValueTypeMap1234 {
 			yyl1402 := r.ReadMapStart()
 			if yyl1402 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1402, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1402 == codecSelferValueTypeArray1234 {
 			yyl1402 := r.ReadArrayStart()
 			if yyl1402 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1402, d)
 			}
@@ -17736,8 +19065,10 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1403Slc = r.DecodeBytes(yys1403Slc, true, true)
 		yys1403 := string(yys1403Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1403 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -17780,9 +19111,7 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1403)
 		} // end switch yys1403
 	} // end for yyj1403
-	if !yyhl1403 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -17799,9 +19128,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1410 = r.CheckBreak()
 	}
 	if yyb1410 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -17814,9 +19144,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1410 = r.CheckBreak()
 	}
 	if yyb1410 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -17829,9 +19160,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1410 = r.CheckBreak()
 	}
 	if yyb1410 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -17851,9 +19183,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1410 = r.CheckBreak()
 	}
 	if yyb1410 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -17875,9 +19208,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1410 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1410-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x DNSPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -17931,18 +19265,21 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1420[8] = x.NodeName != ""
 			yyq1420[9] = x.SecurityContext != nil
 			yyq1420[10] = len(x.ImagePullSecrets) != 0
+			var yynn1420 int
 			if yyr1420 || yy2arr1420 {
 				r.EncodeArrayStart(11)
 			} else {
-				var yynn1420 int = 3
+				yynn1420 = 3
 				for _, b := range yyq1420 {
 					if b {
 						yynn1420++
 					}
 				}
 				r.EncodeMapStart(yynn1420)
+				yynn1420 = 0
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Volumes == nil {
 					r.EncodeNil()
 				} else {
@@ -17954,7 +19291,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Volumes == nil {
 					r.EncodeNil()
 				} else {
@@ -17967,6 +19306,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Containers == nil {
 					r.EncodeNil()
 				} else {
@@ -17978,7 +19318,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("containers"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Containers == nil {
 					r.EncodeNil()
 				} else {
@@ -17991,6 +19333,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1420[2] {
 					x.RestartPolicy.CodecEncodeSelf(e)
 				} else {
@@ -17998,11 +19341,14 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1420[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("restartPolicy"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.RestartPolicy.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1420[3] {
 					if x.TerminationGracePeriodSeconds == nil {
 						r.EncodeNil()
@@ -18020,7 +19366,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1420[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("terminationGracePeriodSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TerminationGracePeriodSeconds == nil {
 						r.EncodeNil()
 					} else {
@@ -18035,6 +19383,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1420[4] {
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
@@ -18052,7 +19401,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1420[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("activeDeadlineSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
@@ -18067,6 +19418,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1420[5] {
 					x.DNSPolicy.CodecEncodeSelf(e)
 				} else {
@@ -18074,11 +19426,14 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1420[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("dnsPolicy"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.DNSPolicy.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1420[6] {
 					if x.NodeSelector == nil {
 						r.EncodeNil()
@@ -18095,7 +19450,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1420[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nodeSelector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.NodeSelector == nil {
 						r.EncodeNil()
 					} else {
@@ -18109,6 +19466,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1443 := z.EncBinary()
 				_ = yym1443
 				if false {
@@ -18116,7 +19474,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceAccountName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("serviceAccountName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1444 := z.EncBinary()
 				_ = yym1444
 				if false {
@@ -18125,6 +19485,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1420[8] {
 					yym1446 := z.EncBinary()
 					_ = yym1446
@@ -18137,7 +19498,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1420[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nodeName"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1447 := z.EncBinary()
 					_ = yym1447
 					if false {
@@ -18147,6 +19510,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1420[9] {
 					if x.SecurityContext == nil {
 						r.EncodeNil()
@@ -18158,7 +19522,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1420[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("securityContext"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SecurityContext == nil {
 						r.EncodeNil()
 					} else {
@@ -18167,6 +19533,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1420[10] {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
@@ -18183,7 +19550,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1420[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("imagePullSecrets"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
@@ -18196,8 +19565,10 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1420 {
-				r.EncodeEnd()
+			if yyr1420 || yy2arr1420 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -18212,17 +19583,18 @@ func (x *PodSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1453 := r.ContainerType()
+		if yyct1453 == codecSelferValueTypeMap1234 {
 			yyl1453 := r.ReadMapStart()
 			if yyl1453 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1453, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1453 == codecSelferValueTypeArray1234 {
 			yyl1453 := r.ReadArrayStart()
 			if yyl1453 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1453, d)
 			}
@@ -18249,8 +19621,10 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1454Slc = r.DecodeBytes(yys1454Slc, true, true)
 		yys1454 := string(yys1454Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1454 {
 		case "volumes":
 			if r.TryDecodeAsNil() {
@@ -18371,9 +19745,7 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1454)
 		} // end switch yys1454
 	} // end for yyj1454
-	if !yyhl1454 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -18390,9 +19762,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Volumes = nil
 	} else {
@@ -18411,9 +19784,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Containers = nil
 	} else {
@@ -18432,9 +19806,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RestartPolicy = ""
 	} else {
@@ -18447,9 +19822,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TerminationGracePeriodSeconds != nil {
 			x.TerminationGracePeriodSeconds = nil
@@ -18472,9 +19848,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ActiveDeadlineSeconds != nil {
 			x.ActiveDeadlineSeconds = nil
@@ -18497,9 +19874,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DNSPolicy = ""
 	} else {
@@ -18512,9 +19890,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NodeSelector = nil
 	} else {
@@ -18533,9 +19912,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ServiceAccountName = ""
 	} else {
@@ -18548,9 +19928,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NodeName = ""
 	} else {
@@ -18563,9 +19944,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SecurityContext != nil {
 			x.SecurityContext = nil
@@ -18583,9 +19965,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1472 = r.CheckBreak()
 	}
 	if yyb1472 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ImagePullSecrets = nil
 	} else {
@@ -18607,9 +19990,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1472 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1472-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -18637,18 +20021,21 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1491[5] = x.RunAsNonRoot != nil
 			yyq1491[6] = len(x.SupplementalGroups) != 0
 			yyq1491[7] = x.FSGroup != nil
+			var yynn1491 int
 			if yyr1491 || yy2arr1491 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1491 int = 0
+				yynn1491 = 0
 				for _, b := range yyq1491 {
 					if b {
 						yynn1491++
 					}
 				}
 				r.EncodeMapStart(yynn1491)
+				yynn1491 = 0
 			}
 			if yyr1491 || yy2arr1491 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1491[0] {
 					yym1493 := z.EncBinary()
 					_ = yym1493
@@ -18661,7 +20048,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1491[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostNetwork"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1494 := z.EncBinary()
 					_ = yym1494
 					if false {
@@ -18671,6 +20060,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1491 || yy2arr1491 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1491[1] {
 					yym1496 := z.EncBinary()
 					_ = yym1496
@@ -18683,7 +20073,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1491[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1497 := z.EncBinary()
 					_ = yym1497
 					if false {
@@ -18693,6 +20085,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1491 || yy2arr1491 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1491[2] {
 					yym1499 := z.EncBinary()
 					_ = yym1499
@@ -18705,7 +20098,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1491[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostIPC"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1500 := z.EncBinary()
 					_ = yym1500
 					if false {
@@ -18715,6 +20110,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1491 || yy2arr1491 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1491[3] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -18726,7 +20122,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1491[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -18735,6 +20133,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1491 || yy2arr1491 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1491[4] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
@@ -18752,7 +20151,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1491[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
@@ -18767,6 +20168,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1491 || yy2arr1491 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1491[5] {
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
@@ -18784,7 +20186,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1491[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
@@ -18799,6 +20203,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1491 || yy2arr1491 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1491[6] {
 					if x.SupplementalGroups == nil {
 						r.EncodeNil()
@@ -18815,7 +20220,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1491[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("supplementalGroups"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SupplementalGroups == nil {
 						r.EncodeNil()
 					} else {
@@ -18829,6 +20236,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1491 || yy2arr1491 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1491[7] {
 					if x.FSGroup == nil {
 						r.EncodeNil()
@@ -18846,7 +20254,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1491[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fsGroup"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.FSGroup == nil {
 						r.EncodeNil()
 					} else {
@@ -18860,8 +20270,10 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1491 {
-				r.EncodeEnd()
+			if yyr1491 || yy2arr1491 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -18876,17 +20288,18 @@ func (x *PodSecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1521 := r.ContainerType()
+		if yyct1521 == codecSelferValueTypeMap1234 {
 			yyl1521 := r.ReadMapStart()
 			if yyl1521 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1521, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1521 == codecSelferValueTypeArray1234 {
 			yyl1521 := r.ReadArrayStart()
 			if yyl1521 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1521, d)
 			}
@@ -18913,8 +20326,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1522Slc = r.DecodeBytes(yys1522Slc, true, true)
 		yys1522 := string(yys1522Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1522 {
 		case "hostNetwork":
 			if r.TryDecodeAsNil() {
@@ -19009,9 +20424,7 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys1522)
 		} // end switch yys1522
 	} // end for yyj1522
-	if !yyhl1522 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -19028,9 +20441,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1535 = r.CheckBreak()
 	}
 	if yyb1535 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostNetwork = false
 	} else {
@@ -19043,9 +20457,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1535 = r.CheckBreak()
 	}
 	if yyb1535 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostPID = false
 	} else {
@@ -19058,9 +20473,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1535 = r.CheckBreak()
 	}
 	if yyb1535 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostIPC = false
 	} else {
@@ -19073,9 +20489,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1535 = r.CheckBreak()
 	}
 	if yyb1535 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SELinuxOptions != nil {
 			x.SELinuxOptions = nil
@@ -19093,9 +20510,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1535 = r.CheckBreak()
 	}
 	if yyb1535 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RunAsUser != nil {
 			x.RunAsUser = nil
@@ -19118,9 +20536,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1535 = r.CheckBreak()
 	}
 	if yyb1535 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RunAsNonRoot != nil {
 			x.RunAsNonRoot = nil
@@ -19143,9 +20562,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1535 = r.CheckBreak()
 	}
 	if yyb1535 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SupplementalGroups = nil
 	} else {
@@ -19164,9 +20584,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1535 = r.CheckBreak()
 	}
 	if yyb1535 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FSGroup != nil {
 			x.FSGroup = nil
@@ -19192,9 +20613,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb1535 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1535-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -19222,18 +20644,21 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1549[5] = x.PodIP != ""
 			yyq1549[6] = x.StartTime != nil
 			yyq1549[7] = len(x.ContainerStatuses) != 0
+			var yynn1549 int
 			if yyr1549 || yy2arr1549 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1549 int = 0
+				yynn1549 = 0
 				for _, b := range yyq1549 {
 					if b {
 						yynn1549++
 					}
 				}
 				r.EncodeMapStart(yynn1549)
+				yynn1549 = 0
 			}
 			if yyr1549 || yy2arr1549 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1549[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -19241,11 +20666,14 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1549[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1549 || yy2arr1549 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1549[1] {
 					if x.Conditions == nil {
 						r.EncodeNil()
@@ -19262,7 +20690,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1549[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
@@ -19276,6 +20706,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1549 || yy2arr1549 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1549[2] {
 					yym1555 := z.EncBinary()
 					_ = yym1555
@@ -19288,7 +20719,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1549[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1556 := z.EncBinary()
 					_ = yym1556
 					if false {
@@ -19298,6 +20731,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1549 || yy2arr1549 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1549[3] {
 					yym1558 := z.EncBinary()
 					_ = yym1558
@@ -19310,7 +20744,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1549[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1559 := z.EncBinary()
 					_ = yym1559
 					if false {
@@ -19320,6 +20756,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1549 || yy2arr1549 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1549[4] {
 					yym1561 := z.EncBinary()
 					_ = yym1561
@@ -19332,7 +20769,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1549[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1562 := z.EncBinary()
 					_ = yym1562
 					if false {
@@ -19342,6 +20781,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1549 || yy2arr1549 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1549[5] {
 					yym1564 := z.EncBinary()
 					_ = yym1564
@@ -19354,7 +20794,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1549[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("podIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1565 := z.EncBinary()
 					_ = yym1565
 					if false {
@@ -19364,6 +20806,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1549 || yy2arr1549 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1549[6] {
 					if x.StartTime == nil {
 						r.EncodeNil()
@@ -19385,7 +20828,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1549[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
@@ -19404,6 +20849,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1549 || yy2arr1549 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1549[7] {
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
@@ -19420,7 +20866,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1549[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("containerStatuses"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
 					} else {
@@ -19433,8 +20881,10 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1549 {
-				r.EncodeEnd()
+			if yyr1549 || yy2arr1549 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -19449,17 +20899,18 @@ func (x *PodStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1573 := r.ContainerType()
+		if yyct1573 == codecSelferValueTypeMap1234 {
 			yyl1573 := r.ReadMapStart()
 			if yyl1573 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1573, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1573 == codecSelferValueTypeArray1234 {
 			yyl1573 := r.ReadArrayStart()
 			if yyl1573 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1573, d)
 			}
@@ -19486,8 +20937,10 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1574Slc = r.DecodeBytes(yys1574Slc, true, true)
 		yys1574 := string(yys1574Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1574 {
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -19568,9 +21021,7 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1574)
 		} // end switch yys1574
 	} // end for yyj1574
-	if !yyhl1574 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -19587,9 +21038,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1586 = r.CheckBreak()
 	}
 	if yyb1586 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -19602,9 +21054,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1586 = r.CheckBreak()
 	}
 	if yyb1586 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
@@ -19623,9 +21076,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1586 = r.CheckBreak()
 	}
 	if yyb1586 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -19638,9 +21092,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1586 = r.CheckBreak()
 	}
 	if yyb1586 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -19653,9 +21108,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1586 = r.CheckBreak()
 	}
 	if yyb1586 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostIP = ""
 	} else {
@@ -19668,9 +21124,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1586 = r.CheckBreak()
 	}
 	if yyb1586 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PodIP = ""
 	} else {
@@ -19683,9 +21140,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1586 = r.CheckBreak()
 	}
 	if yyb1586 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.StartTime != nil {
 			x.StartTime = nil
@@ -19713,9 +21171,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1586 = r.CheckBreak()
 	}
 	if yyb1586 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerStatuses = nil
 	} else {
@@ -19737,9 +21196,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1586 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1586-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -19763,18 +21223,21 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1599[1] = x.APIVersion != ""
 			yyq1599[2] = true
 			yyq1599[3] = true
+			var yynn1599 int
 			if yyr1599 || yy2arr1599 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1599 int = 0
+				yynn1599 = 0
 				for _, b := range yyq1599 {
 					if b {
 						yynn1599++
 					}
 				}
 				r.EncodeMapStart(yynn1599)
+				yynn1599 = 0
 			}
 			if yyr1599 || yy2arr1599 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1599[0] {
 					yym1601 := z.EncBinary()
 					_ = yym1601
@@ -19787,7 +21250,9 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1599[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1602 := z.EncBinary()
 					_ = yym1602
 					if false {
@@ -19797,6 +21262,7 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1599 || yy2arr1599 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1599[1] {
 					yym1604 := z.EncBinary()
 					_ = yym1604
@@ -19809,7 +21275,9 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1599[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1605 := z.EncBinary()
 					_ = yym1605
 					if false {
@@ -19819,6 +21287,7 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1599 || yy2arr1599 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1599[2] {
 					yy1607 := &x.ObjectMeta
 					yy1607.CodecEncodeSelf(e)
@@ -19827,12 +21296,15 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1599[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1608 := &x.ObjectMeta
 					yy1608.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1599 || yy2arr1599 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1599[3] {
 					yy1610 := &x.Status
 					yy1610.CodecEncodeSelf(e)
@@ -19841,13 +21313,17 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1599[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1611 := &x.Status
 					yy1611.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1599 {
-				r.EncodeEnd()
+			if yyr1599 || yy2arr1599 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -19862,17 +21338,18 @@ func (x *PodStatusResult) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1613 := r.ContainerType()
+		if yyct1613 == codecSelferValueTypeMap1234 {
 			yyl1613 := r.ReadMapStart()
 			if yyl1613 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1613, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1613 == codecSelferValueTypeArray1234 {
 			yyl1613 := r.ReadArrayStart()
 			if yyl1613 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1613, d)
 			}
@@ -19899,8 +21376,10 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1614Slc = r.DecodeBytes(yys1614Slc, true, true)
 		yys1614 := string(yys1614Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1614 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -19932,9 +21411,7 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1614)
 		} // end switch yys1614
 	} // end for yyj1614
-	if !yyhl1614 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -19951,9 +21428,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1619 = r.CheckBreak()
 	}
 	if yyb1619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -19966,9 +21444,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1619 = r.CheckBreak()
 	}
 	if yyb1619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -19981,9 +21460,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1619 = r.CheckBreak()
 	}
 	if yyb1619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -19997,9 +21477,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1619 = r.CheckBreak()
 	}
 	if yyb1619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = PodStatus{}
 	} else {
@@ -20016,9 +21497,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb1619 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1619-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -20043,18 +21525,21 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1625[2] = true
 			yyq1625[3] = true
 			yyq1625[4] = true
+			var yynn1625 int
 			if yyr1625 || yy2arr1625 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1625 int = 0
+				yynn1625 = 0
 				for _, b := range yyq1625 {
 					if b {
 						yynn1625++
 					}
 				}
 				r.EncodeMapStart(yynn1625)
+				yynn1625 = 0
 			}
 			if yyr1625 || yy2arr1625 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1625[0] {
 					yym1627 := z.EncBinary()
 					_ = yym1627
@@ -20067,7 +21552,9 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1625[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1628 := z.EncBinary()
 					_ = yym1628
 					if false {
@@ -20077,6 +21564,7 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1625 || yy2arr1625 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1625[1] {
 					yym1630 := z.EncBinary()
 					_ = yym1630
@@ -20089,7 +21577,9 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1625[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1631 := z.EncBinary()
 					_ = yym1631
 					if false {
@@ -20099,6 +21589,7 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1625 || yy2arr1625 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1625[2] {
 					yy1633 := &x.ObjectMeta
 					yy1633.CodecEncodeSelf(e)
@@ -20107,12 +21598,15 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1625[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1634 := &x.ObjectMeta
 					yy1634.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1625 || yy2arr1625 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1625[3] {
 					yy1636 := &x.Spec
 					yy1636.CodecEncodeSelf(e)
@@ -20121,12 +21615,15 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1625[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1637 := &x.Spec
 					yy1637.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1625 || yy2arr1625 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1625[4] {
 					yy1639 := &x.Status
 					yy1639.CodecEncodeSelf(e)
@@ -20135,13 +21632,17 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1625[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1640 := &x.Status
 					yy1640.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1625 {
-				r.EncodeEnd()
+			if yyr1625 || yy2arr1625 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -20156,17 +21657,18 @@ func (x *Pod) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1642 := r.ContainerType()
+		if yyct1642 == codecSelferValueTypeMap1234 {
 			yyl1642 := r.ReadMapStart()
 			if yyl1642 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1642, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1642 == codecSelferValueTypeArray1234 {
 			yyl1642 := r.ReadArrayStart()
 			if yyl1642 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1642, d)
 			}
@@ -20193,8 +21695,10 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1643Slc = r.DecodeBytes(yys1643Slc, true, true)
 		yys1643 := string(yys1643Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1643 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -20233,9 +21737,7 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1643)
 		} // end switch yys1643
 	} // end for yyj1643
-	if !yyhl1643 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -20252,9 +21754,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1649 = r.CheckBreak()
 	}
 	if yyb1649 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -20267,9 +21770,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1649 = r.CheckBreak()
 	}
 	if yyb1649 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -20282,9 +21786,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1649 = r.CheckBreak()
 	}
 	if yyb1649 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -20298,9 +21803,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1649 = r.CheckBreak()
 	}
 	if yyb1649 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSpec{}
 	} else {
@@ -20314,9 +21820,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1649 = r.CheckBreak()
 	}
 	if yyb1649 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = PodStatus{}
 	} else {
@@ -20333,9 +21840,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1649 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1649-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -20357,18 +21865,21 @@ func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1656 bool = false
 			yyq1656[0] = true
 			yyq1656[1] = true
+			var yynn1656 int
 			if yyr1656 || yy2arr1656 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1656 int = 0
+				yynn1656 = 0
 				for _, b := range yyq1656 {
 					if b {
 						yynn1656++
 					}
 				}
 				r.EncodeMapStart(yynn1656)
+				yynn1656 = 0
 			}
 			if yyr1656 || yy2arr1656 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1656[0] {
 					yy1658 := &x.ObjectMeta
 					yy1658.CodecEncodeSelf(e)
@@ -20377,12 +21888,15 @@ func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1656[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1659 := &x.ObjectMeta
 					yy1659.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1656 || yy2arr1656 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1656[1] {
 					yy1661 := &x.Spec
 					yy1661.CodecEncodeSelf(e)
@@ -20391,13 +21905,17 @@ func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1656[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1662 := &x.Spec
 					yy1662.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1656 {
-				r.EncodeEnd()
+			if yyr1656 || yy2arr1656 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -20412,17 +21930,18 @@ func (x *PodTemplateSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1664 := r.ContainerType()
+		if yyct1664 == codecSelferValueTypeMap1234 {
 			yyl1664 := r.ReadMapStart()
 			if yyl1664 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1664, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1664 == codecSelferValueTypeArray1234 {
 			yyl1664 := r.ReadArrayStart()
 			if yyl1664 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1664, d)
 			}
@@ -20449,8 +21968,10 @@ func (x *PodTemplateSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1665Slc = r.DecodeBytes(yys1665Slc, true, true)
 		yys1665 := string(yys1665Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1665 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
@@ -20470,9 +21991,7 @@ func (x *PodTemplateSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1665)
 		} // end switch yys1665
 	} // end for yyj1665
-	if !yyhl1665 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -20489,9 +22008,10 @@ func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1668 = r.CheckBreak()
 	}
 	if yyb1668 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -20505,9 +22025,10 @@ func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1668 = r.CheckBreak()
 	}
 	if yyb1668 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSpec{}
 	} else {
@@ -20524,9 +22045,10 @@ func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb1668 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1668-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -20550,18 +22072,21 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1672[1] = x.APIVersion != ""
 			yyq1672[2] = true
 			yyq1672[3] = true
+			var yynn1672 int
 			if yyr1672 || yy2arr1672 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1672 int = 0
+				yynn1672 = 0
 				for _, b := range yyq1672 {
 					if b {
 						yynn1672++
 					}
 				}
 				r.EncodeMapStart(yynn1672)
+				yynn1672 = 0
 			}
 			if yyr1672 || yy2arr1672 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1672[0] {
 					yym1674 := z.EncBinary()
 					_ = yym1674
@@ -20574,7 +22099,9 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1672[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1675 := z.EncBinary()
 					_ = yym1675
 					if false {
@@ -20584,6 +22111,7 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1672 || yy2arr1672 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1672[1] {
 					yym1677 := z.EncBinary()
 					_ = yym1677
@@ -20596,7 +22124,9 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1672[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1678 := z.EncBinary()
 					_ = yym1678
 					if false {
@@ -20606,6 +22136,7 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1672 || yy2arr1672 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1672[2] {
 					yy1680 := &x.ObjectMeta
 					yy1680.CodecEncodeSelf(e)
@@ -20614,12 +22145,15 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1672[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1681 := &x.ObjectMeta
 					yy1681.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1672 || yy2arr1672 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1672[3] {
 					yy1683 := &x.Template
 					yy1683.CodecEncodeSelf(e)
@@ -20628,13 +22162,17 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1672[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1684 := &x.Template
 					yy1684.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1672 {
-				r.EncodeEnd()
+			if yyr1672 || yy2arr1672 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -20649,17 +22187,18 @@ func (x *PodTemplate) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1686 := r.ContainerType()
+		if yyct1686 == codecSelferValueTypeMap1234 {
 			yyl1686 := r.ReadMapStart()
 			if yyl1686 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1686, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1686 == codecSelferValueTypeArray1234 {
 			yyl1686 := r.ReadArrayStart()
 			if yyl1686 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1686, d)
 			}
@@ -20686,8 +22225,10 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1687Slc = r.DecodeBytes(yys1687Slc, true, true)
 		yys1687 := string(yys1687Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1687 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -20719,9 +22260,7 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1687)
 		} // end switch yys1687
 	} // end for yyj1687
-	if !yyhl1687 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -20738,9 +22277,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1692 = r.CheckBreak()
 	}
 	if yyb1692 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -20753,9 +22293,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1692 = r.CheckBreak()
 	}
 	if yyb1692 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -20768,9 +22309,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1692 = r.CheckBreak()
 	}
 	if yyb1692 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -20784,9 +22326,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1692 = r.CheckBreak()
 	}
 	if yyb1692 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Template = PodTemplateSpec{}
 	} else {
@@ -20803,9 +22346,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1692 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1692-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -20828,18 +22372,21 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1698[0] = x.Kind != ""
 			yyq1698[1] = x.APIVersion != ""
 			yyq1698[2] = true
+			var yynn1698 int
 			if yyr1698 || yy2arr1698 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1698 int = 1
+				yynn1698 = 1
 				for _, b := range yyq1698 {
 					if b {
 						yynn1698++
 					}
 				}
 				r.EncodeMapStart(yynn1698)
+				yynn1698 = 0
 			}
 			if yyr1698 || yy2arr1698 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1698[0] {
 					yym1700 := z.EncBinary()
 					_ = yym1700
@@ -20852,7 +22399,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1698[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1701 := z.EncBinary()
 					_ = yym1701
 					if false {
@@ -20862,6 +22411,7 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1698 || yy2arr1698 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1698[1] {
 					yym1703 := z.EncBinary()
 					_ = yym1703
@@ -20874,7 +22424,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1698[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1704 := z.EncBinary()
 					_ = yym1704
 					if false {
@@ -20884,6 +22436,7 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1698 || yy2arr1698 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1698[2] {
 					yy1706 := &x.ListMeta
 					yym1707 := z.EncBinary()
@@ -20898,7 +22451,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1698[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1708 := &x.ListMeta
 					yym1709 := z.EncBinary()
 					_ = yym1709
@@ -20910,6 +22465,7 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1698 || yy2arr1698 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -20921,7 +22477,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -20933,8 +22491,10 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1698 {
-				r.EncodeEnd()
+			if yyr1698 || yy2arr1698 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -20949,17 +22509,18 @@ func (x *PodTemplateList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1714 := r.ContainerType()
+		if yyct1714 == codecSelferValueTypeMap1234 {
 			yyl1714 := r.ReadMapStart()
 			if yyl1714 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1714, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1714 == codecSelferValueTypeArray1234 {
 			yyl1714 := r.ReadArrayStart()
 			if yyl1714 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1714, d)
 			}
@@ -20986,8 +22547,10 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1715Slc = r.DecodeBytes(yys1715Slc, true, true)
 		yys1715 := string(yys1715Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1715 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -21030,9 +22593,7 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1715)
 		} // end switch yys1715
 	} // end for yyj1715
-	if !yyhl1715 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -21049,9 +22610,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1722 = r.CheckBreak()
 	}
 	if yyb1722 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -21064,9 +22626,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1722 = r.CheckBreak()
 	}
 	if yyb1722 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -21079,9 +22642,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1722 = r.CheckBreak()
 	}
 	if yyb1722 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -21101,9 +22665,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1722 = r.CheckBreak()
 	}
 	if yyb1722 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -21125,9 +22690,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb1722 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1722-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -21148,18 +22714,21 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1730, yyq1730, yy2arr1730
 			const yyr1730 bool = false
 			yyq1730[2] = x.Template != nil
+			var yynn1730 int
 			if yyr1730 || yy2arr1730 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1730 int = 2
+				yynn1730 = 2
 				for _, b := range yyq1730 {
 					if b {
 						yynn1730++
 					}
 				}
 				r.EncodeMapStart(yynn1730)
+				yynn1730 = 0
 			}
 			if yyr1730 || yy2arr1730 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1732 := z.EncBinary()
 				_ = yym1732
 				if false {
@@ -21167,7 +22736,9 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1733 := z.EncBinary()
 				_ = yym1733
 				if false {
@@ -21176,6 +22747,7 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1730 || yy2arr1730 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Selector == nil {
 					r.EncodeNil()
 				} else {
@@ -21187,7 +22759,9 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("selector"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Selector == nil {
 					r.EncodeNil()
 				} else {
@@ -21200,6 +22774,7 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1730 || yy2arr1730 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1730[2] {
 					if x.Template == nil {
 						r.EncodeNil()
@@ -21211,7 +22786,9 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1730[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -21219,8 +22796,10 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1730 {
-				r.EncodeEnd()
+			if yyr1730 || yy2arr1730 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -21235,17 +22814,18 @@ func (x *ReplicationControllerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1739 := r.ContainerType()
+		if yyct1739 == codecSelferValueTypeMap1234 {
 			yyl1739 := r.ReadMapStart()
 			if yyl1739 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1739, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1739 == codecSelferValueTypeArray1234 {
 			yyl1739 := r.ReadArrayStart()
 			if yyl1739 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1739, d)
 			}
@@ -21272,8 +22852,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1740Slc = r.DecodeBytes(yys1740Slc, true, true)
 		yys1740 := string(yys1740Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1740 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -21308,9 +22890,7 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 			z.DecStructFieldNotFound(-1, yys1740)
 		} // end switch yys1740
 	} // end for yyj1740
-	if !yyhl1740 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -21327,9 +22907,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1745 = r.CheckBreak()
 	}
 	if yyb1745 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -21342,9 +22923,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1745 = r.CheckBreak()
 	}
 	if yyb1745 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
@@ -21363,9 +22945,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1745 = r.CheckBreak()
 	}
 	if yyb1745 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Template != nil {
 			x.Template = nil
@@ -21386,9 +22969,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		if yyb1745 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1745-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -21409,18 +22993,21 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1751, yyq1751, yy2arr1751
 			const yyr1751 bool = false
 			yyq1751[1] = x.ObservedGeneration != 0
+			var yynn1751 int
 			if yyr1751 || yy2arr1751 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1751 int = 1
+				yynn1751 = 1
 				for _, b := range yyq1751 {
 					if b {
 						yynn1751++
 					}
 				}
 				r.EncodeMapStart(yynn1751)
+				yynn1751 = 0
 			}
 			if yyr1751 || yy2arr1751 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1753 := z.EncBinary()
 				_ = yym1753
 				if false {
@@ -21428,7 +23015,9 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1754 := z.EncBinary()
 				_ = yym1754
 				if false {
@@ -21437,6 +23026,7 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1751 || yy2arr1751 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1751[1] {
 					yym1756 := z.EncBinary()
 					_ = yym1756
@@ -21449,7 +23039,9 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1751[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1757 := z.EncBinary()
 					_ = yym1757
 					if false {
@@ -21458,8 +23050,10 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1751 {
-				r.EncodeEnd()
+			if yyr1751 || yy2arr1751 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -21474,17 +23068,18 @@ func (x *ReplicationControllerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1759 := r.ContainerType()
+		if yyct1759 == codecSelferValueTypeMap1234 {
 			yyl1759 := r.ReadMapStart()
 			if yyl1759 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1759, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1759 == codecSelferValueTypeArray1234 {
 			yyl1759 := r.ReadArrayStart()
 			if yyl1759 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1759, d)
 			}
@@ -21511,8 +23106,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1760Slc = r.DecodeBytes(yys1760Slc, true, true)
 		yys1760 := string(yys1760Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1760 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -21530,9 +23127,7 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 			z.DecStructFieldNotFound(-1, yys1760)
 		} // end switch yys1760
 	} // end for yyj1760
-	if !yyhl1760 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -21549,9 +23144,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb1763 = r.CheckBreak()
 	}
 	if yyb1763 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -21564,9 +23160,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb1763 = r.CheckBreak()
 	}
 	if yyb1763 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObservedGeneration = 0
 	} else {
@@ -21582,9 +23179,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 		if yyb1763 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1763-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -21609,18 +23207,21 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1767[2] = true
 			yyq1767[3] = true
 			yyq1767[4] = true
+			var yynn1767 int
 			if yyr1767 || yy2arr1767 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1767 int = 0
+				yynn1767 = 0
 				for _, b := range yyq1767 {
 					if b {
 						yynn1767++
 					}
 				}
 				r.EncodeMapStart(yynn1767)
+				yynn1767 = 0
 			}
 			if yyr1767 || yy2arr1767 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1767[0] {
 					yym1769 := z.EncBinary()
 					_ = yym1769
@@ -21633,7 +23234,9 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1767[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1770 := z.EncBinary()
 					_ = yym1770
 					if false {
@@ -21643,6 +23246,7 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1767 || yy2arr1767 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1767[1] {
 					yym1772 := z.EncBinary()
 					_ = yym1772
@@ -21655,7 +23259,9 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1767[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1773 := z.EncBinary()
 					_ = yym1773
 					if false {
@@ -21665,6 +23271,7 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1767 || yy2arr1767 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1767[2] {
 					yy1775 := &x.ObjectMeta
 					yy1775.CodecEncodeSelf(e)
@@ -21673,12 +23280,15 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1767[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1776 := &x.ObjectMeta
 					yy1776.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1767 || yy2arr1767 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1767[3] {
 					yy1778 := &x.Spec
 					yy1778.CodecEncodeSelf(e)
@@ -21687,12 +23297,15 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1767[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1779 := &x.Spec
 					yy1779.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1767 || yy2arr1767 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1767[4] {
 					yy1781 := &x.Status
 					yy1781.CodecEncodeSelf(e)
@@ -21701,13 +23314,17 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1767[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1782 := &x.Status
 					yy1782.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1767 {
-				r.EncodeEnd()
+			if yyr1767 || yy2arr1767 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -21722,17 +23339,18 @@ func (x *ReplicationController) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1784 := r.ContainerType()
+		if yyct1784 == codecSelferValueTypeMap1234 {
 			yyl1784 := r.ReadMapStart()
 			if yyl1784 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1784, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1784 == codecSelferValueTypeArray1234 {
 			yyl1784 := r.ReadArrayStart()
 			if yyl1784 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1784, d)
 			}
@@ -21759,8 +23377,10 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1785Slc = r.DecodeBytes(yys1785Slc, true, true)
 		yys1785 := string(yys1785Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1785 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -21799,9 +23419,7 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1785)
 		} // end switch yys1785
 	} // end for yyj1785
-	if !yyhl1785 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -21818,9 +23436,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1791 = r.CheckBreak()
 	}
 	if yyb1791 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -21833,9 +23452,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1791 = r.CheckBreak()
 	}
 	if yyb1791 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -21848,9 +23468,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1791 = r.CheckBreak()
 	}
 	if yyb1791 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -21864,9 +23485,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1791 = r.CheckBreak()
 	}
 	if yyb1791 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ReplicationControllerSpec{}
 	} else {
@@ -21880,9 +23502,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1791 = r.CheckBreak()
 	}
 	if yyb1791 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ReplicationControllerStatus{}
 	} else {
@@ -21899,9 +23522,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1791 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1791-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -21924,18 +23548,21 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1798[0] = x.Kind != ""
 			yyq1798[1] = x.APIVersion != ""
 			yyq1798[2] = true
+			var yynn1798 int
 			if yyr1798 || yy2arr1798 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1798 int = 1
+				yynn1798 = 1
 				for _, b := range yyq1798 {
 					if b {
 						yynn1798++
 					}
 				}
 				r.EncodeMapStart(yynn1798)
+				yynn1798 = 0
 			}
 			if yyr1798 || yy2arr1798 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1798[0] {
 					yym1800 := z.EncBinary()
 					_ = yym1800
@@ -21948,7 +23575,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1798[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1801 := z.EncBinary()
 					_ = yym1801
 					if false {
@@ -21958,6 +23587,7 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1798 || yy2arr1798 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1798[1] {
 					yym1803 := z.EncBinary()
 					_ = yym1803
@@ -21970,7 +23600,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1798[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1804 := z.EncBinary()
 					_ = yym1804
 					if false {
@@ -21980,6 +23612,7 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1798 || yy2arr1798 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1798[2] {
 					yy1806 := &x.ListMeta
 					yym1807 := z.EncBinary()
@@ -21994,7 +23627,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1798[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1808 := &x.ListMeta
 					yym1809 := z.EncBinary()
 					_ = yym1809
@@ -22006,6 +23641,7 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1798 || yy2arr1798 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -22017,7 +23653,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -22029,8 +23667,10 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1798 {
-				r.EncodeEnd()
+			if yyr1798 || yy2arr1798 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -22045,17 +23685,18 @@ func (x *ReplicationControllerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1814 := r.ContainerType()
+		if yyct1814 == codecSelferValueTypeMap1234 {
 			yyl1814 := r.ReadMapStart()
 			if yyl1814 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1814, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1814 == codecSelferValueTypeArray1234 {
 			yyl1814 := r.ReadArrayStart()
 			if yyl1814 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1814, d)
 			}
@@ -22082,8 +23723,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1815Slc = r.DecodeBytes(yys1815Slc, true, true)
 		yys1815 := string(yys1815Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1815 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -22126,9 +23769,7 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 			z.DecStructFieldNotFound(-1, yys1815)
 		} // end switch yys1815
 	} // end for yyj1815
-	if !yyhl1815 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -22145,9 +23786,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1822 = r.CheckBreak()
 	}
 	if yyb1822 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -22160,9 +23802,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1822 = r.CheckBreak()
 	}
 	if yyb1822 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -22175,9 +23818,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1822 = r.CheckBreak()
 	}
 	if yyb1822 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -22197,9 +23841,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1822 = r.CheckBreak()
 	}
 	if yyb1822 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -22221,9 +23866,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		if yyb1822 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1822-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -22246,18 +23892,21 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1830[0] = x.Kind != ""
 			yyq1830[1] = x.APIVersion != ""
 			yyq1830[2] = true
+			var yynn1830 int
 			if yyr1830 || yy2arr1830 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1830 int = 1
+				yynn1830 = 1
 				for _, b := range yyq1830 {
 					if b {
 						yynn1830++
 					}
 				}
 				r.EncodeMapStart(yynn1830)
+				yynn1830 = 0
 			}
 			if yyr1830 || yy2arr1830 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1830[0] {
 					yym1832 := z.EncBinary()
 					_ = yym1832
@@ -22270,7 +23919,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1830[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1833 := z.EncBinary()
 					_ = yym1833
 					if false {
@@ -22280,6 +23931,7 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1830 || yy2arr1830 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1830[1] {
 					yym1835 := z.EncBinary()
 					_ = yym1835
@@ -22292,7 +23944,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1830[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1836 := z.EncBinary()
 					_ = yym1836
 					if false {
@@ -22302,6 +23956,7 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1830 || yy2arr1830 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1830[2] {
 					yy1838 := &x.ListMeta
 					yym1839 := z.EncBinary()
@@ -22316,7 +23971,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1830[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1840 := &x.ListMeta
 					yym1841 := z.EncBinary()
 					_ = yym1841
@@ -22328,6 +23985,7 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1830 || yy2arr1830 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -22339,7 +23997,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -22351,8 +24011,10 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1830 {
-				r.EncodeEnd()
+			if yyr1830 || yy2arr1830 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -22367,17 +24029,18 @@ func (x *ServiceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1846 := r.ContainerType()
+		if yyct1846 == codecSelferValueTypeMap1234 {
 			yyl1846 := r.ReadMapStart()
 			if yyl1846 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1846, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1846 == codecSelferValueTypeArray1234 {
 			yyl1846 := r.ReadArrayStart()
 			if yyl1846 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1846, d)
 			}
@@ -22404,8 +24067,10 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1847Slc = r.DecodeBytes(yys1847Slc, true, true)
 		yys1847 := string(yys1847Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1847 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -22448,9 +24113,7 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1847)
 		} // end switch yys1847
 	} // end for yyj1847
-	if !yyhl1847 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -22467,9 +24130,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1854 = r.CheckBreak()
 	}
 	if yyb1854 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -22482,9 +24146,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1854 = r.CheckBreak()
 	}
 	if yyb1854 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -22497,9 +24162,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1854 = r.CheckBreak()
 	}
 	if yyb1854 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -22519,9 +24185,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1854 = r.CheckBreak()
 	}
 	if yyb1854 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -22543,9 +24210,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1854 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1854-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x ServiceAffinity) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -22618,18 +24286,21 @@ func (x *ServiceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1866, yyq1866, yy2arr1866
 			const yyr1866 bool = false
 			yyq1866[0] = true
+			var yynn1866 int
 			if yyr1866 || yy2arr1866 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1866 int = 0
+				yynn1866 = 0
 				for _, b := range yyq1866 {
 					if b {
 						yynn1866++
 					}
 				}
 				r.EncodeMapStart(yynn1866)
+				yynn1866 = 0
 			}
 			if yyr1866 || yy2arr1866 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1866[0] {
 					yy1868 := &x.LoadBalancer
 					yy1868.CodecEncodeSelf(e)
@@ -22638,13 +24309,17 @@ func (x *ServiceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1866[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1869 := &x.LoadBalancer
 					yy1869.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1866 {
-				r.EncodeEnd()
+			if yyr1866 || yy2arr1866 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -22659,17 +24334,18 @@ func (x *ServiceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1871 := r.ContainerType()
+		if yyct1871 == codecSelferValueTypeMap1234 {
 			yyl1871 := r.ReadMapStart()
 			if yyl1871 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1871, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1871 == codecSelferValueTypeArray1234 {
 			yyl1871 := r.ReadArrayStart()
 			if yyl1871 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1871, d)
 			}
@@ -22696,8 +24372,10 @@ func (x *ServiceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1872Slc = r.DecodeBytes(yys1872Slc, true, true)
 		yys1872 := string(yys1872Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1872 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
@@ -22710,9 +24388,7 @@ func (x *ServiceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1872)
 		} // end switch yys1872
 	} // end for yyj1872
-	if !yyhl1872 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -22729,9 +24405,10 @@ func (x *ServiceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1874 = r.CheckBreak()
 	}
 	if yyb1874 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = LoadBalancerStatus{}
 	} else {
@@ -22748,9 +24425,10 @@ func (x *ServiceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1874 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1874-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -22771,18 +24449,21 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1877, yyq1877, yy2arr1877
 			const yyr1877 bool = false
 			yyq1877[0] = len(x.Ingress) != 0
+			var yynn1877 int
 			if yyr1877 || yy2arr1877 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1877 int = 0
+				yynn1877 = 0
 				for _, b := range yyq1877 {
 					if b {
 						yynn1877++
 					}
 				}
 				r.EncodeMapStart(yynn1877)
+				yynn1877 = 0
 			}
 			if yyr1877 || yy2arr1877 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1877[0] {
 					if x.Ingress == nil {
 						r.EncodeNil()
@@ -22799,7 +24480,9 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1877[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("ingress"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Ingress == nil {
 						r.EncodeNil()
 					} else {
@@ -22812,8 +24495,10 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1877 {
-				r.EncodeEnd()
+			if yyr1877 || yy2arr1877 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -22828,17 +24513,18 @@ func (x *LoadBalancerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1882 := r.ContainerType()
+		if yyct1882 == codecSelferValueTypeMap1234 {
 			yyl1882 := r.ReadMapStart()
 			if yyl1882 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1882, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1882 == codecSelferValueTypeArray1234 {
 			yyl1882 := r.ReadArrayStart()
 			if yyl1882 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1882, d)
 			}
@@ -22865,8 +24551,10 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1883Slc = r.DecodeBytes(yys1883Slc, true, true)
 		yys1883 := string(yys1883Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1883 {
 		case "ingress":
 			if r.TryDecodeAsNil() {
@@ -22884,9 +24572,7 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys1883)
 		} // end switch yys1883
 	} // end for yyj1883
-	if !yyhl1883 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LoadBalancerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -22903,9 +24589,10 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1886 = r.CheckBreak()
 	}
 	if yyb1886 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ingress = nil
 	} else {
@@ -22927,9 +24614,10 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb1886 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1886-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -22951,18 +24639,21 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1890 bool = false
 			yyq1890[0] = x.IP != ""
 			yyq1890[1] = x.Hostname != ""
+			var yynn1890 int
 			if yyr1890 || yy2arr1890 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1890 int = 0
+				yynn1890 = 0
 				for _, b := range yyq1890 {
 					if b {
 						yynn1890++
 					}
 				}
 				r.EncodeMapStart(yynn1890)
+				yynn1890 = 0
 			}
 			if yyr1890 || yy2arr1890 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1890[0] {
 					yym1892 := z.EncBinary()
 					_ = yym1892
@@ -22975,7 +24666,9 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1890[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("ip"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1893 := z.EncBinary()
 					_ = yym1893
 					if false {
@@ -22985,6 +24678,7 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1890 || yy2arr1890 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1890[1] {
 					yym1895 := z.EncBinary()
 					_ = yym1895
@@ -22997,7 +24691,9 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1890[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostname"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1896 := z.EncBinary()
 					_ = yym1896
 					if false {
@@ -23006,8 +24702,10 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1890 {
-				r.EncodeEnd()
+			if yyr1890 || yy2arr1890 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -23022,17 +24720,18 @@ func (x *LoadBalancerIngress) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1898 := r.ContainerType()
+		if yyct1898 == codecSelferValueTypeMap1234 {
 			yyl1898 := r.ReadMapStart()
 			if yyl1898 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1898, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1898 == codecSelferValueTypeArray1234 {
 			yyl1898 := r.ReadArrayStart()
 			if yyl1898 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1898, d)
 			}
@@ -23059,8 +24758,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1899Slc = r.DecodeBytes(yys1899Slc, true, true)
 		yys1899 := string(yys1899Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1899 {
 		case "ip":
 			if r.TryDecodeAsNil() {
@@ -23078,9 +24779,7 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys1899)
 		} // end switch yys1899
 	} // end for yyj1899
-	if !yyhl1899 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -23097,9 +24796,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb1902 = r.CheckBreak()
 	}
 	if yyb1902 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.IP = ""
 	} else {
@@ -23112,9 +24812,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb1902 = r.CheckBreak()
 	}
 	if yyb1902 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Hostname = ""
 	} else {
@@ -23130,9 +24831,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb1902 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1902-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -23157,18 +24859,21 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1906[4] = len(x.ExternalIPs) != 0
 			yyq1906[5] = x.LoadBalancerIP != ""
 			yyq1906[6] = x.SessionAffinity != ""
+			var yynn1906 int
 			if yyr1906 || yy2arr1906 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn1906 int = 2
+				yynn1906 = 2
 				for _, b := range yyq1906 {
 					if b {
 						yynn1906++
 					}
 				}
 				r.EncodeMapStart(yynn1906)
+				yynn1906 = 0
 			}
 			if yyr1906 || yy2arr1906 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1906[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
@@ -23176,11 +24881,14 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1906[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1906 || yy2arr1906 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
@@ -23192,7 +24900,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("ports"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
@@ -23205,6 +24915,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1906 || yy2arr1906 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Selector == nil {
 					r.EncodeNil()
 				} else {
@@ -23216,7 +24927,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("selector"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Selector == nil {
 					r.EncodeNil()
 				} else {
@@ -23229,6 +24942,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1906 || yy2arr1906 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1906[3] {
 					yym1915 := z.EncBinary()
 					_ = yym1915
@@ -23241,7 +24955,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1906[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("clusterIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1916 := z.EncBinary()
 					_ = yym1916
 					if false {
@@ -23251,6 +24967,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1906 || yy2arr1906 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1906[4] {
 					if x.ExternalIPs == nil {
 						r.EncodeNil()
@@ -23267,7 +24984,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1906[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("externalIPs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ExternalIPs == nil {
 						r.EncodeNil()
 					} else {
@@ -23281,6 +25000,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1906 || yy2arr1906 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1906[5] {
 					yym1921 := z.EncBinary()
 					_ = yym1921
@@ -23293,7 +25013,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1906[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancerIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1922 := z.EncBinary()
 					_ = yym1922
 					if false {
@@ -23303,6 +25025,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1906 || yy2arr1906 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1906[6] {
 					x.SessionAffinity.CodecEncodeSelf(e)
 				} else {
@@ -23310,12 +25033,16 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1906[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("sessionAffinity"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.SessionAffinity.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1906 {
-				r.EncodeEnd()
+			if yyr1906 || yy2arr1906 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -23330,17 +25057,18 @@ func (x *ServiceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1925 := r.ContainerType()
+		if yyct1925 == codecSelferValueTypeMap1234 {
 			yyl1925 := r.ReadMapStart()
 			if yyl1925 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1925, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1925 == codecSelferValueTypeArray1234 {
 			yyl1925 := r.ReadArrayStart()
 			if yyl1925 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1925, d)
 			}
@@ -23367,8 +25095,10 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1926Slc = r.DecodeBytes(yys1926Slc, true, true)
 		yys1926 := string(yys1926Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1926 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -23434,9 +25164,7 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1926)
 		} // end switch yys1926
 	} // end for yyj1926
-	if !yyhl1926 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -23453,9 +25181,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1937 = r.CheckBreak()
 	}
 	if yyb1937 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -23468,9 +25197,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1937 = r.CheckBreak()
 	}
 	if yyb1937 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
@@ -23489,9 +25219,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1937 = r.CheckBreak()
 	}
 	if yyb1937 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
@@ -23510,9 +25241,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1937 = r.CheckBreak()
 	}
 	if yyb1937 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ClusterIP = ""
 	} else {
@@ -23525,9 +25257,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1937 = r.CheckBreak()
 	}
 	if yyb1937 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ExternalIPs = nil
 	} else {
@@ -23546,9 +25279,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1937 = r.CheckBreak()
 	}
 	if yyb1937 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LoadBalancerIP = ""
 	} else {
@@ -23561,9 +25295,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1937 = r.CheckBreak()
 	}
 	if yyb1937 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SessionAffinity = ""
 	} else {
@@ -23579,9 +25314,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1937 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1937-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -23601,18 +25337,21 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1949 [5]bool
 			_, _, _ = yysep1949, yyq1949, yy2arr1949
 			const yyr1949 bool = false
+			var yynn1949 int
 			if yyr1949 || yy2arr1949 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1949 int = 5
+				yynn1949 = 5
 				for _, b := range yyq1949 {
 					if b {
 						yynn1949++
 					}
 				}
 				r.EncodeMapStart(yynn1949)
+				yynn1949 = 0
 			}
 			if yyr1949 || yy2arr1949 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1951 := z.EncBinary()
 				_ = yym1951
 				if false {
@@ -23620,7 +25359,9 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1952 := z.EncBinary()
 				_ = yym1952
 				if false {
@@ -23629,12 +25370,16 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1949 || yy2arr1949 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Protocol.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("protocol"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Protocol.CodecEncodeSelf(e)
 			}
 			if yyr1949 || yy2arr1949 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1955 := z.EncBinary()
 				_ = yym1955
 				if false {
@@ -23642,7 +25387,9 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1956 := z.EncBinary()
 				_ = yym1956
 				if false {
@@ -23651,6 +25398,7 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1949 || yy2arr1949 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy1958 := &x.TargetPort
 				yym1959 := z.EncBinary()
 				_ = yym1959
@@ -23662,7 +25410,9 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy1958)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("targetPort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy1960 := &x.TargetPort
 				yym1961 := z.EncBinary()
 				_ = yym1961
@@ -23675,6 +25425,7 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1949 || yy2arr1949 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1963 := z.EncBinary()
 				_ = yym1963
 				if false {
@@ -23682,7 +25433,9 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.NodePort))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("nodePort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1964 := z.EncBinary()
 				_ = yym1964
 				if false {
@@ -23690,8 +25443,10 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.NodePort))
 				}
 			}
-			if yysep1949 {
-				r.EncodeEnd()
+			if yyr1949 || yy2arr1949 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -23706,17 +25461,18 @@ func (x *ServicePort) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1966 := r.ContainerType()
+		if yyct1966 == codecSelferValueTypeMap1234 {
 			yyl1966 := r.ReadMapStart()
 			if yyl1966 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1966, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1966 == codecSelferValueTypeArray1234 {
 			yyl1966 := r.ReadArrayStart()
 			if yyl1966 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1966, d)
 			}
@@ -23743,8 +25499,10 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1967Slc = r.DecodeBytes(yys1967Slc, true, true)
 		yys1967 := string(yys1967Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1967 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -23789,9 +25547,7 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1967)
 		} // end switch yys1967
 	} // end for yyj1967
-	if !yyhl1967 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -23808,9 +25564,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1974 = r.CheckBreak()
 	}
 	if yyb1974 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -23823,9 +25580,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1974 = r.CheckBreak()
 	}
 	if yyb1974 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Protocol = ""
 	} else {
@@ -23838,9 +25596,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1974 = r.CheckBreak()
 	}
 	if yyb1974 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = 0
 	} else {
@@ -23853,9 +25612,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1974 = r.CheckBreak()
 	}
 	if yyb1974 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetPort = pkg5_intstr.IntOrString{}
 	} else {
@@ -23877,9 +25637,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1974 = r.CheckBreak()
 	}
 	if yyb1974 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NodePort = 0
 	} else {
@@ -23895,9 +25656,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1974 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1974-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -23922,18 +25684,21 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1982[2] = true
 			yyq1982[3] = true
 			yyq1982[4] = true
+			var yynn1982 int
 			if yyr1982 || yy2arr1982 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1982 int = 0
+				yynn1982 = 0
 				for _, b := range yyq1982 {
 					if b {
 						yynn1982++
 					}
 				}
 				r.EncodeMapStart(yynn1982)
+				yynn1982 = 0
 			}
 			if yyr1982 || yy2arr1982 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1982[0] {
 					yym1984 := z.EncBinary()
 					_ = yym1984
@@ -23946,7 +25711,9 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1982[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1985 := z.EncBinary()
 					_ = yym1985
 					if false {
@@ -23956,6 +25723,7 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1982 || yy2arr1982 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1982[1] {
 					yym1987 := z.EncBinary()
 					_ = yym1987
@@ -23968,7 +25736,9 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1982[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1988 := z.EncBinary()
 					_ = yym1988
 					if false {
@@ -23978,6 +25748,7 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1982 || yy2arr1982 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1982[2] {
 					yy1990 := &x.ObjectMeta
 					yy1990.CodecEncodeSelf(e)
@@ -23986,12 +25757,15 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1982[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1991 := &x.ObjectMeta
 					yy1991.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1982 || yy2arr1982 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1982[3] {
 					yy1993 := &x.Spec
 					yy1993.CodecEncodeSelf(e)
@@ -24000,12 +25774,15 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1982[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1994 := &x.Spec
 					yy1994.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1982 || yy2arr1982 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1982[4] {
 					yy1996 := &x.Status
 					yy1996.CodecEncodeSelf(e)
@@ -24014,13 +25791,17 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1982[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1997 := &x.Status
 					yy1997.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1982 {
-				r.EncodeEnd()
+			if yyr1982 || yy2arr1982 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -24035,17 +25816,18 @@ func (x *Service) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1999 := r.ContainerType()
+		if yyct1999 == codecSelferValueTypeMap1234 {
 			yyl1999 := r.ReadMapStart()
 			if yyl1999 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1999, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1999 == codecSelferValueTypeArray1234 {
 			yyl1999 := r.ReadArrayStart()
 			if yyl1999 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1999, d)
 			}
@@ -24072,8 +25854,10 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2000Slc = r.DecodeBytes(yys2000Slc, true, true)
 		yys2000 := string(yys2000Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2000 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -24112,9 +25896,7 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2000)
 		} // end switch yys2000
 	} // end for yyj2000
-	if !yyhl2000 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -24131,9 +25913,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2006 = r.CheckBreak()
 	}
 	if yyb2006 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -24146,9 +25929,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2006 = r.CheckBreak()
 	}
 	if yyb2006 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -24161,9 +25945,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2006 = r.CheckBreak()
 	}
 	if yyb2006 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -24177,9 +25962,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2006 = r.CheckBreak()
 	}
 	if yyb2006 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ServiceSpec{}
 	} else {
@@ -24193,9 +25979,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2006 = r.CheckBreak()
 	}
 	if yyb2006 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ServiceStatus{}
 	} else {
@@ -24212,9 +25999,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2006 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2006-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -24238,18 +26026,21 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2013[1] = x.APIVersion != ""
 			yyq2013[2] = true
 			yyq2013[4] = len(x.ImagePullSecrets) != 0
+			var yynn2013 int
 			if yyr2013 || yy2arr2013 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2013 int = 1
+				yynn2013 = 1
 				for _, b := range yyq2013 {
 					if b {
 						yynn2013++
 					}
 				}
 				r.EncodeMapStart(yynn2013)
+				yynn2013 = 0
 			}
 			if yyr2013 || yy2arr2013 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2013[0] {
 					yym2015 := z.EncBinary()
 					_ = yym2015
@@ -24262,7 +26053,9 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2013[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2016 := z.EncBinary()
 					_ = yym2016
 					if false {
@@ -24272,6 +26065,7 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2013 || yy2arr2013 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2013[1] {
 					yym2018 := z.EncBinary()
 					_ = yym2018
@@ -24284,7 +26078,9 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2013[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2019 := z.EncBinary()
 					_ = yym2019
 					if false {
@@ -24294,6 +26090,7 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2013 || yy2arr2013 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2013[2] {
 					yy2021 := &x.ObjectMeta
 					yy2021.CodecEncodeSelf(e)
@@ -24302,12 +26099,15 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2013[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2022 := &x.ObjectMeta
 					yy2022.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2013 || yy2arr2013 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Secrets == nil {
 					r.EncodeNil()
 				} else {
@@ -24319,7 +26119,9 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("secrets"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Secrets == nil {
 					r.EncodeNil()
 				} else {
@@ -24332,6 +26134,7 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2013 || yy2arr2013 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2013[4] {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
@@ -24348,7 +26151,9 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2013[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("imagePullSecrets"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
@@ -24361,8 +26166,10 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2013 {
-				r.EncodeEnd()
+			if yyr2013 || yy2arr2013 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -24377,17 +26184,18 @@ func (x *ServiceAccount) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2030 := r.ContainerType()
+		if yyct2030 == codecSelferValueTypeMap1234 {
 			yyl2030 := r.ReadMapStart()
 			if yyl2030 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2030, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2030 == codecSelferValueTypeArray1234 {
 			yyl2030 := r.ReadArrayStart()
 			if yyl2030 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2030, d)
 			}
@@ -24414,8 +26222,10 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2031Slc = r.DecodeBytes(yys2031Slc, true, true)
 		yys2031 := string(yys2031Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2031 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -24464,9 +26274,7 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2031)
 		} // end switch yys2031
 	} // end for yyj2031
-	if !yyhl2031 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -24483,9 +26291,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2039 = r.CheckBreak()
 	}
 	if yyb2039 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -24498,9 +26307,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2039 = r.CheckBreak()
 	}
 	if yyb2039 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -24513,9 +26323,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2039 = r.CheckBreak()
 	}
 	if yyb2039 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -24529,9 +26340,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2039 = r.CheckBreak()
 	}
 	if yyb2039 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Secrets = nil
 	} else {
@@ -24550,9 +26362,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2039 = r.CheckBreak()
 	}
 	if yyb2039 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ImagePullSecrets = nil
 	} else {
@@ -24574,9 +26387,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2039 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2039-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -24599,18 +26413,21 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2048[0] = x.Kind != ""
 			yyq2048[1] = x.APIVersion != ""
 			yyq2048[2] = true
+			var yynn2048 int
 			if yyr2048 || yy2arr2048 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2048 int = 1
+				yynn2048 = 1
 				for _, b := range yyq2048 {
 					if b {
 						yynn2048++
 					}
 				}
 				r.EncodeMapStart(yynn2048)
+				yynn2048 = 0
 			}
 			if yyr2048 || yy2arr2048 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2048[0] {
 					yym2050 := z.EncBinary()
 					_ = yym2050
@@ -24623,7 +26440,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2048[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2051 := z.EncBinary()
 					_ = yym2051
 					if false {
@@ -24633,6 +26452,7 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2048 || yy2arr2048 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2048[1] {
 					yym2053 := z.EncBinary()
 					_ = yym2053
@@ -24645,7 +26465,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2048[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2054 := z.EncBinary()
 					_ = yym2054
 					if false {
@@ -24655,6 +26477,7 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2048 || yy2arr2048 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2048[2] {
 					yy2056 := &x.ListMeta
 					yym2057 := z.EncBinary()
@@ -24669,7 +26492,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2048[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2058 := &x.ListMeta
 					yym2059 := z.EncBinary()
 					_ = yym2059
@@ -24681,6 +26506,7 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2048 || yy2arr2048 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -24692,7 +26518,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -24704,8 +26532,10 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2048 {
-				r.EncodeEnd()
+			if yyr2048 || yy2arr2048 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -24720,17 +26550,18 @@ func (x *ServiceAccountList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2064 := r.ContainerType()
+		if yyct2064 == codecSelferValueTypeMap1234 {
 			yyl2064 := r.ReadMapStart()
 			if yyl2064 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2064, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2064 == codecSelferValueTypeArray1234 {
 			yyl2064 := r.ReadArrayStart()
 			if yyl2064 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2064, d)
 			}
@@ -24757,8 +26588,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2065Slc = r.DecodeBytes(yys2065Slc, true, true)
 		yys2065 := string(yys2065Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2065 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -24801,9 +26634,7 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys2065)
 		} // end switch yys2065
 	} // end for yyj2065
-	if !yyhl2065 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -24820,9 +26651,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb2072 = r.CheckBreak()
 	}
 	if yyb2072 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -24835,9 +26667,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb2072 = r.CheckBreak()
 	}
 	if yyb2072 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -24850,9 +26683,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb2072 = r.CheckBreak()
 	}
 	if yyb2072 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -24872,9 +26706,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb2072 = r.CheckBreak()
 	}
 	if yyb2072 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -24896,9 +26731,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb2072 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2072-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -24921,18 +26757,21 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2080[0] = x.Kind != ""
 			yyq2080[1] = x.APIVersion != ""
 			yyq2080[2] = true
+			var yynn2080 int
 			if yyr2080 || yy2arr2080 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2080 int = 1
+				yynn2080 = 1
 				for _, b := range yyq2080 {
 					if b {
 						yynn2080++
 					}
 				}
 				r.EncodeMapStart(yynn2080)
+				yynn2080 = 0
 			}
 			if yyr2080 || yy2arr2080 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2080[0] {
 					yym2082 := z.EncBinary()
 					_ = yym2082
@@ -24945,7 +26784,9 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2080[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2083 := z.EncBinary()
 					_ = yym2083
 					if false {
@@ -24955,6 +26796,7 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2080 || yy2arr2080 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2080[1] {
 					yym2085 := z.EncBinary()
 					_ = yym2085
@@ -24967,7 +26809,9 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2080[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2086 := z.EncBinary()
 					_ = yym2086
 					if false {
@@ -24977,6 +26821,7 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2080 || yy2arr2080 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2080[2] {
 					yy2088 := &x.ObjectMeta
 					yy2088.CodecEncodeSelf(e)
@@ -24985,12 +26830,15 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2080[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2089 := &x.ObjectMeta
 					yy2089.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2080 || yy2arr2080 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
@@ -25002,7 +26850,9 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Subsets"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
@@ -25014,8 +26864,10 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2080 {
-				r.EncodeEnd()
+			if yyr2080 || yy2arr2080 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -25030,17 +26882,18 @@ func (x *Endpoints) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2094 := r.ContainerType()
+		if yyct2094 == codecSelferValueTypeMap1234 {
 			yyl2094 := r.ReadMapStart()
 			if yyl2094 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2094, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2094 == codecSelferValueTypeArray1234 {
 			yyl2094 := r.ReadArrayStart()
 			if yyl2094 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2094, d)
 			}
@@ -25067,8 +26920,10 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2095Slc = r.DecodeBytes(yys2095Slc, true, true)
 		yys2095 := string(yys2095Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2095 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -25105,9 +26960,7 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2095)
 		} // end switch yys2095
 	} // end for yyj2095
-	if !yyhl2095 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -25124,9 +26977,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2101 = r.CheckBreak()
 	}
 	if yyb2101 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -25139,9 +26993,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2101 = r.CheckBreak()
 	}
 	if yyb2101 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -25154,9 +27009,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2101 = r.CheckBreak()
 	}
 	if yyb2101 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -25170,9 +27026,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2101 = r.CheckBreak()
 	}
 	if yyb2101 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Subsets = nil
 	} else {
@@ -25194,9 +27051,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2101 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2101-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -25216,18 +27074,21 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2108 [3]bool
 			_, _, _ = yysep2108, yyq2108, yy2arr2108
 			const yyr2108 bool = false
+			var yynn2108 int
 			if yyr2108 || yy2arr2108 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2108 int = 3
+				yynn2108 = 3
 				for _, b := range yyq2108 {
 					if b {
 						yynn2108++
 					}
 				}
 				r.EncodeMapStart(yynn2108)
+				yynn2108 = 0
 			}
 			if yyr2108 || yy2arr2108 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Addresses == nil {
 					r.EncodeNil()
 				} else {
@@ -25239,7 +27100,9 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Addresses"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Addresses == nil {
 					r.EncodeNil()
 				} else {
@@ -25252,6 +27115,7 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2108 || yy2arr2108 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.NotReadyAddresses == nil {
 					r.EncodeNil()
 				} else {
@@ -25263,7 +27127,9 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("NotReadyAddresses"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.NotReadyAddresses == nil {
 					r.EncodeNil()
 				} else {
@@ -25276,6 +27142,7 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2108 || yy2arr2108 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
@@ -25287,7 +27154,9 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Ports"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
@@ -25299,8 +27168,10 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2108 {
-				r.EncodeEnd()
+			if yyr2108 || yy2arr2108 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -25315,17 +27186,18 @@ func (x *EndpointSubset) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2119 := r.ContainerType()
+		if yyct2119 == codecSelferValueTypeMap1234 {
 			yyl2119 := r.ReadMapStart()
 			if yyl2119 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2119, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2119 == codecSelferValueTypeArray1234 {
 			yyl2119 := r.ReadArrayStart()
 			if yyl2119 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2119, d)
 			}
@@ -25352,8 +27224,10 @@ func (x *EndpointSubset) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2120Slc = r.DecodeBytes(yys2120Slc, true, true)
 		yys2120 := string(yys2120Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2120 {
 		case "Addresses":
 			if r.TryDecodeAsNil() {
@@ -25395,9 +27269,7 @@ func (x *EndpointSubset) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2120)
 		} // end switch yys2120
 	} // end for yyj2120
-	if !yyhl2120 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -25414,9 +27286,10 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2127 = r.CheckBreak()
 	}
 	if yyb2127 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Addresses = nil
 	} else {
@@ -25435,9 +27308,10 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2127 = r.CheckBreak()
 	}
 	if yyb2127 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NotReadyAddresses = nil
 	} else {
@@ -25456,9 +27330,10 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2127 = r.CheckBreak()
 	}
 	if yyb2127 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
@@ -25480,9 +27355,10 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2127 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2127-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -25502,18 +27378,21 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2135 [2]bool
 			_, _, _ = yysep2135, yyq2135, yy2arr2135
 			const yyr2135 bool = false
+			var yynn2135 int
 			if yyr2135 || yy2arr2135 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2135 int = 2
+				yynn2135 = 2
 				for _, b := range yyq2135 {
 					if b {
 						yynn2135++
 					}
 				}
 				r.EncodeMapStart(yynn2135)
+				yynn2135 = 0
 			}
 			if yyr2135 || yy2arr2135 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2137 := z.EncBinary()
 				_ = yym2137
 				if false {
@@ -25521,7 +27400,9 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.IP))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("IP"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2138 := z.EncBinary()
 				_ = yym2138
 				if false {
@@ -25530,21 +27411,26 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2135 || yy2arr2135 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.TargetRef == nil {
 					r.EncodeNil()
 				} else {
 					x.TargetRef.CodecEncodeSelf(e)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("TargetRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.TargetRef == nil {
 					r.EncodeNil()
 				} else {
 					x.TargetRef.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2135 {
-				r.EncodeEnd()
+			if yyr2135 || yy2arr2135 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -25559,17 +27445,18 @@ func (x *EndpointAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2141 := r.ContainerType()
+		if yyct2141 == codecSelferValueTypeMap1234 {
 			yyl2141 := r.ReadMapStart()
 			if yyl2141 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2141, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2141 == codecSelferValueTypeArray1234 {
 			yyl2141 := r.ReadArrayStart()
 			if yyl2141 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2141, d)
 			}
@@ -25596,8 +27483,10 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2142Slc = r.DecodeBytes(yys2142Slc, true, true)
 		yys2142 := string(yys2142Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2142 {
 		case "IP":
 			if r.TryDecodeAsNil() {
@@ -25620,9 +27509,7 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2142)
 		} // end switch yys2142
 	} // end for yyj2142
-	if !yyhl2142 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -25639,9 +27526,10 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2145 = r.CheckBreak()
 	}
 	if yyb2145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.IP = ""
 	} else {
@@ -25654,9 +27542,10 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2145 = r.CheckBreak()
 	}
 	if yyb2145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TargetRef != nil {
 			x.TargetRef = nil
@@ -25677,9 +27566,10 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb2145 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2145-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -25699,18 +27589,21 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2149 [3]bool
 			_, _, _ = yysep2149, yyq2149, yy2arr2149
 			const yyr2149 bool = false
+			var yynn2149 int
 			if yyr2149 || yy2arr2149 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2149 int = 3
+				yynn2149 = 3
 				for _, b := range yyq2149 {
 					if b {
 						yynn2149++
 					}
 				}
 				r.EncodeMapStart(yynn2149)
+				yynn2149 = 0
 			}
 			if yyr2149 || yy2arr2149 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2151 := z.EncBinary()
 				_ = yym2151
 				if false {
@@ -25718,7 +27611,9 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2152 := z.EncBinary()
 				_ = yym2152
 				if false {
@@ -25727,6 +27622,7 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2149 || yy2arr2149 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2154 := z.EncBinary()
 				_ = yym2154
 				if false {
@@ -25734,7 +27630,9 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Port"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2155 := z.EncBinary()
 				_ = yym2155
 				if false {
@@ -25743,13 +27641,18 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2149 || yy2arr2149 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Protocol.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Protocol"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Protocol.CodecEncodeSelf(e)
 			}
-			if yysep2149 {
-				r.EncodeEnd()
+			if yyr2149 || yy2arr2149 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -25764,17 +27667,18 @@ func (x *EndpointPort) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2158 := r.ContainerType()
+		if yyct2158 == codecSelferValueTypeMap1234 {
 			yyl2158 := r.ReadMapStart()
 			if yyl2158 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2158, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2158 == codecSelferValueTypeArray1234 {
 			yyl2158 := r.ReadArrayStart()
 			if yyl2158 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2158, d)
 			}
@@ -25801,8 +27705,10 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2159Slc = r.DecodeBytes(yys2159Slc, true, true)
 		yys2159 := string(yys2159Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2159 {
 		case "Name":
 			if r.TryDecodeAsNil() {
@@ -25826,9 +27732,7 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2159)
 		} // end switch yys2159
 	} // end for yyj2159
-	if !yyhl2159 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -25845,9 +27749,10 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2163 = r.CheckBreak()
 	}
 	if yyb2163 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -25860,9 +27765,10 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2163 = r.CheckBreak()
 	}
 	if yyb2163 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = 0
 	} else {
@@ -25875,9 +27781,10 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2163 = r.CheckBreak()
 	}
 	if yyb2163 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Protocol = ""
 	} else {
@@ -25893,9 +27800,10 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2163 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2163-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -25918,18 +27826,21 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2168[0] = x.Kind != ""
 			yyq2168[1] = x.APIVersion != ""
 			yyq2168[2] = true
+			var yynn2168 int
 			if yyr2168 || yy2arr2168 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2168 int = 1
+				yynn2168 = 1
 				for _, b := range yyq2168 {
 					if b {
 						yynn2168++
 					}
 				}
 				r.EncodeMapStart(yynn2168)
+				yynn2168 = 0
 			}
 			if yyr2168 || yy2arr2168 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2168[0] {
 					yym2170 := z.EncBinary()
 					_ = yym2170
@@ -25942,7 +27853,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2168[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2171 := z.EncBinary()
 					_ = yym2171
 					if false {
@@ -25952,6 +27865,7 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2168 || yy2arr2168 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2168[1] {
 					yym2173 := z.EncBinary()
 					_ = yym2173
@@ -25964,7 +27878,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2168[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2174 := z.EncBinary()
 					_ = yym2174
 					if false {
@@ -25974,6 +27890,7 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2168 || yy2arr2168 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2168[2] {
 					yy2176 := &x.ListMeta
 					yym2177 := z.EncBinary()
@@ -25988,7 +27905,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2168[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2178 := &x.ListMeta
 					yym2179 := z.EncBinary()
 					_ = yym2179
@@ -26000,6 +27919,7 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2168 || yy2arr2168 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -26011,7 +27931,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -26023,8 +27945,10 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2168 {
-				r.EncodeEnd()
+			if yyr2168 || yy2arr2168 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -26039,17 +27963,18 @@ func (x *EndpointsList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2184 := r.ContainerType()
+		if yyct2184 == codecSelferValueTypeMap1234 {
 			yyl2184 := r.ReadMapStart()
 			if yyl2184 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2184, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2184 == codecSelferValueTypeArray1234 {
 			yyl2184 := r.ReadArrayStart()
 			if yyl2184 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2184, d)
 			}
@@ -26076,8 +28001,10 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2185Slc = r.DecodeBytes(yys2185Slc, true, true)
 		yys2185 := string(yys2185Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2185 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -26120,9 +28047,7 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2185)
 		} // end switch yys2185
 	} // end for yyj2185
-	if !yyhl2185 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -26139,9 +28064,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2192 = r.CheckBreak()
 	}
 	if yyb2192 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -26154,9 +28080,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2192 = r.CheckBreak()
 	}
 	if yyb2192 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -26169,9 +28096,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2192 = r.CheckBreak()
 	}
 	if yyb2192 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -26191,9 +28119,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2192 = r.CheckBreak()
 	}
 	if yyb2192 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -26215,9 +28144,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2192 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2192-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -26241,18 +28171,21 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2200[1] = x.ExternalID != ""
 			yyq2200[2] = x.ProviderID != ""
 			yyq2200[3] = x.Unschedulable != false
+			var yynn2200 int
 			if yyr2200 || yy2arr2200 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2200 int = 0
+				yynn2200 = 0
 				for _, b := range yyq2200 {
 					if b {
 						yynn2200++
 					}
 				}
 				r.EncodeMapStart(yynn2200)
+				yynn2200 = 0
 			}
 			if yyr2200 || yy2arr2200 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2200[0] {
 					yym2202 := z.EncBinary()
 					_ = yym2202
@@ -26265,7 +28198,9 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2200[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("podCIDR"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2203 := z.EncBinary()
 					_ = yym2203
 					if false {
@@ -26275,6 +28210,7 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2200 || yy2arr2200 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2200[1] {
 					yym2205 := z.EncBinary()
 					_ = yym2205
@@ -26287,7 +28223,9 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2200[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("externalID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2206 := z.EncBinary()
 					_ = yym2206
 					if false {
@@ -26297,6 +28235,7 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2200 || yy2arr2200 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2200[2] {
 					yym2208 := z.EncBinary()
 					_ = yym2208
@@ -26309,7 +28248,9 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2200[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("providerID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2209 := z.EncBinary()
 					_ = yym2209
 					if false {
@@ -26319,6 +28260,7 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2200 || yy2arr2200 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2200[3] {
 					yym2211 := z.EncBinary()
 					_ = yym2211
@@ -26331,7 +28273,9 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2200[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("unschedulable"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2212 := z.EncBinary()
 					_ = yym2212
 					if false {
@@ -26340,8 +28284,10 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2200 {
-				r.EncodeEnd()
+			if yyr2200 || yy2arr2200 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -26356,17 +28302,18 @@ func (x *NodeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2214 := r.ContainerType()
+		if yyct2214 == codecSelferValueTypeMap1234 {
 			yyl2214 := r.ReadMapStart()
 			if yyl2214 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2214, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2214 == codecSelferValueTypeArray1234 {
 			yyl2214 := r.ReadArrayStart()
 			if yyl2214 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2214, d)
 			}
@@ -26393,8 +28340,10 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2215Slc = r.DecodeBytes(yys2215Slc, true, true)
 		yys2215 := string(yys2215Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2215 {
 		case "podCIDR":
 			if r.TryDecodeAsNil() {
@@ -26424,9 +28373,7 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2215)
 		} // end switch yys2215
 	} // end for yyj2215
-	if !yyhl2215 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -26443,9 +28390,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2220 = r.CheckBreak()
 	}
 	if yyb2220 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PodCIDR = ""
 	} else {
@@ -26458,9 +28406,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2220 = r.CheckBreak()
 	}
 	if yyb2220 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ExternalID = ""
 	} else {
@@ -26473,9 +28422,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2220 = r.CheckBreak()
 	}
 	if yyb2220 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ProviderID = ""
 	} else {
@@ -26488,9 +28438,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2220 = r.CheckBreak()
 	}
 	if yyb2220 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Unschedulable = false
 	} else {
@@ -26506,9 +28457,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2220 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2220-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -26528,18 +28480,21 @@ func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2226 [1]bool
 			_, _, _ = yysep2226, yyq2226, yy2arr2226
 			const yyr2226 bool = false
+			var yynn2226 int
 			if yyr2226 || yy2arr2226 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2226 int = 1
+				yynn2226 = 1
 				for _, b := range yyq2226 {
 					if b {
 						yynn2226++
 					}
 				}
 				r.EncodeMapStart(yynn2226)
+				yynn2226 = 0
 			}
 			if yyr2226 || yy2arr2226 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2228 := z.EncBinary()
 				_ = yym2228
 				if false {
@@ -26547,7 +28502,9 @@ func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Port"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2229 := z.EncBinary()
 				_ = yym2229
 				if false {
@@ -26555,8 +28512,10 @@ func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yysep2226 {
-				r.EncodeEnd()
+			if yyr2226 || yy2arr2226 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -26571,17 +28530,18 @@ func (x *DaemonEndpoint) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2231 := r.ContainerType()
+		if yyct2231 == codecSelferValueTypeMap1234 {
 			yyl2231 := r.ReadMapStart()
 			if yyl2231 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2231, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2231 == codecSelferValueTypeArray1234 {
 			yyl2231 := r.ReadArrayStart()
 			if yyl2231 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2231, d)
 			}
@@ -26608,8 +28568,10 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2232Slc = r.DecodeBytes(yys2232Slc, true, true)
 		yys2232 := string(yys2232Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2232 {
 		case "Port":
 			if r.TryDecodeAsNil() {
@@ -26621,9 +28583,7 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2232)
 		} // end switch yys2232
 	} // end for yyj2232
-	if !yyhl2232 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -26640,9 +28600,10 @@ func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2234 = r.CheckBreak()
 	}
 	if yyb2234 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = 0
 	} else {
@@ -26658,9 +28619,10 @@ func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2234 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2234-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeDaemonEndpoints) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -26681,18 +28643,21 @@ func (x *NodeDaemonEndpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2237, yyq2237, yy2arr2237
 			const yyr2237 bool = false
 			yyq2237[0] = true
+			var yynn2237 int
 			if yyr2237 || yy2arr2237 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2237 int = 0
+				yynn2237 = 0
 				for _, b := range yyq2237 {
 					if b {
 						yynn2237++
 					}
 				}
 				r.EncodeMapStart(yynn2237)
+				yynn2237 = 0
 			}
 			if yyr2237 || yy2arr2237 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2237[0] {
 					yy2239 := &x.KubeletEndpoint
 					yy2239.CodecEncodeSelf(e)
@@ -26701,13 +28666,17 @@ func (x *NodeDaemonEndpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2237[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kubeletEndpoint"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2240 := &x.KubeletEndpoint
 					yy2240.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2237 {
-				r.EncodeEnd()
+			if yyr2237 || yy2arr2237 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -26722,17 +28691,18 @@ func (x *NodeDaemonEndpoints) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2242 := r.ContainerType()
+		if yyct2242 == codecSelferValueTypeMap1234 {
 			yyl2242 := r.ReadMapStart()
 			if yyl2242 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2242, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2242 == codecSelferValueTypeArray1234 {
 			yyl2242 := r.ReadArrayStart()
 			if yyl2242 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2242, d)
 			}
@@ -26759,8 +28729,10 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2243Slc = r.DecodeBytes(yys2243Slc, true, true)
 		yys2243 := string(yys2243Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2243 {
 		case "kubeletEndpoint":
 			if r.TryDecodeAsNil() {
@@ -26773,9 +28745,7 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys2243)
 		} // end switch yys2243
 	} // end for yyj2243
-	if !yyhl2243 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeDaemonEndpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -26792,9 +28762,10 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb2245 = r.CheckBreak()
 	}
 	if yyb2245 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeletEndpoint = DaemonEndpoint{}
 	} else {
@@ -26811,9 +28782,10 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb2245 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2245-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -26833,18 +28805,21 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2248 [8]bool
 			_, _, _ = yysep2248, yyq2248, yy2arr2248
 			const yyr2248 bool = false
+			var yynn2248 int
 			if yyr2248 || yy2arr2248 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2248 int = 8
+				yynn2248 = 8
 				for _, b := range yyq2248 {
 					if b {
 						yynn2248++
 					}
 				}
 				r.EncodeMapStart(yynn2248)
+				yynn2248 = 0
 			}
 			if yyr2248 || yy2arr2248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2250 := z.EncBinary()
 				_ = yym2250
 				if false {
@@ -26852,7 +28827,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MachineID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("machineID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2251 := z.EncBinary()
 				_ = yym2251
 				if false {
@@ -26861,6 +28838,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2248 || yy2arr2248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2253 := z.EncBinary()
 				_ = yym2253
 				if false {
@@ -26868,7 +28846,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SystemUUID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("systemUUID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2254 := z.EncBinary()
 				_ = yym2254
 				if false {
@@ -26877,6 +28857,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2248 || yy2arr2248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2256 := z.EncBinary()
 				_ = yym2256
 				if false {
@@ -26884,7 +28865,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BootID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("bootID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2257 := z.EncBinary()
 				_ = yym2257
 				if false {
@@ -26893,6 +28876,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2248 || yy2arr2248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2259 := z.EncBinary()
 				_ = yym2259
 				if false {
@@ -26900,7 +28884,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KernelVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kernelVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2260 := z.EncBinary()
 				_ = yym2260
 				if false {
@@ -26909,6 +28895,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2248 || yy2arr2248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2262 := z.EncBinary()
 				_ = yym2262
 				if false {
@@ -26916,7 +28903,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.OsImage))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("osImage"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2263 := z.EncBinary()
 				_ = yym2263
 				if false {
@@ -26925,6 +28914,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2248 || yy2arr2248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2265 := z.EncBinary()
 				_ = yym2265
 				if false {
@@ -26932,7 +28922,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntimeVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("containerRuntimeVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2266 := z.EncBinary()
 				_ = yym2266
 				if false {
@@ -26941,6 +28933,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2248 || yy2arr2248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2268 := z.EncBinary()
 				_ = yym2268
 				if false {
@@ -26948,7 +28941,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeletVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeletVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2269 := z.EncBinary()
 				_ = yym2269
 				if false {
@@ -26957,6 +28952,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2248 || yy2arr2248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2271 := z.EncBinary()
 				_ = yym2271
 				if false {
@@ -26964,7 +28960,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeProxyVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeProxyVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2272 := z.EncBinary()
 				_ = yym2272
 				if false {
@@ -26972,8 +28970,10 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeProxyVersion))
 				}
 			}
-			if yysep2248 {
-				r.EncodeEnd()
+			if yyr2248 || yy2arr2248 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -26988,17 +28988,18 @@ func (x *NodeSystemInfo) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2274 := r.ContainerType()
+		if yyct2274 == codecSelferValueTypeMap1234 {
 			yyl2274 := r.ReadMapStart()
 			if yyl2274 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2274, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2274 == codecSelferValueTypeArray1234 {
 			yyl2274 := r.ReadArrayStart()
 			if yyl2274 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2274, d)
 			}
@@ -27025,8 +29026,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2275Slc = r.DecodeBytes(yys2275Slc, true, true)
 		yys2275 := string(yys2275Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2275 {
 		case "machineID":
 			if r.TryDecodeAsNil() {
@@ -27080,9 +29083,7 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2275)
 		} // end switch yys2275
 	} // end for yyj2275
-	if !yyhl2275 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -27099,9 +29100,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2284 = r.CheckBreak()
 	}
 	if yyb2284 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MachineID = ""
 	} else {
@@ -27114,9 +29116,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2284 = r.CheckBreak()
 	}
 	if yyb2284 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SystemUUID = ""
 	} else {
@@ -27129,9 +29132,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2284 = r.CheckBreak()
 	}
 	if yyb2284 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.BootID = ""
 	} else {
@@ -27144,9 +29148,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2284 = r.CheckBreak()
 	}
 	if yyb2284 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KernelVersion = ""
 	} else {
@@ -27159,9 +29164,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2284 = r.CheckBreak()
 	}
 	if yyb2284 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.OsImage = ""
 	} else {
@@ -27174,9 +29180,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2284 = r.CheckBreak()
 	}
 	if yyb2284 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerRuntimeVersion = ""
 	} else {
@@ -27189,9 +29196,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2284 = r.CheckBreak()
 	}
 	if yyb2284 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeletVersion = ""
 	} else {
@@ -27204,9 +29212,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2284 = r.CheckBreak()
 	}
 	if yyb2284 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeProxyVersion = ""
 	} else {
@@ -27222,9 +29231,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2284 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2284-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -27250,18 +29260,21 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2294[3] = len(x.Addresses) != 0
 			yyq2294[4] = true
 			yyq2294[5] = true
+			var yynn2294 int
 			if yyr2294 || yy2arr2294 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn2294 int = 0
+				yynn2294 = 0
 				for _, b := range yyq2294 {
 					if b {
 						yynn2294++
 					}
 				}
 				r.EncodeMapStart(yynn2294)
+				yynn2294 = 0
 			}
 			if yyr2294 || yy2arr2294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2294[0] {
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -27273,7 +29286,9 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2294[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -27282,6 +29297,7 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2294 || yy2arr2294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2294[1] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -27289,11 +29305,14 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2294[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2294 || yy2arr2294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2294[2] {
 					if x.Conditions == nil {
 						r.EncodeNil()
@@ -27310,7 +29329,9 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2294[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
@@ -27324,6 +29345,7 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2294 || yy2arr2294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2294[3] {
 					if x.Addresses == nil {
 						r.EncodeNil()
@@ -27340,7 +29362,9 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2294[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("addresses"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Addresses == nil {
 						r.EncodeNil()
 					} else {
@@ -27354,6 +29378,7 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2294 || yy2arr2294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2294[4] {
 					yy2304 := &x.DaemonEndpoints
 					yy2304.CodecEncodeSelf(e)
@@ -27362,12 +29387,15 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2294[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("daemonEndpoints"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2305 := &x.DaemonEndpoints
 					yy2305.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2294 || yy2arr2294 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2294[5] {
 					yy2307 := &x.NodeInfo
 					yy2307.CodecEncodeSelf(e)
@@ -27376,13 +29404,17 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2294[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nodeInfo"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2308 := &x.NodeInfo
 					yy2308.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2294 {
-				r.EncodeEnd()
+			if yyr2294 || yy2arr2294 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -27397,17 +29429,18 @@ func (x *NodeStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2310 := r.ContainerType()
+		if yyct2310 == codecSelferValueTypeMap1234 {
 			yyl2310 := r.ReadMapStart()
 			if yyl2310 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2310, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2310 == codecSelferValueTypeArray1234 {
 			yyl2310 := r.ReadArrayStart()
 			if yyl2310 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2310, d)
 			}
@@ -27434,8 +29467,10 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2311Slc = r.DecodeBytes(yys2311Slc, true, true)
 		yys2311 := string(yys2311Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2311 {
 		case "capacity":
 			if r.TryDecodeAsNil() {
@@ -27492,9 +29527,7 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2311)
 		} // end switch yys2311
 	} // end for yyj2311
-	if !yyhl2311 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -27511,9 +29544,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2320 = r.CheckBreak()
 	}
 	if yyb2320 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
@@ -27527,9 +29561,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2320 = r.CheckBreak()
 	}
 	if yyb2320 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -27542,9 +29577,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2320 = r.CheckBreak()
 	}
 	if yyb2320 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
@@ -27563,9 +29599,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2320 = r.CheckBreak()
 	}
 	if yyb2320 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Addresses = nil
 	} else {
@@ -27584,9 +29621,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2320 = r.CheckBreak()
 	}
 	if yyb2320 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DaemonEndpoints = NodeDaemonEndpoints{}
 	} else {
@@ -27600,9 +29638,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2320 = r.CheckBreak()
 	}
 	if yyb2320 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NodeInfo = NodeSystemInfo{}
 	} else {
@@ -27619,9 +29658,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2320 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2320-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x NodePhase) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -27697,30 +29737,39 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2334[3] = true
 			yyq2334[4] = x.Reason != ""
 			yyq2334[5] = x.Message != ""
+			var yynn2334 int
 			if yyr2334 || yy2arr2334 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn2334 int = 2
+				yynn2334 = 2
 				for _, b := range yyq2334 {
 					if b {
 						yynn2334++
 					}
 				}
 				r.EncodeMapStart(yynn2334)
+				yynn2334 = 0
 			}
 			if yyr2334 || yy2arr2334 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr2334 || yy2arr2334 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Status.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Status.CodecEncodeSelf(e)
 			}
 			if yyr2334 || yy2arr2334 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2334[2] {
 					yy2338 := &x.LastHeartbeatTime
 					yym2339 := z.EncBinary()
@@ -27739,7 +29788,9 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2334[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastHeartbeatTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2340 := &x.LastHeartbeatTime
 					yym2341 := z.EncBinary()
 					_ = yym2341
@@ -27755,6 +29806,7 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2334 || yy2arr2334 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2334[3] {
 					yy2343 := &x.LastTransitionTime
 					yym2344 := z.EncBinary()
@@ -27773,7 +29825,9 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2334[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2345 := &x.LastTransitionTime
 					yym2346 := z.EncBinary()
 					_ = yym2346
@@ -27789,6 +29843,7 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2334 || yy2arr2334 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2334[4] {
 					yym2348 := z.EncBinary()
 					_ = yym2348
@@ -27801,7 +29856,9 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2334[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2349 := z.EncBinary()
 					_ = yym2349
 					if false {
@@ -27811,6 +29868,7 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2334 || yy2arr2334 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2334[5] {
 					yym2351 := z.EncBinary()
 					_ = yym2351
@@ -27823,7 +29881,9 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2334[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2352 := z.EncBinary()
 					_ = yym2352
 					if false {
@@ -27832,8 +29892,10 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2334 {
-				r.EncodeEnd()
+			if yyr2334 || yy2arr2334 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -27848,17 +29910,18 @@ func (x *NodeCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2354 := r.ContainerType()
+		if yyct2354 == codecSelferValueTypeMap1234 {
 			yyl2354 := r.ReadMapStart()
 			if yyl2354 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2354, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2354 == codecSelferValueTypeArray1234 {
 			yyl2354 := r.ReadArrayStart()
 			if yyl2354 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2354, d)
 			}
@@ -27885,8 +29948,10 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2355Slc = r.DecodeBytes(yys2355Slc, true, true)
 		yys2355 := string(yys2355Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2355 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -27950,9 +30015,7 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2355)
 		} // end switch yys2355
 	} // end for yyj2355
-	if !yyhl2355 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -27969,9 +30032,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2364 = r.CheckBreak()
 	}
 	if yyb2364 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -27984,9 +30048,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2364 = r.CheckBreak()
 	}
 	if yyb2364 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ""
 	} else {
@@ -27999,9 +30064,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2364 = r.CheckBreak()
 	}
 	if yyb2364 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastHeartbeatTime = pkg2_unversioned.Time{}
 	} else {
@@ -28025,9 +30091,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2364 = r.CheckBreak()
 	}
 	if yyb2364 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg2_unversioned.Time{}
 	} else {
@@ -28051,9 +30118,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2364 = r.CheckBreak()
 	}
 	if yyb2364 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -28066,9 +30134,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2364 = r.CheckBreak()
 	}
 	if yyb2364 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -28084,9 +30153,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2364 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2364-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x NodeAddressType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -28132,24 +30202,30 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2376 [2]bool
 			_, _, _ = yysep2376, yyq2376, yy2arr2376
 			const yyr2376 bool = false
+			var yynn2376 int
 			if yyr2376 || yy2arr2376 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2376 int = 2
+				yynn2376 = 2
 				for _, b := range yyq2376 {
 					if b {
 						yynn2376++
 					}
 				}
 				r.EncodeMapStart(yynn2376)
+				yynn2376 = 0
 			}
 			if yyr2376 || yy2arr2376 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr2376 || yy2arr2376 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2379 := z.EncBinary()
 				_ = yym2379
 				if false {
@@ -28157,7 +30233,9 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2380 := z.EncBinary()
 				_ = yym2380
 				if false {
@@ -28165,8 +30243,10 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
-			if yysep2376 {
-				r.EncodeEnd()
+			if yyr2376 || yy2arr2376 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -28181,17 +30261,18 @@ func (x *NodeAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2382 := r.ContainerType()
+		if yyct2382 == codecSelferValueTypeMap1234 {
 			yyl2382 := r.ReadMapStart()
 			if yyl2382 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2382, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2382 == codecSelferValueTypeArray1234 {
 			yyl2382 := r.ReadArrayStart()
 			if yyl2382 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2382, d)
 			}
@@ -28218,8 +30299,10 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2383Slc = r.DecodeBytes(yys2383Slc, true, true)
 		yys2383 := string(yys2383Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2383 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -28237,9 +30320,7 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2383)
 		} // end switch yys2383
 	} // end for yyj2383
-	if !yyhl2383 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -28256,9 +30337,10 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2386 = r.CheckBreak()
 	}
 	if yyb2386 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -28271,9 +30353,10 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2386 = r.CheckBreak()
 	}
 	if yyb2386 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Address = ""
 	} else {
@@ -28289,9 +30372,10 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2386 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2386-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -28312,18 +30396,21 @@ func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2390, yyq2390, yy2arr2390
 			const yyr2390 bool = false
 			yyq2390[0] = len(x.Capacity) != 0
+			var yynn2390 int
 			if yyr2390 || yy2arr2390 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2390 int = 0
+				yynn2390 = 0
 				for _, b := range yyq2390 {
 					if b {
 						yynn2390++
 					}
 				}
 				r.EncodeMapStart(yynn2390)
+				yynn2390 = 0
 			}
 			if yyr2390 || yy2arr2390 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2390[0] {
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -28335,7 +30422,9 @@ func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2390[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -28343,8 +30432,10 @@ func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2390 {
-				r.EncodeEnd()
+			if yyr2390 || yy2arr2390 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -28359,17 +30450,18 @@ func (x *NodeResources) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2393 := r.ContainerType()
+		if yyct2393 == codecSelferValueTypeMap1234 {
 			yyl2393 := r.ReadMapStart()
 			if yyl2393 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2393, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2393 == codecSelferValueTypeArray1234 {
 			yyl2393 := r.ReadArrayStart()
 			if yyl2393 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2393, d)
 			}
@@ -28396,8 +30488,10 @@ func (x *NodeResources) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2394Slc = r.DecodeBytes(yys2394Slc, true, true)
 		yys2394 := string(yys2394Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2394 {
 		case "capacity":
 			if r.TryDecodeAsNil() {
@@ -28410,9 +30504,7 @@ func (x *NodeResources) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2394)
 		} // end switch yys2394
 	} // end for yyj2394
-	if !yyhl2394 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeResources) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -28429,9 +30521,10 @@ func (x *NodeResources) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2396 = r.CheckBreak()
 	}
 	if yyb2396 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
@@ -28448,9 +30541,10 @@ func (x *NodeResources) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2396 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2396-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x ResourceName) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -28531,18 +30625,21 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2403[2] = true
 			yyq2403[3] = true
 			yyq2403[4] = true
+			var yynn2403 int
 			if yyr2403 || yy2arr2403 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2403 int = 0
+				yynn2403 = 0
 				for _, b := range yyq2403 {
 					if b {
 						yynn2403++
 					}
 				}
 				r.EncodeMapStart(yynn2403)
+				yynn2403 = 0
 			}
 			if yyr2403 || yy2arr2403 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2403[0] {
 					yym2405 := z.EncBinary()
 					_ = yym2405
@@ -28555,7 +30652,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2403[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2406 := z.EncBinary()
 					_ = yym2406
 					if false {
@@ -28565,6 +30664,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2403 || yy2arr2403 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2403[1] {
 					yym2408 := z.EncBinary()
 					_ = yym2408
@@ -28577,7 +30677,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2403[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2409 := z.EncBinary()
 					_ = yym2409
 					if false {
@@ -28587,6 +30689,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2403 || yy2arr2403 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2403[2] {
 					yy2411 := &x.ObjectMeta
 					yy2411.CodecEncodeSelf(e)
@@ -28595,12 +30698,15 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2403[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2412 := &x.ObjectMeta
 					yy2412.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2403 || yy2arr2403 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2403[3] {
 					yy2414 := &x.Spec
 					yy2414.CodecEncodeSelf(e)
@@ -28609,12 +30715,15 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2403[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2415 := &x.Spec
 					yy2415.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2403 || yy2arr2403 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2403[4] {
 					yy2417 := &x.Status
 					yy2417.CodecEncodeSelf(e)
@@ -28623,13 +30732,17 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2403[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2418 := &x.Status
 					yy2418.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2403 {
-				r.EncodeEnd()
+			if yyr2403 || yy2arr2403 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -28644,17 +30757,18 @@ func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2420 := r.ContainerType()
+		if yyct2420 == codecSelferValueTypeMap1234 {
 			yyl2420 := r.ReadMapStart()
 			if yyl2420 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2420, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2420 == codecSelferValueTypeArray1234 {
 			yyl2420 := r.ReadArrayStart()
 			if yyl2420 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2420, d)
 			}
@@ -28681,8 +30795,10 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2421Slc = r.DecodeBytes(yys2421Slc, true, true)
 		yys2421 := string(yys2421Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2421 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -28721,9 +30837,7 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2421)
 		} // end switch yys2421
 	} // end for yyj2421
-	if !yyhl2421 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -28740,9 +30854,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2427 = r.CheckBreak()
 	}
 	if yyb2427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -28755,9 +30870,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2427 = r.CheckBreak()
 	}
 	if yyb2427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -28770,9 +30886,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2427 = r.CheckBreak()
 	}
 	if yyb2427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -28786,9 +30903,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2427 = r.CheckBreak()
 	}
 	if yyb2427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = NodeSpec{}
 	} else {
@@ -28802,9 +30920,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2427 = r.CheckBreak()
 	}
 	if yyb2427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = NodeStatus{}
 	} else {
@@ -28821,9 +30940,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2427 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2427-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -28846,18 +30966,21 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2434[0] = x.Kind != ""
 			yyq2434[1] = x.APIVersion != ""
 			yyq2434[2] = true
+			var yynn2434 int
 			if yyr2434 || yy2arr2434 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2434 int = 1
+				yynn2434 = 1
 				for _, b := range yyq2434 {
 					if b {
 						yynn2434++
 					}
 				}
 				r.EncodeMapStart(yynn2434)
+				yynn2434 = 0
 			}
 			if yyr2434 || yy2arr2434 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2434[0] {
 					yym2436 := z.EncBinary()
 					_ = yym2436
@@ -28870,7 +30993,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2434[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2437 := z.EncBinary()
 					_ = yym2437
 					if false {
@@ -28880,6 +31005,7 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2434 || yy2arr2434 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2434[1] {
 					yym2439 := z.EncBinary()
 					_ = yym2439
@@ -28892,7 +31018,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2434[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2440 := z.EncBinary()
 					_ = yym2440
 					if false {
@@ -28902,6 +31030,7 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2434 || yy2arr2434 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2434[2] {
 					yy2442 := &x.ListMeta
 					yym2443 := z.EncBinary()
@@ -28916,7 +31045,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2434[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2444 := &x.ListMeta
 					yym2445 := z.EncBinary()
 					_ = yym2445
@@ -28928,6 +31059,7 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2434 || yy2arr2434 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -28939,7 +31071,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -28951,8 +31085,10 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2434 {
-				r.EncodeEnd()
+			if yyr2434 || yy2arr2434 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -28967,17 +31103,18 @@ func (x *NodeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2450 := r.ContainerType()
+		if yyct2450 == codecSelferValueTypeMap1234 {
 			yyl2450 := r.ReadMapStart()
 			if yyl2450 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2450, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2450 == codecSelferValueTypeArray1234 {
 			yyl2450 := r.ReadArrayStart()
 			if yyl2450 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2450, d)
 			}
@@ -29004,8 +31141,10 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2451Slc = r.DecodeBytes(yys2451Slc, true, true)
 		yys2451 := string(yys2451Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2451 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -29048,9 +31187,7 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2451)
 		} // end switch yys2451
 	} // end for yyj2451
-	if !yyhl2451 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -29067,9 +31204,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2458 = r.CheckBreak()
 	}
 	if yyb2458 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -29082,9 +31220,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2458 = r.CheckBreak()
 	}
 	if yyb2458 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -29097,9 +31236,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2458 = r.CheckBreak()
 	}
 	if yyb2458 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -29119,9 +31259,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2458 = r.CheckBreak()
 	}
 	if yyb2458 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -29143,9 +31284,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2458 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2458-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -29165,18 +31307,21 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2466 [1]bool
 			_, _, _ = yysep2466, yyq2466, yy2arr2466
 			const yyr2466 bool = false
+			var yynn2466 int
 			if yyr2466 || yy2arr2466 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2466 int = 1
+				yynn2466 = 1
 				for _, b := range yyq2466 {
 					if b {
 						yynn2466++
 					}
 				}
 				r.EncodeMapStart(yynn2466)
+				yynn2466 = 0
 			}
 			if yyr2466 || yy2arr2466 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Finalizers == nil {
 					r.EncodeNil()
 				} else {
@@ -29188,7 +31333,9 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Finalizers"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Finalizers == nil {
 					r.EncodeNil()
 				} else {
@@ -29200,8 +31347,10 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2466 {
-				r.EncodeEnd()
+			if yyr2466 || yy2arr2466 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -29216,17 +31365,18 @@ func (x *NamespaceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2471 := r.ContainerType()
+		if yyct2471 == codecSelferValueTypeMap1234 {
 			yyl2471 := r.ReadMapStart()
 			if yyl2471 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2471, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2471 == codecSelferValueTypeArray1234 {
 			yyl2471 := r.ReadArrayStart()
 			if yyl2471 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2471, d)
 			}
@@ -29253,8 +31403,10 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2472Slc = r.DecodeBytes(yys2472Slc, true, true)
 		yys2472 := string(yys2472Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2472 {
 		case "Finalizers":
 			if r.TryDecodeAsNil() {
@@ -29272,9 +31424,7 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2472)
 		} // end switch yys2472
 	} // end for yyj2472
-	if !yyhl2472 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -29291,9 +31441,10 @@ func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2475 = r.CheckBreak()
 	}
 	if yyb2475 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Finalizers = nil
 	} else {
@@ -29315,9 +31466,10 @@ func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2475 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2475-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x FinalizerName) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -29364,18 +31516,21 @@ func (x *NamespaceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2481, yyq2481, yy2arr2481
 			const yyr2481 bool = false
 			yyq2481[0] = x.Phase != ""
+			var yynn2481 int
 			if yyr2481 || yy2arr2481 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2481 int = 0
+				yynn2481 = 0
 				for _, b := range yyq2481 {
 					if b {
 						yynn2481++
 					}
 				}
 				r.EncodeMapStart(yynn2481)
+				yynn2481 = 0
 			}
 			if yyr2481 || yy2arr2481 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2481[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -29383,12 +31538,16 @@ func (x *NamespaceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2481[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2481 {
-				r.EncodeEnd()
+			if yyr2481 || yy2arr2481 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -29403,17 +31562,18 @@ func (x *NamespaceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2484 := r.ContainerType()
+		if yyct2484 == codecSelferValueTypeMap1234 {
 			yyl2484 := r.ReadMapStart()
 			if yyl2484 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2484, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2484 == codecSelferValueTypeArray1234 {
 			yyl2484 := r.ReadArrayStart()
 			if yyl2484 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2484, d)
 			}
@@ -29440,8 +31600,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2485Slc = r.DecodeBytes(yys2485Slc, true, true)
 		yys2485 := string(yys2485Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2485 {
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -29453,9 +31615,7 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2485)
 		} // end switch yys2485
 	} // end for yyj2485
-	if !yyhl2485 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -29472,9 +31632,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2487 = r.CheckBreak()
 	}
 	if yyb2487 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -29490,9 +31651,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb2487 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2487-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x NamespacePhase) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -29543,18 +31705,21 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2492[2] = true
 			yyq2492[3] = true
 			yyq2492[4] = true
+			var yynn2492 int
 			if yyr2492 || yy2arr2492 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2492 int = 0
+				yynn2492 = 0
 				for _, b := range yyq2492 {
 					if b {
 						yynn2492++
 					}
 				}
 				r.EncodeMapStart(yynn2492)
+				yynn2492 = 0
 			}
 			if yyr2492 || yy2arr2492 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2492[0] {
 					yym2494 := z.EncBinary()
 					_ = yym2494
@@ -29567,7 +31732,9 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2492[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2495 := z.EncBinary()
 					_ = yym2495
 					if false {
@@ -29577,6 +31744,7 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2492 || yy2arr2492 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2492[1] {
 					yym2497 := z.EncBinary()
 					_ = yym2497
@@ -29589,7 +31757,9 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2492[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2498 := z.EncBinary()
 					_ = yym2498
 					if false {
@@ -29599,6 +31769,7 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2492 || yy2arr2492 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2492[2] {
 					yy2500 := &x.ObjectMeta
 					yy2500.CodecEncodeSelf(e)
@@ -29607,12 +31778,15 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2492[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2501 := &x.ObjectMeta
 					yy2501.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2492 || yy2arr2492 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2492[3] {
 					yy2503 := &x.Spec
 					yy2503.CodecEncodeSelf(e)
@@ -29621,12 +31795,15 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2492[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2504 := &x.Spec
 					yy2504.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2492 || yy2arr2492 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2492[4] {
 					yy2506 := &x.Status
 					yy2506.CodecEncodeSelf(e)
@@ -29635,13 +31812,17 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2492[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2507 := &x.Status
 					yy2507.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2492 {
-				r.EncodeEnd()
+			if yyr2492 || yy2arr2492 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -29656,17 +31837,18 @@ func (x *Namespace) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2509 := r.ContainerType()
+		if yyct2509 == codecSelferValueTypeMap1234 {
 			yyl2509 := r.ReadMapStart()
 			if yyl2509 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2509, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2509 == codecSelferValueTypeArray1234 {
 			yyl2509 := r.ReadArrayStart()
 			if yyl2509 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2509, d)
 			}
@@ -29693,8 +31875,10 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2510Slc = r.DecodeBytes(yys2510Slc, true, true)
 		yys2510 := string(yys2510Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2510 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -29733,9 +31917,7 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2510)
 		} // end switch yys2510
 	} // end for yyj2510
-	if !yyhl2510 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -29752,9 +31934,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2516 = r.CheckBreak()
 	}
 	if yyb2516 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -29767,9 +31950,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2516 = r.CheckBreak()
 	}
 	if yyb2516 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -29782,9 +31966,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2516 = r.CheckBreak()
 	}
 	if yyb2516 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -29798,9 +31983,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2516 = r.CheckBreak()
 	}
 	if yyb2516 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = NamespaceSpec{}
 	} else {
@@ -29814,9 +32000,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2516 = r.CheckBreak()
 	}
 	if yyb2516 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = NamespaceStatus{}
 	} else {
@@ -29833,9 +32020,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2516 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2516-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -29858,18 +32046,21 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2523[0] = x.Kind != ""
 			yyq2523[1] = x.APIVersion != ""
 			yyq2523[2] = true
+			var yynn2523 int
 			if yyr2523 || yy2arr2523 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2523 int = 1
+				yynn2523 = 1
 				for _, b := range yyq2523 {
 					if b {
 						yynn2523++
 					}
 				}
 				r.EncodeMapStart(yynn2523)
+				yynn2523 = 0
 			}
 			if yyr2523 || yy2arr2523 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2523[0] {
 					yym2525 := z.EncBinary()
 					_ = yym2525
@@ -29882,7 +32073,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2523[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2526 := z.EncBinary()
 					_ = yym2526
 					if false {
@@ -29892,6 +32085,7 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2523 || yy2arr2523 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2523[1] {
 					yym2528 := z.EncBinary()
 					_ = yym2528
@@ -29904,7 +32098,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2523[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2529 := z.EncBinary()
 					_ = yym2529
 					if false {
@@ -29914,6 +32110,7 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2523 || yy2arr2523 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2523[2] {
 					yy2531 := &x.ListMeta
 					yym2532 := z.EncBinary()
@@ -29928,7 +32125,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2523[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2533 := &x.ListMeta
 					yym2534 := z.EncBinary()
 					_ = yym2534
@@ -29940,6 +32139,7 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2523 || yy2arr2523 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -29951,7 +32151,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -29963,8 +32165,10 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2523 {
-				r.EncodeEnd()
+			if yyr2523 || yy2arr2523 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -29979,17 +32183,18 @@ func (x *NamespaceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2539 := r.ContainerType()
+		if yyct2539 == codecSelferValueTypeMap1234 {
 			yyl2539 := r.ReadMapStart()
 			if yyl2539 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2539, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2539 == codecSelferValueTypeArray1234 {
 			yyl2539 := r.ReadArrayStart()
 			if yyl2539 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2539, d)
 			}
@@ -30016,8 +32221,10 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2540Slc = r.DecodeBytes(yys2540Slc, true, true)
 		yys2540 := string(yys2540Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2540 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -30060,9 +32267,7 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2540)
 		} // end switch yys2540
 	} // end for yyj2540
-	if !yyhl2540 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -30079,9 +32284,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2547 = r.CheckBreak()
 	}
 	if yyb2547 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -30094,9 +32300,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2547 = r.CheckBreak()
 	}
 	if yyb2547 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -30109,9 +32316,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2547 = r.CheckBreak()
 	}
 	if yyb2547 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -30131,9 +32339,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2547 = r.CheckBreak()
 	}
 	if yyb2547 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -30155,9 +32364,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2547 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2547-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -30180,18 +32390,21 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2555[0] = x.Kind != ""
 			yyq2555[1] = x.APIVersion != ""
 			yyq2555[2] = true
+			var yynn2555 int
 			if yyr2555 || yy2arr2555 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2555 int = 1
+				yynn2555 = 1
 				for _, b := range yyq2555 {
 					if b {
 						yynn2555++
 					}
 				}
 				r.EncodeMapStart(yynn2555)
+				yynn2555 = 0
 			}
 			if yyr2555 || yy2arr2555 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2555[0] {
 					yym2557 := z.EncBinary()
 					_ = yym2557
@@ -30204,7 +32417,9 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2555[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2558 := z.EncBinary()
 					_ = yym2558
 					if false {
@@ -30214,6 +32429,7 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2555 || yy2arr2555 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2555[1] {
 					yym2560 := z.EncBinary()
 					_ = yym2560
@@ -30226,7 +32442,9 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2555[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2561 := z.EncBinary()
 					_ = yym2561
 					if false {
@@ -30236,6 +32454,7 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2555 || yy2arr2555 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2555[2] {
 					yy2563 := &x.ObjectMeta
 					yy2563.CodecEncodeSelf(e)
@@ -30244,21 +32463,28 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2555[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2564 := &x.ObjectMeta
 					yy2564.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2555 || yy2arr2555 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy2566 := &x.Target
 				yy2566.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy2567 := &x.Target
 				yy2567.CodecEncodeSelf(e)
 			}
-			if yysep2555 {
-				r.EncodeEnd()
+			if yyr2555 || yy2arr2555 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -30273,17 +32499,18 @@ func (x *Binding) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2569 := r.ContainerType()
+		if yyct2569 == codecSelferValueTypeMap1234 {
 			yyl2569 := r.ReadMapStart()
 			if yyl2569 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2569, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2569 == codecSelferValueTypeArray1234 {
 			yyl2569 := r.ReadArrayStart()
 			if yyl2569 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2569, d)
 			}
@@ -30310,8 +32537,10 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2570Slc = r.DecodeBytes(yys2570Slc, true, true)
 		yys2570 := string(yys2570Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2570 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -30343,9 +32572,7 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2570)
 		} // end switch yys2570
 	} // end for yyj2570
-	if !yyhl2570 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -30362,9 +32589,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2575 = r.CheckBreak()
 	}
 	if yyb2575 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -30377,9 +32605,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2575 = r.CheckBreak()
 	}
 	if yyb2575 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -30392,9 +32621,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2575 = r.CheckBreak()
 	}
 	if yyb2575 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -30408,9 +32638,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2575 = r.CheckBreak()
 	}
 	if yyb2575 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Target = ObjectReference{}
 	} else {
@@ -30427,9 +32658,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2575 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2575-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -30451,18 +32683,21 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2581 bool = false
 			yyq2581[0] = x.Kind != ""
 			yyq2581[1] = x.APIVersion != ""
+			var yynn2581 int
 			if yyr2581 || yy2arr2581 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2581 int = 1
+				yynn2581 = 1
 				for _, b := range yyq2581 {
 					if b {
 						yynn2581++
 					}
 				}
 				r.EncodeMapStart(yynn2581)
+				yynn2581 = 0
 			}
 			if yyr2581 || yy2arr2581 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2581[0] {
 					yym2583 := z.EncBinary()
 					_ = yym2583
@@ -30475,7 +32710,9 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2581[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2584 := z.EncBinary()
 					_ = yym2584
 					if false {
@@ -30485,6 +32722,7 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2581 || yy2arr2581 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2581[1] {
 					yym2586 := z.EncBinary()
 					_ = yym2586
@@ -30497,7 +32735,9 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2581[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2587 := z.EncBinary()
 					_ = yym2587
 					if false {
@@ -30507,6 +32747,7 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2581 || yy2arr2581 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
@@ -30519,7 +32760,9 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("gracePeriodSeconds"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
@@ -30532,8 +32775,10 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2581 {
-				r.EncodeEnd()
+			if yyr2581 || yy2arr2581 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -30548,17 +32793,18 @@ func (x *DeleteOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2594 := r.ContainerType()
+		if yyct2594 == codecSelferValueTypeMap1234 {
 			yyl2594 := r.ReadMapStart()
 			if yyl2594 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2594, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2594 == codecSelferValueTypeArray1234 {
 			yyl2594 := r.ReadArrayStart()
 			if yyl2594 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2594, d)
 			}
@@ -30585,8 +32831,10 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2595Slc = r.DecodeBytes(yys2595Slc, true, true)
 		yys2595 := string(yys2595Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2595 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -30620,9 +32868,7 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2595)
 		} // end switch yys2595
 	} // end for yyj2595
-	if !yyhl2595 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -30639,9 +32885,10 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2600 = r.CheckBreak()
 	}
 	if yyb2600 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -30654,9 +32901,10 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2600 = r.CheckBreak()
 	}
 	if yyb2600 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -30669,9 +32917,10 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2600 = r.CheckBreak()
 	}
 	if yyb2600 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GracePeriodSeconds != nil {
 			x.GracePeriodSeconds = nil
@@ -30697,9 +32946,10 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2600 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2600-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -30721,18 +32971,21 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2606 bool = false
 			yyq2606[0] = x.Kind != ""
 			yyq2606[1] = x.APIVersion != ""
+			var yynn2606 int
 			if yyr2606 || yy2arr2606 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2606 int = 5
+				yynn2606 = 5
 				for _, b := range yyq2606 {
 					if b {
 						yynn2606++
 					}
 				}
 				r.EncodeMapStart(yynn2606)
+				yynn2606 = 0
 			}
 			if yyr2606 || yy2arr2606 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2606[0] {
 					yym2608 := z.EncBinary()
 					_ = yym2608
@@ -30745,7 +32998,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2606[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2609 := z.EncBinary()
 					_ = yym2609
 					if false {
@@ -30755,6 +33010,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2606 || yy2arr2606 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2606[1] {
 					yym2611 := z.EncBinary()
 					_ = yym2611
@@ -30767,7 +33023,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2606[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2612 := z.EncBinary()
 					_ = yym2612
 					if false {
@@ -30777,6 +33035,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2606 || yy2arr2606 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.LabelSelector == nil {
 					r.EncodeNil()
 				} else {
@@ -30789,7 +33048,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("LabelSelector"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.LabelSelector == nil {
 					r.EncodeNil()
 				} else {
@@ -30803,6 +33064,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2606 || yy2arr2606 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.FieldSelector == nil {
 					r.EncodeNil()
 				} else {
@@ -30815,7 +33077,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("FieldSelector"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.FieldSelector == nil {
 					r.EncodeNil()
 				} else {
@@ -30829,6 +33093,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2606 || yy2arr2606 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2620 := z.EncBinary()
 				_ = yym2620
 				if false {
@@ -30836,7 +33101,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.Watch))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Watch"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2621 := z.EncBinary()
 				_ = yym2621
 				if false {
@@ -30845,6 +33112,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2606 || yy2arr2606 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2623 := z.EncBinary()
 				_ = yym2623
 				if false {
@@ -30852,7 +33120,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("ResourceVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2624 := z.EncBinary()
 				_ = yym2624
 				if false {
@@ -30861,6 +33131,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2606 || yy2arr2606 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.TimeoutSeconds == nil {
 					r.EncodeNil()
 				} else {
@@ -30873,7 +33144,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("TimeoutSeconds"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.TimeoutSeconds == nil {
 					r.EncodeNil()
 				} else {
@@ -30886,8 +33159,10 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2606 {
-				r.EncodeEnd()
+			if yyr2606 || yy2arr2606 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -30902,17 +33177,18 @@ func (x *ListOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2631 := r.ContainerType()
+		if yyct2631 == codecSelferValueTypeMap1234 {
 			yyl2631 := r.ReadMapStart()
 			if yyl2631 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2631, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2631 == codecSelferValueTypeArray1234 {
 			yyl2631 := r.ReadArrayStart()
 			if yyl2631 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2631, d)
 			}
@@ -30939,8 +33215,10 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2632Slc = r.DecodeBytes(yys2632Slc, true, true)
 		yys2632 := string(yys2632Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2632 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -31012,9 +33290,7 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2632)
 		} // end switch yys2632
 	} // end for yyj2632
-	if !yyhl2632 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -31031,9 +33307,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2643 = r.CheckBreak()
 	}
 	if yyb2643 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -31046,9 +33323,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2643 = r.CheckBreak()
 	}
 	if yyb2643 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -31061,9 +33339,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2643 = r.CheckBreak()
 	}
 	if yyb2643 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LabelSelector = nil
 	} else {
@@ -31083,9 +33362,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2643 = r.CheckBreak()
 	}
 	if yyb2643 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FieldSelector = nil
 	} else {
@@ -31105,9 +33385,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2643 = r.CheckBreak()
 	}
 	if yyb2643 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Watch = false
 	} else {
@@ -31120,9 +33401,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2643 = r.CheckBreak()
 	}
 	if yyb2643 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ResourceVersion = ""
 	} else {
@@ -31135,9 +33417,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2643 = r.CheckBreak()
 	}
 	if yyb2643 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TimeoutSeconds != nil {
 			x.TimeoutSeconds = nil
@@ -31163,9 +33446,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2643 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2643-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -31187,18 +33471,21 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2655 bool = false
 			yyq2655[0] = x.Kind != ""
 			yyq2655[1] = x.APIVersion != ""
+			var yynn2655 int
 			if yyr2655 || yy2arr2655 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2655 int = 8
+				yynn2655 = 8
 				for _, b := range yyq2655 {
 					if b {
 						yynn2655++
 					}
 				}
 				r.EncodeMapStart(yynn2655)
+				yynn2655 = 0
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2655[0] {
 					yym2657 := z.EncBinary()
 					_ = yym2657
@@ -31211,7 +33498,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2655[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2658 := z.EncBinary()
 					_ = yym2658
 					if false {
@@ -31221,6 +33510,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2655[1] {
 					yym2660 := z.EncBinary()
 					_ = yym2660
@@ -31233,7 +33523,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2655[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2661 := z.EncBinary()
 					_ = yym2661
 					if false {
@@ -31243,6 +33535,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2663 := z.EncBinary()
 				_ = yym2663
 				if false {
@@ -31250,7 +33543,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Container"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2664 := z.EncBinary()
 				_ = yym2664
 				if false {
@@ -31259,6 +33554,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2666 := z.EncBinary()
 				_ = yym2666
 				if false {
@@ -31266,7 +33562,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.Follow))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Follow"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2667 := z.EncBinary()
 				_ = yym2667
 				if false {
@@ -31275,6 +33573,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2669 := z.EncBinary()
 				_ = yym2669
 				if false {
@@ -31282,7 +33581,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.Previous))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Previous"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2670 := z.EncBinary()
 				_ = yym2670
 				if false {
@@ -31291,6 +33592,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.SinceSeconds == nil {
 					r.EncodeNil()
 				} else {
@@ -31303,7 +33605,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("SinceSeconds"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.SinceSeconds == nil {
 					r.EncodeNil()
 				} else {
@@ -31317,6 +33621,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.SinceTime == nil {
 					r.EncodeNil()
 				} else {
@@ -31333,7 +33638,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("SinceTime"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.SinceTime == nil {
 					r.EncodeNil()
 				} else {
@@ -31351,6 +33658,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2680 := z.EncBinary()
 				_ = yym2680
 				if false {
@@ -31358,7 +33666,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.Timestamps))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Timestamps"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2681 := z.EncBinary()
 				_ = yym2681
 				if false {
@@ -31367,6 +33677,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.TailLines == nil {
 					r.EncodeNil()
 				} else {
@@ -31379,7 +33690,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("TailLines"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.TailLines == nil {
 					r.EncodeNil()
 				} else {
@@ -31393,6 +33706,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.LimitBytes == nil {
 					r.EncodeNil()
 				} else {
@@ -31405,7 +33719,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("LimitBytes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.LimitBytes == nil {
 					r.EncodeNil()
 				} else {
@@ -31418,8 +33734,10 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2655 {
-				r.EncodeEnd()
+			if yyr2655 || yy2arr2655 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -31434,17 +33752,18 @@ func (x *PodLogOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2693 := r.ContainerType()
+		if yyct2693 == codecSelferValueTypeMap1234 {
 			yyl2693 := r.ReadMapStart()
 			if yyl2693 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2693, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2693 == codecSelferValueTypeArray1234 {
 			yyl2693 := r.ReadArrayStart()
 			if yyl2693 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2693, d)
 			}
@@ -31471,8 +33790,10 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2694Slc = r.DecodeBytes(yys2694Slc, true, true)
 		yys2694 := string(yys2694Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2694 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -31583,9 +33904,7 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2694)
 		} // end switch yys2694
 	} // end for yyj2694
-	if !yyhl2694 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -31602,9 +33921,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -31617,9 +33937,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -31632,9 +33953,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Container = ""
 	} else {
@@ -31647,9 +33969,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Follow = false
 	} else {
@@ -31662,9 +33985,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Previous = false
 	} else {
@@ -31677,9 +34001,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SinceSeconds != nil {
 			x.SinceSeconds = nil
@@ -31702,9 +34027,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SinceTime != nil {
 			x.SinceTime = nil
@@ -31732,9 +34058,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Timestamps = false
 	} else {
@@ -31747,9 +34074,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TailLines != nil {
 			x.TailLines = nil
@@ -31772,9 +34100,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2709 = r.CheckBreak()
 	}
 	if yyb2709 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.LimitBytes != nil {
 			x.LimitBytes = nil
@@ -31800,9 +34129,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2709 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2709-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -31829,18 +34159,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2725[4] = x.Stderr != false
 			yyq2725[5] = x.TTY != false
 			yyq2725[6] = x.Container != ""
+			var yynn2725 int
 			if yyr2725 || yy2arr2725 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2725 int = 0
+				yynn2725 = 0
 				for _, b := range yyq2725 {
 					if b {
 						yynn2725++
 					}
 				}
 				r.EncodeMapStart(yynn2725)
+				yynn2725 = 0
 			}
 			if yyr2725 || yy2arr2725 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2725[0] {
 					yym2727 := z.EncBinary()
 					_ = yym2727
@@ -31853,7 +34186,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2725[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2728 := z.EncBinary()
 					_ = yym2728
 					if false {
@@ -31863,6 +34198,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2725 || yy2arr2725 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2725[1] {
 					yym2730 := z.EncBinary()
 					_ = yym2730
@@ -31875,7 +34211,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2725[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2731 := z.EncBinary()
 					_ = yym2731
 					if false {
@@ -31885,6 +34223,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2725 || yy2arr2725 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2725[2] {
 					yym2733 := z.EncBinary()
 					_ = yym2733
@@ -31897,7 +34236,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2725[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2734 := z.EncBinary()
 					_ = yym2734
 					if false {
@@ -31907,6 +34248,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2725 || yy2arr2725 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2725[3] {
 					yym2736 := z.EncBinary()
 					_ = yym2736
@@ -31919,7 +34261,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2725[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2737 := z.EncBinary()
 					_ = yym2737
 					if false {
@@ -31929,6 +34273,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2725 || yy2arr2725 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2725[4] {
 					yym2739 := z.EncBinary()
 					_ = yym2739
@@ -31941,7 +34286,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2725[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2740 := z.EncBinary()
 					_ = yym2740
 					if false {
@@ -31951,6 +34298,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2725 || yy2arr2725 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2725[5] {
 					yym2742 := z.EncBinary()
 					_ = yym2742
@@ -31963,7 +34311,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2725[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2743 := z.EncBinary()
 					_ = yym2743
 					if false {
@@ -31973,6 +34323,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2725 || yy2arr2725 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2725[6] {
 					yym2745 := z.EncBinary()
 					_ = yym2745
@@ -31985,7 +34336,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2725[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2746 := z.EncBinary()
 					_ = yym2746
 					if false {
@@ -31994,8 +34347,10 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2725 {
-				r.EncodeEnd()
+			if yyr2725 || yy2arr2725 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -32010,17 +34365,18 @@ func (x *PodAttachOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2748 := r.ContainerType()
+		if yyct2748 == codecSelferValueTypeMap1234 {
 			yyl2748 := r.ReadMapStart()
 			if yyl2748 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2748, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2748 == codecSelferValueTypeArray1234 {
 			yyl2748 := r.ReadArrayStart()
 			if yyl2748 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2748, d)
 			}
@@ -32047,8 +34403,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2749Slc = r.DecodeBytes(yys2749Slc, true, true)
 		yys2749 := string(yys2749Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2749 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -32096,9 +34454,7 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2749)
 		} // end switch yys2749
 	} // end for yyj2749
-	if !yyhl2749 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -32115,9 +34471,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2757 = r.CheckBreak()
 	}
 	if yyb2757 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -32130,9 +34487,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2757 = r.CheckBreak()
 	}
 	if yyb2757 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -32145,9 +34503,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2757 = r.CheckBreak()
 	}
 	if yyb2757 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdin = false
 	} else {
@@ -32160,9 +34519,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2757 = r.CheckBreak()
 	}
 	if yyb2757 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdout = false
 	} else {
@@ -32175,9 +34535,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2757 = r.CheckBreak()
 	}
 	if yyb2757 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stderr = false
 	} else {
@@ -32190,9 +34551,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2757 = r.CheckBreak()
 	}
 	if yyb2757 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TTY = false
 	} else {
@@ -32205,9 +34567,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2757 = r.CheckBreak()
 	}
 	if yyb2757 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Container = ""
 	} else {
@@ -32223,9 +34586,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if yyb2757 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2757-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -32247,18 +34611,21 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2766 bool = false
 			yyq2766[0] = x.Kind != ""
 			yyq2766[1] = x.APIVersion != ""
+			var yynn2766 int
 			if yyr2766 || yy2arr2766 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2766 int = 6
+				yynn2766 = 6
 				for _, b := range yyq2766 {
 					if b {
 						yynn2766++
 					}
 				}
 				r.EncodeMapStart(yynn2766)
+				yynn2766 = 0
 			}
 			if yyr2766 || yy2arr2766 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2766[0] {
 					yym2768 := z.EncBinary()
 					_ = yym2768
@@ -32271,7 +34638,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2766[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2769 := z.EncBinary()
 					_ = yym2769
 					if false {
@@ -32281,6 +34650,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2766 || yy2arr2766 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2766[1] {
 					yym2771 := z.EncBinary()
 					_ = yym2771
@@ -32293,7 +34663,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2766[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2772 := z.EncBinary()
 					_ = yym2772
 					if false {
@@ -32303,6 +34675,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2766 || yy2arr2766 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2774 := z.EncBinary()
 				_ = yym2774
 				if false {
@@ -32310,7 +34683,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.Stdin))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Stdin"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2775 := z.EncBinary()
 				_ = yym2775
 				if false {
@@ -32319,6 +34694,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2766 || yy2arr2766 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2777 := z.EncBinary()
 				_ = yym2777
 				if false {
@@ -32326,7 +34702,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.Stdout))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Stdout"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2778 := z.EncBinary()
 				_ = yym2778
 				if false {
@@ -32335,6 +34713,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2766 || yy2arr2766 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2780 := z.EncBinary()
 				_ = yym2780
 				if false {
@@ -32342,7 +34721,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.Stderr))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Stderr"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2781 := z.EncBinary()
 				_ = yym2781
 				if false {
@@ -32351,6 +34732,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2766 || yy2arr2766 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2783 := z.EncBinary()
 				_ = yym2783
 				if false {
@@ -32358,7 +34740,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.TTY))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("TTY"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2784 := z.EncBinary()
 				_ = yym2784
 				if false {
@@ -32367,6 +34751,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2766 || yy2arr2766 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2786 := z.EncBinary()
 				_ = yym2786
 				if false {
@@ -32374,7 +34759,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Container"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2787 := z.EncBinary()
 				_ = yym2787
 				if false {
@@ -32383,6 +34770,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2766 || yy2arr2766 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
@@ -32394,7 +34782,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Command"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
@@ -32406,8 +34796,10 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2766 {
-				r.EncodeEnd()
+			if yyr2766 || yy2arr2766 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -32422,17 +34814,18 @@ func (x *PodExecOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2792 := r.ContainerType()
+		if yyct2792 == codecSelferValueTypeMap1234 {
 			yyl2792 := r.ReadMapStart()
 			if yyl2792 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2792, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2792 == codecSelferValueTypeArray1234 {
 			yyl2792 := r.ReadArrayStart()
 			if yyl2792 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2792, d)
 			}
@@ -32459,8 +34852,10 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2793Slc = r.DecodeBytes(yys2793Slc, true, true)
 		yys2793 := string(yys2793Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2793 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -32520,9 +34915,7 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2793)
 		} // end switch yys2793
 	} // end for yyj2793
-	if !yyhl2793 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -32539,9 +34932,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2803 = r.CheckBreak()
 	}
 	if yyb2803 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -32554,9 +34948,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2803 = r.CheckBreak()
 	}
 	if yyb2803 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -32569,9 +34964,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2803 = r.CheckBreak()
 	}
 	if yyb2803 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdin = false
 	} else {
@@ -32584,9 +34980,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2803 = r.CheckBreak()
 	}
 	if yyb2803 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdout = false
 	} else {
@@ -32599,9 +34996,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2803 = r.CheckBreak()
 	}
 	if yyb2803 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stderr = false
 	} else {
@@ -32614,9 +35012,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2803 = r.CheckBreak()
 	}
 	if yyb2803 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TTY = false
 	} else {
@@ -32629,9 +35028,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2803 = r.CheckBreak()
 	}
 	if yyb2803 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Container = ""
 	} else {
@@ -32644,9 +35044,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2803 = r.CheckBreak()
 	}
 	if yyb2803 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
@@ -32668,9 +35069,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2803 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2803-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -32692,18 +35094,21 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2814 bool = false
 			yyq2814[0] = x.Kind != ""
 			yyq2814[1] = x.APIVersion != ""
+			var yynn2814 int
 			if yyr2814 || yy2arr2814 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2814 int = 1
+				yynn2814 = 1
 				for _, b := range yyq2814 {
 					if b {
 						yynn2814++
 					}
 				}
 				r.EncodeMapStart(yynn2814)
+				yynn2814 = 0
 			}
 			if yyr2814 || yy2arr2814 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2814[0] {
 					yym2816 := z.EncBinary()
 					_ = yym2816
@@ -32716,7 +35121,9 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2814[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2817 := z.EncBinary()
 					_ = yym2817
 					if false {
@@ -32726,6 +35133,7 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2814 || yy2arr2814 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2814[1] {
 					yym2819 := z.EncBinary()
 					_ = yym2819
@@ -32738,7 +35146,9 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2814[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2820 := z.EncBinary()
 					_ = yym2820
 					if false {
@@ -32748,6 +35158,7 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2814 || yy2arr2814 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2822 := z.EncBinary()
 				_ = yym2822
 				if false {
@@ -32755,7 +35166,9 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2823 := z.EncBinary()
 				_ = yym2823
 				if false {
@@ -32763,8 +35176,10 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yysep2814 {
-				r.EncodeEnd()
+			if yyr2814 || yy2arr2814 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -32779,17 +35194,18 @@ func (x *PodProxyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2825 := r.ContainerType()
+		if yyct2825 == codecSelferValueTypeMap1234 {
 			yyl2825 := r.ReadMapStart()
 			if yyl2825 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2825, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2825 == codecSelferValueTypeArray1234 {
 			yyl2825 := r.ReadArrayStart()
 			if yyl2825 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2825, d)
 			}
@@ -32816,8 +35232,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2826Slc = r.DecodeBytes(yys2826Slc, true, true)
 		yys2826 := string(yys2826Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2826 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -32841,9 +35259,7 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2826)
 		} // end switch yys2826
 	} // end for yyj2826
-	if !yyhl2826 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -32860,9 +35276,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2830 = r.CheckBreak()
 	}
 	if yyb2830 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -32875,9 +35292,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2830 = r.CheckBreak()
 	}
 	if yyb2830 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -32890,9 +35308,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2830 = r.CheckBreak()
 	}
 	if yyb2830 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -32908,9 +35327,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb2830 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2830-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -32937,18 +35357,21 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2835[4] = x.APIVersion != ""
 			yyq2835[5] = x.ResourceVersion != ""
 			yyq2835[6] = x.FieldPath != ""
+			var yynn2835 int
 			if yyr2835 || yy2arr2835 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2835 int = 0
+				yynn2835 = 0
 				for _, b := range yyq2835 {
 					if b {
 						yynn2835++
 					}
 				}
 				r.EncodeMapStart(yynn2835)
+				yynn2835 = 0
 			}
 			if yyr2835 || yy2arr2835 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2835[0] {
 					yym2837 := z.EncBinary()
 					_ = yym2837
@@ -32961,7 +35384,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2835[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2838 := z.EncBinary()
 					_ = yym2838
 					if false {
@@ -32971,6 +35396,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2835 || yy2arr2835 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2835[1] {
 					yym2840 := z.EncBinary()
 					_ = yym2840
@@ -32983,7 +35409,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2835[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2841 := z.EncBinary()
 					_ = yym2841
 					if false {
@@ -32993,6 +35421,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2835 || yy2arr2835 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2835[2] {
 					yym2843 := z.EncBinary()
 					_ = yym2843
@@ -33005,7 +35434,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2835[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2844 := z.EncBinary()
 					_ = yym2844
 					if false {
@@ -33015,6 +35446,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2835 || yy2arr2835 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2835[3] {
 					yym2846 := z.EncBinary()
 					_ = yym2846
@@ -33028,7 +35460,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2835[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("uid"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2847 := z.EncBinary()
 					_ = yym2847
 					if false {
@@ -33039,6 +35473,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2835 || yy2arr2835 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2835[4] {
 					yym2849 := z.EncBinary()
 					_ = yym2849
@@ -33051,7 +35486,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2835[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2850 := z.EncBinary()
 					_ = yym2850
 					if false {
@@ -33061,6 +35498,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2835 || yy2arr2835 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2835[5] {
 					yym2852 := z.EncBinary()
 					_ = yym2852
@@ -33073,7 +35511,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2835[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2853 := z.EncBinary()
 					_ = yym2853
 					if false {
@@ -33083,6 +35523,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2835 || yy2arr2835 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2835[6] {
 					yym2855 := z.EncBinary()
 					_ = yym2855
@@ -33095,7 +35536,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2835[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fieldPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2856 := z.EncBinary()
 					_ = yym2856
 					if false {
@@ -33104,8 +35547,10 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2835 {
-				r.EncodeEnd()
+			if yyr2835 || yy2arr2835 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -33120,17 +35565,18 @@ func (x *ObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2858 := r.ContainerType()
+		if yyct2858 == codecSelferValueTypeMap1234 {
 			yyl2858 := r.ReadMapStart()
 			if yyl2858 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2858, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2858 == codecSelferValueTypeArray1234 {
 			yyl2858 := r.ReadArrayStart()
 			if yyl2858 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2858, d)
 			}
@@ -33157,8 +35603,10 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2859Slc = r.DecodeBytes(yys2859Slc, true, true)
 		yys2859 := string(yys2859Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2859 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -33206,9 +35654,7 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2859)
 		} // end switch yys2859
 	} // end for yyj2859
-	if !yyhl2859 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -33225,9 +35671,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2867 = r.CheckBreak()
 	}
 	if yyb2867 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -33240,9 +35687,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2867 = r.CheckBreak()
 	}
 	if yyb2867 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Namespace = ""
 	} else {
@@ -33255,9 +35703,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2867 = r.CheckBreak()
 	}
 	if yyb2867 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -33270,9 +35719,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2867 = r.CheckBreak()
 	}
 	if yyb2867 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.UID = ""
 	} else {
@@ -33285,9 +35735,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2867 = r.CheckBreak()
 	}
 	if yyb2867 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -33300,9 +35751,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2867 = r.CheckBreak()
 	}
 	if yyb2867 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ResourceVersion = ""
 	} else {
@@ -33315,9 +35767,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2867 = r.CheckBreak()
 	}
 	if yyb2867 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FieldPath = ""
 	} else {
@@ -33333,9 +35786,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb2867 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2867-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -33355,18 +35809,21 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2876 [1]bool
 			_, _, _ = yysep2876, yyq2876, yy2arr2876
 			const yyr2876 bool = false
+			var yynn2876 int
 			if yyr2876 || yy2arr2876 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2876 int = 1
+				yynn2876 = 1
 				for _, b := range yyq2876 {
 					if b {
 						yynn2876++
 					}
 				}
 				r.EncodeMapStart(yynn2876)
+				yynn2876 = 0
 			}
 			if yyr2876 || yy2arr2876 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2878 := z.EncBinary()
 				_ = yym2878
 				if false {
@@ -33374,7 +35831,9 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2879 := z.EncBinary()
 				_ = yym2879
 				if false {
@@ -33382,8 +35841,10 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yysep2876 {
-				r.EncodeEnd()
+			if yyr2876 || yy2arr2876 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -33398,17 +35859,18 @@ func (x *LocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2881 := r.ContainerType()
+		if yyct2881 == codecSelferValueTypeMap1234 {
 			yyl2881 := r.ReadMapStart()
 			if yyl2881 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2881, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2881 == codecSelferValueTypeArray1234 {
 			yyl2881 := r.ReadArrayStart()
 			if yyl2881 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2881, d)
 			}
@@ -33435,8 +35897,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2882Slc = r.DecodeBytes(yys2882Slc, true, true)
 		yys2882 := string(yys2882Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2882 {
 		case "Name":
 			if r.TryDecodeAsNil() {
@@ -33448,9 +35912,7 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys2882)
 		} // end switch yys2882
 	} // end for yyj2882
-	if !yyhl2882 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -33467,9 +35929,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb2884 = r.CheckBreak()
 	}
 	if yyb2884 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -33485,9 +35948,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb2884 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2884-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -33510,18 +35974,21 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2887[0] = x.Kind != ""
 			yyq2887[1] = x.APIVersion != ""
 			yyq2887[2] = true
+			var yynn2887 int
 			if yyr2887 || yy2arr2887 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2887 int = 0
+				yynn2887 = 0
 				for _, b := range yyq2887 {
 					if b {
 						yynn2887++
 					}
 				}
 				r.EncodeMapStart(yynn2887)
+				yynn2887 = 0
 			}
 			if yyr2887 || yy2arr2887 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2887[0] {
 					yym2889 := z.EncBinary()
 					_ = yym2889
@@ -33534,7 +36001,9 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2887[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2890 := z.EncBinary()
 					_ = yym2890
 					if false {
@@ -33544,6 +36013,7 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2887 || yy2arr2887 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2887[1] {
 					yym2892 := z.EncBinary()
 					_ = yym2892
@@ -33556,7 +36026,9 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2887[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2893 := z.EncBinary()
 					_ = yym2893
 					if false {
@@ -33566,6 +36038,7 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2887 || yy2arr2887 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2887[2] {
 					yy2895 := &x.Reference
 					yy2895.CodecEncodeSelf(e)
@@ -33574,13 +36047,17 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2887[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reference"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2896 := &x.Reference
 					yy2896.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2887 {
-				r.EncodeEnd()
+			if yyr2887 || yy2arr2887 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -33595,17 +36072,18 @@ func (x *SerializedReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2898 := r.ContainerType()
+		if yyct2898 == codecSelferValueTypeMap1234 {
 			yyl2898 := r.ReadMapStart()
 			if yyl2898 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2898, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2898 == codecSelferValueTypeArray1234 {
 			yyl2898 := r.ReadArrayStart()
 			if yyl2898 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2898, d)
 			}
@@ -33632,8 +36110,10 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2899Slc = r.DecodeBytes(yys2899Slc, true, true)
 		yys2899 := string(yys2899Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2899 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -33658,9 +36138,7 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys2899)
 		} // end switch yys2899
 	} // end for yyj2899
-	if !yyhl2899 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -33677,9 +36155,10 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb2903 = r.CheckBreak()
 	}
 	if yyb2903 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -33692,9 +36171,10 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb2903 = r.CheckBreak()
 	}
 	if yyb2903 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -33707,9 +36187,10 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb2903 = r.CheckBreak()
 	}
 	if yyb2903 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reference = ObjectReference{}
 	} else {
@@ -33726,9 +36207,10 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb2903 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2903-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -33750,18 +36232,21 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2908 bool = false
 			yyq2908[0] = x.Component != ""
 			yyq2908[1] = x.Host != ""
+			var yynn2908 int
 			if yyr2908 || yy2arr2908 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2908 int = 0
+				yynn2908 = 0
 				for _, b := range yyq2908 {
 					if b {
 						yynn2908++
 					}
 				}
 				r.EncodeMapStart(yynn2908)
+				yynn2908 = 0
 			}
 			if yyr2908 || yy2arr2908 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2908[0] {
 					yym2910 := z.EncBinary()
 					_ = yym2910
@@ -33774,7 +36259,9 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2908[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("component"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2911 := z.EncBinary()
 					_ = yym2911
 					if false {
@@ -33784,6 +36271,7 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2908 || yy2arr2908 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2908[1] {
 					yym2913 := z.EncBinary()
 					_ = yym2913
@@ -33796,7 +36284,9 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2908[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2914 := z.EncBinary()
 					_ = yym2914
 					if false {
@@ -33805,8 +36295,10 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2908 {
-				r.EncodeEnd()
+			if yyr2908 || yy2arr2908 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -33821,17 +36313,18 @@ func (x *EventSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2916 := r.ContainerType()
+		if yyct2916 == codecSelferValueTypeMap1234 {
 			yyl2916 := r.ReadMapStart()
 			if yyl2916 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2916, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2916 == codecSelferValueTypeArray1234 {
 			yyl2916 := r.ReadArrayStart()
 			if yyl2916 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2916, d)
 			}
@@ -33858,8 +36351,10 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2917Slc = r.DecodeBytes(yys2917Slc, true, true)
 		yys2917 := string(yys2917Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2917 {
 		case "component":
 			if r.TryDecodeAsNil() {
@@ -33877,9 +36372,7 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2917)
 		} // end switch yys2917
 	} // end for yyj2917
-	if !yyhl2917 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -33896,9 +36389,10 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2920 = r.CheckBreak()
 	}
 	if yyb2920 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Component = ""
 	} else {
@@ -33911,9 +36405,10 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2920 = r.CheckBreak()
 	}
 	if yyb2920 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Host = ""
 	} else {
@@ -33929,9 +36424,10 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2920 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2920-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -33962,18 +36458,21 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2924[8] = true
 			yyq2924[9] = x.Count != 0
 			yyq2924[10] = x.Type != ""
+			var yynn2924 int
 			if yyr2924 || yy2arr2924 {
 				r.EncodeArrayStart(11)
 			} else {
-				var yynn2924 int = 0
+				yynn2924 = 0
 				for _, b := range yyq2924 {
 					if b {
 						yynn2924++
 					}
 				}
 				r.EncodeMapStart(yynn2924)
+				yynn2924 = 0
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[0] {
 					yym2926 := z.EncBinary()
 					_ = yym2926
@@ -33986,7 +36485,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2927 := z.EncBinary()
 					_ = yym2927
 					if false {
@@ -33996,6 +36497,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[1] {
 					yym2929 := z.EncBinary()
 					_ = yym2929
@@ -34008,7 +36510,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2930 := z.EncBinary()
 					_ = yym2930
 					if false {
@@ -34018,6 +36522,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[2] {
 					yy2932 := &x.ObjectMeta
 					yy2932.CodecEncodeSelf(e)
@@ -34026,12 +36531,15 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2933 := &x.ObjectMeta
 					yy2933.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[3] {
 					yy2935 := &x.InvolvedObject
 					yy2935.CodecEncodeSelf(e)
@@ -34040,12 +36548,15 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2936 := &x.InvolvedObject
 					yy2936.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[4] {
 					yym2938 := z.EncBinary()
 					_ = yym2938
@@ -34058,7 +36569,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2939 := z.EncBinary()
 					_ = yym2939
 					if false {
@@ -34068,6 +36581,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[5] {
 					yym2941 := z.EncBinary()
 					_ = yym2941
@@ -34080,7 +36594,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2942 := z.EncBinary()
 					_ = yym2942
 					if false {
@@ -34090,6 +36606,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[6] {
 					yy2944 := &x.Source
 					yy2944.CodecEncodeSelf(e)
@@ -34098,12 +36615,15 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("source"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2945 := &x.Source
 					yy2945.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[7] {
 					yy2947 := &x.FirstTimestamp
 					yym2948 := z.EncBinary()
@@ -34122,7 +36642,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2949 := &x.FirstTimestamp
 					yym2950 := z.EncBinary()
 					_ = yym2950
@@ -34138,6 +36660,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[8] {
 					yy2952 := &x.LastTimestamp
 					yym2953 := z.EncBinary()
@@ -34156,7 +36679,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2954 := &x.LastTimestamp
 					yym2955 := z.EncBinary()
 					_ = yym2955
@@ -34172,6 +36697,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[9] {
 					yym2957 := z.EncBinary()
 					_ = yym2957
@@ -34184,7 +36710,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("count"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2958 := z.EncBinary()
 					_ = yym2958
 					if false {
@@ -34194,6 +36722,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2924[10] {
 					yym2960 := z.EncBinary()
 					_ = yym2960
@@ -34206,7 +36735,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2924[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2961 := z.EncBinary()
 					_ = yym2961
 					if false {
@@ -34215,8 +36746,10 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2924 {
-				r.EncodeEnd()
+			if yyr2924 || yy2arr2924 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -34231,17 +36764,18 @@ func (x *Event) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2963 := r.ContainerType()
+		if yyct2963 == codecSelferValueTypeMap1234 {
 			yyl2963 := r.ReadMapStart()
 			if yyl2963 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2963, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2963 == codecSelferValueTypeArray1234 {
 			yyl2963 := r.ReadArrayStart()
 			if yyl2963 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2963, d)
 			}
@@ -34268,8 +36802,10 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2964Slc = r.DecodeBytes(yys2964Slc, true, true)
 		yys2964 := string(yys2964Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2964 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -34366,9 +36902,7 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2964)
 		} // end switch yys2964
 	} // end for yyj2964
-	if !yyhl2964 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -34385,9 +36919,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -34400,9 +36935,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -34415,9 +36951,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -34431,9 +36968,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.InvolvedObject = ObjectReference{}
 	} else {
@@ -34447,9 +36985,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -34462,9 +37001,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -34477,9 +37017,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Source = EventSource{}
 	} else {
@@ -34493,9 +37034,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FirstTimestamp = pkg2_unversioned.Time{}
 	} else {
@@ -34519,9 +37061,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTimestamp = pkg2_unversioned.Time{}
 	} else {
@@ -34545,9 +37088,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Count = 0
 	} else {
@@ -34560,9 +37104,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2978 = r.CheckBreak()
 	}
 	if yyb2978 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -34578,9 +37123,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2978 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2978-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -34603,18 +37149,21 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2993[0] = x.Kind != ""
 			yyq2993[1] = x.APIVersion != ""
 			yyq2993[2] = true
+			var yynn2993 int
 			if yyr2993 || yy2arr2993 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2993 int = 1
+				yynn2993 = 1
 				for _, b := range yyq2993 {
 					if b {
 						yynn2993++
 					}
 				}
 				r.EncodeMapStart(yynn2993)
+				yynn2993 = 0
 			}
 			if yyr2993 || yy2arr2993 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2993[0] {
 					yym2995 := z.EncBinary()
 					_ = yym2995
@@ -34627,7 +37176,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2993[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2996 := z.EncBinary()
 					_ = yym2996
 					if false {
@@ -34637,6 +37188,7 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2993 || yy2arr2993 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2993[1] {
 					yym2998 := z.EncBinary()
 					_ = yym2998
@@ -34649,7 +37201,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2993[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2999 := z.EncBinary()
 					_ = yym2999
 					if false {
@@ -34659,6 +37213,7 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2993 || yy2arr2993 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2993[2] {
 					yy3001 := &x.ListMeta
 					yym3002 := z.EncBinary()
@@ -34673,7 +37228,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2993[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3003 := &x.ListMeta
 					yym3004 := z.EncBinary()
 					_ = yym3004
@@ -34685,6 +37242,7 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2993 || yy2arr2993 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -34696,7 +37254,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -34708,8 +37268,10 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2993 {
-				r.EncodeEnd()
+			if yyr2993 || yy2arr2993 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -34724,17 +37286,18 @@ func (x *EventList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3009 := r.ContainerType()
+		if yyct3009 == codecSelferValueTypeMap1234 {
 			yyl3009 := r.ReadMapStart()
 			if yyl3009 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3009, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3009 == codecSelferValueTypeArray1234 {
 			yyl3009 := r.ReadArrayStart()
 			if yyl3009 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3009, d)
 			}
@@ -34761,8 +37324,10 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3010Slc = r.DecodeBytes(yys3010Slc, true, true)
 		yys3010 := string(yys3010Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3010 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -34805,9 +37370,7 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3010)
 		} // end switch yys3010
 	} // end for yyj3010
-	if !yyhl3010 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -34824,9 +37387,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3017 = r.CheckBreak()
 	}
 	if yyb3017 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -34839,9 +37403,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3017 = r.CheckBreak()
 	}
 	if yyb3017 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -34854,9 +37419,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3017 = r.CheckBreak()
 	}
 	if yyb3017 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -34876,9 +37442,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3017 = r.CheckBreak()
 	}
 	if yyb3017 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -34900,9 +37467,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3017 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3017-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -34925,18 +37493,21 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3025[0] = x.Kind != ""
 			yyq3025[1] = x.APIVersion != ""
 			yyq3025[2] = true
+			var yynn3025 int
 			if yyr3025 || yy2arr3025 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3025 int = 1
+				yynn3025 = 1
 				for _, b := range yyq3025 {
 					if b {
 						yynn3025++
 					}
 				}
 				r.EncodeMapStart(yynn3025)
+				yynn3025 = 0
 			}
 			if yyr3025 || yy2arr3025 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3025[0] {
 					yym3027 := z.EncBinary()
 					_ = yym3027
@@ -34949,7 +37520,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3025[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3028 := z.EncBinary()
 					_ = yym3028
 					if false {
@@ -34959,6 +37532,7 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3025 || yy2arr3025 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3025[1] {
 					yym3030 := z.EncBinary()
 					_ = yym3030
@@ -34971,7 +37545,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3025[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3031 := z.EncBinary()
 					_ = yym3031
 					if false {
@@ -34981,6 +37557,7 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3025 || yy2arr3025 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3025[2] {
 					yy3033 := &x.ListMeta
 					yym3034 := z.EncBinary()
@@ -34995,7 +37572,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3025[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3035 := &x.ListMeta
 					yym3036 := z.EncBinary()
 					_ = yym3036
@@ -35007,6 +37586,7 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3025 || yy2arr3025 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -35018,7 +37598,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -35030,8 +37612,10 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3025 {
-				r.EncodeEnd()
+			if yyr3025 || yy2arr3025 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -35046,17 +37630,18 @@ func (x *List) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3041 := r.ContainerType()
+		if yyct3041 == codecSelferValueTypeMap1234 {
 			yyl3041 := r.ReadMapStart()
 			if yyl3041 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3041, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3041 == codecSelferValueTypeArray1234 {
 			yyl3041 := r.ReadArrayStart()
 			if yyl3041 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3041, d)
 			}
@@ -35083,8 +37668,10 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3042Slc = r.DecodeBytes(yys3042Slc, true, true)
 		yys3042 := string(yys3042Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3042 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -35127,9 +37714,7 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3042)
 		} // end switch yys3042
 	} // end for yyj3042
-	if !yyhl3042 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -35146,9 +37731,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -35161,9 +37747,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -35176,9 +37763,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -35198,9 +37786,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -35222,9 +37811,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3049 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3049-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x LimitType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -35276,18 +37866,21 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3059[3] = len(x.Default) != 0
 			yyq3059[4] = len(x.DefaultRequest) != 0
 			yyq3059[5] = len(x.MaxLimitRequestRatio) != 0
+			var yynn3059 int
 			if yyr3059 || yy2arr3059 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn3059 int = 0
+				yynn3059 = 0
 				for _, b := range yyq3059 {
 					if b {
 						yynn3059++
 					}
 				}
 				r.EncodeMapStart(yynn3059)
+				yynn3059 = 0
 			}
 			if yyr3059 || yy2arr3059 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3059[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
@@ -35295,11 +37888,14 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3059[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3059 || yy2arr3059 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3059[1] {
 					if x.Max == nil {
 						r.EncodeNil()
@@ -35311,7 +37907,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3059[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("max"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Max == nil {
 						r.EncodeNil()
 					} else {
@@ -35320,6 +37918,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3059 || yy2arr3059 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3059[2] {
 					if x.Min == nil {
 						r.EncodeNil()
@@ -35331,7 +37930,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3059[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("min"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Min == nil {
 						r.EncodeNil()
 					} else {
@@ -35340,6 +37941,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3059 || yy2arr3059 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3059[3] {
 					if x.Default == nil {
 						r.EncodeNil()
@@ -35351,7 +37953,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3059[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("default"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Default == nil {
 						r.EncodeNil()
 					} else {
@@ -35360,6 +37964,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3059 || yy2arr3059 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3059[4] {
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
@@ -35371,7 +37976,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3059[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("defaultRequest"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
 					} else {
@@ -35380,6 +37987,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3059 || yy2arr3059 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3059[5] {
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
@@ -35391,7 +37999,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3059[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxLimitRequestRatio"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
 					} else {
@@ -35399,8 +38009,10 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3059 {
-				r.EncodeEnd()
+			if yyr3059 || yy2arr3059 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -35415,17 +38027,18 @@ func (x *LimitRangeItem) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3067 := r.ContainerType()
+		if yyct3067 == codecSelferValueTypeMap1234 {
 			yyl3067 := r.ReadMapStart()
 			if yyl3067 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3067, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3067 == codecSelferValueTypeArray1234 {
 			yyl3067 := r.ReadArrayStart()
 			if yyl3067 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3067, d)
 			}
@@ -35452,8 +38065,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3068Slc = r.DecodeBytes(yys3068Slc, true, true)
 		yys3068 := string(yys3068Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3068 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -35500,9 +38115,7 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3068)
 		} // end switch yys3068
 	} // end for yyj3068
-	if !yyhl3068 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -35519,9 +38132,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3075 = r.CheckBreak()
 	}
 	if yyb3075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -35534,9 +38148,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3075 = r.CheckBreak()
 	}
 	if yyb3075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Max = nil
 	} else {
@@ -35550,9 +38165,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3075 = r.CheckBreak()
 	}
 	if yyb3075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Min = nil
 	} else {
@@ -35566,9 +38182,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3075 = r.CheckBreak()
 	}
 	if yyb3075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Default = nil
 	} else {
@@ -35582,9 +38199,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3075 = r.CheckBreak()
 	}
 	if yyb3075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DefaultRequest = nil
 	} else {
@@ -35598,9 +38216,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3075 = r.CheckBreak()
 	}
 	if yyb3075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MaxLimitRequestRatio = nil
 	} else {
@@ -35617,9 +38236,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3075 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3075-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -35639,18 +38259,21 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3083 [1]bool
 			_, _, _ = yysep3083, yyq3083, yy2arr3083
 			const yyr3083 bool = false
+			var yynn3083 int
 			if yyr3083 || yy2arr3083 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3083 int = 1
+				yynn3083 = 1
 				for _, b := range yyq3083 {
 					if b {
 						yynn3083++
 					}
 				}
 				r.EncodeMapStart(yynn3083)
+				yynn3083 = 0
 			}
 			if yyr3083 || yy2arr3083 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
@@ -35662,7 +38285,9 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("limits"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
@@ -35674,8 +38299,10 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3083 {
-				r.EncodeEnd()
+			if yyr3083 || yy2arr3083 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -35690,17 +38317,18 @@ func (x *LimitRangeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3088 := r.ContainerType()
+		if yyct3088 == codecSelferValueTypeMap1234 {
 			yyl3088 := r.ReadMapStart()
 			if yyl3088 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3088, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3088 == codecSelferValueTypeArray1234 {
 			yyl3088 := r.ReadArrayStart()
 			if yyl3088 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3088, d)
 			}
@@ -35727,8 +38355,10 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3089Slc = r.DecodeBytes(yys3089Slc, true, true)
 		yys3089 := string(yys3089Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3089 {
 		case "limits":
 			if r.TryDecodeAsNil() {
@@ -35746,9 +38376,7 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3089)
 		} // end switch yys3089
 	} // end for yyj3089
-	if !yyhl3089 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -35765,9 +38393,10 @@ func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3092 = r.CheckBreak()
 	}
 	if yyb3092 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Limits = nil
 	} else {
@@ -35789,9 +38418,10 @@ func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3092 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3092-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -35815,18 +38445,21 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3096[1] = x.APIVersion != ""
 			yyq3096[2] = true
 			yyq3096[3] = true
+			var yynn3096 int
 			if yyr3096 || yy2arr3096 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3096 int = 0
+				yynn3096 = 0
 				for _, b := range yyq3096 {
 					if b {
 						yynn3096++
 					}
 				}
 				r.EncodeMapStart(yynn3096)
+				yynn3096 = 0
 			}
 			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3096[0] {
 					yym3098 := z.EncBinary()
 					_ = yym3098
@@ -35839,7 +38472,9 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3096[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3099 := z.EncBinary()
 					_ = yym3099
 					if false {
@@ -35849,6 +38484,7 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3096[1] {
 					yym3101 := z.EncBinary()
 					_ = yym3101
@@ -35861,7 +38497,9 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3096[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3102 := z.EncBinary()
 					_ = yym3102
 					if false {
@@ -35871,6 +38509,7 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3096[2] {
 					yy3104 := &x.ObjectMeta
 					yy3104.CodecEncodeSelf(e)
@@ -35879,12 +38518,15 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3096[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3105 := &x.ObjectMeta
 					yy3105.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3096[3] {
 					yy3107 := &x.Spec
 					yy3107.CodecEncodeSelf(e)
@@ -35893,13 +38535,17 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3096[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3108 := &x.Spec
 					yy3108.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3096 {
-				r.EncodeEnd()
+			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -35914,17 +38560,18 @@ func (x *LimitRange) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3110 := r.ContainerType()
+		if yyct3110 == codecSelferValueTypeMap1234 {
 			yyl3110 := r.ReadMapStart()
 			if yyl3110 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3110, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3110 == codecSelferValueTypeArray1234 {
 			yyl3110 := r.ReadArrayStart()
 			if yyl3110 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3110, d)
 			}
@@ -35951,8 +38598,10 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3111Slc = r.DecodeBytes(yys3111Slc, true, true)
 		yys3111 := string(yys3111Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3111 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -35984,9 +38633,7 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3111)
 		} // end switch yys3111
 	} // end for yyj3111
-	if !yyhl3111 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -36003,9 +38650,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3116 = r.CheckBreak()
 	}
 	if yyb3116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -36018,9 +38666,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3116 = r.CheckBreak()
 	}
 	if yyb3116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -36033,9 +38682,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3116 = r.CheckBreak()
 	}
 	if yyb3116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -36049,9 +38699,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3116 = r.CheckBreak()
 	}
 	if yyb3116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = LimitRangeSpec{}
 	} else {
@@ -36068,9 +38719,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3116 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3116-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -36093,18 +38745,21 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3122[0] = x.Kind != ""
 			yyq3122[1] = x.APIVersion != ""
 			yyq3122[2] = true
+			var yynn3122 int
 			if yyr3122 || yy2arr3122 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3122 int = 1
+				yynn3122 = 1
 				for _, b := range yyq3122 {
 					if b {
 						yynn3122++
 					}
 				}
 				r.EncodeMapStart(yynn3122)
+				yynn3122 = 0
 			}
 			if yyr3122 || yy2arr3122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3122[0] {
 					yym3124 := z.EncBinary()
 					_ = yym3124
@@ -36117,7 +38772,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3122[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3125 := z.EncBinary()
 					_ = yym3125
 					if false {
@@ -36127,6 +38784,7 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3122 || yy2arr3122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3122[1] {
 					yym3127 := z.EncBinary()
 					_ = yym3127
@@ -36139,7 +38797,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3122[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3128 := z.EncBinary()
 					_ = yym3128
 					if false {
@@ -36149,6 +38809,7 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3122 || yy2arr3122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3122[2] {
 					yy3130 := &x.ListMeta
 					yym3131 := z.EncBinary()
@@ -36163,7 +38824,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3122[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3132 := &x.ListMeta
 					yym3133 := z.EncBinary()
 					_ = yym3133
@@ -36175,6 +38838,7 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3122 || yy2arr3122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -36186,7 +38850,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -36198,8 +38864,10 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3122 {
-				r.EncodeEnd()
+			if yyr3122 || yy2arr3122 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -36214,17 +38882,18 @@ func (x *LimitRangeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3138 := r.ContainerType()
+		if yyct3138 == codecSelferValueTypeMap1234 {
 			yyl3138 := r.ReadMapStart()
 			if yyl3138 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3138, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3138 == codecSelferValueTypeArray1234 {
 			yyl3138 := r.ReadArrayStart()
 			if yyl3138 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3138, d)
 			}
@@ -36251,8 +38920,10 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3139Slc = r.DecodeBytes(yys3139Slc, true, true)
 		yys3139 := string(yys3139Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3139 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -36295,9 +38966,7 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3139)
 		} // end switch yys3139
 	} // end for yyj3139
-	if !yyhl3139 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -36314,9 +38983,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3146 = r.CheckBreak()
 	}
 	if yyb3146 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -36329,9 +38999,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3146 = r.CheckBreak()
 	}
 	if yyb3146 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -36344,9 +39015,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3146 = r.CheckBreak()
 	}
 	if yyb3146 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -36366,9 +39038,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3146 = r.CheckBreak()
 	}
 	if yyb3146 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -36390,9 +39063,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3146 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3146-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -36413,18 +39087,21 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep3154, yyq3154, yy2arr3154
 			const yyr3154 bool = false
 			yyq3154[0] = len(x.Hard) != 0
+			var yynn3154 int
 			if yyr3154 || yy2arr3154 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3154 int = 0
+				yynn3154 = 0
 				for _, b := range yyq3154 {
 					if b {
 						yynn3154++
 					}
 				}
 				r.EncodeMapStart(yynn3154)
+				yynn3154 = 0
 			}
 			if yyr3154 || yy2arr3154 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3154[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36436,7 +39113,9 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3154[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36444,8 +39123,10 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3154 {
-				r.EncodeEnd()
+			if yyr3154 || yy2arr3154 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -36460,17 +39141,18 @@ func (x *ResourceQuotaSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3157 := r.ContainerType()
+		if yyct3157 == codecSelferValueTypeMap1234 {
 			yyl3157 := r.ReadMapStart()
 			if yyl3157 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3157, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3157 == codecSelferValueTypeArray1234 {
 			yyl3157 := r.ReadArrayStart()
 			if yyl3157 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3157, d)
 			}
@@ -36497,8 +39179,10 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3158Slc = r.DecodeBytes(yys3158Slc, true, true)
 		yys3158 := string(yys3158Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3158 {
 		case "hard":
 			if r.TryDecodeAsNil() {
@@ -36511,9 +39195,7 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			z.DecStructFieldNotFound(-1, yys3158)
 		} // end switch yys3158
 	} // end for yyj3158
-	if !yyhl3158 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -36530,9 +39212,10 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3160 = r.CheckBreak()
 	}
 	if yyb3160 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
@@ -36549,9 +39232,10 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if yyb3160 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3160-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -36573,18 +39257,21 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr3163 bool = false
 			yyq3163[0] = len(x.Hard) != 0
 			yyq3163[1] = len(x.Used) != 0
+			var yynn3163 int
 			if yyr3163 || yy2arr3163 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn3163 int = 0
+				yynn3163 = 0
 				for _, b := range yyq3163 {
 					if b {
 						yynn3163++
 					}
 				}
 				r.EncodeMapStart(yynn3163)
+				yynn3163 = 0
 			}
 			if yyr3163 || yy2arr3163 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3163[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36596,7 +39283,9 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3163[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36605,6 +39294,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3163 || yy2arr3163 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3163[1] {
 					if x.Used == nil {
 						r.EncodeNil()
@@ -36616,7 +39306,9 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3163[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("used"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Used == nil {
 						r.EncodeNil()
 					} else {
@@ -36624,8 +39316,10 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3163 {
-				r.EncodeEnd()
+			if yyr3163 || yy2arr3163 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -36640,17 +39334,18 @@ func (x *ResourceQuotaStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3167 := r.ContainerType()
+		if yyct3167 == codecSelferValueTypeMap1234 {
 			yyl3167 := r.ReadMapStart()
 			if yyl3167 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3167, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3167 == codecSelferValueTypeArray1234 {
 			yyl3167 := r.ReadArrayStart()
 			if yyl3167 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3167, d)
 			}
@@ -36677,8 +39372,10 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3168Slc = r.DecodeBytes(yys3168Slc, true, true)
 		yys3168 := string(yys3168Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3168 {
 		case "hard":
 			if r.TryDecodeAsNil() {
@@ -36698,9 +39395,7 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys3168)
 		} // end switch yys3168
 	} // end for yyj3168
-	if !yyhl3168 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -36717,9 +39412,10 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3171 = r.CheckBreak()
 	}
 	if yyb3171 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
@@ -36733,9 +39429,10 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3171 = r.CheckBreak()
 	}
 	if yyb3171 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Used = nil
 	} else {
@@ -36752,9 +39449,10 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb3171 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3171-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -36779,18 +39477,21 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3175[2] = true
 			yyq3175[3] = true
 			yyq3175[4] = true
+			var yynn3175 int
 			if yyr3175 || yy2arr3175 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3175 int = 0
+				yynn3175 = 0
 				for _, b := range yyq3175 {
 					if b {
 						yynn3175++
 					}
 				}
 				r.EncodeMapStart(yynn3175)
+				yynn3175 = 0
 			}
 			if yyr3175 || yy2arr3175 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3175[0] {
 					yym3177 := z.EncBinary()
 					_ = yym3177
@@ -36803,7 +39504,9 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3175[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3178 := z.EncBinary()
 					_ = yym3178
 					if false {
@@ -36813,6 +39516,7 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3175 || yy2arr3175 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3175[1] {
 					yym3180 := z.EncBinary()
 					_ = yym3180
@@ -36825,7 +39529,9 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3175[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3181 := z.EncBinary()
 					_ = yym3181
 					if false {
@@ -36835,6 +39541,7 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3175 || yy2arr3175 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3175[2] {
 					yy3183 := &x.ObjectMeta
 					yy3183.CodecEncodeSelf(e)
@@ -36843,12 +39550,15 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3175[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3184 := &x.ObjectMeta
 					yy3184.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3175 || yy2arr3175 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3175[3] {
 					yy3186 := &x.Spec
 					yy3186.CodecEncodeSelf(e)
@@ -36857,12 +39567,15 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3175[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3187 := &x.Spec
 					yy3187.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3175 || yy2arr3175 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3175[4] {
 					yy3189 := &x.Status
 					yy3189.CodecEncodeSelf(e)
@@ -36871,13 +39584,17 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3175[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3190 := &x.Status
 					yy3190.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3175 {
-				r.EncodeEnd()
+			if yyr3175 || yy2arr3175 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -36892,17 +39609,18 @@ func (x *ResourceQuota) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3192 := r.ContainerType()
+		if yyct3192 == codecSelferValueTypeMap1234 {
 			yyl3192 := r.ReadMapStart()
 			if yyl3192 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3192, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3192 == codecSelferValueTypeArray1234 {
 			yyl3192 := r.ReadArrayStart()
 			if yyl3192 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3192, d)
 			}
@@ -36929,8 +39647,10 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3193Slc = r.DecodeBytes(yys3193Slc, true, true)
 		yys3193 := string(yys3193Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3193 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -36969,9 +39689,7 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3193)
 		} // end switch yys3193
 	} // end for yyj3193
-	if !yyhl3193 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -36988,9 +39706,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3199 = r.CheckBreak()
 	}
 	if yyb3199 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -37003,9 +39722,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3199 = r.CheckBreak()
 	}
 	if yyb3199 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -37018,9 +39738,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3199 = r.CheckBreak()
 	}
 	if yyb3199 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -37034,9 +39755,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3199 = r.CheckBreak()
 	}
 	if yyb3199 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ResourceQuotaSpec{}
 	} else {
@@ -37050,9 +39772,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3199 = r.CheckBreak()
 	}
 	if yyb3199 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ResourceQuotaStatus{}
 	} else {
@@ -37069,9 +39792,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3199 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3199-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -37094,18 +39818,21 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3206[0] = x.Kind != ""
 			yyq3206[1] = x.APIVersion != ""
 			yyq3206[2] = true
+			var yynn3206 int
 			if yyr3206 || yy2arr3206 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3206 int = 1
+				yynn3206 = 1
 				for _, b := range yyq3206 {
 					if b {
 						yynn3206++
 					}
 				}
 				r.EncodeMapStart(yynn3206)
+				yynn3206 = 0
 			}
 			if yyr3206 || yy2arr3206 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3206[0] {
 					yym3208 := z.EncBinary()
 					_ = yym3208
@@ -37118,7 +39845,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3206[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3209 := z.EncBinary()
 					_ = yym3209
 					if false {
@@ -37128,6 +39857,7 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3206 || yy2arr3206 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3206[1] {
 					yym3211 := z.EncBinary()
 					_ = yym3211
@@ -37140,7 +39870,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3206[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3212 := z.EncBinary()
 					_ = yym3212
 					if false {
@@ -37150,6 +39882,7 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3206 || yy2arr3206 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3206[2] {
 					yy3214 := &x.ListMeta
 					yym3215 := z.EncBinary()
@@ -37164,7 +39897,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3206[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3216 := &x.ListMeta
 					yym3217 := z.EncBinary()
 					_ = yym3217
@@ -37176,6 +39911,7 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3206 || yy2arr3206 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -37187,7 +39923,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -37199,8 +39937,10 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3206 {
-				r.EncodeEnd()
+			if yyr3206 || yy2arr3206 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -37215,17 +39955,18 @@ func (x *ResourceQuotaList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3222 := r.ContainerType()
+		if yyct3222 == codecSelferValueTypeMap1234 {
 			yyl3222 := r.ReadMapStart()
 			if yyl3222 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3222, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3222 == codecSelferValueTypeArray1234 {
 			yyl3222 := r.ReadArrayStart()
 			if yyl3222 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3222, d)
 			}
@@ -37252,8 +39993,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3223Slc = r.DecodeBytes(yys3223Slc, true, true)
 		yys3223 := string(yys3223Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3223 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -37296,9 +40039,7 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			z.DecStructFieldNotFound(-1, yys3223)
 		} // end switch yys3223
 	} // end for yyj3223
-	if !yyhl3223 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -37315,9 +40056,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3230 = r.CheckBreak()
 	}
 	if yyb3230 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -37330,9 +40072,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3230 = r.CheckBreak()
 	}
 	if yyb3230 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -37345,9 +40088,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3230 = r.CheckBreak()
 	}
 	if yyb3230 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -37367,9 +40111,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3230 = r.CheckBreak()
 	}
 	if yyb3230 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -37391,9 +40136,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if yyb3230 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3230-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -37418,18 +40164,21 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3238[2] = true
 			yyq3238[3] = len(x.Data) != 0
 			yyq3238[4] = x.Type != ""
+			var yynn3238 int
 			if yyr3238 || yy2arr3238 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3238 int = 0
+				yynn3238 = 0
 				for _, b := range yyq3238 {
 					if b {
 						yynn3238++
 					}
 				}
 				r.EncodeMapStart(yynn3238)
+				yynn3238 = 0
 			}
 			if yyr3238 || yy2arr3238 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3238[0] {
 					yym3240 := z.EncBinary()
 					_ = yym3240
@@ -37442,7 +40191,9 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3238[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3241 := z.EncBinary()
 					_ = yym3241
 					if false {
@@ -37452,6 +40203,7 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3238 || yy2arr3238 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3238[1] {
 					yym3243 := z.EncBinary()
 					_ = yym3243
@@ -37464,7 +40216,9 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3238[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3244 := z.EncBinary()
 					_ = yym3244
 					if false {
@@ -37474,6 +40228,7 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3238 || yy2arr3238 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3238[2] {
 					yy3246 := &x.ObjectMeta
 					yy3246.CodecEncodeSelf(e)
@@ -37482,12 +40237,15 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3238[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3247 := &x.ObjectMeta
 					yy3247.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3238 || yy2arr3238 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3238[3] {
 					if x.Data == nil {
 						r.EncodeNil()
@@ -37504,7 +40262,9 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3238[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
@@ -37518,6 +40278,7 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3238 || yy2arr3238 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3238[4] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
@@ -37525,12 +40286,16 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3238[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3238 {
-				r.EncodeEnd()
+			if yyr3238 || yy2arr3238 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -37545,17 +40310,18 @@ func (x *Secret) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3253 := r.ContainerType()
+		if yyct3253 == codecSelferValueTypeMap1234 {
 			yyl3253 := r.ReadMapStart()
 			if yyl3253 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3253, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3253 == codecSelferValueTypeArray1234 {
 			yyl3253 := r.ReadArrayStart()
 			if yyl3253 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3253, d)
 			}
@@ -37582,8 +40348,10 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3254Slc = r.DecodeBytes(yys3254Slc, true, true)
 		yys3254 := string(yys3254Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3254 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -37626,9 +40394,7 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3254)
 		} // end switch yys3254
 	} // end for yyj3254
-	if !yyhl3254 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -37645,9 +40411,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3261 = r.CheckBreak()
 	}
 	if yyb3261 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -37660,9 +40427,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3261 = r.CheckBreak()
 	}
 	if yyb3261 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -37675,9 +40443,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3261 = r.CheckBreak()
 	}
 	if yyb3261 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -37691,9 +40460,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3261 = r.CheckBreak()
 	}
 	if yyb3261 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
@@ -37712,9 +40482,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3261 = r.CheckBreak()
 	}
 	if yyb3261 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -37730,9 +40501,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3261 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3261-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x SecretType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -37781,18 +40553,21 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3271[0] = x.Kind != ""
 			yyq3271[1] = x.APIVersion != ""
 			yyq3271[2] = true
+			var yynn3271 int
 			if yyr3271 || yy2arr3271 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3271 int = 1
+				yynn3271 = 1
 				for _, b := range yyq3271 {
 					if b {
 						yynn3271++
 					}
 				}
 				r.EncodeMapStart(yynn3271)
+				yynn3271 = 0
 			}
 			if yyr3271 || yy2arr3271 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3271[0] {
 					yym3273 := z.EncBinary()
 					_ = yym3273
@@ -37805,7 +40580,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3271[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3274 := z.EncBinary()
 					_ = yym3274
 					if false {
@@ -37815,6 +40592,7 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3271 || yy2arr3271 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3271[1] {
 					yym3276 := z.EncBinary()
 					_ = yym3276
@@ -37827,7 +40605,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3271[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3277 := z.EncBinary()
 					_ = yym3277
 					if false {
@@ -37837,6 +40617,7 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3271 || yy2arr3271 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3271[2] {
 					yy3279 := &x.ListMeta
 					yym3280 := z.EncBinary()
@@ -37851,7 +40632,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3271[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3281 := &x.ListMeta
 					yym3282 := z.EncBinary()
 					_ = yym3282
@@ -37863,6 +40646,7 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3271 || yy2arr3271 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -37874,7 +40658,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -37886,8 +40672,10 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3271 {
-				r.EncodeEnd()
+			if yyr3271 || yy2arr3271 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -37902,17 +40690,18 @@ func (x *SecretList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3287 := r.ContainerType()
+		if yyct3287 == codecSelferValueTypeMap1234 {
 			yyl3287 := r.ReadMapStart()
 			if yyl3287 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3287, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3287 == codecSelferValueTypeArray1234 {
 			yyl3287 := r.ReadArrayStart()
 			if yyl3287 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3287, d)
 			}
@@ -37939,8 +40728,10 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3288Slc = r.DecodeBytes(yys3288Slc, true, true)
 		yys3288 := string(yys3288Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3288 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -37983,9 +40774,7 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3288)
 		} // end switch yys3288
 	} // end for yyj3288
-	if !yyhl3288 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -38002,9 +40791,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3295 = r.CheckBreak()
 	}
 	if yyb3295 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -38017,9 +40807,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3295 = r.CheckBreak()
 	}
 	if yyb3295 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -38032,9 +40823,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3295 = r.CheckBreak()
 	}
 	if yyb3295 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -38054,9 +40846,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3295 = r.CheckBreak()
 	}
 	if yyb3295 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -38078,9 +40871,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3295 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3295-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PatchType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -38154,30 +40948,39 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr3307 bool = false
 			yyq3307[2] = x.Message != ""
 			yyq3307[3] = x.Error != ""
+			var yynn3307 int
 			if yyr3307 || yy2arr3307 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3307 int = 2
+				yynn3307 = 2
 				for _, b := range yyq3307 {
 					if b {
 						yynn3307++
 					}
 				}
 				r.EncodeMapStart(yynn3307)
+				yynn3307 = 0
 			}
 			if yyr3307 || yy2arr3307 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr3307 || yy2arr3307 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Status.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Status.CodecEncodeSelf(e)
 			}
 			if yyr3307 || yy2arr3307 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3307[2] {
 					yym3311 := z.EncBinary()
 					_ = yym3311
@@ -38190,7 +40993,9 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3307[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3312 := z.EncBinary()
 					_ = yym3312
 					if false {
@@ -38200,6 +41005,7 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3307 || yy2arr3307 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3307[3] {
 					yym3314 := z.EncBinary()
 					_ = yym3314
@@ -38212,7 +41018,9 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3307[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("error"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3315 := z.EncBinary()
 					_ = yym3315
 					if false {
@@ -38221,8 +41029,10 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3307 {
-				r.EncodeEnd()
+			if yyr3307 || yy2arr3307 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -38237,17 +41047,18 @@ func (x *ComponentCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3317 := r.ContainerType()
+		if yyct3317 == codecSelferValueTypeMap1234 {
 			yyl3317 := r.ReadMapStart()
 			if yyl3317 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3317, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3317 == codecSelferValueTypeArray1234 {
 			yyl3317 := r.ReadArrayStart()
 			if yyl3317 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3317, d)
 			}
@@ -38274,8 +41085,10 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3318Slc = r.DecodeBytes(yys3318Slc, true, true)
 		yys3318 := string(yys3318Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3318 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -38305,9 +41118,7 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys3318)
 		} // end switch yys3318
 	} // end for yyj3318
-	if !yyhl3318 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -38324,9 +41135,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb3323 = r.CheckBreak()
 	}
 	if yyb3323 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -38339,9 +41151,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb3323 = r.CheckBreak()
 	}
 	if yyb3323 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ""
 	} else {
@@ -38354,9 +41167,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb3323 = r.CheckBreak()
 	}
 	if yyb3323 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -38369,9 +41183,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb3323 = r.CheckBreak()
 	}
 	if yyb3323 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Error = ""
 	} else {
@@ -38387,9 +41202,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb3323 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3323-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -38413,18 +41229,21 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3329[1] = x.APIVersion != ""
 			yyq3329[2] = true
 			yyq3329[3] = len(x.Conditions) != 0
+			var yynn3329 int
 			if yyr3329 || yy2arr3329 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3329 int = 0
+				yynn3329 = 0
 				for _, b := range yyq3329 {
 					if b {
 						yynn3329++
 					}
 				}
 				r.EncodeMapStart(yynn3329)
+				yynn3329 = 0
 			}
 			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3329[0] {
 					yym3331 := z.EncBinary()
 					_ = yym3331
@@ -38437,7 +41256,9 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3329[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3332 := z.EncBinary()
 					_ = yym3332
 					if false {
@@ -38447,6 +41268,7 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3329[1] {
 					yym3334 := z.EncBinary()
 					_ = yym3334
@@ -38459,7 +41281,9 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3329[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3335 := z.EncBinary()
 					_ = yym3335
 					if false {
@@ -38469,6 +41293,7 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3329[2] {
 					yy3337 := &x.ObjectMeta
 					yy3337.CodecEncodeSelf(e)
@@ -38477,12 +41302,15 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3329[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3338 := &x.ObjectMeta
 					yy3338.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3329[3] {
 					if x.Conditions == nil {
 						r.EncodeNil()
@@ -38499,7 +41327,9 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3329[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
@@ -38512,8 +41342,10 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3329 {
-				r.EncodeEnd()
+			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -38528,17 +41360,18 @@ func (x *ComponentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3343 := r.ContainerType()
+		if yyct3343 == codecSelferValueTypeMap1234 {
 			yyl3343 := r.ReadMapStart()
 			if yyl3343 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3343, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3343 == codecSelferValueTypeArray1234 {
 			yyl3343 := r.ReadArrayStart()
 			if yyl3343 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3343, d)
 			}
@@ -38565,8 +41398,10 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3344Slc = r.DecodeBytes(yys3344Slc, true, true)
 		yys3344 := string(yys3344Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3344 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -38603,9 +41438,7 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3344)
 		} // end switch yys3344
 	} // end for yyj3344
-	if !yyhl3344 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -38622,9 +41455,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3350 = r.CheckBreak()
 	}
 	if yyb3350 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -38637,9 +41471,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3350 = r.CheckBreak()
 	}
 	if yyb3350 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -38652,9 +41487,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3350 = r.CheckBreak()
 	}
 	if yyb3350 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -38668,9 +41504,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3350 = r.CheckBreak()
 	}
 	if yyb3350 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
@@ -38692,9 +41529,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb3350 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3350-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -38717,18 +41555,21 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3357[0] = x.Kind != ""
 			yyq3357[1] = x.APIVersion != ""
 			yyq3357[2] = true
+			var yynn3357 int
 			if yyr3357 || yy2arr3357 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3357 int = 1
+				yynn3357 = 1
 				for _, b := range yyq3357 {
 					if b {
 						yynn3357++
 					}
 				}
 				r.EncodeMapStart(yynn3357)
+				yynn3357 = 0
 			}
 			if yyr3357 || yy2arr3357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3357[0] {
 					yym3359 := z.EncBinary()
 					_ = yym3359
@@ -38741,7 +41582,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3357[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3360 := z.EncBinary()
 					_ = yym3360
 					if false {
@@ -38751,6 +41594,7 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3357 || yy2arr3357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3357[1] {
 					yym3362 := z.EncBinary()
 					_ = yym3362
@@ -38763,7 +41607,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3357[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3363 := z.EncBinary()
 					_ = yym3363
 					if false {
@@ -38773,6 +41619,7 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3357 || yy2arr3357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3357[2] {
 					yy3365 := &x.ListMeta
 					yym3366 := z.EncBinary()
@@ -38787,7 +41634,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3357[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3367 := &x.ListMeta
 					yym3368 := z.EncBinary()
 					_ = yym3368
@@ -38799,6 +41648,7 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3357 || yy2arr3357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -38810,7 +41660,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -38822,8 +41674,10 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3357 {
-				r.EncodeEnd()
+			if yyr3357 || yy2arr3357 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -38838,17 +41692,18 @@ func (x *ComponentStatusList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3373 := r.ContainerType()
+		if yyct3373 == codecSelferValueTypeMap1234 {
 			yyl3373 := r.ReadMapStart()
 			if yyl3373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3373, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3373 == codecSelferValueTypeArray1234 {
 			yyl3373 := r.ReadArrayStart()
 			if yyl3373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3373, d)
 			}
@@ -38875,8 +41730,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3374Slc = r.DecodeBytes(yys3374Slc, true, true)
 		yys3374 := string(yys3374Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3374 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -38919,9 +41776,7 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys3374)
 		} // end switch yys3374
 	} // end for yyj3374
-	if !yyhl3374 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -38938,9 +41793,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3381 = r.CheckBreak()
 	}
 	if yyb3381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -38953,9 +41809,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3381 = r.CheckBreak()
 	}
 	if yyb3381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -38968,9 +41825,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3381 = r.CheckBreak()
 	}
 	if yyb3381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -38990,9 +41848,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3381 = r.CheckBreak()
 	}
 	if yyb3381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -39014,9 +41873,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb3381 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3381-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -39041,18 +41901,21 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3389[2] = x.SELinuxOptions != nil
 			yyq3389[3] = x.RunAsUser != nil
 			yyq3389[4] = x.RunAsNonRoot != nil
+			var yynn3389 int
 			if yyr3389 || yy2arr3389 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3389 int = 0
+				yynn3389 = 0
 				for _, b := range yyq3389 {
 					if b {
 						yynn3389++
 					}
 				}
 				r.EncodeMapStart(yynn3389)
+				yynn3389 = 0
 			}
 			if yyr3389 || yy2arr3389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3389[0] {
 					if x.Capabilities == nil {
 						r.EncodeNil()
@@ -39064,7 +41927,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3389[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capabilities"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
@@ -39073,6 +41938,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3389 || yy2arr3389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3389[1] {
 					if x.Privileged == nil {
 						r.EncodeNil()
@@ -39090,7 +41956,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3389[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("privileged"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
@@ -39105,6 +41973,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3389 || yy2arr3389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3389[2] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -39116,7 +41985,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3389[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -39125,6 +41996,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3389 || yy2arr3389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3389[3] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
@@ -39142,7 +42014,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3389[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
@@ -39157,6 +42031,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3389 || yy2arr3389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3389[4] {
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
@@ -39174,7 +42049,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3389[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
@@ -39188,8 +42065,10 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3389 {
-				r.EncodeEnd()
+			if yyr3389 || yy2arr3389 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -39204,17 +42083,18 @@ func (x *SecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3408 := r.ContainerType()
+		if yyct3408 == codecSelferValueTypeMap1234 {
 			yyl3408 := r.ReadMapStart()
 			if yyl3408 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3408, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3408 == codecSelferValueTypeArray1234 {
 			yyl3408 := r.ReadArrayStart()
 			if yyl3408 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3408, d)
 			}
@@ -39241,8 +42121,10 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3409Slc = r.DecodeBytes(yys3409Slc, true, true)
 		yys3409 := string(yys3409Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3409 {
 		case "capabilities":
 			if r.TryDecodeAsNil() {
@@ -39318,9 +42200,7 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3409)
 		} // end switch yys3409
 	} // end for yyj3409
-	if !yyhl3409 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -39337,9 +42217,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3418 = r.CheckBreak()
 	}
 	if yyb3418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Capabilities != nil {
 			x.Capabilities = nil
@@ -39357,9 +42238,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3418 = r.CheckBreak()
 	}
 	if yyb3418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Privileged != nil {
 			x.Privileged = nil
@@ -39382,9 +42264,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3418 = r.CheckBreak()
 	}
 	if yyb3418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SELinuxOptions != nil {
 			x.SELinuxOptions = nil
@@ -39402,9 +42285,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3418 = r.CheckBreak()
 	}
 	if yyb3418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RunAsUser != nil {
 			x.RunAsUser = nil
@@ -39427,9 +42311,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3418 = r.CheckBreak()
 	}
 	if yyb3418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RunAsNonRoot != nil {
 			x.RunAsNonRoot = nil
@@ -39455,9 +42340,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb3418 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3418-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -39481,18 +42367,21 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3428[1] = x.Role != ""
 			yyq3428[2] = x.Type != ""
 			yyq3428[3] = x.Level != ""
+			var yynn3428 int
 			if yyr3428 || yy2arr3428 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3428 int = 0
+				yynn3428 = 0
 				for _, b := range yyq3428 {
 					if b {
 						yynn3428++
 					}
 				}
 				r.EncodeMapStart(yynn3428)
+				yynn3428 = 0
 			}
 			if yyr3428 || yy2arr3428 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3428[0] {
 					yym3430 := z.EncBinary()
 					_ = yym3430
@@ -39505,7 +42394,9 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3428[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("user"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3431 := z.EncBinary()
 					_ = yym3431
 					if false {
@@ -39515,6 +42406,7 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3428 || yy2arr3428 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3428[1] {
 					yym3433 := z.EncBinary()
 					_ = yym3433
@@ -39527,7 +42419,9 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3428[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("role"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3434 := z.EncBinary()
 					_ = yym3434
 					if false {
@@ -39537,6 +42431,7 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3428 || yy2arr3428 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3428[2] {
 					yym3436 := z.EncBinary()
 					_ = yym3436
@@ -39549,7 +42444,9 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3428[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3437 := z.EncBinary()
 					_ = yym3437
 					if false {
@@ -39559,6 +42456,7 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3428 || yy2arr3428 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3428[3] {
 					yym3439 := z.EncBinary()
 					_ = yym3439
@@ -39571,7 +42469,9 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3428[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("level"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3440 := z.EncBinary()
 					_ = yym3440
 					if false {
@@ -39580,8 +42480,10 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3428 {
-				r.EncodeEnd()
+			if yyr3428 || yy2arr3428 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -39596,17 +42498,18 @@ func (x *SELinuxOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3442 := r.ContainerType()
+		if yyct3442 == codecSelferValueTypeMap1234 {
 			yyl3442 := r.ReadMapStart()
 			if yyl3442 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3442, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3442 == codecSelferValueTypeArray1234 {
 			yyl3442 := r.ReadArrayStart()
 			if yyl3442 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3442, d)
 			}
@@ -39633,8 +42536,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3443Slc = r.DecodeBytes(yys3443Slc, true, true)
 		yys3443 := string(yys3443Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3443 {
 		case "user":
 			if r.TryDecodeAsNil() {
@@ -39664,9 +42569,7 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3443)
 		} // end switch yys3443
 	} // end for yyj3443
-	if !yyhl3443 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -39683,9 +42586,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3448 = r.CheckBreak()
 	}
 	if yyb3448 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.User = ""
 	} else {
@@ -39698,9 +42602,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3448 = r.CheckBreak()
 	}
 	if yyb3448 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Role = ""
 	} else {
@@ -39713,9 +42618,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3448 = r.CheckBreak()
 	}
 	if yyb3448 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -39728,9 +42634,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3448 = r.CheckBreak()
 	}
 	if yyb3448 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Level = ""
 	} else {
@@ -39746,9 +42653,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3448 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3448-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -39771,18 +42679,21 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3454[0] = x.Kind != ""
 			yyq3454[1] = x.APIVersion != ""
 			yyq3454[2] = true
+			var yynn3454 int
 			if yyr3454 || yy2arr3454 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3454 int = 2
+				yynn3454 = 2
 				for _, b := range yyq3454 {
 					if b {
 						yynn3454++
 					}
 				}
 				r.EncodeMapStart(yynn3454)
+				yynn3454 = 0
 			}
 			if yyr3454 || yy2arr3454 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3454[0] {
 					yym3456 := z.EncBinary()
 					_ = yym3456
@@ -39795,7 +42706,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3454[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3457 := z.EncBinary()
 					_ = yym3457
 					if false {
@@ -39805,6 +42718,7 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3454 || yy2arr3454 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3454[1] {
 					yym3459 := z.EncBinary()
 					_ = yym3459
@@ -39817,7 +42731,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3454[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3460 := z.EncBinary()
 					_ = yym3460
 					if false {
@@ -39827,6 +42743,7 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3454 || yy2arr3454 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3454[2] {
 					yy3462 := &x.ObjectMeta
 					yy3462.CodecEncodeSelf(e)
@@ -39835,12 +42752,15 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3454[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3463 := &x.ObjectMeta
 					yy3463.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3454 || yy2arr3454 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym3465 := z.EncBinary()
 				_ = yym3465
 				if false {
@@ -39848,7 +42768,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("range"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym3466 := z.EncBinary()
 				_ = yym3466
 				if false {
@@ -39857,6 +42779,7 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3454 || yy2arr3454 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
@@ -39868,7 +42791,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("data"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
@@ -39880,8 +42805,10 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3454 {
-				r.EncodeEnd()
+			if yyr3454 || yy2arr3454 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -39896,17 +42823,18 @@ func (x *RangeAllocation) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3471 := r.ContainerType()
+		if yyct3471 == codecSelferValueTypeMap1234 {
 			yyl3471 := r.ReadMapStart()
 			if yyl3471 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3471, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3471 == codecSelferValueTypeArray1234 {
 			yyl3471 := r.ReadArrayStart()
 			if yyl3471 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3471, d)
 			}
@@ -39933,8 +42861,10 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3472Slc = r.DecodeBytes(yys3472Slc, true, true)
 		yys3472 := string(yys3472Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3472 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -39977,9 +42907,7 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3472)
 		} // end switch yys3472
 	} // end for yyj3472
-	if !yyhl3472 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -39996,9 +42924,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3479 = r.CheckBreak()
 	}
 	if yyb3479 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -40011,9 +42940,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3479 = r.CheckBreak()
 	}
 	if yyb3479 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -40026,9 +42956,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3479 = r.CheckBreak()
 	}
 	if yyb3479 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -40042,9 +42973,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3479 = r.CheckBreak()
 	}
 	if yyb3479 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Range = ""
 	} else {
@@ -40057,9 +42989,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3479 = r.CheckBreak()
 	}
 	if yyb3479 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
@@ -40081,9 +43014,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb3479 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3479-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) encSlicePersistentVolumeAccessMode(v []PersistentVolumeAccessMode, e *codec1978.Encoder) {
@@ -40092,9 +43026,10 @@ func (x codecSelfer1234) encSlicePersistentVolumeAccessMode(v []PersistentVolume
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3486 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yyv3486.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolumeAccessMode, d *codec1978.Decoder) {
@@ -40104,37 +43039,31 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 
 	yyv3487 := *v
 	yyh3487, yyl3487 := z.DecSliceHelperStart()
-
-	var yyrr3487, yyrl3487 int
-	var yyc3487, yyrt3487 bool
-	_, _, _ = yyc3487, yyrt3487, yyrl3487
-	yyrr3487 = yyl3487
-
-	if yyv3487 == nil {
-		if yyrl3487, yyrt3487 = z.DecInferLen(yyl3487, z.DecBasicHandle().MaxInitLen, 16); yyrt3487 {
-			yyrr3487 = yyrl3487
-		}
-		yyv3487 = make([]PersistentVolumeAccessMode, yyrl3487)
-		yyc3487 = true
-	}
-
+	var yyc3487 bool
 	if yyl3487 == 0 {
-		if len(yyv3487) != 0 {
+		if yyv3487 == nil {
+			yyv3487 = []PersistentVolumeAccessMode{}
+			yyc3487 = true
+		} else if len(yyv3487) != 0 {
 			yyv3487 = yyv3487[:0]
 			yyc3487 = true
 		}
 	} else if yyl3487 > 0 {
-
+		var yyrr3487, yyrl3487 int
+		var yyrt3487 bool
 		if yyl3487 > cap(yyv3487) {
-			yyrl3487, yyrt3487 = z.DecInferLen(yyl3487, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23487 := yyv3487
-			yyv3487 = make([]PersistentVolumeAccessMode, yyrl3487)
-			if len(yyv3487) > 0 {
-				copy(yyv3487, yyv23487[:cap(yyv23487)])
+			yyrl3487, yyrt3487 = z.DecInferLen(yyl3487, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt3487 {
+				if yyrl3487 <= cap(yyv3487) {
+					yyv3487 = yyv3487[:yyrl3487]
+				} else {
+					yyv3487 = make([]PersistentVolumeAccessMode, yyrl3487)
+				}
+			} else {
+				yyv3487 = make([]PersistentVolumeAccessMode, yyrl3487)
 			}
 			yyc3487 = true
-
 			yyrr3487 = len(yyv3487)
 		} else if yyl3487 != len(yyv3487) {
 			yyv3487 = yyv3487[:yyl3487]
@@ -40142,6 +43071,7 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 		}
 		yyj3487 := 0
 		for ; yyj3487 < yyrr3487; yyj3487++ {
+			yyh3487.ElemContainerState(yyj3487)
 			if r.TryDecodeAsNil() {
 				yyv3487[yyj3487] = ""
 			} else {
@@ -40152,6 +43082,7 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 		if yyrt3487 {
 			for ; yyj3487 < yyl3487; yyj3487++ {
 				yyv3487 = append(yyv3487, "")
+				yyh3487.ElemContainerState(yyj3487)
 				if r.TryDecodeAsNil() {
 					yyv3487[yyj3487] = ""
 				} else {
@@ -40162,12 +43093,14 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 		}
 
 	} else {
-		for yyj3487 := 0; !r.CheckBreak(); yyj3487++ {
+		yyj3487 := 0
+		for ; !r.CheckBreak(); yyj3487++ {
+
 			if yyj3487 >= len(yyv3487) {
 				yyv3487 = append(yyv3487, "") // var yyz3487 PersistentVolumeAccessMode
 				yyc3487 = true
 			}
-
+			yyh3487.ElemContainerState(yyj3487)
 			if yyj3487 < len(yyv3487) {
 				if r.TryDecodeAsNil() {
 					yyv3487[yyj3487] = ""
@@ -40180,12 +43113,18 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 			}
 
 		}
-		yyh3487.End()
+		if yyj3487 < len(yyv3487) {
+			yyv3487 = yyv3487[:yyj3487]
+			yyc3487 = true
+		} else if yyj3487 == 0 && yyv3487 == nil {
+			yyv3487 = []PersistentVolumeAccessMode{}
+			yyc3487 = true
+		}
 	}
+	yyh3487.End()
 	if yyc3487 {
 		*v = yyv3487
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePersistentVolume(v []PersistentVolume, e *codec1978.Encoder) {
@@ -40194,10 +43133,11 @@ func (x codecSelfer1234) encSlicePersistentVolume(v []PersistentVolume, e *codec
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3491 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3492 := &yyv3491
 		yy3492.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *codec1978.Decoder) {
@@ -40207,39 +43147,44 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 
 	yyv3493 := *v
 	yyh3493, yyl3493 := z.DecSliceHelperStart()
-
-	var yyrr3493, yyrl3493 int
-	var yyc3493, yyrt3493 bool
-	_, _, _ = yyc3493, yyrt3493, yyrl3493
-	yyrr3493 = yyl3493
-
-	if yyv3493 == nil {
-		if yyrl3493, yyrt3493 = z.DecInferLen(yyl3493, z.DecBasicHandle().MaxInitLen, 384); yyrt3493 {
-			yyrr3493 = yyrl3493
-		}
-		yyv3493 = make([]PersistentVolume, yyrl3493)
-		yyc3493 = true
-	}
-
+	var yyc3493 bool
 	if yyl3493 == 0 {
-		if len(yyv3493) != 0 {
+		if yyv3493 == nil {
+			yyv3493 = []PersistentVolume{}
+			yyc3493 = true
+		} else if len(yyv3493) != 0 {
 			yyv3493 = yyv3493[:0]
 			yyc3493 = true
 		}
 	} else if yyl3493 > 0 {
-
+		var yyrr3493, yyrl3493 int
+		var yyrt3493 bool
 		if yyl3493 > cap(yyv3493) {
-			yyrl3493, yyrt3493 = z.DecInferLen(yyl3493, z.DecBasicHandle().MaxInitLen, 384)
-			yyv3493 = make([]PersistentVolume, yyrl3493)
-			yyc3493 = true
 
+			yyrg3493 := len(yyv3493) > 0
+			yyv23493 := yyv3493
+			yyrl3493, yyrt3493 = z.DecInferLen(yyl3493, z.DecBasicHandle().MaxInitLen, 384)
+			if yyrt3493 {
+				if yyrl3493 <= cap(yyv3493) {
+					yyv3493 = yyv3493[:yyrl3493]
+				} else {
+					yyv3493 = make([]PersistentVolume, yyrl3493)
+				}
+			} else {
+				yyv3493 = make([]PersistentVolume, yyrl3493)
+			}
+			yyc3493 = true
 			yyrr3493 = len(yyv3493)
+			if yyrg3493 {
+				copy(yyv3493, yyv23493)
+			}
 		} else if yyl3493 != len(yyv3493) {
 			yyv3493 = yyv3493[:yyl3493]
 			yyc3493 = true
 		}
 		yyj3493 := 0
 		for ; yyj3493 < yyrr3493; yyj3493++ {
+			yyh3493.ElemContainerState(yyj3493)
 			if r.TryDecodeAsNil() {
 				yyv3493[yyj3493] = PersistentVolume{}
 			} else {
@@ -40251,6 +43196,7 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 		if yyrt3493 {
 			for ; yyj3493 < yyl3493; yyj3493++ {
 				yyv3493 = append(yyv3493, PersistentVolume{})
+				yyh3493.ElemContainerState(yyj3493)
 				if r.TryDecodeAsNil() {
 					yyv3493[yyj3493] = PersistentVolume{}
 				} else {
@@ -40262,12 +43208,14 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 		}
 
 	} else {
-		for yyj3493 := 0; !r.CheckBreak(); yyj3493++ {
+		yyj3493 := 0
+		for ; !r.CheckBreak(); yyj3493++ {
+
 			if yyj3493 >= len(yyv3493) {
 				yyv3493 = append(yyv3493, PersistentVolume{}) // var yyz3493 PersistentVolume
 				yyc3493 = true
 			}
-
+			yyh3493.ElemContainerState(yyj3493)
 			if yyj3493 < len(yyv3493) {
 				if r.TryDecodeAsNil() {
 					yyv3493[yyj3493] = PersistentVolume{}
@@ -40281,12 +43229,18 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 			}
 
 		}
-		yyh3493.End()
+		if yyj3493 < len(yyv3493) {
+			yyv3493 = yyv3493[:yyj3493]
+			yyc3493 = true
+		} else if yyj3493 == 0 && yyv3493 == nil {
+			yyv3493 = []PersistentVolume{}
+			yyc3493 = true
+		}
 	}
+	yyh3493.End()
 	if yyc3493 {
 		*v = yyv3493
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePersistentVolumeClaim(v []PersistentVolumeClaim, e *codec1978.Encoder) {
@@ -40295,10 +43249,11 @@ func (x codecSelfer1234) encSlicePersistentVolumeClaim(v []PersistentVolumeClaim
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3497 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3498 := &yyv3497
 		yy3498.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClaim, d *codec1978.Decoder) {
@@ -40308,39 +43263,44 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 
 	yyv3499 := *v
 	yyh3499, yyl3499 := z.DecSliceHelperStart()
-
-	var yyrr3499, yyrl3499 int
-	var yyc3499, yyrt3499 bool
-	_, _, _ = yyc3499, yyrt3499, yyrl3499
-	yyrr3499 = yyl3499
-
-	if yyv3499 == nil {
-		if yyrl3499, yyrt3499 = z.DecInferLen(yyl3499, z.DecBasicHandle().MaxInitLen, 296); yyrt3499 {
-			yyrr3499 = yyrl3499
-		}
-		yyv3499 = make([]PersistentVolumeClaim, yyrl3499)
-		yyc3499 = true
-	}
-
+	var yyc3499 bool
 	if yyl3499 == 0 {
-		if len(yyv3499) != 0 {
+		if yyv3499 == nil {
+			yyv3499 = []PersistentVolumeClaim{}
+			yyc3499 = true
+		} else if len(yyv3499) != 0 {
 			yyv3499 = yyv3499[:0]
 			yyc3499 = true
 		}
 	} else if yyl3499 > 0 {
-
+		var yyrr3499, yyrl3499 int
+		var yyrt3499 bool
 		if yyl3499 > cap(yyv3499) {
-			yyrl3499, yyrt3499 = z.DecInferLen(yyl3499, z.DecBasicHandle().MaxInitLen, 296)
-			yyv3499 = make([]PersistentVolumeClaim, yyrl3499)
-			yyc3499 = true
 
+			yyrg3499 := len(yyv3499) > 0
+			yyv23499 := yyv3499
+			yyrl3499, yyrt3499 = z.DecInferLen(yyl3499, z.DecBasicHandle().MaxInitLen, 296)
+			if yyrt3499 {
+				if yyrl3499 <= cap(yyv3499) {
+					yyv3499 = yyv3499[:yyrl3499]
+				} else {
+					yyv3499 = make([]PersistentVolumeClaim, yyrl3499)
+				}
+			} else {
+				yyv3499 = make([]PersistentVolumeClaim, yyrl3499)
+			}
+			yyc3499 = true
 			yyrr3499 = len(yyv3499)
+			if yyrg3499 {
+				copy(yyv3499, yyv23499)
+			}
 		} else if yyl3499 != len(yyv3499) {
 			yyv3499 = yyv3499[:yyl3499]
 			yyc3499 = true
 		}
 		yyj3499 := 0
 		for ; yyj3499 < yyrr3499; yyj3499++ {
+			yyh3499.ElemContainerState(yyj3499)
 			if r.TryDecodeAsNil() {
 				yyv3499[yyj3499] = PersistentVolumeClaim{}
 			} else {
@@ -40352,6 +43312,7 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 		if yyrt3499 {
 			for ; yyj3499 < yyl3499; yyj3499++ {
 				yyv3499 = append(yyv3499, PersistentVolumeClaim{})
+				yyh3499.ElemContainerState(yyj3499)
 				if r.TryDecodeAsNil() {
 					yyv3499[yyj3499] = PersistentVolumeClaim{}
 				} else {
@@ -40363,12 +43324,14 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 		}
 
 	} else {
-		for yyj3499 := 0; !r.CheckBreak(); yyj3499++ {
+		yyj3499 := 0
+		for ; !r.CheckBreak(); yyj3499++ {
+
 			if yyj3499 >= len(yyv3499) {
 				yyv3499 = append(yyv3499, PersistentVolumeClaim{}) // var yyz3499 PersistentVolumeClaim
 				yyc3499 = true
 			}
-
+			yyh3499.ElemContainerState(yyj3499)
 			if yyj3499 < len(yyv3499) {
 				if r.TryDecodeAsNil() {
 					yyv3499[yyj3499] = PersistentVolumeClaim{}
@@ -40382,12 +43345,18 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 			}
 
 		}
-		yyh3499.End()
+		if yyj3499 < len(yyv3499) {
+			yyv3499 = yyv3499[:yyj3499]
+			yyc3499 = true
+		} else if yyj3499 == 0 && yyv3499 == nil {
+			yyv3499 = []PersistentVolumeClaim{}
+			yyc3499 = true
+		}
 	}
+	yyh3499.End()
 	if yyc3499 {
 		*v = yyv3499
 	}
-
 }
 
 func (x codecSelfer1234) encSliceDownwardAPIVolumeFile(v []DownwardAPIVolumeFile, e *codec1978.Encoder) {
@@ -40396,10 +43365,11 @@ func (x codecSelfer1234) encSliceDownwardAPIVolumeFile(v []DownwardAPIVolumeFile
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3503 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3504 := &yyv3503
 		yy3504.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFile, d *codec1978.Decoder) {
@@ -40409,39 +43379,44 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 
 	yyv3505 := *v
 	yyh3505, yyl3505 := z.DecSliceHelperStart()
-
-	var yyrr3505, yyrl3505 int
-	var yyc3505, yyrt3505 bool
-	_, _, _ = yyc3505, yyrt3505, yyrl3505
-	yyrr3505 = yyl3505
-
-	if yyv3505 == nil {
-		if yyrl3505, yyrt3505 = z.DecInferLen(yyl3505, z.DecBasicHandle().MaxInitLen, 48); yyrt3505 {
-			yyrr3505 = yyrl3505
-		}
-		yyv3505 = make([]DownwardAPIVolumeFile, yyrl3505)
-		yyc3505 = true
-	}
-
+	var yyc3505 bool
 	if yyl3505 == 0 {
-		if len(yyv3505) != 0 {
+		if yyv3505 == nil {
+			yyv3505 = []DownwardAPIVolumeFile{}
+			yyc3505 = true
+		} else if len(yyv3505) != 0 {
 			yyv3505 = yyv3505[:0]
 			yyc3505 = true
 		}
 	} else if yyl3505 > 0 {
-
+		var yyrr3505, yyrl3505 int
+		var yyrt3505 bool
 		if yyl3505 > cap(yyv3505) {
-			yyrl3505, yyrt3505 = z.DecInferLen(yyl3505, z.DecBasicHandle().MaxInitLen, 48)
-			yyv3505 = make([]DownwardAPIVolumeFile, yyrl3505)
-			yyc3505 = true
 
+			yyrg3505 := len(yyv3505) > 0
+			yyv23505 := yyv3505
+			yyrl3505, yyrt3505 = z.DecInferLen(yyl3505, z.DecBasicHandle().MaxInitLen, 48)
+			if yyrt3505 {
+				if yyrl3505 <= cap(yyv3505) {
+					yyv3505 = yyv3505[:yyrl3505]
+				} else {
+					yyv3505 = make([]DownwardAPIVolumeFile, yyrl3505)
+				}
+			} else {
+				yyv3505 = make([]DownwardAPIVolumeFile, yyrl3505)
+			}
+			yyc3505 = true
 			yyrr3505 = len(yyv3505)
+			if yyrg3505 {
+				copy(yyv3505, yyv23505)
+			}
 		} else if yyl3505 != len(yyv3505) {
 			yyv3505 = yyv3505[:yyl3505]
 			yyc3505 = true
 		}
 		yyj3505 := 0
 		for ; yyj3505 < yyrr3505; yyj3505++ {
+			yyh3505.ElemContainerState(yyj3505)
 			if r.TryDecodeAsNil() {
 				yyv3505[yyj3505] = DownwardAPIVolumeFile{}
 			} else {
@@ -40453,6 +43428,7 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 		if yyrt3505 {
 			for ; yyj3505 < yyl3505; yyj3505++ {
 				yyv3505 = append(yyv3505, DownwardAPIVolumeFile{})
+				yyh3505.ElemContainerState(yyj3505)
 				if r.TryDecodeAsNil() {
 					yyv3505[yyj3505] = DownwardAPIVolumeFile{}
 				} else {
@@ -40464,12 +43440,14 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 		}
 
 	} else {
-		for yyj3505 := 0; !r.CheckBreak(); yyj3505++ {
+		yyj3505 := 0
+		for ; !r.CheckBreak(); yyj3505++ {
+
 			if yyj3505 >= len(yyv3505) {
 				yyv3505 = append(yyv3505, DownwardAPIVolumeFile{}) // var yyz3505 DownwardAPIVolumeFile
 				yyc3505 = true
 			}
-
+			yyh3505.ElemContainerState(yyj3505)
 			if yyj3505 < len(yyv3505) {
 				if r.TryDecodeAsNil() {
 					yyv3505[yyj3505] = DownwardAPIVolumeFile{}
@@ -40483,12 +43461,18 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 			}
 
 		}
-		yyh3505.End()
+		if yyj3505 < len(yyv3505) {
+			yyv3505 = yyv3505[:yyj3505]
+			yyc3505 = true
+		} else if yyj3505 == 0 && yyv3505 == nil {
+			yyv3505 = []DownwardAPIVolumeFile{}
+			yyc3505 = true
+		}
 	}
+	yyh3505.End()
 	if yyc3505 {
 		*v = yyv3505
 	}
-
 }
 
 func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder) {
@@ -40497,9 +43481,10 @@ func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3509 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yyv3509.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decoder) {
@@ -40509,37 +43494,31 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 
 	yyv3510 := *v
 	yyh3510, yyl3510 := z.DecSliceHelperStart()
-
-	var yyrr3510, yyrl3510 int
-	var yyc3510, yyrt3510 bool
-	_, _, _ = yyc3510, yyrt3510, yyrl3510
-	yyrr3510 = yyl3510
-
-	if yyv3510 == nil {
-		if yyrl3510, yyrt3510 = z.DecInferLen(yyl3510, z.DecBasicHandle().MaxInitLen, 16); yyrt3510 {
-			yyrr3510 = yyrl3510
-		}
-		yyv3510 = make([]Capability, yyrl3510)
-		yyc3510 = true
-	}
-
+	var yyc3510 bool
 	if yyl3510 == 0 {
-		if len(yyv3510) != 0 {
+		if yyv3510 == nil {
+			yyv3510 = []Capability{}
+			yyc3510 = true
+		} else if len(yyv3510) != 0 {
 			yyv3510 = yyv3510[:0]
 			yyc3510 = true
 		}
 	} else if yyl3510 > 0 {
-
+		var yyrr3510, yyrl3510 int
+		var yyrt3510 bool
 		if yyl3510 > cap(yyv3510) {
-			yyrl3510, yyrt3510 = z.DecInferLen(yyl3510, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23510 := yyv3510
-			yyv3510 = make([]Capability, yyrl3510)
-			if len(yyv3510) > 0 {
-				copy(yyv3510, yyv23510[:cap(yyv23510)])
+			yyrl3510, yyrt3510 = z.DecInferLen(yyl3510, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt3510 {
+				if yyrl3510 <= cap(yyv3510) {
+					yyv3510 = yyv3510[:yyrl3510]
+				} else {
+					yyv3510 = make([]Capability, yyrl3510)
+				}
+			} else {
+				yyv3510 = make([]Capability, yyrl3510)
 			}
 			yyc3510 = true
-
 			yyrr3510 = len(yyv3510)
 		} else if yyl3510 != len(yyv3510) {
 			yyv3510 = yyv3510[:yyl3510]
@@ -40547,6 +43526,7 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 		}
 		yyj3510 := 0
 		for ; yyj3510 < yyrr3510; yyj3510++ {
+			yyh3510.ElemContainerState(yyj3510)
 			if r.TryDecodeAsNil() {
 				yyv3510[yyj3510] = ""
 			} else {
@@ -40557,6 +43537,7 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 		if yyrt3510 {
 			for ; yyj3510 < yyl3510; yyj3510++ {
 				yyv3510 = append(yyv3510, "")
+				yyh3510.ElemContainerState(yyj3510)
 				if r.TryDecodeAsNil() {
 					yyv3510[yyj3510] = ""
 				} else {
@@ -40567,12 +43548,14 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 		}
 
 	} else {
-		for yyj3510 := 0; !r.CheckBreak(); yyj3510++ {
+		yyj3510 := 0
+		for ; !r.CheckBreak(); yyj3510++ {
+
 			if yyj3510 >= len(yyv3510) {
 				yyv3510 = append(yyv3510, "") // var yyz3510 Capability
 				yyc3510 = true
 			}
-
+			yyh3510.ElemContainerState(yyj3510)
 			if yyj3510 < len(yyv3510) {
 				if r.TryDecodeAsNil() {
 					yyv3510[yyj3510] = ""
@@ -40585,12 +43568,18 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 			}
 
 		}
-		yyh3510.End()
+		if yyj3510 < len(yyv3510) {
+			yyv3510 = yyv3510[:yyj3510]
+			yyc3510 = true
+		} else if yyj3510 == 0 && yyv3510 == nil {
+			yyv3510 = []Capability{}
+			yyc3510 = true
+		}
 	}
+	yyh3510.End()
 	if yyc3510 {
 		*v = yyv3510
 	}
-
 }
 
 func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.Encoder) {
@@ -40599,10 +43588,11 @@ func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.E
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3514 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3515 := &yyv3514
 		yy3515.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.Decoder) {
@@ -40612,39 +43602,44 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 
 	yyv3516 := *v
 	yyh3516, yyl3516 := z.DecSliceHelperStart()
-
-	var yyrr3516, yyrl3516 int
-	var yyc3516, yyrt3516 bool
-	_, _, _ = yyc3516, yyrt3516, yyrl3516
-	yyrr3516 = yyl3516
-
-	if yyv3516 == nil {
-		if yyrl3516, yyrt3516 = z.DecInferLen(yyl3516, z.DecBasicHandle().MaxInitLen, 64); yyrt3516 {
-			yyrr3516 = yyrl3516
-		}
-		yyv3516 = make([]ContainerPort, yyrl3516)
-		yyc3516 = true
-	}
-
+	var yyc3516 bool
 	if yyl3516 == 0 {
-		if len(yyv3516) != 0 {
+		if yyv3516 == nil {
+			yyv3516 = []ContainerPort{}
+			yyc3516 = true
+		} else if len(yyv3516) != 0 {
 			yyv3516 = yyv3516[:0]
 			yyc3516 = true
 		}
 	} else if yyl3516 > 0 {
-
+		var yyrr3516, yyrl3516 int
+		var yyrt3516 bool
 		if yyl3516 > cap(yyv3516) {
-			yyrl3516, yyrt3516 = z.DecInferLen(yyl3516, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3516 = make([]ContainerPort, yyrl3516)
-			yyc3516 = true
 
+			yyrg3516 := len(yyv3516) > 0
+			yyv23516 := yyv3516
+			yyrl3516, yyrt3516 = z.DecInferLen(yyl3516, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt3516 {
+				if yyrl3516 <= cap(yyv3516) {
+					yyv3516 = yyv3516[:yyrl3516]
+				} else {
+					yyv3516 = make([]ContainerPort, yyrl3516)
+				}
+			} else {
+				yyv3516 = make([]ContainerPort, yyrl3516)
+			}
+			yyc3516 = true
 			yyrr3516 = len(yyv3516)
+			if yyrg3516 {
+				copy(yyv3516, yyv23516)
+			}
 		} else if yyl3516 != len(yyv3516) {
 			yyv3516 = yyv3516[:yyl3516]
 			yyc3516 = true
 		}
 		yyj3516 := 0
 		for ; yyj3516 < yyrr3516; yyj3516++ {
+			yyh3516.ElemContainerState(yyj3516)
 			if r.TryDecodeAsNil() {
 				yyv3516[yyj3516] = ContainerPort{}
 			} else {
@@ -40656,6 +43651,7 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 		if yyrt3516 {
 			for ; yyj3516 < yyl3516; yyj3516++ {
 				yyv3516 = append(yyv3516, ContainerPort{})
+				yyh3516.ElemContainerState(yyj3516)
 				if r.TryDecodeAsNil() {
 					yyv3516[yyj3516] = ContainerPort{}
 				} else {
@@ -40667,12 +43663,14 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 		}
 
 	} else {
-		for yyj3516 := 0; !r.CheckBreak(); yyj3516++ {
+		yyj3516 := 0
+		for ; !r.CheckBreak(); yyj3516++ {
+
 			if yyj3516 >= len(yyv3516) {
 				yyv3516 = append(yyv3516, ContainerPort{}) // var yyz3516 ContainerPort
 				yyc3516 = true
 			}
-
+			yyh3516.ElemContainerState(yyj3516)
 			if yyj3516 < len(yyv3516) {
 				if r.TryDecodeAsNil() {
 					yyv3516[yyj3516] = ContainerPort{}
@@ -40686,12 +43684,18 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 			}
 
 		}
-		yyh3516.End()
+		if yyj3516 < len(yyv3516) {
+			yyv3516 = yyv3516[:yyj3516]
+			yyc3516 = true
+		} else if yyj3516 == 0 && yyv3516 == nil {
+			yyv3516 = []ContainerPort{}
+			yyc3516 = true
+		}
 	}
+	yyh3516.End()
 	if yyc3516 {
 		*v = yyv3516
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEnvVar(v []EnvVar, e *codec1978.Encoder) {
@@ -40700,10 +43704,11 @@ func (x codecSelfer1234) encSliceEnvVar(v []EnvVar, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3520 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3521 := &yyv3520
 		yy3521.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
@@ -40713,39 +43718,44 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 
 	yyv3522 := *v
 	yyh3522, yyl3522 := z.DecSliceHelperStart()
-
-	var yyrr3522, yyrl3522 int
-	var yyc3522, yyrt3522 bool
-	_, _, _ = yyc3522, yyrt3522, yyrl3522
-	yyrr3522 = yyl3522
-
-	if yyv3522 == nil {
-		if yyrl3522, yyrt3522 = z.DecInferLen(yyl3522, z.DecBasicHandle().MaxInitLen, 40); yyrt3522 {
-			yyrr3522 = yyrl3522
-		}
-		yyv3522 = make([]EnvVar, yyrl3522)
-		yyc3522 = true
-	}
-
+	var yyc3522 bool
 	if yyl3522 == 0 {
-		if len(yyv3522) != 0 {
+		if yyv3522 == nil {
+			yyv3522 = []EnvVar{}
+			yyc3522 = true
+		} else if len(yyv3522) != 0 {
 			yyv3522 = yyv3522[:0]
 			yyc3522 = true
 		}
 	} else if yyl3522 > 0 {
-
+		var yyrr3522, yyrl3522 int
+		var yyrt3522 bool
 		if yyl3522 > cap(yyv3522) {
-			yyrl3522, yyrt3522 = z.DecInferLen(yyl3522, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3522 = make([]EnvVar, yyrl3522)
-			yyc3522 = true
 
+			yyrg3522 := len(yyv3522) > 0
+			yyv23522 := yyv3522
+			yyrl3522, yyrt3522 = z.DecInferLen(yyl3522, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt3522 {
+				if yyrl3522 <= cap(yyv3522) {
+					yyv3522 = yyv3522[:yyrl3522]
+				} else {
+					yyv3522 = make([]EnvVar, yyrl3522)
+				}
+			} else {
+				yyv3522 = make([]EnvVar, yyrl3522)
+			}
+			yyc3522 = true
 			yyrr3522 = len(yyv3522)
+			if yyrg3522 {
+				copy(yyv3522, yyv23522)
+			}
 		} else if yyl3522 != len(yyv3522) {
 			yyv3522 = yyv3522[:yyl3522]
 			yyc3522 = true
 		}
 		yyj3522 := 0
 		for ; yyj3522 < yyrr3522; yyj3522++ {
+			yyh3522.ElemContainerState(yyj3522)
 			if r.TryDecodeAsNil() {
 				yyv3522[yyj3522] = EnvVar{}
 			} else {
@@ -40757,6 +43767,7 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 		if yyrt3522 {
 			for ; yyj3522 < yyl3522; yyj3522++ {
 				yyv3522 = append(yyv3522, EnvVar{})
+				yyh3522.ElemContainerState(yyj3522)
 				if r.TryDecodeAsNil() {
 					yyv3522[yyj3522] = EnvVar{}
 				} else {
@@ -40768,12 +43779,14 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3522 := 0; !r.CheckBreak(); yyj3522++ {
+		yyj3522 := 0
+		for ; !r.CheckBreak(); yyj3522++ {
+
 			if yyj3522 >= len(yyv3522) {
 				yyv3522 = append(yyv3522, EnvVar{}) // var yyz3522 EnvVar
 				yyc3522 = true
 			}
-
+			yyh3522.ElemContainerState(yyj3522)
 			if yyj3522 < len(yyv3522) {
 				if r.TryDecodeAsNil() {
 					yyv3522[yyj3522] = EnvVar{}
@@ -40787,12 +43800,18 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3522.End()
+		if yyj3522 < len(yyv3522) {
+			yyv3522 = yyv3522[:yyj3522]
+			yyc3522 = true
+		} else if yyj3522 == 0 && yyv3522 == nil {
+			yyv3522 = []EnvVar{}
+			yyc3522 = true
+		}
 	}
+	yyh3522.End()
 	if yyc3522 {
 		*v = yyv3522
 	}
-
 }
 
 func (x codecSelfer1234) encSliceVolumeMount(v []VolumeMount, e *codec1978.Encoder) {
@@ -40801,10 +43820,11 @@ func (x codecSelfer1234) encSliceVolumeMount(v []VolumeMount, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3526 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3527 := &yyv3526
 		yy3527.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Decoder) {
@@ -40814,39 +43834,44 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 
 	yyv3528 := *v
 	yyh3528, yyl3528 := z.DecSliceHelperStart()
-
-	var yyrr3528, yyrl3528 int
-	var yyc3528, yyrt3528 bool
-	_, _, _ = yyc3528, yyrt3528, yyrl3528
-	yyrr3528 = yyl3528
-
-	if yyv3528 == nil {
-		if yyrl3528, yyrt3528 = z.DecInferLen(yyl3528, z.DecBasicHandle().MaxInitLen, 40); yyrt3528 {
-			yyrr3528 = yyrl3528
-		}
-		yyv3528 = make([]VolumeMount, yyrl3528)
-		yyc3528 = true
-	}
-
+	var yyc3528 bool
 	if yyl3528 == 0 {
-		if len(yyv3528) != 0 {
+		if yyv3528 == nil {
+			yyv3528 = []VolumeMount{}
+			yyc3528 = true
+		} else if len(yyv3528) != 0 {
 			yyv3528 = yyv3528[:0]
 			yyc3528 = true
 		}
 	} else if yyl3528 > 0 {
-
+		var yyrr3528, yyrl3528 int
+		var yyrt3528 bool
 		if yyl3528 > cap(yyv3528) {
-			yyrl3528, yyrt3528 = z.DecInferLen(yyl3528, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3528 = make([]VolumeMount, yyrl3528)
-			yyc3528 = true
 
+			yyrg3528 := len(yyv3528) > 0
+			yyv23528 := yyv3528
+			yyrl3528, yyrt3528 = z.DecInferLen(yyl3528, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt3528 {
+				if yyrl3528 <= cap(yyv3528) {
+					yyv3528 = yyv3528[:yyrl3528]
+				} else {
+					yyv3528 = make([]VolumeMount, yyrl3528)
+				}
+			} else {
+				yyv3528 = make([]VolumeMount, yyrl3528)
+			}
+			yyc3528 = true
 			yyrr3528 = len(yyv3528)
+			if yyrg3528 {
+				copy(yyv3528, yyv23528)
+			}
 		} else if yyl3528 != len(yyv3528) {
 			yyv3528 = yyv3528[:yyl3528]
 			yyc3528 = true
 		}
 		yyj3528 := 0
 		for ; yyj3528 < yyrr3528; yyj3528++ {
+			yyh3528.ElemContainerState(yyj3528)
 			if r.TryDecodeAsNil() {
 				yyv3528[yyj3528] = VolumeMount{}
 			} else {
@@ -40858,6 +43883,7 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 		if yyrt3528 {
 			for ; yyj3528 < yyl3528; yyj3528++ {
 				yyv3528 = append(yyv3528, VolumeMount{})
+				yyh3528.ElemContainerState(yyj3528)
 				if r.TryDecodeAsNil() {
 					yyv3528[yyj3528] = VolumeMount{}
 				} else {
@@ -40869,12 +43895,14 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj3528 := 0; !r.CheckBreak(); yyj3528++ {
+		yyj3528 := 0
+		for ; !r.CheckBreak(); yyj3528++ {
+
 			if yyj3528 >= len(yyv3528) {
 				yyv3528 = append(yyv3528, VolumeMount{}) // var yyz3528 VolumeMount
 				yyc3528 = true
 			}
-
+			yyh3528.ElemContainerState(yyj3528)
 			if yyj3528 < len(yyv3528) {
 				if r.TryDecodeAsNil() {
 					yyv3528[yyj3528] = VolumeMount{}
@@ -40888,12 +43916,18 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 			}
 
 		}
-		yyh3528.End()
+		if yyj3528 < len(yyv3528) {
+			yyv3528 = yyv3528[:yyj3528]
+			yyc3528 = true
+		} else if yyj3528 == 0 && yyv3528 == nil {
+			yyv3528 = []VolumeMount{}
+			yyc3528 = true
+		}
 	}
+	yyh3528.End()
 	if yyc3528 {
 		*v = yyv3528
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePod(v []Pod, e *codec1978.Encoder) {
@@ -40902,10 +43936,11 @@ func (x codecSelfer1234) encSlicePod(v []Pod, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3532 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3533 := &yyv3532
 		yy3533.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
@@ -40915,39 +43950,44 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 
 	yyv3534 := *v
 	yyh3534, yyl3534 := z.DecSliceHelperStart()
-
-	var yyrr3534, yyrl3534 int
-	var yyc3534, yyrt3534 bool
-	_, _, _ = yyc3534, yyrt3534, yyrl3534
-	yyrr3534 = yyl3534
-
-	if yyv3534 == nil {
-		if yyrl3534, yyrt3534 = z.DecInferLen(yyl3534, z.DecBasicHandle().MaxInitLen, 496); yyrt3534 {
-			yyrr3534 = yyrl3534
-		}
-		yyv3534 = make([]Pod, yyrl3534)
-		yyc3534 = true
-	}
-
+	var yyc3534 bool
 	if yyl3534 == 0 {
-		if len(yyv3534) != 0 {
+		if yyv3534 == nil {
+			yyv3534 = []Pod{}
+			yyc3534 = true
+		} else if len(yyv3534) != 0 {
 			yyv3534 = yyv3534[:0]
 			yyc3534 = true
 		}
 	} else if yyl3534 > 0 {
-
+		var yyrr3534, yyrl3534 int
+		var yyrt3534 bool
 		if yyl3534 > cap(yyv3534) {
-			yyrl3534, yyrt3534 = z.DecInferLen(yyl3534, z.DecBasicHandle().MaxInitLen, 496)
-			yyv3534 = make([]Pod, yyrl3534)
-			yyc3534 = true
 
+			yyrg3534 := len(yyv3534) > 0
+			yyv23534 := yyv3534
+			yyrl3534, yyrt3534 = z.DecInferLen(yyl3534, z.DecBasicHandle().MaxInitLen, 496)
+			if yyrt3534 {
+				if yyrl3534 <= cap(yyv3534) {
+					yyv3534 = yyv3534[:yyrl3534]
+				} else {
+					yyv3534 = make([]Pod, yyrl3534)
+				}
+			} else {
+				yyv3534 = make([]Pod, yyrl3534)
+			}
+			yyc3534 = true
 			yyrr3534 = len(yyv3534)
+			if yyrg3534 {
+				copy(yyv3534, yyv23534)
+			}
 		} else if yyl3534 != len(yyv3534) {
 			yyv3534 = yyv3534[:yyl3534]
 			yyc3534 = true
 		}
 		yyj3534 := 0
 		for ; yyj3534 < yyrr3534; yyj3534++ {
+			yyh3534.ElemContainerState(yyj3534)
 			if r.TryDecodeAsNil() {
 				yyv3534[yyj3534] = Pod{}
 			} else {
@@ -40959,6 +43999,7 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 		if yyrt3534 {
 			for ; yyj3534 < yyl3534; yyj3534++ {
 				yyv3534 = append(yyv3534, Pod{})
+				yyh3534.ElemContainerState(yyj3534)
 				if r.TryDecodeAsNil() {
 					yyv3534[yyj3534] = Pod{}
 				} else {
@@ -40970,12 +44011,14 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3534 := 0; !r.CheckBreak(); yyj3534++ {
+		yyj3534 := 0
+		for ; !r.CheckBreak(); yyj3534++ {
+
 			if yyj3534 >= len(yyv3534) {
 				yyv3534 = append(yyv3534, Pod{}) // var yyz3534 Pod
 				yyc3534 = true
 			}
-
+			yyh3534.ElemContainerState(yyj3534)
 			if yyj3534 < len(yyv3534) {
 				if r.TryDecodeAsNil() {
 					yyv3534[yyj3534] = Pod{}
@@ -40989,12 +44032,18 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3534.End()
+		if yyj3534 < len(yyv3534) {
+			yyv3534 = yyv3534[:yyj3534]
+			yyc3534 = true
+		} else if yyj3534 == 0 && yyv3534 == nil {
+			yyv3534 = []Pod{}
+			yyc3534 = true
+		}
 	}
+	yyh3534.End()
 	if yyc3534 {
 		*v = yyv3534
 	}
-
 }
 
 func (x codecSelfer1234) encSliceVolume(v []Volume, e *codec1978.Encoder) {
@@ -41003,10 +44052,11 @@ func (x codecSelfer1234) encSliceVolume(v []Volume, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3538 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3539 := &yyv3538
 		yy3539.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
@@ -41016,39 +44066,44 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 
 	yyv3540 := *v
 	yyh3540, yyl3540 := z.DecSliceHelperStart()
-
-	var yyrr3540, yyrl3540 int
-	var yyc3540, yyrt3540 bool
-	_, _, _ = yyc3540, yyrt3540, yyrl3540
-	yyrr3540 = yyl3540
-
-	if yyv3540 == nil {
-		if yyrl3540, yyrt3540 = z.DecInferLen(yyl3540, z.DecBasicHandle().MaxInitLen, 144); yyrt3540 {
-			yyrr3540 = yyrl3540
-		}
-		yyv3540 = make([]Volume, yyrl3540)
-		yyc3540 = true
-	}
-
+	var yyc3540 bool
 	if yyl3540 == 0 {
-		if len(yyv3540) != 0 {
+		if yyv3540 == nil {
+			yyv3540 = []Volume{}
+			yyc3540 = true
+		} else if len(yyv3540) != 0 {
 			yyv3540 = yyv3540[:0]
 			yyc3540 = true
 		}
 	} else if yyl3540 > 0 {
-
+		var yyrr3540, yyrl3540 int
+		var yyrt3540 bool
 		if yyl3540 > cap(yyv3540) {
-			yyrl3540, yyrt3540 = z.DecInferLen(yyl3540, z.DecBasicHandle().MaxInitLen, 144)
-			yyv3540 = make([]Volume, yyrl3540)
-			yyc3540 = true
 
+			yyrg3540 := len(yyv3540) > 0
+			yyv23540 := yyv3540
+			yyrl3540, yyrt3540 = z.DecInferLen(yyl3540, z.DecBasicHandle().MaxInitLen, 144)
+			if yyrt3540 {
+				if yyrl3540 <= cap(yyv3540) {
+					yyv3540 = yyv3540[:yyrl3540]
+				} else {
+					yyv3540 = make([]Volume, yyrl3540)
+				}
+			} else {
+				yyv3540 = make([]Volume, yyrl3540)
+			}
+			yyc3540 = true
 			yyrr3540 = len(yyv3540)
+			if yyrg3540 {
+				copy(yyv3540, yyv23540)
+			}
 		} else if yyl3540 != len(yyv3540) {
 			yyv3540 = yyv3540[:yyl3540]
 			yyc3540 = true
 		}
 		yyj3540 := 0
 		for ; yyj3540 < yyrr3540; yyj3540++ {
+			yyh3540.ElemContainerState(yyj3540)
 			if r.TryDecodeAsNil() {
 				yyv3540[yyj3540] = Volume{}
 			} else {
@@ -41060,6 +44115,7 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 		if yyrt3540 {
 			for ; yyj3540 < yyl3540; yyj3540++ {
 				yyv3540 = append(yyv3540, Volume{})
+				yyh3540.ElemContainerState(yyj3540)
 				if r.TryDecodeAsNil() {
 					yyv3540[yyj3540] = Volume{}
 				} else {
@@ -41071,12 +44127,14 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3540 := 0; !r.CheckBreak(); yyj3540++ {
+		yyj3540 := 0
+		for ; !r.CheckBreak(); yyj3540++ {
+
 			if yyj3540 >= len(yyv3540) {
 				yyv3540 = append(yyv3540, Volume{}) // var yyz3540 Volume
 				yyc3540 = true
 			}
-
+			yyh3540.ElemContainerState(yyj3540)
 			if yyj3540 < len(yyv3540) {
 				if r.TryDecodeAsNil() {
 					yyv3540[yyj3540] = Volume{}
@@ -41090,12 +44148,18 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3540.End()
+		if yyj3540 < len(yyv3540) {
+			yyv3540 = yyv3540[:yyj3540]
+			yyc3540 = true
+		} else if yyj3540 == 0 && yyv3540 == nil {
+			yyv3540 = []Volume{}
+			yyc3540 = true
+		}
 	}
+	yyh3540.End()
 	if yyc3540 {
 		*v = yyv3540
 	}
-
 }
 
 func (x codecSelfer1234) encSliceContainer(v []Container, e *codec1978.Encoder) {
@@ -41104,10 +44168,11 @@ func (x codecSelfer1234) encSliceContainer(v []Container, e *codec1978.Encoder) 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3544 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3545 := &yyv3544
 		yy3545.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder) {
@@ -41117,39 +44182,44 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 
 	yyv3546 := *v
 	yyh3546, yyl3546 := z.DecSliceHelperStart()
-
-	var yyrr3546, yyrl3546 int
-	var yyc3546, yyrt3546 bool
-	_, _, _ = yyc3546, yyrt3546, yyrl3546
-	yyrr3546 = yyl3546
-
-	if yyv3546 == nil {
-		if yyrl3546, yyrt3546 = z.DecInferLen(yyl3546, z.DecBasicHandle().MaxInitLen, 256); yyrt3546 {
-			yyrr3546 = yyrl3546
-		}
-		yyv3546 = make([]Container, yyrl3546)
-		yyc3546 = true
-	}
-
+	var yyc3546 bool
 	if yyl3546 == 0 {
-		if len(yyv3546) != 0 {
+		if yyv3546 == nil {
+			yyv3546 = []Container{}
+			yyc3546 = true
+		} else if len(yyv3546) != 0 {
 			yyv3546 = yyv3546[:0]
 			yyc3546 = true
 		}
 	} else if yyl3546 > 0 {
-
+		var yyrr3546, yyrl3546 int
+		var yyrt3546 bool
 		if yyl3546 > cap(yyv3546) {
-			yyrl3546, yyrt3546 = z.DecInferLen(yyl3546, z.DecBasicHandle().MaxInitLen, 256)
-			yyv3546 = make([]Container, yyrl3546)
-			yyc3546 = true
 
+			yyrg3546 := len(yyv3546) > 0
+			yyv23546 := yyv3546
+			yyrl3546, yyrt3546 = z.DecInferLen(yyl3546, z.DecBasicHandle().MaxInitLen, 256)
+			if yyrt3546 {
+				if yyrl3546 <= cap(yyv3546) {
+					yyv3546 = yyv3546[:yyrl3546]
+				} else {
+					yyv3546 = make([]Container, yyrl3546)
+				}
+			} else {
+				yyv3546 = make([]Container, yyrl3546)
+			}
+			yyc3546 = true
 			yyrr3546 = len(yyv3546)
+			if yyrg3546 {
+				copy(yyv3546, yyv23546)
+			}
 		} else if yyl3546 != len(yyv3546) {
 			yyv3546 = yyv3546[:yyl3546]
 			yyc3546 = true
 		}
 		yyj3546 := 0
 		for ; yyj3546 < yyrr3546; yyj3546++ {
+			yyh3546.ElemContainerState(yyj3546)
 			if r.TryDecodeAsNil() {
 				yyv3546[yyj3546] = Container{}
 			} else {
@@ -41161,6 +44231,7 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 		if yyrt3546 {
 			for ; yyj3546 < yyl3546; yyj3546++ {
 				yyv3546 = append(yyv3546, Container{})
+				yyh3546.ElemContainerState(yyj3546)
 				if r.TryDecodeAsNil() {
 					yyv3546[yyj3546] = Container{}
 				} else {
@@ -41172,12 +44243,14 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 		}
 
 	} else {
-		for yyj3546 := 0; !r.CheckBreak(); yyj3546++ {
+		yyj3546 := 0
+		for ; !r.CheckBreak(); yyj3546++ {
+
 			if yyj3546 >= len(yyv3546) {
 				yyv3546 = append(yyv3546, Container{}) // var yyz3546 Container
 				yyc3546 = true
 			}
-
+			yyh3546.ElemContainerState(yyj3546)
 			if yyj3546 < len(yyv3546) {
 				if r.TryDecodeAsNil() {
 					yyv3546[yyj3546] = Container{}
@@ -41191,12 +44264,18 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3546.End()
+		if yyj3546 < len(yyv3546) {
+			yyv3546 = yyv3546[:yyj3546]
+			yyc3546 = true
+		} else if yyj3546 == 0 && yyv3546 == nil {
+			yyv3546 = []Container{}
+			yyc3546 = true
+		}
 	}
+	yyh3546.End()
 	if yyc3546 {
 		*v = yyv3546
 	}
-
 }
 
 func (x codecSelfer1234) encSliceLocalObjectReference(v []LocalObjectReference, e *codec1978.Encoder) {
@@ -41205,10 +44284,11 @@ func (x codecSelfer1234) encSliceLocalObjectReference(v []LocalObjectReference, 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3550 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3551 := &yyv3550
 		yy3551.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference, d *codec1978.Decoder) {
@@ -41218,39 +44298,44 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 
 	yyv3552 := *v
 	yyh3552, yyl3552 := z.DecSliceHelperStart()
-
-	var yyrr3552, yyrl3552 int
-	var yyc3552, yyrt3552 bool
-	_, _, _ = yyc3552, yyrt3552, yyrl3552
-	yyrr3552 = yyl3552
-
-	if yyv3552 == nil {
-		if yyrl3552, yyrt3552 = z.DecInferLen(yyl3552, z.DecBasicHandle().MaxInitLen, 16); yyrt3552 {
-			yyrr3552 = yyrl3552
-		}
-		yyv3552 = make([]LocalObjectReference, yyrl3552)
-		yyc3552 = true
-	}
-
+	var yyc3552 bool
 	if yyl3552 == 0 {
-		if len(yyv3552) != 0 {
+		if yyv3552 == nil {
+			yyv3552 = []LocalObjectReference{}
+			yyc3552 = true
+		} else if len(yyv3552) != 0 {
 			yyv3552 = yyv3552[:0]
 			yyc3552 = true
 		}
 	} else if yyl3552 > 0 {
-
+		var yyrr3552, yyrl3552 int
+		var yyrt3552 bool
 		if yyl3552 > cap(yyv3552) {
-			yyrl3552, yyrt3552 = z.DecInferLen(yyl3552, z.DecBasicHandle().MaxInitLen, 16)
-			yyv3552 = make([]LocalObjectReference, yyrl3552)
-			yyc3552 = true
 
+			yyrg3552 := len(yyv3552) > 0
+			yyv23552 := yyv3552
+			yyrl3552, yyrt3552 = z.DecInferLen(yyl3552, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt3552 {
+				if yyrl3552 <= cap(yyv3552) {
+					yyv3552 = yyv3552[:yyrl3552]
+				} else {
+					yyv3552 = make([]LocalObjectReference, yyrl3552)
+				}
+			} else {
+				yyv3552 = make([]LocalObjectReference, yyrl3552)
+			}
+			yyc3552 = true
 			yyrr3552 = len(yyv3552)
+			if yyrg3552 {
+				copy(yyv3552, yyv23552)
+			}
 		} else if yyl3552 != len(yyv3552) {
 			yyv3552 = yyv3552[:yyl3552]
 			yyc3552 = true
 		}
 		yyj3552 := 0
 		for ; yyj3552 < yyrr3552; yyj3552++ {
+			yyh3552.ElemContainerState(yyj3552)
 			if r.TryDecodeAsNil() {
 				yyv3552[yyj3552] = LocalObjectReference{}
 			} else {
@@ -41262,6 +44347,7 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 		if yyrt3552 {
 			for ; yyj3552 < yyl3552; yyj3552++ {
 				yyv3552 = append(yyv3552, LocalObjectReference{})
+				yyh3552.ElemContainerState(yyj3552)
 				if r.TryDecodeAsNil() {
 					yyv3552[yyj3552] = LocalObjectReference{}
 				} else {
@@ -41273,12 +44359,14 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 		}
 
 	} else {
-		for yyj3552 := 0; !r.CheckBreak(); yyj3552++ {
+		yyj3552 := 0
+		for ; !r.CheckBreak(); yyj3552++ {
+
 			if yyj3552 >= len(yyv3552) {
 				yyv3552 = append(yyv3552, LocalObjectReference{}) // var yyz3552 LocalObjectReference
 				yyc3552 = true
 			}
-
+			yyh3552.ElemContainerState(yyj3552)
 			if yyj3552 < len(yyv3552) {
 				if r.TryDecodeAsNil() {
 					yyv3552[yyj3552] = LocalObjectReference{}
@@ -41292,12 +44380,18 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 			}
 
 		}
-		yyh3552.End()
+		if yyj3552 < len(yyv3552) {
+			yyv3552 = yyv3552[:yyj3552]
+			yyc3552 = true
+		} else if yyj3552 == 0 && yyv3552 == nil {
+			yyv3552 = []LocalObjectReference{}
+			yyc3552 = true
+		}
 	}
+	yyh3552.End()
 	if yyc3552 {
 		*v = yyv3552
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePodCondition(v []PodCondition, e *codec1978.Encoder) {
@@ -41306,10 +44400,11 @@ func (x codecSelfer1234) encSlicePodCondition(v []PodCondition, e *codec1978.Enc
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3556 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3557 := &yyv3556
 		yy3557.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.Decoder) {
@@ -41319,39 +44414,44 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 
 	yyv3558 := *v
 	yyh3558, yyl3558 := z.DecSliceHelperStart()
-
-	var yyrr3558, yyrl3558 int
-	var yyc3558, yyrt3558 bool
-	_, _, _ = yyc3558, yyrt3558, yyrl3558
-	yyrr3558 = yyl3558
-
-	if yyv3558 == nil {
-		if yyrl3558, yyrt3558 = z.DecInferLen(yyl3558, z.DecBasicHandle().MaxInitLen, 112); yyrt3558 {
-			yyrr3558 = yyrl3558
-		}
-		yyv3558 = make([]PodCondition, yyrl3558)
-		yyc3558 = true
-	}
-
+	var yyc3558 bool
 	if yyl3558 == 0 {
-		if len(yyv3558) != 0 {
+		if yyv3558 == nil {
+			yyv3558 = []PodCondition{}
+			yyc3558 = true
+		} else if len(yyv3558) != 0 {
 			yyv3558 = yyv3558[:0]
 			yyc3558 = true
 		}
 	} else if yyl3558 > 0 {
-
+		var yyrr3558, yyrl3558 int
+		var yyrt3558 bool
 		if yyl3558 > cap(yyv3558) {
-			yyrl3558, yyrt3558 = z.DecInferLen(yyl3558, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3558 = make([]PodCondition, yyrl3558)
-			yyc3558 = true
 
+			yyrg3558 := len(yyv3558) > 0
+			yyv23558 := yyv3558
+			yyrl3558, yyrt3558 = z.DecInferLen(yyl3558, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt3558 {
+				if yyrl3558 <= cap(yyv3558) {
+					yyv3558 = yyv3558[:yyrl3558]
+				} else {
+					yyv3558 = make([]PodCondition, yyrl3558)
+				}
+			} else {
+				yyv3558 = make([]PodCondition, yyrl3558)
+			}
+			yyc3558 = true
 			yyrr3558 = len(yyv3558)
+			if yyrg3558 {
+				copy(yyv3558, yyv23558)
+			}
 		} else if yyl3558 != len(yyv3558) {
 			yyv3558 = yyv3558[:yyl3558]
 			yyc3558 = true
 		}
 		yyj3558 := 0
 		for ; yyj3558 < yyrr3558; yyj3558++ {
+			yyh3558.ElemContainerState(yyj3558)
 			if r.TryDecodeAsNil() {
 				yyv3558[yyj3558] = PodCondition{}
 			} else {
@@ -41363,6 +44463,7 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 		if yyrt3558 {
 			for ; yyj3558 < yyl3558; yyj3558++ {
 				yyv3558 = append(yyv3558, PodCondition{})
+				yyh3558.ElemContainerState(yyj3558)
 				if r.TryDecodeAsNil() {
 					yyv3558[yyj3558] = PodCondition{}
 				} else {
@@ -41374,12 +44475,14 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 		}
 
 	} else {
-		for yyj3558 := 0; !r.CheckBreak(); yyj3558++ {
+		yyj3558 := 0
+		for ; !r.CheckBreak(); yyj3558++ {
+
 			if yyj3558 >= len(yyv3558) {
 				yyv3558 = append(yyv3558, PodCondition{}) // var yyz3558 PodCondition
 				yyc3558 = true
 			}
-
+			yyh3558.ElemContainerState(yyj3558)
 			if yyj3558 < len(yyv3558) {
 				if r.TryDecodeAsNil() {
 					yyv3558[yyj3558] = PodCondition{}
@@ -41393,12 +44496,18 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 			}
 
 		}
-		yyh3558.End()
+		if yyj3558 < len(yyv3558) {
+			yyv3558 = yyv3558[:yyj3558]
+			yyc3558 = true
+		} else if yyj3558 == 0 && yyv3558 == nil {
+			yyv3558 = []PodCondition{}
+			yyc3558 = true
+		}
 	}
+	yyh3558.End()
 	if yyc3558 {
 		*v = yyv3558
 	}
-
 }
 
 func (x codecSelfer1234) encSliceContainerStatus(v []ContainerStatus, e *codec1978.Encoder) {
@@ -41407,10 +44516,11 @@ func (x codecSelfer1234) encSliceContainerStatus(v []ContainerStatus, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3562 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3563 := &yyv3562
 		yy3563.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1978.Decoder) {
@@ -41420,39 +44530,44 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 
 	yyv3564 := *v
 	yyh3564, yyl3564 := z.DecSliceHelperStart()
-
-	var yyrr3564, yyrl3564 int
-	var yyc3564, yyrt3564 bool
-	_, _, _ = yyc3564, yyrt3564, yyrl3564
-	yyrr3564 = yyl3564
-
-	if yyv3564 == nil {
-		if yyrl3564, yyrt3564 = z.DecInferLen(yyl3564, z.DecBasicHandle().MaxInitLen, 128); yyrt3564 {
-			yyrr3564 = yyrl3564
-		}
-		yyv3564 = make([]ContainerStatus, yyrl3564)
-		yyc3564 = true
-	}
-
+	var yyc3564 bool
 	if yyl3564 == 0 {
-		if len(yyv3564) != 0 {
+		if yyv3564 == nil {
+			yyv3564 = []ContainerStatus{}
+			yyc3564 = true
+		} else if len(yyv3564) != 0 {
 			yyv3564 = yyv3564[:0]
 			yyc3564 = true
 		}
 	} else if yyl3564 > 0 {
-
+		var yyrr3564, yyrl3564 int
+		var yyrt3564 bool
 		if yyl3564 > cap(yyv3564) {
-			yyrl3564, yyrt3564 = z.DecInferLen(yyl3564, z.DecBasicHandle().MaxInitLen, 128)
-			yyv3564 = make([]ContainerStatus, yyrl3564)
-			yyc3564 = true
 
+			yyrg3564 := len(yyv3564) > 0
+			yyv23564 := yyv3564
+			yyrl3564, yyrt3564 = z.DecInferLen(yyl3564, z.DecBasicHandle().MaxInitLen, 128)
+			if yyrt3564 {
+				if yyrl3564 <= cap(yyv3564) {
+					yyv3564 = yyv3564[:yyrl3564]
+				} else {
+					yyv3564 = make([]ContainerStatus, yyrl3564)
+				}
+			} else {
+				yyv3564 = make([]ContainerStatus, yyrl3564)
+			}
+			yyc3564 = true
 			yyrr3564 = len(yyv3564)
+			if yyrg3564 {
+				copy(yyv3564, yyv23564)
+			}
 		} else if yyl3564 != len(yyv3564) {
 			yyv3564 = yyv3564[:yyl3564]
 			yyc3564 = true
 		}
 		yyj3564 := 0
 		for ; yyj3564 < yyrr3564; yyj3564++ {
+			yyh3564.ElemContainerState(yyj3564)
 			if r.TryDecodeAsNil() {
 				yyv3564[yyj3564] = ContainerStatus{}
 			} else {
@@ -41464,6 +44579,7 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 		if yyrt3564 {
 			for ; yyj3564 < yyl3564; yyj3564++ {
 				yyv3564 = append(yyv3564, ContainerStatus{})
+				yyh3564.ElemContainerState(yyj3564)
 				if r.TryDecodeAsNil() {
 					yyv3564[yyj3564] = ContainerStatus{}
 				} else {
@@ -41475,12 +44591,14 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 		}
 
 	} else {
-		for yyj3564 := 0; !r.CheckBreak(); yyj3564++ {
+		yyj3564 := 0
+		for ; !r.CheckBreak(); yyj3564++ {
+
 			if yyj3564 >= len(yyv3564) {
 				yyv3564 = append(yyv3564, ContainerStatus{}) // var yyz3564 ContainerStatus
 				yyc3564 = true
 			}
-
+			yyh3564.ElemContainerState(yyj3564)
 			if yyj3564 < len(yyv3564) {
 				if r.TryDecodeAsNil() {
 					yyv3564[yyj3564] = ContainerStatus{}
@@ -41494,12 +44612,18 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 			}
 
 		}
-		yyh3564.End()
+		if yyj3564 < len(yyv3564) {
+			yyv3564 = yyv3564[:yyj3564]
+			yyc3564 = true
+		} else if yyj3564 == 0 && yyv3564 == nil {
+			yyv3564 = []ContainerStatus{}
+			yyc3564 = true
+		}
 	}
+	yyh3564.End()
 	if yyc3564 {
 		*v = yyv3564
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePodTemplate(v []PodTemplate, e *codec1978.Encoder) {
@@ -41508,10 +44632,11 @@ func (x codecSelfer1234) encSlicePodTemplate(v []PodTemplate, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3568 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3569 := &yyv3568
 		yy3569.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Decoder) {
@@ -41521,39 +44646,44 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 
 	yyv3570 := *v
 	yyh3570, yyl3570 := z.DecSliceHelperStart()
-
-	var yyrr3570, yyrl3570 int
-	var yyc3570, yyrt3570 bool
-	_, _, _ = yyc3570, yyrt3570, yyrl3570
-	yyrr3570 = yyl3570
-
-	if yyv3570 == nil {
-		if yyrl3570, yyrt3570 = z.DecInferLen(yyl3570, z.DecBasicHandle().MaxInitLen, 520); yyrt3570 {
-			yyrr3570 = yyrl3570
-		}
-		yyv3570 = make([]PodTemplate, yyrl3570)
-		yyc3570 = true
-	}
-
+	var yyc3570 bool
 	if yyl3570 == 0 {
-		if len(yyv3570) != 0 {
+		if yyv3570 == nil {
+			yyv3570 = []PodTemplate{}
+			yyc3570 = true
+		} else if len(yyv3570) != 0 {
 			yyv3570 = yyv3570[:0]
 			yyc3570 = true
 		}
 	} else if yyl3570 > 0 {
-
+		var yyrr3570, yyrl3570 int
+		var yyrt3570 bool
 		if yyl3570 > cap(yyv3570) {
-			yyrl3570, yyrt3570 = z.DecInferLen(yyl3570, z.DecBasicHandle().MaxInitLen, 520)
-			yyv3570 = make([]PodTemplate, yyrl3570)
-			yyc3570 = true
 
+			yyrg3570 := len(yyv3570) > 0
+			yyv23570 := yyv3570
+			yyrl3570, yyrt3570 = z.DecInferLen(yyl3570, z.DecBasicHandle().MaxInitLen, 520)
+			if yyrt3570 {
+				if yyrl3570 <= cap(yyv3570) {
+					yyv3570 = yyv3570[:yyrl3570]
+				} else {
+					yyv3570 = make([]PodTemplate, yyrl3570)
+				}
+			} else {
+				yyv3570 = make([]PodTemplate, yyrl3570)
+			}
+			yyc3570 = true
 			yyrr3570 = len(yyv3570)
+			if yyrg3570 {
+				copy(yyv3570, yyv23570)
+			}
 		} else if yyl3570 != len(yyv3570) {
 			yyv3570 = yyv3570[:yyl3570]
 			yyc3570 = true
 		}
 		yyj3570 := 0
 		for ; yyj3570 < yyrr3570; yyj3570++ {
+			yyh3570.ElemContainerState(yyj3570)
 			if r.TryDecodeAsNil() {
 				yyv3570[yyj3570] = PodTemplate{}
 			} else {
@@ -41565,6 +44695,7 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 		if yyrt3570 {
 			for ; yyj3570 < yyl3570; yyj3570++ {
 				yyv3570 = append(yyv3570, PodTemplate{})
+				yyh3570.ElemContainerState(yyj3570)
 				if r.TryDecodeAsNil() {
 					yyv3570[yyj3570] = PodTemplate{}
 				} else {
@@ -41576,12 +44707,14 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj3570 := 0; !r.CheckBreak(); yyj3570++ {
+		yyj3570 := 0
+		for ; !r.CheckBreak(); yyj3570++ {
+
 			if yyj3570 >= len(yyv3570) {
 				yyv3570 = append(yyv3570, PodTemplate{}) // var yyz3570 PodTemplate
 				yyc3570 = true
 			}
-
+			yyh3570.ElemContainerState(yyj3570)
 			if yyj3570 < len(yyv3570) {
 				if r.TryDecodeAsNil() {
 					yyv3570[yyj3570] = PodTemplate{}
@@ -41595,12 +44728,18 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 			}
 
 		}
-		yyh3570.End()
+		if yyj3570 < len(yyv3570) {
+			yyv3570 = yyv3570[:yyj3570]
+			yyc3570 = true
+		} else if yyj3570 == 0 && yyv3570 == nil {
+			yyv3570 = []PodTemplate{}
+			yyc3570 = true
+		}
 	}
+	yyh3570.End()
 	if yyc3570 {
 		*v = yyv3570
 	}
-
 }
 
 func (x codecSelfer1234) encSliceReplicationController(v []ReplicationController, e *codec1978.Encoder) {
@@ -41609,10 +44748,11 @@ func (x codecSelfer1234) encSliceReplicationController(v []ReplicationController
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3574 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3575 := &yyv3574
 		yy3575.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationController, d *codec1978.Decoder) {
@@ -41622,39 +44762,44 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 
 	yyv3576 := *v
 	yyh3576, yyl3576 := z.DecSliceHelperStart()
-
-	var yyrr3576, yyrl3576 int
-	var yyc3576, yyrt3576 bool
-	_, _, _ = yyc3576, yyrt3576, yyrl3576
-	yyrr3576 = yyl3576
-
-	if yyv3576 == nil {
-		if yyrl3576, yyrt3576 = z.DecInferLen(yyl3576, z.DecBasicHandle().MaxInitLen, 232); yyrt3576 {
-			yyrr3576 = yyrl3576
-		}
-		yyv3576 = make([]ReplicationController, yyrl3576)
-		yyc3576 = true
-	}
-
+	var yyc3576 bool
 	if yyl3576 == 0 {
-		if len(yyv3576) != 0 {
+		if yyv3576 == nil {
+			yyv3576 = []ReplicationController{}
+			yyc3576 = true
+		} else if len(yyv3576) != 0 {
 			yyv3576 = yyv3576[:0]
 			yyc3576 = true
 		}
 	} else if yyl3576 > 0 {
-
+		var yyrr3576, yyrl3576 int
+		var yyrt3576 bool
 		if yyl3576 > cap(yyv3576) {
-			yyrl3576, yyrt3576 = z.DecInferLen(yyl3576, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3576 = make([]ReplicationController, yyrl3576)
-			yyc3576 = true
 
+			yyrg3576 := len(yyv3576) > 0
+			yyv23576 := yyv3576
+			yyrl3576, yyrt3576 = z.DecInferLen(yyl3576, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt3576 {
+				if yyrl3576 <= cap(yyv3576) {
+					yyv3576 = yyv3576[:yyrl3576]
+				} else {
+					yyv3576 = make([]ReplicationController, yyrl3576)
+				}
+			} else {
+				yyv3576 = make([]ReplicationController, yyrl3576)
+			}
+			yyc3576 = true
 			yyrr3576 = len(yyv3576)
+			if yyrg3576 {
+				copy(yyv3576, yyv23576)
+			}
 		} else if yyl3576 != len(yyv3576) {
 			yyv3576 = yyv3576[:yyl3576]
 			yyc3576 = true
 		}
 		yyj3576 := 0
 		for ; yyj3576 < yyrr3576; yyj3576++ {
+			yyh3576.ElemContainerState(yyj3576)
 			if r.TryDecodeAsNil() {
 				yyv3576[yyj3576] = ReplicationController{}
 			} else {
@@ -41666,6 +44811,7 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 		if yyrt3576 {
 			for ; yyj3576 < yyl3576; yyj3576++ {
 				yyv3576 = append(yyv3576, ReplicationController{})
+				yyh3576.ElemContainerState(yyj3576)
 				if r.TryDecodeAsNil() {
 					yyv3576[yyj3576] = ReplicationController{}
 				} else {
@@ -41677,12 +44823,14 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 		}
 
 	} else {
-		for yyj3576 := 0; !r.CheckBreak(); yyj3576++ {
+		yyj3576 := 0
+		for ; !r.CheckBreak(); yyj3576++ {
+
 			if yyj3576 >= len(yyv3576) {
 				yyv3576 = append(yyv3576, ReplicationController{}) // var yyz3576 ReplicationController
 				yyc3576 = true
 			}
-
+			yyh3576.ElemContainerState(yyj3576)
 			if yyj3576 < len(yyv3576) {
 				if r.TryDecodeAsNil() {
 					yyv3576[yyj3576] = ReplicationController{}
@@ -41696,12 +44844,18 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 			}
 
 		}
-		yyh3576.End()
+		if yyj3576 < len(yyv3576) {
+			yyv3576 = yyv3576[:yyj3576]
+			yyc3576 = true
+		} else if yyj3576 == 0 && yyv3576 == nil {
+			yyv3576 = []ReplicationController{}
+			yyc3576 = true
+		}
 	}
+	yyh3576.End()
 	if yyc3576 {
 		*v = yyv3576
 	}
-
 }
 
 func (x codecSelfer1234) encSliceService(v []Service, e *codec1978.Encoder) {
@@ -41710,10 +44864,11 @@ func (x codecSelfer1234) encSliceService(v []Service, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3580 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3581 := &yyv3580
 		yy3581.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
@@ -41723,39 +44878,44 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 
 	yyv3582 := *v
 	yyh3582, yyl3582 := z.DecSliceHelperStart()
-
-	var yyrr3582, yyrl3582 int
-	var yyc3582, yyrt3582 bool
-	_, _, _ = yyc3582, yyrt3582, yyrl3582
-	yyrr3582 = yyl3582
-
-	if yyv3582 == nil {
-		if yyrl3582, yyrt3582 = z.DecInferLen(yyl3582, z.DecBasicHandle().MaxInitLen, 336); yyrt3582 {
-			yyrr3582 = yyrl3582
-		}
-		yyv3582 = make([]Service, yyrl3582)
-		yyc3582 = true
-	}
-
+	var yyc3582 bool
 	if yyl3582 == 0 {
-		if len(yyv3582) != 0 {
+		if yyv3582 == nil {
+			yyv3582 = []Service{}
+			yyc3582 = true
+		} else if len(yyv3582) != 0 {
 			yyv3582 = yyv3582[:0]
 			yyc3582 = true
 		}
 	} else if yyl3582 > 0 {
-
+		var yyrr3582, yyrl3582 int
+		var yyrt3582 bool
 		if yyl3582 > cap(yyv3582) {
-			yyrl3582, yyrt3582 = z.DecInferLen(yyl3582, z.DecBasicHandle().MaxInitLen, 336)
-			yyv3582 = make([]Service, yyrl3582)
-			yyc3582 = true
 
+			yyrg3582 := len(yyv3582) > 0
+			yyv23582 := yyv3582
+			yyrl3582, yyrt3582 = z.DecInferLen(yyl3582, z.DecBasicHandle().MaxInitLen, 336)
+			if yyrt3582 {
+				if yyrl3582 <= cap(yyv3582) {
+					yyv3582 = yyv3582[:yyrl3582]
+				} else {
+					yyv3582 = make([]Service, yyrl3582)
+				}
+			} else {
+				yyv3582 = make([]Service, yyrl3582)
+			}
+			yyc3582 = true
 			yyrr3582 = len(yyv3582)
+			if yyrg3582 {
+				copy(yyv3582, yyv23582)
+			}
 		} else if yyl3582 != len(yyv3582) {
 			yyv3582 = yyv3582[:yyl3582]
 			yyc3582 = true
 		}
 		yyj3582 := 0
 		for ; yyj3582 < yyrr3582; yyj3582++ {
+			yyh3582.ElemContainerState(yyj3582)
 			if r.TryDecodeAsNil() {
 				yyv3582[yyj3582] = Service{}
 			} else {
@@ -41767,6 +44927,7 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 		if yyrt3582 {
 			for ; yyj3582 < yyl3582; yyj3582++ {
 				yyv3582 = append(yyv3582, Service{})
+				yyh3582.ElemContainerState(yyj3582)
 				if r.TryDecodeAsNil() {
 					yyv3582[yyj3582] = Service{}
 				} else {
@@ -41778,12 +44939,14 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3582 := 0; !r.CheckBreak(); yyj3582++ {
+		yyj3582 := 0
+		for ; !r.CheckBreak(); yyj3582++ {
+
 			if yyj3582 >= len(yyv3582) {
 				yyv3582 = append(yyv3582, Service{}) // var yyz3582 Service
 				yyc3582 = true
 			}
-
+			yyh3582.ElemContainerState(yyj3582)
 			if yyj3582 < len(yyv3582) {
 				if r.TryDecodeAsNil() {
 					yyv3582[yyj3582] = Service{}
@@ -41797,12 +44960,18 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3582.End()
+		if yyj3582 < len(yyv3582) {
+			yyv3582 = yyv3582[:yyj3582]
+			yyc3582 = true
+		} else if yyj3582 == 0 && yyv3582 == nil {
+			yyv3582 = []Service{}
+			yyc3582 = true
+		}
 	}
+	yyh3582.End()
 	if yyc3582 {
 		*v = yyv3582
 	}
-
 }
 
 func (x codecSelfer1234) encSliceLoadBalancerIngress(v []LoadBalancerIngress, e *codec1978.Encoder) {
@@ -41811,10 +44980,11 @@ func (x codecSelfer1234) encSliceLoadBalancerIngress(v []LoadBalancerIngress, e 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3586 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3587 := &yyv3586
 		yy3587.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d *codec1978.Decoder) {
@@ -41824,39 +44994,44 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 
 	yyv3588 := *v
 	yyh3588, yyl3588 := z.DecSliceHelperStart()
-
-	var yyrr3588, yyrl3588 int
-	var yyc3588, yyrt3588 bool
-	_, _, _ = yyc3588, yyrt3588, yyrl3588
-	yyrr3588 = yyl3588
-
-	if yyv3588 == nil {
-		if yyrl3588, yyrt3588 = z.DecInferLen(yyl3588, z.DecBasicHandle().MaxInitLen, 32); yyrt3588 {
-			yyrr3588 = yyrl3588
-		}
-		yyv3588 = make([]LoadBalancerIngress, yyrl3588)
-		yyc3588 = true
-	}
-
+	var yyc3588 bool
 	if yyl3588 == 0 {
-		if len(yyv3588) != 0 {
+		if yyv3588 == nil {
+			yyv3588 = []LoadBalancerIngress{}
+			yyc3588 = true
+		} else if len(yyv3588) != 0 {
 			yyv3588 = yyv3588[:0]
 			yyc3588 = true
 		}
 	} else if yyl3588 > 0 {
-
+		var yyrr3588, yyrl3588 int
+		var yyrt3588 bool
 		if yyl3588 > cap(yyv3588) {
-			yyrl3588, yyrt3588 = z.DecInferLen(yyl3588, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3588 = make([]LoadBalancerIngress, yyrl3588)
-			yyc3588 = true
 
+			yyrg3588 := len(yyv3588) > 0
+			yyv23588 := yyv3588
+			yyrl3588, yyrt3588 = z.DecInferLen(yyl3588, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt3588 {
+				if yyrl3588 <= cap(yyv3588) {
+					yyv3588 = yyv3588[:yyrl3588]
+				} else {
+					yyv3588 = make([]LoadBalancerIngress, yyrl3588)
+				}
+			} else {
+				yyv3588 = make([]LoadBalancerIngress, yyrl3588)
+			}
+			yyc3588 = true
 			yyrr3588 = len(yyv3588)
+			if yyrg3588 {
+				copy(yyv3588, yyv23588)
+			}
 		} else if yyl3588 != len(yyv3588) {
 			yyv3588 = yyv3588[:yyl3588]
 			yyc3588 = true
 		}
 		yyj3588 := 0
 		for ; yyj3588 < yyrr3588; yyj3588++ {
+			yyh3588.ElemContainerState(yyj3588)
 			if r.TryDecodeAsNil() {
 				yyv3588[yyj3588] = LoadBalancerIngress{}
 			} else {
@@ -41868,6 +45043,7 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 		if yyrt3588 {
 			for ; yyj3588 < yyl3588; yyj3588++ {
 				yyv3588 = append(yyv3588, LoadBalancerIngress{})
+				yyh3588.ElemContainerState(yyj3588)
 				if r.TryDecodeAsNil() {
 					yyv3588[yyj3588] = LoadBalancerIngress{}
 				} else {
@@ -41879,12 +45055,14 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 		}
 
 	} else {
-		for yyj3588 := 0; !r.CheckBreak(); yyj3588++ {
+		yyj3588 := 0
+		for ; !r.CheckBreak(); yyj3588++ {
+
 			if yyj3588 >= len(yyv3588) {
 				yyv3588 = append(yyv3588, LoadBalancerIngress{}) // var yyz3588 LoadBalancerIngress
 				yyc3588 = true
 			}
-
+			yyh3588.ElemContainerState(yyj3588)
 			if yyj3588 < len(yyv3588) {
 				if r.TryDecodeAsNil() {
 					yyv3588[yyj3588] = LoadBalancerIngress{}
@@ -41898,12 +45076,18 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 			}
 
 		}
-		yyh3588.End()
+		if yyj3588 < len(yyv3588) {
+			yyv3588 = yyv3588[:yyj3588]
+			yyc3588 = true
+		} else if yyj3588 == 0 && yyv3588 == nil {
+			yyv3588 = []LoadBalancerIngress{}
+			yyc3588 = true
+		}
 	}
+	yyh3588.End()
 	if yyc3588 {
 		*v = yyv3588
 	}
-
 }
 
 func (x codecSelfer1234) encSliceServicePort(v []ServicePort, e *codec1978.Encoder) {
@@ -41912,10 +45096,11 @@ func (x codecSelfer1234) encSliceServicePort(v []ServicePort, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3592 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3593 := &yyv3592
 		yy3593.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Decoder) {
@@ -41925,39 +45110,44 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 
 	yyv3594 := *v
 	yyh3594, yyl3594 := z.DecSliceHelperStart()
-
-	var yyrr3594, yyrl3594 int
-	var yyc3594, yyrt3594 bool
-	_, _, _ = yyc3594, yyrt3594, yyrl3594
-	yyrr3594 = yyl3594
-
-	if yyv3594 == nil {
-		if yyrl3594, yyrt3594 = z.DecInferLen(yyl3594, z.DecBasicHandle().MaxInitLen, 80); yyrt3594 {
-			yyrr3594 = yyrl3594
-		}
-		yyv3594 = make([]ServicePort, yyrl3594)
-		yyc3594 = true
-	}
-
+	var yyc3594 bool
 	if yyl3594 == 0 {
-		if len(yyv3594) != 0 {
+		if yyv3594 == nil {
+			yyv3594 = []ServicePort{}
+			yyc3594 = true
+		} else if len(yyv3594) != 0 {
 			yyv3594 = yyv3594[:0]
 			yyc3594 = true
 		}
 	} else if yyl3594 > 0 {
-
+		var yyrr3594, yyrl3594 int
+		var yyrt3594 bool
 		if yyl3594 > cap(yyv3594) {
-			yyrl3594, yyrt3594 = z.DecInferLen(yyl3594, z.DecBasicHandle().MaxInitLen, 80)
-			yyv3594 = make([]ServicePort, yyrl3594)
-			yyc3594 = true
 
+			yyrg3594 := len(yyv3594) > 0
+			yyv23594 := yyv3594
+			yyrl3594, yyrt3594 = z.DecInferLen(yyl3594, z.DecBasicHandle().MaxInitLen, 80)
+			if yyrt3594 {
+				if yyrl3594 <= cap(yyv3594) {
+					yyv3594 = yyv3594[:yyrl3594]
+				} else {
+					yyv3594 = make([]ServicePort, yyrl3594)
+				}
+			} else {
+				yyv3594 = make([]ServicePort, yyrl3594)
+			}
+			yyc3594 = true
 			yyrr3594 = len(yyv3594)
+			if yyrg3594 {
+				copy(yyv3594, yyv23594)
+			}
 		} else if yyl3594 != len(yyv3594) {
 			yyv3594 = yyv3594[:yyl3594]
 			yyc3594 = true
 		}
 		yyj3594 := 0
 		for ; yyj3594 < yyrr3594; yyj3594++ {
+			yyh3594.ElemContainerState(yyj3594)
 			if r.TryDecodeAsNil() {
 				yyv3594[yyj3594] = ServicePort{}
 			} else {
@@ -41969,6 +45159,7 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 		if yyrt3594 {
 			for ; yyj3594 < yyl3594; yyj3594++ {
 				yyv3594 = append(yyv3594, ServicePort{})
+				yyh3594.ElemContainerState(yyj3594)
 				if r.TryDecodeAsNil() {
 					yyv3594[yyj3594] = ServicePort{}
 				} else {
@@ -41980,12 +45171,14 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj3594 := 0; !r.CheckBreak(); yyj3594++ {
+		yyj3594 := 0
+		for ; !r.CheckBreak(); yyj3594++ {
+
 			if yyj3594 >= len(yyv3594) {
 				yyv3594 = append(yyv3594, ServicePort{}) // var yyz3594 ServicePort
 				yyc3594 = true
 			}
-
+			yyh3594.ElemContainerState(yyj3594)
 			if yyj3594 < len(yyv3594) {
 				if r.TryDecodeAsNil() {
 					yyv3594[yyj3594] = ServicePort{}
@@ -41999,12 +45192,18 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 			}
 
 		}
-		yyh3594.End()
+		if yyj3594 < len(yyv3594) {
+			yyv3594 = yyv3594[:yyj3594]
+			yyc3594 = true
+		} else if yyj3594 == 0 && yyv3594 == nil {
+			yyv3594 = []ServicePort{}
+			yyc3594 = true
+		}
 	}
+	yyh3594.End()
 	if yyc3594 {
 		*v = yyv3594
 	}
-
 }
 
 func (x codecSelfer1234) encSliceObjectReference(v []ObjectReference, e *codec1978.Encoder) {
@@ -42013,10 +45212,11 @@ func (x codecSelfer1234) encSliceObjectReference(v []ObjectReference, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3598 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3599 := &yyv3598
 		yy3599.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1978.Decoder) {
@@ -42026,39 +45226,44 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 
 	yyv3600 := *v
 	yyh3600, yyl3600 := z.DecSliceHelperStart()
-
-	var yyrr3600, yyrl3600 int
-	var yyc3600, yyrt3600 bool
-	_, _, _ = yyc3600, yyrt3600, yyrl3600
-	yyrr3600 = yyl3600
-
-	if yyv3600 == nil {
-		if yyrl3600, yyrt3600 = z.DecInferLen(yyl3600, z.DecBasicHandle().MaxInitLen, 112); yyrt3600 {
-			yyrr3600 = yyrl3600
-		}
-		yyv3600 = make([]ObjectReference, yyrl3600)
-		yyc3600 = true
-	}
-
+	var yyc3600 bool
 	if yyl3600 == 0 {
-		if len(yyv3600) != 0 {
+		if yyv3600 == nil {
+			yyv3600 = []ObjectReference{}
+			yyc3600 = true
+		} else if len(yyv3600) != 0 {
 			yyv3600 = yyv3600[:0]
 			yyc3600 = true
 		}
 	} else if yyl3600 > 0 {
-
+		var yyrr3600, yyrl3600 int
+		var yyrt3600 bool
 		if yyl3600 > cap(yyv3600) {
-			yyrl3600, yyrt3600 = z.DecInferLen(yyl3600, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3600 = make([]ObjectReference, yyrl3600)
-			yyc3600 = true
 
+			yyrg3600 := len(yyv3600) > 0
+			yyv23600 := yyv3600
+			yyrl3600, yyrt3600 = z.DecInferLen(yyl3600, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt3600 {
+				if yyrl3600 <= cap(yyv3600) {
+					yyv3600 = yyv3600[:yyrl3600]
+				} else {
+					yyv3600 = make([]ObjectReference, yyrl3600)
+				}
+			} else {
+				yyv3600 = make([]ObjectReference, yyrl3600)
+			}
+			yyc3600 = true
 			yyrr3600 = len(yyv3600)
+			if yyrg3600 {
+				copy(yyv3600, yyv23600)
+			}
 		} else if yyl3600 != len(yyv3600) {
 			yyv3600 = yyv3600[:yyl3600]
 			yyc3600 = true
 		}
 		yyj3600 := 0
 		for ; yyj3600 < yyrr3600; yyj3600++ {
+			yyh3600.ElemContainerState(yyj3600)
 			if r.TryDecodeAsNil() {
 				yyv3600[yyj3600] = ObjectReference{}
 			} else {
@@ -42070,6 +45275,7 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 		if yyrt3600 {
 			for ; yyj3600 < yyl3600; yyj3600++ {
 				yyv3600 = append(yyv3600, ObjectReference{})
+				yyh3600.ElemContainerState(yyj3600)
 				if r.TryDecodeAsNil() {
 					yyv3600[yyj3600] = ObjectReference{}
 				} else {
@@ -42081,12 +45287,14 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 		}
 
 	} else {
-		for yyj3600 := 0; !r.CheckBreak(); yyj3600++ {
+		yyj3600 := 0
+		for ; !r.CheckBreak(); yyj3600++ {
+
 			if yyj3600 >= len(yyv3600) {
 				yyv3600 = append(yyv3600, ObjectReference{}) // var yyz3600 ObjectReference
 				yyc3600 = true
 			}
-
+			yyh3600.ElemContainerState(yyj3600)
 			if yyj3600 < len(yyv3600) {
 				if r.TryDecodeAsNil() {
 					yyv3600[yyj3600] = ObjectReference{}
@@ -42100,12 +45308,18 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 			}
 
 		}
-		yyh3600.End()
+		if yyj3600 < len(yyv3600) {
+			yyv3600 = yyv3600[:yyj3600]
+			yyc3600 = true
+		} else if yyj3600 == 0 && yyv3600 == nil {
+			yyv3600 = []ObjectReference{}
+			yyc3600 = true
+		}
 	}
+	yyh3600.End()
 	if yyc3600 {
 		*v = yyv3600
 	}
-
 }
 
 func (x codecSelfer1234) encSliceServiceAccount(v []ServiceAccount, e *codec1978.Encoder) {
@@ -42114,10 +45328,11 @@ func (x codecSelfer1234) encSliceServiceAccount(v []ServiceAccount, e *codec1978
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3604 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3605 := &yyv3604
 		yy3605.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec1978.Decoder) {
@@ -42127,39 +45342,44 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 
 	yyv3606 := *v
 	yyh3606, yyl3606 := z.DecSliceHelperStart()
-
-	var yyrr3606, yyrl3606 int
-	var yyc3606, yyrt3606 bool
-	_, _, _ = yyc3606, yyrt3606, yyrl3606
-	yyrr3606 = yyl3606
-
-	if yyv3606 == nil {
-		if yyrl3606, yyrt3606 = z.DecInferLen(yyl3606, z.DecBasicHandle().MaxInitLen, 240); yyrt3606 {
-			yyrr3606 = yyrl3606
-		}
-		yyv3606 = make([]ServiceAccount, yyrl3606)
-		yyc3606 = true
-	}
-
+	var yyc3606 bool
 	if yyl3606 == 0 {
-		if len(yyv3606) != 0 {
+		if yyv3606 == nil {
+			yyv3606 = []ServiceAccount{}
+			yyc3606 = true
+		} else if len(yyv3606) != 0 {
 			yyv3606 = yyv3606[:0]
 			yyc3606 = true
 		}
 	} else if yyl3606 > 0 {
-
+		var yyrr3606, yyrl3606 int
+		var yyrt3606 bool
 		if yyl3606 > cap(yyv3606) {
-			yyrl3606, yyrt3606 = z.DecInferLen(yyl3606, z.DecBasicHandle().MaxInitLen, 240)
-			yyv3606 = make([]ServiceAccount, yyrl3606)
-			yyc3606 = true
 
+			yyrg3606 := len(yyv3606) > 0
+			yyv23606 := yyv3606
+			yyrl3606, yyrt3606 = z.DecInferLen(yyl3606, z.DecBasicHandle().MaxInitLen, 240)
+			if yyrt3606 {
+				if yyrl3606 <= cap(yyv3606) {
+					yyv3606 = yyv3606[:yyrl3606]
+				} else {
+					yyv3606 = make([]ServiceAccount, yyrl3606)
+				}
+			} else {
+				yyv3606 = make([]ServiceAccount, yyrl3606)
+			}
+			yyc3606 = true
 			yyrr3606 = len(yyv3606)
+			if yyrg3606 {
+				copy(yyv3606, yyv23606)
+			}
 		} else if yyl3606 != len(yyv3606) {
 			yyv3606 = yyv3606[:yyl3606]
 			yyc3606 = true
 		}
 		yyj3606 := 0
 		for ; yyj3606 < yyrr3606; yyj3606++ {
+			yyh3606.ElemContainerState(yyj3606)
 			if r.TryDecodeAsNil() {
 				yyv3606[yyj3606] = ServiceAccount{}
 			} else {
@@ -42171,6 +45391,7 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 		if yyrt3606 {
 			for ; yyj3606 < yyl3606; yyj3606++ {
 				yyv3606 = append(yyv3606, ServiceAccount{})
+				yyh3606.ElemContainerState(yyj3606)
 				if r.TryDecodeAsNil() {
 					yyv3606[yyj3606] = ServiceAccount{}
 				} else {
@@ -42182,12 +45403,14 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 		}
 
 	} else {
-		for yyj3606 := 0; !r.CheckBreak(); yyj3606++ {
+		yyj3606 := 0
+		for ; !r.CheckBreak(); yyj3606++ {
+
 			if yyj3606 >= len(yyv3606) {
 				yyv3606 = append(yyv3606, ServiceAccount{}) // var yyz3606 ServiceAccount
 				yyc3606 = true
 			}
-
+			yyh3606.ElemContainerState(yyj3606)
 			if yyj3606 < len(yyv3606) {
 				if r.TryDecodeAsNil() {
 					yyv3606[yyj3606] = ServiceAccount{}
@@ -42201,12 +45424,18 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 			}
 
 		}
-		yyh3606.End()
+		if yyj3606 < len(yyv3606) {
+			yyv3606 = yyv3606[:yyj3606]
+			yyc3606 = true
+		} else if yyj3606 == 0 && yyv3606 == nil {
+			yyv3606 = []ServiceAccount{}
+			yyc3606 = true
+		}
 	}
+	yyh3606.End()
 	if yyc3606 {
 		*v = yyv3606
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEndpointSubset(v []EndpointSubset, e *codec1978.Encoder) {
@@ -42215,10 +45444,11 @@ func (x codecSelfer1234) encSliceEndpointSubset(v []EndpointSubset, e *codec1978
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3610 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3611 := &yyv3610
 		yy3611.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec1978.Decoder) {
@@ -42228,39 +45458,44 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 
 	yyv3612 := *v
 	yyh3612, yyl3612 := z.DecSliceHelperStart()
-
-	var yyrr3612, yyrl3612 int
-	var yyc3612, yyrt3612 bool
-	_, _, _ = yyc3612, yyrt3612, yyrl3612
-	yyrr3612 = yyl3612
-
-	if yyv3612 == nil {
-		if yyrl3612, yyrt3612 = z.DecInferLen(yyl3612, z.DecBasicHandle().MaxInitLen, 72); yyrt3612 {
-			yyrr3612 = yyrl3612
-		}
-		yyv3612 = make([]EndpointSubset, yyrl3612)
-		yyc3612 = true
-	}
-
+	var yyc3612 bool
 	if yyl3612 == 0 {
-		if len(yyv3612) != 0 {
+		if yyv3612 == nil {
+			yyv3612 = []EndpointSubset{}
+			yyc3612 = true
+		} else if len(yyv3612) != 0 {
 			yyv3612 = yyv3612[:0]
 			yyc3612 = true
 		}
 	} else if yyl3612 > 0 {
-
+		var yyrr3612, yyrl3612 int
+		var yyrt3612 bool
 		if yyl3612 > cap(yyv3612) {
-			yyrl3612, yyrt3612 = z.DecInferLen(yyl3612, z.DecBasicHandle().MaxInitLen, 72)
-			yyv3612 = make([]EndpointSubset, yyrl3612)
-			yyc3612 = true
 
+			yyrg3612 := len(yyv3612) > 0
+			yyv23612 := yyv3612
+			yyrl3612, yyrt3612 = z.DecInferLen(yyl3612, z.DecBasicHandle().MaxInitLen, 72)
+			if yyrt3612 {
+				if yyrl3612 <= cap(yyv3612) {
+					yyv3612 = yyv3612[:yyrl3612]
+				} else {
+					yyv3612 = make([]EndpointSubset, yyrl3612)
+				}
+			} else {
+				yyv3612 = make([]EndpointSubset, yyrl3612)
+			}
+			yyc3612 = true
 			yyrr3612 = len(yyv3612)
+			if yyrg3612 {
+				copy(yyv3612, yyv23612)
+			}
 		} else if yyl3612 != len(yyv3612) {
 			yyv3612 = yyv3612[:yyl3612]
 			yyc3612 = true
 		}
 		yyj3612 := 0
 		for ; yyj3612 < yyrr3612; yyj3612++ {
+			yyh3612.ElemContainerState(yyj3612)
 			if r.TryDecodeAsNil() {
 				yyv3612[yyj3612] = EndpointSubset{}
 			} else {
@@ -42272,6 +45507,7 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 		if yyrt3612 {
 			for ; yyj3612 < yyl3612; yyj3612++ {
 				yyv3612 = append(yyv3612, EndpointSubset{})
+				yyh3612.ElemContainerState(yyj3612)
 				if r.TryDecodeAsNil() {
 					yyv3612[yyj3612] = EndpointSubset{}
 				} else {
@@ -42283,12 +45519,14 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 		}
 
 	} else {
-		for yyj3612 := 0; !r.CheckBreak(); yyj3612++ {
+		yyj3612 := 0
+		for ; !r.CheckBreak(); yyj3612++ {
+
 			if yyj3612 >= len(yyv3612) {
 				yyv3612 = append(yyv3612, EndpointSubset{}) // var yyz3612 EndpointSubset
 				yyc3612 = true
 			}
-
+			yyh3612.ElemContainerState(yyj3612)
 			if yyj3612 < len(yyv3612) {
 				if r.TryDecodeAsNil() {
 					yyv3612[yyj3612] = EndpointSubset{}
@@ -42302,12 +45540,18 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 			}
 
 		}
-		yyh3612.End()
+		if yyj3612 < len(yyv3612) {
+			yyv3612 = yyv3612[:yyj3612]
+			yyc3612 = true
+		} else if yyj3612 == 0 && yyv3612 == nil {
+			yyv3612 = []EndpointSubset{}
+			yyc3612 = true
+		}
 	}
+	yyh3612.End()
 	if yyc3612 {
 		*v = yyv3612
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEndpointAddress(v []EndpointAddress, e *codec1978.Encoder) {
@@ -42316,10 +45560,11 @@ func (x codecSelfer1234) encSliceEndpointAddress(v []EndpointAddress, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3616 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3617 := &yyv3616
 		yy3617.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1978.Decoder) {
@@ -42329,39 +45574,44 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 
 	yyv3618 := *v
 	yyh3618, yyl3618 := z.DecSliceHelperStart()
-
-	var yyrr3618, yyrl3618 int
-	var yyc3618, yyrt3618 bool
-	_, _, _ = yyc3618, yyrt3618, yyrl3618
-	yyrr3618 = yyl3618
-
-	if yyv3618 == nil {
-		if yyrl3618, yyrt3618 = z.DecInferLen(yyl3618, z.DecBasicHandle().MaxInitLen, 24); yyrt3618 {
-			yyrr3618 = yyrl3618
-		}
-		yyv3618 = make([]EndpointAddress, yyrl3618)
-		yyc3618 = true
-	}
-
+	var yyc3618 bool
 	if yyl3618 == 0 {
-		if len(yyv3618) != 0 {
+		if yyv3618 == nil {
+			yyv3618 = []EndpointAddress{}
+			yyc3618 = true
+		} else if len(yyv3618) != 0 {
 			yyv3618 = yyv3618[:0]
 			yyc3618 = true
 		}
 	} else if yyl3618 > 0 {
-
+		var yyrr3618, yyrl3618 int
+		var yyrt3618 bool
 		if yyl3618 > cap(yyv3618) {
-			yyrl3618, yyrt3618 = z.DecInferLen(yyl3618, z.DecBasicHandle().MaxInitLen, 24)
-			yyv3618 = make([]EndpointAddress, yyrl3618)
-			yyc3618 = true
 
+			yyrg3618 := len(yyv3618) > 0
+			yyv23618 := yyv3618
+			yyrl3618, yyrt3618 = z.DecInferLen(yyl3618, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt3618 {
+				if yyrl3618 <= cap(yyv3618) {
+					yyv3618 = yyv3618[:yyrl3618]
+				} else {
+					yyv3618 = make([]EndpointAddress, yyrl3618)
+				}
+			} else {
+				yyv3618 = make([]EndpointAddress, yyrl3618)
+			}
+			yyc3618 = true
 			yyrr3618 = len(yyv3618)
+			if yyrg3618 {
+				copy(yyv3618, yyv23618)
+			}
 		} else if yyl3618 != len(yyv3618) {
 			yyv3618 = yyv3618[:yyl3618]
 			yyc3618 = true
 		}
 		yyj3618 := 0
 		for ; yyj3618 < yyrr3618; yyj3618++ {
+			yyh3618.ElemContainerState(yyj3618)
 			if r.TryDecodeAsNil() {
 				yyv3618[yyj3618] = EndpointAddress{}
 			} else {
@@ -42373,6 +45623,7 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 		if yyrt3618 {
 			for ; yyj3618 < yyl3618; yyj3618++ {
 				yyv3618 = append(yyv3618, EndpointAddress{})
+				yyh3618.ElemContainerState(yyj3618)
 				if r.TryDecodeAsNil() {
 					yyv3618[yyj3618] = EndpointAddress{}
 				} else {
@@ -42384,12 +45635,14 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 		}
 
 	} else {
-		for yyj3618 := 0; !r.CheckBreak(); yyj3618++ {
+		yyj3618 := 0
+		for ; !r.CheckBreak(); yyj3618++ {
+
 			if yyj3618 >= len(yyv3618) {
 				yyv3618 = append(yyv3618, EndpointAddress{}) // var yyz3618 EndpointAddress
 				yyc3618 = true
 			}
-
+			yyh3618.ElemContainerState(yyj3618)
 			if yyj3618 < len(yyv3618) {
 				if r.TryDecodeAsNil() {
 					yyv3618[yyj3618] = EndpointAddress{}
@@ -42403,12 +45656,18 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 			}
 
 		}
-		yyh3618.End()
+		if yyj3618 < len(yyv3618) {
+			yyv3618 = yyv3618[:yyj3618]
+			yyc3618 = true
+		} else if yyj3618 == 0 && yyv3618 == nil {
+			yyv3618 = []EndpointAddress{}
+			yyc3618 = true
+		}
 	}
+	yyh3618.End()
 	if yyc3618 {
 		*v = yyv3618
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEndpointPort(v []EndpointPort, e *codec1978.Encoder) {
@@ -42417,10 +45676,11 @@ func (x codecSelfer1234) encSliceEndpointPort(v []EndpointPort, e *codec1978.Enc
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3622 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3623 := &yyv3622
 		yy3623.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.Decoder) {
@@ -42430,39 +45690,44 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 
 	yyv3624 := *v
 	yyh3624, yyl3624 := z.DecSliceHelperStart()
-
-	var yyrr3624, yyrl3624 int
-	var yyc3624, yyrt3624 bool
-	_, _, _ = yyc3624, yyrt3624, yyrl3624
-	yyrr3624 = yyl3624
-
-	if yyv3624 == nil {
-		if yyrl3624, yyrt3624 = z.DecInferLen(yyl3624, z.DecBasicHandle().MaxInitLen, 40); yyrt3624 {
-			yyrr3624 = yyrl3624
-		}
-		yyv3624 = make([]EndpointPort, yyrl3624)
-		yyc3624 = true
-	}
-
+	var yyc3624 bool
 	if yyl3624 == 0 {
-		if len(yyv3624) != 0 {
+		if yyv3624 == nil {
+			yyv3624 = []EndpointPort{}
+			yyc3624 = true
+		} else if len(yyv3624) != 0 {
 			yyv3624 = yyv3624[:0]
 			yyc3624 = true
 		}
 	} else if yyl3624 > 0 {
-
+		var yyrr3624, yyrl3624 int
+		var yyrt3624 bool
 		if yyl3624 > cap(yyv3624) {
-			yyrl3624, yyrt3624 = z.DecInferLen(yyl3624, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3624 = make([]EndpointPort, yyrl3624)
-			yyc3624 = true
 
+			yyrg3624 := len(yyv3624) > 0
+			yyv23624 := yyv3624
+			yyrl3624, yyrt3624 = z.DecInferLen(yyl3624, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt3624 {
+				if yyrl3624 <= cap(yyv3624) {
+					yyv3624 = yyv3624[:yyrl3624]
+				} else {
+					yyv3624 = make([]EndpointPort, yyrl3624)
+				}
+			} else {
+				yyv3624 = make([]EndpointPort, yyrl3624)
+			}
+			yyc3624 = true
 			yyrr3624 = len(yyv3624)
+			if yyrg3624 {
+				copy(yyv3624, yyv23624)
+			}
 		} else if yyl3624 != len(yyv3624) {
 			yyv3624 = yyv3624[:yyl3624]
 			yyc3624 = true
 		}
 		yyj3624 := 0
 		for ; yyj3624 < yyrr3624; yyj3624++ {
+			yyh3624.ElemContainerState(yyj3624)
 			if r.TryDecodeAsNil() {
 				yyv3624[yyj3624] = EndpointPort{}
 			} else {
@@ -42474,6 +45739,7 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 		if yyrt3624 {
 			for ; yyj3624 < yyl3624; yyj3624++ {
 				yyv3624 = append(yyv3624, EndpointPort{})
+				yyh3624.ElemContainerState(yyj3624)
 				if r.TryDecodeAsNil() {
 					yyv3624[yyj3624] = EndpointPort{}
 				} else {
@@ -42485,12 +45751,14 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 		}
 
 	} else {
-		for yyj3624 := 0; !r.CheckBreak(); yyj3624++ {
+		yyj3624 := 0
+		for ; !r.CheckBreak(); yyj3624++ {
+
 			if yyj3624 >= len(yyv3624) {
 				yyv3624 = append(yyv3624, EndpointPort{}) // var yyz3624 EndpointPort
 				yyc3624 = true
 			}
-
+			yyh3624.ElemContainerState(yyj3624)
 			if yyj3624 < len(yyv3624) {
 				if r.TryDecodeAsNil() {
 					yyv3624[yyj3624] = EndpointPort{}
@@ -42504,12 +45772,18 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 			}
 
 		}
-		yyh3624.End()
+		if yyj3624 < len(yyv3624) {
+			yyv3624 = yyv3624[:yyj3624]
+			yyc3624 = true
+		} else if yyj3624 == 0 && yyv3624 == nil {
+			yyv3624 = []EndpointPort{}
+			yyc3624 = true
+		}
 	}
+	yyh3624.End()
 	if yyc3624 {
 		*v = yyv3624
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEndpoints(v []Endpoints, e *codec1978.Encoder) {
@@ -42518,10 +45792,11 @@ func (x codecSelfer1234) encSliceEndpoints(v []Endpoints, e *codec1978.Encoder) 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3628 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3629 := &yyv3628
 		yy3629.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder) {
@@ -42531,39 +45806,44 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 
 	yyv3630 := *v
 	yyh3630, yyl3630 := z.DecSliceHelperStart()
-
-	var yyrr3630, yyrl3630 int
-	var yyc3630, yyrt3630 bool
-	_, _, _ = yyc3630, yyrt3630, yyrl3630
-	yyrr3630 = yyl3630
-
-	if yyv3630 == nil {
-		if yyrl3630, yyrt3630 = z.DecInferLen(yyl3630, z.DecBasicHandle().MaxInitLen, 216); yyrt3630 {
-			yyrr3630 = yyrl3630
-		}
-		yyv3630 = make([]Endpoints, yyrl3630)
-		yyc3630 = true
-	}
-
+	var yyc3630 bool
 	if yyl3630 == 0 {
-		if len(yyv3630) != 0 {
+		if yyv3630 == nil {
+			yyv3630 = []Endpoints{}
+			yyc3630 = true
+		} else if len(yyv3630) != 0 {
 			yyv3630 = yyv3630[:0]
 			yyc3630 = true
 		}
 	} else if yyl3630 > 0 {
-
+		var yyrr3630, yyrl3630 int
+		var yyrt3630 bool
 		if yyl3630 > cap(yyv3630) {
-			yyrl3630, yyrt3630 = z.DecInferLen(yyl3630, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3630 = make([]Endpoints, yyrl3630)
-			yyc3630 = true
 
+			yyrg3630 := len(yyv3630) > 0
+			yyv23630 := yyv3630
+			yyrl3630, yyrt3630 = z.DecInferLen(yyl3630, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3630 {
+				if yyrl3630 <= cap(yyv3630) {
+					yyv3630 = yyv3630[:yyrl3630]
+				} else {
+					yyv3630 = make([]Endpoints, yyrl3630)
+				}
+			} else {
+				yyv3630 = make([]Endpoints, yyrl3630)
+			}
+			yyc3630 = true
 			yyrr3630 = len(yyv3630)
+			if yyrg3630 {
+				copy(yyv3630, yyv23630)
+			}
 		} else if yyl3630 != len(yyv3630) {
 			yyv3630 = yyv3630[:yyl3630]
 			yyc3630 = true
 		}
 		yyj3630 := 0
 		for ; yyj3630 < yyrr3630; yyj3630++ {
+			yyh3630.ElemContainerState(yyj3630)
 			if r.TryDecodeAsNil() {
 				yyv3630[yyj3630] = Endpoints{}
 			} else {
@@ -42575,6 +45855,7 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 		if yyrt3630 {
 			for ; yyj3630 < yyl3630; yyj3630++ {
 				yyv3630 = append(yyv3630, Endpoints{})
+				yyh3630.ElemContainerState(yyj3630)
 				if r.TryDecodeAsNil() {
 					yyv3630[yyj3630] = Endpoints{}
 				} else {
@@ -42586,12 +45867,14 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 		}
 
 	} else {
-		for yyj3630 := 0; !r.CheckBreak(); yyj3630++ {
+		yyj3630 := 0
+		for ; !r.CheckBreak(); yyj3630++ {
+
 			if yyj3630 >= len(yyv3630) {
 				yyv3630 = append(yyv3630, Endpoints{}) // var yyz3630 Endpoints
 				yyc3630 = true
 			}
-
+			yyh3630.ElemContainerState(yyj3630)
 			if yyj3630 < len(yyv3630) {
 				if r.TryDecodeAsNil() {
 					yyv3630[yyj3630] = Endpoints{}
@@ -42605,12 +45888,18 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3630.End()
+		if yyj3630 < len(yyv3630) {
+			yyv3630 = yyv3630[:yyj3630]
+			yyc3630 = true
+		} else if yyj3630 == 0 && yyv3630 == nil {
+			yyv3630 = []Endpoints{}
+			yyc3630 = true
+		}
 	}
+	yyh3630.End()
 	if yyc3630 {
 		*v = yyv3630
 	}
-
 }
 
 func (x codecSelfer1234) encSliceNodeCondition(v []NodeCondition, e *codec1978.Encoder) {
@@ -42619,10 +45908,11 @@ func (x codecSelfer1234) encSliceNodeCondition(v []NodeCondition, e *codec1978.E
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3634 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3635 := &yyv3634
 		yy3635.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.Decoder) {
@@ -42632,39 +45922,44 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 
 	yyv3636 := *v
 	yyh3636, yyl3636 := z.DecSliceHelperStart()
-
-	var yyrr3636, yyrl3636 int
-	var yyc3636, yyrt3636 bool
-	_, _, _ = yyc3636, yyrt3636, yyrl3636
-	yyrr3636 = yyl3636
-
-	if yyv3636 == nil {
-		if yyrl3636, yyrt3636 = z.DecInferLen(yyl3636, z.DecBasicHandle().MaxInitLen, 112); yyrt3636 {
-			yyrr3636 = yyrl3636
-		}
-		yyv3636 = make([]NodeCondition, yyrl3636)
-		yyc3636 = true
-	}
-
+	var yyc3636 bool
 	if yyl3636 == 0 {
-		if len(yyv3636) != 0 {
+		if yyv3636 == nil {
+			yyv3636 = []NodeCondition{}
+			yyc3636 = true
+		} else if len(yyv3636) != 0 {
 			yyv3636 = yyv3636[:0]
 			yyc3636 = true
 		}
 	} else if yyl3636 > 0 {
-
+		var yyrr3636, yyrl3636 int
+		var yyrt3636 bool
 		if yyl3636 > cap(yyv3636) {
-			yyrl3636, yyrt3636 = z.DecInferLen(yyl3636, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3636 = make([]NodeCondition, yyrl3636)
-			yyc3636 = true
 
+			yyrg3636 := len(yyv3636) > 0
+			yyv23636 := yyv3636
+			yyrl3636, yyrt3636 = z.DecInferLen(yyl3636, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt3636 {
+				if yyrl3636 <= cap(yyv3636) {
+					yyv3636 = yyv3636[:yyrl3636]
+				} else {
+					yyv3636 = make([]NodeCondition, yyrl3636)
+				}
+			} else {
+				yyv3636 = make([]NodeCondition, yyrl3636)
+			}
+			yyc3636 = true
 			yyrr3636 = len(yyv3636)
+			if yyrg3636 {
+				copy(yyv3636, yyv23636)
+			}
 		} else if yyl3636 != len(yyv3636) {
 			yyv3636 = yyv3636[:yyl3636]
 			yyc3636 = true
 		}
 		yyj3636 := 0
 		for ; yyj3636 < yyrr3636; yyj3636++ {
+			yyh3636.ElemContainerState(yyj3636)
 			if r.TryDecodeAsNil() {
 				yyv3636[yyj3636] = NodeCondition{}
 			} else {
@@ -42676,6 +45971,7 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 		if yyrt3636 {
 			for ; yyj3636 < yyl3636; yyj3636++ {
 				yyv3636 = append(yyv3636, NodeCondition{})
+				yyh3636.ElemContainerState(yyj3636)
 				if r.TryDecodeAsNil() {
 					yyv3636[yyj3636] = NodeCondition{}
 				} else {
@@ -42687,12 +45983,14 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 		}
 
 	} else {
-		for yyj3636 := 0; !r.CheckBreak(); yyj3636++ {
+		yyj3636 := 0
+		for ; !r.CheckBreak(); yyj3636++ {
+
 			if yyj3636 >= len(yyv3636) {
 				yyv3636 = append(yyv3636, NodeCondition{}) // var yyz3636 NodeCondition
 				yyc3636 = true
 			}
-
+			yyh3636.ElemContainerState(yyj3636)
 			if yyj3636 < len(yyv3636) {
 				if r.TryDecodeAsNil() {
 					yyv3636[yyj3636] = NodeCondition{}
@@ -42706,12 +46004,18 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 			}
 
 		}
-		yyh3636.End()
+		if yyj3636 < len(yyv3636) {
+			yyv3636 = yyv3636[:yyj3636]
+			yyc3636 = true
+		} else if yyj3636 == 0 && yyv3636 == nil {
+			yyv3636 = []NodeCondition{}
+			yyc3636 = true
+		}
 	}
+	yyh3636.End()
 	if yyc3636 {
 		*v = yyv3636
 	}
-
 }
 
 func (x codecSelfer1234) encSliceNodeAddress(v []NodeAddress, e *codec1978.Encoder) {
@@ -42720,10 +46024,11 @@ func (x codecSelfer1234) encSliceNodeAddress(v []NodeAddress, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3640 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3641 := &yyv3640
 		yy3641.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Decoder) {
@@ -42733,39 +46038,44 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 
 	yyv3642 := *v
 	yyh3642, yyl3642 := z.DecSliceHelperStart()
-
-	var yyrr3642, yyrl3642 int
-	var yyc3642, yyrt3642 bool
-	_, _, _ = yyc3642, yyrt3642, yyrl3642
-	yyrr3642 = yyl3642
-
-	if yyv3642 == nil {
-		if yyrl3642, yyrt3642 = z.DecInferLen(yyl3642, z.DecBasicHandle().MaxInitLen, 32); yyrt3642 {
-			yyrr3642 = yyrl3642
-		}
-		yyv3642 = make([]NodeAddress, yyrl3642)
-		yyc3642 = true
-	}
-
+	var yyc3642 bool
 	if yyl3642 == 0 {
-		if len(yyv3642) != 0 {
+		if yyv3642 == nil {
+			yyv3642 = []NodeAddress{}
+			yyc3642 = true
+		} else if len(yyv3642) != 0 {
 			yyv3642 = yyv3642[:0]
 			yyc3642 = true
 		}
 	} else if yyl3642 > 0 {
-
+		var yyrr3642, yyrl3642 int
+		var yyrt3642 bool
 		if yyl3642 > cap(yyv3642) {
-			yyrl3642, yyrt3642 = z.DecInferLen(yyl3642, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3642 = make([]NodeAddress, yyrl3642)
-			yyc3642 = true
 
+			yyrg3642 := len(yyv3642) > 0
+			yyv23642 := yyv3642
+			yyrl3642, yyrt3642 = z.DecInferLen(yyl3642, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt3642 {
+				if yyrl3642 <= cap(yyv3642) {
+					yyv3642 = yyv3642[:yyrl3642]
+				} else {
+					yyv3642 = make([]NodeAddress, yyrl3642)
+				}
+			} else {
+				yyv3642 = make([]NodeAddress, yyrl3642)
+			}
+			yyc3642 = true
 			yyrr3642 = len(yyv3642)
+			if yyrg3642 {
+				copy(yyv3642, yyv23642)
+			}
 		} else if yyl3642 != len(yyv3642) {
 			yyv3642 = yyv3642[:yyl3642]
 			yyc3642 = true
 		}
 		yyj3642 := 0
 		for ; yyj3642 < yyrr3642; yyj3642++ {
+			yyh3642.ElemContainerState(yyj3642)
 			if r.TryDecodeAsNil() {
 				yyv3642[yyj3642] = NodeAddress{}
 			} else {
@@ -42777,6 +46087,7 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 		if yyrt3642 {
 			for ; yyj3642 < yyl3642; yyj3642++ {
 				yyv3642 = append(yyv3642, NodeAddress{})
+				yyh3642.ElemContainerState(yyj3642)
 				if r.TryDecodeAsNil() {
 					yyv3642[yyj3642] = NodeAddress{}
 				} else {
@@ -42788,12 +46099,14 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj3642 := 0; !r.CheckBreak(); yyj3642++ {
+		yyj3642 := 0
+		for ; !r.CheckBreak(); yyj3642++ {
+
 			if yyj3642 >= len(yyv3642) {
 				yyv3642 = append(yyv3642, NodeAddress{}) // var yyz3642 NodeAddress
 				yyc3642 = true
 			}
-
+			yyh3642.ElemContainerState(yyj3642)
 			if yyj3642 < len(yyv3642) {
 				if r.TryDecodeAsNil() {
 					yyv3642[yyj3642] = NodeAddress{}
@@ -42807,12 +46120,18 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 			}
 
 		}
-		yyh3642.End()
+		if yyj3642 < len(yyv3642) {
+			yyv3642 = yyv3642[:yyj3642]
+			yyc3642 = true
+		} else if yyj3642 == 0 && yyv3642 == nil {
+			yyv3642 = []NodeAddress{}
+			yyc3642 = true
+		}
 	}
+	yyh3642.End()
 	if yyc3642 {
 		*v = yyv3642
 	}
-
 }
 
 func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
@@ -42821,7 +46140,9 @@ func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
 	for yyk3646, yyv3646 := range v {
+		z.EncSendContainerState(codecSelfer_containerMapKey1234)
 		yyk3646.CodecEncodeSelf(e)
+		z.EncSendContainerState(codecSelfer_containerMapValue1234)
 		yy3647 := &yyv3646
 		yym3648 := z.EncBinary()
 		_ = yym3648
@@ -42833,7 +46154,7 @@ func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
 			z.EncFallback(yy3647)
 		}
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) {
@@ -42857,6 +46178,7 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 	}
 	if yyl3649 > 0 {
 		for yyj3649 := 0; yyj3649 < yyl3649; yyj3649++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
 				yymk3649 = ""
 			} else {
@@ -42868,6 +46190,7 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 			} else {
 				yymv3649 = pkg3_resource.Quantity{}
 			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
 				yymv3649 = pkg3_resource.Quantity{}
 			} else {
@@ -42889,6 +46212,7 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 		}
 	} else if yyl3649 < 0 {
 		for yyj3649 := 0; !r.CheckBreak(); yyj3649++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
 				yymk3649 = ""
 			} else {
@@ -42900,6 +46224,7 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 			} else {
 				yymv3649 = pkg3_resource.Quantity{}
 			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
 				yymv3649 = pkg3_resource.Quantity{}
 			} else {
@@ -42919,8 +46244,8 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 				yyv3649[yymk3649] = yymv3649
 			}
 		}
-		r.ReadEnd()
 	} // else len==0: TODO: Should we clear map entries?
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x codecSelfer1234) encSliceNode(v []Node, e *codec1978.Encoder) {
@@ -42929,10 +46254,11 @@ func (x codecSelfer1234) encSliceNode(v []Node, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3656 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3657 := &yyv3656
 		yy3657.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
@@ -42942,39 +46268,44 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 
 	yyv3658 := *v
 	yyh3658, yyl3658 := z.DecSliceHelperStart()
-
-	var yyrr3658, yyrl3658 int
-	var yyc3658, yyrt3658 bool
-	_, _, _ = yyc3658, yyrt3658, yyrl3658
-	yyrr3658 = yyl3658
-
-	if yyv3658 == nil {
-		if yyrl3658, yyrt3658 = z.DecInferLen(yyl3658, z.DecBasicHandle().MaxInitLen, 456); yyrt3658 {
-			yyrr3658 = yyrl3658
-		}
-		yyv3658 = make([]Node, yyrl3658)
-		yyc3658 = true
-	}
-
+	var yyc3658 bool
 	if yyl3658 == 0 {
-		if len(yyv3658) != 0 {
+		if yyv3658 == nil {
+			yyv3658 = []Node{}
+			yyc3658 = true
+		} else if len(yyv3658) != 0 {
 			yyv3658 = yyv3658[:0]
 			yyc3658 = true
 		}
 	} else if yyl3658 > 0 {
-
+		var yyrr3658, yyrl3658 int
+		var yyrt3658 bool
 		if yyl3658 > cap(yyv3658) {
-			yyrl3658, yyrt3658 = z.DecInferLen(yyl3658, z.DecBasicHandle().MaxInitLen, 456)
-			yyv3658 = make([]Node, yyrl3658)
-			yyc3658 = true
 
+			yyrg3658 := len(yyv3658) > 0
+			yyv23658 := yyv3658
+			yyrl3658, yyrt3658 = z.DecInferLen(yyl3658, z.DecBasicHandle().MaxInitLen, 456)
+			if yyrt3658 {
+				if yyrl3658 <= cap(yyv3658) {
+					yyv3658 = yyv3658[:yyrl3658]
+				} else {
+					yyv3658 = make([]Node, yyrl3658)
+				}
+			} else {
+				yyv3658 = make([]Node, yyrl3658)
+			}
+			yyc3658 = true
 			yyrr3658 = len(yyv3658)
+			if yyrg3658 {
+				copy(yyv3658, yyv23658)
+			}
 		} else if yyl3658 != len(yyv3658) {
 			yyv3658 = yyv3658[:yyl3658]
 			yyc3658 = true
 		}
 		yyj3658 := 0
 		for ; yyj3658 < yyrr3658; yyj3658++ {
+			yyh3658.ElemContainerState(yyj3658)
 			if r.TryDecodeAsNil() {
 				yyv3658[yyj3658] = Node{}
 			} else {
@@ -42986,6 +46317,7 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 		if yyrt3658 {
 			for ; yyj3658 < yyl3658; yyj3658++ {
 				yyv3658 = append(yyv3658, Node{})
+				yyh3658.ElemContainerState(yyj3658)
 				if r.TryDecodeAsNil() {
 					yyv3658[yyj3658] = Node{}
 				} else {
@@ -42997,12 +46329,14 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3658 := 0; !r.CheckBreak(); yyj3658++ {
+		yyj3658 := 0
+		for ; !r.CheckBreak(); yyj3658++ {
+
 			if yyj3658 >= len(yyv3658) {
 				yyv3658 = append(yyv3658, Node{}) // var yyz3658 Node
 				yyc3658 = true
 			}
-
+			yyh3658.ElemContainerState(yyj3658)
 			if yyj3658 < len(yyv3658) {
 				if r.TryDecodeAsNil() {
 					yyv3658[yyj3658] = Node{}
@@ -43016,12 +46350,18 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3658.End()
+		if yyj3658 < len(yyv3658) {
+			yyv3658 = yyv3658[:yyj3658]
+			yyc3658 = true
+		} else if yyj3658 == 0 && yyv3658 == nil {
+			yyv3658 = []Node{}
+			yyc3658 = true
+		}
 	}
+	yyh3658.End()
 	if yyc3658 {
 		*v = yyv3658
 	}
-
 }
 
 func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.Encoder) {
@@ -43030,9 +46370,10 @@ func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.E
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3662 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yyv3662.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.Decoder) {
@@ -43042,37 +46383,31 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 
 	yyv3663 := *v
 	yyh3663, yyl3663 := z.DecSliceHelperStart()
-
-	var yyrr3663, yyrl3663 int
-	var yyc3663, yyrt3663 bool
-	_, _, _ = yyc3663, yyrt3663, yyrl3663
-	yyrr3663 = yyl3663
-
-	if yyv3663 == nil {
-		if yyrl3663, yyrt3663 = z.DecInferLen(yyl3663, z.DecBasicHandle().MaxInitLen, 16); yyrt3663 {
-			yyrr3663 = yyrl3663
-		}
-		yyv3663 = make([]FinalizerName, yyrl3663)
-		yyc3663 = true
-	}
-
+	var yyc3663 bool
 	if yyl3663 == 0 {
-		if len(yyv3663) != 0 {
+		if yyv3663 == nil {
+			yyv3663 = []FinalizerName{}
+			yyc3663 = true
+		} else if len(yyv3663) != 0 {
 			yyv3663 = yyv3663[:0]
 			yyc3663 = true
 		}
 	} else if yyl3663 > 0 {
-
+		var yyrr3663, yyrl3663 int
+		var yyrt3663 bool
 		if yyl3663 > cap(yyv3663) {
-			yyrl3663, yyrt3663 = z.DecInferLen(yyl3663, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23663 := yyv3663
-			yyv3663 = make([]FinalizerName, yyrl3663)
-			if len(yyv3663) > 0 {
-				copy(yyv3663, yyv23663[:cap(yyv23663)])
+			yyrl3663, yyrt3663 = z.DecInferLen(yyl3663, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt3663 {
+				if yyrl3663 <= cap(yyv3663) {
+					yyv3663 = yyv3663[:yyrl3663]
+				} else {
+					yyv3663 = make([]FinalizerName, yyrl3663)
+				}
+			} else {
+				yyv3663 = make([]FinalizerName, yyrl3663)
 			}
 			yyc3663 = true
-
 			yyrr3663 = len(yyv3663)
 		} else if yyl3663 != len(yyv3663) {
 			yyv3663 = yyv3663[:yyl3663]
@@ -43080,6 +46415,7 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 		}
 		yyj3663 := 0
 		for ; yyj3663 < yyrr3663; yyj3663++ {
+			yyh3663.ElemContainerState(yyj3663)
 			if r.TryDecodeAsNil() {
 				yyv3663[yyj3663] = ""
 			} else {
@@ -43090,6 +46426,7 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 		if yyrt3663 {
 			for ; yyj3663 < yyl3663; yyj3663++ {
 				yyv3663 = append(yyv3663, "")
+				yyh3663.ElemContainerState(yyj3663)
 				if r.TryDecodeAsNil() {
 					yyv3663[yyj3663] = ""
 				} else {
@@ -43100,12 +46437,14 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 		}
 
 	} else {
-		for yyj3663 := 0; !r.CheckBreak(); yyj3663++ {
+		yyj3663 := 0
+		for ; !r.CheckBreak(); yyj3663++ {
+
 			if yyj3663 >= len(yyv3663) {
 				yyv3663 = append(yyv3663, "") // var yyz3663 FinalizerName
 				yyc3663 = true
 			}
-
+			yyh3663.ElemContainerState(yyj3663)
 			if yyj3663 < len(yyv3663) {
 				if r.TryDecodeAsNil() {
 					yyv3663[yyj3663] = ""
@@ -43118,12 +46457,18 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 			}
 
 		}
-		yyh3663.End()
+		if yyj3663 < len(yyv3663) {
+			yyv3663 = yyv3663[:yyj3663]
+			yyc3663 = true
+		} else if yyj3663 == 0 && yyv3663 == nil {
+			yyv3663 = []FinalizerName{}
+			yyc3663 = true
+		}
 	}
+	yyh3663.End()
 	if yyc3663 {
 		*v = yyv3663
 	}
-
 }
 
 func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) {
@@ -43132,10 +46477,11 @@ func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3667 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3668 := &yyv3667
 		yy3668.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder) {
@@ -43145,39 +46491,44 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 
 	yyv3669 := *v
 	yyh3669, yyl3669 := z.DecSliceHelperStart()
-
-	var yyrr3669, yyrl3669 int
-	var yyc3669, yyrt3669 bool
-	_, _, _ = yyc3669, yyrt3669, yyrl3669
-	yyrr3669 = yyl3669
-
-	if yyv3669 == nil {
-		if yyrl3669, yyrt3669 = z.DecInferLen(yyl3669, z.DecBasicHandle().MaxInitLen, 232); yyrt3669 {
-			yyrr3669 = yyrl3669
-		}
-		yyv3669 = make([]Namespace, yyrl3669)
-		yyc3669 = true
-	}
-
+	var yyc3669 bool
 	if yyl3669 == 0 {
-		if len(yyv3669) != 0 {
+		if yyv3669 == nil {
+			yyv3669 = []Namespace{}
+			yyc3669 = true
+		} else if len(yyv3669) != 0 {
 			yyv3669 = yyv3669[:0]
 			yyc3669 = true
 		}
 	} else if yyl3669 > 0 {
-
+		var yyrr3669, yyrl3669 int
+		var yyrt3669 bool
 		if yyl3669 > cap(yyv3669) {
-			yyrl3669, yyrt3669 = z.DecInferLen(yyl3669, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3669 = make([]Namespace, yyrl3669)
-			yyc3669 = true
 
+			yyrg3669 := len(yyv3669) > 0
+			yyv23669 := yyv3669
+			yyrl3669, yyrt3669 = z.DecInferLen(yyl3669, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt3669 {
+				if yyrl3669 <= cap(yyv3669) {
+					yyv3669 = yyv3669[:yyrl3669]
+				} else {
+					yyv3669 = make([]Namespace, yyrl3669)
+				}
+			} else {
+				yyv3669 = make([]Namespace, yyrl3669)
+			}
+			yyc3669 = true
 			yyrr3669 = len(yyv3669)
+			if yyrg3669 {
+				copy(yyv3669, yyv23669)
+			}
 		} else if yyl3669 != len(yyv3669) {
 			yyv3669 = yyv3669[:yyl3669]
 			yyc3669 = true
 		}
 		yyj3669 := 0
 		for ; yyj3669 < yyrr3669; yyj3669++ {
+			yyh3669.ElemContainerState(yyj3669)
 			if r.TryDecodeAsNil() {
 				yyv3669[yyj3669] = Namespace{}
 			} else {
@@ -43189,6 +46540,7 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 		if yyrt3669 {
 			for ; yyj3669 < yyl3669; yyj3669++ {
 				yyv3669 = append(yyv3669, Namespace{})
+				yyh3669.ElemContainerState(yyj3669)
 				if r.TryDecodeAsNil() {
 					yyv3669[yyj3669] = Namespace{}
 				} else {
@@ -43200,12 +46552,14 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 		}
 
 	} else {
-		for yyj3669 := 0; !r.CheckBreak(); yyj3669++ {
+		yyj3669 := 0
+		for ; !r.CheckBreak(); yyj3669++ {
+
 			if yyj3669 >= len(yyv3669) {
 				yyv3669 = append(yyv3669, Namespace{}) // var yyz3669 Namespace
 				yyc3669 = true
 			}
-
+			yyh3669.ElemContainerState(yyj3669)
 			if yyj3669 < len(yyv3669) {
 				if r.TryDecodeAsNil() {
 					yyv3669[yyj3669] = Namespace{}
@@ -43219,12 +46573,18 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3669.End()
+		if yyj3669 < len(yyv3669) {
+			yyv3669 = yyv3669[:yyj3669]
+			yyc3669 = true
+		} else if yyj3669 == 0 && yyv3669 == nil {
+			yyv3669 = []Namespace{}
+			yyc3669 = true
+		}
 	}
+	yyh3669.End()
 	if yyc3669 {
 		*v = yyv3669
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEvent(v []Event, e *codec1978.Encoder) {
@@ -43233,10 +46593,11 @@ func (x codecSelfer1234) encSliceEvent(v []Event, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3673 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3674 := &yyv3673
 		yy3674.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
@@ -43246,39 +46607,44 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 
 	yyv3675 := *v
 	yyh3675, yyl3675 := z.DecSliceHelperStart()
-
-	var yyrr3675, yyrl3675 int
-	var yyc3675, yyrt3675 bool
-	_, _, _ = yyc3675, yyrt3675, yyrl3675
-	yyrr3675 = yyl3675
-
-	if yyv3675 == nil {
-		if yyrl3675, yyrt3675 = z.DecInferLen(yyl3675, z.DecBasicHandle().MaxInitLen, 440); yyrt3675 {
-			yyrr3675 = yyrl3675
-		}
-		yyv3675 = make([]Event, yyrl3675)
-		yyc3675 = true
-	}
-
+	var yyc3675 bool
 	if yyl3675 == 0 {
-		if len(yyv3675) != 0 {
+		if yyv3675 == nil {
+			yyv3675 = []Event{}
+			yyc3675 = true
+		} else if len(yyv3675) != 0 {
 			yyv3675 = yyv3675[:0]
 			yyc3675 = true
 		}
 	} else if yyl3675 > 0 {
-
+		var yyrr3675, yyrl3675 int
+		var yyrt3675 bool
 		if yyl3675 > cap(yyv3675) {
-			yyrl3675, yyrt3675 = z.DecInferLen(yyl3675, z.DecBasicHandle().MaxInitLen, 440)
-			yyv3675 = make([]Event, yyrl3675)
-			yyc3675 = true
 
+			yyrg3675 := len(yyv3675) > 0
+			yyv23675 := yyv3675
+			yyrl3675, yyrt3675 = z.DecInferLen(yyl3675, z.DecBasicHandle().MaxInitLen, 440)
+			if yyrt3675 {
+				if yyrl3675 <= cap(yyv3675) {
+					yyv3675 = yyv3675[:yyrl3675]
+				} else {
+					yyv3675 = make([]Event, yyrl3675)
+				}
+			} else {
+				yyv3675 = make([]Event, yyrl3675)
+			}
+			yyc3675 = true
 			yyrr3675 = len(yyv3675)
+			if yyrg3675 {
+				copy(yyv3675, yyv23675)
+			}
 		} else if yyl3675 != len(yyv3675) {
 			yyv3675 = yyv3675[:yyl3675]
 			yyc3675 = true
 		}
 		yyj3675 := 0
 		for ; yyj3675 < yyrr3675; yyj3675++ {
+			yyh3675.ElemContainerState(yyj3675)
 			if r.TryDecodeAsNil() {
 				yyv3675[yyj3675] = Event{}
 			} else {
@@ -43290,6 +46656,7 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 		if yyrt3675 {
 			for ; yyj3675 < yyl3675; yyj3675++ {
 				yyv3675 = append(yyv3675, Event{})
+				yyh3675.ElemContainerState(yyj3675)
 				if r.TryDecodeAsNil() {
 					yyv3675[yyj3675] = Event{}
 				} else {
@@ -43301,12 +46668,14 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3675 := 0; !r.CheckBreak(); yyj3675++ {
+		yyj3675 := 0
+		for ; !r.CheckBreak(); yyj3675++ {
+
 			if yyj3675 >= len(yyv3675) {
 				yyv3675 = append(yyv3675, Event{}) // var yyz3675 Event
 				yyc3675 = true
 			}
-
+			yyh3675.ElemContainerState(yyj3675)
 			if yyj3675 < len(yyv3675) {
 				if r.TryDecodeAsNil() {
 					yyv3675[yyj3675] = Event{}
@@ -43320,12 +46689,18 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3675.End()
+		if yyj3675 < len(yyv3675) {
+			yyv3675 = yyv3675[:yyj3675]
+			yyc3675 = true
+		} else if yyj3675 == 0 && yyv3675 == nil {
+			yyv3675 = []Event{}
+			yyc3675 = true
+		}
 	}
+	yyh3675.End()
 	if yyc3675 {
 		*v = yyv3675
 	}
-
 }
 
 func (x codecSelfer1234) encSliceruntime_Object(v []pkg8_runtime.Object, e *codec1978.Encoder) {
@@ -43334,6 +46709,7 @@ func (x codecSelfer1234) encSliceruntime_Object(v []pkg8_runtime.Object, e *code
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3679 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		if yyv3679 == nil {
 			r.EncodeNil()
 		} else {
@@ -43346,7 +46722,7 @@ func (x codecSelfer1234) encSliceruntime_Object(v []pkg8_runtime.Object, e *code
 			}
 		}
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *codec1978.Decoder) {
@@ -43356,39 +46732,44 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 
 	yyv3681 := *v
 	yyh3681, yyl3681 := z.DecSliceHelperStart()
-
-	var yyrr3681, yyrl3681 int
-	var yyc3681, yyrt3681 bool
-	_, _, _ = yyc3681, yyrt3681, yyrl3681
-	yyrr3681 = yyl3681
-
-	if yyv3681 == nil {
-		if yyrl3681, yyrt3681 = z.DecInferLen(yyl3681, z.DecBasicHandle().MaxInitLen, 16); yyrt3681 {
-			yyrr3681 = yyrl3681
-		}
-		yyv3681 = make([]pkg8_runtime.Object, yyrl3681)
-		yyc3681 = true
-	}
-
+	var yyc3681 bool
 	if yyl3681 == 0 {
-		if len(yyv3681) != 0 {
+		if yyv3681 == nil {
+			yyv3681 = []pkg8_runtime.Object{}
+			yyc3681 = true
+		} else if len(yyv3681) != 0 {
 			yyv3681 = yyv3681[:0]
 			yyc3681 = true
 		}
 	} else if yyl3681 > 0 {
-
+		var yyrr3681, yyrl3681 int
+		var yyrt3681 bool
 		if yyl3681 > cap(yyv3681) {
-			yyrl3681, yyrt3681 = z.DecInferLen(yyl3681, z.DecBasicHandle().MaxInitLen, 16)
-			yyv3681 = make([]pkg8_runtime.Object, yyrl3681)
-			yyc3681 = true
 
+			yyrg3681 := len(yyv3681) > 0
+			yyv23681 := yyv3681
+			yyrl3681, yyrt3681 = z.DecInferLen(yyl3681, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt3681 {
+				if yyrl3681 <= cap(yyv3681) {
+					yyv3681 = yyv3681[:yyrl3681]
+				} else {
+					yyv3681 = make([]pkg8_runtime.Object, yyrl3681)
+				}
+			} else {
+				yyv3681 = make([]pkg8_runtime.Object, yyrl3681)
+			}
+			yyc3681 = true
 			yyrr3681 = len(yyv3681)
+			if yyrg3681 {
+				copy(yyv3681, yyv23681)
+			}
 		} else if yyl3681 != len(yyv3681) {
 			yyv3681 = yyv3681[:yyl3681]
 			yyc3681 = true
 		}
 		yyj3681 := 0
 		for ; yyj3681 < yyrr3681; yyj3681++ {
+			yyh3681.ElemContainerState(yyj3681)
 			if r.TryDecodeAsNil() {
 				yyv3681[yyj3681] = nil
 			} else {
@@ -43406,6 +46787,7 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 		if yyrt3681 {
 			for ; yyj3681 < yyl3681; yyj3681++ {
 				yyv3681 = append(yyv3681, nil)
+				yyh3681.ElemContainerState(yyj3681)
 				if r.TryDecodeAsNil() {
 					yyv3681[yyj3681] = nil
 				} else {
@@ -43423,12 +46805,14 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 		}
 
 	} else {
-		for yyj3681 := 0; !r.CheckBreak(); yyj3681++ {
+		yyj3681 := 0
+		for ; !r.CheckBreak(); yyj3681++ {
+
 			if yyj3681 >= len(yyv3681) {
 				yyv3681 = append(yyv3681, nil) // var yyz3681 pkg8_runtime.Object
 				yyc3681 = true
 			}
-
+			yyh3681.ElemContainerState(yyj3681)
 			if yyj3681 < len(yyv3681) {
 				if r.TryDecodeAsNil() {
 					yyv3681[yyj3681] = nil
@@ -43448,12 +46832,18 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 			}
 
 		}
-		yyh3681.End()
+		if yyj3681 < len(yyv3681) {
+			yyv3681 = yyv3681[:yyj3681]
+			yyc3681 = true
+		} else if yyj3681 == 0 && yyv3681 == nil {
+			yyv3681 = []pkg8_runtime.Object{}
+			yyc3681 = true
+		}
 	}
+	yyh3681.End()
 	if yyc3681 {
 		*v = yyv3681
 	}
-
 }
 
 func (x codecSelfer1234) encSliceLimitRangeItem(v []LimitRangeItem, e *codec1978.Encoder) {
@@ -43462,10 +46852,11 @@ func (x codecSelfer1234) encSliceLimitRangeItem(v []LimitRangeItem, e *codec1978
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3688 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3689 := &yyv3688
 		yy3689.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec1978.Decoder) {
@@ -43475,39 +46866,44 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 
 	yyv3690 := *v
 	yyh3690, yyl3690 := z.DecSliceHelperStart()
-
-	var yyrr3690, yyrl3690 int
-	var yyc3690, yyrt3690 bool
-	_, _, _ = yyc3690, yyrt3690, yyrl3690
-	yyrr3690 = yyl3690
-
-	if yyv3690 == nil {
-		if yyrl3690, yyrt3690 = z.DecInferLen(yyl3690, z.DecBasicHandle().MaxInitLen, 56); yyrt3690 {
-			yyrr3690 = yyrl3690
-		}
-		yyv3690 = make([]LimitRangeItem, yyrl3690)
-		yyc3690 = true
-	}
-
+	var yyc3690 bool
 	if yyl3690 == 0 {
-		if len(yyv3690) != 0 {
+		if yyv3690 == nil {
+			yyv3690 = []LimitRangeItem{}
+			yyc3690 = true
+		} else if len(yyv3690) != 0 {
 			yyv3690 = yyv3690[:0]
 			yyc3690 = true
 		}
 	} else if yyl3690 > 0 {
-
+		var yyrr3690, yyrl3690 int
+		var yyrt3690 bool
 		if yyl3690 > cap(yyv3690) {
-			yyrl3690, yyrt3690 = z.DecInferLen(yyl3690, z.DecBasicHandle().MaxInitLen, 56)
-			yyv3690 = make([]LimitRangeItem, yyrl3690)
-			yyc3690 = true
 
+			yyrg3690 := len(yyv3690) > 0
+			yyv23690 := yyv3690
+			yyrl3690, yyrt3690 = z.DecInferLen(yyl3690, z.DecBasicHandle().MaxInitLen, 56)
+			if yyrt3690 {
+				if yyrl3690 <= cap(yyv3690) {
+					yyv3690 = yyv3690[:yyrl3690]
+				} else {
+					yyv3690 = make([]LimitRangeItem, yyrl3690)
+				}
+			} else {
+				yyv3690 = make([]LimitRangeItem, yyrl3690)
+			}
+			yyc3690 = true
 			yyrr3690 = len(yyv3690)
+			if yyrg3690 {
+				copy(yyv3690, yyv23690)
+			}
 		} else if yyl3690 != len(yyv3690) {
 			yyv3690 = yyv3690[:yyl3690]
 			yyc3690 = true
 		}
 		yyj3690 := 0
 		for ; yyj3690 < yyrr3690; yyj3690++ {
+			yyh3690.ElemContainerState(yyj3690)
 			if r.TryDecodeAsNil() {
 				yyv3690[yyj3690] = LimitRangeItem{}
 			} else {
@@ -43519,6 +46915,7 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 		if yyrt3690 {
 			for ; yyj3690 < yyl3690; yyj3690++ {
 				yyv3690 = append(yyv3690, LimitRangeItem{})
+				yyh3690.ElemContainerState(yyj3690)
 				if r.TryDecodeAsNil() {
 					yyv3690[yyj3690] = LimitRangeItem{}
 				} else {
@@ -43530,12 +46927,14 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 		}
 
 	} else {
-		for yyj3690 := 0; !r.CheckBreak(); yyj3690++ {
+		yyj3690 := 0
+		for ; !r.CheckBreak(); yyj3690++ {
+
 			if yyj3690 >= len(yyv3690) {
 				yyv3690 = append(yyv3690, LimitRangeItem{}) // var yyz3690 LimitRangeItem
 				yyc3690 = true
 			}
-
+			yyh3690.ElemContainerState(yyj3690)
 			if yyj3690 < len(yyv3690) {
 				if r.TryDecodeAsNil() {
 					yyv3690[yyj3690] = LimitRangeItem{}
@@ -43549,12 +46948,18 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 			}
 
 		}
-		yyh3690.End()
+		if yyj3690 < len(yyv3690) {
+			yyv3690 = yyv3690[:yyj3690]
+			yyc3690 = true
+		} else if yyj3690 == 0 && yyv3690 == nil {
+			yyv3690 = []LimitRangeItem{}
+			yyc3690 = true
+		}
 	}
+	yyh3690.End()
 	if yyc3690 {
 		*v = yyv3690
 	}
-
 }
 
 func (x codecSelfer1234) encSliceLimitRange(v []LimitRange, e *codec1978.Encoder) {
@@ -43563,10 +46968,11 @@ func (x codecSelfer1234) encSliceLimitRange(v []LimitRange, e *codec1978.Encoder
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3694 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3695 := &yyv3694
 		yy3695.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decoder) {
@@ -43576,39 +46982,44 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 
 	yyv3696 := *v
 	yyh3696, yyl3696 := z.DecSliceHelperStart()
-
-	var yyrr3696, yyrl3696 int
-	var yyc3696, yyrt3696 bool
-	_, _, _ = yyc3696, yyrt3696, yyrl3696
-	yyrr3696 = yyl3696
-
-	if yyv3696 == nil {
-		if yyrl3696, yyrt3696 = z.DecInferLen(yyl3696, z.DecBasicHandle().MaxInitLen, 216); yyrt3696 {
-			yyrr3696 = yyrl3696
-		}
-		yyv3696 = make([]LimitRange, yyrl3696)
-		yyc3696 = true
-	}
-
+	var yyc3696 bool
 	if yyl3696 == 0 {
-		if len(yyv3696) != 0 {
+		if yyv3696 == nil {
+			yyv3696 = []LimitRange{}
+			yyc3696 = true
+		} else if len(yyv3696) != 0 {
 			yyv3696 = yyv3696[:0]
 			yyc3696 = true
 		}
 	} else if yyl3696 > 0 {
-
+		var yyrr3696, yyrl3696 int
+		var yyrt3696 bool
 		if yyl3696 > cap(yyv3696) {
-			yyrl3696, yyrt3696 = z.DecInferLen(yyl3696, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3696 = make([]LimitRange, yyrl3696)
-			yyc3696 = true
 
+			yyrg3696 := len(yyv3696) > 0
+			yyv23696 := yyv3696
+			yyrl3696, yyrt3696 = z.DecInferLen(yyl3696, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3696 {
+				if yyrl3696 <= cap(yyv3696) {
+					yyv3696 = yyv3696[:yyrl3696]
+				} else {
+					yyv3696 = make([]LimitRange, yyrl3696)
+				}
+			} else {
+				yyv3696 = make([]LimitRange, yyrl3696)
+			}
+			yyc3696 = true
 			yyrr3696 = len(yyv3696)
+			if yyrg3696 {
+				copy(yyv3696, yyv23696)
+			}
 		} else if yyl3696 != len(yyv3696) {
 			yyv3696 = yyv3696[:yyl3696]
 			yyc3696 = true
 		}
 		yyj3696 := 0
 		for ; yyj3696 < yyrr3696; yyj3696++ {
+			yyh3696.ElemContainerState(yyj3696)
 			if r.TryDecodeAsNil() {
 				yyv3696[yyj3696] = LimitRange{}
 			} else {
@@ -43620,6 +47031,7 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 		if yyrt3696 {
 			for ; yyj3696 < yyl3696; yyj3696++ {
 				yyv3696 = append(yyv3696, LimitRange{})
+				yyh3696.ElemContainerState(yyj3696)
 				if r.TryDecodeAsNil() {
 					yyv3696[yyj3696] = LimitRange{}
 				} else {
@@ -43631,12 +47043,14 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 		}
 
 	} else {
-		for yyj3696 := 0; !r.CheckBreak(); yyj3696++ {
+		yyj3696 := 0
+		for ; !r.CheckBreak(); yyj3696++ {
+
 			if yyj3696 >= len(yyv3696) {
 				yyv3696 = append(yyv3696, LimitRange{}) // var yyz3696 LimitRange
 				yyc3696 = true
 			}
-
+			yyh3696.ElemContainerState(yyj3696)
 			if yyj3696 < len(yyv3696) {
 				if r.TryDecodeAsNil() {
 					yyv3696[yyj3696] = LimitRange{}
@@ -43650,12 +47064,18 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 			}
 
 		}
-		yyh3696.End()
+		if yyj3696 < len(yyv3696) {
+			yyv3696 = yyv3696[:yyj3696]
+			yyc3696 = true
+		} else if yyj3696 == 0 && yyv3696 == nil {
+			yyv3696 = []LimitRange{}
+			yyc3696 = true
+		}
 	}
+	yyh3696.End()
 	if yyc3696 {
 		*v = yyv3696
 	}
-
 }
 
 func (x codecSelfer1234) encSliceResourceQuota(v []ResourceQuota, e *codec1978.Encoder) {
@@ -43664,10 +47084,11 @@ func (x codecSelfer1234) encSliceResourceQuota(v []ResourceQuota, e *codec1978.E
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3700 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3701 := &yyv3700
 		yy3701.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.Decoder) {
@@ -43677,39 +47098,44 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 
 	yyv3702 := *v
 	yyh3702, yyl3702 := z.DecSliceHelperStart()
-
-	var yyrr3702, yyrl3702 int
-	var yyc3702, yyrt3702 bool
-	_, _, _ = yyc3702, yyrt3702, yyrl3702
-	yyrr3702 = yyl3702
-
-	if yyv3702 == nil {
-		if yyrl3702, yyrt3702 = z.DecInferLen(yyl3702, z.DecBasicHandle().MaxInitLen, 216); yyrt3702 {
-			yyrr3702 = yyrl3702
-		}
-		yyv3702 = make([]ResourceQuota, yyrl3702)
-		yyc3702 = true
-	}
-
+	var yyc3702 bool
 	if yyl3702 == 0 {
-		if len(yyv3702) != 0 {
+		if yyv3702 == nil {
+			yyv3702 = []ResourceQuota{}
+			yyc3702 = true
+		} else if len(yyv3702) != 0 {
 			yyv3702 = yyv3702[:0]
 			yyc3702 = true
 		}
 	} else if yyl3702 > 0 {
-
+		var yyrr3702, yyrl3702 int
+		var yyrt3702 bool
 		if yyl3702 > cap(yyv3702) {
-			yyrl3702, yyrt3702 = z.DecInferLen(yyl3702, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3702 = make([]ResourceQuota, yyrl3702)
-			yyc3702 = true
 
+			yyrg3702 := len(yyv3702) > 0
+			yyv23702 := yyv3702
+			yyrl3702, yyrt3702 = z.DecInferLen(yyl3702, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3702 {
+				if yyrl3702 <= cap(yyv3702) {
+					yyv3702 = yyv3702[:yyrl3702]
+				} else {
+					yyv3702 = make([]ResourceQuota, yyrl3702)
+				}
+			} else {
+				yyv3702 = make([]ResourceQuota, yyrl3702)
+			}
+			yyc3702 = true
 			yyrr3702 = len(yyv3702)
+			if yyrg3702 {
+				copy(yyv3702, yyv23702)
+			}
 		} else if yyl3702 != len(yyv3702) {
 			yyv3702 = yyv3702[:yyl3702]
 			yyc3702 = true
 		}
 		yyj3702 := 0
 		for ; yyj3702 < yyrr3702; yyj3702++ {
+			yyh3702.ElemContainerState(yyj3702)
 			if r.TryDecodeAsNil() {
 				yyv3702[yyj3702] = ResourceQuota{}
 			} else {
@@ -43721,6 +47147,7 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 		if yyrt3702 {
 			for ; yyj3702 < yyl3702; yyj3702++ {
 				yyv3702 = append(yyv3702, ResourceQuota{})
+				yyh3702.ElemContainerState(yyj3702)
 				if r.TryDecodeAsNil() {
 					yyv3702[yyj3702] = ResourceQuota{}
 				} else {
@@ -43732,12 +47159,14 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 		}
 
 	} else {
-		for yyj3702 := 0; !r.CheckBreak(); yyj3702++ {
+		yyj3702 := 0
+		for ; !r.CheckBreak(); yyj3702++ {
+
 			if yyj3702 >= len(yyv3702) {
 				yyv3702 = append(yyv3702, ResourceQuota{}) // var yyz3702 ResourceQuota
 				yyc3702 = true
 			}
-
+			yyh3702.ElemContainerState(yyj3702)
 			if yyj3702 < len(yyv3702) {
 				if r.TryDecodeAsNil() {
 					yyv3702[yyj3702] = ResourceQuota{}
@@ -43751,12 +47180,18 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 			}
 
 		}
-		yyh3702.End()
+		if yyj3702 < len(yyv3702) {
+			yyv3702 = yyv3702[:yyj3702]
+			yyc3702 = true
+		} else if yyj3702 == 0 && yyv3702 == nil {
+			yyv3702 = []ResourceQuota{}
+			yyc3702 = true
+		}
 	}
+	yyh3702.End()
 	if yyc3702 {
 		*v = yyv3702
 	}
-
 }
 
 func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec1978.Encoder) {
@@ -43765,12 +47200,14 @@ func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
 	for yyk3706, yyv3706 := range v {
+		z.EncSendContainerState(codecSelfer_containerMapKey1234)
 		yym3707 := z.EncBinary()
 		_ = yym3707
 		if false {
 		} else {
 			r.EncodeString(codecSelferC_UTF81234, string(yyk3706))
 		}
+		z.EncSendContainerState(codecSelfer_containerMapValue1234)
 		if yyv3706 == nil {
 			r.EncodeNil()
 		} else {
@@ -43782,7 +47219,7 @@ func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec19
 			}
 		}
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1978.Decoder) {
@@ -43806,6 +47243,7 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 	}
 	if yyl3709 > 0 {
 		for yyj3709 := 0; yyj3709 < yyl3709; yyj3709++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
 				yymk3709 = ""
 			} else {
@@ -43817,6 +47255,7 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 			} else {
 				yymv3709 = nil
 			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
 				yymv3709 = nil
 			} else {
@@ -43835,6 +47274,7 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 		}
 	} else if yyl3709 < 0 {
 		for yyj3709 := 0; !r.CheckBreak(); yyj3709++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
 				yymk3709 = ""
 			} else {
@@ -43846,6 +47286,7 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 			} else {
 				yymv3709 = nil
 			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
 				yymv3709 = nil
 			} else {
@@ -43862,8 +47303,8 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 				yyv3709[yymk3709] = yymv3709
 			}
 		}
-		r.ReadEnd()
 	} // else len==0: TODO: Should we clear map entries?
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x codecSelfer1234) encSliceSecret(v []Secret, e *codec1978.Encoder) {
@@ -43872,10 +47313,11 @@ func (x codecSelfer1234) encSliceSecret(v []Secret, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3716 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3717 := &yyv3716
 		yy3717.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
@@ -43885,39 +47327,44 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 
 	yyv3718 := *v
 	yyh3718, yyl3718 := z.DecSliceHelperStart()
-
-	var yyrr3718, yyrl3718 int
-	var yyc3718, yyrt3718 bool
-	_, _, _ = yyc3718, yyrt3718, yyrl3718
-	yyrr3718 = yyl3718
-
-	if yyv3718 == nil {
-		if yyrl3718, yyrt3718 = z.DecInferLen(yyl3718, z.DecBasicHandle().MaxInitLen, 216); yyrt3718 {
-			yyrr3718 = yyrl3718
-		}
-		yyv3718 = make([]Secret, yyrl3718)
-		yyc3718 = true
-	}
-
+	var yyc3718 bool
 	if yyl3718 == 0 {
-		if len(yyv3718) != 0 {
+		if yyv3718 == nil {
+			yyv3718 = []Secret{}
+			yyc3718 = true
+		} else if len(yyv3718) != 0 {
 			yyv3718 = yyv3718[:0]
 			yyc3718 = true
 		}
 	} else if yyl3718 > 0 {
-
+		var yyrr3718, yyrl3718 int
+		var yyrt3718 bool
 		if yyl3718 > cap(yyv3718) {
-			yyrl3718, yyrt3718 = z.DecInferLen(yyl3718, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3718 = make([]Secret, yyrl3718)
-			yyc3718 = true
 
+			yyrg3718 := len(yyv3718) > 0
+			yyv23718 := yyv3718
+			yyrl3718, yyrt3718 = z.DecInferLen(yyl3718, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3718 {
+				if yyrl3718 <= cap(yyv3718) {
+					yyv3718 = yyv3718[:yyrl3718]
+				} else {
+					yyv3718 = make([]Secret, yyrl3718)
+				}
+			} else {
+				yyv3718 = make([]Secret, yyrl3718)
+			}
+			yyc3718 = true
 			yyrr3718 = len(yyv3718)
+			if yyrg3718 {
+				copy(yyv3718, yyv23718)
+			}
 		} else if yyl3718 != len(yyv3718) {
 			yyv3718 = yyv3718[:yyl3718]
 			yyc3718 = true
 		}
 		yyj3718 := 0
 		for ; yyj3718 < yyrr3718; yyj3718++ {
+			yyh3718.ElemContainerState(yyj3718)
 			if r.TryDecodeAsNil() {
 				yyv3718[yyj3718] = Secret{}
 			} else {
@@ -43929,6 +47376,7 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 		if yyrt3718 {
 			for ; yyj3718 < yyl3718; yyj3718++ {
 				yyv3718 = append(yyv3718, Secret{})
+				yyh3718.ElemContainerState(yyj3718)
 				if r.TryDecodeAsNil() {
 					yyv3718[yyj3718] = Secret{}
 				} else {
@@ -43940,12 +47388,14 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3718 := 0; !r.CheckBreak(); yyj3718++ {
+		yyj3718 := 0
+		for ; !r.CheckBreak(); yyj3718++ {
+
 			if yyj3718 >= len(yyv3718) {
 				yyv3718 = append(yyv3718, Secret{}) // var yyz3718 Secret
 				yyc3718 = true
 			}
-
+			yyh3718.ElemContainerState(yyj3718)
 			if yyj3718 < len(yyv3718) {
 				if r.TryDecodeAsNil() {
 					yyv3718[yyj3718] = Secret{}
@@ -43959,12 +47409,18 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3718.End()
+		if yyj3718 < len(yyv3718) {
+			yyv3718 = yyv3718[:yyj3718]
+			yyc3718 = true
+		} else if yyj3718 == 0 && yyv3718 == nil {
+			yyv3718 = []Secret{}
+			yyc3718 = true
+		}
 	}
+	yyh3718.End()
 	if yyc3718 {
 		*v = yyv3718
 	}
-
 }
 
 func (x codecSelfer1234) encSliceComponentCondition(v []ComponentCondition, e *codec1978.Encoder) {
@@ -43973,10 +47429,11 @@ func (x codecSelfer1234) encSliceComponentCondition(v []ComponentCondition, e *c
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3722 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3723 := &yyv3722
 		yy3723.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *codec1978.Decoder) {
@@ -43986,39 +47443,44 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 
 	yyv3724 := *v
 	yyh3724, yyl3724 := z.DecSliceHelperStart()
-
-	var yyrr3724, yyrl3724 int
-	var yyc3724, yyrt3724 bool
-	_, _, _ = yyc3724, yyrt3724, yyrl3724
-	yyrr3724 = yyl3724
-
-	if yyv3724 == nil {
-		if yyrl3724, yyrt3724 = z.DecInferLen(yyl3724, z.DecBasicHandle().MaxInitLen, 64); yyrt3724 {
-			yyrr3724 = yyrl3724
-		}
-		yyv3724 = make([]ComponentCondition, yyrl3724)
-		yyc3724 = true
-	}
-
+	var yyc3724 bool
 	if yyl3724 == 0 {
-		if len(yyv3724) != 0 {
+		if yyv3724 == nil {
+			yyv3724 = []ComponentCondition{}
+			yyc3724 = true
+		} else if len(yyv3724) != 0 {
 			yyv3724 = yyv3724[:0]
 			yyc3724 = true
 		}
 	} else if yyl3724 > 0 {
-
+		var yyrr3724, yyrl3724 int
+		var yyrt3724 bool
 		if yyl3724 > cap(yyv3724) {
-			yyrl3724, yyrt3724 = z.DecInferLen(yyl3724, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3724 = make([]ComponentCondition, yyrl3724)
-			yyc3724 = true
 
+			yyrg3724 := len(yyv3724) > 0
+			yyv23724 := yyv3724
+			yyrl3724, yyrt3724 = z.DecInferLen(yyl3724, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt3724 {
+				if yyrl3724 <= cap(yyv3724) {
+					yyv3724 = yyv3724[:yyrl3724]
+				} else {
+					yyv3724 = make([]ComponentCondition, yyrl3724)
+				}
+			} else {
+				yyv3724 = make([]ComponentCondition, yyrl3724)
+			}
+			yyc3724 = true
 			yyrr3724 = len(yyv3724)
+			if yyrg3724 {
+				copy(yyv3724, yyv23724)
+			}
 		} else if yyl3724 != len(yyv3724) {
 			yyv3724 = yyv3724[:yyl3724]
 			yyc3724 = true
 		}
 		yyj3724 := 0
 		for ; yyj3724 < yyrr3724; yyj3724++ {
+			yyh3724.ElemContainerState(yyj3724)
 			if r.TryDecodeAsNil() {
 				yyv3724[yyj3724] = ComponentCondition{}
 			} else {
@@ -44030,6 +47492,7 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 		if yyrt3724 {
 			for ; yyj3724 < yyl3724; yyj3724++ {
 				yyv3724 = append(yyv3724, ComponentCondition{})
+				yyh3724.ElemContainerState(yyj3724)
 				if r.TryDecodeAsNil() {
 					yyv3724[yyj3724] = ComponentCondition{}
 				} else {
@@ -44041,12 +47504,14 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 		}
 
 	} else {
-		for yyj3724 := 0; !r.CheckBreak(); yyj3724++ {
+		yyj3724 := 0
+		for ; !r.CheckBreak(); yyj3724++ {
+
 			if yyj3724 >= len(yyv3724) {
 				yyv3724 = append(yyv3724, ComponentCondition{}) // var yyz3724 ComponentCondition
 				yyc3724 = true
 			}
-
+			yyh3724.ElemContainerState(yyj3724)
 			if yyj3724 < len(yyv3724) {
 				if r.TryDecodeAsNil() {
 					yyv3724[yyj3724] = ComponentCondition{}
@@ -44060,12 +47525,18 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 			}
 
 		}
-		yyh3724.End()
+		if yyj3724 < len(yyv3724) {
+			yyv3724 = yyv3724[:yyj3724]
+			yyc3724 = true
+		} else if yyj3724 == 0 && yyv3724 == nil {
+			yyv3724 = []ComponentCondition{}
+			yyc3724 = true
+		}
 	}
+	yyh3724.End()
 	if yyc3724 {
 		*v = yyv3724
 	}
-
 }
 
 func (x codecSelfer1234) encSliceComponentStatus(v []ComponentStatus, e *codec1978.Encoder) {
@@ -44074,10 +47545,11 @@ func (x codecSelfer1234) encSliceComponentStatus(v []ComponentStatus, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3728 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3729 := &yyv3728
 		yy3729.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1978.Decoder) {
@@ -44087,39 +47559,44 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 
 	yyv3730 := *v
 	yyh3730, yyl3730 := z.DecSliceHelperStart()
-
-	var yyrr3730, yyrl3730 int
-	var yyc3730, yyrt3730 bool
-	_, _, _ = yyc3730, yyrt3730, yyrl3730
-	yyrr3730 = yyl3730
-
-	if yyv3730 == nil {
-		if yyrl3730, yyrt3730 = z.DecInferLen(yyl3730, z.DecBasicHandle().MaxInitLen, 216); yyrt3730 {
-			yyrr3730 = yyrl3730
-		}
-		yyv3730 = make([]ComponentStatus, yyrl3730)
-		yyc3730 = true
-	}
-
+	var yyc3730 bool
 	if yyl3730 == 0 {
-		if len(yyv3730) != 0 {
+		if yyv3730 == nil {
+			yyv3730 = []ComponentStatus{}
+			yyc3730 = true
+		} else if len(yyv3730) != 0 {
 			yyv3730 = yyv3730[:0]
 			yyc3730 = true
 		}
 	} else if yyl3730 > 0 {
-
+		var yyrr3730, yyrl3730 int
+		var yyrt3730 bool
 		if yyl3730 > cap(yyv3730) {
-			yyrl3730, yyrt3730 = z.DecInferLen(yyl3730, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3730 = make([]ComponentStatus, yyrl3730)
-			yyc3730 = true
 
+			yyrg3730 := len(yyv3730) > 0
+			yyv23730 := yyv3730
+			yyrl3730, yyrt3730 = z.DecInferLen(yyl3730, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3730 {
+				if yyrl3730 <= cap(yyv3730) {
+					yyv3730 = yyv3730[:yyrl3730]
+				} else {
+					yyv3730 = make([]ComponentStatus, yyrl3730)
+				}
+			} else {
+				yyv3730 = make([]ComponentStatus, yyrl3730)
+			}
+			yyc3730 = true
 			yyrr3730 = len(yyv3730)
+			if yyrg3730 {
+				copy(yyv3730, yyv23730)
+			}
 		} else if yyl3730 != len(yyv3730) {
 			yyv3730 = yyv3730[:yyl3730]
 			yyc3730 = true
 		}
 		yyj3730 := 0
 		for ; yyj3730 < yyrr3730; yyj3730++ {
+			yyh3730.ElemContainerState(yyj3730)
 			if r.TryDecodeAsNil() {
 				yyv3730[yyj3730] = ComponentStatus{}
 			} else {
@@ -44131,6 +47608,7 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 		if yyrt3730 {
 			for ; yyj3730 < yyl3730; yyj3730++ {
 				yyv3730 = append(yyv3730, ComponentStatus{})
+				yyh3730.ElemContainerState(yyj3730)
 				if r.TryDecodeAsNil() {
 					yyv3730[yyj3730] = ComponentStatus{}
 				} else {
@@ -44142,12 +47620,14 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 		}
 
 	} else {
-		for yyj3730 := 0; !r.CheckBreak(); yyj3730++ {
+		yyj3730 := 0
+		for ; !r.CheckBreak(); yyj3730++ {
+
 			if yyj3730 >= len(yyv3730) {
 				yyv3730 = append(yyv3730, ComponentStatus{}) // var yyz3730 ComponentStatus
 				yyc3730 = true
 			}
-
+			yyh3730.ElemContainerState(yyj3730)
 			if yyj3730 < len(yyv3730) {
 				if r.TryDecodeAsNil() {
 					yyv3730[yyj3730] = ComponentStatus{}
@@ -44161,10 +47641,16 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 			}
 
 		}
-		yyh3730.End()
+		if yyj3730 < len(yyv3730) {
+			yyv3730 = yyv3730[:yyj3730]
+			yyc3730 = true
+		} else if yyj3730 == 0 && yyv3730 == nil {
+			yyv3730 = []ComponentStatus{}
+			yyc3730 = true
+		}
 	}
+	yyh3730.End()
 	if yyc3730 {
 		*v = yyv3730
 	}
-
 }

--- a/pkg/api/v1/types.generated.go
+++ b/pkg/api/v1/types.generated.go
@@ -37,10 +37,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -51,10 +59,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -98,18 +106,21 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2[9] = x.DeletionGracePeriodSeconds != nil
 			yyq2[10] = len(x.Labels) != 0
 			yyq2[11] = len(x.Annotations) != 0
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(12)
 			} else {
-				var yynn2 int = 0
+				yynn2 = 0
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -122,7 +133,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -132,6 +145,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
@@ -144,7 +158,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("generateName"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
@@ -154,6 +170,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[2] {
 					yym10 := z.EncBinary()
 					_ = yym10
@@ -166,7 +183,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym11 := z.EncBinary()
 					_ = yym11
 					if false {
@@ -176,6 +195,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[3] {
 					yym13 := z.EncBinary()
 					_ = yym13
@@ -188,7 +208,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selfLink"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym14 := z.EncBinary()
 					_ = yym14
 					if false {
@@ -198,6 +220,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[4] {
 					yym16 := z.EncBinary()
 					_ = yym16
@@ -211,7 +234,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("uid"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym17 := z.EncBinary()
 					_ = yym17
 					if false {
@@ -222,6 +247,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[5] {
 					yym19 := z.EncBinary()
 					_ = yym19
@@ -234,7 +260,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym20 := z.EncBinary()
 					_ = yym20
 					if false {
@@ -244,6 +272,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[6] {
 					yym22 := z.EncBinary()
 					_ = yym22
@@ -256,7 +285,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("generation"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym23 := z.EncBinary()
 					_ = yym23
 					if false {
@@ -266,6 +297,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[7] {
 					yy25 := &x.CreationTimestamp
 					yym26 := z.EncBinary()
@@ -284,7 +316,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("creationTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy27 := &x.CreationTimestamp
 					yym28 := z.EncBinary()
 					_ = yym28
@@ -300,6 +334,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[8] {
 					if x.DeletionTimestamp == nil {
 						r.EncodeNil()
@@ -321,7 +356,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("deletionTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DeletionTimestamp == nil {
 						r.EncodeNil()
 					} else {
@@ -340,6 +377,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[9] {
 					if x.DeletionGracePeriodSeconds == nil {
 						r.EncodeNil()
@@ -357,7 +395,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("deletionGracePeriodSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DeletionGracePeriodSeconds == nil {
 						r.EncodeNil()
 					} else {
@@ -372,6 +412,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[10] {
 					if x.Labels == nil {
 						r.EncodeNil()
@@ -388,7 +429,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("labels"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
@@ -402,6 +445,7 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[11] {
 					if x.Annotations == nil {
 						r.EncodeNil()
@@ -418,7 +462,9 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("annotations"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Annotations == nil {
 						r.EncodeNil()
 					} else {
@@ -431,8 +477,10 @@ func (x *ObjectMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -447,17 +495,18 @@ func (x *ObjectMeta) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct44 := r.ContainerType()
+		if yyct44 == codecSelferValueTypeMap1234 {
 			yyl44 := r.ReadMapStart()
 			if yyl44 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl44, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct44 == codecSelferValueTypeArray1234 {
 			yyl44 := r.ReadArrayStart()
 			if yyl44 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl44, d)
 			}
@@ -484,8 +533,10 @@ func (x *ObjectMeta) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys45Slc = r.DecodeBytes(yys45Slc, true, true)
 		yys45 := string(yys45Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys45 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -611,9 +662,7 @@ func (x *ObjectMeta) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys45)
 		} // end switch yys45
 	} // end for yyj45
-	if !yyhl45 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -630,9 +679,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -645,9 +695,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.GenerateName = ""
 	} else {
@@ -660,9 +711,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Namespace = ""
 	} else {
@@ -675,9 +727,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SelfLink = ""
 	} else {
@@ -690,9 +743,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.UID = ""
 	} else {
@@ -705,9 +759,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ResourceVersion = ""
 	} else {
@@ -720,9 +775,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Generation = 0
 	} else {
@@ -735,9 +791,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CreationTimestamp = pkg2_unversioned.Time{}
 	} else {
@@ -761,9 +818,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.DeletionTimestamp != nil {
 			x.DeletionTimestamp = nil
@@ -791,9 +849,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.DeletionGracePeriodSeconds != nil {
 			x.DeletionGracePeriodSeconds = nil
@@ -816,9 +875,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
@@ -837,9 +897,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb63 = r.CheckBreak()
 	}
 	if yyb63 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Annotations = nil
 	} else {
@@ -861,9 +922,10 @@ func (x *ObjectMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb63 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj63-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -899,18 +961,21 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq82[14] = x.VolumeSource.Flocker != nil && x.Flocker != nil
 			yyq82[15] = x.VolumeSource.DownwardAPI != nil && x.DownwardAPI != nil
 			yyq82[16] = x.VolumeSource.FC != nil && x.FC != nil
+			var yynn82 int
 			if yyr82 || yy2arr82 {
 				r.EncodeArrayStart(17)
 			} else {
-				var yynn82 int = 1
+				yynn82 = 1
 				for _, b := range yyq82 {
 					if b {
 						yynn82++
 					}
 				}
 				r.EncodeMapStart(yynn82)
+				yynn82 = 0
 			}
 			if yyr82 || yy2arr82 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym84 := z.EncBinary()
 				_ = yym84
 				if false {
@@ -918,7 +983,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym85 := z.EncBinary()
 				_ = yym85
 				if false {
@@ -936,6 +1003,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn86 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[1] {
 						if x.HostPath == nil {
 							r.EncodeNil()
@@ -948,7 +1016,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn86 {
 						r.EncodeNil()
 					} else {
@@ -970,6 +1040,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn87 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[2] {
 						if x.EmptyDir == nil {
 							r.EncodeNil()
@@ -982,7 +1053,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("emptyDir"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn87 {
 						r.EncodeNil()
 					} else {
@@ -1004,6 +1077,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn88 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[3] {
 						if x.GCEPersistentDisk == nil {
 							r.EncodeNil()
@@ -1016,7 +1090,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn88 {
 						r.EncodeNil()
 					} else {
@@ -1038,6 +1114,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn89 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[4] {
 						if x.AWSElasticBlockStore == nil {
 							r.EncodeNil()
@@ -1050,7 +1127,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn89 {
 						r.EncodeNil()
 					} else {
@@ -1072,6 +1151,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn90 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[5] {
 						if x.GitRepo == nil {
 							r.EncodeNil()
@@ -1084,7 +1164,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gitRepo"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn90 {
 						r.EncodeNil()
 					} else {
@@ -1106,6 +1188,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn91 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[6] {
 						if x.Secret == nil {
 							r.EncodeNil()
@@ -1118,7 +1201,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secret"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn91 {
 						r.EncodeNil()
 					} else {
@@ -1140,6 +1225,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn92 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[7] {
 						if x.NFS == nil {
 							r.EncodeNil()
@@ -1152,7 +1238,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn92 {
 						r.EncodeNil()
 					} else {
@@ -1174,6 +1262,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn93 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[8] {
 						if x.ISCSI == nil {
 							r.EncodeNil()
@@ -1186,7 +1275,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn93 {
 						r.EncodeNil()
 					} else {
@@ -1208,6 +1299,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn94 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[9] {
 						if x.Glusterfs == nil {
 							r.EncodeNil()
@@ -1220,7 +1312,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn94 {
 						r.EncodeNil()
 					} else {
@@ -1242,6 +1336,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn95 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[10] {
 						if x.PersistentVolumeClaim == nil {
 							r.EncodeNil()
@@ -1254,7 +1349,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("persistentVolumeClaim"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn95 {
 						r.EncodeNil()
 					} else {
@@ -1276,6 +1373,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn96 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[11] {
 						if x.RBD == nil {
 							r.EncodeNil()
@@ -1288,7 +1386,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn96 {
 						r.EncodeNil()
 					} else {
@@ -1310,6 +1410,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn97 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[12] {
 						if x.Cinder == nil {
 							r.EncodeNil()
@@ -1322,7 +1423,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn97 {
 						r.EncodeNil()
 					} else {
@@ -1344,6 +1447,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn98 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[13] {
 						if x.CephFS == nil {
 							r.EncodeNil()
@@ -1356,7 +1460,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn98 {
 						r.EncodeNil()
 					} else {
@@ -1378,6 +1484,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn99 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[14] {
 						if x.Flocker == nil {
 							r.EncodeNil()
@@ -1390,7 +1497,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn99 {
 						r.EncodeNil()
 					} else {
@@ -1412,6 +1521,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn100 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[15] {
 						if x.DownwardAPI == nil {
 							r.EncodeNil()
@@ -1424,7 +1534,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[15] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("downwardAPI"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn100 {
 						r.EncodeNil()
 					} else {
@@ -1446,6 +1558,7 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn101 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq82[16] {
 						if x.FC == nil {
 							r.EncodeNil()
@@ -1458,7 +1571,9 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq82[16] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn101 {
 						r.EncodeNil()
 					} else {
@@ -1470,8 +1585,10 @@ func (x *Volume) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep82 {
-				r.EncodeEnd()
+			if yyr82 || yy2arr82 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1486,17 +1603,18 @@ func (x *Volume) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct103 := r.ContainerType()
+		if yyct103 == codecSelferValueTypeMap1234 {
 			yyl103 := r.ReadMapStart()
 			if yyl103 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl103, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct103 == codecSelferValueTypeArray1234 {
 			yyl103 := r.ReadArrayStart()
 			if yyl103 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl103, d)
 			}
@@ -1523,8 +1641,10 @@ func (x *Volume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys104Slc = r.DecodeBytes(yys104Slc, true, true)
 		yys104 := string(yys104Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys104 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -1760,9 +1880,7 @@ func (x *Volume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys104)
 		} // end switch yys104
 	} // end for yyj104
-	if !yyhl104 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -1779,13 +1897,17 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
 		x.Name = string(r.DecodeString())
+	}
+	if x.VolumeSource.HostPath == nil {
+		x.VolumeSource.HostPath = new(HostPathVolumeSource)
 	}
 	yyj122++
 	if yyhl122 {
@@ -1794,9 +1916,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HostPath != nil {
 			x.HostPath = nil
@@ -1807,6 +1930,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.HostPath.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.EmptyDir == nil {
+		x.VolumeSource.EmptyDir = new(EmptyDirVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1814,9 +1940,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.EmptyDir != nil {
 			x.EmptyDir = nil
@@ -1827,6 +1954,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.EmptyDir.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.GCEPersistentDisk == nil {
+		x.VolumeSource.GCEPersistentDisk = new(GCEPersistentDiskVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1834,9 +1964,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GCEPersistentDisk != nil {
 			x.GCEPersistentDisk = nil
@@ -1847,6 +1978,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.GCEPersistentDisk.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.AWSElasticBlockStore == nil {
+		x.VolumeSource.AWSElasticBlockStore = new(AWSElasticBlockStoreVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1854,9 +1988,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.AWSElasticBlockStore != nil {
 			x.AWSElasticBlockStore = nil
@@ -1867,6 +2002,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.AWSElasticBlockStore.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.GitRepo == nil {
+		x.VolumeSource.GitRepo = new(GitRepoVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1874,9 +2012,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GitRepo != nil {
 			x.GitRepo = nil
@@ -1887,6 +2026,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.GitRepo.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.Secret == nil {
+		x.VolumeSource.Secret = new(SecretVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1894,9 +2036,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Secret != nil {
 			x.Secret = nil
@@ -1907,6 +2050,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Secret.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.NFS == nil {
+		x.VolumeSource.NFS = new(NFSVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1914,9 +2060,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.NFS != nil {
 			x.NFS = nil
@@ -1927,6 +2074,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.NFS.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.ISCSI == nil {
+		x.VolumeSource.ISCSI = new(ISCSIVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1934,9 +2084,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ISCSI != nil {
 			x.ISCSI = nil
@@ -1947,6 +2098,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.ISCSI.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.Glusterfs == nil {
+		x.VolumeSource.Glusterfs = new(GlusterfsVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1954,9 +2108,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Glusterfs != nil {
 			x.Glusterfs = nil
@@ -1967,6 +2122,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Glusterfs.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.PersistentVolumeClaim == nil {
+		x.VolumeSource.PersistentVolumeClaim = new(PersistentVolumeClaimVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1974,9 +2132,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.PersistentVolumeClaim != nil {
 			x.PersistentVolumeClaim = nil
@@ -1987,6 +2146,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.PersistentVolumeClaim.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.RBD == nil {
+		x.VolumeSource.RBD = new(RBDVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -1994,9 +2156,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RBD != nil {
 			x.RBD = nil
@@ -2007,6 +2170,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.RBD.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.Cinder == nil {
+		x.VolumeSource.Cinder = new(CinderVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2014,9 +2180,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Cinder != nil {
 			x.Cinder = nil
@@ -2027,6 +2194,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Cinder.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.CephFS == nil {
+		x.VolumeSource.CephFS = new(CephFSVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2034,9 +2204,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CephFS != nil {
 			x.CephFS = nil
@@ -2047,6 +2218,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.CephFS.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.Flocker == nil {
+		x.VolumeSource.Flocker = new(FlockerVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2054,9 +2228,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Flocker != nil {
 			x.Flocker = nil
@@ -2067,6 +2242,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Flocker.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.DownwardAPI == nil {
+		x.VolumeSource.DownwardAPI = new(DownwardAPIVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2074,9 +2252,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.DownwardAPI != nil {
 			x.DownwardAPI = nil
@@ -2087,6 +2266,9 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.DownwardAPI.CodecDecodeSelf(d)
 	}
+	if x.VolumeSource.FC == nil {
+		x.VolumeSource.FC = new(FCVolumeSource)
+	}
 	yyj122++
 	if yyhl122 {
 		yyb122 = yyj122 > l
@@ -2094,9 +2276,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb122 = r.CheckBreak()
 	}
 	if yyb122 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FC != nil {
 			x.FC = nil
@@ -2117,9 +2300,10 @@ func (x *Volume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb122 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj122-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -2155,18 +2339,21 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq141[13] = x.Flocker != nil
 			yyq141[14] = x.DownwardAPI != nil
 			yyq141[15] = x.FC != nil
+			var yynn141 int
 			if yyr141 || yy2arr141 {
 				r.EncodeArrayStart(16)
 			} else {
-				var yynn141 int = 0
+				yynn141 = 0
 				for _, b := range yyq141 {
 					if b {
 						yynn141++
 					}
 				}
 				r.EncodeMapStart(yynn141)
+				yynn141 = 0
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[0] {
 					if x.HostPath == nil {
 						r.EncodeNil()
@@ -2178,7 +2365,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HostPath == nil {
 						r.EncodeNil()
 					} else {
@@ -2187,6 +2376,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[1] {
 					if x.EmptyDir == nil {
 						r.EncodeNil()
@@ -2198,7 +2388,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("emptyDir"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.EmptyDir == nil {
 						r.EncodeNil()
 					} else {
@@ -2207,6 +2399,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[2] {
 					if x.GCEPersistentDisk == nil {
 						r.EncodeNil()
@@ -2218,7 +2411,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.GCEPersistentDisk == nil {
 						r.EncodeNil()
 					} else {
@@ -2227,6 +2422,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[3] {
 					if x.AWSElasticBlockStore == nil {
 						r.EncodeNil()
@@ -2238,7 +2434,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AWSElasticBlockStore == nil {
 						r.EncodeNil()
 					} else {
@@ -2247,6 +2445,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[4] {
 					if x.GitRepo == nil {
 						r.EncodeNil()
@@ -2258,7 +2457,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gitRepo"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.GitRepo == nil {
 						r.EncodeNil()
 					} else {
@@ -2267,6 +2468,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[5] {
 					if x.Secret == nil {
 						r.EncodeNil()
@@ -2278,7 +2480,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secret"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Secret == nil {
 						r.EncodeNil()
 					} else {
@@ -2287,6 +2491,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[6] {
 					if x.NFS == nil {
 						r.EncodeNil()
@@ -2298,7 +2503,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.NFS == nil {
 						r.EncodeNil()
 					} else {
@@ -2307,6 +2514,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[7] {
 					if x.ISCSI == nil {
 						r.EncodeNil()
@@ -2318,7 +2526,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ISCSI == nil {
 						r.EncodeNil()
 					} else {
@@ -2327,6 +2537,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[8] {
 					if x.Glusterfs == nil {
 						r.EncodeNil()
@@ -2338,7 +2549,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Glusterfs == nil {
 						r.EncodeNil()
 					} else {
@@ -2347,6 +2560,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[9] {
 					if x.PersistentVolumeClaim == nil {
 						r.EncodeNil()
@@ -2358,7 +2572,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("persistentVolumeClaim"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.PersistentVolumeClaim == nil {
 						r.EncodeNil()
 					} else {
@@ -2367,6 +2583,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[10] {
 					if x.RBD == nil {
 						r.EncodeNil()
@@ -2378,7 +2595,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RBD == nil {
 						r.EncodeNil()
 					} else {
@@ -2387,6 +2606,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[11] {
 					if x.Cinder == nil {
 						r.EncodeNil()
@@ -2398,7 +2618,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Cinder == nil {
 						r.EncodeNil()
 					} else {
@@ -2407,6 +2629,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[12] {
 					if x.CephFS == nil {
 						r.EncodeNil()
@@ -2418,7 +2641,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CephFS == nil {
 						r.EncodeNil()
 					} else {
@@ -2427,6 +2652,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[13] {
 					if x.Flocker == nil {
 						r.EncodeNil()
@@ -2438,7 +2664,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Flocker == nil {
 						r.EncodeNil()
 					} else {
@@ -2447,6 +2675,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[14] {
 					if x.DownwardAPI == nil {
 						r.EncodeNil()
@@ -2458,7 +2687,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("downwardAPI"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DownwardAPI == nil {
 						r.EncodeNil()
 					} else {
@@ -2467,6 +2698,7 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq141[15] {
 					if x.FC == nil {
 						r.EncodeNil()
@@ -2478,7 +2710,9 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq141[15] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.FC == nil {
 						r.EncodeNil()
 					} else {
@@ -2486,8 +2720,10 @@ func (x *VolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep141 {
-				r.EncodeEnd()
+			if yyr141 || yy2arr141 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -2502,17 +2738,18 @@ func (x *VolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct159 := r.ContainerType()
+		if yyct159 == codecSelferValueTypeMap1234 {
 			yyl159 := r.ReadMapStart()
 			if yyl159 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl159, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct159 == codecSelferValueTypeArray1234 {
 			yyl159 := r.ReadArrayStart()
 			if yyl159 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl159, d)
 			}
@@ -2539,8 +2776,10 @@ func (x *VolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys160Slc = r.DecodeBytes(yys160Slc, true, true)
 		yys160 := string(yys160Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys160 {
 		case "hostPath":
 			if r.TryDecodeAsNil() {
@@ -2722,9 +2961,7 @@ func (x *VolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys160)
 		} // end switch yys160
 	} // end for yyj160
-	if !yyhl160 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -2741,9 +2978,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HostPath != nil {
 			x.HostPath = nil
@@ -2761,9 +2999,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.EmptyDir != nil {
 			x.EmptyDir = nil
@@ -2781,9 +3020,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GCEPersistentDisk != nil {
 			x.GCEPersistentDisk = nil
@@ -2801,9 +3041,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.AWSElasticBlockStore != nil {
 			x.AWSElasticBlockStore = nil
@@ -2821,9 +3062,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GitRepo != nil {
 			x.GitRepo = nil
@@ -2841,9 +3083,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Secret != nil {
 			x.Secret = nil
@@ -2861,9 +3104,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.NFS != nil {
 			x.NFS = nil
@@ -2881,9 +3125,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ISCSI != nil {
 			x.ISCSI = nil
@@ -2901,9 +3146,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Glusterfs != nil {
 			x.Glusterfs = nil
@@ -2921,9 +3167,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.PersistentVolumeClaim != nil {
 			x.PersistentVolumeClaim = nil
@@ -2941,9 +3188,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RBD != nil {
 			x.RBD = nil
@@ -2961,9 +3209,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Cinder != nil {
 			x.Cinder = nil
@@ -2981,9 +3230,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CephFS != nil {
 			x.CephFS = nil
@@ -3001,9 +3251,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Flocker != nil {
 			x.Flocker = nil
@@ -3021,9 +3272,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.DownwardAPI != nil {
 			x.DownwardAPI = nil
@@ -3041,9 +3293,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb177 = r.CheckBreak()
 	}
 	if yyb177 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FC != nil {
 			x.FC = nil
@@ -3064,9 +3317,10 @@ func (x *VolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb177 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj177-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3087,18 +3341,21 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 			_, _, _ = yysep195, yyq195, yy2arr195
 			const yyr195 bool = false
 			yyq195[1] = x.ReadOnly != false
+			var yynn195 int
 			if yyr195 || yy2arr195 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn195 int = 1
+				yynn195 = 1
 				for _, b := range yyq195 {
 					if b {
 						yynn195++
 					}
 				}
 				r.EncodeMapStart(yynn195)
+				yynn195 = 0
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym197 := z.EncBinary()
 				_ = yym197
 				if false {
@@ -3106,7 +3363,9 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 					r.EncodeString(codecSelferC_UTF81234, string(x.ClaimName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("claimName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym198 := z.EncBinary()
 				_ = yym198
 				if false {
@@ -3115,6 +3374,7 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 				}
 			}
 			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq195[1] {
 					yym200 := z.EncBinary()
 					_ = yym200
@@ -3127,7 +3387,9 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 				}
 			} else {
 				if yyq195[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym201 := z.EncBinary()
 					_ = yym201
 					if false {
@@ -3136,8 +3398,10 @@ func (x *PersistentVolumeClaimVolumeSource) CodecEncodeSelf(e *codec1978.Encoder
 					}
 				}
 			}
-			if yysep195 {
-				r.EncodeEnd()
+			if yyr195 || yy2arr195 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3152,17 +3416,18 @@ func (x *PersistentVolumeClaimVolumeSource) CodecDecodeSelf(d *codec1978.Decoder
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct203 := r.ContainerType()
+		if yyct203 == codecSelferValueTypeMap1234 {
 			yyl203 := r.ReadMapStart()
 			if yyl203 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl203, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct203 == codecSelferValueTypeArray1234 {
 			yyl203 := r.ReadArrayStart()
 			if yyl203 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl203, d)
 			}
@@ -3189,8 +3454,10 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromMap(l int, d *cod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys204Slc = r.DecodeBytes(yys204Slc, true, true)
 		yys204 := string(yys204Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys204 {
 		case "claimName":
 			if r.TryDecodeAsNil() {
@@ -3208,9 +3475,7 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromMap(l int, d *cod
 			z.DecStructFieldNotFound(-1, yys204)
 		} // end switch yys204
 	} // end for yyj204
-	if !yyhl204 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3227,9 +3492,10 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromArray(l int, d *c
 		yyb207 = r.CheckBreak()
 	}
 	if yyb207 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ClaimName = ""
 	} else {
@@ -3242,9 +3508,10 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromArray(l int, d *c
 		yyb207 = r.CheckBreak()
 	}
 	if yyb207 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -3260,9 +3527,10 @@ func (x *PersistentVolumeClaimVolumeSource) codecDecodeSelfFromArray(l int, d *c
 		if yyb207 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj207-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3293,18 +3561,21 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq211[8] = x.CephFS != nil
 			yyq211[9] = x.FC != nil
 			yyq211[10] = x.Flocker != nil
+			var yynn211 int
 			if yyr211 || yy2arr211 {
 				r.EncodeArrayStart(11)
 			} else {
-				var yynn211 int = 0
+				yynn211 = 0
 				for _, b := range yyq211 {
 					if b {
 						yynn211++
 					}
 				}
 				r.EncodeMapStart(yynn211)
+				yynn211 = 0
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[0] {
 					if x.GCEPersistentDisk == nil {
 						r.EncodeNil()
@@ -3316,7 +3587,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.GCEPersistentDisk == nil {
 						r.EncodeNil()
 					} else {
@@ -3325,6 +3598,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[1] {
 					if x.AWSElasticBlockStore == nil {
 						r.EncodeNil()
@@ -3336,7 +3610,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AWSElasticBlockStore == nil {
 						r.EncodeNil()
 					} else {
@@ -3345,6 +3621,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[2] {
 					if x.HostPath == nil {
 						r.EncodeNil()
@@ -3356,7 +3633,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HostPath == nil {
 						r.EncodeNil()
 					} else {
@@ -3365,6 +3644,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[3] {
 					if x.Glusterfs == nil {
 						r.EncodeNil()
@@ -3376,7 +3656,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Glusterfs == nil {
 						r.EncodeNil()
 					} else {
@@ -3385,6 +3667,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[4] {
 					if x.NFS == nil {
 						r.EncodeNil()
@@ -3396,7 +3679,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.NFS == nil {
 						r.EncodeNil()
 					} else {
@@ -3405,6 +3690,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[5] {
 					if x.RBD == nil {
 						r.EncodeNil()
@@ -3416,7 +3702,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RBD == nil {
 						r.EncodeNil()
 					} else {
@@ -3425,6 +3713,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[6] {
 					if x.ISCSI == nil {
 						r.EncodeNil()
@@ -3436,7 +3725,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ISCSI == nil {
 						r.EncodeNil()
 					} else {
@@ -3445,6 +3736,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[7] {
 					if x.Cinder == nil {
 						r.EncodeNil()
@@ -3456,7 +3748,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Cinder == nil {
 						r.EncodeNil()
 					} else {
@@ -3465,6 +3759,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[8] {
 					if x.CephFS == nil {
 						r.EncodeNil()
@@ -3476,7 +3771,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CephFS == nil {
 						r.EncodeNil()
 					} else {
@@ -3485,6 +3782,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[9] {
 					if x.FC == nil {
 						r.EncodeNil()
@@ -3496,7 +3794,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.FC == nil {
 						r.EncodeNil()
 					} else {
@@ -3505,6 +3805,7 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq211[10] {
 					if x.Flocker == nil {
 						r.EncodeNil()
@@ -3516,7 +3817,9 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq211[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Flocker == nil {
 						r.EncodeNil()
 					} else {
@@ -3524,8 +3827,10 @@ func (x *PersistentVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep211 {
-				r.EncodeEnd()
+			if yyr211 || yy2arr211 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3540,17 +3845,18 @@ func (x *PersistentVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct224 := r.ContainerType()
+		if yyct224 == codecSelferValueTypeMap1234 {
 			yyl224 := r.ReadMapStart()
 			if yyl224 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl224, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct224 == codecSelferValueTypeArray1234 {
 			yyl224 := r.ReadArrayStart()
 			if yyl224 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl224, d)
 			}
@@ -3577,8 +3883,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys225Slc = r.DecodeBytes(yys225Slc, true, true)
 		yys225 := string(yys225Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys225 {
 		case "gcePersistentDisk":
 			if r.TryDecodeAsNil() {
@@ -3705,9 +4013,7 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys225)
 		} // end switch yys225
 	} // end for yyj225
-	if !yyhl225 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3724,9 +4030,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GCEPersistentDisk != nil {
 			x.GCEPersistentDisk = nil
@@ -3744,9 +4051,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.AWSElasticBlockStore != nil {
 			x.AWSElasticBlockStore = nil
@@ -3764,9 +4072,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HostPath != nil {
 			x.HostPath = nil
@@ -3784,9 +4093,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Glusterfs != nil {
 			x.Glusterfs = nil
@@ -3804,9 +4114,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.NFS != nil {
 			x.NFS = nil
@@ -3824,9 +4135,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RBD != nil {
 			x.RBD = nil
@@ -3844,9 +4156,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ISCSI != nil {
 			x.ISCSI = nil
@@ -3864,9 +4177,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Cinder != nil {
 			x.Cinder = nil
@@ -3884,9 +4198,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CephFS != nil {
 			x.CephFS = nil
@@ -3904,9 +4219,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FC != nil {
 			x.FC = nil
@@ -3924,9 +4240,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb237 = r.CheckBreak()
 	}
 	if yyb237 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Flocker != nil {
 			x.Flocker = nil
@@ -3947,9 +4264,10 @@ func (x *PersistentVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb237 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj237-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3974,18 +4292,21 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq250[2] = true
 			yyq250[3] = true
 			yyq250[4] = true
+			var yynn250 int
 			if yyr250 || yy2arr250 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn250 int = 0
+				yynn250 = 0
 				for _, b := range yyq250 {
 					if b {
 						yynn250++
 					}
 				}
 				r.EncodeMapStart(yynn250)
+				yynn250 = 0
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[0] {
 					yym252 := z.EncBinary()
 					_ = yym252
@@ -3998,7 +4319,9 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym253 := z.EncBinary()
 					_ = yym253
 					if false {
@@ -4008,6 +4331,7 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[1] {
 					yym255 := z.EncBinary()
 					_ = yym255
@@ -4020,7 +4344,9 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym256 := z.EncBinary()
 					_ = yym256
 					if false {
@@ -4030,6 +4356,7 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[2] {
 					yy258 := &x.ObjectMeta
 					yy258.CodecEncodeSelf(e)
@@ -4038,12 +4365,15 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy259 := &x.ObjectMeta
 					yy259.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[3] {
 					yy261 := &x.Spec
 					yy261.CodecEncodeSelf(e)
@@ -4052,12 +4382,15 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy262 := &x.Spec
 					yy262.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[4] {
 					yy264 := &x.Status
 					yy264.CodecEncodeSelf(e)
@@ -4066,13 +4399,17 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq250[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy265 := &x.Status
 					yy265.CodecEncodeSelf(e)
 				}
 			}
-			if yysep250 {
-				r.EncodeEnd()
+			if yyr250 || yy2arr250 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4087,17 +4424,18 @@ func (x *PersistentVolume) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct267 := r.ContainerType()
+		if yyct267 == codecSelferValueTypeMap1234 {
 			yyl267 := r.ReadMapStart()
 			if yyl267 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl267, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct267 == codecSelferValueTypeArray1234 {
 			yyl267 := r.ReadArrayStart()
 			if yyl267 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl267, d)
 			}
@@ -4124,8 +4462,10 @@ func (x *PersistentVolume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys268Slc = r.DecodeBytes(yys268Slc, true, true)
 		yys268 := string(yys268Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys268 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -4164,9 +4504,7 @@ func (x *PersistentVolume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys268)
 		} // end switch yys268
 	} // end for yyj268
-	if !yyhl268 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -4183,9 +4521,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -4198,9 +4537,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -4213,9 +4553,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -4229,9 +4570,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = PersistentVolumeSpec{}
 	} else {
@@ -4245,9 +4587,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb274 = r.CheckBreak()
 	}
 	if yyb274 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = PersistentVolumeStatus{}
 	} else {
@@ -4264,9 +4607,10 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if yyb274 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj274-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -4301,18 +4645,21 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq281[12] = len(x.AccessModes) != 0
 			yyq281[13] = x.ClaimRef != nil
 			yyq281[14] = x.PersistentVolumeReclaimPolicy != ""
+			var yynn281 int
 			if yyr281 || yy2arr281 {
 				r.EncodeArrayStart(15)
 			} else {
-				var yynn281 int = 0
+				yynn281 = 0
 				for _, b := range yyq281 {
 					if b {
 						yynn281++
 					}
 				}
 				r.EncodeMapStart(yynn281)
+				yynn281 = 0
 			}
 			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq281[0] {
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -4324,7 +4671,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -4342,6 +4691,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn283 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[1] {
 						if x.GCEPersistentDisk == nil {
 							r.EncodeNil()
@@ -4354,7 +4704,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn283 {
 						r.EncodeNil()
 					} else {
@@ -4376,6 +4728,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn284 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[2] {
 						if x.AWSElasticBlockStore == nil {
 							r.EncodeNil()
@@ -4388,7 +4741,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn284 {
 						r.EncodeNil()
 					} else {
@@ -4410,6 +4765,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn285 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[3] {
 						if x.HostPath == nil {
 							r.EncodeNil()
@@ -4422,7 +4778,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn285 {
 						r.EncodeNil()
 					} else {
@@ -4444,6 +4802,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn286 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[4] {
 						if x.Glusterfs == nil {
 							r.EncodeNil()
@@ -4456,7 +4815,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn286 {
 						r.EncodeNil()
 					} else {
@@ -4478,6 +4839,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn287 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[5] {
 						if x.NFS == nil {
 							r.EncodeNil()
@@ -4490,7 +4852,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn287 {
 						r.EncodeNil()
 					} else {
@@ -4512,6 +4876,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn288 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[6] {
 						if x.RBD == nil {
 							r.EncodeNil()
@@ -4524,7 +4889,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn288 {
 						r.EncodeNil()
 					} else {
@@ -4546,6 +4913,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn289 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[7] {
 						if x.ISCSI == nil {
 							r.EncodeNil()
@@ -4558,7 +4926,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn289 {
 						r.EncodeNil()
 					} else {
@@ -4580,6 +4950,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn290 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[8] {
 						if x.Cinder == nil {
 							r.EncodeNil()
@@ -4592,7 +4963,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn290 {
 						r.EncodeNil()
 					} else {
@@ -4614,6 +4987,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn291 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[9] {
 						if x.CephFS == nil {
 							r.EncodeNil()
@@ -4626,7 +5000,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn291 {
 						r.EncodeNil()
 					} else {
@@ -4648,6 +5024,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn292 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[10] {
 						if x.FC == nil {
 							r.EncodeNil()
@@ -4660,7 +5037,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn292 {
 						r.EncodeNil()
 					} else {
@@ -4682,6 +5061,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn293 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq281[11] {
 						if x.Flocker == nil {
 							r.EncodeNil()
@@ -4694,7 +5074,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn293 {
 						r.EncodeNil()
 					} else {
@@ -4707,6 +5089,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq281[12] {
 					if x.AccessModes == nil {
 						r.EncodeNil()
@@ -4723,7 +5106,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("accessModes"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
@@ -4737,6 +5122,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq281[13] {
 					if x.ClaimRef == nil {
 						r.EncodeNil()
@@ -4748,7 +5134,9 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("claimRef"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ClaimRef == nil {
 						r.EncodeNil()
 					} else {
@@ -4757,6 +5145,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq281[14] {
 					x.PersistentVolumeReclaimPolicy.CodecEncodeSelf(e)
 				} else {
@@ -4764,12 +5153,16 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq281[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("persistentVolumeReclaimPolicy"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.PersistentVolumeReclaimPolicy.CodecEncodeSelf(e)
 				}
 			}
-			if yysep281 {
-				r.EncodeEnd()
+			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4784,17 +5177,18 @@ func (x *PersistentVolumeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct300 := r.ContainerType()
+		if yyct300 == codecSelferValueTypeMap1234 {
 			yyl300 := r.ReadMapStart()
 			if yyl300 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl300, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct300 == codecSelferValueTypeArray1234 {
 			yyl300 := r.ReadArrayStart()
 			if yyl300 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl300, d)
 			}
@@ -4821,8 +5215,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys301Slc = r.DecodeBytes(yys301Slc, true, true)
 		yys301 := string(yys301Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys301 {
 		case "capacity":
 			if r.TryDecodeAsNil() {
@@ -5018,9 +5414,7 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys301)
 		} // end switch yys301
 	} // end for yyj301
-	if !yyhl301 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5037,14 +5431,18 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
 		yyv319 := &x.Capacity
 		yyv319.CodecDecodeSelf(d)
+	}
+	if x.PersistentVolumeSource.GCEPersistentDisk == nil {
+		x.PersistentVolumeSource.GCEPersistentDisk = new(GCEPersistentDiskVolumeSource)
 	}
 	yyj318++
 	if yyhl318 {
@@ -5053,9 +5451,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GCEPersistentDisk != nil {
 			x.GCEPersistentDisk = nil
@@ -5066,6 +5465,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.GCEPersistentDisk.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.AWSElasticBlockStore == nil {
+		x.PersistentVolumeSource.AWSElasticBlockStore = new(AWSElasticBlockStoreVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5073,9 +5475,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.AWSElasticBlockStore != nil {
 			x.AWSElasticBlockStore = nil
@@ -5086,6 +5489,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.AWSElasticBlockStore.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.HostPath == nil {
+		x.PersistentVolumeSource.HostPath = new(HostPathVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5093,9 +5499,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HostPath != nil {
 			x.HostPath = nil
@@ -5106,6 +5513,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.HostPath.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.Glusterfs == nil {
+		x.PersistentVolumeSource.Glusterfs = new(GlusterfsVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5113,9 +5523,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Glusterfs != nil {
 			x.Glusterfs = nil
@@ -5126,6 +5537,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.Glusterfs.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.NFS == nil {
+		x.PersistentVolumeSource.NFS = new(NFSVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5133,9 +5547,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.NFS != nil {
 			x.NFS = nil
@@ -5146,6 +5561,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.NFS.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.RBD == nil {
+		x.PersistentVolumeSource.RBD = new(RBDVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5153,9 +5571,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RBD != nil {
 			x.RBD = nil
@@ -5166,6 +5585,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.RBD.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.ISCSI == nil {
+		x.PersistentVolumeSource.ISCSI = new(ISCSIVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5173,9 +5595,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ISCSI != nil {
 			x.ISCSI = nil
@@ -5186,6 +5609,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.ISCSI.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.Cinder == nil {
+		x.PersistentVolumeSource.Cinder = new(CinderVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5193,9 +5619,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Cinder != nil {
 			x.Cinder = nil
@@ -5206,6 +5633,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.Cinder.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.CephFS == nil {
+		x.PersistentVolumeSource.CephFS = new(CephFSVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5213,9 +5643,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CephFS != nil {
 			x.CephFS = nil
@@ -5226,6 +5657,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.CephFS.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.FC == nil {
+		x.PersistentVolumeSource.FC = new(FCVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5233,9 +5667,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FC != nil {
 			x.FC = nil
@@ -5246,6 +5681,9 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		}
 		x.FC.CodecDecodeSelf(d)
 	}
+	if x.PersistentVolumeSource.Flocker == nil {
+		x.PersistentVolumeSource.Flocker = new(FlockerVolumeSource)
+	}
 	yyj318++
 	if yyhl318 {
 		yyb318 = yyj318 > l
@@ -5253,9 +5691,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Flocker != nil {
 			x.Flocker = nil
@@ -5273,9 +5712,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.AccessModes = nil
 	} else {
@@ -5294,9 +5734,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ClaimRef != nil {
 			x.ClaimRef = nil
@@ -5314,9 +5755,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb318 = r.CheckBreak()
 	}
 	if yyb318 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PersistentVolumeReclaimPolicy = ""
 	} else {
@@ -5332,9 +5774,10 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb318 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj318-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PersistentVolumeReclaimPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5383,18 +5826,21 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq338[0] = x.Phase != ""
 			yyq338[1] = x.Message != ""
 			yyq338[2] = x.Reason != ""
+			var yynn338 int
 			if yyr338 || yy2arr338 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn338 int = 0
+				yynn338 = 0
 				for _, b := range yyq338 {
 					if b {
 						yynn338++
 					}
 				}
 				r.EncodeMapStart(yynn338)
+				yynn338 = 0
 			}
 			if yyr338 || yy2arr338 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq338[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -5402,11 +5848,14 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq338[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
 			if yyr338 || yy2arr338 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq338[1] {
 					yym341 := z.EncBinary()
 					_ = yym341
@@ -5419,7 +5868,9 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq338[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym342 := z.EncBinary()
 					_ = yym342
 					if false {
@@ -5429,6 +5880,7 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr338 || yy2arr338 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq338[2] {
 					yym344 := z.EncBinary()
 					_ = yym344
@@ -5441,7 +5893,9 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq338[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym345 := z.EncBinary()
 					_ = yym345
 					if false {
@@ -5450,8 +5904,10 @@ func (x *PersistentVolumeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep338 {
-				r.EncodeEnd()
+			if yyr338 || yy2arr338 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5466,17 +5922,18 @@ func (x *PersistentVolumeStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct347 := r.ContainerType()
+		if yyct347 == codecSelferValueTypeMap1234 {
 			yyl347 := r.ReadMapStart()
 			if yyl347 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl347, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct347 == codecSelferValueTypeArray1234 {
 			yyl347 := r.ReadArrayStart()
 			if yyl347 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl347, d)
 			}
@@ -5503,8 +5960,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys348Slc = r.DecodeBytes(yys348Slc, true, true)
 		yys348 := string(yys348Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys348 {
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -5528,9 +5987,7 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys348)
 		} // end switch yys348
 	} // end for yyj348
-	if !yyhl348 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5547,9 +6004,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb352 = r.CheckBreak()
 	}
 	if yyb352 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -5562,9 +6020,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb352 = r.CheckBreak()
 	}
 	if yyb352 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -5577,9 +6036,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb352 = r.CheckBreak()
 	}
 	if yyb352 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -5595,9 +6055,10 @@ func (x *PersistentVolumeStatus) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb352 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj352-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5620,18 +6081,21 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq357[0] = x.Kind != ""
 			yyq357[1] = x.APIVersion != ""
 			yyq357[2] = true
+			var yynn357 int
 			if yyr357 || yy2arr357 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn357 int = 1
+				yynn357 = 1
 				for _, b := range yyq357 {
 					if b {
 						yynn357++
 					}
 				}
 				r.EncodeMapStart(yynn357)
+				yynn357 = 0
 			}
 			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq357[0] {
 					yym359 := z.EncBinary()
 					_ = yym359
@@ -5644,7 +6108,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq357[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym360 := z.EncBinary()
 					_ = yym360
 					if false {
@@ -5654,6 +6120,7 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq357[1] {
 					yym362 := z.EncBinary()
 					_ = yym362
@@ -5666,7 +6133,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq357[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym363 := z.EncBinary()
 					_ = yym363
 					if false {
@@ -5676,6 +6145,7 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq357[2] {
 					yy365 := &x.ListMeta
 					yym366 := z.EncBinary()
@@ -5690,7 +6160,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq357[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy367 := &x.ListMeta
 					yym368 := z.EncBinary()
 					_ = yym368
@@ -5702,6 +6174,7 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -5713,7 +6186,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -5725,8 +6200,10 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep357 {
-				r.EncodeEnd()
+			if yyr357 || yy2arr357 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5741,17 +6218,18 @@ func (x *PersistentVolumeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct373 := r.ContainerType()
+		if yyct373 == codecSelferValueTypeMap1234 {
 			yyl373 := r.ReadMapStart()
 			if yyl373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl373, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct373 == codecSelferValueTypeArray1234 {
 			yyl373 := r.ReadArrayStart()
 			if yyl373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl373, d)
 			}
@@ -5778,8 +6256,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys374Slc = r.DecodeBytes(yys374Slc, true, true)
 		yys374 := string(yys374Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys374 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -5822,9 +6302,7 @@ func (x *PersistentVolumeList) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys374)
 		} // end switch yys374
 	} // end for yyj374
-	if !yyhl374 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5841,9 +6319,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb381 = r.CheckBreak()
 	}
 	if yyb381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -5856,9 +6335,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb381 = r.CheckBreak()
 	}
 	if yyb381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -5871,9 +6351,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb381 = r.CheckBreak()
 	}
 	if yyb381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -5893,9 +6374,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb381 = r.CheckBreak()
 	}
 	if yyb381 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -5917,9 +6399,10 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb381 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj381-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5944,18 +6427,21 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq389[2] = true
 			yyq389[3] = true
 			yyq389[4] = true
+			var yynn389 int
 			if yyr389 || yy2arr389 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn389 int = 0
+				yynn389 = 0
 				for _, b := range yyq389 {
 					if b {
 						yynn389++
 					}
 				}
 				r.EncodeMapStart(yynn389)
+				yynn389 = 0
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[0] {
 					yym391 := z.EncBinary()
 					_ = yym391
@@ -5968,7 +6454,9 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym392 := z.EncBinary()
 					_ = yym392
 					if false {
@@ -5978,6 +6466,7 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[1] {
 					yym394 := z.EncBinary()
 					_ = yym394
@@ -5990,7 +6479,9 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym395 := z.EncBinary()
 					_ = yym395
 					if false {
@@ -6000,6 +6491,7 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[2] {
 					yy397 := &x.ObjectMeta
 					yy397.CodecEncodeSelf(e)
@@ -6008,12 +6500,15 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy398 := &x.ObjectMeta
 					yy398.CodecEncodeSelf(e)
 				}
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[3] {
 					yy400 := &x.Spec
 					yy400.CodecEncodeSelf(e)
@@ -6022,12 +6517,15 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy401 := &x.Spec
 					yy401.CodecEncodeSelf(e)
 				}
 			}
 			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq389[4] {
 					yy403 := &x.Status
 					yy403.CodecEncodeSelf(e)
@@ -6036,13 +6534,17 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq389[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy404 := &x.Status
 					yy404.CodecEncodeSelf(e)
 				}
 			}
-			if yysep389 {
-				r.EncodeEnd()
+			if yyr389 || yy2arr389 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6057,17 +6559,18 @@ func (x *PersistentVolumeClaim) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct406 := r.ContainerType()
+		if yyct406 == codecSelferValueTypeMap1234 {
 			yyl406 := r.ReadMapStart()
 			if yyl406 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl406, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct406 == codecSelferValueTypeArray1234 {
 			yyl406 := r.ReadArrayStart()
 			if yyl406 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl406, d)
 			}
@@ -6094,8 +6597,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys407Slc = r.DecodeBytes(yys407Slc, true, true)
 		yys407 := string(yys407Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys407 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -6134,9 +6639,7 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys407)
 		} // end switch yys407
 	} // end for yyj407
-	if !yyhl407 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6153,9 +6656,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -6168,9 +6672,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -6183,9 +6688,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -6199,9 +6705,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = PersistentVolumeClaimSpec{}
 	} else {
@@ -6215,9 +6722,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb413 = r.CheckBreak()
 	}
 	if yyb413 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = PersistentVolumeClaimStatus{}
 	} else {
@@ -6234,9 +6742,10 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb413 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj413-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6259,18 +6768,21 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq420[0] = x.Kind != ""
 			yyq420[1] = x.APIVersion != ""
 			yyq420[2] = true
+			var yynn420 int
 			if yyr420 || yy2arr420 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn420 int = 1
+				yynn420 = 1
 				for _, b := range yyq420 {
 					if b {
 						yynn420++
 					}
 				}
 				r.EncodeMapStart(yynn420)
+				yynn420 = 0
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq420[0] {
 					yym422 := z.EncBinary()
 					_ = yym422
@@ -6283,7 +6795,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq420[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym423 := z.EncBinary()
 					_ = yym423
 					if false {
@@ -6293,6 +6807,7 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq420[1] {
 					yym425 := z.EncBinary()
 					_ = yym425
@@ -6305,7 +6820,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq420[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym426 := z.EncBinary()
 					_ = yym426
 					if false {
@@ -6315,6 +6832,7 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq420[2] {
 					yy428 := &x.ListMeta
 					yym429 := z.EncBinary()
@@ -6329,7 +6847,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq420[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy430 := &x.ListMeta
 					yym431 := z.EncBinary()
 					_ = yym431
@@ -6341,6 +6861,7 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6352,7 +6873,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6364,8 +6887,10 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep420 {
-				r.EncodeEnd()
+			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6380,17 +6905,18 @@ func (x *PersistentVolumeClaimList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct436 := r.ContainerType()
+		if yyct436 == codecSelferValueTypeMap1234 {
 			yyl436 := r.ReadMapStart()
 			if yyl436 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl436, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct436 == codecSelferValueTypeArray1234 {
 			yyl436 := r.ReadArrayStart()
 			if yyl436 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl436, d)
 			}
@@ -6417,8 +6943,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys437Slc = r.DecodeBytes(yys437Slc, true, true)
 		yys437 := string(yys437Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys437 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -6461,9 +6989,7 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromMap(l int, d *codec1978.D
 			z.DecStructFieldNotFound(-1, yys437)
 		} // end switch yys437
 	} // end for yyj437
-	if !yyhl437 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6480,9 +7006,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb444 = r.CheckBreak()
 	}
 	if yyb444 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -6495,9 +7022,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb444 = r.CheckBreak()
 	}
 	if yyb444 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -6510,9 +7038,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb444 = r.CheckBreak()
 	}
 	if yyb444 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -6532,9 +7061,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb444 = r.CheckBreak()
 	}
 	if yyb444 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -6556,9 +7086,10 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		if yyb444 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj444-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6581,18 +7112,21 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq452[0] = len(x.AccessModes) != 0
 			yyq452[1] = true
 			yyq452[2] = x.VolumeName != ""
+			var yynn452 int
 			if yyr452 || yy2arr452 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn452 int = 0
+				yynn452 = 0
 				for _, b := range yyq452 {
 					if b {
 						yynn452++
 					}
 				}
 				r.EncodeMapStart(yynn452)
+				yynn452 = 0
 			}
 			if yyr452 || yy2arr452 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq452[0] {
 					if x.AccessModes == nil {
 						r.EncodeNil()
@@ -6609,7 +7143,9 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq452[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("accessModes"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
@@ -6623,6 +7159,7 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr452 || yy2arr452 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq452[1] {
 					yy457 := &x.Resources
 					yy457.CodecEncodeSelf(e)
@@ -6631,12 +7168,15 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq452[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resources"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy458 := &x.Resources
 					yy458.CodecEncodeSelf(e)
 				}
 			}
 			if yyr452 || yy2arr452 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq452[2] {
 					yym460 := z.EncBinary()
 					_ = yym460
@@ -6649,7 +7189,9 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq452[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("volumeName"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym461 := z.EncBinary()
 					_ = yym461
 					if false {
@@ -6658,8 +7200,10 @@ func (x *PersistentVolumeClaimSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep452 {
-				r.EncodeEnd()
+			if yyr452 || yy2arr452 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6674,17 +7218,18 @@ func (x *PersistentVolumeClaimSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct463 := r.ContainerType()
+		if yyct463 == codecSelferValueTypeMap1234 {
 			yyl463 := r.ReadMapStart()
 			if yyl463 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl463, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct463 == codecSelferValueTypeArray1234 {
 			yyl463 := r.ReadArrayStart()
 			if yyl463 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl463, d)
 			}
@@ -6711,8 +7256,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys464Slc = r.DecodeBytes(yys464Slc, true, true)
 		yys464 := string(yys464Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys464 {
 		case "accessModes":
 			if r.TryDecodeAsNil() {
@@ -6743,9 +7290,7 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 			z.DecStructFieldNotFound(-1, yys464)
 		} // end switch yys464
 	} // end for yyj464
-	if !yyhl464 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6762,9 +7307,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb469 = r.CheckBreak()
 	}
 	if yyb469 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.AccessModes = nil
 	} else {
@@ -6783,9 +7329,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb469 = r.CheckBreak()
 	}
 	if yyb469 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Resources = ResourceRequirements{}
 	} else {
@@ -6799,9 +7346,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb469 = r.CheckBreak()
 	}
 	if yyb469 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.VolumeName = ""
 	} else {
@@ -6817,9 +7365,10 @@ func (x *PersistentVolumeClaimSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		if yyb469 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj469-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6842,18 +7391,21 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq475[0] = x.Phase != ""
 			yyq475[1] = len(x.AccessModes) != 0
 			yyq475[2] = len(x.Capacity) != 0
+			var yynn475 int
 			if yyr475 || yy2arr475 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn475 int = 0
+				yynn475 = 0
 				for _, b := range yyq475 {
 					if b {
 						yynn475++
 					}
 				}
 				r.EncodeMapStart(yynn475)
+				yynn475 = 0
 			}
 			if yyr475 || yy2arr475 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq475[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -6861,11 +7413,14 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq475[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
 			if yyr475 || yy2arr475 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq475[1] {
 					if x.AccessModes == nil {
 						r.EncodeNil()
@@ -6882,7 +7437,9 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq475[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("accessModes"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
@@ -6896,6 +7453,7 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr475 || yy2arr475 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq475[2] {
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -6907,7 +7465,9 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq475[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -6915,8 +7475,10 @@ func (x *PersistentVolumeClaimStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep475 {
-				r.EncodeEnd()
+			if yyr475 || yy2arr475 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6931,17 +7493,18 @@ func (x *PersistentVolumeClaimStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct482 := r.ContainerType()
+		if yyct482 == codecSelferValueTypeMap1234 {
 			yyl482 := r.ReadMapStart()
 			if yyl482 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl482, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct482 == codecSelferValueTypeArray1234 {
 			yyl482 := r.ReadArrayStart()
 			if yyl482 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl482, d)
 			}
@@ -6968,8 +7531,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys483Slc = r.DecodeBytes(yys483Slc, true, true)
 		yys483 := string(yys483Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys483 {
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -7000,9 +7565,7 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromMap(l int, d *codec1978
 			z.DecStructFieldNotFound(-1, yys483)
 		} // end switch yys483
 	} // end for yyj483
-	if !yyhl483 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7019,9 +7582,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb488 = r.CheckBreak()
 	}
 	if yyb488 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -7034,9 +7598,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb488 = r.CheckBreak()
 	}
 	if yyb488 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.AccessModes = nil
 	} else {
@@ -7055,9 +7620,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb488 = r.CheckBreak()
 	}
 	if yyb488 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
@@ -7074,9 +7640,10 @@ func (x *PersistentVolumeClaimStatus) codecDecodeSelfFromArray(l int, d *codec19
 		if yyb488 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj488-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PersistentVolumeAccessMode) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7174,18 +7741,21 @@ func (x *HostPathVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq500 [1]bool
 			_, _, _ = yysep500, yyq500, yy2arr500
 			const yyr500 bool = false
+			var yynn500 int
 			if yyr500 || yy2arr500 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn500 int = 1
+				yynn500 = 1
 				for _, b := range yyq500 {
 					if b {
 						yynn500++
 					}
 				}
 				r.EncodeMapStart(yynn500)
+				yynn500 = 0
 			}
 			if yyr500 || yy2arr500 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym502 := z.EncBinary()
 				_ = yym502
 				if false {
@@ -7193,7 +7763,9 @@ func (x *HostPathVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym503 := z.EncBinary()
 				_ = yym503
 				if false {
@@ -7201,8 +7773,10 @@ func (x *HostPathVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yysep500 {
-				r.EncodeEnd()
+			if yyr500 || yy2arr500 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7217,17 +7791,18 @@ func (x *HostPathVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct505 := r.ContainerType()
+		if yyct505 == codecSelferValueTypeMap1234 {
 			yyl505 := r.ReadMapStart()
 			if yyl505 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl505, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct505 == codecSelferValueTypeArray1234 {
 			yyl505 := r.ReadArrayStart()
 			if yyl505 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl505, d)
 			}
@@ -7254,8 +7829,10 @@ func (x *HostPathVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys506Slc = r.DecodeBytes(yys506Slc, true, true)
 		yys506 := string(yys506Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys506 {
 		case "path":
 			if r.TryDecodeAsNil() {
@@ -7267,9 +7844,7 @@ func (x *HostPathVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys506)
 		} // end switch yys506
 	} // end for yyj506
-	if !yyhl506 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HostPathVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7286,9 +7861,10 @@ func (x *HostPathVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb508 = r.CheckBreak()
 	}
 	if yyb508 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -7304,9 +7880,10 @@ func (x *HostPathVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb508 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj508-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EmptyDirVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7327,18 +7904,21 @@ func (x *EmptyDirVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep511, yyq511, yy2arr511
 			const yyr511 bool = false
 			yyq511[0] = x.Medium != ""
+			var yynn511 int
 			if yyr511 || yy2arr511 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn511 int = 0
+				yynn511 = 0
 				for _, b := range yyq511 {
 					if b {
 						yynn511++
 					}
 				}
 				r.EncodeMapStart(yynn511)
+				yynn511 = 0
 			}
 			if yyr511 || yy2arr511 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq511[0] {
 					x.Medium.CodecEncodeSelf(e)
 				} else {
@@ -7346,12 +7926,16 @@ func (x *EmptyDirVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq511[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("medium"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Medium.CodecEncodeSelf(e)
 				}
 			}
-			if yysep511 {
-				r.EncodeEnd()
+			if yyr511 || yy2arr511 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7366,17 +7950,18 @@ func (x *EmptyDirVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct514 := r.ContainerType()
+		if yyct514 == codecSelferValueTypeMap1234 {
 			yyl514 := r.ReadMapStart()
 			if yyl514 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl514, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct514 == codecSelferValueTypeArray1234 {
 			yyl514 := r.ReadArrayStart()
 			if yyl514 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl514, d)
 			}
@@ -7403,8 +7988,10 @@ func (x *EmptyDirVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys515Slc = r.DecodeBytes(yys515Slc, true, true)
 		yys515 := string(yys515Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys515 {
 		case "medium":
 			if r.TryDecodeAsNil() {
@@ -7416,9 +8003,7 @@ func (x *EmptyDirVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys515)
 		} // end switch yys515
 	} // end for yyj515
-	if !yyhl515 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EmptyDirVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7435,9 +8020,10 @@ func (x *EmptyDirVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb517 = r.CheckBreak()
 	}
 	if yyb517 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Medium = ""
 	} else {
@@ -7453,9 +8039,10 @@ func (x *EmptyDirVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb517 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj517-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7476,18 +8063,21 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep520, yyq520, yy2arr520
 			const yyr520 bool = false
 			yyq520[2] = x.ReadOnly != false
+			var yynn520 int
 			if yyr520 || yy2arr520 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn520 int = 2
+				yynn520 = 2
 				for _, b := range yyq520 {
 					if b {
 						yynn520++
 					}
 				}
 				r.EncodeMapStart(yynn520)
+				yynn520 = 0
 			}
 			if yyr520 || yy2arr520 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym522 := z.EncBinary()
 				_ = yym522
 				if false {
@@ -7495,7 +8085,9 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.EndpointsName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("endpoints"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym523 := z.EncBinary()
 				_ = yym523
 				if false {
@@ -7504,6 +8096,7 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr520 || yy2arr520 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym525 := z.EncBinary()
 				_ = yym525
 				if false {
@@ -7511,7 +8104,9 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym526 := z.EncBinary()
 				_ = yym526
 				if false {
@@ -7520,6 +8115,7 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr520 || yy2arr520 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq520[2] {
 					yym528 := z.EncBinary()
 					_ = yym528
@@ -7532,7 +8128,9 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq520[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym529 := z.EncBinary()
 					_ = yym529
 					if false {
@@ -7541,8 +8139,10 @@ func (x *GlusterfsVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep520 {
-				r.EncodeEnd()
+			if yyr520 || yy2arr520 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7557,17 +8157,18 @@ func (x *GlusterfsVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct531 := r.ContainerType()
+		if yyct531 == codecSelferValueTypeMap1234 {
 			yyl531 := r.ReadMapStart()
 			if yyl531 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl531, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct531 == codecSelferValueTypeArray1234 {
 			yyl531 := r.ReadArrayStart()
 			if yyl531 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl531, d)
 			}
@@ -7594,8 +8195,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys532Slc = r.DecodeBytes(yys532Slc, true, true)
 		yys532 := string(yys532Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys532 {
 		case "endpoints":
 			if r.TryDecodeAsNil() {
@@ -7619,9 +8222,7 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys532)
 		} // end switch yys532
 	} // end for yyj532
-	if !yyhl532 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7638,9 +8239,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb536 = r.CheckBreak()
 	}
 	if yyb536 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.EndpointsName = ""
 	} else {
@@ -7653,9 +8255,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb536 = r.CheckBreak()
 	}
 	if yyb536 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -7668,9 +8271,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb536 = r.CheckBreak()
 	}
 	if yyb536 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -7686,9 +8290,10 @@ func (x *GlusterfsVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb536 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj536-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x StorageMedium) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7736,18 +8341,21 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr543 bool = false
 			yyq543[2] = x.FSType != ""
 			yyq543[7] = x.ReadOnly != false
+			var yynn543 int
 			if yyr543 || yy2arr543 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn543 int = 6
+				yynn543 = 6
 				for _, b := range yyq543 {
 					if b {
 						yynn543++
 					}
 				}
 				r.EncodeMapStart(yynn543)
+				yynn543 = 0
 			}
 			if yyr543 || yy2arr543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.CephMonitors == nil {
 					r.EncodeNil()
 				} else {
@@ -7759,7 +8367,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("monitors"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.CephMonitors == nil {
 					r.EncodeNil()
 				} else {
@@ -7772,6 +8382,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr543 || yy2arr543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym548 := z.EncBinary()
 				_ = yym548
 				if false {
@@ -7779,7 +8390,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RBDImage))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("image"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym549 := z.EncBinary()
 				_ = yym549
 				if false {
@@ -7788,6 +8401,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr543 || yy2arr543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq543[2] {
 					yym551 := z.EncBinary()
 					_ = yym551
@@ -7800,7 +8414,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq543[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym552 := z.EncBinary()
 					_ = yym552
 					if false {
@@ -7810,6 +8426,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr543 || yy2arr543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym554 := z.EncBinary()
 				_ = yym554
 				if false {
@@ -7817,7 +8434,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RBDPool))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("pool"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym555 := z.EncBinary()
 				_ = yym555
 				if false {
@@ -7826,6 +8445,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr543 || yy2arr543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym557 := z.EncBinary()
 				_ = yym557
 				if false {
@@ -7833,7 +8453,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.RadosUser))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("user"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym558 := z.EncBinary()
 				_ = yym558
 				if false {
@@ -7842,6 +8464,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr543 || yy2arr543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym560 := z.EncBinary()
 				_ = yym560
 				if false {
@@ -7849,7 +8472,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Keyring))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("keyring"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym561 := z.EncBinary()
 				_ = yym561
 				if false {
@@ -7858,13 +8483,16 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr543 || yy2arr543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.SecretRef == nil {
 					r.EncodeNil()
 				} else {
 					x.SecretRef.CodecEncodeSelf(e)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.SecretRef == nil {
 					r.EncodeNil()
 				} else {
@@ -7872,6 +8500,7 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr543 || yy2arr543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq543[7] {
 					yym564 := z.EncBinary()
 					_ = yym564
@@ -7884,7 +8513,9 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq543[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym565 := z.EncBinary()
 					_ = yym565
 					if false {
@@ -7893,8 +8524,10 @@ func (x *RBDVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep543 {
-				r.EncodeEnd()
+			if yyr543 || yy2arr543 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7909,17 +8542,18 @@ func (x *RBDVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct567 := r.ContainerType()
+		if yyct567 == codecSelferValueTypeMap1234 {
 			yyl567 := r.ReadMapStart()
 			if yyl567 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl567, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct567 == codecSelferValueTypeArray1234 {
 			yyl567 := r.ReadArrayStart()
 			if yyl567 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl567, d)
 			}
@@ -7946,8 +8580,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys568Slc = r.DecodeBytes(yys568Slc, true, true)
 		yys568 := string(yys568Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys568 {
 		case "monitors":
 			if r.TryDecodeAsNil() {
@@ -8012,9 +8648,7 @@ func (x *RBDVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys568)
 		} // end switch yys568
 	} // end for yyj568
-	if !yyhl568 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8031,9 +8665,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb578 = r.CheckBreak()
 	}
 	if yyb578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CephMonitors = nil
 	} else {
@@ -8052,9 +8687,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb578 = r.CheckBreak()
 	}
 	if yyb578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RBDImage = ""
 	} else {
@@ -8067,9 +8703,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb578 = r.CheckBreak()
 	}
 	if yyb578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -8082,9 +8719,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb578 = r.CheckBreak()
 	}
 	if yyb578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RBDPool = ""
 	} else {
@@ -8097,9 +8735,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb578 = r.CheckBreak()
 	}
 	if yyb578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RadosUser = ""
 	} else {
@@ -8112,9 +8751,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb578 = r.CheckBreak()
 	}
 	if yyb578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Keyring = ""
 	} else {
@@ -8127,9 +8767,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb578 = r.CheckBreak()
 	}
 	if yyb578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SecretRef != nil {
 			x.SecretRef = nil
@@ -8147,9 +8788,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb578 = r.CheckBreak()
 	}
 	if yyb578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -8165,9 +8807,10 @@ func (x *RBDVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb578 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj578-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8189,18 +8832,21 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr589 bool = false
 			yyq589[1] = x.FSType != ""
 			yyq589[2] = x.ReadOnly != false
+			var yynn589 int
 			if yyr589 || yy2arr589 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn589 int = 1
+				yynn589 = 1
 				for _, b := range yyq589 {
 					if b {
 						yynn589++
 					}
 				}
 				r.EncodeMapStart(yynn589)
+				yynn589 = 0
 			}
 			if yyr589 || yy2arr589 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym591 := z.EncBinary()
 				_ = yym591
 				if false {
@@ -8208,7 +8854,9 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.VolumeID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumeID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym592 := z.EncBinary()
 				_ = yym592
 				if false {
@@ -8217,6 +8865,7 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr589 || yy2arr589 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq589[1] {
 					yym594 := z.EncBinary()
 					_ = yym594
@@ -8229,7 +8878,9 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq589[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym595 := z.EncBinary()
 					_ = yym595
 					if false {
@@ -8239,6 +8890,7 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr589 || yy2arr589 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq589[2] {
 					yym597 := z.EncBinary()
 					_ = yym597
@@ -8251,7 +8903,9 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq589[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym598 := z.EncBinary()
 					_ = yym598
 					if false {
@@ -8260,8 +8914,10 @@ func (x *CinderVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep589 {
-				r.EncodeEnd()
+			if yyr589 || yy2arr589 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8276,17 +8932,18 @@ func (x *CinderVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct600 := r.ContainerType()
+		if yyct600 == codecSelferValueTypeMap1234 {
 			yyl600 := r.ReadMapStart()
 			if yyl600 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl600, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct600 == codecSelferValueTypeArray1234 {
 			yyl600 := r.ReadArrayStart()
 			if yyl600 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl600, d)
 			}
@@ -8313,8 +8970,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys601Slc = r.DecodeBytes(yys601Slc, true, true)
 		yys601 := string(yys601Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys601 {
 		case "volumeID":
 			if r.TryDecodeAsNil() {
@@ -8338,9 +8997,7 @@ func (x *CinderVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys601)
 		} // end switch yys601
 	} // end for yyj601
-	if !yyhl601 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8357,9 +9014,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb605 = r.CheckBreak()
 	}
 	if yyb605 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.VolumeID = ""
 	} else {
@@ -8372,9 +9030,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb605 = r.CheckBreak()
 	}
 	if yyb605 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -8387,9 +9046,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb605 = r.CheckBreak()
 	}
 	if yyb605 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -8405,9 +9065,10 @@ func (x *CinderVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb605 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj605-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8431,18 +9092,21 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq610[2] = x.SecretFile != ""
 			yyq610[3] = x.SecretRef != nil
 			yyq610[4] = x.ReadOnly != false
+			var yynn610 int
 			if yyr610 || yy2arr610 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn610 int = 1
+				yynn610 = 1
 				for _, b := range yyq610 {
 					if b {
 						yynn610++
 					}
 				}
 				r.EncodeMapStart(yynn610)
+				yynn610 = 0
 			}
 			if yyr610 || yy2arr610 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Monitors == nil {
 					r.EncodeNil()
 				} else {
@@ -8454,7 +9118,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("monitors"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Monitors == nil {
 					r.EncodeNil()
 				} else {
@@ -8467,6 +9133,7 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr610 || yy2arr610 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq610[1] {
 					yym615 := z.EncBinary()
 					_ = yym615
@@ -8479,7 +9146,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq610[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("user"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym616 := z.EncBinary()
 					_ = yym616
 					if false {
@@ -8489,6 +9158,7 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr610 || yy2arr610 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq610[2] {
 					yym618 := z.EncBinary()
 					_ = yym618
@@ -8501,7 +9171,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq610[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secretFile"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym619 := z.EncBinary()
 					_ = yym619
 					if false {
@@ -8511,6 +9183,7 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr610 || yy2arr610 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq610[3] {
 					if x.SecretRef == nil {
 						r.EncodeNil()
@@ -8522,7 +9195,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq610[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SecretRef == nil {
 						r.EncodeNil()
 					} else {
@@ -8531,6 +9206,7 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr610 || yy2arr610 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq610[4] {
 					yym622 := z.EncBinary()
 					_ = yym622
@@ -8543,7 +9219,9 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq610[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym623 := z.EncBinary()
 					_ = yym623
 					if false {
@@ -8552,8 +9230,10 @@ func (x *CephFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep610 {
-				r.EncodeEnd()
+			if yyr610 || yy2arr610 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8568,17 +9248,18 @@ func (x *CephFSVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct625 := r.ContainerType()
+		if yyct625 == codecSelferValueTypeMap1234 {
 			yyl625 := r.ReadMapStart()
 			if yyl625 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl625, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct625 == codecSelferValueTypeArray1234 {
 			yyl625 := r.ReadArrayStart()
 			if yyl625 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl625, d)
 			}
@@ -8605,8 +9286,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys626Slc = r.DecodeBytes(yys626Slc, true, true)
 		yys626 := string(yys626Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys626 {
 		case "monitors":
 			if r.TryDecodeAsNil() {
@@ -8653,9 +9336,7 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys626)
 		} // end switch yys626
 	} // end for yyj626
-	if !yyhl626 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8672,9 +9353,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb633 = r.CheckBreak()
 	}
 	if yyb633 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Monitors = nil
 	} else {
@@ -8693,9 +9375,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb633 = r.CheckBreak()
 	}
 	if yyb633 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.User = ""
 	} else {
@@ -8708,9 +9391,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb633 = r.CheckBreak()
 	}
 	if yyb633 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SecretFile = ""
 	} else {
@@ -8723,9 +9407,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb633 = r.CheckBreak()
 	}
 	if yyb633 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SecretRef != nil {
 			x.SecretRef = nil
@@ -8743,9 +9428,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb633 = r.CheckBreak()
 	}
 	if yyb633 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -8761,9 +9447,10 @@ func (x *CephFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb633 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj633-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *FlockerVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8783,18 +9470,21 @@ func (x *FlockerVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq641 [1]bool
 			_, _, _ = yysep641, yyq641, yy2arr641
 			const yyr641 bool = false
+			var yynn641 int
 			if yyr641 || yy2arr641 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn641 int = 1
+				yynn641 = 1
 				for _, b := range yyq641 {
 					if b {
 						yynn641++
 					}
 				}
 				r.EncodeMapStart(yynn641)
+				yynn641 = 0
 			}
 			if yyr641 || yy2arr641 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym643 := z.EncBinary()
 				_ = yym643
 				if false {
@@ -8802,7 +9492,9 @@ func (x *FlockerVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.DatasetName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("datasetName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym644 := z.EncBinary()
 				_ = yym644
 				if false {
@@ -8810,8 +9502,10 @@ func (x *FlockerVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.DatasetName))
 				}
 			}
-			if yysep641 {
-				r.EncodeEnd()
+			if yyr641 || yy2arr641 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8826,17 +9520,18 @@ func (x *FlockerVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct646 := r.ContainerType()
+		if yyct646 == codecSelferValueTypeMap1234 {
 			yyl646 := r.ReadMapStart()
 			if yyl646 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl646, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct646 == codecSelferValueTypeArray1234 {
 			yyl646 := r.ReadArrayStart()
 			if yyl646 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl646, d)
 			}
@@ -8863,8 +9558,10 @@ func (x *FlockerVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys647Slc = r.DecodeBytes(yys647Slc, true, true)
 		yys647 := string(yys647Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys647 {
 		case "datasetName":
 			if r.TryDecodeAsNil() {
@@ -8876,9 +9573,7 @@ func (x *FlockerVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys647)
 		} // end switch yys647
 	} // end for yyj647
-	if !yyhl647 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *FlockerVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8895,9 +9590,10 @@ func (x *FlockerVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb649 = r.CheckBreak()
 	}
 	if yyb649 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DatasetName = ""
 	} else {
@@ -8913,9 +9609,10 @@ func (x *FlockerVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb649 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj649-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x Protocol) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8963,18 +9660,21 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr654 bool = false
 			yyq654[2] = x.Partition != 0
 			yyq654[3] = x.ReadOnly != false
+			var yynn654 int
 			if yyr654 || yy2arr654 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn654 int = 2
+				yynn654 = 2
 				for _, b := range yyq654 {
 					if b {
 						yynn654++
 					}
 				}
 				r.EncodeMapStart(yynn654)
+				yynn654 = 0
 			}
 			if yyr654 || yy2arr654 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym656 := z.EncBinary()
 				_ = yym656
 				if false {
@@ -8982,7 +9682,9 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PDName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("pdName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym657 := z.EncBinary()
 				_ = yym657
 				if false {
@@ -8991,6 +9693,7 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr654 || yy2arr654 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym659 := z.EncBinary()
 				_ = yym659
 				if false {
@@ -8998,7 +9701,9 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FSType))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym660 := z.EncBinary()
 				_ = yym660
 				if false {
@@ -9007,6 +9712,7 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr654 || yy2arr654 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq654[2] {
 					yym662 := z.EncBinary()
 					_ = yym662
@@ -9019,7 +9725,9 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq654[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("partition"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym663 := z.EncBinary()
 					_ = yym663
 					if false {
@@ -9029,6 +9737,7 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr654 || yy2arr654 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq654[3] {
 					yym665 := z.EncBinary()
 					_ = yym665
@@ -9041,7 +9750,9 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq654[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym666 := z.EncBinary()
 					_ = yym666
 					if false {
@@ -9050,8 +9761,10 @@ func (x *GCEPersistentDiskVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep654 {
-				r.EncodeEnd()
+			if yyr654 || yy2arr654 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9066,17 +9779,18 @@ func (x *GCEPersistentDiskVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct668 := r.ContainerType()
+		if yyct668 == codecSelferValueTypeMap1234 {
 			yyl668 := r.ReadMapStart()
 			if yyl668 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl668, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct668 == codecSelferValueTypeArray1234 {
 			yyl668 := r.ReadArrayStart()
 			if yyl668 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl668, d)
 			}
@@ -9103,8 +9817,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromMap(l int, d *codec19
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys669Slc = r.DecodeBytes(yys669Slc, true, true)
 		yys669 := string(yys669Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys669 {
 		case "pdName":
 			if r.TryDecodeAsNil() {
@@ -9134,9 +9850,7 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromMap(l int, d *codec19
 			z.DecStructFieldNotFound(-1, yys669)
 		} // end switch yys669
 	} // end for yyj669
-	if !yyhl669 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9153,9 +9867,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		yyb674 = r.CheckBreak()
 	}
 	if yyb674 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PDName = ""
 	} else {
@@ -9168,9 +9883,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		yyb674 = r.CheckBreak()
 	}
 	if yyb674 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -9183,9 +9899,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		yyb674 = r.CheckBreak()
 	}
 	if yyb674 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Partition = 0
 	} else {
@@ -9198,9 +9915,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		yyb674 = r.CheckBreak()
 	}
 	if yyb674 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -9216,9 +9934,10 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 		if yyb674 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj674-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9240,18 +9959,21 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 			const yyr680 bool = false
 			yyq680[2] = x.Partition != 0
 			yyq680[3] = x.ReadOnly != false
+			var yynn680 int
 			if yyr680 || yy2arr680 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn680 int = 2
+				yynn680 = 2
 				for _, b := range yyq680 {
 					if b {
 						yynn680++
 					}
 				}
 				r.EncodeMapStart(yynn680)
+				yynn680 = 0
 			}
 			if yyr680 || yy2arr680 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym682 := z.EncBinary()
 				_ = yym682
 				if false {
@@ -9259,7 +9981,9 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 					r.EncodeString(codecSelferC_UTF81234, string(x.VolumeID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("volumeID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym683 := z.EncBinary()
 				_ = yym683
 				if false {
@@ -9268,6 +9992,7 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			}
 			if yyr680 || yy2arr680 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym685 := z.EncBinary()
 				_ = yym685
 				if false {
@@ -9275,7 +10000,9 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 					r.EncodeString(codecSelferC_UTF81234, string(x.FSType))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym686 := z.EncBinary()
 				_ = yym686
 				if false {
@@ -9284,6 +10011,7 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			}
 			if yyr680 || yy2arr680 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq680[2] {
 					yym688 := z.EncBinary()
 					_ = yym688
@@ -9296,7 +10024,9 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			} else {
 				if yyq680[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("partition"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym689 := z.EncBinary()
 					_ = yym689
 					if false {
@@ -9306,6 +10036,7 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			}
 			if yyr680 || yy2arr680 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq680[3] {
 					yym691 := z.EncBinary()
 					_ = yym691
@@ -9318,7 +10049,9 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 				}
 			} else {
 				if yyq680[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym692 := z.EncBinary()
 					_ = yym692
 					if false {
@@ -9327,8 +10060,10 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecEncodeSelf(e *codec1978.Encoder)
 					}
 				}
 			}
-			if yysep680 {
-				r.EncodeEnd()
+			if yyr680 || yy2arr680 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9343,17 +10078,18 @@ func (x *AWSElasticBlockStoreVolumeSource) CodecDecodeSelf(d *codec1978.Decoder)
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct694 := r.ContainerType()
+		if yyct694 == codecSelferValueTypeMap1234 {
 			yyl694 := r.ReadMapStart()
 			if yyl694 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl694, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct694 == codecSelferValueTypeArray1234 {
 			yyl694 := r.ReadArrayStart()
 			if yyl694 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl694, d)
 			}
@@ -9380,8 +10116,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromMap(l int, d *code
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys695Slc = r.DecodeBytes(yys695Slc, true, true)
 		yys695 := string(yys695Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys695 {
 		case "volumeID":
 			if r.TryDecodeAsNil() {
@@ -9411,9 +10149,7 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromMap(l int, d *code
 			z.DecStructFieldNotFound(-1, yys695)
 		} // end switch yys695
 	} // end for yyj695
-	if !yyhl695 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9430,9 +10166,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		yyb700 = r.CheckBreak()
 	}
 	if yyb700 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.VolumeID = ""
 	} else {
@@ -9445,9 +10182,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		yyb700 = r.CheckBreak()
 	}
 	if yyb700 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -9460,9 +10198,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		yyb700 = r.CheckBreak()
 	}
 	if yyb700 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Partition = 0
 	} else {
@@ -9475,9 +10214,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		yyb700 = r.CheckBreak()
 	}
 	if yyb700 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -9493,9 +10233,10 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 		if yyb700 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj700-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9515,18 +10256,21 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq706 [2]bool
 			_, _, _ = yysep706, yyq706, yy2arr706
 			const yyr706 bool = false
+			var yynn706 int
 			if yyr706 || yy2arr706 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn706 int = 2
+				yynn706 = 2
 				for _, b := range yyq706 {
 					if b {
 						yynn706++
 					}
 				}
 				r.EncodeMapStart(yynn706)
+				yynn706 = 0
 			}
 			if yyr706 || yy2arr706 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym708 := z.EncBinary()
 				_ = yym708
 				if false {
@@ -9534,7 +10278,9 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Repository))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("repository"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym709 := z.EncBinary()
 				_ = yym709
 				if false {
@@ -9543,6 +10289,7 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr706 || yy2arr706 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym711 := z.EncBinary()
 				_ = yym711
 				if false {
@@ -9550,7 +10297,9 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Revision))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("revision"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym712 := z.EncBinary()
 				_ = yym712
 				if false {
@@ -9558,8 +10307,10 @@ func (x *GitRepoVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Revision))
 				}
 			}
-			if yysep706 {
-				r.EncodeEnd()
+			if yyr706 || yy2arr706 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9574,17 +10325,18 @@ func (x *GitRepoVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct714 := r.ContainerType()
+		if yyct714 == codecSelferValueTypeMap1234 {
 			yyl714 := r.ReadMapStart()
 			if yyl714 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl714, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct714 == codecSelferValueTypeArray1234 {
 			yyl714 := r.ReadArrayStart()
 			if yyl714 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl714, d)
 			}
@@ -9611,8 +10363,10 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys715Slc = r.DecodeBytes(yys715Slc, true, true)
 		yys715 := string(yys715Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys715 {
 		case "repository":
 			if r.TryDecodeAsNil() {
@@ -9630,9 +10384,7 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys715)
 		} // end switch yys715
 	} // end for yyj715
-	if !yyhl715 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *GitRepoVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9649,9 +10401,10 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb718 = r.CheckBreak()
 	}
 	if yyb718 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Repository = ""
 	} else {
@@ -9664,9 +10417,10 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb718 = r.CheckBreak()
 	}
 	if yyb718 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Revision = ""
 	} else {
@@ -9682,9 +10436,10 @@ func (x *GitRepoVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb718 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj718-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SecretVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9704,18 +10459,21 @@ func (x *SecretVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq722 [1]bool
 			_, _, _ = yysep722, yyq722, yy2arr722
 			const yyr722 bool = false
+			var yynn722 int
 			if yyr722 || yy2arr722 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn722 int = 1
+				yynn722 = 1
 				for _, b := range yyq722 {
 					if b {
 						yynn722++
 					}
 				}
 				r.EncodeMapStart(yynn722)
+				yynn722 = 0
 			}
 			if yyr722 || yy2arr722 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym724 := z.EncBinary()
 				_ = yym724
 				if false {
@@ -9723,7 +10481,9 @@ func (x *SecretVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("secretName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym725 := z.EncBinary()
 				_ = yym725
 				if false {
@@ -9731,8 +10491,10 @@ func (x *SecretVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
 				}
 			}
-			if yysep722 {
-				r.EncodeEnd()
+			if yyr722 || yy2arr722 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9747,17 +10509,18 @@ func (x *SecretVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct727 := r.ContainerType()
+		if yyct727 == codecSelferValueTypeMap1234 {
 			yyl727 := r.ReadMapStart()
 			if yyl727 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl727, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct727 == codecSelferValueTypeArray1234 {
 			yyl727 := r.ReadArrayStart()
 			if yyl727 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl727, d)
 			}
@@ -9784,8 +10547,10 @@ func (x *SecretVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys728Slc = r.DecodeBytes(yys728Slc, true, true)
 		yys728 := string(yys728Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys728 {
 		case "secretName":
 			if r.TryDecodeAsNil() {
@@ -9797,9 +10562,7 @@ func (x *SecretVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys728)
 		} // end switch yys728
 	} // end for yyj728
-	if !yyhl728 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SecretVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9816,9 +10579,10 @@ func (x *SecretVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb730 = r.CheckBreak()
 	}
 	if yyb730 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SecretName = ""
 	} else {
@@ -9834,9 +10598,10 @@ func (x *SecretVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb730 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj730-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9857,18 +10622,21 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep733, yyq733, yy2arr733
 			const yyr733 bool = false
 			yyq733[2] = x.ReadOnly != false
+			var yynn733 int
 			if yyr733 || yy2arr733 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn733 int = 2
+				yynn733 = 2
 				for _, b := range yyq733 {
 					if b {
 						yynn733++
 					}
 				}
 				r.EncodeMapStart(yynn733)
+				yynn733 = 0
 			}
 			if yyr733 || yy2arr733 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym735 := z.EncBinary()
 				_ = yym735
 				if false {
@@ -9876,7 +10644,9 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Server))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("server"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym736 := z.EncBinary()
 				_ = yym736
 				if false {
@@ -9885,6 +10655,7 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr733 || yy2arr733 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym738 := z.EncBinary()
 				_ = yym738
 				if false {
@@ -9892,7 +10663,9 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym739 := z.EncBinary()
 				_ = yym739
 				if false {
@@ -9901,6 +10674,7 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr733 || yy2arr733 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq733[2] {
 					yym741 := z.EncBinary()
 					_ = yym741
@@ -9913,7 +10687,9 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq733[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym742 := z.EncBinary()
 					_ = yym742
 					if false {
@@ -9922,8 +10698,10 @@ func (x *NFSVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep733 {
-				r.EncodeEnd()
+			if yyr733 || yy2arr733 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9938,17 +10716,18 @@ func (x *NFSVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct744 := r.ContainerType()
+		if yyct744 == codecSelferValueTypeMap1234 {
 			yyl744 := r.ReadMapStart()
 			if yyl744 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl744, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct744 == codecSelferValueTypeArray1234 {
 			yyl744 := r.ReadArrayStart()
 			if yyl744 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl744, d)
 			}
@@ -9975,8 +10754,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys745Slc = r.DecodeBytes(yys745Slc, true, true)
 		yys745 := string(yys745Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys745 {
 		case "server":
 			if r.TryDecodeAsNil() {
@@ -10000,9 +10781,7 @@ func (x *NFSVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys745)
 		} // end switch yys745
 	} // end for yyj745
-	if !yyhl745 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10019,9 +10798,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb749 = r.CheckBreak()
 	}
 	if yyb749 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Server = ""
 	} else {
@@ -10034,9 +10814,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb749 = r.CheckBreak()
 	}
 	if yyb749 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -10049,9 +10830,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb749 = r.CheckBreak()
 	}
 	if yyb749 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -10067,9 +10849,10 @@ func (x *NFSVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb749 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj749-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10090,18 +10873,21 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep754, yyq754, yy2arr754
 			const yyr754 bool = false
 			yyq754[4] = x.ReadOnly != false
+			var yynn754 int
 			if yyr754 || yy2arr754 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn754 int = 4
+				yynn754 = 4
 				for _, b := range yyq754 {
 					if b {
 						yynn754++
 					}
 				}
 				r.EncodeMapStart(yynn754)
+				yynn754 = 0
 			}
 			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym756 := z.EncBinary()
 				_ = yym756
 				if false {
@@ -10109,7 +10895,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.TargetPortal))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("targetPortal"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym757 := z.EncBinary()
 				_ = yym757
 				if false {
@@ -10118,6 +10906,7 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym759 := z.EncBinary()
 				_ = yym759
 				if false {
@@ -10125,7 +10914,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.IQN))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("iqn"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym760 := z.EncBinary()
 				_ = yym760
 				if false {
@@ -10134,6 +10925,7 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym762 := z.EncBinary()
 				_ = yym762
 				if false {
@@ -10141,7 +10933,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Lun))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lun"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym763 := z.EncBinary()
 				_ = yym763
 				if false {
@@ -10150,6 +10944,7 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym765 := z.EncBinary()
 				_ = yym765
 				if false {
@@ -10157,7 +10952,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FSType))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym766 := z.EncBinary()
 				_ = yym766
 				if false {
@@ -10166,6 +10963,7 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq754[4] {
 					yym768 := z.EncBinary()
 					_ = yym768
@@ -10178,7 +10976,9 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq754[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym769 := z.EncBinary()
 					_ = yym769
 					if false {
@@ -10187,8 +10987,10 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep754 {
-				r.EncodeEnd()
+			if yyr754 || yy2arr754 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10203,17 +11005,18 @@ func (x *ISCSIVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct771 := r.ContainerType()
+		if yyct771 == codecSelferValueTypeMap1234 {
 			yyl771 := r.ReadMapStart()
 			if yyl771 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl771, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct771 == codecSelferValueTypeArray1234 {
 			yyl771 := r.ReadArrayStart()
 			if yyl771 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl771, d)
 			}
@@ -10240,8 +11043,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys772Slc = r.DecodeBytes(yys772Slc, true, true)
 		yys772 := string(yys772Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys772 {
 		case "targetPortal":
 			if r.TryDecodeAsNil() {
@@ -10277,9 +11082,7 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			z.DecStructFieldNotFound(-1, yys772)
 		} // end switch yys772
 	} // end for yyj772
-	if !yyhl772 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10296,9 +11099,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb778 = r.CheckBreak()
 	}
 	if yyb778 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetPortal = ""
 	} else {
@@ -10311,9 +11115,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb778 = r.CheckBreak()
 	}
 	if yyb778 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.IQN = ""
 	} else {
@@ -10326,9 +11131,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb778 = r.CheckBreak()
 	}
 	if yyb778 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Lun = 0
 	} else {
@@ -10341,9 +11147,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb778 = r.CheckBreak()
 	}
 	if yyb778 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -10356,9 +11163,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb778 = r.CheckBreak()
 	}
 	if yyb778 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -10374,9 +11182,10 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if yyb778 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj778-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10397,18 +11206,21 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep785, yyq785, yy2arr785
 			const yyr785 bool = false
 			yyq785[3] = x.ReadOnly != false
+			var yynn785 int
 			if yyr785 || yy2arr785 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn785 int = 3
+				yynn785 = 3
 				for _, b := range yyq785 {
 					if b {
 						yynn785++
 					}
 				}
 				r.EncodeMapStart(yynn785)
+				yynn785 = 0
 			}
 			if yyr785 || yy2arr785 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.TargetWWNs == nil {
 					r.EncodeNil()
 				} else {
@@ -10420,7 +11232,9 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("targetWWNs"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.TargetWWNs == nil {
 					r.EncodeNil()
 				} else {
@@ -10433,6 +11247,7 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr785 || yy2arr785 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Lun == nil {
 					r.EncodeNil()
 				} else {
@@ -10445,7 +11260,9 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("lun"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Lun == nil {
 					r.EncodeNil()
 				} else {
@@ -10459,6 +11276,7 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr785 || yy2arr785 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym795 := z.EncBinary()
 				_ = yym795
 				if false {
@@ -10466,7 +11284,9 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FSType))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fsType"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym796 := z.EncBinary()
 				_ = yym796
 				if false {
@@ -10475,6 +11295,7 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr785 || yy2arr785 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq785[3] {
 					yym798 := z.EncBinary()
 					_ = yym798
@@ -10487,7 +11308,9 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq785[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym799 := z.EncBinary()
 					_ = yym799
 					if false {
@@ -10496,8 +11319,10 @@ func (x *FCVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep785 {
-				r.EncodeEnd()
+			if yyr785 || yy2arr785 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10512,17 +11337,18 @@ func (x *FCVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct801 := r.ContainerType()
+		if yyct801 == codecSelferValueTypeMap1234 {
 			yyl801 := r.ReadMapStart()
 			if yyl801 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl801, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct801 == codecSelferValueTypeArray1234 {
 			yyl801 := r.ReadArrayStart()
 			if yyl801 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl801, d)
 			}
@@ -10549,8 +11375,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys802Slc = r.DecodeBytes(yys802Slc, true, true)
 		yys802 := string(yys802Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys802 {
 		case "targetWWNs":
 			if r.TryDecodeAsNil() {
@@ -10596,9 +11424,7 @@ func (x *FCVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys802)
 		} // end switch yys802
 	} // end for yyj802
-	if !yyhl802 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10615,9 +11441,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb809 = r.CheckBreak()
 	}
 	if yyb809 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetWWNs = nil
 	} else {
@@ -10636,9 +11463,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb809 = r.CheckBreak()
 	}
 	if yyb809 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Lun != nil {
 			x.Lun = nil
@@ -10661,9 +11489,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb809 = r.CheckBreak()
 	}
 	if yyb809 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FSType = ""
 	} else {
@@ -10676,9 +11505,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb809 = r.CheckBreak()
 	}
 	if yyb809 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -10694,9 +11524,10 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb809 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj809-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10720,18 +11551,21 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq817[1] = x.HostPort != 0
 			yyq817[3] = x.Protocol != ""
 			yyq817[4] = x.HostIP != ""
+			var yynn817 int
 			if yyr817 || yy2arr817 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn817 int = 1
+				yynn817 = 1
 				for _, b := range yyq817 {
 					if b {
 						yynn817++
 					}
 				}
 				r.EncodeMapStart(yynn817)
+				yynn817 = 0
 			}
 			if yyr817 || yy2arr817 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq817[0] {
 					yym819 := z.EncBinary()
 					_ = yym819
@@ -10744,7 +11578,9 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq817[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym820 := z.EncBinary()
 					_ = yym820
 					if false {
@@ -10754,6 +11590,7 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr817 || yy2arr817 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq817[1] {
 					yym822 := z.EncBinary()
 					_ = yym822
@@ -10766,7 +11603,9 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq817[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPort"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym823 := z.EncBinary()
 					_ = yym823
 					if false {
@@ -10776,6 +11615,7 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr817 || yy2arr817 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym825 := z.EncBinary()
 				_ = yym825
 				if false {
@@ -10783,7 +11623,9 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.ContainerPort))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("containerPort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym826 := z.EncBinary()
 				_ = yym826
 				if false {
@@ -10792,6 +11634,7 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr817 || yy2arr817 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq817[3] {
 					x.Protocol.CodecEncodeSelf(e)
 				} else {
@@ -10799,11 +11642,14 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq817[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("protocol"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Protocol.CodecEncodeSelf(e)
 				}
 			}
 			if yyr817 || yy2arr817 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq817[4] {
 					yym829 := z.EncBinary()
 					_ = yym829
@@ -10816,7 +11662,9 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq817[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym830 := z.EncBinary()
 					_ = yym830
 					if false {
@@ -10825,8 +11673,10 @@ func (x *ContainerPort) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep817 {
-				r.EncodeEnd()
+			if yyr817 || yy2arr817 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10841,17 +11691,18 @@ func (x *ContainerPort) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct832 := r.ContainerType()
+		if yyct832 == codecSelferValueTypeMap1234 {
 			yyl832 := r.ReadMapStart()
 			if yyl832 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl832, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct832 == codecSelferValueTypeArray1234 {
 			yyl832 := r.ReadArrayStart()
 			if yyl832 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl832, d)
 			}
@@ -10878,8 +11729,10 @@ func (x *ContainerPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys833Slc = r.DecodeBytes(yys833Slc, true, true)
 		yys833 := string(yys833Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys833 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -10915,9 +11768,7 @@ func (x *ContainerPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys833)
 		} // end switch yys833
 	} // end for yyj833
-	if !yyhl833 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10934,9 +11785,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb839 = r.CheckBreak()
 	}
 	if yyb839 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -10949,9 +11801,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb839 = r.CheckBreak()
 	}
 	if yyb839 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostPort = 0
 	} else {
@@ -10964,9 +11817,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb839 = r.CheckBreak()
 	}
 	if yyb839 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerPort = 0
 	} else {
@@ -10979,9 +11833,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb839 = r.CheckBreak()
 	}
 	if yyb839 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Protocol = ""
 	} else {
@@ -10994,9 +11849,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb839 = r.CheckBreak()
 	}
 	if yyb839 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostIP = ""
 	} else {
@@ -11012,9 +11868,10 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb839 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj839-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11035,18 +11892,21 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep846, yyq846, yy2arr846
 			const yyr846 bool = false
 			yyq846[1] = x.ReadOnly != false
+			var yynn846 int
 			if yyr846 || yy2arr846 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn846 int = 2
+				yynn846 = 2
 				for _, b := range yyq846 {
 					if b {
 						yynn846++
 					}
 				}
 				r.EncodeMapStart(yynn846)
+				yynn846 = 0
 			}
 			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym848 := z.EncBinary()
 				_ = yym848
 				if false {
@@ -11054,7 +11914,9 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym849 := z.EncBinary()
 				_ = yym849
 				if false {
@@ -11063,6 +11925,7 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq846[1] {
 					yym851 := z.EncBinary()
 					_ = yym851
@@ -11075,7 +11938,9 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq846[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readOnly"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym852 := z.EncBinary()
 					_ = yym852
 					if false {
@@ -11085,6 +11950,7 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym854 := z.EncBinary()
 				_ = yym854
 				if false {
@@ -11092,7 +11958,9 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MountPath))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("mountPath"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym855 := z.EncBinary()
 				_ = yym855
 				if false {
@@ -11100,8 +11968,10 @@ func (x *VolumeMount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MountPath))
 				}
 			}
-			if yysep846 {
-				r.EncodeEnd()
+			if yyr846 || yy2arr846 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11116,17 +11986,18 @@ func (x *VolumeMount) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct857 := r.ContainerType()
+		if yyct857 == codecSelferValueTypeMap1234 {
 			yyl857 := r.ReadMapStart()
 			if yyl857 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl857, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct857 == codecSelferValueTypeArray1234 {
 			yyl857 := r.ReadArrayStart()
 			if yyl857 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl857, d)
 			}
@@ -11153,8 +12024,10 @@ func (x *VolumeMount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys858Slc = r.DecodeBytes(yys858Slc, true, true)
 		yys858 := string(yys858Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys858 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -11178,9 +12051,7 @@ func (x *VolumeMount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys858)
 		} // end switch yys858
 	} // end for yyj858
-	if !yyhl858 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11197,9 +12068,10 @@ func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb862 = r.CheckBreak()
 	}
 	if yyb862 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -11212,9 +12084,10 @@ func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb862 = r.CheckBreak()
 	}
 	if yyb862 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ReadOnly = false
 	} else {
@@ -11227,9 +12100,10 @@ func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb862 = r.CheckBreak()
 	}
 	if yyb862 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MountPath = ""
 	} else {
@@ -11245,9 +12119,10 @@ func (x *VolumeMount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb862 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj862-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11269,18 +12144,21 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr867 bool = false
 			yyq867[1] = x.Value != ""
 			yyq867[2] = x.ValueFrom != nil
+			var yynn867 int
 			if yyr867 || yy2arr867 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn867 int = 1
+				yynn867 = 1
 				for _, b := range yyq867 {
 					if b {
 						yynn867++
 					}
 				}
 				r.EncodeMapStart(yynn867)
+				yynn867 = 0
 			}
 			if yyr867 || yy2arr867 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym869 := z.EncBinary()
 				_ = yym869
 				if false {
@@ -11288,7 +12166,9 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym870 := z.EncBinary()
 				_ = yym870
 				if false {
@@ -11297,6 +12177,7 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr867 || yy2arr867 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq867[1] {
 					yym872 := z.EncBinary()
 					_ = yym872
@@ -11309,7 +12190,9 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq867[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("value"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym873 := z.EncBinary()
 					_ = yym873
 					if false {
@@ -11319,6 +12202,7 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr867 || yy2arr867 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq867[2] {
 					if x.ValueFrom == nil {
 						r.EncodeNil()
@@ -11330,7 +12214,9 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq867[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("valueFrom"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ValueFrom == nil {
 						r.EncodeNil()
 					} else {
@@ -11338,8 +12224,10 @@ func (x *EnvVar) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep867 {
-				r.EncodeEnd()
+			if yyr867 || yy2arr867 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11354,17 +12242,18 @@ func (x *EnvVar) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct876 := r.ContainerType()
+		if yyct876 == codecSelferValueTypeMap1234 {
 			yyl876 := r.ReadMapStart()
 			if yyl876 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl876, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct876 == codecSelferValueTypeArray1234 {
 			yyl876 := r.ReadArrayStart()
 			if yyl876 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl876, d)
 			}
@@ -11391,8 +12280,10 @@ func (x *EnvVar) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys877Slc = r.DecodeBytes(yys877Slc, true, true)
 		yys877 := string(yys877Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys877 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -11421,9 +12312,7 @@ func (x *EnvVar) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys877)
 		} // end switch yys877
 	} // end for yyj877
-	if !yyhl877 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11440,9 +12329,10 @@ func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb881 = r.CheckBreak()
 	}
 	if yyb881 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -11455,9 +12345,10 @@ func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb881 = r.CheckBreak()
 	}
 	if yyb881 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Value = ""
 	} else {
@@ -11470,9 +12361,10 @@ func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb881 = r.CheckBreak()
 	}
 	if yyb881 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ValueFrom != nil {
 			x.ValueFrom = nil
@@ -11493,9 +12385,10 @@ func (x *EnvVar) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb881 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj881-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EnvVarSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11515,33 +12408,40 @@ func (x *EnvVarSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq886 [1]bool
 			_, _, _ = yysep886, yyq886, yy2arr886
 			const yyr886 bool = false
+			var yynn886 int
 			if yyr886 || yy2arr886 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn886 int = 1
+				yynn886 = 1
 				for _, b := range yyq886 {
 					if b {
 						yynn886++
 					}
 				}
 				r.EncodeMapStart(yynn886)
+				yynn886 = 0
 			}
 			if yyr886 || yy2arr886 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.FieldRef == nil {
 					r.EncodeNil()
 				} else {
 					x.FieldRef.CodecEncodeSelf(e)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fieldRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.FieldRef == nil {
 					r.EncodeNil()
 				} else {
 					x.FieldRef.CodecEncodeSelf(e)
 				}
 			}
-			if yysep886 {
-				r.EncodeEnd()
+			if yyr886 || yy2arr886 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11556,17 +12456,18 @@ func (x *EnvVarSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct889 := r.ContainerType()
+		if yyct889 == codecSelferValueTypeMap1234 {
 			yyl889 := r.ReadMapStart()
 			if yyl889 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl889, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct889 == codecSelferValueTypeArray1234 {
 			yyl889 := r.ReadArrayStart()
 			if yyl889 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl889, d)
 			}
@@ -11593,8 +12494,10 @@ func (x *EnvVarSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys890Slc = r.DecodeBytes(yys890Slc, true, true)
 		yys890 := string(yys890Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys890 {
 		case "fieldRef":
 			if r.TryDecodeAsNil() {
@@ -11611,9 +12514,7 @@ func (x *EnvVarSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys890)
 		} // end switch yys890
 	} // end for yyj890
-	if !yyhl890 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EnvVarSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11630,9 +12531,10 @@ func (x *EnvVarSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb892 = r.CheckBreak()
 	}
 	if yyb892 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FieldRef != nil {
 			x.FieldRef = nil
@@ -11653,9 +12555,10 @@ func (x *EnvVarSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb892 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj892-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11676,18 +12579,21 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep895, yyq895, yy2arr895
 			const yyr895 bool = false
 			yyq895[0] = x.APIVersion != ""
+			var yynn895 int
 			if yyr895 || yy2arr895 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn895 int = 1
+				yynn895 = 1
 				for _, b := range yyq895 {
 					if b {
 						yynn895++
 					}
 				}
 				r.EncodeMapStart(yynn895)
+				yynn895 = 0
 			}
 			if yyr895 || yy2arr895 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq895[0] {
 					yym897 := z.EncBinary()
 					_ = yym897
@@ -11700,7 +12606,9 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq895[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym898 := z.EncBinary()
 					_ = yym898
 					if false {
@@ -11710,6 +12618,7 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr895 || yy2arr895 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym900 := z.EncBinary()
 				_ = yym900
 				if false {
@@ -11717,7 +12626,9 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fieldPath"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym901 := z.EncBinary()
 				_ = yym901
 				if false {
@@ -11725,8 +12636,10 @@ func (x *ObjectFieldSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 				}
 			}
-			if yysep895 {
-				r.EncodeEnd()
+			if yyr895 || yy2arr895 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11741,17 +12654,18 @@ func (x *ObjectFieldSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct903 := r.ContainerType()
+		if yyct903 == codecSelferValueTypeMap1234 {
 			yyl903 := r.ReadMapStart()
 			if yyl903 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl903, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct903 == codecSelferValueTypeArray1234 {
 			yyl903 := r.ReadArrayStart()
 			if yyl903 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl903, d)
 			}
@@ -11778,8 +12692,10 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys904Slc = r.DecodeBytes(yys904Slc, true, true)
 		yys904 := string(yys904Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys904 {
 		case "apiVersion":
 			if r.TryDecodeAsNil() {
@@ -11797,9 +12713,7 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys904)
 		} // end switch yys904
 	} // end for yyj904
-	if !yyhl904 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ObjectFieldSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11816,9 +12730,10 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb907 = r.CheckBreak()
 	}
 	if yyb907 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -11831,9 +12746,10 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb907 = r.CheckBreak()
 	}
 	if yyb907 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FieldPath = ""
 	} else {
@@ -11849,9 +12765,10 @@ func (x *ObjectFieldSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb907 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj907-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11874,18 +12791,21 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq911[0] = x.Path != ""
 			yyq911[2] = x.Host != ""
 			yyq911[3] = x.Scheme != ""
+			var yynn911 int
 			if yyr911 || yy2arr911 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn911 int = 1
+				yynn911 = 1
 				for _, b := range yyq911 {
 					if b {
 						yynn911++
 					}
 				}
 				r.EncodeMapStart(yynn911)
+				yynn911 = 0
 			}
 			if yyr911 || yy2arr911 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq911[0] {
 					yym913 := z.EncBinary()
 					_ = yym913
@@ -11898,7 +12818,9 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq911[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym914 := z.EncBinary()
 					_ = yym914
 					if false {
@@ -11908,6 +12830,7 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr911 || yy2arr911 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy916 := &x.Port
 				yym917 := z.EncBinary()
 				_ = yym917
@@ -11919,7 +12842,9 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy916)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy918 := &x.Port
 				yym919 := z.EncBinary()
 				_ = yym919
@@ -11932,6 +12857,7 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr911 || yy2arr911 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq911[2] {
 					yym921 := z.EncBinary()
 					_ = yym921
@@ -11944,7 +12870,9 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq911[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym922 := z.EncBinary()
 					_ = yym922
 					if false {
@@ -11954,6 +12882,7 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr911 || yy2arr911 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq911[3] {
 					x.Scheme.CodecEncodeSelf(e)
 				} else {
@@ -11961,12 +12890,16 @@ func (x *HTTPGetAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq911[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("scheme"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Scheme.CodecEncodeSelf(e)
 				}
 			}
-			if yysep911 {
-				r.EncodeEnd()
+			if yyr911 || yy2arr911 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11981,17 +12914,18 @@ func (x *HTTPGetAction) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct925 := r.ContainerType()
+		if yyct925 == codecSelferValueTypeMap1234 {
 			yyl925 := r.ReadMapStart()
 			if yyl925 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl925, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct925 == codecSelferValueTypeArray1234 {
 			yyl925 := r.ReadArrayStart()
 			if yyl925 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl925, d)
 			}
@@ -12018,8 +12952,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys926Slc = r.DecodeBytes(yys926Slc, true, true)
 		yys926 := string(yys926Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys926 {
 		case "path":
 			if r.TryDecodeAsNil() {
@@ -12058,9 +12994,7 @@ func (x *HTTPGetAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys926)
 		} // end switch yys926
 	} // end for yyj926
-	if !yyhl926 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12077,9 +13011,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb932 = r.CheckBreak()
 	}
 	if yyb932 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -12092,9 +13027,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb932 = r.CheckBreak()
 	}
 	if yyb932 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = pkg5_intstr.IntOrString{}
 	} else {
@@ -12116,9 +13052,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb932 = r.CheckBreak()
 	}
 	if yyb932 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Host = ""
 	} else {
@@ -12131,9 +13068,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb932 = r.CheckBreak()
 	}
 	if yyb932 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Scheme = ""
 	} else {
@@ -12149,9 +13087,10 @@ func (x *HTTPGetAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb932 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj932-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x URIScheme) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12197,18 +13136,21 @@ func (x *TCPSocketAction) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq941 [1]bool
 			_, _, _ = yysep941, yyq941, yy2arr941
 			const yyr941 bool = false
+			var yynn941 int
 			if yyr941 || yy2arr941 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn941 int = 1
+				yynn941 = 1
 				for _, b := range yyq941 {
 					if b {
 						yynn941++
 					}
 				}
 				r.EncodeMapStart(yynn941)
+				yynn941 = 0
 			}
 			if yyr941 || yy2arr941 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy943 := &x.Port
 				yym944 := z.EncBinary()
 				_ = yym944
@@ -12220,7 +13162,9 @@ func (x *TCPSocketAction) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy943)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy945 := &x.Port
 				yym946 := z.EncBinary()
 				_ = yym946
@@ -12232,8 +13176,10 @@ func (x *TCPSocketAction) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy945)
 				}
 			}
-			if yysep941 {
-				r.EncodeEnd()
+			if yyr941 || yy2arr941 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12248,17 +13194,18 @@ func (x *TCPSocketAction) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct948 := r.ContainerType()
+		if yyct948 == codecSelferValueTypeMap1234 {
 			yyl948 := r.ReadMapStart()
 			if yyl948 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl948, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct948 == codecSelferValueTypeArray1234 {
 			yyl948 := r.ReadArrayStart()
 			if yyl948 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl948, d)
 			}
@@ -12285,8 +13232,10 @@ func (x *TCPSocketAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys949Slc = r.DecodeBytes(yys949Slc, true, true)
 		yys949 := string(yys949Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys949 {
 		case "port":
 			if r.TryDecodeAsNil() {
@@ -12307,9 +13256,7 @@ func (x *TCPSocketAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys949)
 		} // end switch yys949
 	} // end for yyj949
-	if !yyhl949 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *TCPSocketAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12326,9 +13273,10 @@ func (x *TCPSocketAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb952 = r.CheckBreak()
 	}
 	if yyb952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = pkg5_intstr.IntOrString{}
 	} else {
@@ -12353,9 +13301,10 @@ func (x *TCPSocketAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb952 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj952-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ExecAction) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12376,18 +13325,21 @@ func (x *ExecAction) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep956, yyq956, yy2arr956
 			const yyr956 bool = false
 			yyq956[0] = len(x.Command) != 0
+			var yynn956 int
 			if yyr956 || yy2arr956 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn956 int = 0
+				yynn956 = 0
 				for _, b := range yyq956 {
 					if b {
 						yynn956++
 					}
 				}
 				r.EncodeMapStart(yynn956)
+				yynn956 = 0
 			}
 			if yyr956 || yy2arr956 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq956[0] {
 					if x.Command == nil {
 						r.EncodeNil()
@@ -12404,7 +13356,9 @@ func (x *ExecAction) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq956[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("command"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Command == nil {
 						r.EncodeNil()
 					} else {
@@ -12417,8 +13371,10 @@ func (x *ExecAction) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep956 {
-				r.EncodeEnd()
+			if yyr956 || yy2arr956 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12433,17 +13389,18 @@ func (x *ExecAction) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct961 := r.ContainerType()
+		if yyct961 == codecSelferValueTypeMap1234 {
 			yyl961 := r.ReadMapStart()
 			if yyl961 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl961, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct961 == codecSelferValueTypeArray1234 {
 			yyl961 := r.ReadArrayStart()
 			if yyl961 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl961, d)
 			}
@@ -12470,8 +13427,10 @@ func (x *ExecAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys962Slc = r.DecodeBytes(yys962Slc, true, true)
 		yys962 := string(yys962Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys962 {
 		case "command":
 			if r.TryDecodeAsNil() {
@@ -12489,9 +13448,7 @@ func (x *ExecAction) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys962)
 		} // end switch yys962
 	} // end for yyj962
-	if !yyhl962 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ExecAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12508,9 +13465,10 @@ func (x *ExecAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb965 = r.CheckBreak()
 	}
 	if yyb965 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
@@ -12532,9 +13490,10 @@ func (x *ExecAction) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb965 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj965-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12562,16 +13521,18 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq969[5] = x.PeriodSeconds != 0
 			yyq969[6] = x.SuccessThreshold != 0
 			yyq969[7] = x.FailureThreshold != 0
+			var yynn969 int
 			if yyr969 || yy2arr969 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn969 int = 0
+				yynn969 = 0
 				for _, b := range yyq969 {
 					if b {
 						yynn969++
 					}
 				}
 				r.EncodeMapStart(yynn969)
+				yynn969 = 0
 			}
 			var yyn970 bool
 			if x.Handler.Exec == nil {
@@ -12583,6 +13544,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn970 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq969[0] {
 						if x.Exec == nil {
 							r.EncodeNil()
@@ -12595,7 +13557,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq969[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("exec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn970 {
 						r.EncodeNil()
 					} else {
@@ -12617,6 +13581,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn971 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq969[1] {
 						if x.HTTPGet == nil {
 							r.EncodeNil()
@@ -12629,7 +13594,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq969[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("httpGet"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn971 {
 						r.EncodeNil()
 					} else {
@@ -12651,6 +13618,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn972 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq969[2] {
 						if x.TCPSocket == nil {
 							r.EncodeNil()
@@ -12663,7 +13631,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq969[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tcpSocket"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn972 {
 						r.EncodeNil()
 					} else {
@@ -12676,6 +13646,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr969 || yy2arr969 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq969[3] {
 					yym974 := z.EncBinary()
 					_ = yym974
@@ -12688,7 +13659,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq969[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("initialDelaySeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym975 := z.EncBinary()
 					_ = yym975
 					if false {
@@ -12698,6 +13671,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr969 || yy2arr969 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq969[4] {
 					yym977 := z.EncBinary()
 					_ = yym977
@@ -12710,7 +13684,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq969[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym978 := z.EncBinary()
 					_ = yym978
 					if false {
@@ -12720,6 +13696,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr969 || yy2arr969 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq969[5] {
 					yym980 := z.EncBinary()
 					_ = yym980
@@ -12732,7 +13709,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq969[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("periodSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym981 := z.EncBinary()
 					_ = yym981
 					if false {
@@ -12742,6 +13721,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr969 || yy2arr969 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq969[6] {
 					yym983 := z.EncBinary()
 					_ = yym983
@@ -12754,7 +13734,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq969[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("successThreshold"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym984 := z.EncBinary()
 					_ = yym984
 					if false {
@@ -12764,6 +13746,7 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr969 || yy2arr969 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq969[7] {
 					yym986 := z.EncBinary()
 					_ = yym986
@@ -12776,7 +13759,9 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq969[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("failureThreshold"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym987 := z.EncBinary()
 					_ = yym987
 					if false {
@@ -12785,8 +13770,10 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep969 {
-				r.EncodeEnd()
+			if yyr969 || yy2arr969 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12801,17 +13788,18 @@ func (x *Probe) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct989 := r.ContainerType()
+		if yyct989 == codecSelferValueTypeMap1234 {
 			yyl989 := r.ReadMapStart()
 			if yyl989 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl989, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct989 == codecSelferValueTypeArray1234 {
 			yyl989 := r.ReadArrayStart()
 			if yyl989 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl989, d)
 			}
@@ -12838,8 +13826,10 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys990Slc = r.DecodeBytes(yys990Slc, true, true)
 		yys990 := string(yys990Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys990 {
 		case "exec":
 			if x.Handler.Exec == nil {
@@ -12917,9 +13907,7 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys990)
 		} // end switch yys990
 	} // end for yyj990
-	if !yyhl990 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12929,6 +13917,9 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj999 int
 	var yyb999 bool
 	var yyhl999 bool = l >= 0
+	if x.Handler.Exec == nil {
+		x.Handler.Exec = new(ExecAction)
+	}
 	yyj999++
 	if yyhl999 {
 		yyb999 = yyj999 > l
@@ -12936,9 +13927,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb999 = r.CheckBreak()
 	}
 	if yyb999 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Exec != nil {
 			x.Exec = nil
@@ -12949,6 +13941,9 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Exec.CodecDecodeSelf(d)
 	}
+	if x.Handler.HTTPGet == nil {
+		x.Handler.HTTPGet = new(HTTPGetAction)
+	}
 	yyj999++
 	if yyhl999 {
 		yyb999 = yyj999 > l
@@ -12956,9 +13951,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb999 = r.CheckBreak()
 	}
 	if yyb999 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HTTPGet != nil {
 			x.HTTPGet = nil
@@ -12969,6 +13965,9 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.HTTPGet.CodecDecodeSelf(d)
 	}
+	if x.Handler.TCPSocket == nil {
+		x.Handler.TCPSocket = new(TCPSocketAction)
+	}
 	yyj999++
 	if yyhl999 {
 		yyb999 = yyj999 > l
@@ -12976,9 +13975,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb999 = r.CheckBreak()
 	}
 	if yyb999 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TCPSocket != nil {
 			x.TCPSocket = nil
@@ -12996,9 +13996,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb999 = r.CheckBreak()
 	}
 	if yyb999 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.InitialDelaySeconds = 0
 	} else {
@@ -13011,9 +14012,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb999 = r.CheckBreak()
 	}
 	if yyb999 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TimeoutSeconds = 0
 	} else {
@@ -13026,9 +14028,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb999 = r.CheckBreak()
 	}
 	if yyb999 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PeriodSeconds = 0
 	} else {
@@ -13041,9 +14044,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb999 = r.CheckBreak()
 	}
 	if yyb999 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SuccessThreshold = 0
 	} else {
@@ -13056,9 +14060,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb999 = r.CheckBreak()
 	}
 	if yyb999 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FailureThreshold = 0
 	} else {
@@ -13074,9 +14079,10 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb999 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj999-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PullPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -13150,18 +14156,21 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1013 bool = false
 			yyq1013[0] = len(x.Add) != 0
 			yyq1013[1] = len(x.Drop) != 0
+			var yynn1013 int
 			if yyr1013 || yy2arr1013 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1013 int = 0
+				yynn1013 = 0
 				for _, b := range yyq1013 {
 					if b {
 						yynn1013++
 					}
 				}
 				r.EncodeMapStart(yynn1013)
+				yynn1013 = 0
 			}
 			if yyr1013 || yy2arr1013 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1013[0] {
 					if x.Add == nil {
 						r.EncodeNil()
@@ -13178,7 +14187,9 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1013[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("add"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Add == nil {
 						r.EncodeNil()
 					} else {
@@ -13192,6 +14203,7 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1013 || yy2arr1013 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1013[1] {
 					if x.Drop == nil {
 						r.EncodeNil()
@@ -13208,7 +14220,9 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1013[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("drop"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Drop == nil {
 						r.EncodeNil()
 					} else {
@@ -13221,8 +14235,10 @@ func (x *Capabilities) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1013 {
-				r.EncodeEnd()
+			if yyr1013 || yy2arr1013 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -13237,17 +14253,18 @@ func (x *Capabilities) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1021 := r.ContainerType()
+		if yyct1021 == codecSelferValueTypeMap1234 {
 			yyl1021 := r.ReadMapStart()
 			if yyl1021 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1021, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1021 == codecSelferValueTypeArray1234 {
 			yyl1021 := r.ReadArrayStart()
 			if yyl1021 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1021, d)
 			}
@@ -13274,8 +14291,10 @@ func (x *Capabilities) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1022Slc = r.DecodeBytes(yys1022Slc, true, true)
 		yys1022 := string(yys1022Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1022 {
 		case "add":
 			if r.TryDecodeAsNil() {
@@ -13305,9 +14324,7 @@ func (x *Capabilities) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1022)
 		} // end switch yys1022
 	} // end for yyj1022
-	if !yyhl1022 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Capabilities) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -13324,9 +14341,10 @@ func (x *Capabilities) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1027 = r.CheckBreak()
 	}
 	if yyb1027 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Add = nil
 	} else {
@@ -13345,9 +14363,10 @@ func (x *Capabilities) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1027 = r.CheckBreak()
 	}
 	if yyb1027 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Drop = nil
 	} else {
@@ -13369,9 +14388,10 @@ func (x *Capabilities) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1027 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1027-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -13393,18 +14413,21 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1033 bool = false
 			yyq1033[0] = len(x.Limits) != 0
 			yyq1033[1] = len(x.Requests) != 0
+			var yynn1033 int
 			if yyr1033 || yy2arr1033 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1033 int = 0
+				yynn1033 = 0
 				for _, b := range yyq1033 {
 					if b {
 						yynn1033++
 					}
 				}
 				r.EncodeMapStart(yynn1033)
+				yynn1033 = 0
 			}
 			if yyr1033 || yy2arr1033 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1033[0] {
 					if x.Limits == nil {
 						r.EncodeNil()
@@ -13416,7 +14439,9 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1033[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("limits"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Limits == nil {
 						r.EncodeNil()
 					} else {
@@ -13425,6 +14450,7 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1033 || yy2arr1033 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1033[1] {
 					if x.Requests == nil {
 						r.EncodeNil()
@@ -13436,7 +14462,9 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1033[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("requests"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Requests == nil {
 						r.EncodeNil()
 					} else {
@@ -13444,8 +14472,10 @@ func (x *ResourceRequirements) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1033 {
-				r.EncodeEnd()
+			if yyr1033 || yy2arr1033 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -13460,17 +14490,18 @@ func (x *ResourceRequirements) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1037 := r.ContainerType()
+		if yyct1037 == codecSelferValueTypeMap1234 {
 			yyl1037 := r.ReadMapStart()
 			if yyl1037 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1037, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1037 == codecSelferValueTypeArray1234 {
 			yyl1037 := r.ReadArrayStart()
 			if yyl1037 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1037, d)
 			}
@@ -13497,8 +14528,10 @@ func (x *ResourceRequirements) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1038Slc = r.DecodeBytes(yys1038Slc, true, true)
 		yys1038 := string(yys1038Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1038 {
 		case "limits":
 			if r.TryDecodeAsNil() {
@@ -13518,9 +14551,7 @@ func (x *ResourceRequirements) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys1038)
 		} // end switch yys1038
 	} // end for yyj1038
-	if !yyhl1038 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceRequirements) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -13537,9 +14568,10 @@ func (x *ResourceRequirements) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb1041 = r.CheckBreak()
 	}
 	if yyb1041 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Limits = nil
 	} else {
@@ -13553,9 +14585,10 @@ func (x *ResourceRequirements) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb1041 = r.CheckBreak()
 	}
 	if yyb1041 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Requests = nil
 	} else {
@@ -13572,9 +14605,10 @@ func (x *ResourceRequirements) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb1041 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1041-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -13611,18 +14645,21 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1045[15] = x.Stdin != false
 			yyq1045[16] = x.StdinOnce != false
 			yyq1045[17] = x.TTY != false
+			var yynn1045 int
 			if yyr1045 || yy2arr1045 {
 				r.EncodeArrayStart(18)
 			} else {
-				var yynn1045 int = 1
+				yynn1045 = 1
 				for _, b := range yyq1045 {
 					if b {
 						yynn1045++
 					}
 				}
 				r.EncodeMapStart(yynn1045)
+				yynn1045 = 0
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1047 := z.EncBinary()
 				_ = yym1047
 				if false {
@@ -13630,7 +14667,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1048 := z.EncBinary()
 				_ = yym1048
 				if false {
@@ -13639,6 +14678,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[1] {
 					yym1050 := z.EncBinary()
 					_ = yym1050
@@ -13651,7 +14691,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("image"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1051 := z.EncBinary()
 					_ = yym1051
 					if false {
@@ -13661,6 +14703,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[2] {
 					if x.Command == nil {
 						r.EncodeNil()
@@ -13677,7 +14720,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("command"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Command == nil {
 						r.EncodeNil()
 					} else {
@@ -13691,6 +14736,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[3] {
 					if x.Args == nil {
 						r.EncodeNil()
@@ -13707,7 +14753,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("args"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Args == nil {
 						r.EncodeNil()
 					} else {
@@ -13721,6 +14769,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[4] {
 					yym1059 := z.EncBinary()
 					_ = yym1059
@@ -13733,7 +14782,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("workingDir"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1060 := z.EncBinary()
 					_ = yym1060
 					if false {
@@ -13743,6 +14794,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[5] {
 					if x.Ports == nil {
 						r.EncodeNil()
@@ -13759,7 +14811,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("ports"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Ports == nil {
 						r.EncodeNil()
 					} else {
@@ -13773,6 +14827,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[6] {
 					if x.Env == nil {
 						r.EncodeNil()
@@ -13789,7 +14844,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("env"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Env == nil {
 						r.EncodeNil()
 					} else {
@@ -13803,6 +14860,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[7] {
 					yy1068 := &x.Resources
 					yy1068.CodecEncodeSelf(e)
@@ -13811,12 +14869,15 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resources"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1069 := &x.Resources
 					yy1069.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[8] {
 					if x.VolumeMounts == nil {
 						r.EncodeNil()
@@ -13833,7 +14894,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("volumeMounts"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.VolumeMounts == nil {
 						r.EncodeNil()
 					} else {
@@ -13847,6 +14910,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[9] {
 					if x.LivenessProbe == nil {
 						r.EncodeNil()
@@ -13858,7 +14922,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("livenessProbe"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.LivenessProbe == nil {
 						r.EncodeNil()
 					} else {
@@ -13867,6 +14933,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[10] {
 					if x.ReadinessProbe == nil {
 						r.EncodeNil()
@@ -13878,7 +14945,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("readinessProbe"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ReadinessProbe == nil {
 						r.EncodeNil()
 					} else {
@@ -13887,6 +14956,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[11] {
 					if x.Lifecycle == nil {
 						r.EncodeNil()
@@ -13898,7 +14968,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lifecycle"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Lifecycle == nil {
 						r.EncodeNil()
 					} else {
@@ -13907,6 +14979,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[12] {
 					yym1077 := z.EncBinary()
 					_ = yym1077
@@ -13919,7 +14992,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("terminationMessagePath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1078 := z.EncBinary()
 					_ = yym1078
 					if false {
@@ -13929,6 +15004,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[13] {
 					x.ImagePullPolicy.CodecEncodeSelf(e)
 				} else {
@@ -13936,11 +15012,14 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("imagePullPolicy"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.ImagePullPolicy.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[14] {
 					if x.SecurityContext == nil {
 						r.EncodeNil()
@@ -13952,7 +15031,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("securityContext"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SecurityContext == nil {
 						r.EncodeNil()
 					} else {
@@ -13961,6 +15042,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[15] {
 					yym1082 := z.EncBinary()
 					_ = yym1082
@@ -13973,7 +15055,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[15] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1083 := z.EncBinary()
 					_ = yym1083
 					if false {
@@ -13983,6 +15067,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[16] {
 					yym1085 := z.EncBinary()
 					_ = yym1085
@@ -13995,7 +15080,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[16] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdinOnce"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1086 := z.EncBinary()
 					_ = yym1086
 					if false {
@@ -14005,6 +15092,7 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1045[17] {
 					yym1088 := z.EncBinary()
 					_ = yym1088
@@ -14017,7 +15105,9 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1045[17] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1089 := z.EncBinary()
 					_ = yym1089
 					if false {
@@ -14026,8 +15116,10 @@ func (x *Container) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1045 {
-				r.EncodeEnd()
+			if yyr1045 || yy2arr1045 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -14042,17 +15134,18 @@ func (x *Container) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1091 := r.ContainerType()
+		if yyct1091 == codecSelferValueTypeMap1234 {
 			yyl1091 := r.ReadMapStart()
 			if yyl1091 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1091, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1091 == codecSelferValueTypeArray1234 {
 			yyl1091 := r.ReadArrayStart()
 			if yyl1091 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1091, d)
 			}
@@ -14079,8 +15172,10 @@ func (x *Container) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1092Slc = r.DecodeBytes(yys1092Slc, true, true)
 		yys1092 := string(yys1092Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1092 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -14245,9 +15340,7 @@ func (x *Container) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1092)
 		} // end switch yys1092
 	} // end for yyj1092
-	if !yyhl1092 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -14264,9 +15357,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -14279,9 +15373,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Image = ""
 	} else {
@@ -14294,9 +15389,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
@@ -14315,9 +15411,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Args = nil
 	} else {
@@ -14336,9 +15433,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.WorkingDir = ""
 	} else {
@@ -14351,9 +15449,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
@@ -14372,9 +15471,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Env = nil
 	} else {
@@ -14393,9 +15493,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Resources = ResourceRequirements{}
 	} else {
@@ -14409,9 +15510,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.VolumeMounts = nil
 	} else {
@@ -14430,9 +15532,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.LivenessProbe != nil {
 			x.LivenessProbe = nil
@@ -14450,9 +15553,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ReadinessProbe != nil {
 			x.ReadinessProbe = nil
@@ -14470,9 +15574,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Lifecycle != nil {
 			x.Lifecycle = nil
@@ -14490,9 +15595,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TerminationMessagePath = ""
 	} else {
@@ -14505,9 +15611,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ImagePullPolicy = ""
 	} else {
@@ -14520,9 +15627,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SecurityContext != nil {
 			x.SecurityContext = nil
@@ -14540,9 +15648,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdin = false
 	} else {
@@ -14555,9 +15664,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.StdinOnce = false
 	} else {
@@ -14570,9 +15680,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1116 = r.CheckBreak()
 	}
 	if yyb1116 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TTY = false
 	} else {
@@ -14588,9 +15699,10 @@ func (x *Container) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1116 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1116-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -14613,18 +15725,21 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1141[0] = x.Exec != nil
 			yyq1141[1] = x.HTTPGet != nil
 			yyq1141[2] = x.TCPSocket != nil
+			var yynn1141 int
 			if yyr1141 || yy2arr1141 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1141 int = 0
+				yynn1141 = 0
 				for _, b := range yyq1141 {
 					if b {
 						yynn1141++
 					}
 				}
 				r.EncodeMapStart(yynn1141)
+				yynn1141 = 0
 			}
 			if yyr1141 || yy2arr1141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1141[0] {
 					if x.Exec == nil {
 						r.EncodeNil()
@@ -14636,7 +15751,9 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1141[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("exec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Exec == nil {
 						r.EncodeNil()
 					} else {
@@ -14645,6 +15762,7 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1141 || yy2arr1141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1141[1] {
 					if x.HTTPGet == nil {
 						r.EncodeNil()
@@ -14656,7 +15774,9 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1141[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("httpGet"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HTTPGet == nil {
 						r.EncodeNil()
 					} else {
@@ -14665,6 +15785,7 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1141 || yy2arr1141 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1141[2] {
 					if x.TCPSocket == nil {
 						r.EncodeNil()
@@ -14676,7 +15797,9 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1141[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tcpSocket"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TCPSocket == nil {
 						r.EncodeNil()
 					} else {
@@ -14684,8 +15807,10 @@ func (x *Handler) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1141 {
-				r.EncodeEnd()
+			if yyr1141 || yy2arr1141 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -14700,17 +15825,18 @@ func (x *Handler) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1146 := r.ContainerType()
+		if yyct1146 == codecSelferValueTypeMap1234 {
 			yyl1146 := r.ReadMapStart()
 			if yyl1146 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1146, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1146 == codecSelferValueTypeArray1234 {
 			yyl1146 := r.ReadArrayStart()
 			if yyl1146 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1146, d)
 			}
@@ -14737,8 +15863,10 @@ func (x *Handler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1147Slc = r.DecodeBytes(yys1147Slc, true, true)
 		yys1147 := string(yys1147Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1147 {
 		case "exec":
 			if r.TryDecodeAsNil() {
@@ -14777,9 +15905,7 @@ func (x *Handler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1147)
 		} // end switch yys1147
 	} // end for yyj1147
-	if !yyhl1147 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -14796,9 +15922,10 @@ func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1151 = r.CheckBreak()
 	}
 	if yyb1151 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Exec != nil {
 			x.Exec = nil
@@ -14816,9 +15943,10 @@ func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1151 = r.CheckBreak()
 	}
 	if yyb1151 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HTTPGet != nil {
 			x.HTTPGet = nil
@@ -14836,9 +15964,10 @@ func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1151 = r.CheckBreak()
 	}
 	if yyb1151 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TCPSocket != nil {
 			x.TCPSocket = nil
@@ -14859,9 +15988,10 @@ func (x *Handler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1151 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1151-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -14883,18 +16013,21 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1156 bool = false
 			yyq1156[0] = x.PostStart != nil
 			yyq1156[1] = x.PreStop != nil
+			var yynn1156 int
 			if yyr1156 || yy2arr1156 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1156 int = 0
+				yynn1156 = 0
 				for _, b := range yyq1156 {
 					if b {
 						yynn1156++
 					}
 				}
 				r.EncodeMapStart(yynn1156)
+				yynn1156 = 0
 			}
 			if yyr1156 || yy2arr1156 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1156[0] {
 					if x.PostStart == nil {
 						r.EncodeNil()
@@ -14906,7 +16039,9 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1156[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("postStart"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.PostStart == nil {
 						r.EncodeNil()
 					} else {
@@ -14915,6 +16050,7 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1156 || yy2arr1156 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1156[1] {
 					if x.PreStop == nil {
 						r.EncodeNil()
@@ -14926,7 +16062,9 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1156[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("preStop"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.PreStop == nil {
 						r.EncodeNil()
 					} else {
@@ -14934,8 +16072,10 @@ func (x *Lifecycle) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1156 {
-				r.EncodeEnd()
+			if yyr1156 || yy2arr1156 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -14950,17 +16090,18 @@ func (x *Lifecycle) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1160 := r.ContainerType()
+		if yyct1160 == codecSelferValueTypeMap1234 {
 			yyl1160 := r.ReadMapStart()
 			if yyl1160 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1160, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1160 == codecSelferValueTypeArray1234 {
 			yyl1160 := r.ReadArrayStart()
 			if yyl1160 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1160, d)
 			}
@@ -14987,8 +16128,10 @@ func (x *Lifecycle) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1161Slc = r.DecodeBytes(yys1161Slc, true, true)
 		yys1161 := string(yys1161Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1161 {
 		case "postStart":
 			if r.TryDecodeAsNil() {
@@ -15016,9 +16159,7 @@ func (x *Lifecycle) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1161)
 		} // end switch yys1161
 	} // end for yyj1161
-	if !yyhl1161 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Lifecycle) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -15035,9 +16176,10 @@ func (x *Lifecycle) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1164 = r.CheckBreak()
 	}
 	if yyb1164 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.PostStart != nil {
 			x.PostStart = nil
@@ -15055,9 +16197,10 @@ func (x *Lifecycle) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1164 = r.CheckBreak()
 	}
 	if yyb1164 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.PreStop != nil {
 			x.PreStop = nil
@@ -15078,9 +16221,10 @@ func (x *Lifecycle) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1164 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1164-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x ConditionStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -15128,18 +16272,21 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1170 bool = false
 			yyq1170[0] = x.Reason != ""
 			yyq1170[1] = x.Message != ""
+			var yynn1170 int
 			if yyr1170 || yy2arr1170 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1170 int = 0
+				yynn1170 = 0
 				for _, b := range yyq1170 {
 					if b {
 						yynn1170++
 					}
 				}
 				r.EncodeMapStart(yynn1170)
+				yynn1170 = 0
 			}
 			if yyr1170 || yy2arr1170 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1170[0] {
 					yym1172 := z.EncBinary()
 					_ = yym1172
@@ -15152,7 +16299,9 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1170[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1173 := z.EncBinary()
 					_ = yym1173
 					if false {
@@ -15162,6 +16311,7 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1170 || yy2arr1170 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1170[1] {
 					yym1175 := z.EncBinary()
 					_ = yym1175
@@ -15174,7 +16324,9 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1170[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1176 := z.EncBinary()
 					_ = yym1176
 					if false {
@@ -15183,8 +16335,10 @@ func (x *ContainerStateWaiting) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1170 {
-				r.EncodeEnd()
+			if yyr1170 || yy2arr1170 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -15199,17 +16353,18 @@ func (x *ContainerStateWaiting) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1178 := r.ContainerType()
+		if yyct1178 == codecSelferValueTypeMap1234 {
 			yyl1178 := r.ReadMapStart()
 			if yyl1178 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1178, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1178 == codecSelferValueTypeArray1234 {
 			yyl1178 := r.ReadArrayStart()
 			if yyl1178 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1178, d)
 			}
@@ -15236,8 +16391,10 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1179Slc = r.DecodeBytes(yys1179Slc, true, true)
 		yys1179 := string(yys1179Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1179 {
 		case "reason":
 			if r.TryDecodeAsNil() {
@@ -15255,9 +16412,7 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1179)
 		} // end switch yys1179
 	} // end for yyj1179
-	if !yyhl1179 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerStateWaiting) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -15274,9 +16429,10 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1182 = r.CheckBreak()
 	}
 	if yyb1182 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -15289,9 +16445,10 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1182 = r.CheckBreak()
 	}
 	if yyb1182 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -15307,9 +16464,10 @@ func (x *ContainerStateWaiting) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1182 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1182-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerStateRunning) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -15330,18 +16488,21 @@ func (x *ContainerStateRunning) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1186, yyq1186, yy2arr1186
 			const yyr1186 bool = false
 			yyq1186[0] = true
+			var yynn1186 int
 			if yyr1186 || yy2arr1186 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1186 int = 0
+				yynn1186 = 0
 				for _, b := range yyq1186 {
 					if b {
 						yynn1186++
 					}
 				}
 				r.EncodeMapStart(yynn1186)
+				yynn1186 = 0
 			}
 			if yyr1186 || yy2arr1186 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1186[0] {
 					yy1188 := &x.StartedAt
 					yym1189 := z.EncBinary()
@@ -15360,7 +16521,9 @@ func (x *ContainerStateRunning) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1186[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startedAt"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1190 := &x.StartedAt
 					yym1191 := z.EncBinary()
 					_ = yym1191
@@ -15375,8 +16538,10 @@ func (x *ContainerStateRunning) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1186 {
-				r.EncodeEnd()
+			if yyr1186 || yy2arr1186 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -15391,17 +16556,18 @@ func (x *ContainerStateRunning) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1193 := r.ContainerType()
+		if yyct1193 == codecSelferValueTypeMap1234 {
 			yyl1193 := r.ReadMapStart()
 			if yyl1193 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1193, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1193 == codecSelferValueTypeArray1234 {
 			yyl1193 := r.ReadArrayStart()
 			if yyl1193 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1193, d)
 			}
@@ -15428,8 +16594,10 @@ func (x *ContainerStateRunning) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1194Slc = r.DecodeBytes(yys1194Slc, true, true)
 		yys1194 := string(yys1194Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1194 {
 		case "startedAt":
 			if r.TryDecodeAsNil() {
@@ -15452,9 +16620,7 @@ func (x *ContainerStateRunning) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1194)
 		} // end switch yys1194
 	} // end for yyj1194
-	if !yyhl1194 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerStateRunning) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -15471,9 +16637,10 @@ func (x *ContainerStateRunning) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1197 = r.CheckBreak()
 	}
 	if yyb1197 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.StartedAt = pkg2_unversioned.Time{}
 	} else {
@@ -15500,9 +16667,10 @@ func (x *ContainerStateRunning) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1197 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1197-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -15528,18 +16696,21 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1201[4] = true
 			yyq1201[5] = true
 			yyq1201[6] = x.ContainerID != ""
+			var yynn1201 int
 			if yyr1201 || yy2arr1201 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn1201 int = 1
+				yynn1201 = 1
 				for _, b := range yyq1201 {
 					if b {
 						yynn1201++
 					}
 				}
 				r.EncodeMapStart(yynn1201)
+				yynn1201 = 0
 			}
 			if yyr1201 || yy2arr1201 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1203 := z.EncBinary()
 				_ = yym1203
 				if false {
@@ -15547,7 +16718,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.ExitCode))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("exitCode"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1204 := z.EncBinary()
 				_ = yym1204
 				if false {
@@ -15556,6 +16729,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1201 || yy2arr1201 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1201[1] {
 					yym1206 := z.EncBinary()
 					_ = yym1206
@@ -15568,7 +16742,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1201[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("signal"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1207 := z.EncBinary()
 					_ = yym1207
 					if false {
@@ -15578,6 +16754,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1201 || yy2arr1201 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1201[2] {
 					yym1209 := z.EncBinary()
 					_ = yym1209
@@ -15590,7 +16767,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1201[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1210 := z.EncBinary()
 					_ = yym1210
 					if false {
@@ -15600,6 +16779,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1201 || yy2arr1201 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1201[3] {
 					yym1212 := z.EncBinary()
 					_ = yym1212
@@ -15612,7 +16792,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1201[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1213 := z.EncBinary()
 					_ = yym1213
 					if false {
@@ -15622,6 +16804,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1201 || yy2arr1201 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1201[4] {
 					yy1215 := &x.StartedAt
 					yym1216 := z.EncBinary()
@@ -15640,7 +16823,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1201[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startedAt"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1217 := &x.StartedAt
 					yym1218 := z.EncBinary()
 					_ = yym1218
@@ -15656,6 +16841,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1201 || yy2arr1201 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1201[5] {
 					yy1220 := &x.FinishedAt
 					yym1221 := z.EncBinary()
@@ -15674,7 +16860,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1201[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("finishedAt"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1222 := &x.FinishedAt
 					yym1223 := z.EncBinary()
 					_ = yym1223
@@ -15690,6 +16878,7 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1201 || yy2arr1201 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1201[6] {
 					yym1225 := z.EncBinary()
 					_ = yym1225
@@ -15702,7 +16891,9 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1201[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("containerID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1226 := z.EncBinary()
 					_ = yym1226
 					if false {
@@ -15711,8 +16902,10 @@ func (x *ContainerStateTerminated) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1201 {
-				r.EncodeEnd()
+			if yyr1201 || yy2arr1201 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -15727,17 +16920,18 @@ func (x *ContainerStateTerminated) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1228 := r.ContainerType()
+		if yyct1228 == codecSelferValueTypeMap1234 {
 			yyl1228 := r.ReadMapStart()
 			if yyl1228 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1228, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1228 == codecSelferValueTypeArray1234 {
 			yyl1228 := r.ReadArrayStart()
 			if yyl1228 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1228, d)
 			}
@@ -15764,8 +16958,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromMap(l int, d *codec1978.De
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1229Slc = r.DecodeBytes(yys1229Slc, true, true)
 		yys1229 := string(yys1229Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1229 {
 		case "exitCode":
 			if r.TryDecodeAsNil() {
@@ -15835,9 +17031,7 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromMap(l int, d *codec1978.De
 			z.DecStructFieldNotFound(-1, yys1229)
 		} // end switch yys1229
 	} // end for yyj1229
-	if !yyhl1229 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -15854,9 +17048,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1239 = r.CheckBreak()
 	}
 	if yyb1239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ExitCode = 0
 	} else {
@@ -15869,9 +17064,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1239 = r.CheckBreak()
 	}
 	if yyb1239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Signal = 0
 	} else {
@@ -15884,9 +17080,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1239 = r.CheckBreak()
 	}
 	if yyb1239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -15899,9 +17096,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1239 = r.CheckBreak()
 	}
 	if yyb1239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -15914,9 +17112,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1239 = r.CheckBreak()
 	}
 	if yyb1239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.StartedAt = pkg2_unversioned.Time{}
 	} else {
@@ -15940,9 +17139,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1239 = r.CheckBreak()
 	}
 	if yyb1239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FinishedAt = pkg2_unversioned.Time{}
 	} else {
@@ -15966,9 +17166,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		yyb1239 = r.CheckBreak()
 	}
 	if yyb1239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerID = ""
 	} else {
@@ -15984,9 +17185,10 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 		if yyb1239 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1239-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -16009,18 +17211,21 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1250[0] = x.Waiting != nil
 			yyq1250[1] = x.Running != nil
 			yyq1250[2] = x.Terminated != nil
+			var yynn1250 int
 			if yyr1250 || yy2arr1250 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1250 int = 0
+				yynn1250 = 0
 				for _, b := range yyq1250 {
 					if b {
 						yynn1250++
 					}
 				}
 				r.EncodeMapStart(yynn1250)
+				yynn1250 = 0
 			}
 			if yyr1250 || yy2arr1250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1250[0] {
 					if x.Waiting == nil {
 						r.EncodeNil()
@@ -16032,7 +17237,9 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1250[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("waiting"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Waiting == nil {
 						r.EncodeNil()
 					} else {
@@ -16041,6 +17248,7 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1250 || yy2arr1250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1250[1] {
 					if x.Running == nil {
 						r.EncodeNil()
@@ -16052,7 +17260,9 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1250[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("running"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Running == nil {
 						r.EncodeNil()
 					} else {
@@ -16061,6 +17271,7 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1250 || yy2arr1250 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1250[2] {
 					if x.Terminated == nil {
 						r.EncodeNil()
@@ -16072,7 +17283,9 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1250[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("terminated"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Terminated == nil {
 						r.EncodeNil()
 					} else {
@@ -16080,8 +17293,10 @@ func (x *ContainerState) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1250 {
-				r.EncodeEnd()
+			if yyr1250 || yy2arr1250 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -16096,17 +17311,18 @@ func (x *ContainerState) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1255 := r.ContainerType()
+		if yyct1255 == codecSelferValueTypeMap1234 {
 			yyl1255 := r.ReadMapStart()
 			if yyl1255 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1255, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1255 == codecSelferValueTypeArray1234 {
 			yyl1255 := r.ReadArrayStart()
 			if yyl1255 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1255, d)
 			}
@@ -16133,8 +17349,10 @@ func (x *ContainerState) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1256Slc = r.DecodeBytes(yys1256Slc, true, true)
 		yys1256 := string(yys1256Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1256 {
 		case "waiting":
 			if r.TryDecodeAsNil() {
@@ -16173,9 +17391,7 @@ func (x *ContainerState) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1256)
 		} // end switch yys1256
 	} // end for yyj1256
-	if !yyhl1256 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -16192,9 +17408,10 @@ func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1260 = r.CheckBreak()
 	}
 	if yyb1260 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Waiting != nil {
 			x.Waiting = nil
@@ -16212,9 +17429,10 @@ func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1260 = r.CheckBreak()
 	}
 	if yyb1260 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Running != nil {
 			x.Running = nil
@@ -16232,9 +17450,10 @@ func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1260 = r.CheckBreak()
 	}
 	if yyb1260 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Terminated != nil {
 			x.Terminated = nil
@@ -16255,9 +17474,10 @@ func (x *ContainerState) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1260 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1260-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -16280,18 +17500,21 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1265[1] = true
 			yyq1265[2] = true
 			yyq1265[7] = x.ContainerID != ""
+			var yynn1265 int
 			if yyr1265 || yy2arr1265 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1265 int = 5
+				yynn1265 = 5
 				for _, b := range yyq1265 {
 					if b {
 						yynn1265++
 					}
 				}
 				r.EncodeMapStart(yynn1265)
+				yynn1265 = 0
 			}
 			if yyr1265 || yy2arr1265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1267 := z.EncBinary()
 				_ = yym1267
 				if false {
@@ -16299,7 +17522,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1268 := z.EncBinary()
 				_ = yym1268
 				if false {
@@ -16308,6 +17533,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1265 || yy2arr1265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1265[1] {
 					yy1270 := &x.State
 					yy1270.CodecEncodeSelf(e)
@@ -16316,12 +17542,15 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1265[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("state"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1271 := &x.State
 					yy1271.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1265 || yy2arr1265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1265[2] {
 					yy1273 := &x.LastTerminationState
 					yy1273.CodecEncodeSelf(e)
@@ -16330,12 +17559,15 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1265[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastState"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1274 := &x.LastTerminationState
 					yy1274.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1265 || yy2arr1265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1276 := z.EncBinary()
 				_ = yym1276
 				if false {
@@ -16343,7 +17575,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.Ready))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("ready"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1277 := z.EncBinary()
 				_ = yym1277
 				if false {
@@ -16352,6 +17586,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1265 || yy2arr1265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1279 := z.EncBinary()
 				_ = yym1279
 				if false {
@@ -16359,7 +17594,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.RestartCount))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("restartCount"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1280 := z.EncBinary()
 				_ = yym1280
 				if false {
@@ -16368,6 +17605,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1265 || yy2arr1265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1282 := z.EncBinary()
 				_ = yym1282
 				if false {
@@ -16375,7 +17613,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Image))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("image"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1283 := z.EncBinary()
 				_ = yym1283
 				if false {
@@ -16384,6 +17624,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1265 || yy2arr1265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1285 := z.EncBinary()
 				_ = yym1285
 				if false {
@@ -16391,7 +17632,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ImageID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("imageID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1286 := z.EncBinary()
 				_ = yym1286
 				if false {
@@ -16400,6 +17643,7 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1265 || yy2arr1265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1265[7] {
 					yym1288 := z.EncBinary()
 					_ = yym1288
@@ -16412,7 +17656,9 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1265[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("containerID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1289 := z.EncBinary()
 					_ = yym1289
 					if false {
@@ -16421,8 +17667,10 @@ func (x *ContainerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1265 {
-				r.EncodeEnd()
+			if yyr1265 || yy2arr1265 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -16437,17 +17685,18 @@ func (x *ContainerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1291 := r.ContainerType()
+		if yyct1291 == codecSelferValueTypeMap1234 {
 			yyl1291 := r.ReadMapStart()
 			if yyl1291 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1291, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1291 == codecSelferValueTypeArray1234 {
 			yyl1291 := r.ReadArrayStart()
 			if yyl1291 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1291, d)
 			}
@@ -16474,8 +17723,10 @@ func (x *ContainerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1292Slc = r.DecodeBytes(yys1292Slc, true, true)
 		yys1292 := string(yys1292Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1292 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -16531,9 +17782,7 @@ func (x *ContainerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1292)
 		} // end switch yys1292
 	} // end for yyj1292
-	if !yyhl1292 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -16550,9 +17799,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1301 = r.CheckBreak()
 	}
 	if yyb1301 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -16565,9 +17815,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1301 = r.CheckBreak()
 	}
 	if yyb1301 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.State = ContainerState{}
 	} else {
@@ -16581,9 +17832,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1301 = r.CheckBreak()
 	}
 	if yyb1301 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTerminationState = ContainerState{}
 	} else {
@@ -16597,9 +17849,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1301 = r.CheckBreak()
 	}
 	if yyb1301 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ready = false
 	} else {
@@ -16612,9 +17865,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1301 = r.CheckBreak()
 	}
 	if yyb1301 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RestartCount = 0
 	} else {
@@ -16627,9 +17881,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1301 = r.CheckBreak()
 	}
 	if yyb1301 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Image = ""
 	} else {
@@ -16642,9 +17897,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1301 = r.CheckBreak()
 	}
 	if yyb1301 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ImageID = ""
 	} else {
@@ -16657,9 +17913,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1301 = r.CheckBreak()
 	}
 	if yyb1301 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerID = ""
 	} else {
@@ -16675,9 +17932,10 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb1301 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1301-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PodPhase) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -16753,30 +18011,39 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1315[3] = true
 			yyq1315[4] = x.Reason != ""
 			yyq1315[5] = x.Message != ""
+			var yynn1315 int
 			if yyr1315 || yy2arr1315 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn1315 int = 2
+				yynn1315 = 2
 				for _, b := range yyq1315 {
 					if b {
 						yynn1315++
 					}
 				}
 				r.EncodeMapStart(yynn1315)
+				yynn1315 = 0
 			}
 			if yyr1315 || yy2arr1315 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr1315 || yy2arr1315 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Status.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Status.CodecEncodeSelf(e)
 			}
 			if yyr1315 || yy2arr1315 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1315[2] {
 					yy1319 := &x.LastProbeTime
 					yym1320 := z.EncBinary()
@@ -16795,7 +18062,9 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1315[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1321 := &x.LastProbeTime
 					yym1322 := z.EncBinary()
 					_ = yym1322
@@ -16811,6 +18080,7 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1315 || yy2arr1315 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1315[3] {
 					yy1324 := &x.LastTransitionTime
 					yym1325 := z.EncBinary()
@@ -16829,7 +18099,9 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1315[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1326 := &x.LastTransitionTime
 					yym1327 := z.EncBinary()
 					_ = yym1327
@@ -16845,6 +18117,7 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1315 || yy2arr1315 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1315[4] {
 					yym1329 := z.EncBinary()
 					_ = yym1329
@@ -16857,7 +18130,9 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1315[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1330 := z.EncBinary()
 					_ = yym1330
 					if false {
@@ -16867,6 +18142,7 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1315 || yy2arr1315 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1315[5] {
 					yym1332 := z.EncBinary()
 					_ = yym1332
@@ -16879,7 +18155,9 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1315[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1333 := z.EncBinary()
 					_ = yym1333
 					if false {
@@ -16888,8 +18166,10 @@ func (x *PodCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1315 {
-				r.EncodeEnd()
+			if yyr1315 || yy2arr1315 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -16904,17 +18184,18 @@ func (x *PodCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1335 := r.ContainerType()
+		if yyct1335 == codecSelferValueTypeMap1234 {
 			yyl1335 := r.ReadMapStart()
 			if yyl1335 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1335, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1335 == codecSelferValueTypeArray1234 {
 			yyl1335 := r.ReadArrayStart()
 			if yyl1335 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1335, d)
 			}
@@ -16941,8 +18222,10 @@ func (x *PodCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1336Slc = r.DecodeBytes(yys1336Slc, true, true)
 		yys1336 := string(yys1336Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1336 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -17006,9 +18289,7 @@ func (x *PodCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1336)
 		} // end switch yys1336
 	} // end for yyj1336
-	if !yyhl1336 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -17025,9 +18306,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1345 = r.CheckBreak()
 	}
 	if yyb1345 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -17040,9 +18322,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1345 = r.CheckBreak()
 	}
 	if yyb1345 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ""
 	} else {
@@ -17055,9 +18338,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1345 = r.CheckBreak()
 	}
 	if yyb1345 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg2_unversioned.Time{}
 	} else {
@@ -17081,9 +18365,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1345 = r.CheckBreak()
 	}
 	if yyb1345 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg2_unversioned.Time{}
 	} else {
@@ -17107,9 +18392,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1345 = r.CheckBreak()
 	}
 	if yyb1345 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -17122,9 +18408,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1345 = r.CheckBreak()
 	}
 	if yyb1345 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -17140,9 +18427,10 @@ func (x *PodCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1345 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1345-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x RestartPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -17228,18 +18516,21 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1359[12] = x.HostIPC != false
 			yyq1359[13] = x.SecurityContext != nil
 			yyq1359[14] = len(x.ImagePullSecrets) != 0
+			var yynn1359 int
 			if yyr1359 || yy2arr1359 {
 				r.EncodeArrayStart(15)
 			} else {
-				var yynn1359 int = 1
+				yynn1359 = 1
 				for _, b := range yyq1359 {
 					if b {
 						yynn1359++
 					}
 				}
 				r.EncodeMapStart(yynn1359)
+				yynn1359 = 0
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[0] {
 					if x.Volumes == nil {
 						r.EncodeNil()
@@ -17256,7 +18547,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("volumes"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Volumes == nil {
 						r.EncodeNil()
 					} else {
@@ -17270,6 +18563,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Containers == nil {
 					r.EncodeNil()
 				} else {
@@ -17281,7 +18575,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("containers"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Containers == nil {
 					r.EncodeNil()
 				} else {
@@ -17294,6 +18590,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[2] {
 					x.RestartPolicy.CodecEncodeSelf(e)
 				} else {
@@ -17301,11 +18598,14 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("restartPolicy"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.RestartPolicy.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[3] {
 					if x.TerminationGracePeriodSeconds == nil {
 						r.EncodeNil()
@@ -17323,7 +18623,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("terminationGracePeriodSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TerminationGracePeriodSeconds == nil {
 						r.EncodeNil()
 					} else {
@@ -17338,6 +18640,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[4] {
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
@@ -17355,7 +18658,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("activeDeadlineSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
@@ -17370,6 +18675,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[5] {
 					x.DNSPolicy.CodecEncodeSelf(e)
 				} else {
@@ -17377,11 +18683,14 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("dnsPolicy"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.DNSPolicy.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[6] {
 					if x.NodeSelector == nil {
 						r.EncodeNil()
@@ -17398,7 +18707,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nodeSelector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.NodeSelector == nil {
 						r.EncodeNil()
 					} else {
@@ -17412,6 +18723,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[7] {
 					yym1382 := z.EncBinary()
 					_ = yym1382
@@ -17424,7 +18736,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("serviceAccountName"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1383 := z.EncBinary()
 					_ = yym1383
 					if false {
@@ -17434,6 +18748,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[8] {
 					yym1385 := z.EncBinary()
 					_ = yym1385
@@ -17446,7 +18761,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("serviceAccount"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1386 := z.EncBinary()
 					_ = yym1386
 					if false {
@@ -17456,6 +18773,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[9] {
 					yym1388 := z.EncBinary()
 					_ = yym1388
@@ -17468,7 +18786,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nodeName"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1389 := z.EncBinary()
 					_ = yym1389
 					if false {
@@ -17478,6 +18798,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[10] {
 					yym1391 := z.EncBinary()
 					_ = yym1391
@@ -17490,7 +18811,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostNetwork"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1392 := z.EncBinary()
 					_ = yym1392
 					if false {
@@ -17500,6 +18823,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[11] {
 					yym1394 := z.EncBinary()
 					_ = yym1394
@@ -17512,7 +18836,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1395 := z.EncBinary()
 					_ = yym1395
 					if false {
@@ -17522,6 +18848,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[12] {
 					yym1397 := z.EncBinary()
 					_ = yym1397
@@ -17534,7 +18861,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostIPC"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1398 := z.EncBinary()
 					_ = yym1398
 					if false {
@@ -17544,6 +18873,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[13] {
 					if x.SecurityContext == nil {
 						r.EncodeNil()
@@ -17555,7 +18885,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("securityContext"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SecurityContext == nil {
 						r.EncodeNil()
 					} else {
@@ -17564,6 +18896,7 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1359[14] {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
@@ -17580,7 +18913,9 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1359[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("imagePullSecrets"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
@@ -17593,8 +18928,10 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1359 {
-				r.EncodeEnd()
+			if yyr1359 || yy2arr1359 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -17609,17 +18946,18 @@ func (x *PodSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1404 := r.ContainerType()
+		if yyct1404 == codecSelferValueTypeMap1234 {
 			yyl1404 := r.ReadMapStart()
 			if yyl1404 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1404, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1404 == codecSelferValueTypeArray1234 {
 			yyl1404 := r.ReadArrayStart()
 			if yyl1404 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1404, d)
 			}
@@ -17646,8 +18984,10 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1405Slc = r.DecodeBytes(yys1405Slc, true, true)
 		yys1405 := string(yys1405Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1405 {
 		case "volumes":
 			if r.TryDecodeAsNil() {
@@ -17792,9 +19132,7 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1405)
 		} // end switch yys1405
 	} // end for yyj1405
-	if !yyhl1405 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -17811,9 +19149,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Volumes = nil
 	} else {
@@ -17832,9 +19171,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Containers = nil
 	} else {
@@ -17853,9 +19193,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.RestartPolicy = ""
 	} else {
@@ -17868,9 +19209,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TerminationGracePeriodSeconds != nil {
 			x.TerminationGracePeriodSeconds = nil
@@ -17893,9 +19235,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ActiveDeadlineSeconds != nil {
 			x.ActiveDeadlineSeconds = nil
@@ -17918,9 +19261,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DNSPolicy = ""
 	} else {
@@ -17933,9 +19277,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NodeSelector = nil
 	} else {
@@ -17954,9 +19299,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ServiceAccountName = ""
 	} else {
@@ -17969,9 +19315,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DeprecatedServiceAccount = ""
 	} else {
@@ -17984,9 +19331,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NodeName = ""
 	} else {
@@ -17999,9 +19347,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostNetwork = false
 	} else {
@@ -18014,9 +19363,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostPID = false
 	} else {
@@ -18029,9 +19379,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostIPC = false
 	} else {
@@ -18044,9 +19395,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SecurityContext != nil {
 			x.SecurityContext = nil
@@ -18064,9 +19416,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1427 = r.CheckBreak()
 	}
 	if yyb1427 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ImagePullSecrets = nil
 	} else {
@@ -18088,9 +19441,10 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1427 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1427-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -18115,18 +19469,21 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1450[2] = x.RunAsNonRoot != nil
 			yyq1450[3] = len(x.SupplementalGroups) != 0
 			yyq1450[4] = x.FSGroup != nil
+			var yynn1450 int
 			if yyr1450 || yy2arr1450 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1450 int = 0
+				yynn1450 = 0
 				for _, b := range yyq1450 {
 					if b {
 						yynn1450++
 					}
 				}
 				r.EncodeMapStart(yynn1450)
+				yynn1450 = 0
 			}
 			if yyr1450 || yy2arr1450 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1450[0] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -18138,7 +19495,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1450[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -18147,6 +19506,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1450 || yy2arr1450 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1450[1] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
@@ -18164,7 +19524,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1450[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
@@ -18179,6 +19541,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1450 || yy2arr1450 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1450[2] {
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
@@ -18196,7 +19559,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1450[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
@@ -18211,6 +19576,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1450 || yy2arr1450 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1450[3] {
 					if x.SupplementalGroups == nil {
 						r.EncodeNil()
@@ -18227,7 +19593,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1450[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("supplementalGroups"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SupplementalGroups == nil {
 						r.EncodeNil()
 					} else {
@@ -18241,6 +19609,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1450 || yy2arr1450 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1450[4] {
 					if x.FSGroup == nil {
 						r.EncodeNil()
@@ -18258,7 +19627,9 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1450[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fsGroup"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.FSGroup == nil {
 						r.EncodeNil()
 					} else {
@@ -18272,8 +19643,10 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1450 {
-				r.EncodeEnd()
+			if yyr1450 || yy2arr1450 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -18288,17 +19661,18 @@ func (x *PodSecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1471 := r.ContainerType()
+		if yyct1471 == codecSelferValueTypeMap1234 {
 			yyl1471 := r.ReadMapStart()
 			if yyl1471 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1471, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1471 == codecSelferValueTypeArray1234 {
 			yyl1471 := r.ReadArrayStart()
 			if yyl1471 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1471, d)
 			}
@@ -18325,8 +19699,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1472Slc = r.DecodeBytes(yys1472Slc, true, true)
 		yys1472 := string(yys1472Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1472 {
 		case "seLinuxOptions":
 			if r.TryDecodeAsNil() {
@@ -18403,9 +19779,7 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys1472)
 		} // end switch yys1472
 	} // end for yyj1472
-	if !yyhl1472 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -18422,9 +19796,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1482 = r.CheckBreak()
 	}
 	if yyb1482 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SELinuxOptions != nil {
 			x.SELinuxOptions = nil
@@ -18442,9 +19817,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1482 = r.CheckBreak()
 	}
 	if yyb1482 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RunAsUser != nil {
 			x.RunAsUser = nil
@@ -18467,9 +19843,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1482 = r.CheckBreak()
 	}
 	if yyb1482 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RunAsNonRoot != nil {
 			x.RunAsNonRoot = nil
@@ -18492,9 +19869,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1482 = r.CheckBreak()
 	}
 	if yyb1482 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SupplementalGroups = nil
 	} else {
@@ -18513,9 +19891,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1482 = r.CheckBreak()
 	}
 	if yyb1482 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.FSGroup != nil {
 			x.FSGroup = nil
@@ -18541,9 +19920,10 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb1482 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1482-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -18571,18 +19951,21 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1493[5] = x.PodIP != ""
 			yyq1493[6] = x.StartTime != nil
 			yyq1493[7] = len(x.ContainerStatuses) != 0
+			var yynn1493 int
 			if yyr1493 || yy2arr1493 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1493 int = 0
+				yynn1493 = 0
 				for _, b := range yyq1493 {
 					if b {
 						yynn1493++
 					}
 				}
 				r.EncodeMapStart(yynn1493)
+				yynn1493 = 0
 			}
 			if yyr1493 || yy2arr1493 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1493[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -18590,11 +19973,14 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1493[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1493 || yy2arr1493 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1493[1] {
 					if x.Conditions == nil {
 						r.EncodeNil()
@@ -18611,7 +19997,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1493[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
@@ -18625,6 +20013,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1493 || yy2arr1493 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1493[2] {
 					yym1499 := z.EncBinary()
 					_ = yym1499
@@ -18637,7 +20026,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1493[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1500 := z.EncBinary()
 					_ = yym1500
 					if false {
@@ -18647,6 +20038,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1493 || yy2arr1493 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1493[3] {
 					yym1502 := z.EncBinary()
 					_ = yym1502
@@ -18659,7 +20051,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1493[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1503 := z.EncBinary()
 					_ = yym1503
 					if false {
@@ -18669,6 +20063,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1493 || yy2arr1493 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1493[4] {
 					yym1505 := z.EncBinary()
 					_ = yym1505
@@ -18681,7 +20076,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1493[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1506 := z.EncBinary()
 					_ = yym1506
 					if false {
@@ -18691,6 +20088,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1493 || yy2arr1493 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1493[5] {
 					yym1508 := z.EncBinary()
 					_ = yym1508
@@ -18703,7 +20101,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1493[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("podIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1509 := z.EncBinary()
 					_ = yym1509
 					if false {
@@ -18713,6 +20113,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1493 || yy2arr1493 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1493[6] {
 					if x.StartTime == nil {
 						r.EncodeNil()
@@ -18734,7 +20135,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1493[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
@@ -18753,6 +20156,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1493 || yy2arr1493 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1493[7] {
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
@@ -18769,7 +20173,9 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1493[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("containerStatuses"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
 					} else {
@@ -18782,8 +20188,10 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1493 {
-				r.EncodeEnd()
+			if yyr1493 || yy2arr1493 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -18798,17 +20206,18 @@ func (x *PodStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1517 := r.ContainerType()
+		if yyct1517 == codecSelferValueTypeMap1234 {
 			yyl1517 := r.ReadMapStart()
 			if yyl1517 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1517, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1517 == codecSelferValueTypeArray1234 {
 			yyl1517 := r.ReadArrayStart()
 			if yyl1517 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1517, d)
 			}
@@ -18835,8 +20244,10 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1518Slc = r.DecodeBytes(yys1518Slc, true, true)
 		yys1518 := string(yys1518Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1518 {
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -18917,9 +20328,7 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1518)
 		} // end switch yys1518
 	} // end for yyj1518
-	if !yyhl1518 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -18936,9 +20345,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1530 = r.CheckBreak()
 	}
 	if yyb1530 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -18951,9 +20361,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1530 = r.CheckBreak()
 	}
 	if yyb1530 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
@@ -18972,9 +20383,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1530 = r.CheckBreak()
 	}
 	if yyb1530 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -18987,9 +20399,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1530 = r.CheckBreak()
 	}
 	if yyb1530 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -19002,9 +20415,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1530 = r.CheckBreak()
 	}
 	if yyb1530 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostIP = ""
 	} else {
@@ -19017,9 +20431,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1530 = r.CheckBreak()
 	}
 	if yyb1530 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PodIP = ""
 	} else {
@@ -19032,9 +20447,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1530 = r.CheckBreak()
 	}
 	if yyb1530 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.StartTime != nil {
 			x.StartTime = nil
@@ -19062,9 +20478,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1530 = r.CheckBreak()
 	}
 	if yyb1530 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerStatuses = nil
 	} else {
@@ -19086,9 +20503,10 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1530 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1530-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -19112,18 +20530,21 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1543[1] = x.APIVersion != ""
 			yyq1543[2] = true
 			yyq1543[3] = true
+			var yynn1543 int
 			if yyr1543 || yy2arr1543 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1543 int = 0
+				yynn1543 = 0
 				for _, b := range yyq1543 {
 					if b {
 						yynn1543++
 					}
 				}
 				r.EncodeMapStart(yynn1543)
+				yynn1543 = 0
 			}
 			if yyr1543 || yy2arr1543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1543[0] {
 					yym1545 := z.EncBinary()
 					_ = yym1545
@@ -19136,7 +20557,9 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1543[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1546 := z.EncBinary()
 					_ = yym1546
 					if false {
@@ -19146,6 +20569,7 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1543 || yy2arr1543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1543[1] {
 					yym1548 := z.EncBinary()
 					_ = yym1548
@@ -19158,7 +20582,9 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1543[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1549 := z.EncBinary()
 					_ = yym1549
 					if false {
@@ -19168,6 +20594,7 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1543 || yy2arr1543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1543[2] {
 					yy1551 := &x.ObjectMeta
 					yy1551.CodecEncodeSelf(e)
@@ -19176,12 +20603,15 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1543[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1552 := &x.ObjectMeta
 					yy1552.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1543 || yy2arr1543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1543[3] {
 					yy1554 := &x.Status
 					yy1554.CodecEncodeSelf(e)
@@ -19190,13 +20620,17 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1543[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1555 := &x.Status
 					yy1555.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1543 {
-				r.EncodeEnd()
+			if yyr1543 || yy2arr1543 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -19211,17 +20645,18 @@ func (x *PodStatusResult) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1557 := r.ContainerType()
+		if yyct1557 == codecSelferValueTypeMap1234 {
 			yyl1557 := r.ReadMapStart()
 			if yyl1557 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1557, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1557 == codecSelferValueTypeArray1234 {
 			yyl1557 := r.ReadArrayStart()
 			if yyl1557 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1557, d)
 			}
@@ -19248,8 +20683,10 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1558Slc = r.DecodeBytes(yys1558Slc, true, true)
 		yys1558 := string(yys1558Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1558 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -19281,9 +20718,7 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1558)
 		} // end switch yys1558
 	} // end for yyj1558
-	if !yyhl1558 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -19300,9 +20735,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1563 = r.CheckBreak()
 	}
 	if yyb1563 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -19315,9 +20751,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1563 = r.CheckBreak()
 	}
 	if yyb1563 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -19330,9 +20767,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1563 = r.CheckBreak()
 	}
 	if yyb1563 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -19346,9 +20784,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1563 = r.CheckBreak()
 	}
 	if yyb1563 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = PodStatus{}
 	} else {
@@ -19365,9 +20804,10 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb1563 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1563-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -19392,18 +20832,21 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1569[2] = true
 			yyq1569[3] = true
 			yyq1569[4] = true
+			var yynn1569 int
 			if yyr1569 || yy2arr1569 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1569 int = 0
+				yynn1569 = 0
 				for _, b := range yyq1569 {
 					if b {
 						yynn1569++
 					}
 				}
 				r.EncodeMapStart(yynn1569)
+				yynn1569 = 0
 			}
 			if yyr1569 || yy2arr1569 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1569[0] {
 					yym1571 := z.EncBinary()
 					_ = yym1571
@@ -19416,7 +20859,9 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1569[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1572 := z.EncBinary()
 					_ = yym1572
 					if false {
@@ -19426,6 +20871,7 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1569 || yy2arr1569 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1569[1] {
 					yym1574 := z.EncBinary()
 					_ = yym1574
@@ -19438,7 +20884,9 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1569[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1575 := z.EncBinary()
 					_ = yym1575
 					if false {
@@ -19448,6 +20896,7 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1569 || yy2arr1569 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1569[2] {
 					yy1577 := &x.ObjectMeta
 					yy1577.CodecEncodeSelf(e)
@@ -19456,12 +20905,15 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1569[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1578 := &x.ObjectMeta
 					yy1578.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1569 || yy2arr1569 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1569[3] {
 					yy1580 := &x.Spec
 					yy1580.CodecEncodeSelf(e)
@@ -19470,12 +20922,15 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1569[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1581 := &x.Spec
 					yy1581.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1569 || yy2arr1569 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1569[4] {
 					yy1583 := &x.Status
 					yy1583.CodecEncodeSelf(e)
@@ -19484,13 +20939,17 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1569[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1584 := &x.Status
 					yy1584.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1569 {
-				r.EncodeEnd()
+			if yyr1569 || yy2arr1569 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -19505,17 +20964,18 @@ func (x *Pod) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1586 := r.ContainerType()
+		if yyct1586 == codecSelferValueTypeMap1234 {
 			yyl1586 := r.ReadMapStart()
 			if yyl1586 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1586, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1586 == codecSelferValueTypeArray1234 {
 			yyl1586 := r.ReadArrayStart()
 			if yyl1586 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1586, d)
 			}
@@ -19542,8 +21002,10 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1587Slc = r.DecodeBytes(yys1587Slc, true, true)
 		yys1587 := string(yys1587Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1587 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -19582,9 +21044,7 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1587)
 		} // end switch yys1587
 	} // end for yyj1587
-	if !yyhl1587 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -19601,9 +21061,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1593 = r.CheckBreak()
 	}
 	if yyb1593 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -19616,9 +21077,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1593 = r.CheckBreak()
 	}
 	if yyb1593 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -19631,9 +21093,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1593 = r.CheckBreak()
 	}
 	if yyb1593 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -19647,9 +21110,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1593 = r.CheckBreak()
 	}
 	if yyb1593 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSpec{}
 	} else {
@@ -19663,9 +21127,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1593 = r.CheckBreak()
 	}
 	if yyb1593 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = PodStatus{}
 	} else {
@@ -19682,9 +21147,10 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1593 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1593-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -19707,18 +21173,21 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1600[0] = x.Kind != ""
 			yyq1600[1] = x.APIVersion != ""
 			yyq1600[2] = true
+			var yynn1600 int
 			if yyr1600 || yy2arr1600 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1600 int = 1
+				yynn1600 = 1
 				for _, b := range yyq1600 {
 					if b {
 						yynn1600++
 					}
 				}
 				r.EncodeMapStart(yynn1600)
+				yynn1600 = 0
 			}
 			if yyr1600 || yy2arr1600 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1600[0] {
 					yym1602 := z.EncBinary()
 					_ = yym1602
@@ -19731,7 +21200,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1600[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1603 := z.EncBinary()
 					_ = yym1603
 					if false {
@@ -19741,6 +21212,7 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1600 || yy2arr1600 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1600[1] {
 					yym1605 := z.EncBinary()
 					_ = yym1605
@@ -19753,7 +21225,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1600[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1606 := z.EncBinary()
 					_ = yym1606
 					if false {
@@ -19763,6 +21237,7 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1600 || yy2arr1600 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1600[2] {
 					yy1608 := &x.ListMeta
 					yym1609 := z.EncBinary()
@@ -19777,7 +21252,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1600[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1610 := &x.ListMeta
 					yym1611 := z.EncBinary()
 					_ = yym1611
@@ -19789,6 +21266,7 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1600 || yy2arr1600 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -19800,7 +21278,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -19812,8 +21292,10 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1600 {
-				r.EncodeEnd()
+			if yyr1600 || yy2arr1600 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -19828,17 +21310,18 @@ func (x *PodList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1616 := r.ContainerType()
+		if yyct1616 == codecSelferValueTypeMap1234 {
 			yyl1616 := r.ReadMapStart()
 			if yyl1616 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1616, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1616 == codecSelferValueTypeArray1234 {
 			yyl1616 := r.ReadArrayStart()
 			if yyl1616 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1616, d)
 			}
@@ -19865,8 +21348,10 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1617Slc = r.DecodeBytes(yys1617Slc, true, true)
 		yys1617 := string(yys1617Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1617 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -19909,9 +21394,7 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1617)
 		} // end switch yys1617
 	} // end for yyj1617
-	if !yyhl1617 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -19928,9 +21411,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1624 = r.CheckBreak()
 	}
 	if yyb1624 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -19943,9 +21427,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1624 = r.CheckBreak()
 	}
 	if yyb1624 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -19958,9 +21443,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1624 = r.CheckBreak()
 	}
 	if yyb1624 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -19980,9 +21466,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1624 = r.CheckBreak()
 	}
 	if yyb1624 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -20004,9 +21491,10 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1624 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1624-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -20028,18 +21516,21 @@ func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1632 bool = false
 			yyq1632[0] = true
 			yyq1632[1] = true
+			var yynn1632 int
 			if yyr1632 || yy2arr1632 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1632 int = 0
+				yynn1632 = 0
 				for _, b := range yyq1632 {
 					if b {
 						yynn1632++
 					}
 				}
 				r.EncodeMapStart(yynn1632)
+				yynn1632 = 0
 			}
 			if yyr1632 || yy2arr1632 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1632[0] {
 					yy1634 := &x.ObjectMeta
 					yy1634.CodecEncodeSelf(e)
@@ -20048,12 +21539,15 @@ func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1632[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1635 := &x.ObjectMeta
 					yy1635.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1632 || yy2arr1632 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1632[1] {
 					yy1637 := &x.Spec
 					yy1637.CodecEncodeSelf(e)
@@ -20062,13 +21556,17 @@ func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1632[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1638 := &x.Spec
 					yy1638.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1632 {
-				r.EncodeEnd()
+			if yyr1632 || yy2arr1632 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -20083,17 +21581,18 @@ func (x *PodTemplateSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1640 := r.ContainerType()
+		if yyct1640 == codecSelferValueTypeMap1234 {
 			yyl1640 := r.ReadMapStart()
 			if yyl1640 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1640, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1640 == codecSelferValueTypeArray1234 {
 			yyl1640 := r.ReadArrayStart()
 			if yyl1640 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1640, d)
 			}
@@ -20120,8 +21619,10 @@ func (x *PodTemplateSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1641Slc = r.DecodeBytes(yys1641Slc, true, true)
 		yys1641 := string(yys1641Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1641 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
@@ -20141,9 +21642,7 @@ func (x *PodTemplateSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1641)
 		} // end switch yys1641
 	} // end for yyj1641
-	if !yyhl1641 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -20160,9 +21659,10 @@ func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1644 = r.CheckBreak()
 	}
 	if yyb1644 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -20176,9 +21676,10 @@ func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1644 = r.CheckBreak()
 	}
 	if yyb1644 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSpec{}
 	} else {
@@ -20195,9 +21696,10 @@ func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb1644 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1644-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -20221,18 +21723,21 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1648[1] = x.APIVersion != ""
 			yyq1648[2] = true
 			yyq1648[3] = true
+			var yynn1648 int
 			if yyr1648 || yy2arr1648 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1648 int = 0
+				yynn1648 = 0
 				for _, b := range yyq1648 {
 					if b {
 						yynn1648++
 					}
 				}
 				r.EncodeMapStart(yynn1648)
+				yynn1648 = 0
 			}
 			if yyr1648 || yy2arr1648 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1648[0] {
 					yym1650 := z.EncBinary()
 					_ = yym1650
@@ -20245,7 +21750,9 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1648[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1651 := z.EncBinary()
 					_ = yym1651
 					if false {
@@ -20255,6 +21762,7 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1648 || yy2arr1648 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1648[1] {
 					yym1653 := z.EncBinary()
 					_ = yym1653
@@ -20267,7 +21775,9 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1648[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1654 := z.EncBinary()
 					_ = yym1654
 					if false {
@@ -20277,6 +21787,7 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1648 || yy2arr1648 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1648[2] {
 					yy1656 := &x.ObjectMeta
 					yy1656.CodecEncodeSelf(e)
@@ -20285,12 +21796,15 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1648[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1657 := &x.ObjectMeta
 					yy1657.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1648 || yy2arr1648 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1648[3] {
 					yy1659 := &x.Template
 					yy1659.CodecEncodeSelf(e)
@@ -20299,13 +21813,17 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1648[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1660 := &x.Template
 					yy1660.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1648 {
-				r.EncodeEnd()
+			if yyr1648 || yy2arr1648 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -20320,17 +21838,18 @@ func (x *PodTemplate) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1662 := r.ContainerType()
+		if yyct1662 == codecSelferValueTypeMap1234 {
 			yyl1662 := r.ReadMapStart()
 			if yyl1662 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1662, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1662 == codecSelferValueTypeArray1234 {
 			yyl1662 := r.ReadArrayStart()
 			if yyl1662 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1662, d)
 			}
@@ -20357,8 +21876,10 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1663Slc = r.DecodeBytes(yys1663Slc, true, true)
 		yys1663 := string(yys1663Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1663 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -20390,9 +21911,7 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1663)
 		} // end switch yys1663
 	} // end for yyj1663
-	if !yyhl1663 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -20409,9 +21928,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1668 = r.CheckBreak()
 	}
 	if yyb1668 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -20424,9 +21944,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1668 = r.CheckBreak()
 	}
 	if yyb1668 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -20439,9 +21960,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1668 = r.CheckBreak()
 	}
 	if yyb1668 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -20455,9 +21977,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1668 = r.CheckBreak()
 	}
 	if yyb1668 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Template = PodTemplateSpec{}
 	} else {
@@ -20474,9 +21997,10 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1668 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1668-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -20499,18 +22023,21 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1674[0] = x.Kind != ""
 			yyq1674[1] = x.APIVersion != ""
 			yyq1674[2] = true
+			var yynn1674 int
 			if yyr1674 || yy2arr1674 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1674 int = 1
+				yynn1674 = 1
 				for _, b := range yyq1674 {
 					if b {
 						yynn1674++
 					}
 				}
 				r.EncodeMapStart(yynn1674)
+				yynn1674 = 0
 			}
 			if yyr1674 || yy2arr1674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1674[0] {
 					yym1676 := z.EncBinary()
 					_ = yym1676
@@ -20523,7 +22050,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1674[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1677 := z.EncBinary()
 					_ = yym1677
 					if false {
@@ -20533,6 +22062,7 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1674 || yy2arr1674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1674[1] {
 					yym1679 := z.EncBinary()
 					_ = yym1679
@@ -20545,7 +22075,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1674[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1680 := z.EncBinary()
 					_ = yym1680
 					if false {
@@ -20555,6 +22087,7 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1674 || yy2arr1674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1674[2] {
 					yy1682 := &x.ListMeta
 					yym1683 := z.EncBinary()
@@ -20569,7 +22102,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1674[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1684 := &x.ListMeta
 					yym1685 := z.EncBinary()
 					_ = yym1685
@@ -20581,6 +22116,7 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1674 || yy2arr1674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -20592,7 +22128,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -20604,8 +22142,10 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1674 {
-				r.EncodeEnd()
+			if yyr1674 || yy2arr1674 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -20620,17 +22160,18 @@ func (x *PodTemplateList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1690 := r.ContainerType()
+		if yyct1690 == codecSelferValueTypeMap1234 {
 			yyl1690 := r.ReadMapStart()
 			if yyl1690 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1690, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1690 == codecSelferValueTypeArray1234 {
 			yyl1690 := r.ReadArrayStart()
 			if yyl1690 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1690, d)
 			}
@@ -20657,8 +22198,10 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1691Slc = r.DecodeBytes(yys1691Slc, true, true)
 		yys1691 := string(yys1691Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1691 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -20701,9 +22244,7 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1691)
 		} // end switch yys1691
 	} // end for yyj1691
-	if !yyhl1691 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -20720,9 +22261,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1698 = r.CheckBreak()
 	}
 	if yyb1698 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -20735,9 +22277,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1698 = r.CheckBreak()
 	}
 	if yyb1698 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -20750,9 +22293,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1698 = r.CheckBreak()
 	}
 	if yyb1698 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -20772,9 +22316,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb1698 = r.CheckBreak()
 	}
 	if yyb1698 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -20796,9 +22341,10 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb1698 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1698-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -20821,18 +22367,21 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1706[0] = x.Replicas != nil
 			yyq1706[1] = len(x.Selector) != 0
 			yyq1706[2] = x.Template != nil
+			var yynn1706 int
 			if yyr1706 || yy2arr1706 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1706 int = 0
+				yynn1706 = 0
 				for _, b := range yyq1706 {
 					if b {
 						yynn1706++
 					}
 				}
 				r.EncodeMapStart(yynn1706)
+				yynn1706 = 0
 			}
 			if yyr1706 || yy2arr1706 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1706[0] {
 					if x.Replicas == nil {
 						r.EncodeNil()
@@ -20850,7 +22399,9 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1706[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
@@ -20865,6 +22416,7 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1706 || yy2arr1706 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1706[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -20881,7 +22433,9 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1706[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -20895,6 +22449,7 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1706 || yy2arr1706 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1706[2] {
 					if x.Template == nil {
 						r.EncodeNil()
@@ -20906,7 +22461,9 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1706[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -20914,8 +22471,10 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1706 {
-				r.EncodeEnd()
+			if yyr1706 || yy2arr1706 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -20930,17 +22489,18 @@ func (x *ReplicationControllerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1717 := r.ContainerType()
+		if yyct1717 == codecSelferValueTypeMap1234 {
 			yyl1717 := r.ReadMapStart()
 			if yyl1717 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1717, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1717 == codecSelferValueTypeArray1234 {
 			yyl1717 := r.ReadArrayStart()
 			if yyl1717 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1717, d)
 			}
@@ -20967,8 +22527,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1718Slc = r.DecodeBytes(yys1718Slc, true, true)
 		yys1718 := string(yys1718Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1718 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -21013,9 +22575,7 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 			z.DecStructFieldNotFound(-1, yys1718)
 		} // end switch yys1718
 	} // end for yyj1718
-	if !yyhl1718 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -21032,9 +22592,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1724 = r.CheckBreak()
 	}
 	if yyb1724 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Replicas != nil {
 			x.Replicas = nil
@@ -21057,9 +22618,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1724 = r.CheckBreak()
 	}
 	if yyb1724 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
@@ -21078,9 +22640,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1724 = r.CheckBreak()
 	}
 	if yyb1724 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Template != nil {
 			x.Template = nil
@@ -21101,9 +22664,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		if yyb1724 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1724-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -21124,18 +22688,21 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1731, yyq1731, yy2arr1731
 			const yyr1731 bool = false
 			yyq1731[1] = x.ObservedGeneration != 0
+			var yynn1731 int
 			if yyr1731 || yy2arr1731 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1731 int = 1
+				yynn1731 = 1
 				for _, b := range yyq1731 {
 					if b {
 						yynn1731++
 					}
 				}
 				r.EncodeMapStart(yynn1731)
+				yynn1731 = 0
 			}
 			if yyr1731 || yy2arr1731 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1733 := z.EncBinary()
 				_ = yym1733
 				if false {
@@ -21143,7 +22710,9 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1734 := z.EncBinary()
 				_ = yym1734
 				if false {
@@ -21152,6 +22721,7 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1731 || yy2arr1731 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1731[1] {
 					yym1736 := z.EncBinary()
 					_ = yym1736
@@ -21164,7 +22734,9 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1731[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1737 := z.EncBinary()
 					_ = yym1737
 					if false {
@@ -21173,8 +22745,10 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1731 {
-				r.EncodeEnd()
+			if yyr1731 || yy2arr1731 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -21189,17 +22763,18 @@ func (x *ReplicationControllerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1739 := r.ContainerType()
+		if yyct1739 == codecSelferValueTypeMap1234 {
 			yyl1739 := r.ReadMapStart()
 			if yyl1739 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1739, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1739 == codecSelferValueTypeArray1234 {
 			yyl1739 := r.ReadArrayStart()
 			if yyl1739 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1739, d)
 			}
@@ -21226,8 +22801,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1740Slc = r.DecodeBytes(yys1740Slc, true, true)
 		yys1740 := string(yys1740Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1740 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -21245,9 +22822,7 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 			z.DecStructFieldNotFound(-1, yys1740)
 		} // end switch yys1740
 	} // end for yyj1740
-	if !yyhl1740 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -21264,9 +22839,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb1743 = r.CheckBreak()
 	}
 	if yyb1743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -21279,9 +22855,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 		yyb1743 = r.CheckBreak()
 	}
 	if yyb1743 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObservedGeneration = 0
 	} else {
@@ -21297,9 +22874,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 		if yyb1743 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1743-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -21324,18 +22902,21 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1747[2] = true
 			yyq1747[3] = true
 			yyq1747[4] = true
+			var yynn1747 int
 			if yyr1747 || yy2arr1747 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1747 int = 0
+				yynn1747 = 0
 				for _, b := range yyq1747 {
 					if b {
 						yynn1747++
 					}
 				}
 				r.EncodeMapStart(yynn1747)
+				yynn1747 = 0
 			}
 			if yyr1747 || yy2arr1747 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1747[0] {
 					yym1749 := z.EncBinary()
 					_ = yym1749
@@ -21348,7 +22929,9 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1747[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1750 := z.EncBinary()
 					_ = yym1750
 					if false {
@@ -21358,6 +22941,7 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1747 || yy2arr1747 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1747[1] {
 					yym1752 := z.EncBinary()
 					_ = yym1752
@@ -21370,7 +22954,9 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1747[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1753 := z.EncBinary()
 					_ = yym1753
 					if false {
@@ -21380,6 +22966,7 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1747 || yy2arr1747 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1747[2] {
 					yy1755 := &x.ObjectMeta
 					yy1755.CodecEncodeSelf(e)
@@ -21388,12 +22975,15 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1747[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1756 := &x.ObjectMeta
 					yy1756.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1747 || yy2arr1747 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1747[3] {
 					yy1758 := &x.Spec
 					yy1758.CodecEncodeSelf(e)
@@ -21402,12 +22992,15 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1747[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1759 := &x.Spec
 					yy1759.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1747 || yy2arr1747 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1747[4] {
 					yy1761 := &x.Status
 					yy1761.CodecEncodeSelf(e)
@@ -21416,13 +23009,17 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1747[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1762 := &x.Status
 					yy1762.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1747 {
-				r.EncodeEnd()
+			if yyr1747 || yy2arr1747 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -21437,17 +23034,18 @@ func (x *ReplicationController) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1764 := r.ContainerType()
+		if yyct1764 == codecSelferValueTypeMap1234 {
 			yyl1764 := r.ReadMapStart()
 			if yyl1764 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1764, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1764 == codecSelferValueTypeArray1234 {
 			yyl1764 := r.ReadArrayStart()
 			if yyl1764 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1764, d)
 			}
@@ -21474,8 +23072,10 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1765Slc = r.DecodeBytes(yys1765Slc, true, true)
 		yys1765 := string(yys1765Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1765 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -21514,9 +23114,7 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1765)
 		} // end switch yys1765
 	} // end for yyj1765
-	if !yyhl1765 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -21533,9 +23131,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1771 = r.CheckBreak()
 	}
 	if yyb1771 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -21548,9 +23147,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1771 = r.CheckBreak()
 	}
 	if yyb1771 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -21563,9 +23163,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1771 = r.CheckBreak()
 	}
 	if yyb1771 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -21579,9 +23180,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1771 = r.CheckBreak()
 	}
 	if yyb1771 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ReplicationControllerSpec{}
 	} else {
@@ -21595,9 +23197,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1771 = r.CheckBreak()
 	}
 	if yyb1771 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ReplicationControllerStatus{}
 	} else {
@@ -21614,9 +23217,10 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1771 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1771-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -21639,18 +23243,21 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1778[0] = x.Kind != ""
 			yyq1778[1] = x.APIVersion != ""
 			yyq1778[2] = true
+			var yynn1778 int
 			if yyr1778 || yy2arr1778 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1778 int = 1
+				yynn1778 = 1
 				for _, b := range yyq1778 {
 					if b {
 						yynn1778++
 					}
 				}
 				r.EncodeMapStart(yynn1778)
+				yynn1778 = 0
 			}
 			if yyr1778 || yy2arr1778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1778[0] {
 					yym1780 := z.EncBinary()
 					_ = yym1780
@@ -21663,7 +23270,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1778[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1781 := z.EncBinary()
 					_ = yym1781
 					if false {
@@ -21673,6 +23282,7 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1778 || yy2arr1778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1778[1] {
 					yym1783 := z.EncBinary()
 					_ = yym1783
@@ -21685,7 +23295,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1778[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1784 := z.EncBinary()
 					_ = yym1784
 					if false {
@@ -21695,6 +23307,7 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1778 || yy2arr1778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1778[2] {
 					yy1786 := &x.ListMeta
 					yym1787 := z.EncBinary()
@@ -21709,7 +23322,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1778[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1788 := &x.ListMeta
 					yym1789 := z.EncBinary()
 					_ = yym1789
@@ -21721,6 +23336,7 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1778 || yy2arr1778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -21732,7 +23348,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -21744,8 +23362,10 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1778 {
-				r.EncodeEnd()
+			if yyr1778 || yy2arr1778 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -21760,17 +23380,18 @@ func (x *ReplicationControllerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1794 := r.ContainerType()
+		if yyct1794 == codecSelferValueTypeMap1234 {
 			yyl1794 := r.ReadMapStart()
 			if yyl1794 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1794, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1794 == codecSelferValueTypeArray1234 {
 			yyl1794 := r.ReadArrayStart()
 			if yyl1794 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1794, d)
 			}
@@ -21797,8 +23418,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1795Slc = r.DecodeBytes(yys1795Slc, true, true)
 		yys1795 := string(yys1795Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1795 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -21841,9 +23464,7 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 			z.DecStructFieldNotFound(-1, yys1795)
 		} // end switch yys1795
 	} // end for yyj1795
-	if !yyhl1795 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -21860,9 +23481,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1802 = r.CheckBreak()
 	}
 	if yyb1802 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -21875,9 +23497,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1802 = r.CheckBreak()
 	}
 	if yyb1802 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -21890,9 +23513,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1802 = r.CheckBreak()
 	}
 	if yyb1802 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -21912,9 +23536,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		yyb1802 = r.CheckBreak()
 	}
 	if yyb1802 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -21936,9 +23561,10 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		if yyb1802 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1802-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x ServiceAffinity) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -22011,18 +23637,21 @@ func (x *ServiceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1814, yyq1814, yy2arr1814
 			const yyr1814 bool = false
 			yyq1814[0] = true
+			var yynn1814 int
 			if yyr1814 || yy2arr1814 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1814 int = 0
+				yynn1814 = 0
 				for _, b := range yyq1814 {
 					if b {
 						yynn1814++
 					}
 				}
 				r.EncodeMapStart(yynn1814)
+				yynn1814 = 0
 			}
 			if yyr1814 || yy2arr1814 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1814[0] {
 					yy1816 := &x.LoadBalancer
 					yy1816.CodecEncodeSelf(e)
@@ -22031,13 +23660,17 @@ func (x *ServiceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1814[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1817 := &x.LoadBalancer
 					yy1817.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1814 {
-				r.EncodeEnd()
+			if yyr1814 || yy2arr1814 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -22052,17 +23685,18 @@ func (x *ServiceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1819 := r.ContainerType()
+		if yyct1819 == codecSelferValueTypeMap1234 {
 			yyl1819 := r.ReadMapStart()
 			if yyl1819 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1819, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1819 == codecSelferValueTypeArray1234 {
 			yyl1819 := r.ReadArrayStart()
 			if yyl1819 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1819, d)
 			}
@@ -22089,8 +23723,10 @@ func (x *ServiceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1820Slc = r.DecodeBytes(yys1820Slc, true, true)
 		yys1820 := string(yys1820Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1820 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
@@ -22103,9 +23739,7 @@ func (x *ServiceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1820)
 		} // end switch yys1820
 	} // end for yyj1820
-	if !yyhl1820 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -22122,9 +23756,10 @@ func (x *ServiceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1822 = r.CheckBreak()
 	}
 	if yyb1822 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = LoadBalancerStatus{}
 	} else {
@@ -22141,9 +23776,10 @@ func (x *ServiceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1822 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1822-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -22164,18 +23800,21 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1825, yyq1825, yy2arr1825
 			const yyr1825 bool = false
 			yyq1825[0] = len(x.Ingress) != 0
+			var yynn1825 int
 			if yyr1825 || yy2arr1825 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1825 int = 0
+				yynn1825 = 0
 				for _, b := range yyq1825 {
 					if b {
 						yynn1825++
 					}
 				}
 				r.EncodeMapStart(yynn1825)
+				yynn1825 = 0
 			}
 			if yyr1825 || yy2arr1825 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1825[0] {
 					if x.Ingress == nil {
 						r.EncodeNil()
@@ -22192,7 +23831,9 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1825[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("ingress"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Ingress == nil {
 						r.EncodeNil()
 					} else {
@@ -22205,8 +23846,10 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1825 {
-				r.EncodeEnd()
+			if yyr1825 || yy2arr1825 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -22221,17 +23864,18 @@ func (x *LoadBalancerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1830 := r.ContainerType()
+		if yyct1830 == codecSelferValueTypeMap1234 {
 			yyl1830 := r.ReadMapStart()
 			if yyl1830 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1830, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1830 == codecSelferValueTypeArray1234 {
 			yyl1830 := r.ReadArrayStart()
 			if yyl1830 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1830, d)
 			}
@@ -22258,8 +23902,10 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1831Slc = r.DecodeBytes(yys1831Slc, true, true)
 		yys1831 := string(yys1831Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1831 {
 		case "ingress":
 			if r.TryDecodeAsNil() {
@@ -22277,9 +23923,7 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys1831)
 		} // end switch yys1831
 	} // end for yyj1831
-	if !yyhl1831 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LoadBalancerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -22296,9 +23940,10 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb1834 = r.CheckBreak()
 	}
 	if yyb1834 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ingress = nil
 	} else {
@@ -22320,9 +23965,10 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb1834 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1834-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -22344,18 +23990,21 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1838 bool = false
 			yyq1838[0] = x.IP != ""
 			yyq1838[1] = x.Hostname != ""
+			var yynn1838 int
 			if yyr1838 || yy2arr1838 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1838 int = 0
+				yynn1838 = 0
 				for _, b := range yyq1838 {
 					if b {
 						yynn1838++
 					}
 				}
 				r.EncodeMapStart(yynn1838)
+				yynn1838 = 0
 			}
 			if yyr1838 || yy2arr1838 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1838[0] {
 					yym1840 := z.EncBinary()
 					_ = yym1840
@@ -22368,7 +24017,9 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1838[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("ip"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1841 := z.EncBinary()
 					_ = yym1841
 					if false {
@@ -22378,6 +24029,7 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1838 || yy2arr1838 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1838[1] {
 					yym1843 := z.EncBinary()
 					_ = yym1843
@@ -22390,7 +24042,9 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1838[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostname"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1844 := z.EncBinary()
 					_ = yym1844
 					if false {
@@ -22399,8 +24053,10 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1838 {
-				r.EncodeEnd()
+			if yyr1838 || yy2arr1838 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -22415,17 +24071,18 @@ func (x *LoadBalancerIngress) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1846 := r.ContainerType()
+		if yyct1846 == codecSelferValueTypeMap1234 {
 			yyl1846 := r.ReadMapStart()
 			if yyl1846 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1846, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1846 == codecSelferValueTypeArray1234 {
 			yyl1846 := r.ReadArrayStart()
 			if yyl1846 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1846, d)
 			}
@@ -22452,8 +24109,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1847Slc = r.DecodeBytes(yys1847Slc, true, true)
 		yys1847 := string(yys1847Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1847 {
 		case "ip":
 			if r.TryDecodeAsNil() {
@@ -22471,9 +24130,7 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys1847)
 		} // end switch yys1847
 	} // end for yyj1847
-	if !yyhl1847 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -22490,9 +24147,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb1850 = r.CheckBreak()
 	}
 	if yyb1850 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.IP = ""
 	} else {
@@ -22505,9 +24163,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb1850 = r.CheckBreak()
 	}
 	if yyb1850 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Hostname = ""
 	} else {
@@ -22523,9 +24182,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb1850 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1850-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -22552,18 +24212,21 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1854[5] = len(x.DeprecatedPublicIPs) != 0
 			yyq1854[6] = x.SessionAffinity != ""
 			yyq1854[7] = x.LoadBalancerIP != ""
+			var yynn1854 int
 			if yyr1854 || yy2arr1854 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1854 int = 1
+				yynn1854 = 1
 				for _, b := range yyq1854 {
 					if b {
 						yynn1854++
 					}
 				}
 				r.EncodeMapStart(yynn1854)
+				yynn1854 = 0
 			}
 			if yyr1854 || yy2arr1854 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
@@ -22575,7 +24238,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("ports"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
@@ -22588,6 +24253,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1854 || yy2arr1854 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1854[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -22604,7 +24270,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1854[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -22618,6 +24286,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1854 || yy2arr1854 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1854[2] {
 					yym1862 := z.EncBinary()
 					_ = yym1862
@@ -22630,7 +24299,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1854[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("clusterIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1863 := z.EncBinary()
 					_ = yym1863
 					if false {
@@ -22640,6 +24311,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1854 || yy2arr1854 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1854[3] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
@@ -22647,11 +24319,14 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1854[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1854 || yy2arr1854 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1854[4] {
 					if x.ExternalIPs == nil {
 						r.EncodeNil()
@@ -22668,7 +24343,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1854[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("externalIPs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ExternalIPs == nil {
 						r.EncodeNil()
 					} else {
@@ -22682,6 +24359,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1854 || yy2arr1854 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1854[5] {
 					if x.DeprecatedPublicIPs == nil {
 						r.EncodeNil()
@@ -22698,7 +24376,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1854[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("deprecatedPublicIPs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DeprecatedPublicIPs == nil {
 						r.EncodeNil()
 					} else {
@@ -22712,6 +24392,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1854 || yy2arr1854 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1854[6] {
 					x.SessionAffinity.CodecEncodeSelf(e)
 				} else {
@@ -22719,11 +24400,14 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1854[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("sessionAffinity"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.SessionAffinity.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1854 || yy2arr1854 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1854[7] {
 					yym1873 := z.EncBinary()
 					_ = yym1873
@@ -22736,7 +24420,9 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1854[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancerIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1874 := z.EncBinary()
 					_ = yym1874
 					if false {
@@ -22745,8 +24431,10 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1854 {
-				r.EncodeEnd()
+			if yyr1854 || yy2arr1854 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -22761,17 +24449,18 @@ func (x *ServiceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1876 := r.ContainerType()
+		if yyct1876 == codecSelferValueTypeMap1234 {
 			yyl1876 := r.ReadMapStart()
 			if yyl1876 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1876, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1876 == codecSelferValueTypeArray1234 {
 			yyl1876 := r.ReadArrayStart()
 			if yyl1876 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1876, d)
 			}
@@ -22798,8 +24487,10 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1877Slc = r.DecodeBytes(yys1877Slc, true, true)
 		yys1877 := string(yys1877Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1877 {
 		case "ports":
 			if r.TryDecodeAsNil() {
@@ -22877,9 +24568,7 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1877)
 		} // end switch yys1877
 	} // end for yyj1877
-	if !yyhl1877 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -22896,9 +24585,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1890 = r.CheckBreak()
 	}
 	if yyb1890 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
@@ -22917,9 +24607,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1890 = r.CheckBreak()
 	}
 	if yyb1890 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
@@ -22938,9 +24629,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1890 = r.CheckBreak()
 	}
 	if yyb1890 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ClusterIP = ""
 	} else {
@@ -22953,9 +24645,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1890 = r.CheckBreak()
 	}
 	if yyb1890 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -22968,9 +24661,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1890 = r.CheckBreak()
 	}
 	if yyb1890 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ExternalIPs = nil
 	} else {
@@ -22989,9 +24683,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1890 = r.CheckBreak()
 	}
 	if yyb1890 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DeprecatedPublicIPs = nil
 	} else {
@@ -23010,9 +24705,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1890 = r.CheckBreak()
 	}
 	if yyb1890 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SessionAffinity = ""
 	} else {
@@ -23025,9 +24721,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1890 = r.CheckBreak()
 	}
 	if yyb1890 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LoadBalancerIP = ""
 	} else {
@@ -23043,9 +24740,10 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1890 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1890-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -23069,18 +24767,21 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1904[1] = x.Protocol != ""
 			yyq1904[3] = true
 			yyq1904[4] = x.NodePort != 0
+			var yynn1904 int
 			if yyr1904 || yy2arr1904 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1904 int = 1
+				yynn1904 = 1
 				for _, b := range yyq1904 {
 					if b {
 						yynn1904++
 					}
 				}
 				r.EncodeMapStart(yynn1904)
+				yynn1904 = 0
 			}
 			if yyr1904 || yy2arr1904 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1904[0] {
 					yym1906 := z.EncBinary()
 					_ = yym1906
@@ -23093,7 +24794,9 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1904[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1907 := z.EncBinary()
 					_ = yym1907
 					if false {
@@ -23103,6 +24806,7 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1904 || yy2arr1904 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1904[1] {
 					x.Protocol.CodecEncodeSelf(e)
 				} else {
@@ -23110,11 +24814,14 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1904[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("protocol"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Protocol.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1904 || yy2arr1904 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1910 := z.EncBinary()
 				_ = yym1910
 				if false {
@@ -23122,7 +24829,9 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1911 := z.EncBinary()
 				_ = yym1911
 				if false {
@@ -23131,6 +24840,7 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1904 || yy2arr1904 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1904[3] {
 					yy1913 := &x.TargetPort
 					yym1914 := z.EncBinary()
@@ -23147,7 +24857,9 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1904[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("targetPort"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1915 := &x.TargetPort
 					yym1916 := z.EncBinary()
 					_ = yym1916
@@ -23161,6 +24873,7 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1904 || yy2arr1904 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1904[4] {
 					yym1918 := z.EncBinary()
 					_ = yym1918
@@ -23173,7 +24886,9 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1904[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nodePort"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1919 := z.EncBinary()
 					_ = yym1919
 					if false {
@@ -23182,8 +24897,10 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1904 {
-				r.EncodeEnd()
+			if yyr1904 || yy2arr1904 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -23198,17 +24915,18 @@ func (x *ServicePort) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1921 := r.ContainerType()
+		if yyct1921 == codecSelferValueTypeMap1234 {
 			yyl1921 := r.ReadMapStart()
 			if yyl1921 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1921, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1921 == codecSelferValueTypeArray1234 {
 			yyl1921 := r.ReadArrayStart()
 			if yyl1921 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1921, d)
 			}
@@ -23235,8 +24953,10 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1922Slc = r.DecodeBytes(yys1922Slc, true, true)
 		yys1922 := string(yys1922Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1922 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -23281,9 +25001,7 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1922)
 		} // end switch yys1922
 	} // end for yyj1922
-	if !yyhl1922 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -23300,9 +25018,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1929 = r.CheckBreak()
 	}
 	if yyb1929 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -23315,9 +25034,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1929 = r.CheckBreak()
 	}
 	if yyb1929 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Protocol = ""
 	} else {
@@ -23330,9 +25050,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1929 = r.CheckBreak()
 	}
 	if yyb1929 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = 0
 	} else {
@@ -23345,9 +25066,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1929 = r.CheckBreak()
 	}
 	if yyb1929 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetPort = pkg5_intstr.IntOrString{}
 	} else {
@@ -23369,9 +25091,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1929 = r.CheckBreak()
 	}
 	if yyb1929 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NodePort = 0
 	} else {
@@ -23387,9 +25110,10 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1929 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1929-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -23414,18 +25138,21 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1937[2] = true
 			yyq1937[3] = true
 			yyq1937[4] = true
+			var yynn1937 int
 			if yyr1937 || yy2arr1937 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1937 int = 0
+				yynn1937 = 0
 				for _, b := range yyq1937 {
 					if b {
 						yynn1937++
 					}
 				}
 				r.EncodeMapStart(yynn1937)
+				yynn1937 = 0
 			}
 			if yyr1937 || yy2arr1937 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1937[0] {
 					yym1939 := z.EncBinary()
 					_ = yym1939
@@ -23438,7 +25165,9 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1937[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1940 := z.EncBinary()
 					_ = yym1940
 					if false {
@@ -23448,6 +25177,7 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1937 || yy2arr1937 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1937[1] {
 					yym1942 := z.EncBinary()
 					_ = yym1942
@@ -23460,7 +25190,9 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1937[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1943 := z.EncBinary()
 					_ = yym1943
 					if false {
@@ -23470,6 +25202,7 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1937 || yy2arr1937 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1937[2] {
 					yy1945 := &x.ObjectMeta
 					yy1945.CodecEncodeSelf(e)
@@ -23478,12 +25211,15 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1937[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1946 := &x.ObjectMeta
 					yy1946.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1937 || yy2arr1937 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1937[3] {
 					yy1948 := &x.Spec
 					yy1948.CodecEncodeSelf(e)
@@ -23492,12 +25228,15 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1937[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1949 := &x.Spec
 					yy1949.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1937 || yy2arr1937 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1937[4] {
 					yy1951 := &x.Status
 					yy1951.CodecEncodeSelf(e)
@@ -23506,13 +25245,17 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1937[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1952 := &x.Status
 					yy1952.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1937 {
-				r.EncodeEnd()
+			if yyr1937 || yy2arr1937 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -23527,17 +25270,18 @@ func (x *Service) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1954 := r.ContainerType()
+		if yyct1954 == codecSelferValueTypeMap1234 {
 			yyl1954 := r.ReadMapStart()
 			if yyl1954 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1954, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1954 == codecSelferValueTypeArray1234 {
 			yyl1954 := r.ReadArrayStart()
 			if yyl1954 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1954, d)
 			}
@@ -23564,8 +25308,10 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1955Slc = r.DecodeBytes(yys1955Slc, true, true)
 		yys1955 := string(yys1955Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1955 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -23604,9 +25350,7 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1955)
 		} // end switch yys1955
 	} // end for yyj1955
-	if !yyhl1955 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -23623,9 +25367,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1961 = r.CheckBreak()
 	}
 	if yyb1961 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -23638,9 +25383,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1961 = r.CheckBreak()
 	}
 	if yyb1961 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -23653,9 +25399,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1961 = r.CheckBreak()
 	}
 	if yyb1961 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -23669,9 +25416,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1961 = r.CheckBreak()
 	}
 	if yyb1961 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ServiceSpec{}
 	} else {
@@ -23685,9 +25433,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1961 = r.CheckBreak()
 	}
 	if yyb1961 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ServiceStatus{}
 	} else {
@@ -23704,9 +25453,10 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1961 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1961-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -23729,18 +25479,21 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1968[0] = x.Kind != ""
 			yyq1968[1] = x.APIVersion != ""
 			yyq1968[2] = true
+			var yynn1968 int
 			if yyr1968 || yy2arr1968 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1968 int = 1
+				yynn1968 = 1
 				for _, b := range yyq1968 {
 					if b {
 						yynn1968++
 					}
 				}
 				r.EncodeMapStart(yynn1968)
+				yynn1968 = 0
 			}
 			if yyr1968 || yy2arr1968 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1968[0] {
 					yym1970 := z.EncBinary()
 					_ = yym1970
@@ -23753,7 +25506,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1968[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1971 := z.EncBinary()
 					_ = yym1971
 					if false {
@@ -23763,6 +25518,7 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1968 || yy2arr1968 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1968[1] {
 					yym1973 := z.EncBinary()
 					_ = yym1973
@@ -23775,7 +25531,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1968[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1974 := z.EncBinary()
 					_ = yym1974
 					if false {
@@ -23785,6 +25543,7 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1968 || yy2arr1968 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1968[2] {
 					yy1976 := &x.ListMeta
 					yym1977 := z.EncBinary()
@@ -23799,7 +25558,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1968[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1978 := &x.ListMeta
 					yym1979 := z.EncBinary()
 					_ = yym1979
@@ -23811,6 +25572,7 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1968 || yy2arr1968 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -23822,7 +25584,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -23834,8 +25598,10 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1968 {
-				r.EncodeEnd()
+			if yyr1968 || yy2arr1968 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -23850,17 +25616,18 @@ func (x *ServiceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1984 := r.ContainerType()
+		if yyct1984 == codecSelferValueTypeMap1234 {
 			yyl1984 := r.ReadMapStart()
 			if yyl1984 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1984, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1984 == codecSelferValueTypeArray1234 {
 			yyl1984 := r.ReadArrayStart()
 			if yyl1984 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1984, d)
 			}
@@ -23887,8 +25654,10 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1985Slc = r.DecodeBytes(yys1985Slc, true, true)
 		yys1985 := string(yys1985Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1985 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -23931,9 +25700,7 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1985)
 		} // end switch yys1985
 	} // end for yyj1985
-	if !yyhl1985 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -23950,9 +25717,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1992 = r.CheckBreak()
 	}
 	if yyb1992 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -23965,9 +25733,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1992 = r.CheckBreak()
 	}
 	if yyb1992 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -23980,9 +25749,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1992 = r.CheckBreak()
 	}
 	if yyb1992 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -24002,9 +25772,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1992 = r.CheckBreak()
 	}
 	if yyb1992 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -24026,9 +25797,10 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1992 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1992-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -24053,18 +25825,21 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2000[2] = true
 			yyq2000[3] = len(x.Secrets) != 0
 			yyq2000[4] = len(x.ImagePullSecrets) != 0
+			var yynn2000 int
 			if yyr2000 || yy2arr2000 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2000 int = 0
+				yynn2000 = 0
 				for _, b := range yyq2000 {
 					if b {
 						yynn2000++
 					}
 				}
 				r.EncodeMapStart(yynn2000)
+				yynn2000 = 0
 			}
 			if yyr2000 || yy2arr2000 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2000[0] {
 					yym2002 := z.EncBinary()
 					_ = yym2002
@@ -24077,7 +25852,9 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2000[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2003 := z.EncBinary()
 					_ = yym2003
 					if false {
@@ -24087,6 +25864,7 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2000 || yy2arr2000 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2000[1] {
 					yym2005 := z.EncBinary()
 					_ = yym2005
@@ -24099,7 +25877,9 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2000[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2006 := z.EncBinary()
 					_ = yym2006
 					if false {
@@ -24109,6 +25889,7 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2000 || yy2arr2000 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2000[2] {
 					yy2008 := &x.ObjectMeta
 					yy2008.CodecEncodeSelf(e)
@@ -24117,12 +25898,15 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2000[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2009 := &x.ObjectMeta
 					yy2009.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2000 || yy2arr2000 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2000[3] {
 					if x.Secrets == nil {
 						r.EncodeNil()
@@ -24139,7 +25923,9 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2000[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secrets"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Secrets == nil {
 						r.EncodeNil()
 					} else {
@@ -24153,6 +25939,7 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2000 || yy2arr2000 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2000[4] {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
@@ -24169,7 +25956,9 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2000[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("imagePullSecrets"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
@@ -24182,8 +25971,10 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2000 {
-				r.EncodeEnd()
+			if yyr2000 || yy2arr2000 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -24198,17 +25989,18 @@ func (x *ServiceAccount) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2017 := r.ContainerType()
+		if yyct2017 == codecSelferValueTypeMap1234 {
 			yyl2017 := r.ReadMapStart()
 			if yyl2017 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2017, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2017 == codecSelferValueTypeArray1234 {
 			yyl2017 := r.ReadArrayStart()
 			if yyl2017 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2017, d)
 			}
@@ -24235,8 +26027,10 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2018Slc = r.DecodeBytes(yys2018Slc, true, true)
 		yys2018 := string(yys2018Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2018 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -24285,9 +26079,7 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2018)
 		} // end switch yys2018
 	} // end for yyj2018
-	if !yyhl2018 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -24304,9 +26096,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2026 = r.CheckBreak()
 	}
 	if yyb2026 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -24319,9 +26112,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2026 = r.CheckBreak()
 	}
 	if yyb2026 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -24334,9 +26128,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2026 = r.CheckBreak()
 	}
 	if yyb2026 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -24350,9 +26145,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2026 = r.CheckBreak()
 	}
 	if yyb2026 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Secrets = nil
 	} else {
@@ -24371,9 +26167,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2026 = r.CheckBreak()
 	}
 	if yyb2026 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ImagePullSecrets = nil
 	} else {
@@ -24395,9 +26192,10 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2026 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2026-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -24420,18 +26218,21 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2035[0] = x.Kind != ""
 			yyq2035[1] = x.APIVersion != ""
 			yyq2035[2] = true
+			var yynn2035 int
 			if yyr2035 || yy2arr2035 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2035 int = 1
+				yynn2035 = 1
 				for _, b := range yyq2035 {
 					if b {
 						yynn2035++
 					}
 				}
 				r.EncodeMapStart(yynn2035)
+				yynn2035 = 0
 			}
 			if yyr2035 || yy2arr2035 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2035[0] {
 					yym2037 := z.EncBinary()
 					_ = yym2037
@@ -24444,7 +26245,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2035[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2038 := z.EncBinary()
 					_ = yym2038
 					if false {
@@ -24454,6 +26257,7 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2035 || yy2arr2035 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2035[1] {
 					yym2040 := z.EncBinary()
 					_ = yym2040
@@ -24466,7 +26270,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2035[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2041 := z.EncBinary()
 					_ = yym2041
 					if false {
@@ -24476,6 +26282,7 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2035 || yy2arr2035 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2035[2] {
 					yy2043 := &x.ListMeta
 					yym2044 := z.EncBinary()
@@ -24490,7 +26297,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2035[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2045 := &x.ListMeta
 					yym2046 := z.EncBinary()
 					_ = yym2046
@@ -24502,6 +26311,7 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2035 || yy2arr2035 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -24513,7 +26323,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -24525,8 +26337,10 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2035 {
-				r.EncodeEnd()
+			if yyr2035 || yy2arr2035 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -24541,17 +26355,18 @@ func (x *ServiceAccountList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2051 := r.ContainerType()
+		if yyct2051 == codecSelferValueTypeMap1234 {
 			yyl2051 := r.ReadMapStart()
 			if yyl2051 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2051, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2051 == codecSelferValueTypeArray1234 {
 			yyl2051 := r.ReadArrayStart()
 			if yyl2051 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2051, d)
 			}
@@ -24578,8 +26393,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2052Slc = r.DecodeBytes(yys2052Slc, true, true)
 		yys2052 := string(yys2052Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2052 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -24622,9 +26439,7 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys2052)
 		} // end switch yys2052
 	} // end for yyj2052
-	if !yyhl2052 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -24641,9 +26456,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb2059 = r.CheckBreak()
 	}
 	if yyb2059 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -24656,9 +26472,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb2059 = r.CheckBreak()
 	}
 	if yyb2059 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -24671,9 +26488,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb2059 = r.CheckBreak()
 	}
 	if yyb2059 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -24693,9 +26511,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb2059 = r.CheckBreak()
 	}
 	if yyb2059 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -24717,9 +26536,10 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb2059 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2059-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -24742,18 +26562,21 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2067[0] = x.Kind != ""
 			yyq2067[1] = x.APIVersion != ""
 			yyq2067[2] = true
+			var yynn2067 int
 			if yyr2067 || yy2arr2067 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2067 int = 1
+				yynn2067 = 1
 				for _, b := range yyq2067 {
 					if b {
 						yynn2067++
 					}
 				}
 				r.EncodeMapStart(yynn2067)
+				yynn2067 = 0
 			}
 			if yyr2067 || yy2arr2067 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2067[0] {
 					yym2069 := z.EncBinary()
 					_ = yym2069
@@ -24766,7 +26589,9 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2067[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2070 := z.EncBinary()
 					_ = yym2070
 					if false {
@@ -24776,6 +26601,7 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2067 || yy2arr2067 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2067[1] {
 					yym2072 := z.EncBinary()
 					_ = yym2072
@@ -24788,7 +26614,9 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2067[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2073 := z.EncBinary()
 					_ = yym2073
 					if false {
@@ -24798,6 +26626,7 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2067 || yy2arr2067 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2067[2] {
 					yy2075 := &x.ObjectMeta
 					yy2075.CodecEncodeSelf(e)
@@ -24806,12 +26635,15 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2067[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2076 := &x.ObjectMeta
 					yy2076.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2067 || yy2arr2067 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
@@ -24823,7 +26655,9 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("subsets"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
@@ -24835,8 +26669,10 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2067 {
-				r.EncodeEnd()
+			if yyr2067 || yy2arr2067 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -24851,17 +26687,18 @@ func (x *Endpoints) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2081 := r.ContainerType()
+		if yyct2081 == codecSelferValueTypeMap1234 {
 			yyl2081 := r.ReadMapStart()
 			if yyl2081 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2081, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2081 == codecSelferValueTypeArray1234 {
 			yyl2081 := r.ReadArrayStart()
 			if yyl2081 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2081, d)
 			}
@@ -24888,8 +26725,10 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2082Slc = r.DecodeBytes(yys2082Slc, true, true)
 		yys2082 := string(yys2082Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2082 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -24926,9 +26765,7 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2082)
 		} // end switch yys2082
 	} // end for yyj2082
-	if !yyhl2082 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -24945,9 +26782,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2088 = r.CheckBreak()
 	}
 	if yyb2088 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -24960,9 +26798,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2088 = r.CheckBreak()
 	}
 	if yyb2088 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -24975,9 +26814,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2088 = r.CheckBreak()
 	}
 	if yyb2088 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -24991,9 +26831,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2088 = r.CheckBreak()
 	}
 	if yyb2088 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Subsets = nil
 	} else {
@@ -25015,9 +26856,10 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2088 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2088-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -25040,18 +26882,21 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2095[0] = len(x.Addresses) != 0
 			yyq2095[1] = len(x.NotReadyAddresses) != 0
 			yyq2095[2] = len(x.Ports) != 0
+			var yynn2095 int
 			if yyr2095 || yy2arr2095 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2095 int = 0
+				yynn2095 = 0
 				for _, b := range yyq2095 {
 					if b {
 						yynn2095++
 					}
 				}
 				r.EncodeMapStart(yynn2095)
+				yynn2095 = 0
 			}
 			if yyr2095 || yy2arr2095 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2095[0] {
 					if x.Addresses == nil {
 						r.EncodeNil()
@@ -25068,7 +26913,9 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2095[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("addresses"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Addresses == nil {
 						r.EncodeNil()
 					} else {
@@ -25082,6 +26929,7 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2095 || yy2arr2095 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2095[1] {
 					if x.NotReadyAddresses == nil {
 						r.EncodeNil()
@@ -25098,7 +26946,9 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2095[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("notReadyAddresses"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.NotReadyAddresses == nil {
 						r.EncodeNil()
 					} else {
@@ -25112,6 +26962,7 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2095 || yy2arr2095 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2095[2] {
 					if x.Ports == nil {
 						r.EncodeNil()
@@ -25128,7 +26979,9 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2095[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("ports"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Ports == nil {
 						r.EncodeNil()
 					} else {
@@ -25141,8 +26994,10 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2095 {
-				r.EncodeEnd()
+			if yyr2095 || yy2arr2095 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -25157,17 +27012,18 @@ func (x *EndpointSubset) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2106 := r.ContainerType()
+		if yyct2106 == codecSelferValueTypeMap1234 {
 			yyl2106 := r.ReadMapStart()
 			if yyl2106 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2106, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2106 == codecSelferValueTypeArray1234 {
 			yyl2106 := r.ReadArrayStart()
 			if yyl2106 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2106, d)
 			}
@@ -25194,8 +27050,10 @@ func (x *EndpointSubset) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2107Slc = r.DecodeBytes(yys2107Slc, true, true)
 		yys2107 := string(yys2107Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2107 {
 		case "addresses":
 			if r.TryDecodeAsNil() {
@@ -25237,9 +27095,7 @@ func (x *EndpointSubset) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2107)
 		} // end switch yys2107
 	} // end for yyj2107
-	if !yyhl2107 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -25256,9 +27112,10 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2114 = r.CheckBreak()
 	}
 	if yyb2114 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Addresses = nil
 	} else {
@@ -25277,9 +27134,10 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2114 = r.CheckBreak()
 	}
 	if yyb2114 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NotReadyAddresses = nil
 	} else {
@@ -25298,9 +27156,10 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2114 = r.CheckBreak()
 	}
 	if yyb2114 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
@@ -25322,9 +27181,10 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2114 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2114-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -25345,18 +27205,21 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2122, yyq2122, yy2arr2122
 			const yyr2122 bool = false
 			yyq2122[1] = x.TargetRef != nil
+			var yynn2122 int
 			if yyr2122 || yy2arr2122 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2122 int = 1
+				yynn2122 = 1
 				for _, b := range yyq2122 {
 					if b {
 						yynn2122++
 					}
 				}
 				r.EncodeMapStart(yynn2122)
+				yynn2122 = 0
 			}
 			if yyr2122 || yy2arr2122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2124 := z.EncBinary()
 				_ = yym2124
 				if false {
@@ -25364,7 +27227,9 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.IP))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("ip"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2125 := z.EncBinary()
 				_ = yym2125
 				if false {
@@ -25373,6 +27238,7 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2122 || yy2arr2122 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2122[1] {
 					if x.TargetRef == nil {
 						r.EncodeNil()
@@ -25384,7 +27250,9 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2122[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("targetRef"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TargetRef == nil {
 						r.EncodeNil()
 					} else {
@@ -25392,8 +27260,10 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2122 {
-				r.EncodeEnd()
+			if yyr2122 || yy2arr2122 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -25408,17 +27278,18 @@ func (x *EndpointAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2128 := r.ContainerType()
+		if yyct2128 == codecSelferValueTypeMap1234 {
 			yyl2128 := r.ReadMapStart()
 			if yyl2128 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2128, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2128 == codecSelferValueTypeArray1234 {
 			yyl2128 := r.ReadArrayStart()
 			if yyl2128 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2128, d)
 			}
@@ -25445,8 +27316,10 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2129Slc = r.DecodeBytes(yys2129Slc, true, true)
 		yys2129 := string(yys2129Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2129 {
 		case "ip":
 			if r.TryDecodeAsNil() {
@@ -25469,9 +27342,7 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2129)
 		} // end switch yys2129
 	} // end for yyj2129
-	if !yyhl2129 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -25488,9 +27359,10 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2132 = r.CheckBreak()
 	}
 	if yyb2132 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.IP = ""
 	} else {
@@ -25503,9 +27375,10 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2132 = r.CheckBreak()
 	}
 	if yyb2132 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TargetRef != nil {
 			x.TargetRef = nil
@@ -25526,9 +27399,10 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb2132 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2132-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -25550,18 +27424,21 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2136 bool = false
 			yyq2136[0] = x.Name != ""
 			yyq2136[2] = x.Protocol != ""
+			var yynn2136 int
 			if yyr2136 || yy2arr2136 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2136 int = 1
+				yynn2136 = 1
 				for _, b := range yyq2136 {
 					if b {
 						yynn2136++
 					}
 				}
 				r.EncodeMapStart(yynn2136)
+				yynn2136 = 0
 			}
 			if yyr2136 || yy2arr2136 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2136[0] {
 					yym2138 := z.EncBinary()
 					_ = yym2138
@@ -25574,7 +27451,9 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2136[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2139 := z.EncBinary()
 					_ = yym2139
 					if false {
@@ -25584,6 +27463,7 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2136 || yy2arr2136 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2141 := z.EncBinary()
 				_ = yym2141
 				if false {
@@ -25591,7 +27471,9 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2142 := z.EncBinary()
 				_ = yym2142
 				if false {
@@ -25600,6 +27482,7 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2136 || yy2arr2136 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2136[2] {
 					x.Protocol.CodecEncodeSelf(e)
 				} else {
@@ -25607,12 +27490,16 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2136[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("protocol"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Protocol.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2136 {
-				r.EncodeEnd()
+			if yyr2136 || yy2arr2136 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -25627,17 +27514,18 @@ func (x *EndpointPort) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2145 := r.ContainerType()
+		if yyct2145 == codecSelferValueTypeMap1234 {
 			yyl2145 := r.ReadMapStart()
 			if yyl2145 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2145, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2145 == codecSelferValueTypeArray1234 {
 			yyl2145 := r.ReadArrayStart()
 			if yyl2145 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2145, d)
 			}
@@ -25664,8 +27552,10 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2146Slc = r.DecodeBytes(yys2146Slc, true, true)
 		yys2146 := string(yys2146Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2146 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -25689,9 +27579,7 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2146)
 		} // end switch yys2146
 	} // end for yyj2146
-	if !yyhl2146 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -25708,9 +27596,10 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2150 = r.CheckBreak()
 	}
 	if yyb2150 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -25723,9 +27612,10 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2150 = r.CheckBreak()
 	}
 	if yyb2150 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = 0
 	} else {
@@ -25738,9 +27628,10 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2150 = r.CheckBreak()
 	}
 	if yyb2150 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Protocol = ""
 	} else {
@@ -25756,9 +27647,10 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2150 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2150-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -25781,18 +27673,21 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2155[0] = x.Kind != ""
 			yyq2155[1] = x.APIVersion != ""
 			yyq2155[2] = true
+			var yynn2155 int
 			if yyr2155 || yy2arr2155 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2155 int = 1
+				yynn2155 = 1
 				for _, b := range yyq2155 {
 					if b {
 						yynn2155++
 					}
 				}
 				r.EncodeMapStart(yynn2155)
+				yynn2155 = 0
 			}
 			if yyr2155 || yy2arr2155 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2155[0] {
 					yym2157 := z.EncBinary()
 					_ = yym2157
@@ -25805,7 +27700,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2155[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2158 := z.EncBinary()
 					_ = yym2158
 					if false {
@@ -25815,6 +27712,7 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2155 || yy2arr2155 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2155[1] {
 					yym2160 := z.EncBinary()
 					_ = yym2160
@@ -25827,7 +27725,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2155[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2161 := z.EncBinary()
 					_ = yym2161
 					if false {
@@ -25837,6 +27737,7 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2155 || yy2arr2155 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2155[2] {
 					yy2163 := &x.ListMeta
 					yym2164 := z.EncBinary()
@@ -25851,7 +27752,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2155[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2165 := &x.ListMeta
 					yym2166 := z.EncBinary()
 					_ = yym2166
@@ -25863,6 +27766,7 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2155 || yy2arr2155 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -25874,7 +27778,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -25886,8 +27792,10 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2155 {
-				r.EncodeEnd()
+			if yyr2155 || yy2arr2155 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -25902,17 +27810,18 @@ func (x *EndpointsList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2171 := r.ContainerType()
+		if yyct2171 == codecSelferValueTypeMap1234 {
 			yyl2171 := r.ReadMapStart()
 			if yyl2171 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2171, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2171 == codecSelferValueTypeArray1234 {
 			yyl2171 := r.ReadArrayStart()
 			if yyl2171 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2171, d)
 			}
@@ -25939,8 +27848,10 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2172Slc = r.DecodeBytes(yys2172Slc, true, true)
 		yys2172 := string(yys2172Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2172 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -25983,9 +27894,7 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2172)
 		} // end switch yys2172
 	} // end for yyj2172
-	if !yyhl2172 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -26002,9 +27911,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2179 = r.CheckBreak()
 	}
 	if yyb2179 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -26017,9 +27927,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2179 = r.CheckBreak()
 	}
 	if yyb2179 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -26032,9 +27943,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2179 = r.CheckBreak()
 	}
 	if yyb2179 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -26054,9 +27966,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2179 = r.CheckBreak()
 	}
 	if yyb2179 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -26078,9 +27991,10 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2179 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2179-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -26104,18 +28018,21 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2187[1] = x.ExternalID != ""
 			yyq2187[2] = x.ProviderID != ""
 			yyq2187[3] = x.Unschedulable != false
+			var yynn2187 int
 			if yyr2187 || yy2arr2187 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2187 int = 0
+				yynn2187 = 0
 				for _, b := range yyq2187 {
 					if b {
 						yynn2187++
 					}
 				}
 				r.EncodeMapStart(yynn2187)
+				yynn2187 = 0
 			}
 			if yyr2187 || yy2arr2187 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2187[0] {
 					yym2189 := z.EncBinary()
 					_ = yym2189
@@ -26128,7 +28045,9 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2187[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("podCIDR"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2190 := z.EncBinary()
 					_ = yym2190
 					if false {
@@ -26138,6 +28057,7 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2187 || yy2arr2187 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2187[1] {
 					yym2192 := z.EncBinary()
 					_ = yym2192
@@ -26150,7 +28070,9 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2187[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("externalID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2193 := z.EncBinary()
 					_ = yym2193
 					if false {
@@ -26160,6 +28082,7 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2187 || yy2arr2187 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2187[2] {
 					yym2195 := z.EncBinary()
 					_ = yym2195
@@ -26172,7 +28095,9 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2187[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("providerID"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2196 := z.EncBinary()
 					_ = yym2196
 					if false {
@@ -26182,6 +28107,7 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2187 || yy2arr2187 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2187[3] {
 					yym2198 := z.EncBinary()
 					_ = yym2198
@@ -26194,7 +28120,9 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2187[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("unschedulable"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2199 := z.EncBinary()
 					_ = yym2199
 					if false {
@@ -26203,8 +28131,10 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2187 {
-				r.EncodeEnd()
+			if yyr2187 || yy2arr2187 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -26219,17 +28149,18 @@ func (x *NodeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2201 := r.ContainerType()
+		if yyct2201 == codecSelferValueTypeMap1234 {
 			yyl2201 := r.ReadMapStart()
 			if yyl2201 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2201, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2201 == codecSelferValueTypeArray1234 {
 			yyl2201 := r.ReadArrayStart()
 			if yyl2201 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2201, d)
 			}
@@ -26256,8 +28187,10 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2202Slc = r.DecodeBytes(yys2202Slc, true, true)
 		yys2202 := string(yys2202Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2202 {
 		case "podCIDR":
 			if r.TryDecodeAsNil() {
@@ -26287,9 +28220,7 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2202)
 		} // end switch yys2202
 	} // end for yyj2202
-	if !yyhl2202 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -26306,9 +28237,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2207 = r.CheckBreak()
 	}
 	if yyb2207 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PodCIDR = ""
 	} else {
@@ -26321,9 +28253,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2207 = r.CheckBreak()
 	}
 	if yyb2207 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ExternalID = ""
 	} else {
@@ -26336,9 +28269,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2207 = r.CheckBreak()
 	}
 	if yyb2207 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ProviderID = ""
 	} else {
@@ -26351,9 +28285,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2207 = r.CheckBreak()
 	}
 	if yyb2207 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Unschedulable = false
 	} else {
@@ -26369,9 +28304,10 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2207 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2207-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -26391,18 +28327,21 @@ func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2213 [1]bool
 			_, _, _ = yysep2213, yyq2213, yy2arr2213
 			const yyr2213 bool = false
+			var yynn2213 int
 			if yyr2213 || yy2arr2213 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2213 int = 1
+				yynn2213 = 1
 				for _, b := range yyq2213 {
 					if b {
 						yynn2213++
 					}
 				}
 				r.EncodeMapStart(yynn2213)
+				yynn2213 = 0
 			}
 			if yyr2213 || yy2arr2213 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2215 := z.EncBinary()
 				_ = yym2215
 				if false {
@@ -26410,7 +28349,9 @@ func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Port"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2216 := z.EncBinary()
 				_ = yym2216
 				if false {
@@ -26418,8 +28359,10 @@ func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yysep2213 {
-				r.EncodeEnd()
+			if yyr2213 || yy2arr2213 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -26434,17 +28377,18 @@ func (x *DaemonEndpoint) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2218 := r.ContainerType()
+		if yyct2218 == codecSelferValueTypeMap1234 {
 			yyl2218 := r.ReadMapStart()
 			if yyl2218 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2218, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2218 == codecSelferValueTypeArray1234 {
 			yyl2218 := r.ReadArrayStart()
 			if yyl2218 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2218, d)
 			}
@@ -26471,8 +28415,10 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2219Slc = r.DecodeBytes(yys2219Slc, true, true)
 		yys2219 := string(yys2219Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2219 {
 		case "Port":
 			if r.TryDecodeAsNil() {
@@ -26484,9 +28430,7 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2219)
 		} // end switch yys2219
 	} // end for yyj2219
-	if !yyhl2219 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -26503,9 +28447,10 @@ func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2221 = r.CheckBreak()
 	}
 	if yyb2221 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Port = 0
 	} else {
@@ -26521,9 +28466,10 @@ func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2221 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2221-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeDaemonEndpoints) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -26544,18 +28490,21 @@ func (x *NodeDaemonEndpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2224, yyq2224, yy2arr2224
 			const yyr2224 bool = false
 			yyq2224[0] = true
+			var yynn2224 int
 			if yyr2224 || yy2arr2224 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2224 int = 0
+				yynn2224 = 0
 				for _, b := range yyq2224 {
 					if b {
 						yynn2224++
 					}
 				}
 				r.EncodeMapStart(yynn2224)
+				yynn2224 = 0
 			}
 			if yyr2224 || yy2arr2224 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2224[0] {
 					yy2226 := &x.KubeletEndpoint
 					yy2226.CodecEncodeSelf(e)
@@ -26564,13 +28513,17 @@ func (x *NodeDaemonEndpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2224[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kubeletEndpoint"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2227 := &x.KubeletEndpoint
 					yy2227.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2224 {
-				r.EncodeEnd()
+			if yyr2224 || yy2arr2224 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -26585,17 +28538,18 @@ func (x *NodeDaemonEndpoints) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2229 := r.ContainerType()
+		if yyct2229 == codecSelferValueTypeMap1234 {
 			yyl2229 := r.ReadMapStart()
 			if yyl2229 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2229, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2229 == codecSelferValueTypeArray1234 {
 			yyl2229 := r.ReadArrayStart()
 			if yyl2229 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2229, d)
 			}
@@ -26622,8 +28576,10 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2230Slc = r.DecodeBytes(yys2230Slc, true, true)
 		yys2230 := string(yys2230Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2230 {
 		case "kubeletEndpoint":
 			if r.TryDecodeAsNil() {
@@ -26636,9 +28592,7 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys2230)
 		} // end switch yys2230
 	} // end for yyj2230
-	if !yyhl2230 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeDaemonEndpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -26655,9 +28609,10 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb2232 = r.CheckBreak()
 	}
 	if yyb2232 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeletEndpoint = DaemonEndpoint{}
 	} else {
@@ -26674,9 +28629,10 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb2232 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2232-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -26696,18 +28652,21 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2235 [8]bool
 			_, _, _ = yysep2235, yyq2235, yy2arr2235
 			const yyr2235 bool = false
+			var yynn2235 int
 			if yyr2235 || yy2arr2235 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2235 int = 8
+				yynn2235 = 8
 				for _, b := range yyq2235 {
 					if b {
 						yynn2235++
 					}
 				}
 				r.EncodeMapStart(yynn2235)
+				yynn2235 = 0
 			}
 			if yyr2235 || yy2arr2235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2237 := z.EncBinary()
 				_ = yym2237
 				if false {
@@ -26715,7 +28674,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MachineID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("machineID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2238 := z.EncBinary()
 				_ = yym2238
 				if false {
@@ -26724,6 +28685,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2235 || yy2arr2235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2240 := z.EncBinary()
 				_ = yym2240
 				if false {
@@ -26731,7 +28693,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SystemUUID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("systemUUID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2241 := z.EncBinary()
 				_ = yym2241
 				if false {
@@ -26740,6 +28704,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2235 || yy2arr2235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2243 := z.EncBinary()
 				_ = yym2243
 				if false {
@@ -26747,7 +28712,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BootID))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("bootID"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2244 := z.EncBinary()
 				_ = yym2244
 				if false {
@@ -26756,6 +28723,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2235 || yy2arr2235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2246 := z.EncBinary()
 				_ = yym2246
 				if false {
@@ -26763,7 +28731,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KernelVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kernelVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2247 := z.EncBinary()
 				_ = yym2247
 				if false {
@@ -26772,6 +28742,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2235 || yy2arr2235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2249 := z.EncBinary()
 				_ = yym2249
 				if false {
@@ -26779,7 +28750,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.OsImage))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("osImage"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2250 := z.EncBinary()
 				_ = yym2250
 				if false {
@@ -26788,6 +28761,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2235 || yy2arr2235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2252 := z.EncBinary()
 				_ = yym2252
 				if false {
@@ -26795,7 +28769,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntimeVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("containerRuntimeVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2253 := z.EncBinary()
 				_ = yym2253
 				if false {
@@ -26804,6 +28780,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2235 || yy2arr2235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2255 := z.EncBinary()
 				_ = yym2255
 				if false {
@@ -26811,7 +28788,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeletVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeletVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2256 := z.EncBinary()
 				_ = yym2256
 				if false {
@@ -26820,6 +28799,7 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2235 || yy2arr2235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2258 := z.EncBinary()
 				_ = yym2258
 				if false {
@@ -26827,7 +28807,9 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeProxyVersion))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeProxyVersion"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2259 := z.EncBinary()
 				_ = yym2259
 				if false {
@@ -26835,8 +28817,10 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeProxyVersion))
 				}
 			}
-			if yysep2235 {
-				r.EncodeEnd()
+			if yyr2235 || yy2arr2235 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -26851,17 +28835,18 @@ func (x *NodeSystemInfo) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2261 := r.ContainerType()
+		if yyct2261 == codecSelferValueTypeMap1234 {
 			yyl2261 := r.ReadMapStart()
 			if yyl2261 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2261, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2261 == codecSelferValueTypeArray1234 {
 			yyl2261 := r.ReadArrayStart()
 			if yyl2261 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2261, d)
 			}
@@ -26888,8 +28873,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2262Slc = r.DecodeBytes(yys2262Slc, true, true)
 		yys2262 := string(yys2262Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2262 {
 		case "machineID":
 			if r.TryDecodeAsNil() {
@@ -26943,9 +28930,7 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2262)
 		} // end switch yys2262
 	} // end for yyj2262
-	if !yyhl2262 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -26962,9 +28947,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2271 = r.CheckBreak()
 	}
 	if yyb2271 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MachineID = ""
 	} else {
@@ -26977,9 +28963,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2271 = r.CheckBreak()
 	}
 	if yyb2271 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.SystemUUID = ""
 	} else {
@@ -26992,9 +28979,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2271 = r.CheckBreak()
 	}
 	if yyb2271 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.BootID = ""
 	} else {
@@ -27007,9 +28995,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2271 = r.CheckBreak()
 	}
 	if yyb2271 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KernelVersion = ""
 	} else {
@@ -27022,9 +29011,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2271 = r.CheckBreak()
 	}
 	if yyb2271 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.OsImage = ""
 	} else {
@@ -27037,9 +29027,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2271 = r.CheckBreak()
 	}
 	if yyb2271 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ContainerRuntimeVersion = ""
 	} else {
@@ -27052,9 +29043,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2271 = r.CheckBreak()
 	}
 	if yyb2271 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeletVersion = ""
 	} else {
@@ -27067,9 +29059,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2271 = r.CheckBreak()
 	}
 	if yyb2271 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeProxyVersion = ""
 	} else {
@@ -27085,9 +29078,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2271 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2271-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -27113,18 +29107,21 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2281[3] = len(x.Addresses) != 0
 			yyq2281[4] = true
 			yyq2281[5] = true
+			var yynn2281 int
 			if yyr2281 || yy2arr2281 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn2281 int = 0
+				yynn2281 = 0
 				for _, b := range yyq2281 {
 					if b {
 						yynn2281++
 					}
 				}
 				r.EncodeMapStart(yynn2281)
+				yynn2281 = 0
 			}
 			if yyr2281 || yy2arr2281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2281[0] {
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -27136,7 +29133,9 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2281[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -27145,6 +29144,7 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2281 || yy2arr2281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2281[1] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -27152,11 +29152,14 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2281[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2281 || yy2arr2281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2281[2] {
 					if x.Conditions == nil {
 						r.EncodeNil()
@@ -27173,7 +29176,9 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2281[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
@@ -27187,6 +29192,7 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2281 || yy2arr2281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2281[3] {
 					if x.Addresses == nil {
 						r.EncodeNil()
@@ -27203,7 +29209,9 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2281[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("addresses"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Addresses == nil {
 						r.EncodeNil()
 					} else {
@@ -27217,6 +29225,7 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2281 || yy2arr2281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2281[4] {
 					yy2291 := &x.DaemonEndpoints
 					yy2291.CodecEncodeSelf(e)
@@ -27225,12 +29234,15 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2281[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("daemonEndpoints"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2292 := &x.DaemonEndpoints
 					yy2292.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2281 || yy2arr2281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2281[5] {
 					yy2294 := &x.NodeInfo
 					yy2294.CodecEncodeSelf(e)
@@ -27239,13 +29251,17 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2281[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("nodeInfo"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2295 := &x.NodeInfo
 					yy2295.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2281 {
-				r.EncodeEnd()
+			if yyr2281 || yy2arr2281 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -27260,17 +29276,18 @@ func (x *NodeStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2297 := r.ContainerType()
+		if yyct2297 == codecSelferValueTypeMap1234 {
 			yyl2297 := r.ReadMapStart()
 			if yyl2297 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2297, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2297 == codecSelferValueTypeArray1234 {
 			yyl2297 := r.ReadArrayStart()
 			if yyl2297 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2297, d)
 			}
@@ -27297,8 +29314,10 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2298Slc = r.DecodeBytes(yys2298Slc, true, true)
 		yys2298 := string(yys2298Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2298 {
 		case "capacity":
 			if r.TryDecodeAsNil() {
@@ -27355,9 +29374,7 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2298)
 		} // end switch yys2298
 	} // end for yyj2298
-	if !yyhl2298 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -27374,9 +29391,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2307 = r.CheckBreak()
 	}
 	if yyb2307 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
@@ -27390,9 +29408,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2307 = r.CheckBreak()
 	}
 	if yyb2307 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -27405,9 +29424,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2307 = r.CheckBreak()
 	}
 	if yyb2307 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
@@ -27426,9 +29446,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2307 = r.CheckBreak()
 	}
 	if yyb2307 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Addresses = nil
 	} else {
@@ -27447,9 +29468,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2307 = r.CheckBreak()
 	}
 	if yyb2307 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DaemonEndpoints = NodeDaemonEndpoints{}
 	} else {
@@ -27463,9 +29485,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2307 = r.CheckBreak()
 	}
 	if yyb2307 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NodeInfo = NodeSystemInfo{}
 	} else {
@@ -27482,9 +29505,10 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2307 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2307-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x NodePhase) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -27560,30 +29584,39 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2321[3] = true
 			yyq2321[4] = x.Reason != ""
 			yyq2321[5] = x.Message != ""
+			var yynn2321 int
 			if yyr2321 || yy2arr2321 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn2321 int = 2
+				yynn2321 = 2
 				for _, b := range yyq2321 {
 					if b {
 						yynn2321++
 					}
 				}
 				r.EncodeMapStart(yynn2321)
+				yynn2321 = 0
 			}
 			if yyr2321 || yy2arr2321 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr2321 || yy2arr2321 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Status.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Status.CodecEncodeSelf(e)
 			}
 			if yyr2321 || yy2arr2321 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2321[2] {
 					yy2325 := &x.LastHeartbeatTime
 					yym2326 := z.EncBinary()
@@ -27602,7 +29635,9 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2321[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastHeartbeatTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2327 := &x.LastHeartbeatTime
 					yym2328 := z.EncBinary()
 					_ = yym2328
@@ -27618,6 +29653,7 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2321 || yy2arr2321 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2321[3] {
 					yy2330 := &x.LastTransitionTime
 					yym2331 := z.EncBinary()
@@ -27636,7 +29672,9 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2321[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2332 := &x.LastTransitionTime
 					yym2333 := z.EncBinary()
 					_ = yym2333
@@ -27652,6 +29690,7 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2321 || yy2arr2321 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2321[4] {
 					yym2335 := z.EncBinary()
 					_ = yym2335
@@ -27664,7 +29703,9 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2321[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2336 := z.EncBinary()
 					_ = yym2336
 					if false {
@@ -27674,6 +29715,7 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2321 || yy2arr2321 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2321[5] {
 					yym2338 := z.EncBinary()
 					_ = yym2338
@@ -27686,7 +29728,9 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2321[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2339 := z.EncBinary()
 					_ = yym2339
 					if false {
@@ -27695,8 +29739,10 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2321 {
-				r.EncodeEnd()
+			if yyr2321 || yy2arr2321 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -27711,17 +29757,18 @@ func (x *NodeCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2341 := r.ContainerType()
+		if yyct2341 == codecSelferValueTypeMap1234 {
 			yyl2341 := r.ReadMapStart()
 			if yyl2341 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2341, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2341 == codecSelferValueTypeArray1234 {
 			yyl2341 := r.ReadArrayStart()
 			if yyl2341 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2341, d)
 			}
@@ -27748,8 +29795,10 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2342Slc = r.DecodeBytes(yys2342Slc, true, true)
 		yys2342 := string(yys2342Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2342 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -27813,9 +29862,7 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2342)
 		} // end switch yys2342
 	} // end for yyj2342
-	if !yyhl2342 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -27832,9 +29879,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2351 = r.CheckBreak()
 	}
 	if yyb2351 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -27847,9 +29895,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2351 = r.CheckBreak()
 	}
 	if yyb2351 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ""
 	} else {
@@ -27862,9 +29911,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2351 = r.CheckBreak()
 	}
 	if yyb2351 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastHeartbeatTime = pkg2_unversioned.Time{}
 	} else {
@@ -27888,9 +29938,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2351 = r.CheckBreak()
 	}
 	if yyb2351 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg2_unversioned.Time{}
 	} else {
@@ -27914,9 +29965,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2351 = r.CheckBreak()
 	}
 	if yyb2351 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -27929,9 +29981,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2351 = r.CheckBreak()
 	}
 	if yyb2351 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -27947,9 +30000,10 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2351 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2351-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x NodeAddressType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -27995,24 +30049,30 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2363 [2]bool
 			_, _, _ = yysep2363, yyq2363, yy2arr2363
 			const yyr2363 bool = false
+			var yynn2363 int
 			if yyr2363 || yy2arr2363 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2363 int = 2
+				yynn2363 = 2
 				for _, b := range yyq2363 {
 					if b {
 						yynn2363++
 					}
 				}
 				r.EncodeMapStart(yynn2363)
+				yynn2363 = 0
 			}
 			if yyr2363 || yy2arr2363 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr2363 || yy2arr2363 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym2366 := z.EncBinary()
 				_ = yym2366
 				if false {
@@ -28020,7 +30080,9 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym2367 := z.EncBinary()
 				_ = yym2367
 				if false {
@@ -28028,8 +30090,10 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
-			if yysep2363 {
-				r.EncodeEnd()
+			if yyr2363 || yy2arr2363 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -28044,17 +30108,18 @@ func (x *NodeAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2369 := r.ContainerType()
+		if yyct2369 == codecSelferValueTypeMap1234 {
 			yyl2369 := r.ReadMapStart()
 			if yyl2369 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2369, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2369 == codecSelferValueTypeArray1234 {
 			yyl2369 := r.ReadArrayStart()
 			if yyl2369 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2369, d)
 			}
@@ -28081,8 +30146,10 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2370Slc = r.DecodeBytes(yys2370Slc, true, true)
 		yys2370 := string(yys2370Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2370 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -28100,9 +30167,7 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2370)
 		} // end switch yys2370
 	} // end for yyj2370
-	if !yyhl2370 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -28119,9 +30184,10 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2373 = r.CheckBreak()
 	}
 	if yyb2373 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -28134,9 +30200,10 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2373 = r.CheckBreak()
 	}
 	if yyb2373 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Address = ""
 	} else {
@@ -28152,9 +30219,10 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2373 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2373-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x ResourceName) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -28235,18 +30303,21 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2381[2] = true
 			yyq2381[3] = true
 			yyq2381[4] = true
+			var yynn2381 int
 			if yyr2381 || yy2arr2381 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2381 int = 0
+				yynn2381 = 0
 				for _, b := range yyq2381 {
 					if b {
 						yynn2381++
 					}
 				}
 				r.EncodeMapStart(yynn2381)
+				yynn2381 = 0
 			}
 			if yyr2381 || yy2arr2381 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2381[0] {
 					yym2383 := z.EncBinary()
 					_ = yym2383
@@ -28259,7 +30330,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2381[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2384 := z.EncBinary()
 					_ = yym2384
 					if false {
@@ -28269,6 +30342,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2381 || yy2arr2381 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2381[1] {
 					yym2386 := z.EncBinary()
 					_ = yym2386
@@ -28281,7 +30355,9 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2381[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2387 := z.EncBinary()
 					_ = yym2387
 					if false {
@@ -28291,6 +30367,7 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2381 || yy2arr2381 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2381[2] {
 					yy2389 := &x.ObjectMeta
 					yy2389.CodecEncodeSelf(e)
@@ -28299,12 +30376,15 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2381[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2390 := &x.ObjectMeta
 					yy2390.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2381 || yy2arr2381 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2381[3] {
 					yy2392 := &x.Spec
 					yy2392.CodecEncodeSelf(e)
@@ -28313,12 +30393,15 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2381[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2393 := &x.Spec
 					yy2393.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2381 || yy2arr2381 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2381[4] {
 					yy2395 := &x.Status
 					yy2395.CodecEncodeSelf(e)
@@ -28327,13 +30410,17 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2381[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2396 := &x.Status
 					yy2396.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2381 {
-				r.EncodeEnd()
+			if yyr2381 || yy2arr2381 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -28348,17 +30435,18 @@ func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2398 := r.ContainerType()
+		if yyct2398 == codecSelferValueTypeMap1234 {
 			yyl2398 := r.ReadMapStart()
 			if yyl2398 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2398, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2398 == codecSelferValueTypeArray1234 {
 			yyl2398 := r.ReadArrayStart()
 			if yyl2398 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2398, d)
 			}
@@ -28385,8 +30473,10 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2399Slc = r.DecodeBytes(yys2399Slc, true, true)
 		yys2399 := string(yys2399Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2399 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -28425,9 +30515,7 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2399)
 		} // end switch yys2399
 	} // end for yyj2399
-	if !yyhl2399 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -28444,9 +30532,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2405 = r.CheckBreak()
 	}
 	if yyb2405 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -28459,9 +30548,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2405 = r.CheckBreak()
 	}
 	if yyb2405 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -28474,9 +30564,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2405 = r.CheckBreak()
 	}
 	if yyb2405 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -28490,9 +30581,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2405 = r.CheckBreak()
 	}
 	if yyb2405 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = NodeSpec{}
 	} else {
@@ -28506,9 +30598,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2405 = r.CheckBreak()
 	}
 	if yyb2405 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = NodeStatus{}
 	} else {
@@ -28525,9 +30618,10 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2405 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2405-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -28550,18 +30644,21 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2412[0] = x.Kind != ""
 			yyq2412[1] = x.APIVersion != ""
 			yyq2412[2] = true
+			var yynn2412 int
 			if yyr2412 || yy2arr2412 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2412 int = 1
+				yynn2412 = 1
 				for _, b := range yyq2412 {
 					if b {
 						yynn2412++
 					}
 				}
 				r.EncodeMapStart(yynn2412)
+				yynn2412 = 0
 			}
 			if yyr2412 || yy2arr2412 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2412[0] {
 					yym2414 := z.EncBinary()
 					_ = yym2414
@@ -28574,7 +30671,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2412[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2415 := z.EncBinary()
 					_ = yym2415
 					if false {
@@ -28584,6 +30683,7 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2412 || yy2arr2412 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2412[1] {
 					yym2417 := z.EncBinary()
 					_ = yym2417
@@ -28596,7 +30696,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2412[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2418 := z.EncBinary()
 					_ = yym2418
 					if false {
@@ -28606,6 +30708,7 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2412 || yy2arr2412 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2412[2] {
 					yy2420 := &x.ListMeta
 					yym2421 := z.EncBinary()
@@ -28620,7 +30723,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2412[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2422 := &x.ListMeta
 					yym2423 := z.EncBinary()
 					_ = yym2423
@@ -28632,6 +30737,7 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2412 || yy2arr2412 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -28643,7 +30749,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -28655,8 +30763,10 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2412 {
-				r.EncodeEnd()
+			if yyr2412 || yy2arr2412 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -28671,17 +30781,18 @@ func (x *NodeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2428 := r.ContainerType()
+		if yyct2428 == codecSelferValueTypeMap1234 {
 			yyl2428 := r.ReadMapStart()
 			if yyl2428 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2428, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2428 == codecSelferValueTypeArray1234 {
 			yyl2428 := r.ReadArrayStart()
 			if yyl2428 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2428, d)
 			}
@@ -28708,8 +30819,10 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2429Slc = r.DecodeBytes(yys2429Slc, true, true)
 		yys2429 := string(yys2429Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2429 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -28752,9 +30865,7 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2429)
 		} // end switch yys2429
 	} // end for yyj2429
-	if !yyhl2429 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -28771,9 +30882,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2436 = r.CheckBreak()
 	}
 	if yyb2436 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -28786,9 +30898,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2436 = r.CheckBreak()
 	}
 	if yyb2436 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -28801,9 +30914,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2436 = r.CheckBreak()
 	}
 	if yyb2436 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -28823,9 +30937,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2436 = r.CheckBreak()
 	}
 	if yyb2436 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -28847,9 +30962,10 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2436 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2436-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x FinalizerName) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -28896,18 +31012,21 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2446, yyq2446, yy2arr2446
 			const yyr2446 bool = false
 			yyq2446[0] = len(x.Finalizers) != 0
+			var yynn2446 int
 			if yyr2446 || yy2arr2446 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2446 int = 0
+				yynn2446 = 0
 				for _, b := range yyq2446 {
 					if b {
 						yynn2446++
 					}
 				}
 				r.EncodeMapStart(yynn2446)
+				yynn2446 = 0
 			}
 			if yyr2446 || yy2arr2446 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2446[0] {
 					if x.Finalizers == nil {
 						r.EncodeNil()
@@ -28924,7 +31043,9 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2446[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("finalizers"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Finalizers == nil {
 						r.EncodeNil()
 					} else {
@@ -28937,8 +31058,10 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2446 {
-				r.EncodeEnd()
+			if yyr2446 || yy2arr2446 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -28953,17 +31076,18 @@ func (x *NamespaceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2451 := r.ContainerType()
+		if yyct2451 == codecSelferValueTypeMap1234 {
 			yyl2451 := r.ReadMapStart()
 			if yyl2451 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2451, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2451 == codecSelferValueTypeArray1234 {
 			yyl2451 := r.ReadArrayStart()
 			if yyl2451 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2451, d)
 			}
@@ -28990,8 +31114,10 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2452Slc = r.DecodeBytes(yys2452Slc, true, true)
 		yys2452 := string(yys2452Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2452 {
 		case "finalizers":
 			if r.TryDecodeAsNil() {
@@ -29009,9 +31135,7 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2452)
 		} // end switch yys2452
 	} // end for yyj2452
-	if !yyhl2452 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -29028,9 +31152,10 @@ func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2455 = r.CheckBreak()
 	}
 	if yyb2455 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Finalizers = nil
 	} else {
@@ -29052,9 +31177,10 @@ func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2455 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2455-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NamespaceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -29075,18 +31201,21 @@ func (x *NamespaceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2459, yyq2459, yy2arr2459
 			const yyr2459 bool = false
 			yyq2459[0] = x.Phase != ""
+			var yynn2459 int
 			if yyr2459 || yy2arr2459 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2459 int = 0
+				yynn2459 = 0
 				for _, b := range yyq2459 {
 					if b {
 						yynn2459++
 					}
 				}
 				r.EncodeMapStart(yynn2459)
+				yynn2459 = 0
 			}
 			if yyr2459 || yy2arr2459 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2459[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
@@ -29094,12 +31223,16 @@ func (x *NamespaceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2459[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2459 {
-				r.EncodeEnd()
+			if yyr2459 || yy2arr2459 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -29114,17 +31247,18 @@ func (x *NamespaceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2462 := r.ContainerType()
+		if yyct2462 == codecSelferValueTypeMap1234 {
 			yyl2462 := r.ReadMapStart()
 			if yyl2462 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2462, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2462 == codecSelferValueTypeArray1234 {
 			yyl2462 := r.ReadArrayStart()
 			if yyl2462 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2462, d)
 			}
@@ -29151,8 +31285,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2463Slc = r.DecodeBytes(yys2463Slc, true, true)
 		yys2463 := string(yys2463Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2463 {
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -29164,9 +31300,7 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2463)
 		} // end switch yys2463
 	} // end for yyj2463
-	if !yyhl2463 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -29183,9 +31317,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2465 = r.CheckBreak()
 	}
 	if yyb2465 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Phase = ""
 	} else {
@@ -29201,9 +31336,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb2465 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2465-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x NamespacePhase) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -29254,18 +31390,21 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2470[2] = true
 			yyq2470[3] = true
 			yyq2470[4] = true
+			var yynn2470 int
 			if yyr2470 || yy2arr2470 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2470 int = 0
+				yynn2470 = 0
 				for _, b := range yyq2470 {
 					if b {
 						yynn2470++
 					}
 				}
 				r.EncodeMapStart(yynn2470)
+				yynn2470 = 0
 			}
 			if yyr2470 || yy2arr2470 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2470[0] {
 					yym2472 := z.EncBinary()
 					_ = yym2472
@@ -29278,7 +31417,9 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2470[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2473 := z.EncBinary()
 					_ = yym2473
 					if false {
@@ -29288,6 +31429,7 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2470 || yy2arr2470 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2470[1] {
 					yym2475 := z.EncBinary()
 					_ = yym2475
@@ -29300,7 +31442,9 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2470[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2476 := z.EncBinary()
 					_ = yym2476
 					if false {
@@ -29310,6 +31454,7 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2470 || yy2arr2470 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2470[2] {
 					yy2478 := &x.ObjectMeta
 					yy2478.CodecEncodeSelf(e)
@@ -29318,12 +31463,15 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2470[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2479 := &x.ObjectMeta
 					yy2479.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2470 || yy2arr2470 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2470[3] {
 					yy2481 := &x.Spec
 					yy2481.CodecEncodeSelf(e)
@@ -29332,12 +31480,15 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2470[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2482 := &x.Spec
 					yy2482.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2470 || yy2arr2470 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2470[4] {
 					yy2484 := &x.Status
 					yy2484.CodecEncodeSelf(e)
@@ -29346,13 +31497,17 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2470[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2485 := &x.Status
 					yy2485.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2470 {
-				r.EncodeEnd()
+			if yyr2470 || yy2arr2470 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -29367,17 +31522,18 @@ func (x *Namespace) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2487 := r.ContainerType()
+		if yyct2487 == codecSelferValueTypeMap1234 {
 			yyl2487 := r.ReadMapStart()
 			if yyl2487 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2487, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2487 == codecSelferValueTypeArray1234 {
 			yyl2487 := r.ReadArrayStart()
 			if yyl2487 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2487, d)
 			}
@@ -29404,8 +31560,10 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2488Slc = r.DecodeBytes(yys2488Slc, true, true)
 		yys2488 := string(yys2488Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2488 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -29444,9 +31602,7 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2488)
 		} // end switch yys2488
 	} // end for yyj2488
-	if !yyhl2488 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -29463,9 +31619,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2494 = r.CheckBreak()
 	}
 	if yyb2494 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -29478,9 +31635,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2494 = r.CheckBreak()
 	}
 	if yyb2494 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -29493,9 +31651,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2494 = r.CheckBreak()
 	}
 	if yyb2494 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -29509,9 +31668,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2494 = r.CheckBreak()
 	}
 	if yyb2494 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = NamespaceSpec{}
 	} else {
@@ -29525,9 +31685,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2494 = r.CheckBreak()
 	}
 	if yyb2494 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = NamespaceStatus{}
 	} else {
@@ -29544,9 +31705,10 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2494 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2494-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -29569,18 +31731,21 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2501[0] = x.Kind != ""
 			yyq2501[1] = x.APIVersion != ""
 			yyq2501[2] = true
+			var yynn2501 int
 			if yyr2501 || yy2arr2501 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2501 int = 1
+				yynn2501 = 1
 				for _, b := range yyq2501 {
 					if b {
 						yynn2501++
 					}
 				}
 				r.EncodeMapStart(yynn2501)
+				yynn2501 = 0
 			}
 			if yyr2501 || yy2arr2501 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2501[0] {
 					yym2503 := z.EncBinary()
 					_ = yym2503
@@ -29593,7 +31758,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2501[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2504 := z.EncBinary()
 					_ = yym2504
 					if false {
@@ -29603,6 +31770,7 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2501 || yy2arr2501 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2501[1] {
 					yym2506 := z.EncBinary()
 					_ = yym2506
@@ -29615,7 +31783,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2501[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2507 := z.EncBinary()
 					_ = yym2507
 					if false {
@@ -29625,6 +31795,7 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2501 || yy2arr2501 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2501[2] {
 					yy2509 := &x.ListMeta
 					yym2510 := z.EncBinary()
@@ -29639,7 +31810,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2501[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2511 := &x.ListMeta
 					yym2512 := z.EncBinary()
 					_ = yym2512
@@ -29651,6 +31824,7 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2501 || yy2arr2501 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -29662,7 +31836,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -29674,8 +31850,10 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2501 {
-				r.EncodeEnd()
+			if yyr2501 || yy2arr2501 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -29690,17 +31868,18 @@ func (x *NamespaceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2517 := r.ContainerType()
+		if yyct2517 == codecSelferValueTypeMap1234 {
 			yyl2517 := r.ReadMapStart()
 			if yyl2517 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2517, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2517 == codecSelferValueTypeArray1234 {
 			yyl2517 := r.ReadArrayStart()
 			if yyl2517 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2517, d)
 			}
@@ -29727,8 +31906,10 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2518Slc = r.DecodeBytes(yys2518Slc, true, true)
 		yys2518 := string(yys2518Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2518 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -29771,9 +31952,7 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2518)
 		} // end switch yys2518
 	} // end for yyj2518
-	if !yyhl2518 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -29790,9 +31969,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2525 = r.CheckBreak()
 	}
 	if yyb2525 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -29805,9 +31985,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2525 = r.CheckBreak()
 	}
 	if yyb2525 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -29820,9 +32001,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2525 = r.CheckBreak()
 	}
 	if yyb2525 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -29842,9 +32024,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2525 = r.CheckBreak()
 	}
 	if yyb2525 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -29866,9 +32049,10 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2525 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2525-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -29891,18 +32075,21 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2533[0] = x.Kind != ""
 			yyq2533[1] = x.APIVersion != ""
 			yyq2533[2] = true
+			var yynn2533 int
 			if yyr2533 || yy2arr2533 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2533 int = 1
+				yynn2533 = 1
 				for _, b := range yyq2533 {
 					if b {
 						yynn2533++
 					}
 				}
 				r.EncodeMapStart(yynn2533)
+				yynn2533 = 0
 			}
 			if yyr2533 || yy2arr2533 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2533[0] {
 					yym2535 := z.EncBinary()
 					_ = yym2535
@@ -29915,7 +32102,9 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2533[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2536 := z.EncBinary()
 					_ = yym2536
 					if false {
@@ -29925,6 +32114,7 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2533 || yy2arr2533 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2533[1] {
 					yym2538 := z.EncBinary()
 					_ = yym2538
@@ -29937,7 +32127,9 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2533[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2539 := z.EncBinary()
 					_ = yym2539
 					if false {
@@ -29947,6 +32139,7 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2533 || yy2arr2533 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2533[2] {
 					yy2541 := &x.ObjectMeta
 					yy2541.CodecEncodeSelf(e)
@@ -29955,21 +32148,28 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2533[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2542 := &x.ObjectMeta
 					yy2542.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2533 || yy2arr2533 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy2544 := &x.Target
 				yy2544.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy2545 := &x.Target
 				yy2545.CodecEncodeSelf(e)
 			}
-			if yysep2533 {
-				r.EncodeEnd()
+			if yyr2533 || yy2arr2533 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -29984,17 +32184,18 @@ func (x *Binding) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2547 := r.ContainerType()
+		if yyct2547 == codecSelferValueTypeMap1234 {
 			yyl2547 := r.ReadMapStart()
 			if yyl2547 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2547, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2547 == codecSelferValueTypeArray1234 {
 			yyl2547 := r.ReadArrayStart()
 			if yyl2547 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2547, d)
 			}
@@ -30021,8 +32222,10 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2548Slc = r.DecodeBytes(yys2548Slc, true, true)
 		yys2548 := string(yys2548Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2548 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -30054,9 +32257,7 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2548)
 		} // end switch yys2548
 	} // end for yyj2548
-	if !yyhl2548 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -30073,9 +32274,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2553 = r.CheckBreak()
 	}
 	if yyb2553 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -30088,9 +32290,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2553 = r.CheckBreak()
 	}
 	if yyb2553 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -30103,9 +32306,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2553 = r.CheckBreak()
 	}
 	if yyb2553 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -30119,9 +32323,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2553 = r.CheckBreak()
 	}
 	if yyb2553 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Target = ObjectReference{}
 	} else {
@@ -30138,9 +32343,10 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2553 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2553-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -30162,18 +32368,21 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2559 bool = false
 			yyq2559[0] = x.Kind != ""
 			yyq2559[1] = x.APIVersion != ""
+			var yynn2559 int
 			if yyr2559 || yy2arr2559 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2559 int = 1
+				yynn2559 = 1
 				for _, b := range yyq2559 {
 					if b {
 						yynn2559++
 					}
 				}
 				r.EncodeMapStart(yynn2559)
+				yynn2559 = 0
 			}
 			if yyr2559 || yy2arr2559 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2559[0] {
 					yym2561 := z.EncBinary()
 					_ = yym2561
@@ -30186,7 +32395,9 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2559[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2562 := z.EncBinary()
 					_ = yym2562
 					if false {
@@ -30196,6 +32407,7 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2559 || yy2arr2559 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2559[1] {
 					yym2564 := z.EncBinary()
 					_ = yym2564
@@ -30208,7 +32420,9 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2559[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2565 := z.EncBinary()
 					_ = yym2565
 					if false {
@@ -30218,6 +32432,7 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2559 || yy2arr2559 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
@@ -30230,7 +32445,9 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("gracePeriodSeconds"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
@@ -30243,8 +32460,10 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2559 {
-				r.EncodeEnd()
+			if yyr2559 || yy2arr2559 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -30259,17 +32478,18 @@ func (x *DeleteOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2572 := r.ContainerType()
+		if yyct2572 == codecSelferValueTypeMap1234 {
 			yyl2572 := r.ReadMapStart()
 			if yyl2572 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2572, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2572 == codecSelferValueTypeArray1234 {
 			yyl2572 := r.ReadArrayStart()
 			if yyl2572 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2572, d)
 			}
@@ -30296,8 +32516,10 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2573Slc = r.DecodeBytes(yys2573Slc, true, true)
 		yys2573 := string(yys2573Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2573 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -30331,9 +32553,7 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2573)
 		} // end switch yys2573
 	} // end for yyj2573
-	if !yyhl2573 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -30350,9 +32570,10 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2578 = r.CheckBreak()
 	}
 	if yyb2578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -30365,9 +32586,10 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2578 = r.CheckBreak()
 	}
 	if yyb2578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -30380,9 +32602,10 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2578 = r.CheckBreak()
 	}
 	if yyb2578 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.GracePeriodSeconds != nil {
 			x.GracePeriodSeconds = nil
@@ -30408,9 +32631,10 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2578 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2578-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -30437,18 +32661,21 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2584[4] = x.Watch != false
 			yyq2584[5] = x.ResourceVersion != ""
 			yyq2584[6] = x.TimeoutSeconds != nil
+			var yynn2584 int
 			if yyr2584 || yy2arr2584 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2584 int = 0
+				yynn2584 = 0
 				for _, b := range yyq2584 {
 					if b {
 						yynn2584++
 					}
 				}
 				r.EncodeMapStart(yynn2584)
+				yynn2584 = 0
 			}
 			if yyr2584 || yy2arr2584 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2584[0] {
 					yym2586 := z.EncBinary()
 					_ = yym2586
@@ -30461,7 +32688,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2584[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2587 := z.EncBinary()
 					_ = yym2587
 					if false {
@@ -30471,6 +32700,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2584 || yy2arr2584 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2584[1] {
 					yym2589 := z.EncBinary()
 					_ = yym2589
@@ -30483,7 +32713,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2584[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2590 := z.EncBinary()
 					_ = yym2590
 					if false {
@@ -30493,6 +32725,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2584 || yy2arr2584 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2584[2] {
 					yym2592 := z.EncBinary()
 					_ = yym2592
@@ -30505,7 +32738,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2584[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2593 := z.EncBinary()
 					_ = yym2593
 					if false {
@@ -30515,6 +32750,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2584 || yy2arr2584 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2584[3] {
 					yym2595 := z.EncBinary()
 					_ = yym2595
@@ -30527,7 +32763,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2584[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fieldSelector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2596 := z.EncBinary()
 					_ = yym2596
 					if false {
@@ -30537,6 +32775,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2584 || yy2arr2584 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2584[4] {
 					yym2598 := z.EncBinary()
 					_ = yym2598
@@ -30549,7 +32788,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2584[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("watch"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2599 := z.EncBinary()
 					_ = yym2599
 					if false {
@@ -30559,6 +32800,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2584 || yy2arr2584 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2584[5] {
 					yym2601 := z.EncBinary()
 					_ = yym2601
@@ -30571,7 +32813,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2584[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2602 := z.EncBinary()
 					_ = yym2602
 					if false {
@@ -30581,6 +32825,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2584 || yy2arr2584 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2584[6] {
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
@@ -30598,7 +32843,9 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2584[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
 					} else {
@@ -30612,8 +32859,10 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2584 {
-				r.EncodeEnd()
+			if yyr2584 || yy2arr2584 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -30628,17 +32877,18 @@ func (x *ListOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2609 := r.ContainerType()
+		if yyct2609 == codecSelferValueTypeMap1234 {
 			yyl2609 := r.ReadMapStart()
 			if yyl2609 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2609, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2609 == codecSelferValueTypeArray1234 {
 			yyl2609 := r.ReadArrayStart()
 			if yyl2609 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2609, d)
 			}
@@ -30665,8 +32915,10 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2610Slc = r.DecodeBytes(yys2610Slc, true, true)
 		yys2610 := string(yys2610Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2610 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -30724,9 +32976,7 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2610)
 		} // end switch yys2610
 	} // end for yyj2610
-	if !yyhl2610 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -30743,9 +32993,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2619 = r.CheckBreak()
 	}
 	if yyb2619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -30758,9 +33009,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2619 = r.CheckBreak()
 	}
 	if yyb2619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -30773,9 +33025,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2619 = r.CheckBreak()
 	}
 	if yyb2619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LabelSelector = ""
 	} else {
@@ -30788,9 +33041,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2619 = r.CheckBreak()
 	}
 	if yyb2619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FieldSelector = ""
 	} else {
@@ -30803,9 +33057,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2619 = r.CheckBreak()
 	}
 	if yyb2619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Watch = false
 	} else {
@@ -30818,9 +33073,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2619 = r.CheckBreak()
 	}
 	if yyb2619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ResourceVersion = ""
 	} else {
@@ -30833,9 +33089,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2619 = r.CheckBreak()
 	}
 	if yyb2619 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TimeoutSeconds != nil {
 			x.TimeoutSeconds = nil
@@ -30861,9 +33118,10 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2619 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2619-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -30893,18 +33151,21 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2629[7] = x.Timestamps != false
 			yyq2629[8] = x.TailLines != nil
 			yyq2629[9] = x.LimitBytes != nil
+			var yynn2629 int
 			if yyr2629 || yy2arr2629 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2629 int = 0
+				yynn2629 = 0
 				for _, b := range yyq2629 {
 					if b {
 						yynn2629++
 					}
 				}
 				r.EncodeMapStart(yynn2629)
+				yynn2629 = 0
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[0] {
 					yym2631 := z.EncBinary()
 					_ = yym2631
@@ -30917,7 +33178,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2632 := z.EncBinary()
 					_ = yym2632
 					if false {
@@ -30927,6 +33190,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[1] {
 					yym2634 := z.EncBinary()
 					_ = yym2634
@@ -30939,7 +33203,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2635 := z.EncBinary()
 					_ = yym2635
 					if false {
@@ -30949,6 +33215,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[2] {
 					yym2637 := z.EncBinary()
 					_ = yym2637
@@ -30961,7 +33228,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2638 := z.EncBinary()
 					_ = yym2638
 					if false {
@@ -30971,6 +33240,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[3] {
 					yym2640 := z.EncBinary()
 					_ = yym2640
@@ -30983,7 +33253,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("follow"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2641 := z.EncBinary()
 					_ = yym2641
 					if false {
@@ -30993,6 +33265,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[4] {
 					yym2643 := z.EncBinary()
 					_ = yym2643
@@ -31005,7 +33278,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("previous"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2644 := z.EncBinary()
 					_ = yym2644
 					if false {
@@ -31015,6 +33290,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[5] {
 					if x.SinceSeconds == nil {
 						r.EncodeNil()
@@ -31032,7 +33308,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("sinceSeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SinceSeconds == nil {
 						r.EncodeNil()
 					} else {
@@ -31047,6 +33325,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[6] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
@@ -31068,7 +33347,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
@@ -31087,6 +33368,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[7] {
 					yym2654 := z.EncBinary()
 					_ = yym2654
@@ -31099,7 +33381,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("timestamps"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2655 := z.EncBinary()
 					_ = yym2655
 					if false {
@@ -31109,6 +33393,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[8] {
 					if x.TailLines == nil {
 						r.EncodeNil()
@@ -31126,7 +33411,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tailLines"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TailLines == nil {
 						r.EncodeNil()
 					} else {
@@ -31141,6 +33428,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2629[9] {
 					if x.LimitBytes == nil {
 						r.EncodeNil()
@@ -31158,7 +33446,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2629[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
@@ -31172,8 +33462,10 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2629 {
-				r.EncodeEnd()
+			if yyr2629 || yy2arr2629 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -31188,17 +33480,18 @@ func (x *PodLogOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2667 := r.ContainerType()
+		if yyct2667 == codecSelferValueTypeMap1234 {
 			yyl2667 := r.ReadMapStart()
 			if yyl2667 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2667, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2667 == codecSelferValueTypeArray1234 {
 			yyl2667 := r.ReadArrayStart()
 			if yyl2667 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2667, d)
 			}
@@ -31225,8 +33518,10 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2668Slc = r.DecodeBytes(yys2668Slc, true, true)
 		yys2668 := string(yys2668Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2668 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -31337,9 +33632,7 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2668)
 		} // end switch yys2668
 	} // end for yyj2668
-	if !yyhl2668 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -31356,9 +33649,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -31371,9 +33665,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -31386,9 +33681,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Container = ""
 	} else {
@@ -31401,9 +33697,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Follow = false
 	} else {
@@ -31416,9 +33713,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Previous = false
 	} else {
@@ -31431,9 +33729,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SinceSeconds != nil {
 			x.SinceSeconds = nil
@@ -31456,9 +33755,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SinceTime != nil {
 			x.SinceTime = nil
@@ -31486,9 +33786,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Timestamps = false
 	} else {
@@ -31501,9 +33802,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.TailLines != nil {
 			x.TailLines = nil
@@ -31526,9 +33828,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2683 = r.CheckBreak()
 	}
 	if yyb2683 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.LimitBytes != nil {
 			x.LimitBytes = nil
@@ -31554,9 +33857,10 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2683 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2683-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -31583,18 +33887,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2699[4] = x.Stderr != false
 			yyq2699[5] = x.TTY != false
 			yyq2699[6] = x.Container != ""
+			var yynn2699 int
 			if yyr2699 || yy2arr2699 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2699 int = 0
+				yynn2699 = 0
 				for _, b := range yyq2699 {
 					if b {
 						yynn2699++
 					}
 				}
 				r.EncodeMapStart(yynn2699)
+				yynn2699 = 0
 			}
 			if yyr2699 || yy2arr2699 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2699[0] {
 					yym2701 := z.EncBinary()
 					_ = yym2701
@@ -31607,7 +33914,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2699[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2702 := z.EncBinary()
 					_ = yym2702
 					if false {
@@ -31617,6 +33926,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2699 || yy2arr2699 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2699[1] {
 					yym2704 := z.EncBinary()
 					_ = yym2704
@@ -31629,7 +33939,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2699[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2705 := z.EncBinary()
 					_ = yym2705
 					if false {
@@ -31639,6 +33951,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2699 || yy2arr2699 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2699[2] {
 					yym2707 := z.EncBinary()
 					_ = yym2707
@@ -31651,7 +33964,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2699[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2708 := z.EncBinary()
 					_ = yym2708
 					if false {
@@ -31661,6 +33976,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2699 || yy2arr2699 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2699[3] {
 					yym2710 := z.EncBinary()
 					_ = yym2710
@@ -31673,7 +33989,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2699[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2711 := z.EncBinary()
 					_ = yym2711
 					if false {
@@ -31683,6 +34001,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2699 || yy2arr2699 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2699[4] {
 					yym2713 := z.EncBinary()
 					_ = yym2713
@@ -31695,7 +34014,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2699[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2714 := z.EncBinary()
 					_ = yym2714
 					if false {
@@ -31705,6 +34026,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2699 || yy2arr2699 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2699[5] {
 					yym2716 := z.EncBinary()
 					_ = yym2716
@@ -31717,7 +34039,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2699[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2717 := z.EncBinary()
 					_ = yym2717
 					if false {
@@ -31727,6 +34051,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2699 || yy2arr2699 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2699[6] {
 					yym2719 := z.EncBinary()
 					_ = yym2719
@@ -31739,7 +34064,9 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2699[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2720 := z.EncBinary()
 					_ = yym2720
 					if false {
@@ -31748,8 +34075,10 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2699 {
-				r.EncodeEnd()
+			if yyr2699 || yy2arr2699 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -31764,17 +34093,18 @@ func (x *PodAttachOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2722 := r.ContainerType()
+		if yyct2722 == codecSelferValueTypeMap1234 {
 			yyl2722 := r.ReadMapStart()
 			if yyl2722 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2722, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2722 == codecSelferValueTypeArray1234 {
 			yyl2722 := r.ReadArrayStart()
 			if yyl2722 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2722, d)
 			}
@@ -31801,8 +34131,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2723Slc = r.DecodeBytes(yys2723Slc, true, true)
 		yys2723 := string(yys2723Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2723 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -31850,9 +34182,7 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2723)
 		} // end switch yys2723
 	} // end for yyj2723
-	if !yyhl2723 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -31869,9 +34199,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2731 = r.CheckBreak()
 	}
 	if yyb2731 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -31884,9 +34215,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2731 = r.CheckBreak()
 	}
 	if yyb2731 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -31899,9 +34231,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2731 = r.CheckBreak()
 	}
 	if yyb2731 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdin = false
 	} else {
@@ -31914,9 +34247,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2731 = r.CheckBreak()
 	}
 	if yyb2731 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdout = false
 	} else {
@@ -31929,9 +34263,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2731 = r.CheckBreak()
 	}
 	if yyb2731 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stderr = false
 	} else {
@@ -31944,9 +34279,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2731 = r.CheckBreak()
 	}
 	if yyb2731 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TTY = false
 	} else {
@@ -31959,9 +34295,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb2731 = r.CheckBreak()
 	}
 	if yyb2731 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Container = ""
 	} else {
@@ -31977,9 +34314,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if yyb2731 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2731-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -32006,18 +34344,21 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2740[4] = x.Stderr != false
 			yyq2740[5] = x.TTY != false
 			yyq2740[6] = x.Container != ""
+			var yynn2740 int
 			if yyr2740 || yy2arr2740 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2740 int = 1
+				yynn2740 = 1
 				for _, b := range yyq2740 {
 					if b {
 						yynn2740++
 					}
 				}
 				r.EncodeMapStart(yynn2740)
+				yynn2740 = 0
 			}
 			if yyr2740 || yy2arr2740 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2740[0] {
 					yym2742 := z.EncBinary()
 					_ = yym2742
@@ -32030,7 +34371,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2740[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2743 := z.EncBinary()
 					_ = yym2743
 					if false {
@@ -32040,6 +34383,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2740 || yy2arr2740 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2740[1] {
 					yym2745 := z.EncBinary()
 					_ = yym2745
@@ -32052,7 +34396,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2740[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2746 := z.EncBinary()
 					_ = yym2746
 					if false {
@@ -32062,6 +34408,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2740 || yy2arr2740 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2740[2] {
 					yym2748 := z.EncBinary()
 					_ = yym2748
@@ -32074,7 +34421,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2740[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2749 := z.EncBinary()
 					_ = yym2749
 					if false {
@@ -32084,6 +34433,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2740 || yy2arr2740 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2740[3] {
 					yym2751 := z.EncBinary()
 					_ = yym2751
@@ -32096,7 +34446,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2740[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2752 := z.EncBinary()
 					_ = yym2752
 					if false {
@@ -32106,6 +34458,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2740 || yy2arr2740 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2740[4] {
 					yym2754 := z.EncBinary()
 					_ = yym2754
@@ -32118,7 +34471,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2740[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2755 := z.EncBinary()
 					_ = yym2755
 					if false {
@@ -32128,6 +34483,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2740 || yy2arr2740 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2740[5] {
 					yym2757 := z.EncBinary()
 					_ = yym2757
@@ -32140,7 +34496,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2740[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2758 := z.EncBinary()
 					_ = yym2758
 					if false {
@@ -32150,6 +34508,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2740 || yy2arr2740 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2740[6] {
 					yym2760 := z.EncBinary()
 					_ = yym2760
@@ -32162,7 +34521,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2740[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2761 := z.EncBinary()
 					_ = yym2761
 					if false {
@@ -32172,6 +34533,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2740 || yy2arr2740 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
@@ -32183,7 +34545,9 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("command"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
@@ -32195,8 +34559,10 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2740 {
-				r.EncodeEnd()
+			if yyr2740 || yy2arr2740 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -32211,17 +34577,18 @@ func (x *PodExecOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2766 := r.ContainerType()
+		if yyct2766 == codecSelferValueTypeMap1234 {
 			yyl2766 := r.ReadMapStart()
 			if yyl2766 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2766, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2766 == codecSelferValueTypeArray1234 {
 			yyl2766 := r.ReadArrayStart()
 			if yyl2766 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2766, d)
 			}
@@ -32248,8 +34615,10 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2767Slc = r.DecodeBytes(yys2767Slc, true, true)
 		yys2767 := string(yys2767Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2767 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -32309,9 +34678,7 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2767)
 		} // end switch yys2767
 	} // end for yyj2767
-	if !yyhl2767 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -32328,9 +34695,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2777 = r.CheckBreak()
 	}
 	if yyb2777 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -32343,9 +34711,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2777 = r.CheckBreak()
 	}
 	if yyb2777 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -32358,9 +34727,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2777 = r.CheckBreak()
 	}
 	if yyb2777 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdin = false
 	} else {
@@ -32373,9 +34743,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2777 = r.CheckBreak()
 	}
 	if yyb2777 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stdout = false
 	} else {
@@ -32388,9 +34759,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2777 = r.CheckBreak()
 	}
 	if yyb2777 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Stderr = false
 	} else {
@@ -32403,9 +34775,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2777 = r.CheckBreak()
 	}
 	if yyb2777 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TTY = false
 	} else {
@@ -32418,9 +34791,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2777 = r.CheckBreak()
 	}
 	if yyb2777 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Container = ""
 	} else {
@@ -32433,9 +34807,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2777 = r.CheckBreak()
 	}
 	if yyb2777 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
@@ -32457,9 +34832,10 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2777 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2777-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -32482,18 +34858,21 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2788[0] = x.Kind != ""
 			yyq2788[1] = x.APIVersion != ""
 			yyq2788[2] = x.Path != ""
+			var yynn2788 int
 			if yyr2788 || yy2arr2788 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2788 int = 0
+				yynn2788 = 0
 				for _, b := range yyq2788 {
 					if b {
 						yynn2788++
 					}
 				}
 				r.EncodeMapStart(yynn2788)
+				yynn2788 = 0
 			}
 			if yyr2788 || yy2arr2788 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2788[0] {
 					yym2790 := z.EncBinary()
 					_ = yym2790
@@ -32506,7 +34885,9 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2788[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2791 := z.EncBinary()
 					_ = yym2791
 					if false {
@@ -32516,6 +34897,7 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2788 || yy2arr2788 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2788[1] {
 					yym2793 := z.EncBinary()
 					_ = yym2793
@@ -32528,7 +34910,9 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2788[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2794 := z.EncBinary()
 					_ = yym2794
 					if false {
@@ -32538,6 +34922,7 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2788 || yy2arr2788 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2788[2] {
 					yym2796 := z.EncBinary()
 					_ = yym2796
@@ -32550,7 +34935,9 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2788[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2797 := z.EncBinary()
 					_ = yym2797
 					if false {
@@ -32559,8 +34946,10 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2788 {
-				r.EncodeEnd()
+			if yyr2788 || yy2arr2788 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -32575,17 +34964,18 @@ func (x *PodProxyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2799 := r.ContainerType()
+		if yyct2799 == codecSelferValueTypeMap1234 {
 			yyl2799 := r.ReadMapStart()
 			if yyl2799 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2799, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2799 == codecSelferValueTypeArray1234 {
 			yyl2799 := r.ReadArrayStart()
 			if yyl2799 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2799, d)
 			}
@@ -32612,8 +35002,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2800Slc = r.DecodeBytes(yys2800Slc, true, true)
 		yys2800 := string(yys2800Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2800 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -32637,9 +35029,7 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2800)
 		} // end switch yys2800
 	} // end for yyj2800
-	if !yyhl2800 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -32656,9 +35046,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2804 = r.CheckBreak()
 	}
 	if yyb2804 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -32671,9 +35062,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2804 = r.CheckBreak()
 	}
 	if yyb2804 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -32686,9 +35078,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2804 = r.CheckBreak()
 	}
 	if yyb2804 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -32704,9 +35097,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb2804 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2804-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -32733,18 +35127,21 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2809[4] = x.APIVersion != ""
 			yyq2809[5] = x.ResourceVersion != ""
 			yyq2809[6] = x.FieldPath != ""
+			var yynn2809 int
 			if yyr2809 || yy2arr2809 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2809 int = 0
+				yynn2809 = 0
 				for _, b := range yyq2809 {
 					if b {
 						yynn2809++
 					}
 				}
 				r.EncodeMapStart(yynn2809)
+				yynn2809 = 0
 			}
 			if yyr2809 || yy2arr2809 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2809[0] {
 					yym2811 := z.EncBinary()
 					_ = yym2811
@@ -32757,7 +35154,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2809[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2812 := z.EncBinary()
 					_ = yym2812
 					if false {
@@ -32767,6 +35166,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2809 || yy2arr2809 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2809[1] {
 					yym2814 := z.EncBinary()
 					_ = yym2814
@@ -32779,7 +35179,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2809[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2815 := z.EncBinary()
 					_ = yym2815
 					if false {
@@ -32789,6 +35191,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2809 || yy2arr2809 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2809[2] {
 					yym2817 := z.EncBinary()
 					_ = yym2817
@@ -32801,7 +35204,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2809[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2818 := z.EncBinary()
 					_ = yym2818
 					if false {
@@ -32811,6 +35216,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2809 || yy2arr2809 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2809[3] {
 					yym2820 := z.EncBinary()
 					_ = yym2820
@@ -32824,7 +35230,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2809[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("uid"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2821 := z.EncBinary()
 					_ = yym2821
 					if false {
@@ -32835,6 +35243,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2809 || yy2arr2809 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2809[4] {
 					yym2823 := z.EncBinary()
 					_ = yym2823
@@ -32847,7 +35256,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2809[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2824 := z.EncBinary()
 					_ = yym2824
 					if false {
@@ -32857,6 +35268,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2809 || yy2arr2809 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2809[5] {
 					yym2826 := z.EncBinary()
 					_ = yym2826
@@ -32869,7 +35281,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2809[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2827 := z.EncBinary()
 					_ = yym2827
 					if false {
@@ -32879,6 +35293,7 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2809 || yy2arr2809 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2809[6] {
 					yym2829 := z.EncBinary()
 					_ = yym2829
@@ -32891,7 +35306,9 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2809[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fieldPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2830 := z.EncBinary()
 					_ = yym2830
 					if false {
@@ -32900,8 +35317,10 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2809 {
-				r.EncodeEnd()
+			if yyr2809 || yy2arr2809 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -32916,17 +35335,18 @@ func (x *ObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2832 := r.ContainerType()
+		if yyct2832 == codecSelferValueTypeMap1234 {
 			yyl2832 := r.ReadMapStart()
 			if yyl2832 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2832, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2832 == codecSelferValueTypeArray1234 {
 			yyl2832 := r.ReadArrayStart()
 			if yyl2832 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2832, d)
 			}
@@ -32953,8 +35373,10 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2833Slc = r.DecodeBytes(yys2833Slc, true, true)
 		yys2833 := string(yys2833Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2833 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -33002,9 +35424,7 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2833)
 		} // end switch yys2833
 	} // end for yyj2833
-	if !yyhl2833 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -33021,9 +35441,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2841 = r.CheckBreak()
 	}
 	if yyb2841 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -33036,9 +35457,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2841 = r.CheckBreak()
 	}
 	if yyb2841 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Namespace = ""
 	} else {
@@ -33051,9 +35473,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2841 = r.CheckBreak()
 	}
 	if yyb2841 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -33066,9 +35489,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2841 = r.CheckBreak()
 	}
 	if yyb2841 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.UID = ""
 	} else {
@@ -33081,9 +35505,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2841 = r.CheckBreak()
 	}
 	if yyb2841 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -33096,9 +35521,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2841 = r.CheckBreak()
 	}
 	if yyb2841 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ResourceVersion = ""
 	} else {
@@ -33111,9 +35537,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb2841 = r.CheckBreak()
 	}
 	if yyb2841 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FieldPath = ""
 	} else {
@@ -33129,9 +35556,10 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb2841 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2841-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -33152,18 +35580,21 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2850, yyq2850, yy2arr2850
 			const yyr2850 bool = false
 			yyq2850[0] = x.Name != ""
+			var yynn2850 int
 			if yyr2850 || yy2arr2850 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2850 int = 0
+				yynn2850 = 0
 				for _, b := range yyq2850 {
 					if b {
 						yynn2850++
 					}
 				}
 				r.EncodeMapStart(yynn2850)
+				yynn2850 = 0
 			}
 			if yyr2850 || yy2arr2850 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2850[0] {
 					yym2852 := z.EncBinary()
 					_ = yym2852
@@ -33176,7 +35607,9 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2850[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2853 := z.EncBinary()
 					_ = yym2853
 					if false {
@@ -33185,8 +35618,10 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2850 {
-				r.EncodeEnd()
+			if yyr2850 || yy2arr2850 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -33201,17 +35636,18 @@ func (x *LocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2855 := r.ContainerType()
+		if yyct2855 == codecSelferValueTypeMap1234 {
 			yyl2855 := r.ReadMapStart()
 			if yyl2855 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2855, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2855 == codecSelferValueTypeArray1234 {
 			yyl2855 := r.ReadArrayStart()
 			if yyl2855 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2855, d)
 			}
@@ -33238,8 +35674,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2856Slc = r.DecodeBytes(yys2856Slc, true, true)
 		yys2856 := string(yys2856Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2856 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -33251,9 +35689,7 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys2856)
 		} // end switch yys2856
 	} // end for yyj2856
-	if !yyhl2856 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -33270,9 +35706,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb2858 = r.CheckBreak()
 	}
 	if yyb2858 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -33288,9 +35725,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb2858 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2858-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -33313,18 +35751,21 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2861[0] = x.Kind != ""
 			yyq2861[1] = x.APIVersion != ""
 			yyq2861[2] = true
+			var yynn2861 int
 			if yyr2861 || yy2arr2861 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2861 int = 0
+				yynn2861 = 0
 				for _, b := range yyq2861 {
 					if b {
 						yynn2861++
 					}
 				}
 				r.EncodeMapStart(yynn2861)
+				yynn2861 = 0
 			}
 			if yyr2861 || yy2arr2861 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2861[0] {
 					yym2863 := z.EncBinary()
 					_ = yym2863
@@ -33337,7 +35778,9 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2861[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2864 := z.EncBinary()
 					_ = yym2864
 					if false {
@@ -33347,6 +35790,7 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2861 || yy2arr2861 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2861[1] {
 					yym2866 := z.EncBinary()
 					_ = yym2866
@@ -33359,7 +35803,9 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2861[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2867 := z.EncBinary()
 					_ = yym2867
 					if false {
@@ -33369,6 +35815,7 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2861 || yy2arr2861 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2861[2] {
 					yy2869 := &x.Reference
 					yy2869.CodecEncodeSelf(e)
@@ -33377,13 +35824,17 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2861[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reference"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2870 := &x.Reference
 					yy2870.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2861 {
-				r.EncodeEnd()
+			if yyr2861 || yy2arr2861 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -33398,17 +35849,18 @@ func (x *SerializedReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2872 := r.ContainerType()
+		if yyct2872 == codecSelferValueTypeMap1234 {
 			yyl2872 := r.ReadMapStart()
 			if yyl2872 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2872, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2872 == codecSelferValueTypeArray1234 {
 			yyl2872 := r.ReadArrayStart()
 			if yyl2872 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2872, d)
 			}
@@ -33435,8 +35887,10 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2873Slc = r.DecodeBytes(yys2873Slc, true, true)
 		yys2873 := string(yys2873Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2873 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -33461,9 +35915,7 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys2873)
 		} // end switch yys2873
 	} // end for yyj2873
-	if !yyhl2873 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -33480,9 +35932,10 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb2877 = r.CheckBreak()
 	}
 	if yyb2877 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -33495,9 +35948,10 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb2877 = r.CheckBreak()
 	}
 	if yyb2877 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -33510,9 +35964,10 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb2877 = r.CheckBreak()
 	}
 	if yyb2877 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reference = ObjectReference{}
 	} else {
@@ -33529,9 +35984,10 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb2877 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2877-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -33553,18 +36009,21 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2882 bool = false
 			yyq2882[0] = x.Component != ""
 			yyq2882[1] = x.Host != ""
+			var yynn2882 int
 			if yyr2882 || yy2arr2882 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2882 int = 0
+				yynn2882 = 0
 				for _, b := range yyq2882 {
 					if b {
 						yynn2882++
 					}
 				}
 				r.EncodeMapStart(yynn2882)
+				yynn2882 = 0
 			}
 			if yyr2882 || yy2arr2882 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2882[0] {
 					yym2884 := z.EncBinary()
 					_ = yym2884
@@ -33577,7 +36036,9 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2882[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("component"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2885 := z.EncBinary()
 					_ = yym2885
 					if false {
@@ -33587,6 +36048,7 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2882 || yy2arr2882 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2882[1] {
 					yym2887 := z.EncBinary()
 					_ = yym2887
@@ -33599,7 +36061,9 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2882[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2888 := z.EncBinary()
 					_ = yym2888
 					if false {
@@ -33608,8 +36072,10 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2882 {
-				r.EncodeEnd()
+			if yyr2882 || yy2arr2882 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -33624,17 +36090,18 @@ func (x *EventSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2890 := r.ContainerType()
+		if yyct2890 == codecSelferValueTypeMap1234 {
 			yyl2890 := r.ReadMapStart()
 			if yyl2890 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2890, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2890 == codecSelferValueTypeArray1234 {
 			yyl2890 := r.ReadArrayStart()
 			if yyl2890 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2890, d)
 			}
@@ -33661,8 +36128,10 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2891Slc = r.DecodeBytes(yys2891Slc, true, true)
 		yys2891 := string(yys2891Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2891 {
 		case "component":
 			if r.TryDecodeAsNil() {
@@ -33680,9 +36149,7 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2891)
 		} // end switch yys2891
 	} // end for yyj2891
-	if !yyhl2891 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -33699,9 +36166,10 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2894 = r.CheckBreak()
 	}
 	if yyb2894 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Component = ""
 	} else {
@@ -33714,9 +36182,10 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2894 = r.CheckBreak()
 	}
 	if yyb2894 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Host = ""
 	} else {
@@ -33732,9 +36201,10 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2894 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2894-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -33763,18 +36233,21 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2898[8] = true
 			yyq2898[9] = x.Count != 0
 			yyq2898[10] = x.Type != ""
+			var yynn2898 int
 			if yyr2898 || yy2arr2898 {
 				r.EncodeArrayStart(11)
 			} else {
-				var yynn2898 int = 2
+				yynn2898 = 2
 				for _, b := range yyq2898 {
 					if b {
 						yynn2898++
 					}
 				}
 				r.EncodeMapStart(yynn2898)
+				yynn2898 = 0
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2898[0] {
 					yym2900 := z.EncBinary()
 					_ = yym2900
@@ -33787,7 +36260,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2898[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2901 := z.EncBinary()
 					_ = yym2901
 					if false {
@@ -33797,6 +36272,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2898[1] {
 					yym2903 := z.EncBinary()
 					_ = yym2903
@@ -33809,7 +36285,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2898[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2904 := z.EncBinary()
 					_ = yym2904
 					if false {
@@ -33819,22 +36297,29 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy2906 := &x.ObjectMeta
 				yy2906.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy2907 := &x.ObjectMeta
 				yy2907.CodecEncodeSelf(e)
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy2909 := &x.InvolvedObject
 				yy2909.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy2910 := &x.InvolvedObject
 				yy2910.CodecEncodeSelf(e)
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2898[4] {
 					yym2912 := z.EncBinary()
 					_ = yym2912
@@ -33847,7 +36332,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2898[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2913 := z.EncBinary()
 					_ = yym2913
 					if false {
@@ -33857,6 +36344,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2898[5] {
 					yym2915 := z.EncBinary()
 					_ = yym2915
@@ -33869,7 +36357,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2898[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2916 := z.EncBinary()
 					_ = yym2916
 					if false {
@@ -33879,6 +36369,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2898[6] {
 					yy2918 := &x.Source
 					yy2918.CodecEncodeSelf(e)
@@ -33887,12 +36378,15 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2898[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("source"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2919 := &x.Source
 					yy2919.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2898[7] {
 					yy2921 := &x.FirstTimestamp
 					yym2922 := z.EncBinary()
@@ -33911,7 +36405,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2898[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2923 := &x.FirstTimestamp
 					yym2924 := z.EncBinary()
 					_ = yym2924
@@ -33927,6 +36423,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2898[8] {
 					yy2926 := &x.LastTimestamp
 					yym2927 := z.EncBinary()
@@ -33945,7 +36442,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2898[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2928 := &x.LastTimestamp
 					yym2929 := z.EncBinary()
 					_ = yym2929
@@ -33961,6 +36460,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2898[9] {
 					yym2931 := z.EncBinary()
 					_ = yym2931
@@ -33973,7 +36473,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2898[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("count"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2932 := z.EncBinary()
 					_ = yym2932
 					if false {
@@ -33983,6 +36485,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2898[10] {
 					yym2934 := z.EncBinary()
 					_ = yym2934
@@ -33995,7 +36498,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2898[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2935 := z.EncBinary()
 					_ = yym2935
 					if false {
@@ -34004,8 +36509,10 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2898 {
-				r.EncodeEnd()
+			if yyr2898 || yy2arr2898 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -34020,17 +36527,18 @@ func (x *Event) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2937 := r.ContainerType()
+		if yyct2937 == codecSelferValueTypeMap1234 {
 			yyl2937 := r.ReadMapStart()
 			if yyl2937 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2937, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2937 == codecSelferValueTypeArray1234 {
 			yyl2937 := r.ReadArrayStart()
 			if yyl2937 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2937, d)
 			}
@@ -34057,8 +36565,10 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2938Slc = r.DecodeBytes(yys2938Slc, true, true)
 		yys2938 := string(yys2938Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2938 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -34155,9 +36665,7 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2938)
 		} // end switch yys2938
 	} // end for yyj2938
-	if !yyhl2938 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -34174,9 +36682,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -34189,9 +36698,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -34204,9 +36714,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -34220,9 +36731,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.InvolvedObject = ObjectReference{}
 	} else {
@@ -34236,9 +36748,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -34251,9 +36764,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -34266,9 +36780,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Source = EventSource{}
 	} else {
@@ -34282,9 +36797,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FirstTimestamp = pkg2_unversioned.Time{}
 	} else {
@@ -34308,9 +36824,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTimestamp = pkg2_unversioned.Time{}
 	} else {
@@ -34334,9 +36851,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Count = 0
 	} else {
@@ -34349,9 +36867,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2952 = r.CheckBreak()
 	}
 	if yyb2952 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -34367,9 +36886,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2952 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2952-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -34392,18 +36912,21 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2967[0] = x.Kind != ""
 			yyq2967[1] = x.APIVersion != ""
 			yyq2967[2] = true
+			var yynn2967 int
 			if yyr2967 || yy2arr2967 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2967 int = 1
+				yynn2967 = 1
 				for _, b := range yyq2967 {
 					if b {
 						yynn2967++
 					}
 				}
 				r.EncodeMapStart(yynn2967)
+				yynn2967 = 0
 			}
 			if yyr2967 || yy2arr2967 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2967[0] {
 					yym2969 := z.EncBinary()
 					_ = yym2969
@@ -34416,7 +36939,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2967[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2970 := z.EncBinary()
 					_ = yym2970
 					if false {
@@ -34426,6 +36951,7 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2967 || yy2arr2967 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2967[1] {
 					yym2972 := z.EncBinary()
 					_ = yym2972
@@ -34438,7 +36964,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2967[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2973 := z.EncBinary()
 					_ = yym2973
 					if false {
@@ -34448,6 +36976,7 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2967 || yy2arr2967 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2967[2] {
 					yy2975 := &x.ListMeta
 					yym2976 := z.EncBinary()
@@ -34462,7 +36991,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2967[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy2977 := &x.ListMeta
 					yym2978 := z.EncBinary()
 					_ = yym2978
@@ -34474,6 +37005,7 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2967 || yy2arr2967 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -34485,7 +37017,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -34497,8 +37031,10 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2967 {
-				r.EncodeEnd()
+			if yyr2967 || yy2arr2967 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -34513,17 +37049,18 @@ func (x *EventList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct2983 := r.ContainerType()
+		if yyct2983 == codecSelferValueTypeMap1234 {
 			yyl2983 := r.ReadMapStart()
 			if yyl2983 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2983, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct2983 == codecSelferValueTypeArray1234 {
 			yyl2983 := r.ReadArrayStart()
 			if yyl2983 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2983, d)
 			}
@@ -34550,8 +37087,10 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys2984Slc = r.DecodeBytes(yys2984Slc, true, true)
 		yys2984 := string(yys2984Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2984 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -34594,9 +37133,7 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys2984)
 		} // end switch yys2984
 	} // end for yyj2984
-	if !yyhl2984 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -34613,9 +37150,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2991 = r.CheckBreak()
 	}
 	if yyb2991 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -34628,9 +37166,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2991 = r.CheckBreak()
 	}
 	if yyb2991 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -34643,9 +37182,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2991 = r.CheckBreak()
 	}
 	if yyb2991 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -34665,9 +37205,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb2991 = r.CheckBreak()
 	}
 	if yyb2991 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -34689,9 +37230,10 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb2991 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj2991-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -34714,18 +37256,21 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2999[0] = x.Kind != ""
 			yyq2999[1] = x.APIVersion != ""
 			yyq2999[2] = true
+			var yynn2999 int
 			if yyr2999 || yy2arr2999 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2999 int = 1
+				yynn2999 = 1
 				for _, b := range yyq2999 {
 					if b {
 						yynn2999++
 					}
 				}
 				r.EncodeMapStart(yynn2999)
+				yynn2999 = 0
 			}
 			if yyr2999 || yy2arr2999 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2999[0] {
 					yym3001 := z.EncBinary()
 					_ = yym3001
@@ -34738,7 +37283,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2999[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3002 := z.EncBinary()
 					_ = yym3002
 					if false {
@@ -34748,6 +37295,7 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2999 || yy2arr2999 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2999[1] {
 					yym3004 := z.EncBinary()
 					_ = yym3004
@@ -34760,7 +37308,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2999[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3005 := z.EncBinary()
 					_ = yym3005
 					if false {
@@ -34770,6 +37320,7 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2999 || yy2arr2999 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2999[2] {
 					yy3007 := &x.ListMeta
 					yym3008 := z.EncBinary()
@@ -34784,7 +37335,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2999[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3009 := &x.ListMeta
 					yym3010 := z.EncBinary()
 					_ = yym3010
@@ -34796,6 +37349,7 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2999 || yy2arr2999 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -34807,7 +37361,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -34819,8 +37375,10 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2999 {
-				r.EncodeEnd()
+			if yyr2999 || yy2arr2999 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -34835,17 +37393,18 @@ func (x *List) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3015 := r.ContainerType()
+		if yyct3015 == codecSelferValueTypeMap1234 {
 			yyl3015 := r.ReadMapStart()
 			if yyl3015 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3015, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3015 == codecSelferValueTypeArray1234 {
 			yyl3015 := r.ReadArrayStart()
 			if yyl3015 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3015, d)
 			}
@@ -34872,8 +37431,10 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3016Slc = r.DecodeBytes(yys3016Slc, true, true)
 		yys3016 := string(yys3016Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3016 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -34916,9 +37477,7 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3016)
 		} // end switch yys3016
 	} // end for yyj3016
-	if !yyhl3016 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -34935,9 +37494,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3023 = r.CheckBreak()
 	}
 	if yyb3023 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -34950,9 +37510,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3023 = r.CheckBreak()
 	}
 	if yyb3023 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -34965,9 +37526,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3023 = r.CheckBreak()
 	}
 	if yyb3023 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -34987,9 +37549,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3023 = r.CheckBreak()
 	}
 	if yyb3023 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -35011,9 +37574,10 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3023 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3023-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x LimitType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -35065,18 +37629,21 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3033[3] = len(x.Default) != 0
 			yyq3033[4] = len(x.DefaultRequest) != 0
 			yyq3033[5] = len(x.MaxLimitRequestRatio) != 0
+			var yynn3033 int
 			if yyr3033 || yy2arr3033 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn3033 int = 0
+				yynn3033 = 0
 				for _, b := range yyq3033 {
 					if b {
 						yynn3033++
 					}
 				}
 				r.EncodeMapStart(yynn3033)
+				yynn3033 = 0
 			}
 			if yyr3033 || yy2arr3033 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3033[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
@@ -35084,11 +37651,14 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3033[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3033 || yy2arr3033 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3033[1] {
 					if x.Max == nil {
 						r.EncodeNil()
@@ -35100,7 +37670,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3033[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("max"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Max == nil {
 						r.EncodeNil()
 					} else {
@@ -35109,6 +37681,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3033 || yy2arr3033 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3033[2] {
 					if x.Min == nil {
 						r.EncodeNil()
@@ -35120,7 +37693,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3033[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("min"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Min == nil {
 						r.EncodeNil()
 					} else {
@@ -35129,6 +37704,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3033 || yy2arr3033 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3033[3] {
 					if x.Default == nil {
 						r.EncodeNil()
@@ -35140,7 +37716,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3033[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("default"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Default == nil {
 						r.EncodeNil()
 					} else {
@@ -35149,6 +37727,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3033 || yy2arr3033 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3033[4] {
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
@@ -35160,7 +37739,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3033[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("defaultRequest"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
 					} else {
@@ -35169,6 +37750,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3033 || yy2arr3033 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3033[5] {
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
@@ -35180,7 +37762,9 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3033[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxLimitRequestRatio"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
 					} else {
@@ -35188,8 +37772,10 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3033 {
-				r.EncodeEnd()
+			if yyr3033 || yy2arr3033 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -35204,17 +37790,18 @@ func (x *LimitRangeItem) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3041 := r.ContainerType()
+		if yyct3041 == codecSelferValueTypeMap1234 {
 			yyl3041 := r.ReadMapStart()
 			if yyl3041 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3041, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3041 == codecSelferValueTypeArray1234 {
 			yyl3041 := r.ReadArrayStart()
 			if yyl3041 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3041, d)
 			}
@@ -35241,8 +37828,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3042Slc = r.DecodeBytes(yys3042Slc, true, true)
 		yys3042 := string(yys3042Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3042 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -35289,9 +37878,7 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3042)
 		} // end switch yys3042
 	} // end for yyj3042
-	if !yyhl3042 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -35308,9 +37895,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -35323,9 +37911,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Max = nil
 	} else {
@@ -35339,9 +37928,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Min = nil
 	} else {
@@ -35355,9 +37945,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Default = nil
 	} else {
@@ -35371,9 +37962,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DefaultRequest = nil
 	} else {
@@ -35387,9 +37979,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3049 = r.CheckBreak()
 	}
 	if yyb3049 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MaxLimitRequestRatio = nil
 	} else {
@@ -35406,9 +37999,10 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3049 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3049-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -35428,18 +38022,21 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3057 [1]bool
 			_, _, _ = yysep3057, yyq3057, yy2arr3057
 			const yyr3057 bool = false
+			var yynn3057 int
 			if yyr3057 || yy2arr3057 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3057 int = 1
+				yynn3057 = 1
 				for _, b := range yyq3057 {
 					if b {
 						yynn3057++
 					}
 				}
 				r.EncodeMapStart(yynn3057)
+				yynn3057 = 0
 			}
 			if yyr3057 || yy2arr3057 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
@@ -35451,7 +38048,9 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("limits"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
@@ -35463,8 +38062,10 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3057 {
-				r.EncodeEnd()
+			if yyr3057 || yy2arr3057 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -35479,17 +38080,18 @@ func (x *LimitRangeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3062 := r.ContainerType()
+		if yyct3062 == codecSelferValueTypeMap1234 {
 			yyl3062 := r.ReadMapStart()
 			if yyl3062 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3062, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3062 == codecSelferValueTypeArray1234 {
 			yyl3062 := r.ReadArrayStart()
 			if yyl3062 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3062, d)
 			}
@@ -35516,8 +38118,10 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3063Slc = r.DecodeBytes(yys3063Slc, true, true)
 		yys3063 := string(yys3063Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3063 {
 		case "limits":
 			if r.TryDecodeAsNil() {
@@ -35535,9 +38139,7 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3063)
 		} // end switch yys3063
 	} // end for yyj3063
-	if !yyhl3063 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -35554,9 +38156,10 @@ func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3066 = r.CheckBreak()
 	}
 	if yyb3066 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Limits = nil
 	} else {
@@ -35578,9 +38181,10 @@ func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3066 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3066-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -35604,18 +38208,21 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3070[1] = x.APIVersion != ""
 			yyq3070[2] = true
 			yyq3070[3] = true
+			var yynn3070 int
 			if yyr3070 || yy2arr3070 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3070 int = 0
+				yynn3070 = 0
 				for _, b := range yyq3070 {
 					if b {
 						yynn3070++
 					}
 				}
 				r.EncodeMapStart(yynn3070)
+				yynn3070 = 0
 			}
 			if yyr3070 || yy2arr3070 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3070[0] {
 					yym3072 := z.EncBinary()
 					_ = yym3072
@@ -35628,7 +38235,9 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3070[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3073 := z.EncBinary()
 					_ = yym3073
 					if false {
@@ -35638,6 +38247,7 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3070 || yy2arr3070 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3070[1] {
 					yym3075 := z.EncBinary()
 					_ = yym3075
@@ -35650,7 +38260,9 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3070[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3076 := z.EncBinary()
 					_ = yym3076
 					if false {
@@ -35660,6 +38272,7 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3070 || yy2arr3070 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3070[2] {
 					yy3078 := &x.ObjectMeta
 					yy3078.CodecEncodeSelf(e)
@@ -35668,12 +38281,15 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3070[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3079 := &x.ObjectMeta
 					yy3079.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3070 || yy2arr3070 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3070[3] {
 					yy3081 := &x.Spec
 					yy3081.CodecEncodeSelf(e)
@@ -35682,13 +38298,17 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3070[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3082 := &x.Spec
 					yy3082.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3070 {
-				r.EncodeEnd()
+			if yyr3070 || yy2arr3070 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -35703,17 +38323,18 @@ func (x *LimitRange) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3084 := r.ContainerType()
+		if yyct3084 == codecSelferValueTypeMap1234 {
 			yyl3084 := r.ReadMapStart()
 			if yyl3084 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3084, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3084 == codecSelferValueTypeArray1234 {
 			yyl3084 := r.ReadArrayStart()
 			if yyl3084 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3084, d)
 			}
@@ -35740,8 +38361,10 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3085Slc = r.DecodeBytes(yys3085Slc, true, true)
 		yys3085 := string(yys3085Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3085 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -35773,9 +38396,7 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3085)
 		} // end switch yys3085
 	} // end for yyj3085
-	if !yyhl3085 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -35792,9 +38413,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3090 = r.CheckBreak()
 	}
 	if yyb3090 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -35807,9 +38429,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3090 = r.CheckBreak()
 	}
 	if yyb3090 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -35822,9 +38445,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3090 = r.CheckBreak()
 	}
 	if yyb3090 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -35838,9 +38462,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3090 = r.CheckBreak()
 	}
 	if yyb3090 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = LimitRangeSpec{}
 	} else {
@@ -35857,9 +38482,10 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3090 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3090-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -35882,18 +38508,21 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3096[0] = x.Kind != ""
 			yyq3096[1] = x.APIVersion != ""
 			yyq3096[2] = true
+			var yynn3096 int
 			if yyr3096 || yy2arr3096 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3096 int = 1
+				yynn3096 = 1
 				for _, b := range yyq3096 {
 					if b {
 						yynn3096++
 					}
 				}
 				r.EncodeMapStart(yynn3096)
+				yynn3096 = 0
 			}
 			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3096[0] {
 					yym3098 := z.EncBinary()
 					_ = yym3098
@@ -35906,7 +38535,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3096[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3099 := z.EncBinary()
 					_ = yym3099
 					if false {
@@ -35916,6 +38547,7 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3096[1] {
 					yym3101 := z.EncBinary()
 					_ = yym3101
@@ -35928,7 +38560,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3096[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3102 := z.EncBinary()
 					_ = yym3102
 					if false {
@@ -35938,6 +38572,7 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3096[2] {
 					yy3104 := &x.ListMeta
 					yym3105 := z.EncBinary()
@@ -35952,7 +38587,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3096[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3106 := &x.ListMeta
 					yym3107 := z.EncBinary()
 					_ = yym3107
@@ -35964,6 +38601,7 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -35975,7 +38613,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -35987,8 +38627,10 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3096 {
-				r.EncodeEnd()
+			if yyr3096 || yy2arr3096 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -36003,17 +38645,18 @@ func (x *LimitRangeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3112 := r.ContainerType()
+		if yyct3112 == codecSelferValueTypeMap1234 {
 			yyl3112 := r.ReadMapStart()
 			if yyl3112 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3112, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3112 == codecSelferValueTypeArray1234 {
 			yyl3112 := r.ReadArrayStart()
 			if yyl3112 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3112, d)
 			}
@@ -36040,8 +38683,10 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3113Slc = r.DecodeBytes(yys3113Slc, true, true)
 		yys3113 := string(yys3113Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3113 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -36084,9 +38729,7 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3113)
 		} // end switch yys3113
 	} // end for yyj3113
-	if !yyhl3113 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -36103,9 +38746,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3120 = r.CheckBreak()
 	}
 	if yyb3120 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -36118,9 +38762,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3120 = r.CheckBreak()
 	}
 	if yyb3120 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -36133,9 +38778,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3120 = r.CheckBreak()
 	}
 	if yyb3120 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -36155,9 +38801,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3120 = r.CheckBreak()
 	}
 	if yyb3120 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -36179,9 +38826,10 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3120 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3120-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -36202,18 +38850,21 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep3128, yyq3128, yy2arr3128
 			const yyr3128 bool = false
 			yyq3128[0] = len(x.Hard) != 0
+			var yynn3128 int
 			if yyr3128 || yy2arr3128 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3128 int = 0
+				yynn3128 = 0
 				for _, b := range yyq3128 {
 					if b {
 						yynn3128++
 					}
 				}
 				r.EncodeMapStart(yynn3128)
+				yynn3128 = 0
 			}
 			if yyr3128 || yy2arr3128 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3128[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36225,7 +38876,9 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3128[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36233,8 +38886,10 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3128 {
-				r.EncodeEnd()
+			if yyr3128 || yy2arr3128 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -36249,17 +38904,18 @@ func (x *ResourceQuotaSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3131 := r.ContainerType()
+		if yyct3131 == codecSelferValueTypeMap1234 {
 			yyl3131 := r.ReadMapStart()
 			if yyl3131 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3131, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3131 == codecSelferValueTypeArray1234 {
 			yyl3131 := r.ReadArrayStart()
 			if yyl3131 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3131, d)
 			}
@@ -36286,8 +38942,10 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3132Slc = r.DecodeBytes(yys3132Slc, true, true)
 		yys3132 := string(yys3132Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3132 {
 		case "hard":
 			if r.TryDecodeAsNil() {
@@ -36300,9 +38958,7 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			z.DecStructFieldNotFound(-1, yys3132)
 		} // end switch yys3132
 	} // end for yyj3132
-	if !yyhl3132 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -36319,9 +38975,10 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3134 = r.CheckBreak()
 	}
 	if yyb3134 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
@@ -36338,9 +38995,10 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if yyb3134 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3134-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -36362,18 +39020,21 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr3137 bool = false
 			yyq3137[0] = len(x.Hard) != 0
 			yyq3137[1] = len(x.Used) != 0
+			var yynn3137 int
 			if yyr3137 || yy2arr3137 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn3137 int = 0
+				yynn3137 = 0
 				for _, b := range yyq3137 {
 					if b {
 						yynn3137++
 					}
 				}
 				r.EncodeMapStart(yynn3137)
+				yynn3137 = 0
 			}
 			if yyr3137 || yy2arr3137 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3137[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36385,7 +39046,9 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3137[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36394,6 +39057,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3137 || yy2arr3137 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3137[1] {
 					if x.Used == nil {
 						r.EncodeNil()
@@ -36405,7 +39069,9 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3137[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("used"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Used == nil {
 						r.EncodeNil()
 					} else {
@@ -36413,8 +39079,10 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3137 {
-				r.EncodeEnd()
+			if yyr3137 || yy2arr3137 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -36429,17 +39097,18 @@ func (x *ResourceQuotaStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3141 := r.ContainerType()
+		if yyct3141 == codecSelferValueTypeMap1234 {
 			yyl3141 := r.ReadMapStart()
 			if yyl3141 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3141, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3141 == codecSelferValueTypeArray1234 {
 			yyl3141 := r.ReadArrayStart()
 			if yyl3141 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3141, d)
 			}
@@ -36466,8 +39135,10 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3142Slc = r.DecodeBytes(yys3142Slc, true, true)
 		yys3142 := string(yys3142Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3142 {
 		case "hard":
 			if r.TryDecodeAsNil() {
@@ -36487,9 +39158,7 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys3142)
 		} // end switch yys3142
 	} // end for yyj3142
-	if !yyhl3142 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -36506,9 +39175,10 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3145 = r.CheckBreak()
 	}
 	if yyb3145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
@@ -36522,9 +39192,10 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3145 = r.CheckBreak()
 	}
 	if yyb3145 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Used = nil
 	} else {
@@ -36541,9 +39212,10 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb3145 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3145-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -36568,18 +39240,21 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3149[2] = true
 			yyq3149[3] = true
 			yyq3149[4] = true
+			var yynn3149 int
 			if yyr3149 || yy2arr3149 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3149 int = 0
+				yynn3149 = 0
 				for _, b := range yyq3149 {
 					if b {
 						yynn3149++
 					}
 				}
 				r.EncodeMapStart(yynn3149)
+				yynn3149 = 0
 			}
 			if yyr3149 || yy2arr3149 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3149[0] {
 					yym3151 := z.EncBinary()
 					_ = yym3151
@@ -36592,7 +39267,9 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3149[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3152 := z.EncBinary()
 					_ = yym3152
 					if false {
@@ -36602,6 +39279,7 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3149 || yy2arr3149 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3149[1] {
 					yym3154 := z.EncBinary()
 					_ = yym3154
@@ -36614,7 +39292,9 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3149[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3155 := z.EncBinary()
 					_ = yym3155
 					if false {
@@ -36624,6 +39304,7 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3149 || yy2arr3149 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3149[2] {
 					yy3157 := &x.ObjectMeta
 					yy3157.CodecEncodeSelf(e)
@@ -36632,12 +39313,15 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3149[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3158 := &x.ObjectMeta
 					yy3158.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3149 || yy2arr3149 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3149[3] {
 					yy3160 := &x.Spec
 					yy3160.CodecEncodeSelf(e)
@@ -36646,12 +39330,15 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3149[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3161 := &x.Spec
 					yy3161.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3149 || yy2arr3149 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3149[4] {
 					yy3163 := &x.Status
 					yy3163.CodecEncodeSelf(e)
@@ -36660,13 +39347,17 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3149[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3164 := &x.Status
 					yy3164.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3149 {
-				r.EncodeEnd()
+			if yyr3149 || yy2arr3149 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -36681,17 +39372,18 @@ func (x *ResourceQuota) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3166 := r.ContainerType()
+		if yyct3166 == codecSelferValueTypeMap1234 {
 			yyl3166 := r.ReadMapStart()
 			if yyl3166 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3166, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3166 == codecSelferValueTypeArray1234 {
 			yyl3166 := r.ReadArrayStart()
 			if yyl3166 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3166, d)
 			}
@@ -36718,8 +39410,10 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3167Slc = r.DecodeBytes(yys3167Slc, true, true)
 		yys3167 := string(yys3167Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3167 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -36758,9 +39452,7 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3167)
 		} // end switch yys3167
 	} // end for yyj3167
-	if !yyhl3167 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -36777,9 +39469,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3173 = r.CheckBreak()
 	}
 	if yyb3173 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -36792,9 +39485,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3173 = r.CheckBreak()
 	}
 	if yyb3173 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -36807,9 +39501,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3173 = r.CheckBreak()
 	}
 	if yyb3173 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -36823,9 +39518,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3173 = r.CheckBreak()
 	}
 	if yyb3173 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ResourceQuotaSpec{}
 	} else {
@@ -36839,9 +39535,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3173 = r.CheckBreak()
 	}
 	if yyb3173 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ResourceQuotaStatus{}
 	} else {
@@ -36858,9 +39555,10 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3173 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3173-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -36883,18 +39581,21 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3180[0] = x.Kind != ""
 			yyq3180[1] = x.APIVersion != ""
 			yyq3180[2] = true
+			var yynn3180 int
 			if yyr3180 || yy2arr3180 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3180 int = 1
+				yynn3180 = 1
 				for _, b := range yyq3180 {
 					if b {
 						yynn3180++
 					}
 				}
 				r.EncodeMapStart(yynn3180)
+				yynn3180 = 0
 			}
 			if yyr3180 || yy2arr3180 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3180[0] {
 					yym3182 := z.EncBinary()
 					_ = yym3182
@@ -36907,7 +39608,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3180[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3183 := z.EncBinary()
 					_ = yym3183
 					if false {
@@ -36917,6 +39620,7 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3180 || yy2arr3180 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3180[1] {
 					yym3185 := z.EncBinary()
 					_ = yym3185
@@ -36929,7 +39633,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3180[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3186 := z.EncBinary()
 					_ = yym3186
 					if false {
@@ -36939,6 +39645,7 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3180 || yy2arr3180 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3180[2] {
 					yy3188 := &x.ListMeta
 					yym3189 := z.EncBinary()
@@ -36953,7 +39660,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3180[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3190 := &x.ListMeta
 					yym3191 := z.EncBinary()
 					_ = yym3191
@@ -36965,6 +39674,7 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3180 || yy2arr3180 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -36976,7 +39686,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -36988,8 +39700,10 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3180 {
-				r.EncodeEnd()
+			if yyr3180 || yy2arr3180 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -37004,17 +39718,18 @@ func (x *ResourceQuotaList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3196 := r.ContainerType()
+		if yyct3196 == codecSelferValueTypeMap1234 {
 			yyl3196 := r.ReadMapStart()
 			if yyl3196 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3196, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3196 == codecSelferValueTypeArray1234 {
 			yyl3196 := r.ReadArrayStart()
 			if yyl3196 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3196, d)
 			}
@@ -37041,8 +39756,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3197Slc = r.DecodeBytes(yys3197Slc, true, true)
 		yys3197 := string(yys3197Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3197 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -37085,9 +39802,7 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			z.DecStructFieldNotFound(-1, yys3197)
 		} // end switch yys3197
 	} // end for yyj3197
-	if !yyhl3197 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -37104,9 +39819,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3204 = r.CheckBreak()
 	}
 	if yyb3204 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -37119,9 +39835,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3204 = r.CheckBreak()
 	}
 	if yyb3204 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -37134,9 +39851,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3204 = r.CheckBreak()
 	}
 	if yyb3204 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -37156,9 +39874,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb3204 = r.CheckBreak()
 	}
 	if yyb3204 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -37180,9 +39899,10 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if yyb3204 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3204-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -37207,18 +39927,21 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3212[2] = true
 			yyq3212[3] = len(x.Data) != 0
 			yyq3212[4] = x.Type != ""
+			var yynn3212 int
 			if yyr3212 || yy2arr3212 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3212 int = 0
+				yynn3212 = 0
 				for _, b := range yyq3212 {
 					if b {
 						yynn3212++
 					}
 				}
 				r.EncodeMapStart(yynn3212)
+				yynn3212 = 0
 			}
 			if yyr3212 || yy2arr3212 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3212[0] {
 					yym3214 := z.EncBinary()
 					_ = yym3214
@@ -37231,7 +39954,9 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3212[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3215 := z.EncBinary()
 					_ = yym3215
 					if false {
@@ -37241,6 +39966,7 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3212 || yy2arr3212 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3212[1] {
 					yym3217 := z.EncBinary()
 					_ = yym3217
@@ -37253,7 +39979,9 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3212[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3218 := z.EncBinary()
 					_ = yym3218
 					if false {
@@ -37263,6 +39991,7 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3212 || yy2arr3212 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3212[2] {
 					yy3220 := &x.ObjectMeta
 					yy3220.CodecEncodeSelf(e)
@@ -37271,12 +40000,15 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3212[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3221 := &x.ObjectMeta
 					yy3221.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3212 || yy2arr3212 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3212[3] {
 					if x.Data == nil {
 						r.EncodeNil()
@@ -37293,7 +40025,9 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3212[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
@@ -37307,6 +40041,7 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3212 || yy2arr3212 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3212[4] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
@@ -37314,12 +40049,16 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3212[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3212 {
-				r.EncodeEnd()
+			if yyr3212 || yy2arr3212 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -37334,17 +40073,18 @@ func (x *Secret) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3227 := r.ContainerType()
+		if yyct3227 == codecSelferValueTypeMap1234 {
 			yyl3227 := r.ReadMapStart()
 			if yyl3227 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3227, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3227 == codecSelferValueTypeArray1234 {
 			yyl3227 := r.ReadArrayStart()
 			if yyl3227 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3227, d)
 			}
@@ -37371,8 +40111,10 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3228Slc = r.DecodeBytes(yys3228Slc, true, true)
 		yys3228 := string(yys3228Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3228 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -37415,9 +40157,7 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3228)
 		} // end switch yys3228
 	} // end for yyj3228
-	if !yyhl3228 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -37434,9 +40174,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3235 = r.CheckBreak()
 	}
 	if yyb3235 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -37449,9 +40190,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3235 = r.CheckBreak()
 	}
 	if yyb3235 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -37464,9 +40206,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3235 = r.CheckBreak()
 	}
 	if yyb3235 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -37480,9 +40223,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3235 = r.CheckBreak()
 	}
 	if yyb3235 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
@@ -37501,9 +40245,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3235 = r.CheckBreak()
 	}
 	if yyb3235 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -37519,9 +40264,10 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3235 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3235-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x SecretType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -37570,18 +40316,21 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3245[0] = x.Kind != ""
 			yyq3245[1] = x.APIVersion != ""
 			yyq3245[2] = true
+			var yynn3245 int
 			if yyr3245 || yy2arr3245 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3245 int = 1
+				yynn3245 = 1
 				for _, b := range yyq3245 {
 					if b {
 						yynn3245++
 					}
 				}
 				r.EncodeMapStart(yynn3245)
+				yynn3245 = 0
 			}
 			if yyr3245 || yy2arr3245 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3245[0] {
 					yym3247 := z.EncBinary()
 					_ = yym3247
@@ -37594,7 +40343,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3245[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3248 := z.EncBinary()
 					_ = yym3248
 					if false {
@@ -37604,6 +40355,7 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3245 || yy2arr3245 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3245[1] {
 					yym3250 := z.EncBinary()
 					_ = yym3250
@@ -37616,7 +40368,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3245[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3251 := z.EncBinary()
 					_ = yym3251
 					if false {
@@ -37626,6 +40380,7 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3245 || yy2arr3245 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3245[2] {
 					yy3253 := &x.ListMeta
 					yym3254 := z.EncBinary()
@@ -37640,7 +40395,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3245[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3255 := &x.ListMeta
 					yym3256 := z.EncBinary()
 					_ = yym3256
@@ -37652,6 +40409,7 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3245 || yy2arr3245 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -37663,7 +40421,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -37675,8 +40435,10 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3245 {
-				r.EncodeEnd()
+			if yyr3245 || yy2arr3245 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -37691,17 +40453,18 @@ func (x *SecretList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3261 := r.ContainerType()
+		if yyct3261 == codecSelferValueTypeMap1234 {
 			yyl3261 := r.ReadMapStart()
 			if yyl3261 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3261, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3261 == codecSelferValueTypeArray1234 {
 			yyl3261 := r.ReadArrayStart()
 			if yyl3261 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3261, d)
 			}
@@ -37728,8 +40491,10 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3262Slc = r.DecodeBytes(yys3262Slc, true, true)
 		yys3262 := string(yys3262Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3262 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -37772,9 +40537,7 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3262)
 		} // end switch yys3262
 	} // end for yyj3262
-	if !yyhl3262 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -37791,9 +40554,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3269 = r.CheckBreak()
 	}
 	if yyb3269 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -37806,9 +40570,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3269 = r.CheckBreak()
 	}
 	if yyb3269 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -37821,9 +40586,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3269 = r.CheckBreak()
 	}
 	if yyb3269 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -37843,9 +40609,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3269 = r.CheckBreak()
 	}
 	if yyb3269 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -37867,9 +40634,10 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3269 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3269-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x ComponentConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -37917,30 +40685,39 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr3279 bool = false
 			yyq3279[2] = x.Message != ""
 			yyq3279[3] = x.Error != ""
+			var yynn3279 int
 			if yyr3279 || yy2arr3279 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3279 int = 2
+				yynn3279 = 2
 				for _, b := range yyq3279 {
 					if b {
 						yynn3279++
 					}
 				}
 				r.EncodeMapStart(yynn3279)
+				yynn3279 = 0
 			}
 			if yyr3279 || yy2arr3279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr3279 || yy2arr3279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Status.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Status.CodecEncodeSelf(e)
 			}
 			if yyr3279 || yy2arr3279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3279[2] {
 					yym3283 := z.EncBinary()
 					_ = yym3283
@@ -37953,7 +40730,9 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3279[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3284 := z.EncBinary()
 					_ = yym3284
 					if false {
@@ -37963,6 +40742,7 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3279 || yy2arr3279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3279[3] {
 					yym3286 := z.EncBinary()
 					_ = yym3286
@@ -37975,7 +40755,9 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3279[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("error"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3287 := z.EncBinary()
 					_ = yym3287
 					if false {
@@ -37984,8 +40766,10 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3279 {
-				r.EncodeEnd()
+			if yyr3279 || yy2arr3279 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -38000,17 +40784,18 @@ func (x *ComponentCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3289 := r.ContainerType()
+		if yyct3289 == codecSelferValueTypeMap1234 {
 			yyl3289 := r.ReadMapStart()
 			if yyl3289 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3289, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3289 == codecSelferValueTypeArray1234 {
 			yyl3289 := r.ReadArrayStart()
 			if yyl3289 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3289, d)
 			}
@@ -38037,8 +40822,10 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3290Slc = r.DecodeBytes(yys3290Slc, true, true)
 		yys3290 := string(yys3290Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3290 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -38068,9 +40855,7 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys3290)
 		} // end switch yys3290
 	} // end for yyj3290
-	if !yyhl3290 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -38087,9 +40872,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb3295 = r.CheckBreak()
 	}
 	if yyb3295 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -38102,9 +40888,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb3295 = r.CheckBreak()
 	}
 	if yyb3295 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ""
 	} else {
@@ -38117,9 +40904,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb3295 = r.CheckBreak()
 	}
 	if yyb3295 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -38132,9 +40920,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb3295 = r.CheckBreak()
 	}
 	if yyb3295 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Error = ""
 	} else {
@@ -38150,9 +40939,10 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb3295 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3295-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -38176,18 +40966,21 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3301[1] = x.APIVersion != ""
 			yyq3301[2] = true
 			yyq3301[3] = len(x.Conditions) != 0
+			var yynn3301 int
 			if yyr3301 || yy2arr3301 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3301 int = 0
+				yynn3301 = 0
 				for _, b := range yyq3301 {
 					if b {
 						yynn3301++
 					}
 				}
 				r.EncodeMapStart(yynn3301)
+				yynn3301 = 0
 			}
 			if yyr3301 || yy2arr3301 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3301[0] {
 					yym3303 := z.EncBinary()
 					_ = yym3303
@@ -38200,7 +40993,9 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3301[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3304 := z.EncBinary()
 					_ = yym3304
 					if false {
@@ -38210,6 +41005,7 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3301 || yy2arr3301 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3301[1] {
 					yym3306 := z.EncBinary()
 					_ = yym3306
@@ -38222,7 +41018,9 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3301[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3307 := z.EncBinary()
 					_ = yym3307
 					if false {
@@ -38232,6 +41030,7 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3301 || yy2arr3301 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3301[2] {
 					yy3309 := &x.ObjectMeta
 					yy3309.CodecEncodeSelf(e)
@@ -38240,12 +41039,15 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3301[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3310 := &x.ObjectMeta
 					yy3310.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3301 || yy2arr3301 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3301[3] {
 					if x.Conditions == nil {
 						r.EncodeNil()
@@ -38262,7 +41064,9 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3301[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
@@ -38275,8 +41079,10 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3301 {
-				r.EncodeEnd()
+			if yyr3301 || yy2arr3301 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -38291,17 +41097,18 @@ func (x *ComponentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3315 := r.ContainerType()
+		if yyct3315 == codecSelferValueTypeMap1234 {
 			yyl3315 := r.ReadMapStart()
 			if yyl3315 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3315, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3315 == codecSelferValueTypeArray1234 {
 			yyl3315 := r.ReadArrayStart()
 			if yyl3315 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3315, d)
 			}
@@ -38328,8 +41135,10 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3316Slc = r.DecodeBytes(yys3316Slc, true, true)
 		yys3316 := string(yys3316Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3316 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -38366,9 +41175,7 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3316)
 		} // end switch yys3316
 	} // end for yyj3316
-	if !yyhl3316 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -38385,9 +41192,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3322 = r.CheckBreak()
 	}
 	if yyb3322 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -38400,9 +41208,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3322 = r.CheckBreak()
 	}
 	if yyb3322 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -38415,9 +41224,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3322 = r.CheckBreak()
 	}
 	if yyb3322 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -38431,9 +41241,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3322 = r.CheckBreak()
 	}
 	if yyb3322 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
@@ -38455,9 +41266,10 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb3322 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3322-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -38480,18 +41292,21 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3329[0] = x.Kind != ""
 			yyq3329[1] = x.APIVersion != ""
 			yyq3329[2] = true
+			var yynn3329 int
 			if yyr3329 || yy2arr3329 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3329 int = 1
+				yynn3329 = 1
 				for _, b := range yyq3329 {
 					if b {
 						yynn3329++
 					}
 				}
 				r.EncodeMapStart(yynn3329)
+				yynn3329 = 0
 			}
 			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3329[0] {
 					yym3331 := z.EncBinary()
 					_ = yym3331
@@ -38504,7 +41319,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3329[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3332 := z.EncBinary()
 					_ = yym3332
 					if false {
@@ -38514,6 +41331,7 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3329[1] {
 					yym3334 := z.EncBinary()
 					_ = yym3334
@@ -38526,7 +41344,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3329[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3335 := z.EncBinary()
 					_ = yym3335
 					if false {
@@ -38536,6 +41356,7 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3329[2] {
 					yy3337 := &x.ListMeta
 					yym3338 := z.EncBinary()
@@ -38550,7 +41371,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3329[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3339 := &x.ListMeta
 					yym3340 := z.EncBinary()
 					_ = yym3340
@@ -38562,6 +41385,7 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -38573,7 +41397,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -38585,8 +41411,10 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3329 {
-				r.EncodeEnd()
+			if yyr3329 || yy2arr3329 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -38601,17 +41429,18 @@ func (x *ComponentStatusList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3345 := r.ContainerType()
+		if yyct3345 == codecSelferValueTypeMap1234 {
 			yyl3345 := r.ReadMapStart()
 			if yyl3345 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3345, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3345 == codecSelferValueTypeArray1234 {
 			yyl3345 := r.ReadArrayStart()
 			if yyl3345 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3345, d)
 			}
@@ -38638,8 +41467,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3346Slc = r.DecodeBytes(yys3346Slc, true, true)
 		yys3346 := string(yys3346Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3346 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -38682,9 +41513,7 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			z.DecStructFieldNotFound(-1, yys3346)
 		} // end switch yys3346
 	} // end for yyj3346
-	if !yyhl3346 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -38701,9 +41530,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3353 = r.CheckBreak()
 	}
 	if yyb3353 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -38716,9 +41546,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3353 = r.CheckBreak()
 	}
 	if yyb3353 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -38731,9 +41562,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3353 = r.CheckBreak()
 	}
 	if yyb3353 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -38753,9 +41585,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		yyb3353 = r.CheckBreak()
 	}
 	if yyb3353 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -38777,9 +41610,10 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		if yyb3353 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3353-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -38800,18 +41634,21 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep3361, yyq3361, yy2arr3361
 			const yyr3361 bool = false
 			yyq3361[0] = len(x.Items) != 0
+			var yynn3361 int
 			if yyr3361 || yy2arr3361 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3361 int = 0
+				yynn3361 = 0
 				for _, b := range yyq3361 {
 					if b {
 						yynn3361++
 					}
 				}
 				r.EncodeMapStart(yynn3361)
+				yynn3361 = 0
 			}
 			if yyr3361 || yy2arr3361 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3361[0] {
 					if x.Items == nil {
 						r.EncodeNil()
@@ -38828,7 +41665,9 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3361[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
@@ -38841,8 +41680,10 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3361 {
-				r.EncodeEnd()
+			if yyr3361 || yy2arr3361 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -38857,17 +41698,18 @@ func (x *DownwardAPIVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3366 := r.ContainerType()
+		if yyct3366 == codecSelferValueTypeMap1234 {
 			yyl3366 := r.ReadMapStart()
 			if yyl3366 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3366, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3366 == codecSelferValueTypeArray1234 {
 			yyl3366 := r.ReadArrayStart()
 			if yyl3366 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3366, d)
 			}
@@ -38894,8 +41736,10 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3367Slc = r.DecodeBytes(yys3367Slc, true, true)
 		yys3367 := string(yys3367Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3367 {
 		case "items":
 			if r.TryDecodeAsNil() {
@@ -38913,9 +41757,7 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			z.DecStructFieldNotFound(-1, yys3367)
 		} // end switch yys3367
 	} // end for yyj3367
-	if !yyhl3367 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DownwardAPIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -38932,9 +41774,10 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb3370 = r.CheckBreak()
 	}
 	if yyb3370 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -38956,9 +41799,10 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if yyb3370 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3370-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -38978,18 +41822,21 @@ func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3374 [2]bool
 			_, _, _ = yysep3374, yyq3374, yy2arr3374
 			const yyr3374 bool = false
+			var yynn3374 int
 			if yyr3374 || yy2arr3374 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn3374 int = 2
+				yynn3374 = 2
 				for _, b := range yyq3374 {
 					if b {
 						yynn3374++
 					}
 				}
 				r.EncodeMapStart(yynn3374)
+				yynn3374 = 0
 			}
 			if yyr3374 || yy2arr3374 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym3376 := z.EncBinary()
 				_ = yym3376
 				if false {
@@ -38997,7 +41844,9 @@ func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym3377 := z.EncBinary()
 				_ = yym3377
 				if false {
@@ -39006,15 +41855,20 @@ func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3374 || yy2arr3374 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy3379 := &x.FieldRef
 				yy3379.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("fieldRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy3380 := &x.FieldRef
 				yy3380.CodecEncodeSelf(e)
 			}
-			if yysep3374 {
-				r.EncodeEnd()
+			if yyr3374 || yy2arr3374 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -39029,17 +41883,18 @@ func (x *DownwardAPIVolumeFile) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3382 := r.ContainerType()
+		if yyct3382 == codecSelferValueTypeMap1234 {
 			yyl3382 := r.ReadMapStart()
 			if yyl3382 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3382, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3382 == codecSelferValueTypeArray1234 {
 			yyl3382 := r.ReadArrayStart()
 			if yyl3382 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3382, d)
 			}
@@ -39066,8 +41921,10 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3383Slc = r.DecodeBytes(yys3383Slc, true, true)
 		yys3383 := string(yys3383Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3383 {
 		case "path":
 			if r.TryDecodeAsNil() {
@@ -39086,9 +41943,7 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys3383)
 		} // end switch yys3383
 	} // end for yyj3383
-	if !yyhl3383 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -39105,9 +41960,10 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb3386 = r.CheckBreak()
 	}
 	if yyb3386 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -39120,9 +41976,10 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb3386 = r.CheckBreak()
 	}
 	if yyb3386 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.FieldRef = ObjectFieldSelector{}
 	} else {
@@ -39139,9 +41996,10 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb3386 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3386-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -39166,18 +42024,21 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3390[2] = x.SELinuxOptions != nil
 			yyq3390[3] = x.RunAsUser != nil
 			yyq3390[4] = x.RunAsNonRoot != nil
+			var yynn3390 int
 			if yyr3390 || yy2arr3390 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3390 int = 0
+				yynn3390 = 0
 				for _, b := range yyq3390 {
 					if b {
 						yynn3390++
 					}
 				}
 				r.EncodeMapStart(yynn3390)
+				yynn3390 = 0
 			}
 			if yyr3390 || yy2arr3390 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3390[0] {
 					if x.Capabilities == nil {
 						r.EncodeNil()
@@ -39189,7 +42050,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3390[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capabilities"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
@@ -39198,6 +42061,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3390 || yy2arr3390 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3390[1] {
 					if x.Privileged == nil {
 						r.EncodeNil()
@@ -39215,7 +42079,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3390[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("privileged"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
@@ -39230,6 +42096,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3390 || yy2arr3390 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3390[2] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -39241,7 +42108,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3390[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -39250,6 +42119,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3390 || yy2arr3390 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3390[3] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
@@ -39267,7 +42137,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3390[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
@@ -39282,6 +42154,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3390 || yy2arr3390 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3390[4] {
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
@@ -39299,7 +42172,9 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3390[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
@@ -39313,8 +42188,10 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3390 {
-				r.EncodeEnd()
+			if yyr3390 || yy2arr3390 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -39329,17 +42206,18 @@ func (x *SecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3409 := r.ContainerType()
+		if yyct3409 == codecSelferValueTypeMap1234 {
 			yyl3409 := r.ReadMapStart()
 			if yyl3409 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3409, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3409 == codecSelferValueTypeArray1234 {
 			yyl3409 := r.ReadArrayStart()
 			if yyl3409 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3409, d)
 			}
@@ -39366,8 +42244,10 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3410Slc = r.DecodeBytes(yys3410Slc, true, true)
 		yys3410 := string(yys3410Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3410 {
 		case "capabilities":
 			if r.TryDecodeAsNil() {
@@ -39443,9 +42323,7 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3410)
 		} // end switch yys3410
 	} // end for yyj3410
-	if !yyhl3410 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -39462,9 +42340,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3419 = r.CheckBreak()
 	}
 	if yyb3419 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Capabilities != nil {
 			x.Capabilities = nil
@@ -39482,9 +42361,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3419 = r.CheckBreak()
 	}
 	if yyb3419 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Privileged != nil {
 			x.Privileged = nil
@@ -39507,9 +42387,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3419 = r.CheckBreak()
 	}
 	if yyb3419 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.SELinuxOptions != nil {
 			x.SELinuxOptions = nil
@@ -39527,9 +42408,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3419 = r.CheckBreak()
 	}
 	if yyb3419 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RunAsUser != nil {
 			x.RunAsUser = nil
@@ -39552,9 +42434,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3419 = r.CheckBreak()
 	}
 	if yyb3419 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RunAsNonRoot != nil {
 			x.RunAsNonRoot = nil
@@ -39580,9 +42463,10 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb3419 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3419-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -39606,18 +42490,21 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3429[1] = x.Role != ""
 			yyq3429[2] = x.Type != ""
 			yyq3429[3] = x.Level != ""
+			var yynn3429 int
 			if yyr3429 || yy2arr3429 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3429 int = 0
+				yynn3429 = 0
 				for _, b := range yyq3429 {
 					if b {
 						yynn3429++
 					}
 				}
 				r.EncodeMapStart(yynn3429)
+				yynn3429 = 0
 			}
 			if yyr3429 || yy2arr3429 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3429[0] {
 					yym3431 := z.EncBinary()
 					_ = yym3431
@@ -39630,7 +42517,9 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3429[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("user"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3432 := z.EncBinary()
 					_ = yym3432
 					if false {
@@ -39640,6 +42529,7 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3429 || yy2arr3429 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3429[1] {
 					yym3434 := z.EncBinary()
 					_ = yym3434
@@ -39652,7 +42542,9 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3429[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("role"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3435 := z.EncBinary()
 					_ = yym3435
 					if false {
@@ -39662,6 +42554,7 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3429 || yy2arr3429 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3429[2] {
 					yym3437 := z.EncBinary()
 					_ = yym3437
@@ -39674,7 +42567,9 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3429[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3438 := z.EncBinary()
 					_ = yym3438
 					if false {
@@ -39684,6 +42579,7 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3429 || yy2arr3429 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3429[3] {
 					yym3440 := z.EncBinary()
 					_ = yym3440
@@ -39696,7 +42592,9 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3429[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("level"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3441 := z.EncBinary()
 					_ = yym3441
 					if false {
@@ -39705,8 +42603,10 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3429 {
-				r.EncodeEnd()
+			if yyr3429 || yy2arr3429 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -39721,17 +42621,18 @@ func (x *SELinuxOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3443 := r.ContainerType()
+		if yyct3443 == codecSelferValueTypeMap1234 {
 			yyl3443 := r.ReadMapStart()
 			if yyl3443 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3443, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3443 == codecSelferValueTypeArray1234 {
 			yyl3443 := r.ReadArrayStart()
 			if yyl3443 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3443, d)
 			}
@@ -39758,8 +42659,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3444Slc = r.DecodeBytes(yys3444Slc, true, true)
 		yys3444 := string(yys3444Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3444 {
 		case "user":
 			if r.TryDecodeAsNil() {
@@ -39789,9 +42692,7 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3444)
 		} // end switch yys3444
 	} // end for yyj3444
-	if !yyhl3444 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -39808,9 +42709,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3449 = r.CheckBreak()
 	}
 	if yyb3449 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.User = ""
 	} else {
@@ -39823,9 +42725,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3449 = r.CheckBreak()
 	}
 	if yyb3449 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Role = ""
 	} else {
@@ -39838,9 +42741,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3449 = r.CheckBreak()
 	}
 	if yyb3449 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -39853,9 +42757,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb3449 = r.CheckBreak()
 	}
 	if yyb3449 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Level = ""
 	} else {
@@ -39871,9 +42776,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb3449 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3449-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -39896,18 +42802,21 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq3455[0] = x.Kind != ""
 			yyq3455[1] = x.APIVersion != ""
 			yyq3455[2] = true
+			var yynn3455 int
 			if yyr3455 || yy2arr3455 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3455 int = 2
+				yynn3455 = 2
 				for _, b := range yyq3455 {
 					if b {
 						yynn3455++
 					}
 				}
 				r.EncodeMapStart(yynn3455)
+				yynn3455 = 0
 			}
 			if yyr3455 || yy2arr3455 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3455[0] {
 					yym3457 := z.EncBinary()
 					_ = yym3457
@@ -39920,7 +42829,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3455[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3458 := z.EncBinary()
 					_ = yym3458
 					if false {
@@ -39930,6 +42841,7 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3455 || yy2arr3455 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3455[1] {
 					yym3460 := z.EncBinary()
 					_ = yym3460
@@ -39942,7 +42854,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3455[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3461 := z.EncBinary()
 					_ = yym3461
 					if false {
@@ -39952,6 +42866,7 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3455 || yy2arr3455 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3455[2] {
 					yy3463 := &x.ObjectMeta
 					yy3463.CodecEncodeSelf(e)
@@ -39960,12 +42875,15 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq3455[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy3464 := &x.ObjectMeta
 					yy3464.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3455 || yy2arr3455 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym3466 := z.EncBinary()
 				_ = yym3466
 				if false {
@@ -39973,7 +42891,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("range"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym3467 := z.EncBinary()
 				_ = yym3467
 				if false {
@@ -39982,6 +42902,7 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr3455 || yy2arr3455 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
@@ -39993,7 +42914,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("data"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
@@ -40005,8 +42928,10 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3455 {
-				r.EncodeEnd()
+			if yyr3455 || yy2arr3455 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -40021,17 +42946,18 @@ func (x *RangeAllocation) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct3472 := r.ContainerType()
+		if yyct3472 == codecSelferValueTypeMap1234 {
 			yyl3472 := r.ReadMapStart()
 			if yyl3472 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl3472, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct3472 == codecSelferValueTypeArray1234 {
 			yyl3472 := r.ReadArrayStart()
 			if yyl3472 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl3472, d)
 			}
@@ -40058,8 +42984,10 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys3473Slc = r.DecodeBytes(yys3473Slc, true, true)
 		yys3473 := string(yys3473Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3473 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -40102,9 +43030,7 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3473)
 		} // end switch yys3473
 	} // end for yyj3473
-	if !yyhl3473 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -40121,9 +43047,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3480 = r.CheckBreak()
 	}
 	if yyb3480 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -40136,9 +43063,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3480 = r.CheckBreak()
 	}
 	if yyb3480 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -40151,9 +43079,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3480 = r.CheckBreak()
 	}
 	if yyb3480 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
@@ -40167,9 +43096,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3480 = r.CheckBreak()
 	}
 	if yyb3480 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Range = ""
 	} else {
@@ -40182,9 +43112,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb3480 = r.CheckBreak()
 	}
 	if yyb3480 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
@@ -40206,9 +43137,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb3480 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj3480-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) encSlicePersistentVolumeAccessMode(v []PersistentVolumeAccessMode, e *codec1978.Encoder) {
@@ -40217,9 +43149,10 @@ func (x codecSelfer1234) encSlicePersistentVolumeAccessMode(v []PersistentVolume
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3487 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yyv3487.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolumeAccessMode, d *codec1978.Decoder) {
@@ -40229,37 +43162,31 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 
 	yyv3488 := *v
 	yyh3488, yyl3488 := z.DecSliceHelperStart()
-
-	var yyrr3488, yyrl3488 int
-	var yyc3488, yyrt3488 bool
-	_, _, _ = yyc3488, yyrt3488, yyrl3488
-	yyrr3488 = yyl3488
-
-	if yyv3488 == nil {
-		if yyrl3488, yyrt3488 = z.DecInferLen(yyl3488, z.DecBasicHandle().MaxInitLen, 16); yyrt3488 {
-			yyrr3488 = yyrl3488
-		}
-		yyv3488 = make([]PersistentVolumeAccessMode, yyrl3488)
-		yyc3488 = true
-	}
-
+	var yyc3488 bool
 	if yyl3488 == 0 {
-		if len(yyv3488) != 0 {
+		if yyv3488 == nil {
+			yyv3488 = []PersistentVolumeAccessMode{}
+			yyc3488 = true
+		} else if len(yyv3488) != 0 {
 			yyv3488 = yyv3488[:0]
 			yyc3488 = true
 		}
 	} else if yyl3488 > 0 {
-
+		var yyrr3488, yyrl3488 int
+		var yyrt3488 bool
 		if yyl3488 > cap(yyv3488) {
-			yyrl3488, yyrt3488 = z.DecInferLen(yyl3488, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23488 := yyv3488
-			yyv3488 = make([]PersistentVolumeAccessMode, yyrl3488)
-			if len(yyv3488) > 0 {
-				copy(yyv3488, yyv23488[:cap(yyv23488)])
+			yyrl3488, yyrt3488 = z.DecInferLen(yyl3488, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt3488 {
+				if yyrl3488 <= cap(yyv3488) {
+					yyv3488 = yyv3488[:yyrl3488]
+				} else {
+					yyv3488 = make([]PersistentVolumeAccessMode, yyrl3488)
+				}
+			} else {
+				yyv3488 = make([]PersistentVolumeAccessMode, yyrl3488)
 			}
 			yyc3488 = true
-
 			yyrr3488 = len(yyv3488)
 		} else if yyl3488 != len(yyv3488) {
 			yyv3488 = yyv3488[:yyl3488]
@@ -40267,6 +43194,7 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 		}
 		yyj3488 := 0
 		for ; yyj3488 < yyrr3488; yyj3488++ {
+			yyh3488.ElemContainerState(yyj3488)
 			if r.TryDecodeAsNil() {
 				yyv3488[yyj3488] = ""
 			} else {
@@ -40277,6 +43205,7 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 		if yyrt3488 {
 			for ; yyj3488 < yyl3488; yyj3488++ {
 				yyv3488 = append(yyv3488, "")
+				yyh3488.ElemContainerState(yyj3488)
 				if r.TryDecodeAsNil() {
 					yyv3488[yyj3488] = ""
 				} else {
@@ -40287,12 +43216,14 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 		}
 
 	} else {
-		for yyj3488 := 0; !r.CheckBreak(); yyj3488++ {
+		yyj3488 := 0
+		for ; !r.CheckBreak(); yyj3488++ {
+
 			if yyj3488 >= len(yyv3488) {
 				yyv3488 = append(yyv3488, "") // var yyz3488 PersistentVolumeAccessMode
 				yyc3488 = true
 			}
-
+			yyh3488.ElemContainerState(yyj3488)
 			if yyj3488 < len(yyv3488) {
 				if r.TryDecodeAsNil() {
 					yyv3488[yyj3488] = ""
@@ -40305,12 +43236,18 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 			}
 
 		}
-		yyh3488.End()
+		if yyj3488 < len(yyv3488) {
+			yyv3488 = yyv3488[:yyj3488]
+			yyc3488 = true
+		} else if yyj3488 == 0 && yyv3488 == nil {
+			yyv3488 = []PersistentVolumeAccessMode{}
+			yyc3488 = true
+		}
 	}
+	yyh3488.End()
 	if yyc3488 {
 		*v = yyv3488
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePersistentVolume(v []PersistentVolume, e *codec1978.Encoder) {
@@ -40319,10 +43256,11 @@ func (x codecSelfer1234) encSlicePersistentVolume(v []PersistentVolume, e *codec
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3492 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3493 := &yyv3492
 		yy3493.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *codec1978.Decoder) {
@@ -40332,39 +43270,44 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 
 	yyv3494 := *v
 	yyh3494, yyl3494 := z.DecSliceHelperStart()
-
-	var yyrr3494, yyrl3494 int
-	var yyc3494, yyrt3494 bool
-	_, _, _ = yyc3494, yyrt3494, yyrl3494
-	yyrr3494 = yyl3494
-
-	if yyv3494 == nil {
-		if yyrl3494, yyrt3494 = z.DecInferLen(yyl3494, z.DecBasicHandle().MaxInitLen, 384); yyrt3494 {
-			yyrr3494 = yyrl3494
-		}
-		yyv3494 = make([]PersistentVolume, yyrl3494)
-		yyc3494 = true
-	}
-
+	var yyc3494 bool
 	if yyl3494 == 0 {
-		if len(yyv3494) != 0 {
+		if yyv3494 == nil {
+			yyv3494 = []PersistentVolume{}
+			yyc3494 = true
+		} else if len(yyv3494) != 0 {
 			yyv3494 = yyv3494[:0]
 			yyc3494 = true
 		}
 	} else if yyl3494 > 0 {
-
+		var yyrr3494, yyrl3494 int
+		var yyrt3494 bool
 		if yyl3494 > cap(yyv3494) {
-			yyrl3494, yyrt3494 = z.DecInferLen(yyl3494, z.DecBasicHandle().MaxInitLen, 384)
-			yyv3494 = make([]PersistentVolume, yyrl3494)
-			yyc3494 = true
 
+			yyrg3494 := len(yyv3494) > 0
+			yyv23494 := yyv3494
+			yyrl3494, yyrt3494 = z.DecInferLen(yyl3494, z.DecBasicHandle().MaxInitLen, 384)
+			if yyrt3494 {
+				if yyrl3494 <= cap(yyv3494) {
+					yyv3494 = yyv3494[:yyrl3494]
+				} else {
+					yyv3494 = make([]PersistentVolume, yyrl3494)
+				}
+			} else {
+				yyv3494 = make([]PersistentVolume, yyrl3494)
+			}
+			yyc3494 = true
 			yyrr3494 = len(yyv3494)
+			if yyrg3494 {
+				copy(yyv3494, yyv23494)
+			}
 		} else if yyl3494 != len(yyv3494) {
 			yyv3494 = yyv3494[:yyl3494]
 			yyc3494 = true
 		}
 		yyj3494 := 0
 		for ; yyj3494 < yyrr3494; yyj3494++ {
+			yyh3494.ElemContainerState(yyj3494)
 			if r.TryDecodeAsNil() {
 				yyv3494[yyj3494] = PersistentVolume{}
 			} else {
@@ -40376,6 +43319,7 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 		if yyrt3494 {
 			for ; yyj3494 < yyl3494; yyj3494++ {
 				yyv3494 = append(yyv3494, PersistentVolume{})
+				yyh3494.ElemContainerState(yyj3494)
 				if r.TryDecodeAsNil() {
 					yyv3494[yyj3494] = PersistentVolume{}
 				} else {
@@ -40387,12 +43331,14 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 		}
 
 	} else {
-		for yyj3494 := 0; !r.CheckBreak(); yyj3494++ {
+		yyj3494 := 0
+		for ; !r.CheckBreak(); yyj3494++ {
+
 			if yyj3494 >= len(yyv3494) {
 				yyv3494 = append(yyv3494, PersistentVolume{}) // var yyz3494 PersistentVolume
 				yyc3494 = true
 			}
-
+			yyh3494.ElemContainerState(yyj3494)
 			if yyj3494 < len(yyv3494) {
 				if r.TryDecodeAsNil() {
 					yyv3494[yyj3494] = PersistentVolume{}
@@ -40406,12 +43352,18 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 			}
 
 		}
-		yyh3494.End()
+		if yyj3494 < len(yyv3494) {
+			yyv3494 = yyv3494[:yyj3494]
+			yyc3494 = true
+		} else if yyj3494 == 0 && yyv3494 == nil {
+			yyv3494 = []PersistentVolume{}
+			yyc3494 = true
+		}
 	}
+	yyh3494.End()
 	if yyc3494 {
 		*v = yyv3494
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePersistentVolumeClaim(v []PersistentVolumeClaim, e *codec1978.Encoder) {
@@ -40420,10 +43372,11 @@ func (x codecSelfer1234) encSlicePersistentVolumeClaim(v []PersistentVolumeClaim
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3498 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3499 := &yyv3498
 		yy3499.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClaim, d *codec1978.Decoder) {
@@ -40433,39 +43386,44 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 
 	yyv3500 := *v
 	yyh3500, yyl3500 := z.DecSliceHelperStart()
-
-	var yyrr3500, yyrl3500 int
-	var yyc3500, yyrt3500 bool
-	_, _, _ = yyc3500, yyrt3500, yyrl3500
-	yyrr3500 = yyl3500
-
-	if yyv3500 == nil {
-		if yyrl3500, yyrt3500 = z.DecInferLen(yyl3500, z.DecBasicHandle().MaxInitLen, 296); yyrt3500 {
-			yyrr3500 = yyrl3500
-		}
-		yyv3500 = make([]PersistentVolumeClaim, yyrl3500)
-		yyc3500 = true
-	}
-
+	var yyc3500 bool
 	if yyl3500 == 0 {
-		if len(yyv3500) != 0 {
+		if yyv3500 == nil {
+			yyv3500 = []PersistentVolumeClaim{}
+			yyc3500 = true
+		} else if len(yyv3500) != 0 {
 			yyv3500 = yyv3500[:0]
 			yyc3500 = true
 		}
 	} else if yyl3500 > 0 {
-
+		var yyrr3500, yyrl3500 int
+		var yyrt3500 bool
 		if yyl3500 > cap(yyv3500) {
-			yyrl3500, yyrt3500 = z.DecInferLen(yyl3500, z.DecBasicHandle().MaxInitLen, 296)
-			yyv3500 = make([]PersistentVolumeClaim, yyrl3500)
-			yyc3500 = true
 
+			yyrg3500 := len(yyv3500) > 0
+			yyv23500 := yyv3500
+			yyrl3500, yyrt3500 = z.DecInferLen(yyl3500, z.DecBasicHandle().MaxInitLen, 296)
+			if yyrt3500 {
+				if yyrl3500 <= cap(yyv3500) {
+					yyv3500 = yyv3500[:yyrl3500]
+				} else {
+					yyv3500 = make([]PersistentVolumeClaim, yyrl3500)
+				}
+			} else {
+				yyv3500 = make([]PersistentVolumeClaim, yyrl3500)
+			}
+			yyc3500 = true
 			yyrr3500 = len(yyv3500)
+			if yyrg3500 {
+				copy(yyv3500, yyv23500)
+			}
 		} else if yyl3500 != len(yyv3500) {
 			yyv3500 = yyv3500[:yyl3500]
 			yyc3500 = true
 		}
 		yyj3500 := 0
 		for ; yyj3500 < yyrr3500; yyj3500++ {
+			yyh3500.ElemContainerState(yyj3500)
 			if r.TryDecodeAsNil() {
 				yyv3500[yyj3500] = PersistentVolumeClaim{}
 			} else {
@@ -40477,6 +43435,7 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 		if yyrt3500 {
 			for ; yyj3500 < yyl3500; yyj3500++ {
 				yyv3500 = append(yyv3500, PersistentVolumeClaim{})
+				yyh3500.ElemContainerState(yyj3500)
 				if r.TryDecodeAsNil() {
 					yyv3500[yyj3500] = PersistentVolumeClaim{}
 				} else {
@@ -40488,12 +43447,14 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 		}
 
 	} else {
-		for yyj3500 := 0; !r.CheckBreak(); yyj3500++ {
+		yyj3500 := 0
+		for ; !r.CheckBreak(); yyj3500++ {
+
 			if yyj3500 >= len(yyv3500) {
 				yyv3500 = append(yyv3500, PersistentVolumeClaim{}) // var yyz3500 PersistentVolumeClaim
 				yyc3500 = true
 			}
-
+			yyh3500.ElemContainerState(yyj3500)
 			if yyj3500 < len(yyv3500) {
 				if r.TryDecodeAsNil() {
 					yyv3500[yyj3500] = PersistentVolumeClaim{}
@@ -40507,12 +43468,18 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 			}
 
 		}
-		yyh3500.End()
+		if yyj3500 < len(yyv3500) {
+			yyv3500 = yyv3500[:yyj3500]
+			yyc3500 = true
+		} else if yyj3500 == 0 && yyv3500 == nil {
+			yyv3500 = []PersistentVolumeClaim{}
+			yyc3500 = true
+		}
 	}
+	yyh3500.End()
 	if yyc3500 {
 		*v = yyv3500
 	}
-
 }
 
 func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder) {
@@ -40521,9 +43488,10 @@ func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3504 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yyv3504.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decoder) {
@@ -40533,37 +43501,31 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 
 	yyv3505 := *v
 	yyh3505, yyl3505 := z.DecSliceHelperStart()
-
-	var yyrr3505, yyrl3505 int
-	var yyc3505, yyrt3505 bool
-	_, _, _ = yyc3505, yyrt3505, yyrl3505
-	yyrr3505 = yyl3505
-
-	if yyv3505 == nil {
-		if yyrl3505, yyrt3505 = z.DecInferLen(yyl3505, z.DecBasicHandle().MaxInitLen, 16); yyrt3505 {
-			yyrr3505 = yyrl3505
-		}
-		yyv3505 = make([]Capability, yyrl3505)
-		yyc3505 = true
-	}
-
+	var yyc3505 bool
 	if yyl3505 == 0 {
-		if len(yyv3505) != 0 {
+		if yyv3505 == nil {
+			yyv3505 = []Capability{}
+			yyc3505 = true
+		} else if len(yyv3505) != 0 {
 			yyv3505 = yyv3505[:0]
 			yyc3505 = true
 		}
 	} else if yyl3505 > 0 {
-
+		var yyrr3505, yyrl3505 int
+		var yyrt3505 bool
 		if yyl3505 > cap(yyv3505) {
-			yyrl3505, yyrt3505 = z.DecInferLen(yyl3505, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23505 := yyv3505
-			yyv3505 = make([]Capability, yyrl3505)
-			if len(yyv3505) > 0 {
-				copy(yyv3505, yyv23505[:cap(yyv23505)])
+			yyrl3505, yyrt3505 = z.DecInferLen(yyl3505, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt3505 {
+				if yyrl3505 <= cap(yyv3505) {
+					yyv3505 = yyv3505[:yyrl3505]
+				} else {
+					yyv3505 = make([]Capability, yyrl3505)
+				}
+			} else {
+				yyv3505 = make([]Capability, yyrl3505)
 			}
 			yyc3505 = true
-
 			yyrr3505 = len(yyv3505)
 		} else if yyl3505 != len(yyv3505) {
 			yyv3505 = yyv3505[:yyl3505]
@@ -40571,6 +43533,7 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 		}
 		yyj3505 := 0
 		for ; yyj3505 < yyrr3505; yyj3505++ {
+			yyh3505.ElemContainerState(yyj3505)
 			if r.TryDecodeAsNil() {
 				yyv3505[yyj3505] = ""
 			} else {
@@ -40581,6 +43544,7 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 		if yyrt3505 {
 			for ; yyj3505 < yyl3505; yyj3505++ {
 				yyv3505 = append(yyv3505, "")
+				yyh3505.ElemContainerState(yyj3505)
 				if r.TryDecodeAsNil() {
 					yyv3505[yyj3505] = ""
 				} else {
@@ -40591,12 +43555,14 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 		}
 
 	} else {
-		for yyj3505 := 0; !r.CheckBreak(); yyj3505++ {
+		yyj3505 := 0
+		for ; !r.CheckBreak(); yyj3505++ {
+
 			if yyj3505 >= len(yyv3505) {
 				yyv3505 = append(yyv3505, "") // var yyz3505 Capability
 				yyc3505 = true
 			}
-
+			yyh3505.ElemContainerState(yyj3505)
 			if yyj3505 < len(yyv3505) {
 				if r.TryDecodeAsNil() {
 					yyv3505[yyj3505] = ""
@@ -40609,12 +43575,18 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 			}
 
 		}
-		yyh3505.End()
+		if yyj3505 < len(yyv3505) {
+			yyv3505 = yyv3505[:yyj3505]
+			yyc3505 = true
+		} else if yyj3505 == 0 && yyv3505 == nil {
+			yyv3505 = []Capability{}
+			yyc3505 = true
+		}
 	}
+	yyh3505.End()
 	if yyc3505 {
 		*v = yyv3505
 	}
-
 }
 
 func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.Encoder) {
@@ -40623,10 +43595,11 @@ func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.E
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3509 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3510 := &yyv3509
 		yy3510.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.Decoder) {
@@ -40636,39 +43609,44 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 
 	yyv3511 := *v
 	yyh3511, yyl3511 := z.DecSliceHelperStart()
-
-	var yyrr3511, yyrl3511 int
-	var yyc3511, yyrt3511 bool
-	_, _, _ = yyc3511, yyrt3511, yyrl3511
-	yyrr3511 = yyl3511
-
-	if yyv3511 == nil {
-		if yyrl3511, yyrt3511 = z.DecInferLen(yyl3511, z.DecBasicHandle().MaxInitLen, 64); yyrt3511 {
-			yyrr3511 = yyrl3511
-		}
-		yyv3511 = make([]ContainerPort, yyrl3511)
-		yyc3511 = true
-	}
-
+	var yyc3511 bool
 	if yyl3511 == 0 {
-		if len(yyv3511) != 0 {
+		if yyv3511 == nil {
+			yyv3511 = []ContainerPort{}
+			yyc3511 = true
+		} else if len(yyv3511) != 0 {
 			yyv3511 = yyv3511[:0]
 			yyc3511 = true
 		}
 	} else if yyl3511 > 0 {
-
+		var yyrr3511, yyrl3511 int
+		var yyrt3511 bool
 		if yyl3511 > cap(yyv3511) {
-			yyrl3511, yyrt3511 = z.DecInferLen(yyl3511, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3511 = make([]ContainerPort, yyrl3511)
-			yyc3511 = true
 
+			yyrg3511 := len(yyv3511) > 0
+			yyv23511 := yyv3511
+			yyrl3511, yyrt3511 = z.DecInferLen(yyl3511, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt3511 {
+				if yyrl3511 <= cap(yyv3511) {
+					yyv3511 = yyv3511[:yyrl3511]
+				} else {
+					yyv3511 = make([]ContainerPort, yyrl3511)
+				}
+			} else {
+				yyv3511 = make([]ContainerPort, yyrl3511)
+			}
+			yyc3511 = true
 			yyrr3511 = len(yyv3511)
+			if yyrg3511 {
+				copy(yyv3511, yyv23511)
+			}
 		} else if yyl3511 != len(yyv3511) {
 			yyv3511 = yyv3511[:yyl3511]
 			yyc3511 = true
 		}
 		yyj3511 := 0
 		for ; yyj3511 < yyrr3511; yyj3511++ {
+			yyh3511.ElemContainerState(yyj3511)
 			if r.TryDecodeAsNil() {
 				yyv3511[yyj3511] = ContainerPort{}
 			} else {
@@ -40680,6 +43658,7 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 		if yyrt3511 {
 			for ; yyj3511 < yyl3511; yyj3511++ {
 				yyv3511 = append(yyv3511, ContainerPort{})
+				yyh3511.ElemContainerState(yyj3511)
 				if r.TryDecodeAsNil() {
 					yyv3511[yyj3511] = ContainerPort{}
 				} else {
@@ -40691,12 +43670,14 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 		}
 
 	} else {
-		for yyj3511 := 0; !r.CheckBreak(); yyj3511++ {
+		yyj3511 := 0
+		for ; !r.CheckBreak(); yyj3511++ {
+
 			if yyj3511 >= len(yyv3511) {
 				yyv3511 = append(yyv3511, ContainerPort{}) // var yyz3511 ContainerPort
 				yyc3511 = true
 			}
-
+			yyh3511.ElemContainerState(yyj3511)
 			if yyj3511 < len(yyv3511) {
 				if r.TryDecodeAsNil() {
 					yyv3511[yyj3511] = ContainerPort{}
@@ -40710,12 +43691,18 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 			}
 
 		}
-		yyh3511.End()
+		if yyj3511 < len(yyv3511) {
+			yyv3511 = yyv3511[:yyj3511]
+			yyc3511 = true
+		} else if yyj3511 == 0 && yyv3511 == nil {
+			yyv3511 = []ContainerPort{}
+			yyc3511 = true
+		}
 	}
+	yyh3511.End()
 	if yyc3511 {
 		*v = yyv3511
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEnvVar(v []EnvVar, e *codec1978.Encoder) {
@@ -40724,10 +43711,11 @@ func (x codecSelfer1234) encSliceEnvVar(v []EnvVar, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3515 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3516 := &yyv3515
 		yy3516.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
@@ -40737,39 +43725,44 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 
 	yyv3517 := *v
 	yyh3517, yyl3517 := z.DecSliceHelperStart()
-
-	var yyrr3517, yyrl3517 int
-	var yyc3517, yyrt3517 bool
-	_, _, _ = yyc3517, yyrt3517, yyrl3517
-	yyrr3517 = yyl3517
-
-	if yyv3517 == nil {
-		if yyrl3517, yyrt3517 = z.DecInferLen(yyl3517, z.DecBasicHandle().MaxInitLen, 40); yyrt3517 {
-			yyrr3517 = yyrl3517
-		}
-		yyv3517 = make([]EnvVar, yyrl3517)
-		yyc3517 = true
-	}
-
+	var yyc3517 bool
 	if yyl3517 == 0 {
-		if len(yyv3517) != 0 {
+		if yyv3517 == nil {
+			yyv3517 = []EnvVar{}
+			yyc3517 = true
+		} else if len(yyv3517) != 0 {
 			yyv3517 = yyv3517[:0]
 			yyc3517 = true
 		}
 	} else if yyl3517 > 0 {
-
+		var yyrr3517, yyrl3517 int
+		var yyrt3517 bool
 		if yyl3517 > cap(yyv3517) {
-			yyrl3517, yyrt3517 = z.DecInferLen(yyl3517, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3517 = make([]EnvVar, yyrl3517)
-			yyc3517 = true
 
+			yyrg3517 := len(yyv3517) > 0
+			yyv23517 := yyv3517
+			yyrl3517, yyrt3517 = z.DecInferLen(yyl3517, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt3517 {
+				if yyrl3517 <= cap(yyv3517) {
+					yyv3517 = yyv3517[:yyrl3517]
+				} else {
+					yyv3517 = make([]EnvVar, yyrl3517)
+				}
+			} else {
+				yyv3517 = make([]EnvVar, yyrl3517)
+			}
+			yyc3517 = true
 			yyrr3517 = len(yyv3517)
+			if yyrg3517 {
+				copy(yyv3517, yyv23517)
+			}
 		} else if yyl3517 != len(yyv3517) {
 			yyv3517 = yyv3517[:yyl3517]
 			yyc3517 = true
 		}
 		yyj3517 := 0
 		for ; yyj3517 < yyrr3517; yyj3517++ {
+			yyh3517.ElemContainerState(yyj3517)
 			if r.TryDecodeAsNil() {
 				yyv3517[yyj3517] = EnvVar{}
 			} else {
@@ -40781,6 +43774,7 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 		if yyrt3517 {
 			for ; yyj3517 < yyl3517; yyj3517++ {
 				yyv3517 = append(yyv3517, EnvVar{})
+				yyh3517.ElemContainerState(yyj3517)
 				if r.TryDecodeAsNil() {
 					yyv3517[yyj3517] = EnvVar{}
 				} else {
@@ -40792,12 +43786,14 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3517 := 0; !r.CheckBreak(); yyj3517++ {
+		yyj3517 := 0
+		for ; !r.CheckBreak(); yyj3517++ {
+
 			if yyj3517 >= len(yyv3517) {
 				yyv3517 = append(yyv3517, EnvVar{}) // var yyz3517 EnvVar
 				yyc3517 = true
 			}
-
+			yyh3517.ElemContainerState(yyj3517)
 			if yyj3517 < len(yyv3517) {
 				if r.TryDecodeAsNil() {
 					yyv3517[yyj3517] = EnvVar{}
@@ -40811,12 +43807,18 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3517.End()
+		if yyj3517 < len(yyv3517) {
+			yyv3517 = yyv3517[:yyj3517]
+			yyc3517 = true
+		} else if yyj3517 == 0 && yyv3517 == nil {
+			yyv3517 = []EnvVar{}
+			yyc3517 = true
+		}
 	}
+	yyh3517.End()
 	if yyc3517 {
 		*v = yyv3517
 	}
-
 }
 
 func (x codecSelfer1234) encSliceVolumeMount(v []VolumeMount, e *codec1978.Encoder) {
@@ -40825,10 +43827,11 @@ func (x codecSelfer1234) encSliceVolumeMount(v []VolumeMount, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3521 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3522 := &yyv3521
 		yy3522.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Decoder) {
@@ -40838,39 +43841,44 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 
 	yyv3523 := *v
 	yyh3523, yyl3523 := z.DecSliceHelperStart()
-
-	var yyrr3523, yyrl3523 int
-	var yyc3523, yyrt3523 bool
-	_, _, _ = yyc3523, yyrt3523, yyrl3523
-	yyrr3523 = yyl3523
-
-	if yyv3523 == nil {
-		if yyrl3523, yyrt3523 = z.DecInferLen(yyl3523, z.DecBasicHandle().MaxInitLen, 40); yyrt3523 {
-			yyrr3523 = yyrl3523
-		}
-		yyv3523 = make([]VolumeMount, yyrl3523)
-		yyc3523 = true
-	}
-
+	var yyc3523 bool
 	if yyl3523 == 0 {
-		if len(yyv3523) != 0 {
+		if yyv3523 == nil {
+			yyv3523 = []VolumeMount{}
+			yyc3523 = true
+		} else if len(yyv3523) != 0 {
 			yyv3523 = yyv3523[:0]
 			yyc3523 = true
 		}
 	} else if yyl3523 > 0 {
-
+		var yyrr3523, yyrl3523 int
+		var yyrt3523 bool
 		if yyl3523 > cap(yyv3523) {
-			yyrl3523, yyrt3523 = z.DecInferLen(yyl3523, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3523 = make([]VolumeMount, yyrl3523)
-			yyc3523 = true
 
+			yyrg3523 := len(yyv3523) > 0
+			yyv23523 := yyv3523
+			yyrl3523, yyrt3523 = z.DecInferLen(yyl3523, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt3523 {
+				if yyrl3523 <= cap(yyv3523) {
+					yyv3523 = yyv3523[:yyrl3523]
+				} else {
+					yyv3523 = make([]VolumeMount, yyrl3523)
+				}
+			} else {
+				yyv3523 = make([]VolumeMount, yyrl3523)
+			}
+			yyc3523 = true
 			yyrr3523 = len(yyv3523)
+			if yyrg3523 {
+				copy(yyv3523, yyv23523)
+			}
 		} else if yyl3523 != len(yyv3523) {
 			yyv3523 = yyv3523[:yyl3523]
 			yyc3523 = true
 		}
 		yyj3523 := 0
 		for ; yyj3523 < yyrr3523; yyj3523++ {
+			yyh3523.ElemContainerState(yyj3523)
 			if r.TryDecodeAsNil() {
 				yyv3523[yyj3523] = VolumeMount{}
 			} else {
@@ -40882,6 +43890,7 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 		if yyrt3523 {
 			for ; yyj3523 < yyl3523; yyj3523++ {
 				yyv3523 = append(yyv3523, VolumeMount{})
+				yyh3523.ElemContainerState(yyj3523)
 				if r.TryDecodeAsNil() {
 					yyv3523[yyj3523] = VolumeMount{}
 				} else {
@@ -40893,12 +43902,14 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj3523 := 0; !r.CheckBreak(); yyj3523++ {
+		yyj3523 := 0
+		for ; !r.CheckBreak(); yyj3523++ {
+
 			if yyj3523 >= len(yyv3523) {
 				yyv3523 = append(yyv3523, VolumeMount{}) // var yyz3523 VolumeMount
 				yyc3523 = true
 			}
-
+			yyh3523.ElemContainerState(yyj3523)
 			if yyj3523 < len(yyv3523) {
 				if r.TryDecodeAsNil() {
 					yyv3523[yyj3523] = VolumeMount{}
@@ -40912,12 +43923,18 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 			}
 
 		}
-		yyh3523.End()
+		if yyj3523 < len(yyv3523) {
+			yyv3523 = yyv3523[:yyj3523]
+			yyc3523 = true
+		} else if yyj3523 == 0 && yyv3523 == nil {
+			yyv3523 = []VolumeMount{}
+			yyc3523 = true
+		}
 	}
+	yyh3523.End()
 	if yyc3523 {
 		*v = yyv3523
 	}
-
 }
 
 func (x codecSelfer1234) encSliceVolume(v []Volume, e *codec1978.Encoder) {
@@ -40926,10 +43943,11 @@ func (x codecSelfer1234) encSliceVolume(v []Volume, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3527 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3528 := &yyv3527
 		yy3528.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
@@ -40939,39 +43957,44 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 
 	yyv3529 := *v
 	yyh3529, yyl3529 := z.DecSliceHelperStart()
-
-	var yyrr3529, yyrl3529 int
-	var yyc3529, yyrt3529 bool
-	_, _, _ = yyc3529, yyrt3529, yyrl3529
-	yyrr3529 = yyl3529
-
-	if yyv3529 == nil {
-		if yyrl3529, yyrt3529 = z.DecInferLen(yyl3529, z.DecBasicHandle().MaxInitLen, 144); yyrt3529 {
-			yyrr3529 = yyrl3529
-		}
-		yyv3529 = make([]Volume, yyrl3529)
-		yyc3529 = true
-	}
-
+	var yyc3529 bool
 	if yyl3529 == 0 {
-		if len(yyv3529) != 0 {
+		if yyv3529 == nil {
+			yyv3529 = []Volume{}
+			yyc3529 = true
+		} else if len(yyv3529) != 0 {
 			yyv3529 = yyv3529[:0]
 			yyc3529 = true
 		}
 	} else if yyl3529 > 0 {
-
+		var yyrr3529, yyrl3529 int
+		var yyrt3529 bool
 		if yyl3529 > cap(yyv3529) {
-			yyrl3529, yyrt3529 = z.DecInferLen(yyl3529, z.DecBasicHandle().MaxInitLen, 144)
-			yyv3529 = make([]Volume, yyrl3529)
-			yyc3529 = true
 
+			yyrg3529 := len(yyv3529) > 0
+			yyv23529 := yyv3529
+			yyrl3529, yyrt3529 = z.DecInferLen(yyl3529, z.DecBasicHandle().MaxInitLen, 144)
+			if yyrt3529 {
+				if yyrl3529 <= cap(yyv3529) {
+					yyv3529 = yyv3529[:yyrl3529]
+				} else {
+					yyv3529 = make([]Volume, yyrl3529)
+				}
+			} else {
+				yyv3529 = make([]Volume, yyrl3529)
+			}
+			yyc3529 = true
 			yyrr3529 = len(yyv3529)
+			if yyrg3529 {
+				copy(yyv3529, yyv23529)
+			}
 		} else if yyl3529 != len(yyv3529) {
 			yyv3529 = yyv3529[:yyl3529]
 			yyc3529 = true
 		}
 		yyj3529 := 0
 		for ; yyj3529 < yyrr3529; yyj3529++ {
+			yyh3529.ElemContainerState(yyj3529)
 			if r.TryDecodeAsNil() {
 				yyv3529[yyj3529] = Volume{}
 			} else {
@@ -40983,6 +44006,7 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 		if yyrt3529 {
 			for ; yyj3529 < yyl3529; yyj3529++ {
 				yyv3529 = append(yyv3529, Volume{})
+				yyh3529.ElemContainerState(yyj3529)
 				if r.TryDecodeAsNil() {
 					yyv3529[yyj3529] = Volume{}
 				} else {
@@ -40994,12 +44018,14 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3529 := 0; !r.CheckBreak(); yyj3529++ {
+		yyj3529 := 0
+		for ; !r.CheckBreak(); yyj3529++ {
+
 			if yyj3529 >= len(yyv3529) {
 				yyv3529 = append(yyv3529, Volume{}) // var yyz3529 Volume
 				yyc3529 = true
 			}
-
+			yyh3529.ElemContainerState(yyj3529)
 			if yyj3529 < len(yyv3529) {
 				if r.TryDecodeAsNil() {
 					yyv3529[yyj3529] = Volume{}
@@ -41013,12 +44039,18 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3529.End()
+		if yyj3529 < len(yyv3529) {
+			yyv3529 = yyv3529[:yyj3529]
+			yyc3529 = true
+		} else if yyj3529 == 0 && yyv3529 == nil {
+			yyv3529 = []Volume{}
+			yyc3529 = true
+		}
 	}
+	yyh3529.End()
 	if yyc3529 {
 		*v = yyv3529
 	}
-
 }
 
 func (x codecSelfer1234) encSliceContainer(v []Container, e *codec1978.Encoder) {
@@ -41027,10 +44059,11 @@ func (x codecSelfer1234) encSliceContainer(v []Container, e *codec1978.Encoder) 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3533 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3534 := &yyv3533
 		yy3534.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder) {
@@ -41040,39 +44073,44 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 
 	yyv3535 := *v
 	yyh3535, yyl3535 := z.DecSliceHelperStart()
-
-	var yyrr3535, yyrl3535 int
-	var yyc3535, yyrt3535 bool
-	_, _, _ = yyc3535, yyrt3535, yyrl3535
-	yyrr3535 = yyl3535
-
-	if yyv3535 == nil {
-		if yyrl3535, yyrt3535 = z.DecInferLen(yyl3535, z.DecBasicHandle().MaxInitLen, 256); yyrt3535 {
-			yyrr3535 = yyrl3535
-		}
-		yyv3535 = make([]Container, yyrl3535)
-		yyc3535 = true
-	}
-
+	var yyc3535 bool
 	if yyl3535 == 0 {
-		if len(yyv3535) != 0 {
+		if yyv3535 == nil {
+			yyv3535 = []Container{}
+			yyc3535 = true
+		} else if len(yyv3535) != 0 {
 			yyv3535 = yyv3535[:0]
 			yyc3535 = true
 		}
 	} else if yyl3535 > 0 {
-
+		var yyrr3535, yyrl3535 int
+		var yyrt3535 bool
 		if yyl3535 > cap(yyv3535) {
-			yyrl3535, yyrt3535 = z.DecInferLen(yyl3535, z.DecBasicHandle().MaxInitLen, 256)
-			yyv3535 = make([]Container, yyrl3535)
-			yyc3535 = true
 
+			yyrg3535 := len(yyv3535) > 0
+			yyv23535 := yyv3535
+			yyrl3535, yyrt3535 = z.DecInferLen(yyl3535, z.DecBasicHandle().MaxInitLen, 256)
+			if yyrt3535 {
+				if yyrl3535 <= cap(yyv3535) {
+					yyv3535 = yyv3535[:yyrl3535]
+				} else {
+					yyv3535 = make([]Container, yyrl3535)
+				}
+			} else {
+				yyv3535 = make([]Container, yyrl3535)
+			}
+			yyc3535 = true
 			yyrr3535 = len(yyv3535)
+			if yyrg3535 {
+				copy(yyv3535, yyv23535)
+			}
 		} else if yyl3535 != len(yyv3535) {
 			yyv3535 = yyv3535[:yyl3535]
 			yyc3535 = true
 		}
 		yyj3535 := 0
 		for ; yyj3535 < yyrr3535; yyj3535++ {
+			yyh3535.ElemContainerState(yyj3535)
 			if r.TryDecodeAsNil() {
 				yyv3535[yyj3535] = Container{}
 			} else {
@@ -41084,6 +44122,7 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 		if yyrt3535 {
 			for ; yyj3535 < yyl3535; yyj3535++ {
 				yyv3535 = append(yyv3535, Container{})
+				yyh3535.ElemContainerState(yyj3535)
 				if r.TryDecodeAsNil() {
 					yyv3535[yyj3535] = Container{}
 				} else {
@@ -41095,12 +44134,14 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 		}
 
 	} else {
-		for yyj3535 := 0; !r.CheckBreak(); yyj3535++ {
+		yyj3535 := 0
+		for ; !r.CheckBreak(); yyj3535++ {
+
 			if yyj3535 >= len(yyv3535) {
 				yyv3535 = append(yyv3535, Container{}) // var yyz3535 Container
 				yyc3535 = true
 			}
-
+			yyh3535.ElemContainerState(yyj3535)
 			if yyj3535 < len(yyv3535) {
 				if r.TryDecodeAsNil() {
 					yyv3535[yyj3535] = Container{}
@@ -41114,12 +44155,18 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3535.End()
+		if yyj3535 < len(yyv3535) {
+			yyv3535 = yyv3535[:yyj3535]
+			yyc3535 = true
+		} else if yyj3535 == 0 && yyv3535 == nil {
+			yyv3535 = []Container{}
+			yyc3535 = true
+		}
 	}
+	yyh3535.End()
 	if yyc3535 {
 		*v = yyv3535
 	}
-
 }
 
 func (x codecSelfer1234) encSliceLocalObjectReference(v []LocalObjectReference, e *codec1978.Encoder) {
@@ -41128,10 +44175,11 @@ func (x codecSelfer1234) encSliceLocalObjectReference(v []LocalObjectReference, 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3539 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3540 := &yyv3539
 		yy3540.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference, d *codec1978.Decoder) {
@@ -41141,39 +44189,44 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 
 	yyv3541 := *v
 	yyh3541, yyl3541 := z.DecSliceHelperStart()
-
-	var yyrr3541, yyrl3541 int
-	var yyc3541, yyrt3541 bool
-	_, _, _ = yyc3541, yyrt3541, yyrl3541
-	yyrr3541 = yyl3541
-
-	if yyv3541 == nil {
-		if yyrl3541, yyrt3541 = z.DecInferLen(yyl3541, z.DecBasicHandle().MaxInitLen, 16); yyrt3541 {
-			yyrr3541 = yyrl3541
-		}
-		yyv3541 = make([]LocalObjectReference, yyrl3541)
-		yyc3541 = true
-	}
-
+	var yyc3541 bool
 	if yyl3541 == 0 {
-		if len(yyv3541) != 0 {
+		if yyv3541 == nil {
+			yyv3541 = []LocalObjectReference{}
+			yyc3541 = true
+		} else if len(yyv3541) != 0 {
 			yyv3541 = yyv3541[:0]
 			yyc3541 = true
 		}
 	} else if yyl3541 > 0 {
-
+		var yyrr3541, yyrl3541 int
+		var yyrt3541 bool
 		if yyl3541 > cap(yyv3541) {
-			yyrl3541, yyrt3541 = z.DecInferLen(yyl3541, z.DecBasicHandle().MaxInitLen, 16)
-			yyv3541 = make([]LocalObjectReference, yyrl3541)
-			yyc3541 = true
 
+			yyrg3541 := len(yyv3541) > 0
+			yyv23541 := yyv3541
+			yyrl3541, yyrt3541 = z.DecInferLen(yyl3541, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt3541 {
+				if yyrl3541 <= cap(yyv3541) {
+					yyv3541 = yyv3541[:yyrl3541]
+				} else {
+					yyv3541 = make([]LocalObjectReference, yyrl3541)
+				}
+			} else {
+				yyv3541 = make([]LocalObjectReference, yyrl3541)
+			}
+			yyc3541 = true
 			yyrr3541 = len(yyv3541)
+			if yyrg3541 {
+				copy(yyv3541, yyv23541)
+			}
 		} else if yyl3541 != len(yyv3541) {
 			yyv3541 = yyv3541[:yyl3541]
 			yyc3541 = true
 		}
 		yyj3541 := 0
 		for ; yyj3541 < yyrr3541; yyj3541++ {
+			yyh3541.ElemContainerState(yyj3541)
 			if r.TryDecodeAsNil() {
 				yyv3541[yyj3541] = LocalObjectReference{}
 			} else {
@@ -41185,6 +44238,7 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 		if yyrt3541 {
 			for ; yyj3541 < yyl3541; yyj3541++ {
 				yyv3541 = append(yyv3541, LocalObjectReference{})
+				yyh3541.ElemContainerState(yyj3541)
 				if r.TryDecodeAsNil() {
 					yyv3541[yyj3541] = LocalObjectReference{}
 				} else {
@@ -41196,12 +44250,14 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 		}
 
 	} else {
-		for yyj3541 := 0; !r.CheckBreak(); yyj3541++ {
+		yyj3541 := 0
+		for ; !r.CheckBreak(); yyj3541++ {
+
 			if yyj3541 >= len(yyv3541) {
 				yyv3541 = append(yyv3541, LocalObjectReference{}) // var yyz3541 LocalObjectReference
 				yyc3541 = true
 			}
-
+			yyh3541.ElemContainerState(yyj3541)
 			if yyj3541 < len(yyv3541) {
 				if r.TryDecodeAsNil() {
 					yyv3541[yyj3541] = LocalObjectReference{}
@@ -41215,12 +44271,18 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 			}
 
 		}
-		yyh3541.End()
+		if yyj3541 < len(yyv3541) {
+			yyv3541 = yyv3541[:yyj3541]
+			yyc3541 = true
+		} else if yyj3541 == 0 && yyv3541 == nil {
+			yyv3541 = []LocalObjectReference{}
+			yyc3541 = true
+		}
 	}
+	yyh3541.End()
 	if yyc3541 {
 		*v = yyv3541
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePodCondition(v []PodCondition, e *codec1978.Encoder) {
@@ -41229,10 +44291,11 @@ func (x codecSelfer1234) encSlicePodCondition(v []PodCondition, e *codec1978.Enc
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3545 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3546 := &yyv3545
 		yy3546.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.Decoder) {
@@ -41242,39 +44305,44 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 
 	yyv3547 := *v
 	yyh3547, yyl3547 := z.DecSliceHelperStart()
-
-	var yyrr3547, yyrl3547 int
-	var yyc3547, yyrt3547 bool
-	_, _, _ = yyc3547, yyrt3547, yyrl3547
-	yyrr3547 = yyl3547
-
-	if yyv3547 == nil {
-		if yyrl3547, yyrt3547 = z.DecInferLen(yyl3547, z.DecBasicHandle().MaxInitLen, 112); yyrt3547 {
-			yyrr3547 = yyrl3547
-		}
-		yyv3547 = make([]PodCondition, yyrl3547)
-		yyc3547 = true
-	}
-
+	var yyc3547 bool
 	if yyl3547 == 0 {
-		if len(yyv3547) != 0 {
+		if yyv3547 == nil {
+			yyv3547 = []PodCondition{}
+			yyc3547 = true
+		} else if len(yyv3547) != 0 {
 			yyv3547 = yyv3547[:0]
 			yyc3547 = true
 		}
 	} else if yyl3547 > 0 {
-
+		var yyrr3547, yyrl3547 int
+		var yyrt3547 bool
 		if yyl3547 > cap(yyv3547) {
-			yyrl3547, yyrt3547 = z.DecInferLen(yyl3547, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3547 = make([]PodCondition, yyrl3547)
-			yyc3547 = true
 
+			yyrg3547 := len(yyv3547) > 0
+			yyv23547 := yyv3547
+			yyrl3547, yyrt3547 = z.DecInferLen(yyl3547, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt3547 {
+				if yyrl3547 <= cap(yyv3547) {
+					yyv3547 = yyv3547[:yyrl3547]
+				} else {
+					yyv3547 = make([]PodCondition, yyrl3547)
+				}
+			} else {
+				yyv3547 = make([]PodCondition, yyrl3547)
+			}
+			yyc3547 = true
 			yyrr3547 = len(yyv3547)
+			if yyrg3547 {
+				copy(yyv3547, yyv23547)
+			}
 		} else if yyl3547 != len(yyv3547) {
 			yyv3547 = yyv3547[:yyl3547]
 			yyc3547 = true
 		}
 		yyj3547 := 0
 		for ; yyj3547 < yyrr3547; yyj3547++ {
+			yyh3547.ElemContainerState(yyj3547)
 			if r.TryDecodeAsNil() {
 				yyv3547[yyj3547] = PodCondition{}
 			} else {
@@ -41286,6 +44354,7 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 		if yyrt3547 {
 			for ; yyj3547 < yyl3547; yyj3547++ {
 				yyv3547 = append(yyv3547, PodCondition{})
+				yyh3547.ElemContainerState(yyj3547)
 				if r.TryDecodeAsNil() {
 					yyv3547[yyj3547] = PodCondition{}
 				} else {
@@ -41297,12 +44366,14 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 		}
 
 	} else {
-		for yyj3547 := 0; !r.CheckBreak(); yyj3547++ {
+		yyj3547 := 0
+		for ; !r.CheckBreak(); yyj3547++ {
+
 			if yyj3547 >= len(yyv3547) {
 				yyv3547 = append(yyv3547, PodCondition{}) // var yyz3547 PodCondition
 				yyc3547 = true
 			}
-
+			yyh3547.ElemContainerState(yyj3547)
 			if yyj3547 < len(yyv3547) {
 				if r.TryDecodeAsNil() {
 					yyv3547[yyj3547] = PodCondition{}
@@ -41316,12 +44387,18 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 			}
 
 		}
-		yyh3547.End()
+		if yyj3547 < len(yyv3547) {
+			yyv3547 = yyv3547[:yyj3547]
+			yyc3547 = true
+		} else if yyj3547 == 0 && yyv3547 == nil {
+			yyv3547 = []PodCondition{}
+			yyc3547 = true
+		}
 	}
+	yyh3547.End()
 	if yyc3547 {
 		*v = yyv3547
 	}
-
 }
 
 func (x codecSelfer1234) encSliceContainerStatus(v []ContainerStatus, e *codec1978.Encoder) {
@@ -41330,10 +44407,11 @@ func (x codecSelfer1234) encSliceContainerStatus(v []ContainerStatus, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3551 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3552 := &yyv3551
 		yy3552.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1978.Decoder) {
@@ -41343,39 +44421,44 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 
 	yyv3553 := *v
 	yyh3553, yyl3553 := z.DecSliceHelperStart()
-
-	var yyrr3553, yyrl3553 int
-	var yyc3553, yyrt3553 bool
-	_, _, _ = yyc3553, yyrt3553, yyrl3553
-	yyrr3553 = yyl3553
-
-	if yyv3553 == nil {
-		if yyrl3553, yyrt3553 = z.DecInferLen(yyl3553, z.DecBasicHandle().MaxInitLen, 128); yyrt3553 {
-			yyrr3553 = yyrl3553
-		}
-		yyv3553 = make([]ContainerStatus, yyrl3553)
-		yyc3553 = true
-	}
-
+	var yyc3553 bool
 	if yyl3553 == 0 {
-		if len(yyv3553) != 0 {
+		if yyv3553 == nil {
+			yyv3553 = []ContainerStatus{}
+			yyc3553 = true
+		} else if len(yyv3553) != 0 {
 			yyv3553 = yyv3553[:0]
 			yyc3553 = true
 		}
 	} else if yyl3553 > 0 {
-
+		var yyrr3553, yyrl3553 int
+		var yyrt3553 bool
 		if yyl3553 > cap(yyv3553) {
-			yyrl3553, yyrt3553 = z.DecInferLen(yyl3553, z.DecBasicHandle().MaxInitLen, 128)
-			yyv3553 = make([]ContainerStatus, yyrl3553)
-			yyc3553 = true
 
+			yyrg3553 := len(yyv3553) > 0
+			yyv23553 := yyv3553
+			yyrl3553, yyrt3553 = z.DecInferLen(yyl3553, z.DecBasicHandle().MaxInitLen, 128)
+			if yyrt3553 {
+				if yyrl3553 <= cap(yyv3553) {
+					yyv3553 = yyv3553[:yyrl3553]
+				} else {
+					yyv3553 = make([]ContainerStatus, yyrl3553)
+				}
+			} else {
+				yyv3553 = make([]ContainerStatus, yyrl3553)
+			}
+			yyc3553 = true
 			yyrr3553 = len(yyv3553)
+			if yyrg3553 {
+				copy(yyv3553, yyv23553)
+			}
 		} else if yyl3553 != len(yyv3553) {
 			yyv3553 = yyv3553[:yyl3553]
 			yyc3553 = true
 		}
 		yyj3553 := 0
 		for ; yyj3553 < yyrr3553; yyj3553++ {
+			yyh3553.ElemContainerState(yyj3553)
 			if r.TryDecodeAsNil() {
 				yyv3553[yyj3553] = ContainerStatus{}
 			} else {
@@ -41387,6 +44470,7 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 		if yyrt3553 {
 			for ; yyj3553 < yyl3553; yyj3553++ {
 				yyv3553 = append(yyv3553, ContainerStatus{})
+				yyh3553.ElemContainerState(yyj3553)
 				if r.TryDecodeAsNil() {
 					yyv3553[yyj3553] = ContainerStatus{}
 				} else {
@@ -41398,12 +44482,14 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 		}
 
 	} else {
-		for yyj3553 := 0; !r.CheckBreak(); yyj3553++ {
+		yyj3553 := 0
+		for ; !r.CheckBreak(); yyj3553++ {
+
 			if yyj3553 >= len(yyv3553) {
 				yyv3553 = append(yyv3553, ContainerStatus{}) // var yyz3553 ContainerStatus
 				yyc3553 = true
 			}
-
+			yyh3553.ElemContainerState(yyj3553)
 			if yyj3553 < len(yyv3553) {
 				if r.TryDecodeAsNil() {
 					yyv3553[yyj3553] = ContainerStatus{}
@@ -41417,12 +44503,18 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 			}
 
 		}
-		yyh3553.End()
+		if yyj3553 < len(yyv3553) {
+			yyv3553 = yyv3553[:yyj3553]
+			yyc3553 = true
+		} else if yyj3553 == 0 && yyv3553 == nil {
+			yyv3553 = []ContainerStatus{}
+			yyc3553 = true
+		}
 	}
+	yyh3553.End()
 	if yyc3553 {
 		*v = yyv3553
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePod(v []Pod, e *codec1978.Encoder) {
@@ -41431,10 +44523,11 @@ func (x codecSelfer1234) encSlicePod(v []Pod, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3557 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3558 := &yyv3557
 		yy3558.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
@@ -41444,39 +44537,44 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 
 	yyv3559 := *v
 	yyh3559, yyl3559 := z.DecSliceHelperStart()
-
-	var yyrr3559, yyrl3559 int
-	var yyc3559, yyrt3559 bool
-	_, _, _ = yyc3559, yyrt3559, yyrl3559
-	yyrr3559 = yyl3559
-
-	if yyv3559 == nil {
-		if yyrl3559, yyrt3559 = z.DecInferLen(yyl3559, z.DecBasicHandle().MaxInitLen, 520); yyrt3559 {
-			yyrr3559 = yyrl3559
-		}
-		yyv3559 = make([]Pod, yyrl3559)
-		yyc3559 = true
-	}
-
+	var yyc3559 bool
 	if yyl3559 == 0 {
-		if len(yyv3559) != 0 {
+		if yyv3559 == nil {
+			yyv3559 = []Pod{}
+			yyc3559 = true
+		} else if len(yyv3559) != 0 {
 			yyv3559 = yyv3559[:0]
 			yyc3559 = true
 		}
 	} else if yyl3559 > 0 {
-
+		var yyrr3559, yyrl3559 int
+		var yyrt3559 bool
 		if yyl3559 > cap(yyv3559) {
-			yyrl3559, yyrt3559 = z.DecInferLen(yyl3559, z.DecBasicHandle().MaxInitLen, 520)
-			yyv3559 = make([]Pod, yyrl3559)
-			yyc3559 = true
 
+			yyrg3559 := len(yyv3559) > 0
+			yyv23559 := yyv3559
+			yyrl3559, yyrt3559 = z.DecInferLen(yyl3559, z.DecBasicHandle().MaxInitLen, 520)
+			if yyrt3559 {
+				if yyrl3559 <= cap(yyv3559) {
+					yyv3559 = yyv3559[:yyrl3559]
+				} else {
+					yyv3559 = make([]Pod, yyrl3559)
+				}
+			} else {
+				yyv3559 = make([]Pod, yyrl3559)
+			}
+			yyc3559 = true
 			yyrr3559 = len(yyv3559)
+			if yyrg3559 {
+				copy(yyv3559, yyv23559)
+			}
 		} else if yyl3559 != len(yyv3559) {
 			yyv3559 = yyv3559[:yyl3559]
 			yyc3559 = true
 		}
 		yyj3559 := 0
 		for ; yyj3559 < yyrr3559; yyj3559++ {
+			yyh3559.ElemContainerState(yyj3559)
 			if r.TryDecodeAsNil() {
 				yyv3559[yyj3559] = Pod{}
 			} else {
@@ -41488,6 +44586,7 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 		if yyrt3559 {
 			for ; yyj3559 < yyl3559; yyj3559++ {
 				yyv3559 = append(yyv3559, Pod{})
+				yyh3559.ElemContainerState(yyj3559)
 				if r.TryDecodeAsNil() {
 					yyv3559[yyj3559] = Pod{}
 				} else {
@@ -41499,12 +44598,14 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3559 := 0; !r.CheckBreak(); yyj3559++ {
+		yyj3559 := 0
+		for ; !r.CheckBreak(); yyj3559++ {
+
 			if yyj3559 >= len(yyv3559) {
 				yyv3559 = append(yyv3559, Pod{}) // var yyz3559 Pod
 				yyc3559 = true
 			}
-
+			yyh3559.ElemContainerState(yyj3559)
 			if yyj3559 < len(yyv3559) {
 				if r.TryDecodeAsNil() {
 					yyv3559[yyj3559] = Pod{}
@@ -41518,12 +44619,18 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3559.End()
+		if yyj3559 < len(yyv3559) {
+			yyv3559 = yyv3559[:yyj3559]
+			yyc3559 = true
+		} else if yyj3559 == 0 && yyv3559 == nil {
+			yyv3559 = []Pod{}
+			yyc3559 = true
+		}
 	}
+	yyh3559.End()
 	if yyc3559 {
 		*v = yyv3559
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePodTemplate(v []PodTemplate, e *codec1978.Encoder) {
@@ -41532,10 +44639,11 @@ func (x codecSelfer1234) encSlicePodTemplate(v []PodTemplate, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3563 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3564 := &yyv3563
 		yy3564.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Decoder) {
@@ -41545,39 +44653,44 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 
 	yyv3565 := *v
 	yyh3565, yyl3565 := z.DecSliceHelperStart()
-
-	var yyrr3565, yyrl3565 int
-	var yyc3565, yyrt3565 bool
-	_, _, _ = yyc3565, yyrt3565, yyrl3565
-	yyrr3565 = yyl3565
-
-	if yyv3565 == nil {
-		if yyrl3565, yyrt3565 = z.DecInferLen(yyl3565, z.DecBasicHandle().MaxInitLen, 544); yyrt3565 {
-			yyrr3565 = yyrl3565
-		}
-		yyv3565 = make([]PodTemplate, yyrl3565)
-		yyc3565 = true
-	}
-
+	var yyc3565 bool
 	if yyl3565 == 0 {
-		if len(yyv3565) != 0 {
+		if yyv3565 == nil {
+			yyv3565 = []PodTemplate{}
+			yyc3565 = true
+		} else if len(yyv3565) != 0 {
 			yyv3565 = yyv3565[:0]
 			yyc3565 = true
 		}
 	} else if yyl3565 > 0 {
-
+		var yyrr3565, yyrl3565 int
+		var yyrt3565 bool
 		if yyl3565 > cap(yyv3565) {
-			yyrl3565, yyrt3565 = z.DecInferLen(yyl3565, z.DecBasicHandle().MaxInitLen, 544)
-			yyv3565 = make([]PodTemplate, yyrl3565)
-			yyc3565 = true
 
+			yyrg3565 := len(yyv3565) > 0
+			yyv23565 := yyv3565
+			yyrl3565, yyrt3565 = z.DecInferLen(yyl3565, z.DecBasicHandle().MaxInitLen, 544)
+			if yyrt3565 {
+				if yyrl3565 <= cap(yyv3565) {
+					yyv3565 = yyv3565[:yyrl3565]
+				} else {
+					yyv3565 = make([]PodTemplate, yyrl3565)
+				}
+			} else {
+				yyv3565 = make([]PodTemplate, yyrl3565)
+			}
+			yyc3565 = true
 			yyrr3565 = len(yyv3565)
+			if yyrg3565 {
+				copy(yyv3565, yyv23565)
+			}
 		} else if yyl3565 != len(yyv3565) {
 			yyv3565 = yyv3565[:yyl3565]
 			yyc3565 = true
 		}
 		yyj3565 := 0
 		for ; yyj3565 < yyrr3565; yyj3565++ {
+			yyh3565.ElemContainerState(yyj3565)
 			if r.TryDecodeAsNil() {
 				yyv3565[yyj3565] = PodTemplate{}
 			} else {
@@ -41589,6 +44702,7 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 		if yyrt3565 {
 			for ; yyj3565 < yyl3565; yyj3565++ {
 				yyv3565 = append(yyv3565, PodTemplate{})
+				yyh3565.ElemContainerState(yyj3565)
 				if r.TryDecodeAsNil() {
 					yyv3565[yyj3565] = PodTemplate{}
 				} else {
@@ -41600,12 +44714,14 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj3565 := 0; !r.CheckBreak(); yyj3565++ {
+		yyj3565 := 0
+		for ; !r.CheckBreak(); yyj3565++ {
+
 			if yyj3565 >= len(yyv3565) {
 				yyv3565 = append(yyv3565, PodTemplate{}) // var yyz3565 PodTemplate
 				yyc3565 = true
 			}
-
+			yyh3565.ElemContainerState(yyj3565)
 			if yyj3565 < len(yyv3565) {
 				if r.TryDecodeAsNil() {
 					yyv3565[yyj3565] = PodTemplate{}
@@ -41619,12 +44735,18 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 			}
 
 		}
-		yyh3565.End()
+		if yyj3565 < len(yyv3565) {
+			yyv3565 = yyv3565[:yyj3565]
+			yyc3565 = true
+		} else if yyj3565 == 0 && yyv3565 == nil {
+			yyv3565 = []PodTemplate{}
+			yyc3565 = true
+		}
 	}
+	yyh3565.End()
 	if yyc3565 {
 		*v = yyv3565
 	}
-
 }
 
 func (x codecSelfer1234) encSliceReplicationController(v []ReplicationController, e *codec1978.Encoder) {
@@ -41633,10 +44755,11 @@ func (x codecSelfer1234) encSliceReplicationController(v []ReplicationController
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3569 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3570 := &yyv3569
 		yy3570.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationController, d *codec1978.Decoder) {
@@ -41646,39 +44769,44 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 
 	yyv3571 := *v
 	yyh3571, yyl3571 := z.DecSliceHelperStart()
-
-	var yyrr3571, yyrl3571 int
-	var yyc3571, yyrt3571 bool
-	_, _, _ = yyc3571, yyrt3571, yyrl3571
-	yyrr3571 = yyl3571
-
-	if yyv3571 == nil {
-		if yyrl3571, yyrt3571 = z.DecInferLen(yyl3571, z.DecBasicHandle().MaxInitLen, 232); yyrt3571 {
-			yyrr3571 = yyrl3571
-		}
-		yyv3571 = make([]ReplicationController, yyrl3571)
-		yyc3571 = true
-	}
-
+	var yyc3571 bool
 	if yyl3571 == 0 {
-		if len(yyv3571) != 0 {
+		if yyv3571 == nil {
+			yyv3571 = []ReplicationController{}
+			yyc3571 = true
+		} else if len(yyv3571) != 0 {
 			yyv3571 = yyv3571[:0]
 			yyc3571 = true
 		}
 	} else if yyl3571 > 0 {
-
+		var yyrr3571, yyrl3571 int
+		var yyrt3571 bool
 		if yyl3571 > cap(yyv3571) {
-			yyrl3571, yyrt3571 = z.DecInferLen(yyl3571, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3571 = make([]ReplicationController, yyrl3571)
-			yyc3571 = true
 
+			yyrg3571 := len(yyv3571) > 0
+			yyv23571 := yyv3571
+			yyrl3571, yyrt3571 = z.DecInferLen(yyl3571, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt3571 {
+				if yyrl3571 <= cap(yyv3571) {
+					yyv3571 = yyv3571[:yyrl3571]
+				} else {
+					yyv3571 = make([]ReplicationController, yyrl3571)
+				}
+			} else {
+				yyv3571 = make([]ReplicationController, yyrl3571)
+			}
+			yyc3571 = true
 			yyrr3571 = len(yyv3571)
+			if yyrg3571 {
+				copy(yyv3571, yyv23571)
+			}
 		} else if yyl3571 != len(yyv3571) {
 			yyv3571 = yyv3571[:yyl3571]
 			yyc3571 = true
 		}
 		yyj3571 := 0
 		for ; yyj3571 < yyrr3571; yyj3571++ {
+			yyh3571.ElemContainerState(yyj3571)
 			if r.TryDecodeAsNil() {
 				yyv3571[yyj3571] = ReplicationController{}
 			} else {
@@ -41690,6 +44818,7 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 		if yyrt3571 {
 			for ; yyj3571 < yyl3571; yyj3571++ {
 				yyv3571 = append(yyv3571, ReplicationController{})
+				yyh3571.ElemContainerState(yyj3571)
 				if r.TryDecodeAsNil() {
 					yyv3571[yyj3571] = ReplicationController{}
 				} else {
@@ -41701,12 +44830,14 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 		}
 
 	} else {
-		for yyj3571 := 0; !r.CheckBreak(); yyj3571++ {
+		yyj3571 := 0
+		for ; !r.CheckBreak(); yyj3571++ {
+
 			if yyj3571 >= len(yyv3571) {
 				yyv3571 = append(yyv3571, ReplicationController{}) // var yyz3571 ReplicationController
 				yyc3571 = true
 			}
-
+			yyh3571.ElemContainerState(yyj3571)
 			if yyj3571 < len(yyv3571) {
 				if r.TryDecodeAsNil() {
 					yyv3571[yyj3571] = ReplicationController{}
@@ -41720,12 +44851,18 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 			}
 
 		}
-		yyh3571.End()
+		if yyj3571 < len(yyv3571) {
+			yyv3571 = yyv3571[:yyj3571]
+			yyc3571 = true
+		} else if yyj3571 == 0 && yyv3571 == nil {
+			yyv3571 = []ReplicationController{}
+			yyc3571 = true
+		}
 	}
+	yyh3571.End()
 	if yyc3571 {
 		*v = yyv3571
 	}
-
 }
 
 func (x codecSelfer1234) encSliceLoadBalancerIngress(v []LoadBalancerIngress, e *codec1978.Encoder) {
@@ -41734,10 +44871,11 @@ func (x codecSelfer1234) encSliceLoadBalancerIngress(v []LoadBalancerIngress, e 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3575 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3576 := &yyv3575
 		yy3576.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d *codec1978.Decoder) {
@@ -41747,39 +44885,44 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 
 	yyv3577 := *v
 	yyh3577, yyl3577 := z.DecSliceHelperStart()
-
-	var yyrr3577, yyrl3577 int
-	var yyc3577, yyrt3577 bool
-	_, _, _ = yyc3577, yyrt3577, yyrl3577
-	yyrr3577 = yyl3577
-
-	if yyv3577 == nil {
-		if yyrl3577, yyrt3577 = z.DecInferLen(yyl3577, z.DecBasicHandle().MaxInitLen, 32); yyrt3577 {
-			yyrr3577 = yyrl3577
-		}
-		yyv3577 = make([]LoadBalancerIngress, yyrl3577)
-		yyc3577 = true
-	}
-
+	var yyc3577 bool
 	if yyl3577 == 0 {
-		if len(yyv3577) != 0 {
+		if yyv3577 == nil {
+			yyv3577 = []LoadBalancerIngress{}
+			yyc3577 = true
+		} else if len(yyv3577) != 0 {
 			yyv3577 = yyv3577[:0]
 			yyc3577 = true
 		}
 	} else if yyl3577 > 0 {
-
+		var yyrr3577, yyrl3577 int
+		var yyrt3577 bool
 		if yyl3577 > cap(yyv3577) {
-			yyrl3577, yyrt3577 = z.DecInferLen(yyl3577, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3577 = make([]LoadBalancerIngress, yyrl3577)
-			yyc3577 = true
 
+			yyrg3577 := len(yyv3577) > 0
+			yyv23577 := yyv3577
+			yyrl3577, yyrt3577 = z.DecInferLen(yyl3577, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt3577 {
+				if yyrl3577 <= cap(yyv3577) {
+					yyv3577 = yyv3577[:yyrl3577]
+				} else {
+					yyv3577 = make([]LoadBalancerIngress, yyrl3577)
+				}
+			} else {
+				yyv3577 = make([]LoadBalancerIngress, yyrl3577)
+			}
+			yyc3577 = true
 			yyrr3577 = len(yyv3577)
+			if yyrg3577 {
+				copy(yyv3577, yyv23577)
+			}
 		} else if yyl3577 != len(yyv3577) {
 			yyv3577 = yyv3577[:yyl3577]
 			yyc3577 = true
 		}
 		yyj3577 := 0
 		for ; yyj3577 < yyrr3577; yyj3577++ {
+			yyh3577.ElemContainerState(yyj3577)
 			if r.TryDecodeAsNil() {
 				yyv3577[yyj3577] = LoadBalancerIngress{}
 			} else {
@@ -41791,6 +44934,7 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 		if yyrt3577 {
 			for ; yyj3577 < yyl3577; yyj3577++ {
 				yyv3577 = append(yyv3577, LoadBalancerIngress{})
+				yyh3577.ElemContainerState(yyj3577)
 				if r.TryDecodeAsNil() {
 					yyv3577[yyj3577] = LoadBalancerIngress{}
 				} else {
@@ -41802,12 +44946,14 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 		}
 
 	} else {
-		for yyj3577 := 0; !r.CheckBreak(); yyj3577++ {
+		yyj3577 := 0
+		for ; !r.CheckBreak(); yyj3577++ {
+
 			if yyj3577 >= len(yyv3577) {
 				yyv3577 = append(yyv3577, LoadBalancerIngress{}) // var yyz3577 LoadBalancerIngress
 				yyc3577 = true
 			}
-
+			yyh3577.ElemContainerState(yyj3577)
 			if yyj3577 < len(yyv3577) {
 				if r.TryDecodeAsNil() {
 					yyv3577[yyj3577] = LoadBalancerIngress{}
@@ -41821,12 +44967,18 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 			}
 
 		}
-		yyh3577.End()
+		if yyj3577 < len(yyv3577) {
+			yyv3577 = yyv3577[:yyj3577]
+			yyc3577 = true
+		} else if yyj3577 == 0 && yyv3577 == nil {
+			yyv3577 = []LoadBalancerIngress{}
+			yyc3577 = true
+		}
 	}
+	yyh3577.End()
 	if yyc3577 {
 		*v = yyv3577
 	}
-
 }
 
 func (x codecSelfer1234) encSliceServicePort(v []ServicePort, e *codec1978.Encoder) {
@@ -41835,10 +44987,11 @@ func (x codecSelfer1234) encSliceServicePort(v []ServicePort, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3581 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3582 := &yyv3581
 		yy3582.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Decoder) {
@@ -41848,39 +45001,44 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 
 	yyv3583 := *v
 	yyh3583, yyl3583 := z.DecSliceHelperStart()
-
-	var yyrr3583, yyrl3583 int
-	var yyc3583, yyrt3583 bool
-	_, _, _ = yyc3583, yyrt3583, yyrl3583
-	yyrr3583 = yyl3583
-
-	if yyv3583 == nil {
-		if yyrl3583, yyrt3583 = z.DecInferLen(yyl3583, z.DecBasicHandle().MaxInitLen, 80); yyrt3583 {
-			yyrr3583 = yyrl3583
-		}
-		yyv3583 = make([]ServicePort, yyrl3583)
-		yyc3583 = true
-	}
-
+	var yyc3583 bool
 	if yyl3583 == 0 {
-		if len(yyv3583) != 0 {
+		if yyv3583 == nil {
+			yyv3583 = []ServicePort{}
+			yyc3583 = true
+		} else if len(yyv3583) != 0 {
 			yyv3583 = yyv3583[:0]
 			yyc3583 = true
 		}
 	} else if yyl3583 > 0 {
-
+		var yyrr3583, yyrl3583 int
+		var yyrt3583 bool
 		if yyl3583 > cap(yyv3583) {
-			yyrl3583, yyrt3583 = z.DecInferLen(yyl3583, z.DecBasicHandle().MaxInitLen, 80)
-			yyv3583 = make([]ServicePort, yyrl3583)
-			yyc3583 = true
 
+			yyrg3583 := len(yyv3583) > 0
+			yyv23583 := yyv3583
+			yyrl3583, yyrt3583 = z.DecInferLen(yyl3583, z.DecBasicHandle().MaxInitLen, 80)
+			if yyrt3583 {
+				if yyrl3583 <= cap(yyv3583) {
+					yyv3583 = yyv3583[:yyrl3583]
+				} else {
+					yyv3583 = make([]ServicePort, yyrl3583)
+				}
+			} else {
+				yyv3583 = make([]ServicePort, yyrl3583)
+			}
+			yyc3583 = true
 			yyrr3583 = len(yyv3583)
+			if yyrg3583 {
+				copy(yyv3583, yyv23583)
+			}
 		} else if yyl3583 != len(yyv3583) {
 			yyv3583 = yyv3583[:yyl3583]
 			yyc3583 = true
 		}
 		yyj3583 := 0
 		for ; yyj3583 < yyrr3583; yyj3583++ {
+			yyh3583.ElemContainerState(yyj3583)
 			if r.TryDecodeAsNil() {
 				yyv3583[yyj3583] = ServicePort{}
 			} else {
@@ -41892,6 +45050,7 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 		if yyrt3583 {
 			for ; yyj3583 < yyl3583; yyj3583++ {
 				yyv3583 = append(yyv3583, ServicePort{})
+				yyh3583.ElemContainerState(yyj3583)
 				if r.TryDecodeAsNil() {
 					yyv3583[yyj3583] = ServicePort{}
 				} else {
@@ -41903,12 +45062,14 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj3583 := 0; !r.CheckBreak(); yyj3583++ {
+		yyj3583 := 0
+		for ; !r.CheckBreak(); yyj3583++ {
+
 			if yyj3583 >= len(yyv3583) {
 				yyv3583 = append(yyv3583, ServicePort{}) // var yyz3583 ServicePort
 				yyc3583 = true
 			}
-
+			yyh3583.ElemContainerState(yyj3583)
 			if yyj3583 < len(yyv3583) {
 				if r.TryDecodeAsNil() {
 					yyv3583[yyj3583] = ServicePort{}
@@ -41922,12 +45083,18 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 			}
 
 		}
-		yyh3583.End()
+		if yyj3583 < len(yyv3583) {
+			yyv3583 = yyv3583[:yyj3583]
+			yyc3583 = true
+		} else if yyj3583 == 0 && yyv3583 == nil {
+			yyv3583 = []ServicePort{}
+			yyc3583 = true
+		}
 	}
+	yyh3583.End()
 	if yyc3583 {
 		*v = yyv3583
 	}
-
 }
 
 func (x codecSelfer1234) encSliceService(v []Service, e *codec1978.Encoder) {
@@ -41936,10 +45103,11 @@ func (x codecSelfer1234) encSliceService(v []Service, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3587 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3588 := &yyv3587
 		yy3588.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
@@ -41949,39 +45117,44 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 
 	yyv3589 := *v
 	yyh3589, yyl3589 := z.DecSliceHelperStart()
-
-	var yyrr3589, yyrl3589 int
-	var yyc3589, yyrt3589 bool
-	_, _, _ = yyc3589, yyrt3589, yyrl3589
-	yyrr3589 = yyl3589
-
-	if yyv3589 == nil {
-		if yyrl3589, yyrt3589 = z.DecInferLen(yyl3589, z.DecBasicHandle().MaxInitLen, 360); yyrt3589 {
-			yyrr3589 = yyrl3589
-		}
-		yyv3589 = make([]Service, yyrl3589)
-		yyc3589 = true
-	}
-
+	var yyc3589 bool
 	if yyl3589 == 0 {
-		if len(yyv3589) != 0 {
+		if yyv3589 == nil {
+			yyv3589 = []Service{}
+			yyc3589 = true
+		} else if len(yyv3589) != 0 {
 			yyv3589 = yyv3589[:0]
 			yyc3589 = true
 		}
 	} else if yyl3589 > 0 {
-
+		var yyrr3589, yyrl3589 int
+		var yyrt3589 bool
 		if yyl3589 > cap(yyv3589) {
-			yyrl3589, yyrt3589 = z.DecInferLen(yyl3589, z.DecBasicHandle().MaxInitLen, 360)
-			yyv3589 = make([]Service, yyrl3589)
-			yyc3589 = true
 
+			yyrg3589 := len(yyv3589) > 0
+			yyv23589 := yyv3589
+			yyrl3589, yyrt3589 = z.DecInferLen(yyl3589, z.DecBasicHandle().MaxInitLen, 360)
+			if yyrt3589 {
+				if yyrl3589 <= cap(yyv3589) {
+					yyv3589 = yyv3589[:yyrl3589]
+				} else {
+					yyv3589 = make([]Service, yyrl3589)
+				}
+			} else {
+				yyv3589 = make([]Service, yyrl3589)
+			}
+			yyc3589 = true
 			yyrr3589 = len(yyv3589)
+			if yyrg3589 {
+				copy(yyv3589, yyv23589)
+			}
 		} else if yyl3589 != len(yyv3589) {
 			yyv3589 = yyv3589[:yyl3589]
 			yyc3589 = true
 		}
 		yyj3589 := 0
 		for ; yyj3589 < yyrr3589; yyj3589++ {
+			yyh3589.ElemContainerState(yyj3589)
 			if r.TryDecodeAsNil() {
 				yyv3589[yyj3589] = Service{}
 			} else {
@@ -41993,6 +45166,7 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 		if yyrt3589 {
 			for ; yyj3589 < yyl3589; yyj3589++ {
 				yyv3589 = append(yyv3589, Service{})
+				yyh3589.ElemContainerState(yyj3589)
 				if r.TryDecodeAsNil() {
 					yyv3589[yyj3589] = Service{}
 				} else {
@@ -42004,12 +45178,14 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3589 := 0; !r.CheckBreak(); yyj3589++ {
+		yyj3589 := 0
+		for ; !r.CheckBreak(); yyj3589++ {
+
 			if yyj3589 >= len(yyv3589) {
 				yyv3589 = append(yyv3589, Service{}) // var yyz3589 Service
 				yyc3589 = true
 			}
-
+			yyh3589.ElemContainerState(yyj3589)
 			if yyj3589 < len(yyv3589) {
 				if r.TryDecodeAsNil() {
 					yyv3589[yyj3589] = Service{}
@@ -42023,12 +45199,18 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3589.End()
+		if yyj3589 < len(yyv3589) {
+			yyv3589 = yyv3589[:yyj3589]
+			yyc3589 = true
+		} else if yyj3589 == 0 && yyv3589 == nil {
+			yyv3589 = []Service{}
+			yyc3589 = true
+		}
 	}
+	yyh3589.End()
 	if yyc3589 {
 		*v = yyv3589
 	}
-
 }
 
 func (x codecSelfer1234) encSliceObjectReference(v []ObjectReference, e *codec1978.Encoder) {
@@ -42037,10 +45219,11 @@ func (x codecSelfer1234) encSliceObjectReference(v []ObjectReference, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3593 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3594 := &yyv3593
 		yy3594.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1978.Decoder) {
@@ -42050,39 +45233,44 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 
 	yyv3595 := *v
 	yyh3595, yyl3595 := z.DecSliceHelperStart()
-
-	var yyrr3595, yyrl3595 int
-	var yyc3595, yyrt3595 bool
-	_, _, _ = yyc3595, yyrt3595, yyrl3595
-	yyrr3595 = yyl3595
-
-	if yyv3595 == nil {
-		if yyrl3595, yyrt3595 = z.DecInferLen(yyl3595, z.DecBasicHandle().MaxInitLen, 112); yyrt3595 {
-			yyrr3595 = yyrl3595
-		}
-		yyv3595 = make([]ObjectReference, yyrl3595)
-		yyc3595 = true
-	}
-
+	var yyc3595 bool
 	if yyl3595 == 0 {
-		if len(yyv3595) != 0 {
+		if yyv3595 == nil {
+			yyv3595 = []ObjectReference{}
+			yyc3595 = true
+		} else if len(yyv3595) != 0 {
 			yyv3595 = yyv3595[:0]
 			yyc3595 = true
 		}
 	} else if yyl3595 > 0 {
-
+		var yyrr3595, yyrl3595 int
+		var yyrt3595 bool
 		if yyl3595 > cap(yyv3595) {
-			yyrl3595, yyrt3595 = z.DecInferLen(yyl3595, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3595 = make([]ObjectReference, yyrl3595)
-			yyc3595 = true
 
+			yyrg3595 := len(yyv3595) > 0
+			yyv23595 := yyv3595
+			yyrl3595, yyrt3595 = z.DecInferLen(yyl3595, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt3595 {
+				if yyrl3595 <= cap(yyv3595) {
+					yyv3595 = yyv3595[:yyrl3595]
+				} else {
+					yyv3595 = make([]ObjectReference, yyrl3595)
+				}
+			} else {
+				yyv3595 = make([]ObjectReference, yyrl3595)
+			}
+			yyc3595 = true
 			yyrr3595 = len(yyv3595)
+			if yyrg3595 {
+				copy(yyv3595, yyv23595)
+			}
 		} else if yyl3595 != len(yyv3595) {
 			yyv3595 = yyv3595[:yyl3595]
 			yyc3595 = true
 		}
 		yyj3595 := 0
 		for ; yyj3595 < yyrr3595; yyj3595++ {
+			yyh3595.ElemContainerState(yyj3595)
 			if r.TryDecodeAsNil() {
 				yyv3595[yyj3595] = ObjectReference{}
 			} else {
@@ -42094,6 +45282,7 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 		if yyrt3595 {
 			for ; yyj3595 < yyl3595; yyj3595++ {
 				yyv3595 = append(yyv3595, ObjectReference{})
+				yyh3595.ElemContainerState(yyj3595)
 				if r.TryDecodeAsNil() {
 					yyv3595[yyj3595] = ObjectReference{}
 				} else {
@@ -42105,12 +45294,14 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 		}
 
 	} else {
-		for yyj3595 := 0; !r.CheckBreak(); yyj3595++ {
+		yyj3595 := 0
+		for ; !r.CheckBreak(); yyj3595++ {
+
 			if yyj3595 >= len(yyv3595) {
 				yyv3595 = append(yyv3595, ObjectReference{}) // var yyz3595 ObjectReference
 				yyc3595 = true
 			}
-
+			yyh3595.ElemContainerState(yyj3595)
 			if yyj3595 < len(yyv3595) {
 				if r.TryDecodeAsNil() {
 					yyv3595[yyj3595] = ObjectReference{}
@@ -42124,12 +45315,18 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 			}
 
 		}
-		yyh3595.End()
+		if yyj3595 < len(yyv3595) {
+			yyv3595 = yyv3595[:yyj3595]
+			yyc3595 = true
+		} else if yyj3595 == 0 && yyv3595 == nil {
+			yyv3595 = []ObjectReference{}
+			yyc3595 = true
+		}
 	}
+	yyh3595.End()
 	if yyc3595 {
 		*v = yyv3595
 	}
-
 }
 
 func (x codecSelfer1234) encSliceServiceAccount(v []ServiceAccount, e *codec1978.Encoder) {
@@ -42138,10 +45335,11 @@ func (x codecSelfer1234) encSliceServiceAccount(v []ServiceAccount, e *codec1978
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3599 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3600 := &yyv3599
 		yy3600.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec1978.Decoder) {
@@ -42151,39 +45349,44 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 
 	yyv3601 := *v
 	yyh3601, yyl3601 := z.DecSliceHelperStart()
-
-	var yyrr3601, yyrl3601 int
-	var yyc3601, yyrt3601 bool
-	_, _, _ = yyc3601, yyrt3601, yyrl3601
-	yyrr3601 = yyl3601
-
-	if yyv3601 == nil {
-		if yyrl3601, yyrt3601 = z.DecInferLen(yyl3601, z.DecBasicHandle().MaxInitLen, 240); yyrt3601 {
-			yyrr3601 = yyrl3601
-		}
-		yyv3601 = make([]ServiceAccount, yyrl3601)
-		yyc3601 = true
-	}
-
+	var yyc3601 bool
 	if yyl3601 == 0 {
-		if len(yyv3601) != 0 {
+		if yyv3601 == nil {
+			yyv3601 = []ServiceAccount{}
+			yyc3601 = true
+		} else if len(yyv3601) != 0 {
 			yyv3601 = yyv3601[:0]
 			yyc3601 = true
 		}
 	} else if yyl3601 > 0 {
-
+		var yyrr3601, yyrl3601 int
+		var yyrt3601 bool
 		if yyl3601 > cap(yyv3601) {
-			yyrl3601, yyrt3601 = z.DecInferLen(yyl3601, z.DecBasicHandle().MaxInitLen, 240)
-			yyv3601 = make([]ServiceAccount, yyrl3601)
-			yyc3601 = true
 
+			yyrg3601 := len(yyv3601) > 0
+			yyv23601 := yyv3601
+			yyrl3601, yyrt3601 = z.DecInferLen(yyl3601, z.DecBasicHandle().MaxInitLen, 240)
+			if yyrt3601 {
+				if yyrl3601 <= cap(yyv3601) {
+					yyv3601 = yyv3601[:yyrl3601]
+				} else {
+					yyv3601 = make([]ServiceAccount, yyrl3601)
+				}
+			} else {
+				yyv3601 = make([]ServiceAccount, yyrl3601)
+			}
+			yyc3601 = true
 			yyrr3601 = len(yyv3601)
+			if yyrg3601 {
+				copy(yyv3601, yyv23601)
+			}
 		} else if yyl3601 != len(yyv3601) {
 			yyv3601 = yyv3601[:yyl3601]
 			yyc3601 = true
 		}
 		yyj3601 := 0
 		for ; yyj3601 < yyrr3601; yyj3601++ {
+			yyh3601.ElemContainerState(yyj3601)
 			if r.TryDecodeAsNil() {
 				yyv3601[yyj3601] = ServiceAccount{}
 			} else {
@@ -42195,6 +45398,7 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 		if yyrt3601 {
 			for ; yyj3601 < yyl3601; yyj3601++ {
 				yyv3601 = append(yyv3601, ServiceAccount{})
+				yyh3601.ElemContainerState(yyj3601)
 				if r.TryDecodeAsNil() {
 					yyv3601[yyj3601] = ServiceAccount{}
 				} else {
@@ -42206,12 +45410,14 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 		}
 
 	} else {
-		for yyj3601 := 0; !r.CheckBreak(); yyj3601++ {
+		yyj3601 := 0
+		for ; !r.CheckBreak(); yyj3601++ {
+
 			if yyj3601 >= len(yyv3601) {
 				yyv3601 = append(yyv3601, ServiceAccount{}) // var yyz3601 ServiceAccount
 				yyc3601 = true
 			}
-
+			yyh3601.ElemContainerState(yyj3601)
 			if yyj3601 < len(yyv3601) {
 				if r.TryDecodeAsNil() {
 					yyv3601[yyj3601] = ServiceAccount{}
@@ -42225,12 +45431,18 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 			}
 
 		}
-		yyh3601.End()
+		if yyj3601 < len(yyv3601) {
+			yyv3601 = yyv3601[:yyj3601]
+			yyc3601 = true
+		} else if yyj3601 == 0 && yyv3601 == nil {
+			yyv3601 = []ServiceAccount{}
+			yyc3601 = true
+		}
 	}
+	yyh3601.End()
 	if yyc3601 {
 		*v = yyv3601
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEndpointSubset(v []EndpointSubset, e *codec1978.Encoder) {
@@ -42239,10 +45451,11 @@ func (x codecSelfer1234) encSliceEndpointSubset(v []EndpointSubset, e *codec1978
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3605 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3606 := &yyv3605
 		yy3606.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec1978.Decoder) {
@@ -42252,39 +45465,44 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 
 	yyv3607 := *v
 	yyh3607, yyl3607 := z.DecSliceHelperStart()
-
-	var yyrr3607, yyrl3607 int
-	var yyc3607, yyrt3607 bool
-	_, _, _ = yyc3607, yyrt3607, yyrl3607
-	yyrr3607 = yyl3607
-
-	if yyv3607 == nil {
-		if yyrl3607, yyrt3607 = z.DecInferLen(yyl3607, z.DecBasicHandle().MaxInitLen, 72); yyrt3607 {
-			yyrr3607 = yyrl3607
-		}
-		yyv3607 = make([]EndpointSubset, yyrl3607)
-		yyc3607 = true
-	}
-
+	var yyc3607 bool
 	if yyl3607 == 0 {
-		if len(yyv3607) != 0 {
+		if yyv3607 == nil {
+			yyv3607 = []EndpointSubset{}
+			yyc3607 = true
+		} else if len(yyv3607) != 0 {
 			yyv3607 = yyv3607[:0]
 			yyc3607 = true
 		}
 	} else if yyl3607 > 0 {
-
+		var yyrr3607, yyrl3607 int
+		var yyrt3607 bool
 		if yyl3607 > cap(yyv3607) {
-			yyrl3607, yyrt3607 = z.DecInferLen(yyl3607, z.DecBasicHandle().MaxInitLen, 72)
-			yyv3607 = make([]EndpointSubset, yyrl3607)
-			yyc3607 = true
 
+			yyrg3607 := len(yyv3607) > 0
+			yyv23607 := yyv3607
+			yyrl3607, yyrt3607 = z.DecInferLen(yyl3607, z.DecBasicHandle().MaxInitLen, 72)
+			if yyrt3607 {
+				if yyrl3607 <= cap(yyv3607) {
+					yyv3607 = yyv3607[:yyrl3607]
+				} else {
+					yyv3607 = make([]EndpointSubset, yyrl3607)
+				}
+			} else {
+				yyv3607 = make([]EndpointSubset, yyrl3607)
+			}
+			yyc3607 = true
 			yyrr3607 = len(yyv3607)
+			if yyrg3607 {
+				copy(yyv3607, yyv23607)
+			}
 		} else if yyl3607 != len(yyv3607) {
 			yyv3607 = yyv3607[:yyl3607]
 			yyc3607 = true
 		}
 		yyj3607 := 0
 		for ; yyj3607 < yyrr3607; yyj3607++ {
+			yyh3607.ElemContainerState(yyj3607)
 			if r.TryDecodeAsNil() {
 				yyv3607[yyj3607] = EndpointSubset{}
 			} else {
@@ -42296,6 +45514,7 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 		if yyrt3607 {
 			for ; yyj3607 < yyl3607; yyj3607++ {
 				yyv3607 = append(yyv3607, EndpointSubset{})
+				yyh3607.ElemContainerState(yyj3607)
 				if r.TryDecodeAsNil() {
 					yyv3607[yyj3607] = EndpointSubset{}
 				} else {
@@ -42307,12 +45526,14 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 		}
 
 	} else {
-		for yyj3607 := 0; !r.CheckBreak(); yyj3607++ {
+		yyj3607 := 0
+		for ; !r.CheckBreak(); yyj3607++ {
+
 			if yyj3607 >= len(yyv3607) {
 				yyv3607 = append(yyv3607, EndpointSubset{}) // var yyz3607 EndpointSubset
 				yyc3607 = true
 			}
-
+			yyh3607.ElemContainerState(yyj3607)
 			if yyj3607 < len(yyv3607) {
 				if r.TryDecodeAsNil() {
 					yyv3607[yyj3607] = EndpointSubset{}
@@ -42326,12 +45547,18 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 			}
 
 		}
-		yyh3607.End()
+		if yyj3607 < len(yyv3607) {
+			yyv3607 = yyv3607[:yyj3607]
+			yyc3607 = true
+		} else if yyj3607 == 0 && yyv3607 == nil {
+			yyv3607 = []EndpointSubset{}
+			yyc3607 = true
+		}
 	}
+	yyh3607.End()
 	if yyc3607 {
 		*v = yyv3607
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEndpointAddress(v []EndpointAddress, e *codec1978.Encoder) {
@@ -42340,10 +45567,11 @@ func (x codecSelfer1234) encSliceEndpointAddress(v []EndpointAddress, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3611 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3612 := &yyv3611
 		yy3612.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1978.Decoder) {
@@ -42353,39 +45581,44 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 
 	yyv3613 := *v
 	yyh3613, yyl3613 := z.DecSliceHelperStart()
-
-	var yyrr3613, yyrl3613 int
-	var yyc3613, yyrt3613 bool
-	_, _, _ = yyc3613, yyrt3613, yyrl3613
-	yyrr3613 = yyl3613
-
-	if yyv3613 == nil {
-		if yyrl3613, yyrt3613 = z.DecInferLen(yyl3613, z.DecBasicHandle().MaxInitLen, 24); yyrt3613 {
-			yyrr3613 = yyrl3613
-		}
-		yyv3613 = make([]EndpointAddress, yyrl3613)
-		yyc3613 = true
-	}
-
+	var yyc3613 bool
 	if yyl3613 == 0 {
-		if len(yyv3613) != 0 {
+		if yyv3613 == nil {
+			yyv3613 = []EndpointAddress{}
+			yyc3613 = true
+		} else if len(yyv3613) != 0 {
 			yyv3613 = yyv3613[:0]
 			yyc3613 = true
 		}
 	} else if yyl3613 > 0 {
-
+		var yyrr3613, yyrl3613 int
+		var yyrt3613 bool
 		if yyl3613 > cap(yyv3613) {
-			yyrl3613, yyrt3613 = z.DecInferLen(yyl3613, z.DecBasicHandle().MaxInitLen, 24)
-			yyv3613 = make([]EndpointAddress, yyrl3613)
-			yyc3613 = true
 
+			yyrg3613 := len(yyv3613) > 0
+			yyv23613 := yyv3613
+			yyrl3613, yyrt3613 = z.DecInferLen(yyl3613, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt3613 {
+				if yyrl3613 <= cap(yyv3613) {
+					yyv3613 = yyv3613[:yyrl3613]
+				} else {
+					yyv3613 = make([]EndpointAddress, yyrl3613)
+				}
+			} else {
+				yyv3613 = make([]EndpointAddress, yyrl3613)
+			}
+			yyc3613 = true
 			yyrr3613 = len(yyv3613)
+			if yyrg3613 {
+				copy(yyv3613, yyv23613)
+			}
 		} else if yyl3613 != len(yyv3613) {
 			yyv3613 = yyv3613[:yyl3613]
 			yyc3613 = true
 		}
 		yyj3613 := 0
 		for ; yyj3613 < yyrr3613; yyj3613++ {
+			yyh3613.ElemContainerState(yyj3613)
 			if r.TryDecodeAsNil() {
 				yyv3613[yyj3613] = EndpointAddress{}
 			} else {
@@ -42397,6 +45630,7 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 		if yyrt3613 {
 			for ; yyj3613 < yyl3613; yyj3613++ {
 				yyv3613 = append(yyv3613, EndpointAddress{})
+				yyh3613.ElemContainerState(yyj3613)
 				if r.TryDecodeAsNil() {
 					yyv3613[yyj3613] = EndpointAddress{}
 				} else {
@@ -42408,12 +45642,14 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 		}
 
 	} else {
-		for yyj3613 := 0; !r.CheckBreak(); yyj3613++ {
+		yyj3613 := 0
+		for ; !r.CheckBreak(); yyj3613++ {
+
 			if yyj3613 >= len(yyv3613) {
 				yyv3613 = append(yyv3613, EndpointAddress{}) // var yyz3613 EndpointAddress
 				yyc3613 = true
 			}
-
+			yyh3613.ElemContainerState(yyj3613)
 			if yyj3613 < len(yyv3613) {
 				if r.TryDecodeAsNil() {
 					yyv3613[yyj3613] = EndpointAddress{}
@@ -42427,12 +45663,18 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 			}
 
 		}
-		yyh3613.End()
+		if yyj3613 < len(yyv3613) {
+			yyv3613 = yyv3613[:yyj3613]
+			yyc3613 = true
+		} else if yyj3613 == 0 && yyv3613 == nil {
+			yyv3613 = []EndpointAddress{}
+			yyc3613 = true
+		}
 	}
+	yyh3613.End()
 	if yyc3613 {
 		*v = yyv3613
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEndpointPort(v []EndpointPort, e *codec1978.Encoder) {
@@ -42441,10 +45683,11 @@ func (x codecSelfer1234) encSliceEndpointPort(v []EndpointPort, e *codec1978.Enc
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3617 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3618 := &yyv3617
 		yy3618.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.Decoder) {
@@ -42454,39 +45697,44 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 
 	yyv3619 := *v
 	yyh3619, yyl3619 := z.DecSliceHelperStart()
-
-	var yyrr3619, yyrl3619 int
-	var yyc3619, yyrt3619 bool
-	_, _, _ = yyc3619, yyrt3619, yyrl3619
-	yyrr3619 = yyl3619
-
-	if yyv3619 == nil {
-		if yyrl3619, yyrt3619 = z.DecInferLen(yyl3619, z.DecBasicHandle().MaxInitLen, 40); yyrt3619 {
-			yyrr3619 = yyrl3619
-		}
-		yyv3619 = make([]EndpointPort, yyrl3619)
-		yyc3619 = true
-	}
-
+	var yyc3619 bool
 	if yyl3619 == 0 {
-		if len(yyv3619) != 0 {
+		if yyv3619 == nil {
+			yyv3619 = []EndpointPort{}
+			yyc3619 = true
+		} else if len(yyv3619) != 0 {
 			yyv3619 = yyv3619[:0]
 			yyc3619 = true
 		}
 	} else if yyl3619 > 0 {
-
+		var yyrr3619, yyrl3619 int
+		var yyrt3619 bool
 		if yyl3619 > cap(yyv3619) {
-			yyrl3619, yyrt3619 = z.DecInferLen(yyl3619, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3619 = make([]EndpointPort, yyrl3619)
-			yyc3619 = true
 
+			yyrg3619 := len(yyv3619) > 0
+			yyv23619 := yyv3619
+			yyrl3619, yyrt3619 = z.DecInferLen(yyl3619, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt3619 {
+				if yyrl3619 <= cap(yyv3619) {
+					yyv3619 = yyv3619[:yyrl3619]
+				} else {
+					yyv3619 = make([]EndpointPort, yyrl3619)
+				}
+			} else {
+				yyv3619 = make([]EndpointPort, yyrl3619)
+			}
+			yyc3619 = true
 			yyrr3619 = len(yyv3619)
+			if yyrg3619 {
+				copy(yyv3619, yyv23619)
+			}
 		} else if yyl3619 != len(yyv3619) {
 			yyv3619 = yyv3619[:yyl3619]
 			yyc3619 = true
 		}
 		yyj3619 := 0
 		for ; yyj3619 < yyrr3619; yyj3619++ {
+			yyh3619.ElemContainerState(yyj3619)
 			if r.TryDecodeAsNil() {
 				yyv3619[yyj3619] = EndpointPort{}
 			} else {
@@ -42498,6 +45746,7 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 		if yyrt3619 {
 			for ; yyj3619 < yyl3619; yyj3619++ {
 				yyv3619 = append(yyv3619, EndpointPort{})
+				yyh3619.ElemContainerState(yyj3619)
 				if r.TryDecodeAsNil() {
 					yyv3619[yyj3619] = EndpointPort{}
 				} else {
@@ -42509,12 +45758,14 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 		}
 
 	} else {
-		for yyj3619 := 0; !r.CheckBreak(); yyj3619++ {
+		yyj3619 := 0
+		for ; !r.CheckBreak(); yyj3619++ {
+
 			if yyj3619 >= len(yyv3619) {
 				yyv3619 = append(yyv3619, EndpointPort{}) // var yyz3619 EndpointPort
 				yyc3619 = true
 			}
-
+			yyh3619.ElemContainerState(yyj3619)
 			if yyj3619 < len(yyv3619) {
 				if r.TryDecodeAsNil() {
 					yyv3619[yyj3619] = EndpointPort{}
@@ -42528,12 +45779,18 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 			}
 
 		}
-		yyh3619.End()
+		if yyj3619 < len(yyv3619) {
+			yyv3619 = yyv3619[:yyj3619]
+			yyc3619 = true
+		} else if yyj3619 == 0 && yyv3619 == nil {
+			yyv3619 = []EndpointPort{}
+			yyc3619 = true
+		}
 	}
+	yyh3619.End()
 	if yyc3619 {
 		*v = yyv3619
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEndpoints(v []Endpoints, e *codec1978.Encoder) {
@@ -42542,10 +45799,11 @@ func (x codecSelfer1234) encSliceEndpoints(v []Endpoints, e *codec1978.Encoder) 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3623 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3624 := &yyv3623
 		yy3624.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder) {
@@ -42555,39 +45813,44 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 
 	yyv3625 := *v
 	yyh3625, yyl3625 := z.DecSliceHelperStart()
-
-	var yyrr3625, yyrl3625 int
-	var yyc3625, yyrt3625 bool
-	_, _, _ = yyc3625, yyrt3625, yyrl3625
-	yyrr3625 = yyl3625
-
-	if yyv3625 == nil {
-		if yyrl3625, yyrt3625 = z.DecInferLen(yyl3625, z.DecBasicHandle().MaxInitLen, 216); yyrt3625 {
-			yyrr3625 = yyrl3625
-		}
-		yyv3625 = make([]Endpoints, yyrl3625)
-		yyc3625 = true
-	}
-
+	var yyc3625 bool
 	if yyl3625 == 0 {
-		if len(yyv3625) != 0 {
+		if yyv3625 == nil {
+			yyv3625 = []Endpoints{}
+			yyc3625 = true
+		} else if len(yyv3625) != 0 {
 			yyv3625 = yyv3625[:0]
 			yyc3625 = true
 		}
 	} else if yyl3625 > 0 {
-
+		var yyrr3625, yyrl3625 int
+		var yyrt3625 bool
 		if yyl3625 > cap(yyv3625) {
-			yyrl3625, yyrt3625 = z.DecInferLen(yyl3625, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3625 = make([]Endpoints, yyrl3625)
-			yyc3625 = true
 
+			yyrg3625 := len(yyv3625) > 0
+			yyv23625 := yyv3625
+			yyrl3625, yyrt3625 = z.DecInferLen(yyl3625, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3625 {
+				if yyrl3625 <= cap(yyv3625) {
+					yyv3625 = yyv3625[:yyrl3625]
+				} else {
+					yyv3625 = make([]Endpoints, yyrl3625)
+				}
+			} else {
+				yyv3625 = make([]Endpoints, yyrl3625)
+			}
+			yyc3625 = true
 			yyrr3625 = len(yyv3625)
+			if yyrg3625 {
+				copy(yyv3625, yyv23625)
+			}
 		} else if yyl3625 != len(yyv3625) {
 			yyv3625 = yyv3625[:yyl3625]
 			yyc3625 = true
 		}
 		yyj3625 := 0
 		for ; yyj3625 < yyrr3625; yyj3625++ {
+			yyh3625.ElemContainerState(yyj3625)
 			if r.TryDecodeAsNil() {
 				yyv3625[yyj3625] = Endpoints{}
 			} else {
@@ -42599,6 +45862,7 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 		if yyrt3625 {
 			for ; yyj3625 < yyl3625; yyj3625++ {
 				yyv3625 = append(yyv3625, Endpoints{})
+				yyh3625.ElemContainerState(yyj3625)
 				if r.TryDecodeAsNil() {
 					yyv3625[yyj3625] = Endpoints{}
 				} else {
@@ -42610,12 +45874,14 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 		}
 
 	} else {
-		for yyj3625 := 0; !r.CheckBreak(); yyj3625++ {
+		yyj3625 := 0
+		for ; !r.CheckBreak(); yyj3625++ {
+
 			if yyj3625 >= len(yyv3625) {
 				yyv3625 = append(yyv3625, Endpoints{}) // var yyz3625 Endpoints
 				yyc3625 = true
 			}
-
+			yyh3625.ElemContainerState(yyj3625)
 			if yyj3625 < len(yyv3625) {
 				if r.TryDecodeAsNil() {
 					yyv3625[yyj3625] = Endpoints{}
@@ -42629,12 +45895,18 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3625.End()
+		if yyj3625 < len(yyv3625) {
+			yyv3625 = yyv3625[:yyj3625]
+			yyc3625 = true
+		} else if yyj3625 == 0 && yyv3625 == nil {
+			yyv3625 = []Endpoints{}
+			yyc3625 = true
+		}
 	}
+	yyh3625.End()
 	if yyc3625 {
 		*v = yyv3625
 	}
-
 }
 
 func (x codecSelfer1234) encSliceNodeCondition(v []NodeCondition, e *codec1978.Encoder) {
@@ -42643,10 +45915,11 @@ func (x codecSelfer1234) encSliceNodeCondition(v []NodeCondition, e *codec1978.E
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3629 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3630 := &yyv3629
 		yy3630.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.Decoder) {
@@ -42656,39 +45929,44 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 
 	yyv3631 := *v
 	yyh3631, yyl3631 := z.DecSliceHelperStart()
-
-	var yyrr3631, yyrl3631 int
-	var yyc3631, yyrt3631 bool
-	_, _, _ = yyc3631, yyrt3631, yyrl3631
-	yyrr3631 = yyl3631
-
-	if yyv3631 == nil {
-		if yyrl3631, yyrt3631 = z.DecInferLen(yyl3631, z.DecBasicHandle().MaxInitLen, 112); yyrt3631 {
-			yyrr3631 = yyrl3631
-		}
-		yyv3631 = make([]NodeCondition, yyrl3631)
-		yyc3631 = true
-	}
-
+	var yyc3631 bool
 	if yyl3631 == 0 {
-		if len(yyv3631) != 0 {
+		if yyv3631 == nil {
+			yyv3631 = []NodeCondition{}
+			yyc3631 = true
+		} else if len(yyv3631) != 0 {
 			yyv3631 = yyv3631[:0]
 			yyc3631 = true
 		}
 	} else if yyl3631 > 0 {
-
+		var yyrr3631, yyrl3631 int
+		var yyrt3631 bool
 		if yyl3631 > cap(yyv3631) {
-			yyrl3631, yyrt3631 = z.DecInferLen(yyl3631, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3631 = make([]NodeCondition, yyrl3631)
-			yyc3631 = true
 
+			yyrg3631 := len(yyv3631) > 0
+			yyv23631 := yyv3631
+			yyrl3631, yyrt3631 = z.DecInferLen(yyl3631, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt3631 {
+				if yyrl3631 <= cap(yyv3631) {
+					yyv3631 = yyv3631[:yyrl3631]
+				} else {
+					yyv3631 = make([]NodeCondition, yyrl3631)
+				}
+			} else {
+				yyv3631 = make([]NodeCondition, yyrl3631)
+			}
+			yyc3631 = true
 			yyrr3631 = len(yyv3631)
+			if yyrg3631 {
+				copy(yyv3631, yyv23631)
+			}
 		} else if yyl3631 != len(yyv3631) {
 			yyv3631 = yyv3631[:yyl3631]
 			yyc3631 = true
 		}
 		yyj3631 := 0
 		for ; yyj3631 < yyrr3631; yyj3631++ {
+			yyh3631.ElemContainerState(yyj3631)
 			if r.TryDecodeAsNil() {
 				yyv3631[yyj3631] = NodeCondition{}
 			} else {
@@ -42700,6 +45978,7 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 		if yyrt3631 {
 			for ; yyj3631 < yyl3631; yyj3631++ {
 				yyv3631 = append(yyv3631, NodeCondition{})
+				yyh3631.ElemContainerState(yyj3631)
 				if r.TryDecodeAsNil() {
 					yyv3631[yyj3631] = NodeCondition{}
 				} else {
@@ -42711,12 +45990,14 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 		}
 
 	} else {
-		for yyj3631 := 0; !r.CheckBreak(); yyj3631++ {
+		yyj3631 := 0
+		for ; !r.CheckBreak(); yyj3631++ {
+
 			if yyj3631 >= len(yyv3631) {
 				yyv3631 = append(yyv3631, NodeCondition{}) // var yyz3631 NodeCondition
 				yyc3631 = true
 			}
-
+			yyh3631.ElemContainerState(yyj3631)
 			if yyj3631 < len(yyv3631) {
 				if r.TryDecodeAsNil() {
 					yyv3631[yyj3631] = NodeCondition{}
@@ -42730,12 +46011,18 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 			}
 
 		}
-		yyh3631.End()
+		if yyj3631 < len(yyv3631) {
+			yyv3631 = yyv3631[:yyj3631]
+			yyc3631 = true
+		} else if yyj3631 == 0 && yyv3631 == nil {
+			yyv3631 = []NodeCondition{}
+			yyc3631 = true
+		}
 	}
+	yyh3631.End()
 	if yyc3631 {
 		*v = yyv3631
 	}
-
 }
 
 func (x codecSelfer1234) encSliceNodeAddress(v []NodeAddress, e *codec1978.Encoder) {
@@ -42744,10 +46031,11 @@ func (x codecSelfer1234) encSliceNodeAddress(v []NodeAddress, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3635 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3636 := &yyv3635
 		yy3636.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Decoder) {
@@ -42757,39 +46045,44 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 
 	yyv3637 := *v
 	yyh3637, yyl3637 := z.DecSliceHelperStart()
-
-	var yyrr3637, yyrl3637 int
-	var yyc3637, yyrt3637 bool
-	_, _, _ = yyc3637, yyrt3637, yyrl3637
-	yyrr3637 = yyl3637
-
-	if yyv3637 == nil {
-		if yyrl3637, yyrt3637 = z.DecInferLen(yyl3637, z.DecBasicHandle().MaxInitLen, 32); yyrt3637 {
-			yyrr3637 = yyrl3637
-		}
-		yyv3637 = make([]NodeAddress, yyrl3637)
-		yyc3637 = true
-	}
-
+	var yyc3637 bool
 	if yyl3637 == 0 {
-		if len(yyv3637) != 0 {
+		if yyv3637 == nil {
+			yyv3637 = []NodeAddress{}
+			yyc3637 = true
+		} else if len(yyv3637) != 0 {
 			yyv3637 = yyv3637[:0]
 			yyc3637 = true
 		}
 	} else if yyl3637 > 0 {
-
+		var yyrr3637, yyrl3637 int
+		var yyrt3637 bool
 		if yyl3637 > cap(yyv3637) {
-			yyrl3637, yyrt3637 = z.DecInferLen(yyl3637, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3637 = make([]NodeAddress, yyrl3637)
-			yyc3637 = true
 
+			yyrg3637 := len(yyv3637) > 0
+			yyv23637 := yyv3637
+			yyrl3637, yyrt3637 = z.DecInferLen(yyl3637, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt3637 {
+				if yyrl3637 <= cap(yyv3637) {
+					yyv3637 = yyv3637[:yyrl3637]
+				} else {
+					yyv3637 = make([]NodeAddress, yyrl3637)
+				}
+			} else {
+				yyv3637 = make([]NodeAddress, yyrl3637)
+			}
+			yyc3637 = true
 			yyrr3637 = len(yyv3637)
+			if yyrg3637 {
+				copy(yyv3637, yyv23637)
+			}
 		} else if yyl3637 != len(yyv3637) {
 			yyv3637 = yyv3637[:yyl3637]
 			yyc3637 = true
 		}
 		yyj3637 := 0
 		for ; yyj3637 < yyrr3637; yyj3637++ {
+			yyh3637.ElemContainerState(yyj3637)
 			if r.TryDecodeAsNil() {
 				yyv3637[yyj3637] = NodeAddress{}
 			} else {
@@ -42801,6 +46094,7 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 		if yyrt3637 {
 			for ; yyj3637 < yyl3637; yyj3637++ {
 				yyv3637 = append(yyv3637, NodeAddress{})
+				yyh3637.ElemContainerState(yyj3637)
 				if r.TryDecodeAsNil() {
 					yyv3637[yyj3637] = NodeAddress{}
 				} else {
@@ -42812,12 +46106,14 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj3637 := 0; !r.CheckBreak(); yyj3637++ {
+		yyj3637 := 0
+		for ; !r.CheckBreak(); yyj3637++ {
+
 			if yyj3637 >= len(yyv3637) {
 				yyv3637 = append(yyv3637, NodeAddress{}) // var yyz3637 NodeAddress
 				yyc3637 = true
 			}
-
+			yyh3637.ElemContainerState(yyj3637)
 			if yyj3637 < len(yyv3637) {
 				if r.TryDecodeAsNil() {
 					yyv3637[yyj3637] = NodeAddress{}
@@ -42831,12 +46127,18 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 			}
 
 		}
-		yyh3637.End()
+		if yyj3637 < len(yyv3637) {
+			yyv3637 = yyv3637[:yyj3637]
+			yyc3637 = true
+		} else if yyj3637 == 0 && yyv3637 == nil {
+			yyv3637 = []NodeAddress{}
+			yyc3637 = true
+		}
 	}
+	yyh3637.End()
 	if yyc3637 {
 		*v = yyv3637
 	}
-
 }
 
 func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
@@ -42845,7 +46147,9 @@ func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
 	for yyk3641, yyv3641 := range v {
+		z.EncSendContainerState(codecSelfer_containerMapKey1234)
 		yyk3641.CodecEncodeSelf(e)
+		z.EncSendContainerState(codecSelfer_containerMapValue1234)
 		yy3642 := &yyv3641
 		yym3643 := z.EncBinary()
 		_ = yym3643
@@ -42857,7 +46161,7 @@ func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
 			z.EncFallback(yy3642)
 		}
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) {
@@ -42881,6 +46185,7 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 	}
 	if yyl3644 > 0 {
 		for yyj3644 := 0; yyj3644 < yyl3644; yyj3644++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
 				yymk3644 = ""
 			} else {
@@ -42892,6 +46197,7 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 			} else {
 				yymv3644 = pkg3_resource.Quantity{}
 			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
 				yymv3644 = pkg3_resource.Quantity{}
 			} else {
@@ -42913,6 +46219,7 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 		}
 	} else if yyl3644 < 0 {
 		for yyj3644 := 0; !r.CheckBreak(); yyj3644++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
 				yymk3644 = ""
 			} else {
@@ -42924,6 +46231,7 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 			} else {
 				yymv3644 = pkg3_resource.Quantity{}
 			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
 				yymv3644 = pkg3_resource.Quantity{}
 			} else {
@@ -42943,8 +46251,8 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 				yyv3644[yymk3644] = yymv3644
 			}
 		}
-		r.ReadEnd()
 	} // else len==0: TODO: Should we clear map entries?
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x codecSelfer1234) encSliceNode(v []Node, e *codec1978.Encoder) {
@@ -42953,10 +46261,11 @@ func (x codecSelfer1234) encSliceNode(v []Node, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3651 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3652 := &yyv3651
 		yy3652.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
@@ -42966,39 +46275,44 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 
 	yyv3653 := *v
 	yyh3653, yyl3653 := z.DecSliceHelperStart()
-
-	var yyrr3653, yyrl3653 int
-	var yyc3653, yyrt3653 bool
-	_, _, _ = yyc3653, yyrt3653, yyrl3653
-	yyrr3653 = yyl3653
-
-	if yyv3653 == nil {
-		if yyrl3653, yyrt3653 = z.DecInferLen(yyl3653, z.DecBasicHandle().MaxInitLen, 456); yyrt3653 {
-			yyrr3653 = yyrl3653
-		}
-		yyv3653 = make([]Node, yyrl3653)
-		yyc3653 = true
-	}
-
+	var yyc3653 bool
 	if yyl3653 == 0 {
-		if len(yyv3653) != 0 {
+		if yyv3653 == nil {
+			yyv3653 = []Node{}
+			yyc3653 = true
+		} else if len(yyv3653) != 0 {
 			yyv3653 = yyv3653[:0]
 			yyc3653 = true
 		}
 	} else if yyl3653 > 0 {
-
+		var yyrr3653, yyrl3653 int
+		var yyrt3653 bool
 		if yyl3653 > cap(yyv3653) {
-			yyrl3653, yyrt3653 = z.DecInferLen(yyl3653, z.DecBasicHandle().MaxInitLen, 456)
-			yyv3653 = make([]Node, yyrl3653)
-			yyc3653 = true
 
+			yyrg3653 := len(yyv3653) > 0
+			yyv23653 := yyv3653
+			yyrl3653, yyrt3653 = z.DecInferLen(yyl3653, z.DecBasicHandle().MaxInitLen, 456)
+			if yyrt3653 {
+				if yyrl3653 <= cap(yyv3653) {
+					yyv3653 = yyv3653[:yyrl3653]
+				} else {
+					yyv3653 = make([]Node, yyrl3653)
+				}
+			} else {
+				yyv3653 = make([]Node, yyrl3653)
+			}
+			yyc3653 = true
 			yyrr3653 = len(yyv3653)
+			if yyrg3653 {
+				copy(yyv3653, yyv23653)
+			}
 		} else if yyl3653 != len(yyv3653) {
 			yyv3653 = yyv3653[:yyl3653]
 			yyc3653 = true
 		}
 		yyj3653 := 0
 		for ; yyj3653 < yyrr3653; yyj3653++ {
+			yyh3653.ElemContainerState(yyj3653)
 			if r.TryDecodeAsNil() {
 				yyv3653[yyj3653] = Node{}
 			} else {
@@ -43010,6 +46324,7 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 		if yyrt3653 {
 			for ; yyj3653 < yyl3653; yyj3653++ {
 				yyv3653 = append(yyv3653, Node{})
+				yyh3653.ElemContainerState(yyj3653)
 				if r.TryDecodeAsNil() {
 					yyv3653[yyj3653] = Node{}
 				} else {
@@ -43021,12 +46336,14 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3653 := 0; !r.CheckBreak(); yyj3653++ {
+		yyj3653 := 0
+		for ; !r.CheckBreak(); yyj3653++ {
+
 			if yyj3653 >= len(yyv3653) {
 				yyv3653 = append(yyv3653, Node{}) // var yyz3653 Node
 				yyc3653 = true
 			}
-
+			yyh3653.ElemContainerState(yyj3653)
 			if yyj3653 < len(yyv3653) {
 				if r.TryDecodeAsNil() {
 					yyv3653[yyj3653] = Node{}
@@ -43040,12 +46357,18 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3653.End()
+		if yyj3653 < len(yyv3653) {
+			yyv3653 = yyv3653[:yyj3653]
+			yyc3653 = true
+		} else if yyj3653 == 0 && yyv3653 == nil {
+			yyv3653 = []Node{}
+			yyc3653 = true
+		}
 	}
+	yyh3653.End()
 	if yyc3653 {
 		*v = yyv3653
 	}
-
 }
 
 func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.Encoder) {
@@ -43054,9 +46377,10 @@ func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.E
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3657 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yyv3657.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.Decoder) {
@@ -43066,37 +46390,31 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 
 	yyv3658 := *v
 	yyh3658, yyl3658 := z.DecSliceHelperStart()
-
-	var yyrr3658, yyrl3658 int
-	var yyc3658, yyrt3658 bool
-	_, _, _ = yyc3658, yyrt3658, yyrl3658
-	yyrr3658 = yyl3658
-
-	if yyv3658 == nil {
-		if yyrl3658, yyrt3658 = z.DecInferLen(yyl3658, z.DecBasicHandle().MaxInitLen, 16); yyrt3658 {
-			yyrr3658 = yyrl3658
-		}
-		yyv3658 = make([]FinalizerName, yyrl3658)
-		yyc3658 = true
-	}
-
+	var yyc3658 bool
 	if yyl3658 == 0 {
-		if len(yyv3658) != 0 {
+		if yyv3658 == nil {
+			yyv3658 = []FinalizerName{}
+			yyc3658 = true
+		} else if len(yyv3658) != 0 {
 			yyv3658 = yyv3658[:0]
 			yyc3658 = true
 		}
 	} else if yyl3658 > 0 {
-
+		var yyrr3658, yyrl3658 int
+		var yyrt3658 bool
 		if yyl3658 > cap(yyv3658) {
-			yyrl3658, yyrt3658 = z.DecInferLen(yyl3658, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23658 := yyv3658
-			yyv3658 = make([]FinalizerName, yyrl3658)
-			if len(yyv3658) > 0 {
-				copy(yyv3658, yyv23658[:cap(yyv23658)])
+			yyrl3658, yyrt3658 = z.DecInferLen(yyl3658, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt3658 {
+				if yyrl3658 <= cap(yyv3658) {
+					yyv3658 = yyv3658[:yyrl3658]
+				} else {
+					yyv3658 = make([]FinalizerName, yyrl3658)
+				}
+			} else {
+				yyv3658 = make([]FinalizerName, yyrl3658)
 			}
 			yyc3658 = true
-
 			yyrr3658 = len(yyv3658)
 		} else if yyl3658 != len(yyv3658) {
 			yyv3658 = yyv3658[:yyl3658]
@@ -43104,6 +46422,7 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 		}
 		yyj3658 := 0
 		for ; yyj3658 < yyrr3658; yyj3658++ {
+			yyh3658.ElemContainerState(yyj3658)
 			if r.TryDecodeAsNil() {
 				yyv3658[yyj3658] = ""
 			} else {
@@ -43114,6 +46433,7 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 		if yyrt3658 {
 			for ; yyj3658 < yyl3658; yyj3658++ {
 				yyv3658 = append(yyv3658, "")
+				yyh3658.ElemContainerState(yyj3658)
 				if r.TryDecodeAsNil() {
 					yyv3658[yyj3658] = ""
 				} else {
@@ -43124,12 +46444,14 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 		}
 
 	} else {
-		for yyj3658 := 0; !r.CheckBreak(); yyj3658++ {
+		yyj3658 := 0
+		for ; !r.CheckBreak(); yyj3658++ {
+
 			if yyj3658 >= len(yyv3658) {
 				yyv3658 = append(yyv3658, "") // var yyz3658 FinalizerName
 				yyc3658 = true
 			}
-
+			yyh3658.ElemContainerState(yyj3658)
 			if yyj3658 < len(yyv3658) {
 				if r.TryDecodeAsNil() {
 					yyv3658[yyj3658] = ""
@@ -43142,12 +46464,18 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 			}
 
 		}
-		yyh3658.End()
+		if yyj3658 < len(yyv3658) {
+			yyv3658 = yyv3658[:yyj3658]
+			yyc3658 = true
+		} else if yyj3658 == 0 && yyv3658 == nil {
+			yyv3658 = []FinalizerName{}
+			yyc3658 = true
+		}
 	}
+	yyh3658.End()
 	if yyc3658 {
 		*v = yyv3658
 	}
-
 }
 
 func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) {
@@ -43156,10 +46484,11 @@ func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3662 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3663 := &yyv3662
 		yy3663.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder) {
@@ -43169,39 +46498,44 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 
 	yyv3664 := *v
 	yyh3664, yyl3664 := z.DecSliceHelperStart()
-
-	var yyrr3664, yyrl3664 int
-	var yyc3664, yyrt3664 bool
-	_, _, _ = yyc3664, yyrt3664, yyrl3664
-	yyrr3664 = yyl3664
-
-	if yyv3664 == nil {
-		if yyrl3664, yyrt3664 = z.DecInferLen(yyl3664, z.DecBasicHandle().MaxInitLen, 232); yyrt3664 {
-			yyrr3664 = yyrl3664
-		}
-		yyv3664 = make([]Namespace, yyrl3664)
-		yyc3664 = true
-	}
-
+	var yyc3664 bool
 	if yyl3664 == 0 {
-		if len(yyv3664) != 0 {
+		if yyv3664 == nil {
+			yyv3664 = []Namespace{}
+			yyc3664 = true
+		} else if len(yyv3664) != 0 {
 			yyv3664 = yyv3664[:0]
 			yyc3664 = true
 		}
 	} else if yyl3664 > 0 {
-
+		var yyrr3664, yyrl3664 int
+		var yyrt3664 bool
 		if yyl3664 > cap(yyv3664) {
-			yyrl3664, yyrt3664 = z.DecInferLen(yyl3664, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3664 = make([]Namespace, yyrl3664)
-			yyc3664 = true
 
+			yyrg3664 := len(yyv3664) > 0
+			yyv23664 := yyv3664
+			yyrl3664, yyrt3664 = z.DecInferLen(yyl3664, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt3664 {
+				if yyrl3664 <= cap(yyv3664) {
+					yyv3664 = yyv3664[:yyrl3664]
+				} else {
+					yyv3664 = make([]Namespace, yyrl3664)
+				}
+			} else {
+				yyv3664 = make([]Namespace, yyrl3664)
+			}
+			yyc3664 = true
 			yyrr3664 = len(yyv3664)
+			if yyrg3664 {
+				copy(yyv3664, yyv23664)
+			}
 		} else if yyl3664 != len(yyv3664) {
 			yyv3664 = yyv3664[:yyl3664]
 			yyc3664 = true
 		}
 		yyj3664 := 0
 		for ; yyj3664 < yyrr3664; yyj3664++ {
+			yyh3664.ElemContainerState(yyj3664)
 			if r.TryDecodeAsNil() {
 				yyv3664[yyj3664] = Namespace{}
 			} else {
@@ -43213,6 +46547,7 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 		if yyrt3664 {
 			for ; yyj3664 < yyl3664; yyj3664++ {
 				yyv3664 = append(yyv3664, Namespace{})
+				yyh3664.ElemContainerState(yyj3664)
 				if r.TryDecodeAsNil() {
 					yyv3664[yyj3664] = Namespace{}
 				} else {
@@ -43224,12 +46559,14 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 		}
 
 	} else {
-		for yyj3664 := 0; !r.CheckBreak(); yyj3664++ {
+		yyj3664 := 0
+		for ; !r.CheckBreak(); yyj3664++ {
+
 			if yyj3664 >= len(yyv3664) {
 				yyv3664 = append(yyv3664, Namespace{}) // var yyz3664 Namespace
 				yyc3664 = true
 			}
-
+			yyh3664.ElemContainerState(yyj3664)
 			if yyj3664 < len(yyv3664) {
 				if r.TryDecodeAsNil() {
 					yyv3664[yyj3664] = Namespace{}
@@ -43243,12 +46580,18 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3664.End()
+		if yyj3664 < len(yyv3664) {
+			yyv3664 = yyv3664[:yyj3664]
+			yyc3664 = true
+		} else if yyj3664 == 0 && yyv3664 == nil {
+			yyv3664 = []Namespace{}
+			yyc3664 = true
+		}
 	}
+	yyh3664.End()
 	if yyc3664 {
 		*v = yyv3664
 	}
-
 }
 
 func (x codecSelfer1234) encSliceEvent(v []Event, e *codec1978.Encoder) {
@@ -43257,10 +46600,11 @@ func (x codecSelfer1234) encSliceEvent(v []Event, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3668 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3669 := &yyv3668
 		yy3669.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
@@ -43270,39 +46614,44 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 
 	yyv3670 := *v
 	yyh3670, yyl3670 := z.DecSliceHelperStart()
-
-	var yyrr3670, yyrl3670 int
-	var yyc3670, yyrt3670 bool
-	_, _, _ = yyc3670, yyrt3670, yyrl3670
-	yyrr3670 = yyl3670
-
-	if yyv3670 == nil {
-		if yyrl3670, yyrt3670 = z.DecInferLen(yyl3670, z.DecBasicHandle().MaxInitLen, 440); yyrt3670 {
-			yyrr3670 = yyrl3670
-		}
-		yyv3670 = make([]Event, yyrl3670)
-		yyc3670 = true
-	}
-
+	var yyc3670 bool
 	if yyl3670 == 0 {
-		if len(yyv3670) != 0 {
+		if yyv3670 == nil {
+			yyv3670 = []Event{}
+			yyc3670 = true
+		} else if len(yyv3670) != 0 {
 			yyv3670 = yyv3670[:0]
 			yyc3670 = true
 		}
 	} else if yyl3670 > 0 {
-
+		var yyrr3670, yyrl3670 int
+		var yyrt3670 bool
 		if yyl3670 > cap(yyv3670) {
-			yyrl3670, yyrt3670 = z.DecInferLen(yyl3670, z.DecBasicHandle().MaxInitLen, 440)
-			yyv3670 = make([]Event, yyrl3670)
-			yyc3670 = true
 
+			yyrg3670 := len(yyv3670) > 0
+			yyv23670 := yyv3670
+			yyrl3670, yyrt3670 = z.DecInferLen(yyl3670, z.DecBasicHandle().MaxInitLen, 440)
+			if yyrt3670 {
+				if yyrl3670 <= cap(yyv3670) {
+					yyv3670 = yyv3670[:yyrl3670]
+				} else {
+					yyv3670 = make([]Event, yyrl3670)
+				}
+			} else {
+				yyv3670 = make([]Event, yyrl3670)
+			}
+			yyc3670 = true
 			yyrr3670 = len(yyv3670)
+			if yyrg3670 {
+				copy(yyv3670, yyv23670)
+			}
 		} else if yyl3670 != len(yyv3670) {
 			yyv3670 = yyv3670[:yyl3670]
 			yyc3670 = true
 		}
 		yyj3670 := 0
 		for ; yyj3670 < yyrr3670; yyj3670++ {
+			yyh3670.ElemContainerState(yyj3670)
 			if r.TryDecodeAsNil() {
 				yyv3670[yyj3670] = Event{}
 			} else {
@@ -43314,6 +46663,7 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 		if yyrt3670 {
 			for ; yyj3670 < yyl3670; yyj3670++ {
 				yyv3670 = append(yyv3670, Event{})
+				yyh3670.ElemContainerState(yyj3670)
 				if r.TryDecodeAsNil() {
 					yyv3670[yyj3670] = Event{}
 				} else {
@@ -43325,12 +46675,14 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3670 := 0; !r.CheckBreak(); yyj3670++ {
+		yyj3670 := 0
+		for ; !r.CheckBreak(); yyj3670++ {
+
 			if yyj3670 >= len(yyv3670) {
 				yyv3670 = append(yyv3670, Event{}) // var yyz3670 Event
 				yyc3670 = true
 			}
-
+			yyh3670.ElemContainerState(yyj3670)
 			if yyj3670 < len(yyv3670) {
 				if r.TryDecodeAsNil() {
 					yyv3670[yyj3670] = Event{}
@@ -43344,12 +46696,18 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3670.End()
+		if yyj3670 < len(yyv3670) {
+			yyv3670 = yyv3670[:yyj3670]
+			yyc3670 = true
+		} else if yyj3670 == 0 && yyv3670 == nil {
+			yyv3670 = []Event{}
+			yyc3670 = true
+		}
 	}
+	yyh3670.End()
 	if yyc3670 {
 		*v = yyv3670
 	}
-
 }
 
 func (x codecSelfer1234) encSliceruntime_RawExtension(v []pkg6_runtime.RawExtension, e *codec1978.Encoder) {
@@ -43358,6 +46716,7 @@ func (x codecSelfer1234) encSliceruntime_RawExtension(v []pkg6_runtime.RawExtens
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3674 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3675 := &yyv3674
 		yym3676 := z.EncBinary()
 		_ = yym3676
@@ -43369,7 +46728,7 @@ func (x codecSelfer1234) encSliceruntime_RawExtension(v []pkg6_runtime.RawExtens
 			z.EncFallback(yy3675)
 		}
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExtension, d *codec1978.Decoder) {
@@ -43379,39 +46738,44 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 
 	yyv3677 := *v
 	yyh3677, yyl3677 := z.DecSliceHelperStart()
-
-	var yyrr3677, yyrl3677 int
-	var yyc3677, yyrt3677 bool
-	_, _, _ = yyc3677, yyrt3677, yyrl3677
-	yyrr3677 = yyl3677
-
-	if yyv3677 == nil {
-		if yyrl3677, yyrt3677 = z.DecInferLen(yyl3677, z.DecBasicHandle().MaxInitLen, 24); yyrt3677 {
-			yyrr3677 = yyrl3677
-		}
-		yyv3677 = make([]pkg6_runtime.RawExtension, yyrl3677)
-		yyc3677 = true
-	}
-
+	var yyc3677 bool
 	if yyl3677 == 0 {
-		if len(yyv3677) != 0 {
+		if yyv3677 == nil {
+			yyv3677 = []pkg6_runtime.RawExtension{}
+			yyc3677 = true
+		} else if len(yyv3677) != 0 {
 			yyv3677 = yyv3677[:0]
 			yyc3677 = true
 		}
 	} else if yyl3677 > 0 {
-
+		var yyrr3677, yyrl3677 int
+		var yyrt3677 bool
 		if yyl3677 > cap(yyv3677) {
-			yyrl3677, yyrt3677 = z.DecInferLen(yyl3677, z.DecBasicHandle().MaxInitLen, 24)
-			yyv3677 = make([]pkg6_runtime.RawExtension, yyrl3677)
-			yyc3677 = true
 
+			yyrg3677 := len(yyv3677) > 0
+			yyv23677 := yyv3677
+			yyrl3677, yyrt3677 = z.DecInferLen(yyl3677, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt3677 {
+				if yyrl3677 <= cap(yyv3677) {
+					yyv3677 = yyv3677[:yyrl3677]
+				} else {
+					yyv3677 = make([]pkg6_runtime.RawExtension, yyrl3677)
+				}
+			} else {
+				yyv3677 = make([]pkg6_runtime.RawExtension, yyrl3677)
+			}
+			yyc3677 = true
 			yyrr3677 = len(yyv3677)
+			if yyrg3677 {
+				copy(yyv3677, yyv23677)
+			}
 		} else if yyl3677 != len(yyv3677) {
 			yyv3677 = yyv3677[:yyl3677]
 			yyc3677 = true
 		}
 		yyj3677 := 0
 		for ; yyj3677 < yyrr3677; yyj3677++ {
+			yyh3677.ElemContainerState(yyj3677)
 			if r.TryDecodeAsNil() {
 				yyv3677[yyj3677] = pkg6_runtime.RawExtension{}
 			} else {
@@ -43431,6 +46795,7 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 		if yyrt3677 {
 			for ; yyj3677 < yyl3677; yyj3677++ {
 				yyv3677 = append(yyv3677, pkg6_runtime.RawExtension{})
+				yyh3677.ElemContainerState(yyj3677)
 				if r.TryDecodeAsNil() {
 					yyv3677[yyj3677] = pkg6_runtime.RawExtension{}
 				} else {
@@ -43450,12 +46815,14 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 		}
 
 	} else {
-		for yyj3677 := 0; !r.CheckBreak(); yyj3677++ {
+		yyj3677 := 0
+		for ; !r.CheckBreak(); yyj3677++ {
+
 			if yyj3677 >= len(yyv3677) {
 				yyv3677 = append(yyv3677, pkg6_runtime.RawExtension{}) // var yyz3677 pkg6_runtime.RawExtension
 				yyc3677 = true
 			}
-
+			yyh3677.ElemContainerState(yyj3677)
 			if yyj3677 < len(yyv3677) {
 				if r.TryDecodeAsNil() {
 					yyv3677[yyj3677] = pkg6_runtime.RawExtension{}
@@ -43477,12 +46844,18 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 			}
 
 		}
-		yyh3677.End()
+		if yyj3677 < len(yyv3677) {
+			yyv3677 = yyv3677[:yyj3677]
+			yyc3677 = true
+		} else if yyj3677 == 0 && yyv3677 == nil {
+			yyv3677 = []pkg6_runtime.RawExtension{}
+			yyc3677 = true
+		}
 	}
+	yyh3677.End()
 	if yyc3677 {
 		*v = yyv3677
 	}
-
 }
 
 func (x codecSelfer1234) encSliceLimitRangeItem(v []LimitRangeItem, e *codec1978.Encoder) {
@@ -43491,10 +46864,11 @@ func (x codecSelfer1234) encSliceLimitRangeItem(v []LimitRangeItem, e *codec1978
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3684 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3685 := &yyv3684
 		yy3685.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec1978.Decoder) {
@@ -43504,39 +46878,44 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 
 	yyv3686 := *v
 	yyh3686, yyl3686 := z.DecSliceHelperStart()
-
-	var yyrr3686, yyrl3686 int
-	var yyc3686, yyrt3686 bool
-	_, _, _ = yyc3686, yyrt3686, yyrl3686
-	yyrr3686 = yyl3686
-
-	if yyv3686 == nil {
-		if yyrl3686, yyrt3686 = z.DecInferLen(yyl3686, z.DecBasicHandle().MaxInitLen, 56); yyrt3686 {
-			yyrr3686 = yyrl3686
-		}
-		yyv3686 = make([]LimitRangeItem, yyrl3686)
-		yyc3686 = true
-	}
-
+	var yyc3686 bool
 	if yyl3686 == 0 {
-		if len(yyv3686) != 0 {
+		if yyv3686 == nil {
+			yyv3686 = []LimitRangeItem{}
+			yyc3686 = true
+		} else if len(yyv3686) != 0 {
 			yyv3686 = yyv3686[:0]
 			yyc3686 = true
 		}
 	} else if yyl3686 > 0 {
-
+		var yyrr3686, yyrl3686 int
+		var yyrt3686 bool
 		if yyl3686 > cap(yyv3686) {
-			yyrl3686, yyrt3686 = z.DecInferLen(yyl3686, z.DecBasicHandle().MaxInitLen, 56)
-			yyv3686 = make([]LimitRangeItem, yyrl3686)
-			yyc3686 = true
 
+			yyrg3686 := len(yyv3686) > 0
+			yyv23686 := yyv3686
+			yyrl3686, yyrt3686 = z.DecInferLen(yyl3686, z.DecBasicHandle().MaxInitLen, 56)
+			if yyrt3686 {
+				if yyrl3686 <= cap(yyv3686) {
+					yyv3686 = yyv3686[:yyrl3686]
+				} else {
+					yyv3686 = make([]LimitRangeItem, yyrl3686)
+				}
+			} else {
+				yyv3686 = make([]LimitRangeItem, yyrl3686)
+			}
+			yyc3686 = true
 			yyrr3686 = len(yyv3686)
+			if yyrg3686 {
+				copy(yyv3686, yyv23686)
+			}
 		} else if yyl3686 != len(yyv3686) {
 			yyv3686 = yyv3686[:yyl3686]
 			yyc3686 = true
 		}
 		yyj3686 := 0
 		for ; yyj3686 < yyrr3686; yyj3686++ {
+			yyh3686.ElemContainerState(yyj3686)
 			if r.TryDecodeAsNil() {
 				yyv3686[yyj3686] = LimitRangeItem{}
 			} else {
@@ -43548,6 +46927,7 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 		if yyrt3686 {
 			for ; yyj3686 < yyl3686; yyj3686++ {
 				yyv3686 = append(yyv3686, LimitRangeItem{})
+				yyh3686.ElemContainerState(yyj3686)
 				if r.TryDecodeAsNil() {
 					yyv3686[yyj3686] = LimitRangeItem{}
 				} else {
@@ -43559,12 +46939,14 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 		}
 
 	} else {
-		for yyj3686 := 0; !r.CheckBreak(); yyj3686++ {
+		yyj3686 := 0
+		for ; !r.CheckBreak(); yyj3686++ {
+
 			if yyj3686 >= len(yyv3686) {
 				yyv3686 = append(yyv3686, LimitRangeItem{}) // var yyz3686 LimitRangeItem
 				yyc3686 = true
 			}
-
+			yyh3686.ElemContainerState(yyj3686)
 			if yyj3686 < len(yyv3686) {
 				if r.TryDecodeAsNil() {
 					yyv3686[yyj3686] = LimitRangeItem{}
@@ -43578,12 +46960,18 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 			}
 
 		}
-		yyh3686.End()
+		if yyj3686 < len(yyv3686) {
+			yyv3686 = yyv3686[:yyj3686]
+			yyc3686 = true
+		} else if yyj3686 == 0 && yyv3686 == nil {
+			yyv3686 = []LimitRangeItem{}
+			yyc3686 = true
+		}
 	}
+	yyh3686.End()
 	if yyc3686 {
 		*v = yyv3686
 	}
-
 }
 
 func (x codecSelfer1234) encSliceLimitRange(v []LimitRange, e *codec1978.Encoder) {
@@ -43592,10 +46980,11 @@ func (x codecSelfer1234) encSliceLimitRange(v []LimitRange, e *codec1978.Encoder
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3690 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3691 := &yyv3690
 		yy3691.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decoder) {
@@ -43605,39 +46994,44 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 
 	yyv3692 := *v
 	yyh3692, yyl3692 := z.DecSliceHelperStart()
-
-	var yyrr3692, yyrl3692 int
-	var yyc3692, yyrt3692 bool
-	_, _, _ = yyc3692, yyrt3692, yyrl3692
-	yyrr3692 = yyl3692
-
-	if yyv3692 == nil {
-		if yyrl3692, yyrt3692 = z.DecInferLen(yyl3692, z.DecBasicHandle().MaxInitLen, 216); yyrt3692 {
-			yyrr3692 = yyrl3692
-		}
-		yyv3692 = make([]LimitRange, yyrl3692)
-		yyc3692 = true
-	}
-
+	var yyc3692 bool
 	if yyl3692 == 0 {
-		if len(yyv3692) != 0 {
+		if yyv3692 == nil {
+			yyv3692 = []LimitRange{}
+			yyc3692 = true
+		} else if len(yyv3692) != 0 {
 			yyv3692 = yyv3692[:0]
 			yyc3692 = true
 		}
 	} else if yyl3692 > 0 {
-
+		var yyrr3692, yyrl3692 int
+		var yyrt3692 bool
 		if yyl3692 > cap(yyv3692) {
-			yyrl3692, yyrt3692 = z.DecInferLen(yyl3692, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3692 = make([]LimitRange, yyrl3692)
-			yyc3692 = true
 
+			yyrg3692 := len(yyv3692) > 0
+			yyv23692 := yyv3692
+			yyrl3692, yyrt3692 = z.DecInferLen(yyl3692, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3692 {
+				if yyrl3692 <= cap(yyv3692) {
+					yyv3692 = yyv3692[:yyrl3692]
+				} else {
+					yyv3692 = make([]LimitRange, yyrl3692)
+				}
+			} else {
+				yyv3692 = make([]LimitRange, yyrl3692)
+			}
+			yyc3692 = true
 			yyrr3692 = len(yyv3692)
+			if yyrg3692 {
+				copy(yyv3692, yyv23692)
+			}
 		} else if yyl3692 != len(yyv3692) {
 			yyv3692 = yyv3692[:yyl3692]
 			yyc3692 = true
 		}
 		yyj3692 := 0
 		for ; yyj3692 < yyrr3692; yyj3692++ {
+			yyh3692.ElemContainerState(yyj3692)
 			if r.TryDecodeAsNil() {
 				yyv3692[yyj3692] = LimitRange{}
 			} else {
@@ -43649,6 +47043,7 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 		if yyrt3692 {
 			for ; yyj3692 < yyl3692; yyj3692++ {
 				yyv3692 = append(yyv3692, LimitRange{})
+				yyh3692.ElemContainerState(yyj3692)
 				if r.TryDecodeAsNil() {
 					yyv3692[yyj3692] = LimitRange{}
 				} else {
@@ -43660,12 +47055,14 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 		}
 
 	} else {
-		for yyj3692 := 0; !r.CheckBreak(); yyj3692++ {
+		yyj3692 := 0
+		for ; !r.CheckBreak(); yyj3692++ {
+
 			if yyj3692 >= len(yyv3692) {
 				yyv3692 = append(yyv3692, LimitRange{}) // var yyz3692 LimitRange
 				yyc3692 = true
 			}
-
+			yyh3692.ElemContainerState(yyj3692)
 			if yyj3692 < len(yyv3692) {
 				if r.TryDecodeAsNil() {
 					yyv3692[yyj3692] = LimitRange{}
@@ -43679,12 +47076,18 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 			}
 
 		}
-		yyh3692.End()
+		if yyj3692 < len(yyv3692) {
+			yyv3692 = yyv3692[:yyj3692]
+			yyc3692 = true
+		} else if yyj3692 == 0 && yyv3692 == nil {
+			yyv3692 = []LimitRange{}
+			yyc3692 = true
+		}
 	}
+	yyh3692.End()
 	if yyc3692 {
 		*v = yyv3692
 	}
-
 }
 
 func (x codecSelfer1234) encSliceResourceQuota(v []ResourceQuota, e *codec1978.Encoder) {
@@ -43693,10 +47096,11 @@ func (x codecSelfer1234) encSliceResourceQuota(v []ResourceQuota, e *codec1978.E
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3696 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3697 := &yyv3696
 		yy3697.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.Decoder) {
@@ -43706,39 +47110,44 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 
 	yyv3698 := *v
 	yyh3698, yyl3698 := z.DecSliceHelperStart()
-
-	var yyrr3698, yyrl3698 int
-	var yyc3698, yyrt3698 bool
-	_, _, _ = yyc3698, yyrt3698, yyrl3698
-	yyrr3698 = yyl3698
-
-	if yyv3698 == nil {
-		if yyrl3698, yyrt3698 = z.DecInferLen(yyl3698, z.DecBasicHandle().MaxInitLen, 216); yyrt3698 {
-			yyrr3698 = yyrl3698
-		}
-		yyv3698 = make([]ResourceQuota, yyrl3698)
-		yyc3698 = true
-	}
-
+	var yyc3698 bool
 	if yyl3698 == 0 {
-		if len(yyv3698) != 0 {
+		if yyv3698 == nil {
+			yyv3698 = []ResourceQuota{}
+			yyc3698 = true
+		} else if len(yyv3698) != 0 {
 			yyv3698 = yyv3698[:0]
 			yyc3698 = true
 		}
 	} else if yyl3698 > 0 {
-
+		var yyrr3698, yyrl3698 int
+		var yyrt3698 bool
 		if yyl3698 > cap(yyv3698) {
-			yyrl3698, yyrt3698 = z.DecInferLen(yyl3698, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3698 = make([]ResourceQuota, yyrl3698)
-			yyc3698 = true
 
+			yyrg3698 := len(yyv3698) > 0
+			yyv23698 := yyv3698
+			yyrl3698, yyrt3698 = z.DecInferLen(yyl3698, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3698 {
+				if yyrl3698 <= cap(yyv3698) {
+					yyv3698 = yyv3698[:yyrl3698]
+				} else {
+					yyv3698 = make([]ResourceQuota, yyrl3698)
+				}
+			} else {
+				yyv3698 = make([]ResourceQuota, yyrl3698)
+			}
+			yyc3698 = true
 			yyrr3698 = len(yyv3698)
+			if yyrg3698 {
+				copy(yyv3698, yyv23698)
+			}
 		} else if yyl3698 != len(yyv3698) {
 			yyv3698 = yyv3698[:yyl3698]
 			yyc3698 = true
 		}
 		yyj3698 := 0
 		for ; yyj3698 < yyrr3698; yyj3698++ {
+			yyh3698.ElemContainerState(yyj3698)
 			if r.TryDecodeAsNil() {
 				yyv3698[yyj3698] = ResourceQuota{}
 			} else {
@@ -43750,6 +47159,7 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 		if yyrt3698 {
 			for ; yyj3698 < yyl3698; yyj3698++ {
 				yyv3698 = append(yyv3698, ResourceQuota{})
+				yyh3698.ElemContainerState(yyj3698)
 				if r.TryDecodeAsNil() {
 					yyv3698[yyj3698] = ResourceQuota{}
 				} else {
@@ -43761,12 +47171,14 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 		}
 
 	} else {
-		for yyj3698 := 0; !r.CheckBreak(); yyj3698++ {
+		yyj3698 := 0
+		for ; !r.CheckBreak(); yyj3698++ {
+
 			if yyj3698 >= len(yyv3698) {
 				yyv3698 = append(yyv3698, ResourceQuota{}) // var yyz3698 ResourceQuota
 				yyc3698 = true
 			}
-
+			yyh3698.ElemContainerState(yyj3698)
 			if yyj3698 < len(yyv3698) {
 				if r.TryDecodeAsNil() {
 					yyv3698[yyj3698] = ResourceQuota{}
@@ -43780,12 +47192,18 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 			}
 
 		}
-		yyh3698.End()
+		if yyj3698 < len(yyv3698) {
+			yyv3698 = yyv3698[:yyj3698]
+			yyc3698 = true
+		} else if yyj3698 == 0 && yyv3698 == nil {
+			yyv3698 = []ResourceQuota{}
+			yyc3698 = true
+		}
 	}
+	yyh3698.End()
 	if yyc3698 {
 		*v = yyv3698
 	}
-
 }
 
 func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec1978.Encoder) {
@@ -43794,12 +47212,14 @@ func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
 	for yyk3702, yyv3702 := range v {
+		z.EncSendContainerState(codecSelfer_containerMapKey1234)
 		yym3703 := z.EncBinary()
 		_ = yym3703
 		if false {
 		} else {
 			r.EncodeString(codecSelferC_UTF81234, string(yyk3702))
 		}
+		z.EncSendContainerState(codecSelfer_containerMapValue1234)
 		if yyv3702 == nil {
 			r.EncodeNil()
 		} else {
@@ -43811,7 +47231,7 @@ func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec19
 			}
 		}
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1978.Decoder) {
@@ -43835,6 +47255,7 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 	}
 	if yyl3705 > 0 {
 		for yyj3705 := 0; yyj3705 < yyl3705; yyj3705++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
 				yymk3705 = ""
 			} else {
@@ -43846,6 +47267,7 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 			} else {
 				yymv3705 = nil
 			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
 				yymv3705 = nil
 			} else {
@@ -43864,6 +47286,7 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 		}
 	} else if yyl3705 < 0 {
 		for yyj3705 := 0; !r.CheckBreak(); yyj3705++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
 			if r.TryDecodeAsNil() {
 				yymk3705 = ""
 			} else {
@@ -43875,6 +47298,7 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 			} else {
 				yymv3705 = nil
 			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
 			if r.TryDecodeAsNil() {
 				yymv3705 = nil
 			} else {
@@ -43891,8 +47315,8 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 				yyv3705[yymk3705] = yymv3705
 			}
 		}
-		r.ReadEnd()
 	} // else len==0: TODO: Should we clear map entries?
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x codecSelfer1234) encSliceSecret(v []Secret, e *codec1978.Encoder) {
@@ -43901,10 +47325,11 @@ func (x codecSelfer1234) encSliceSecret(v []Secret, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3712 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3713 := &yyv3712
 		yy3713.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
@@ -43914,39 +47339,44 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 
 	yyv3714 := *v
 	yyh3714, yyl3714 := z.DecSliceHelperStart()
-
-	var yyrr3714, yyrl3714 int
-	var yyc3714, yyrt3714 bool
-	_, _, _ = yyc3714, yyrt3714, yyrl3714
-	yyrr3714 = yyl3714
-
-	if yyv3714 == nil {
-		if yyrl3714, yyrt3714 = z.DecInferLen(yyl3714, z.DecBasicHandle().MaxInitLen, 216); yyrt3714 {
-			yyrr3714 = yyrl3714
-		}
-		yyv3714 = make([]Secret, yyrl3714)
-		yyc3714 = true
-	}
-
+	var yyc3714 bool
 	if yyl3714 == 0 {
-		if len(yyv3714) != 0 {
+		if yyv3714 == nil {
+			yyv3714 = []Secret{}
+			yyc3714 = true
+		} else if len(yyv3714) != 0 {
 			yyv3714 = yyv3714[:0]
 			yyc3714 = true
 		}
 	} else if yyl3714 > 0 {
-
+		var yyrr3714, yyrl3714 int
+		var yyrt3714 bool
 		if yyl3714 > cap(yyv3714) {
-			yyrl3714, yyrt3714 = z.DecInferLen(yyl3714, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3714 = make([]Secret, yyrl3714)
-			yyc3714 = true
 
+			yyrg3714 := len(yyv3714) > 0
+			yyv23714 := yyv3714
+			yyrl3714, yyrt3714 = z.DecInferLen(yyl3714, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3714 {
+				if yyrl3714 <= cap(yyv3714) {
+					yyv3714 = yyv3714[:yyrl3714]
+				} else {
+					yyv3714 = make([]Secret, yyrl3714)
+				}
+			} else {
+				yyv3714 = make([]Secret, yyrl3714)
+			}
+			yyc3714 = true
 			yyrr3714 = len(yyv3714)
+			if yyrg3714 {
+				copy(yyv3714, yyv23714)
+			}
 		} else if yyl3714 != len(yyv3714) {
 			yyv3714 = yyv3714[:yyl3714]
 			yyc3714 = true
 		}
 		yyj3714 := 0
 		for ; yyj3714 < yyrr3714; yyj3714++ {
+			yyh3714.ElemContainerState(yyj3714)
 			if r.TryDecodeAsNil() {
 				yyv3714[yyj3714] = Secret{}
 			} else {
@@ -43958,6 +47388,7 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 		if yyrt3714 {
 			for ; yyj3714 < yyl3714; yyj3714++ {
 				yyv3714 = append(yyv3714, Secret{})
+				yyh3714.ElemContainerState(yyj3714)
 				if r.TryDecodeAsNil() {
 					yyv3714[yyj3714] = Secret{}
 				} else {
@@ -43969,12 +47400,14 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj3714 := 0; !r.CheckBreak(); yyj3714++ {
+		yyj3714 := 0
+		for ; !r.CheckBreak(); yyj3714++ {
+
 			if yyj3714 >= len(yyv3714) {
 				yyv3714 = append(yyv3714, Secret{}) // var yyz3714 Secret
 				yyc3714 = true
 			}
-
+			yyh3714.ElemContainerState(yyj3714)
 			if yyj3714 < len(yyv3714) {
 				if r.TryDecodeAsNil() {
 					yyv3714[yyj3714] = Secret{}
@@ -43988,12 +47421,18 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3714.End()
+		if yyj3714 < len(yyv3714) {
+			yyv3714 = yyv3714[:yyj3714]
+			yyc3714 = true
+		} else if yyj3714 == 0 && yyv3714 == nil {
+			yyv3714 = []Secret{}
+			yyc3714 = true
+		}
 	}
+	yyh3714.End()
 	if yyc3714 {
 		*v = yyv3714
 	}
-
 }
 
 func (x codecSelfer1234) encSliceComponentCondition(v []ComponentCondition, e *codec1978.Encoder) {
@@ -44002,10 +47441,11 @@ func (x codecSelfer1234) encSliceComponentCondition(v []ComponentCondition, e *c
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3718 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3719 := &yyv3718
 		yy3719.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *codec1978.Decoder) {
@@ -44015,39 +47455,44 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 
 	yyv3720 := *v
 	yyh3720, yyl3720 := z.DecSliceHelperStart()
-
-	var yyrr3720, yyrl3720 int
-	var yyc3720, yyrt3720 bool
-	_, _, _ = yyc3720, yyrt3720, yyrl3720
-	yyrr3720 = yyl3720
-
-	if yyv3720 == nil {
-		if yyrl3720, yyrt3720 = z.DecInferLen(yyl3720, z.DecBasicHandle().MaxInitLen, 64); yyrt3720 {
-			yyrr3720 = yyrl3720
-		}
-		yyv3720 = make([]ComponentCondition, yyrl3720)
-		yyc3720 = true
-	}
-
+	var yyc3720 bool
 	if yyl3720 == 0 {
-		if len(yyv3720) != 0 {
+		if yyv3720 == nil {
+			yyv3720 = []ComponentCondition{}
+			yyc3720 = true
+		} else if len(yyv3720) != 0 {
 			yyv3720 = yyv3720[:0]
 			yyc3720 = true
 		}
 	} else if yyl3720 > 0 {
-
+		var yyrr3720, yyrl3720 int
+		var yyrt3720 bool
 		if yyl3720 > cap(yyv3720) {
-			yyrl3720, yyrt3720 = z.DecInferLen(yyl3720, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3720 = make([]ComponentCondition, yyrl3720)
-			yyc3720 = true
 
+			yyrg3720 := len(yyv3720) > 0
+			yyv23720 := yyv3720
+			yyrl3720, yyrt3720 = z.DecInferLen(yyl3720, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt3720 {
+				if yyrl3720 <= cap(yyv3720) {
+					yyv3720 = yyv3720[:yyrl3720]
+				} else {
+					yyv3720 = make([]ComponentCondition, yyrl3720)
+				}
+			} else {
+				yyv3720 = make([]ComponentCondition, yyrl3720)
+			}
+			yyc3720 = true
 			yyrr3720 = len(yyv3720)
+			if yyrg3720 {
+				copy(yyv3720, yyv23720)
+			}
 		} else if yyl3720 != len(yyv3720) {
 			yyv3720 = yyv3720[:yyl3720]
 			yyc3720 = true
 		}
 		yyj3720 := 0
 		for ; yyj3720 < yyrr3720; yyj3720++ {
+			yyh3720.ElemContainerState(yyj3720)
 			if r.TryDecodeAsNil() {
 				yyv3720[yyj3720] = ComponentCondition{}
 			} else {
@@ -44059,6 +47504,7 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 		if yyrt3720 {
 			for ; yyj3720 < yyl3720; yyj3720++ {
 				yyv3720 = append(yyv3720, ComponentCondition{})
+				yyh3720.ElemContainerState(yyj3720)
 				if r.TryDecodeAsNil() {
 					yyv3720[yyj3720] = ComponentCondition{}
 				} else {
@@ -44070,12 +47516,14 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 		}
 
 	} else {
-		for yyj3720 := 0; !r.CheckBreak(); yyj3720++ {
+		yyj3720 := 0
+		for ; !r.CheckBreak(); yyj3720++ {
+
 			if yyj3720 >= len(yyv3720) {
 				yyv3720 = append(yyv3720, ComponentCondition{}) // var yyz3720 ComponentCondition
 				yyc3720 = true
 			}
-
+			yyh3720.ElemContainerState(yyj3720)
 			if yyj3720 < len(yyv3720) {
 				if r.TryDecodeAsNil() {
 					yyv3720[yyj3720] = ComponentCondition{}
@@ -44089,12 +47537,18 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 			}
 
 		}
-		yyh3720.End()
+		if yyj3720 < len(yyv3720) {
+			yyv3720 = yyv3720[:yyj3720]
+			yyc3720 = true
+		} else if yyj3720 == 0 && yyv3720 == nil {
+			yyv3720 = []ComponentCondition{}
+			yyc3720 = true
+		}
 	}
+	yyh3720.End()
 	if yyc3720 {
 		*v = yyv3720
 	}
-
 }
 
 func (x codecSelfer1234) encSliceComponentStatus(v []ComponentStatus, e *codec1978.Encoder) {
@@ -44103,10 +47557,11 @@ func (x codecSelfer1234) encSliceComponentStatus(v []ComponentStatus, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3724 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3725 := &yyv3724
 		yy3725.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1978.Decoder) {
@@ -44116,39 +47571,44 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 
 	yyv3726 := *v
 	yyh3726, yyl3726 := z.DecSliceHelperStart()
-
-	var yyrr3726, yyrl3726 int
-	var yyc3726, yyrt3726 bool
-	_, _, _ = yyc3726, yyrt3726, yyrl3726
-	yyrr3726 = yyl3726
-
-	if yyv3726 == nil {
-		if yyrl3726, yyrt3726 = z.DecInferLen(yyl3726, z.DecBasicHandle().MaxInitLen, 216); yyrt3726 {
-			yyrr3726 = yyrl3726
-		}
-		yyv3726 = make([]ComponentStatus, yyrl3726)
-		yyc3726 = true
-	}
-
+	var yyc3726 bool
 	if yyl3726 == 0 {
-		if len(yyv3726) != 0 {
+		if yyv3726 == nil {
+			yyv3726 = []ComponentStatus{}
+			yyc3726 = true
+		} else if len(yyv3726) != 0 {
 			yyv3726 = yyv3726[:0]
 			yyc3726 = true
 		}
 	} else if yyl3726 > 0 {
-
+		var yyrr3726, yyrl3726 int
+		var yyrt3726 bool
 		if yyl3726 > cap(yyv3726) {
-			yyrl3726, yyrt3726 = z.DecInferLen(yyl3726, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3726 = make([]ComponentStatus, yyrl3726)
-			yyc3726 = true
 
+			yyrg3726 := len(yyv3726) > 0
+			yyv23726 := yyv3726
+			yyrl3726, yyrt3726 = z.DecInferLen(yyl3726, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt3726 {
+				if yyrl3726 <= cap(yyv3726) {
+					yyv3726 = yyv3726[:yyrl3726]
+				} else {
+					yyv3726 = make([]ComponentStatus, yyrl3726)
+				}
+			} else {
+				yyv3726 = make([]ComponentStatus, yyrl3726)
+			}
+			yyc3726 = true
 			yyrr3726 = len(yyv3726)
+			if yyrg3726 {
+				copy(yyv3726, yyv23726)
+			}
 		} else if yyl3726 != len(yyv3726) {
 			yyv3726 = yyv3726[:yyl3726]
 			yyc3726 = true
 		}
 		yyj3726 := 0
 		for ; yyj3726 < yyrr3726; yyj3726++ {
+			yyh3726.ElemContainerState(yyj3726)
 			if r.TryDecodeAsNil() {
 				yyv3726[yyj3726] = ComponentStatus{}
 			} else {
@@ -44160,6 +47620,7 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 		if yyrt3726 {
 			for ; yyj3726 < yyl3726; yyj3726++ {
 				yyv3726 = append(yyv3726, ComponentStatus{})
+				yyh3726.ElemContainerState(yyj3726)
 				if r.TryDecodeAsNil() {
 					yyv3726[yyj3726] = ComponentStatus{}
 				} else {
@@ -44171,12 +47632,14 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 		}
 
 	} else {
-		for yyj3726 := 0; !r.CheckBreak(); yyj3726++ {
+		yyj3726 := 0
+		for ; !r.CheckBreak(); yyj3726++ {
+
 			if yyj3726 >= len(yyv3726) {
 				yyv3726 = append(yyv3726, ComponentStatus{}) // var yyz3726 ComponentStatus
 				yyc3726 = true
 			}
-
+			yyh3726.ElemContainerState(yyj3726)
 			if yyj3726 < len(yyv3726) {
 				if r.TryDecodeAsNil() {
 					yyv3726[yyj3726] = ComponentStatus{}
@@ -44190,12 +47653,18 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 			}
 
 		}
-		yyh3726.End()
+		if yyj3726 < len(yyv3726) {
+			yyv3726 = yyv3726[:yyj3726]
+			yyc3726 = true
+		} else if yyj3726 == 0 && yyv3726 == nil {
+			yyv3726 = []ComponentStatus{}
+			yyc3726 = true
+		}
 	}
+	yyh3726.End()
 	if yyc3726 {
 		*v = yyv3726
 	}
-
 }
 
 func (x codecSelfer1234) encSliceDownwardAPIVolumeFile(v []DownwardAPIVolumeFile, e *codec1978.Encoder) {
@@ -44204,10 +47673,11 @@ func (x codecSelfer1234) encSliceDownwardAPIVolumeFile(v []DownwardAPIVolumeFile
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3730 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy3731 := &yyv3730
 		yy3731.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFile, d *codec1978.Decoder) {
@@ -44217,39 +47687,44 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 
 	yyv3732 := *v
 	yyh3732, yyl3732 := z.DecSliceHelperStart()
-
-	var yyrr3732, yyrl3732 int
-	var yyc3732, yyrt3732 bool
-	_, _, _ = yyc3732, yyrt3732, yyrl3732
-	yyrr3732 = yyl3732
-
-	if yyv3732 == nil {
-		if yyrl3732, yyrt3732 = z.DecInferLen(yyl3732, z.DecBasicHandle().MaxInitLen, 48); yyrt3732 {
-			yyrr3732 = yyrl3732
-		}
-		yyv3732 = make([]DownwardAPIVolumeFile, yyrl3732)
-		yyc3732 = true
-	}
-
+	var yyc3732 bool
 	if yyl3732 == 0 {
-		if len(yyv3732) != 0 {
+		if yyv3732 == nil {
+			yyv3732 = []DownwardAPIVolumeFile{}
+			yyc3732 = true
+		} else if len(yyv3732) != 0 {
 			yyv3732 = yyv3732[:0]
 			yyc3732 = true
 		}
 	} else if yyl3732 > 0 {
-
+		var yyrr3732, yyrl3732 int
+		var yyrt3732 bool
 		if yyl3732 > cap(yyv3732) {
-			yyrl3732, yyrt3732 = z.DecInferLen(yyl3732, z.DecBasicHandle().MaxInitLen, 48)
-			yyv3732 = make([]DownwardAPIVolumeFile, yyrl3732)
-			yyc3732 = true
 
+			yyrg3732 := len(yyv3732) > 0
+			yyv23732 := yyv3732
+			yyrl3732, yyrt3732 = z.DecInferLen(yyl3732, z.DecBasicHandle().MaxInitLen, 48)
+			if yyrt3732 {
+				if yyrl3732 <= cap(yyv3732) {
+					yyv3732 = yyv3732[:yyrl3732]
+				} else {
+					yyv3732 = make([]DownwardAPIVolumeFile, yyrl3732)
+				}
+			} else {
+				yyv3732 = make([]DownwardAPIVolumeFile, yyrl3732)
+			}
+			yyc3732 = true
 			yyrr3732 = len(yyv3732)
+			if yyrg3732 {
+				copy(yyv3732, yyv23732)
+			}
 		} else if yyl3732 != len(yyv3732) {
 			yyv3732 = yyv3732[:yyl3732]
 			yyc3732 = true
 		}
 		yyj3732 := 0
 		for ; yyj3732 < yyrr3732; yyj3732++ {
+			yyh3732.ElemContainerState(yyj3732)
 			if r.TryDecodeAsNil() {
 				yyv3732[yyj3732] = DownwardAPIVolumeFile{}
 			} else {
@@ -44261,6 +47736,7 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 		if yyrt3732 {
 			for ; yyj3732 < yyl3732; yyj3732++ {
 				yyv3732 = append(yyv3732, DownwardAPIVolumeFile{})
+				yyh3732.ElemContainerState(yyj3732)
 				if r.TryDecodeAsNil() {
 					yyv3732[yyj3732] = DownwardAPIVolumeFile{}
 				} else {
@@ -44272,12 +47748,14 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 		}
 
 	} else {
-		for yyj3732 := 0; !r.CheckBreak(); yyj3732++ {
+		yyj3732 := 0
+		for ; !r.CheckBreak(); yyj3732++ {
+
 			if yyj3732 >= len(yyv3732) {
 				yyv3732 = append(yyv3732, DownwardAPIVolumeFile{}) // var yyz3732 DownwardAPIVolumeFile
 				yyc3732 = true
 			}
-
+			yyh3732.ElemContainerState(yyj3732)
 			if yyj3732 < len(yyv3732) {
 				if r.TryDecodeAsNil() {
 					yyv3732[yyj3732] = DownwardAPIVolumeFile{}
@@ -44291,10 +47769,16 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 			}
 
 		}
-		yyh3732.End()
+		if yyj3732 < len(yyv3732) {
+			yyv3732 = yyv3732[:yyj3732]
+			yyc3732 = true
+		} else if yyj3732 == 0 && yyv3732 == nil {
+			yyv3732 = []DownwardAPIVolumeFile{}
+			yyc3732 = true
+		}
 	}
+	yyh3732.End()
 	if yyc3732 {
 		*v = yyv3732
 	}
-
 }

--- a/pkg/apis/componentconfig/types.generated.go
+++ b/pkg/apis/componentconfig/types.generated.go
@@ -31,10 +31,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -45,10 +53,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -76,18 +84,21 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2 bool = false
 			yyq2[0] = x.Kind != ""
 			yyq2[1] = x.APIVersion != ""
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(18)
 			} else {
-				var yynn2 int = 16
+				yynn2 = 16
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -100,7 +111,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -110,6 +123,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
@@ -122,7 +136,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
@@ -132,6 +148,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym10 := z.EncBinary()
 				_ = yym10
 				if false {
@@ -139,7 +156,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BindAddress))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("bindAddress"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym11 := z.EncBinary()
 				_ = yym11
 				if false {
@@ -148,6 +167,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym13 := z.EncBinary()
 				_ = yym13
 				if false {
@@ -155,7 +175,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.CleanupIPTables))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("cleanupIPTables"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym14 := z.EncBinary()
 				_ = yym14
 				if false {
@@ -164,6 +186,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym16 := z.EncBinary()
 				_ = yym16
 				if false {
@@ -171,7 +194,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("healthzBindAddress"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym17 := z.EncBinary()
 				_ = yym17
 				if false {
@@ -180,6 +205,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym19 := z.EncBinary()
 				_ = yym19
 				if false {
@@ -187,7 +213,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.HealthzPort))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("healthzPort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym20 := z.EncBinary()
 				_ = yym20
 				if false {
@@ -196,6 +224,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym22 := z.EncBinary()
 				_ = yym22
 				if false {
@@ -203,7 +232,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("hostnameOverride"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym23 := z.EncBinary()
 				_ = yym23
 				if false {
@@ -212,6 +243,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym25 := z.EncBinary()
 				_ = yym25
 				if false {
@@ -219,7 +251,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.IPTablesSyncePeriodSeconds))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("iptablesSyncPeriodSeconds"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym26 := z.EncBinary()
 				_ = yym26
 				if false {
@@ -228,6 +262,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym28 := z.EncBinary()
 				_ = yym28
 				if false {
@@ -235,7 +270,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.KubeAPIBurst))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym29 := z.EncBinary()
 				_ = yym29
 				if false {
@@ -244,6 +281,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym31 := z.EncBinary()
 				_ = yym31
 				if false {
@@ -251,7 +289,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.KubeAPIQPS))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym32 := z.EncBinary()
 				_ = yym32
 				if false {
@@ -260,6 +300,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym34 := z.EncBinary()
 				_ = yym34
 				if false {
@@ -267,7 +308,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeconfigPath))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeconfigPath"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym35 := z.EncBinary()
 				_ = yym35
 				if false {
@@ -276,6 +319,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym37 := z.EncBinary()
 				_ = yym37
 				if false {
@@ -283,7 +327,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.MasqueradeAll))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("masqueradeAll"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym38 := z.EncBinary()
 				_ = yym38
 				if false {
@@ -292,6 +338,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym40 := z.EncBinary()
 				_ = yym40
 				if false {
@@ -299,7 +346,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Master))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("master"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym41 := z.EncBinary()
 				_ = yym41
 				if false {
@@ -308,6 +357,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.OOMScoreAdj == nil {
 					r.EncodeNil()
 				} else {
@@ -320,7 +370,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("oomScoreAdj"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.OOMScoreAdj == nil {
 					r.EncodeNil()
 				} else {
@@ -334,12 +386,16 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Mode.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("mode"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Mode.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym49 := z.EncBinary()
 				_ = yym49
 				if false {
@@ -347,7 +403,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PortRange))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("portRange"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym50 := z.EncBinary()
 				_ = yym50
 				if false {
@@ -356,6 +414,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym52 := z.EncBinary()
 				_ = yym52
 				if false {
@@ -363,7 +422,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceContainer))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("resourceContainer"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym53 := z.EncBinary()
 				_ = yym53
 				if false {
@@ -372,6 +433,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym55 := z.EncBinary()
 				_ = yym55
 				if false {
@@ -379,7 +441,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.UDPTimeoutMilliseconds))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("udpTimeoutMilliseconds"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym56 := z.EncBinary()
 				_ = yym56
 				if false {
@@ -387,8 +451,10 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.UDPTimeoutMilliseconds))
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -403,17 +469,18 @@ func (x *KubeProxyConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct58 := r.ContainerType()
+		if yyct58 == codecSelferValueTypeMap1234 {
 			yyl58 := r.ReadMapStart()
 			if yyl58 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl58, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct58 == codecSelferValueTypeArray1234 {
 			yyl58 := r.ReadArrayStart()
 			if yyl58 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl58, d)
 			}
@@ -440,8 +507,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys59Slc = r.DecodeBytes(yys59Slc, true, true)
 		yys59 := string(yys59Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys59 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -565,9 +634,7 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys59)
 		} // end switch yys59
 	} // end for yyj59
-	if !yyhl59 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -584,9 +651,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -599,9 +667,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -614,9 +683,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.BindAddress = ""
 	} else {
@@ -629,9 +699,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CleanupIPTables = false
 	} else {
@@ -644,9 +715,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HealthzBindAddress = ""
 	} else {
@@ -659,9 +731,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HealthzPort = 0
 	} else {
@@ -674,9 +747,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostnameOverride = ""
 	} else {
@@ -689,9 +763,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.IPTablesSyncePeriodSeconds = 0
 	} else {
@@ -704,9 +779,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeAPIBurst = 0
 	} else {
@@ -719,9 +795,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeAPIQPS = 0
 	} else {
@@ -734,9 +811,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeconfigPath = ""
 	} else {
@@ -749,9 +827,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MasqueradeAll = false
 	} else {
@@ -764,9 +843,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Master = ""
 	} else {
@@ -779,9 +859,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.OOMScoreAdj != nil {
 			x.OOMScoreAdj = nil
@@ -804,9 +885,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Mode = ""
 	} else {
@@ -819,9 +901,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PortRange = ""
 	} else {
@@ -834,9 +917,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ResourceContainer = ""
 	} else {
@@ -849,9 +933,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.UDPTimeoutMilliseconds = 0
 	} else {
@@ -867,9 +952,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb79 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj79-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x ProxyMode) CodecEncodeSelf(e *codec1978.Encoder) {

--- a/pkg/apis/componentconfig/v1alpha1/types.generated.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.generated.go
@@ -31,10 +31,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -45,10 +53,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -76,18 +84,21 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2 bool = false
 			yyq2[0] = x.Kind != ""
 			yyq2[1] = x.APIVersion != ""
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(18)
 			} else {
-				var yynn2 int = 16
+				yynn2 = 16
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -100,7 +111,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -110,6 +123,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
@@ -122,7 +136,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
@@ -132,6 +148,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym10 := z.EncBinary()
 				_ = yym10
 				if false {
@@ -139,7 +156,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BindAddress))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("bindAddress"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym11 := z.EncBinary()
 				_ = yym11
 				if false {
@@ -148,6 +167,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym13 := z.EncBinary()
 				_ = yym13
 				if false {
@@ -155,7 +175,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.CleanupIPTables))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("cleanupIPTables"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym14 := z.EncBinary()
 				_ = yym14
 				if false {
@@ -164,6 +186,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym16 := z.EncBinary()
 				_ = yym16
 				if false {
@@ -171,7 +194,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("healthzBindAddress"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym17 := z.EncBinary()
 				_ = yym17
 				if false {
@@ -180,6 +205,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym19 := z.EncBinary()
 				_ = yym19
 				if false {
@@ -187,7 +213,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.HealthzPort))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("healthzPort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym20 := z.EncBinary()
 				_ = yym20
 				if false {
@@ -196,6 +224,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym22 := z.EncBinary()
 				_ = yym22
 				if false {
@@ -203,7 +232,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("hostnameOverride"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym23 := z.EncBinary()
 				_ = yym23
 				if false {
@@ -212,6 +243,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym25 := z.EncBinary()
 				_ = yym25
 				if false {
@@ -219,7 +251,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.IPTablesSyncePeriodSeconds))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("iptablesSyncPeriodSeconds"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym26 := z.EncBinary()
 				_ = yym26
 				if false {
@@ -228,6 +262,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym28 := z.EncBinary()
 				_ = yym28
 				if false {
@@ -235,7 +270,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.KubeAPIBurst))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym29 := z.EncBinary()
 				_ = yym29
 				if false {
@@ -244,6 +281,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym31 := z.EncBinary()
 				_ = yym31
 				if false {
@@ -251,7 +289,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.KubeAPIQPS))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym32 := z.EncBinary()
 				_ = yym32
 				if false {
@@ -260,6 +300,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym34 := z.EncBinary()
 				_ = yym34
 				if false {
@@ -267,7 +308,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeconfigPath))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeconfigPath"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym35 := z.EncBinary()
 				_ = yym35
 				if false {
@@ -276,6 +319,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym37 := z.EncBinary()
 				_ = yym37
 				if false {
@@ -283,7 +327,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(bool(x.MasqueradeAll))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("masqueradeAll"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym38 := z.EncBinary()
 				_ = yym38
 				if false {
@@ -292,6 +338,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym40 := z.EncBinary()
 				_ = yym40
 				if false {
@@ -299,7 +346,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Master))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("master"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym41 := z.EncBinary()
 				_ = yym41
 				if false {
@@ -308,6 +357,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.OOMScoreAdj == nil {
 					r.EncodeNil()
 				} else {
@@ -320,7 +370,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("oomScoreAdj"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.OOMScoreAdj == nil {
 					r.EncodeNil()
 				} else {
@@ -334,12 +386,16 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Mode.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("mode"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Mode.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym49 := z.EncBinary()
 				_ = yym49
 				if false {
@@ -347,7 +403,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PortRange))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("portRange"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym50 := z.EncBinary()
 				_ = yym50
 				if false {
@@ -356,6 +414,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym52 := z.EncBinary()
 				_ = yym52
 				if false {
@@ -363,7 +422,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceContainer))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("resourceContainer"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym53 := z.EncBinary()
 				_ = yym53
 				if false {
@@ -372,6 +433,7 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym55 := z.EncBinary()
 				_ = yym55
 				if false {
@@ -379,7 +441,9 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.UDPTimeoutMilliseconds))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("udpTimeoutMilliseconds"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym56 := z.EncBinary()
 				_ = yym56
 				if false {
@@ -387,8 +451,10 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.UDPTimeoutMilliseconds))
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -403,17 +469,18 @@ func (x *KubeProxyConfiguration) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct58 := r.ContainerType()
+		if yyct58 == codecSelferValueTypeMap1234 {
 			yyl58 := r.ReadMapStart()
 			if yyl58 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl58, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct58 == codecSelferValueTypeArray1234 {
 			yyl58 := r.ReadArrayStart()
 			if yyl58 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl58, d)
 			}
@@ -440,8 +507,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys59Slc = r.DecodeBytes(yys59Slc, true, true)
 		yys59 := string(yys59Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys59 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -565,9 +634,7 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys59)
 		} // end switch yys59
 	} // end for yyj59
-	if !yyhl59 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -584,9 +651,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -599,9 +667,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -614,9 +683,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.BindAddress = ""
 	} else {
@@ -629,9 +699,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CleanupIPTables = false
 	} else {
@@ -644,9 +715,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HealthzBindAddress = ""
 	} else {
@@ -659,9 +731,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HealthzPort = 0
 	} else {
@@ -674,9 +747,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.HostnameOverride = ""
 	} else {
@@ -689,9 +763,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.IPTablesSyncePeriodSeconds = 0
 	} else {
@@ -704,9 +779,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeAPIBurst = 0
 	} else {
@@ -719,9 +795,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeAPIQPS = 0
 	} else {
@@ -734,9 +811,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.KubeconfigPath = ""
 	} else {
@@ -749,9 +827,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MasqueradeAll = false
 	} else {
@@ -764,9 +843,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Master = ""
 	} else {
@@ -779,9 +859,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.OOMScoreAdj != nil {
 			x.OOMScoreAdj = nil
@@ -804,9 +885,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Mode = ""
 	} else {
@@ -819,9 +901,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.PortRange = ""
 	} else {
@@ -834,9 +917,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ResourceContainer = ""
 	} else {
@@ -849,9 +933,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb79 = r.CheckBreak()
 	}
 	if yyb79 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.UDPTimeoutMilliseconds = 0
 	} else {
@@ -867,9 +952,10 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb79 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj79-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x ProxyMode) CodecEncodeSelf(e *codec1978.Encoder) {

--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -37,10 +37,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -51,10 +59,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -87,18 +95,21 @@ func (x *ScaleSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			yyq2[0] = x.Replicas != 0
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2 int = 0
+				yynn2 = 0
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -111,7 +122,9 @@ func (x *ScaleSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -120,8 +133,10 @@ func (x *ScaleSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -136,17 +151,18 @@ func (x *ScaleSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct7 := r.ContainerType()
+		if yyct7 == codecSelferValueTypeMap1234 {
 			yyl7 := r.ReadMapStart()
 			if yyl7 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl7, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct7 == codecSelferValueTypeArray1234 {
 			yyl7 := r.ReadArrayStart()
 			if yyl7 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl7, d)
 			}
@@ -173,8 +189,10 @@ func (x *ScaleSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys8Slc = r.DecodeBytes(yys8Slc, true, true)
 		yys8 := string(yys8Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys8 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -186,9 +204,7 @@ func (x *ScaleSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys8)
 		} // end switch yys8
 	} // end for yyj8
-	if !yyhl8 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ScaleSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -205,9 +221,10 @@ func (x *ScaleSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb10 = r.CheckBreak()
 	}
 	if yyb10 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -223,9 +240,10 @@ func (x *ScaleSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb10 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj10-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -246,18 +264,21 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep13, yyq13, yy2arr13
 			const yyr13 bool = false
 			yyq13[1] = len(x.Selector) != 0
+			var yynn13 int
 			if yyr13 || yy2arr13 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn13 int = 1
+				yynn13 = 1
 				for _, b := range yyq13 {
 					if b {
 						yynn13++
 					}
 				}
 				r.EncodeMapStart(yynn13)
+				yynn13 = 0
 			}
 			if yyr13 || yy2arr13 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym15 := z.EncBinary()
 				_ = yym15
 				if false {
@@ -265,7 +286,9 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym16 := z.EncBinary()
 				_ = yym16
 				if false {
@@ -274,6 +297,7 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr13 || yy2arr13 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq13[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -290,7 +314,9 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq13[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -303,8 +329,10 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep13 {
-				r.EncodeEnd()
+			if yyr13 || yy2arr13 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -319,17 +347,18 @@ func (x *ScaleStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct21 := r.ContainerType()
+		if yyct21 == codecSelferValueTypeMap1234 {
 			yyl21 := r.ReadMapStart()
 			if yyl21 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl21, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct21 == codecSelferValueTypeArray1234 {
 			yyl21 := r.ReadArrayStart()
 			if yyl21 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl21, d)
 			}
@@ -356,8 +385,10 @@ func (x *ScaleStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys22Slc = r.DecodeBytes(yys22Slc, true, true)
 		yys22 := string(yys22Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys22 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -381,9 +412,7 @@ func (x *ScaleStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys22)
 		} // end switch yys22
 	} // end for yyj22
-	if !yyhl22 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ScaleStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -400,9 +429,10 @@ func (x *ScaleStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb26 = r.CheckBreak()
 	}
 	if yyb26 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -415,9 +445,10 @@ func (x *ScaleStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb26 = r.CheckBreak()
 	}
 	if yyb26 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
@@ -439,9 +470,10 @@ func (x *ScaleStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb26 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj26-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -466,18 +498,21 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq31[2] = true
 			yyq31[3] = true
 			yyq31[4] = true
+			var yynn31 int
 			if yyr31 || yy2arr31 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn31 int = 0
+				yynn31 = 0
 				for _, b := range yyq31 {
 					if b {
 						yynn31++
 					}
 				}
 				r.EncodeMapStart(yynn31)
+				yynn31 = 0
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[0] {
 					yym33 := z.EncBinary()
 					_ = yym33
@@ -490,7 +525,9 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym34 := z.EncBinary()
 					_ = yym34
 					if false {
@@ -500,6 +537,7 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[1] {
 					yym36 := z.EncBinary()
 					_ = yym36
@@ -512,7 +550,9 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym37 := z.EncBinary()
 					_ = yym37
 					if false {
@@ -522,6 +562,7 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[2] {
 					yy39 := &x.ObjectMeta
 					yy39.CodecEncodeSelf(e)
@@ -530,12 +571,15 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy40 := &x.ObjectMeta
 					yy40.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[3] {
 					yy42 := &x.Spec
 					yy42.CodecEncodeSelf(e)
@@ -544,12 +588,15 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy43 := &x.Spec
 					yy43.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[4] {
 					yy45 := &x.Status
 					yy45.CodecEncodeSelf(e)
@@ -558,13 +605,17 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy46 := &x.Status
 					yy46.CodecEncodeSelf(e)
 				}
 			}
-			if yysep31 {
-				r.EncodeEnd()
+			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -579,17 +630,18 @@ func (x *Scale) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct48 := r.ContainerType()
+		if yyct48 == codecSelferValueTypeMap1234 {
 			yyl48 := r.ReadMapStart()
 			if yyl48 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl48, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct48 == codecSelferValueTypeArray1234 {
 			yyl48 := r.ReadArrayStart()
 			if yyl48 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl48, d)
 			}
@@ -616,8 +668,10 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys49Slc = r.DecodeBytes(yys49Slc, true, true)
 		yys49 := string(yys49Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys49 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -656,9 +710,7 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys49)
 		} // end switch yys49
 	} // end for yyj49
-	if !yyhl49 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -675,9 +727,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -690,9 +743,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -705,9 +759,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -721,9 +776,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ScaleSpec{}
 	} else {
@@ -737,9 +793,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ScaleStatus{}
 	} else {
@@ -756,9 +813,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb55 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj55-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -780,18 +838,21 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr62 bool = false
 			yyq62[0] = x.Kind != ""
 			yyq62[1] = x.APIVersion != ""
+			var yynn62 int
 			if yyr62 || yy2arr62 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn62 int = 0
+				yynn62 = 0
 				for _, b := range yyq62 {
 					if b {
 						yynn62++
 					}
 				}
 				r.EncodeMapStart(yynn62)
+				yynn62 = 0
 			}
 			if yyr62 || yy2arr62 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq62[0] {
 					yym64 := z.EncBinary()
 					_ = yym64
@@ -804,7 +865,9 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq62[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym65 := z.EncBinary()
 					_ = yym65
 					if false {
@@ -814,6 +877,7 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr62 || yy2arr62 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq62[1] {
 					yym67 := z.EncBinary()
 					_ = yym67
@@ -826,7 +890,9 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq62[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym68 := z.EncBinary()
 					_ = yym68
 					if false {
@@ -835,8 +901,10 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep62 {
-				r.EncodeEnd()
+			if yyr62 || yy2arr62 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -851,17 +919,18 @@ func (x *ReplicationControllerDummy) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct70 := r.ContainerType()
+		if yyct70 == codecSelferValueTypeMap1234 {
 			yyl70 := r.ReadMapStart()
 			if yyl70 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl70, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct70 == codecSelferValueTypeArray1234 {
 			yyl70 := r.ReadArrayStart()
 			if yyl70 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl70, d)
 			}
@@ -888,8 +957,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys71Slc = r.DecodeBytes(yys71Slc, true, true)
 		yys71 := string(yys71Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys71 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -907,9 +978,7 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 			z.DecStructFieldNotFound(-1, yys71)
 		} // end switch yys71
 	} // end for yyj71
-	if !yyhl71 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -926,9 +995,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 		yyb74 = r.CheckBreak()
 	}
 	if yyb74 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -941,9 +1011,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 		yyb74 = r.CheckBreak()
 	}
 	if yyb74 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -959,9 +1030,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 		if yyb74 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj74-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -985,18 +1057,21 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq78[1] = x.Name != ""
 			yyq78[2] = x.APIVersion != ""
 			yyq78[3] = x.Subresource != ""
+			var yynn78 int
 			if yyr78 || yy2arr78 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn78 int = 0
+				yynn78 = 0
 				for _, b := range yyq78 {
 					if b {
 						yynn78++
 					}
 				}
 				r.EncodeMapStart(yynn78)
+				yynn78 = 0
 			}
 			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq78[0] {
 					yym80 := z.EncBinary()
 					_ = yym80
@@ -1009,7 +1084,9 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq78[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym81 := z.EncBinary()
 					_ = yym81
 					if false {
@@ -1019,6 +1096,7 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq78[1] {
 					yym83 := z.EncBinary()
 					_ = yym83
@@ -1031,7 +1109,9 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq78[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym84 := z.EncBinary()
 					_ = yym84
 					if false {
@@ -1041,6 +1121,7 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq78[2] {
 					yym86 := z.EncBinary()
 					_ = yym86
@@ -1053,7 +1134,9 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq78[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym87 := z.EncBinary()
 					_ = yym87
 					if false {
@@ -1063,6 +1146,7 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq78[3] {
 					yym89 := z.EncBinary()
 					_ = yym89
@@ -1075,7 +1159,9 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq78[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("subresource"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym90 := z.EncBinary()
 					_ = yym90
 					if false {
@@ -1084,8 +1170,10 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep78 {
-				r.EncodeEnd()
+			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1100,17 +1188,18 @@ func (x *SubresourceReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct92 := r.ContainerType()
+		if yyct92 == codecSelferValueTypeMap1234 {
 			yyl92 := r.ReadMapStart()
 			if yyl92 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl92, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct92 == codecSelferValueTypeArray1234 {
 			yyl92 := r.ReadArrayStart()
 			if yyl92 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl92, d)
 			}
@@ -1137,8 +1226,10 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys93Slc = r.DecodeBytes(yys93Slc, true, true)
 		yys93 := string(yys93Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys93 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -1168,9 +1259,7 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys93)
 		} // end switch yys93
 	} // end for yyj93
-	if !yyhl93 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -1187,9 +1276,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb98 = r.CheckBreak()
 	}
 	if yyb98 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -1202,9 +1292,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb98 = r.CheckBreak()
 	}
 	if yyb98 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -1217,9 +1308,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb98 = r.CheckBreak()
 	}
 	if yyb98 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -1232,9 +1324,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb98 = r.CheckBreak()
 	}
 	if yyb98 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Subresource = ""
 	} else {
@@ -1250,9 +1343,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb98 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj98-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -1272,18 +1366,21 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq104 [1]bool
 			_, _, _ = yysep104, yyq104, yy2arr104
 			const yyr104 bool = false
+			var yynn104 int
 			if yyr104 || yy2arr104 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn104 int = 1
+				yynn104 = 1
 				for _, b := range yyq104 {
 					if b {
 						yynn104++
 					}
 				}
 				r.EncodeMapStart(yynn104)
+				yynn104 = 0
 			}
 			if yyr104 || yy2arr104 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym106 := z.EncBinary()
 				_ = yym106
 				if false {
@@ -1291,7 +1388,9 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("targetPercentage"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym107 := z.EncBinary()
 				_ = yym107
 				if false {
@@ -1299,8 +1398,10 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			}
-			if yysep104 {
-				r.EncodeEnd()
+			if yyr104 || yy2arr104 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1315,17 +1416,18 @@ func (x *CPUTargetUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct109 := r.ContainerType()
+		if yyct109 == codecSelferValueTypeMap1234 {
 			yyl109 := r.ReadMapStart()
 			if yyl109 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl109, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct109 == codecSelferValueTypeArray1234 {
 			yyl109 := r.ReadArrayStart()
 			if yyl109 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl109, d)
 			}
@@ -1352,8 +1454,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys110Slc = r.DecodeBytes(yys110Slc, true, true)
 		yys110 := string(yys110Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys110 {
 		case "targetPercentage":
 			if r.TryDecodeAsNil() {
@@ -1365,9 +1469,7 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys110)
 		} // end switch yys110
 	} // end for yyj110
-	if !yyhl110 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -1384,9 +1486,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb112 = r.CheckBreak()
 	}
 	if yyb112 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetPercentage = 0
 	} else {
@@ -1402,9 +1505,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb112 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj112-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -1426,26 +1530,32 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr115 bool = false
 			yyq115[1] = x.MinReplicas != nil
 			yyq115[3] = x.CPUUtilization != nil
+			var yynn115 int
 			if yyr115 || yy2arr115 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn115 int = 2
+				yynn115 = 2
 				for _, b := range yyq115 {
 					if b {
 						yynn115++
 					}
 				}
 				r.EncodeMapStart(yynn115)
+				yynn115 = 0
 			}
 			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy117 := &x.ScaleRef
 				yy117.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("scaleRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy118 := &x.ScaleRef
 				yy118.CodecEncodeSelf(e)
 			}
 			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq115[1] {
 					if x.MinReplicas == nil {
 						r.EncodeNil()
@@ -1463,7 +1573,9 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq115[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("minReplicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
@@ -1478,6 +1590,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym125 := z.EncBinary()
 				_ = yym125
 				if false {
@@ -1485,7 +1598,9 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("maxReplicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym126 := z.EncBinary()
 				_ = yym126
 				if false {
@@ -1494,6 +1609,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq115[3] {
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
@@ -1505,7 +1621,9 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq115[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cpuUtilization"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
 					} else {
@@ -1513,8 +1631,10 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep115 {
-				r.EncodeEnd()
+			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1529,17 +1649,18 @@ func (x *HorizontalPodAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct129 := r.ContainerType()
+		if yyct129 == codecSelferValueTypeMap1234 {
 			yyl129 := r.ReadMapStart()
 			if yyl129 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl129, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct129 == codecSelferValueTypeArray1234 {
 			yyl129 := r.ReadArrayStart()
 			if yyl129 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl129, d)
 			}
@@ -1566,8 +1687,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys130Slc = r.DecodeBytes(yys130Slc, true, true)
 		yys130 := string(yys130Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys130 {
 		case "scaleRef":
 			if r.TryDecodeAsNil() {
@@ -1613,9 +1736,7 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 			z.DecStructFieldNotFound(-1, yys130)
 		} // end switch yys130
 	} // end for yyj130
-	if !yyhl130 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -1632,9 +1753,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		yyb136 = r.CheckBreak()
 	}
 	if yyb136 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ScaleRef = SubresourceReference{}
 	} else {
@@ -1648,9 +1770,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		yyb136 = r.CheckBreak()
 	}
 	if yyb136 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.MinReplicas != nil {
 			x.MinReplicas = nil
@@ -1673,9 +1796,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		yyb136 = r.CheckBreak()
 	}
 	if yyb136 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MaxReplicas = 0
 	} else {
@@ -1688,9 +1812,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		yyb136 = r.CheckBreak()
 	}
 	if yyb136 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CPUUtilization != nil {
 			x.CPUUtilization = nil
@@ -1711,9 +1836,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		if yyb136 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj136-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -1736,18 +1862,21 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq143[0] = x.ObservedGeneration != nil
 			yyq143[1] = x.LastScaleTime != nil
 			yyq143[4] = x.CurrentCPUUtilizationPercentage != nil
+			var yynn143 int
 			if yyr143 || yy2arr143 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn143 int = 2
+				yynn143 = 2
 				for _, b := range yyq143 {
 					if b {
 						yynn143++
 					}
 				}
 				r.EncodeMapStart(yynn143)
+				yynn143 = 0
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq143[0] {
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
@@ -1765,7 +1894,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq143[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
@@ -1780,6 +1911,7 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq143[1] {
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
@@ -1801,7 +1933,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq143[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastScaleTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
@@ -1820,6 +1954,7 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym153 := z.EncBinary()
 				_ = yym153
 				if false {
@@ -1827,7 +1962,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("currentReplicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym154 := z.EncBinary()
 				_ = yym154
 				if false {
@@ -1836,6 +1973,7 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym156 := z.EncBinary()
 				_ = yym156
 				if false {
@@ -1843,7 +1981,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("desiredReplicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym157 := z.EncBinary()
 				_ = yym157
 				if false {
@@ -1852,6 +1992,7 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq143[4] {
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
@@ -1869,7 +2010,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq143[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("currentCPUUtilizationPercentage"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
@@ -1883,8 +2026,10 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep143 {
-				r.EncodeEnd()
+			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1899,17 +2044,18 @@ func (x *HorizontalPodAutoscalerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct164 := r.ContainerType()
+		if yyct164 == codecSelferValueTypeMap1234 {
 			yyl164 := r.ReadMapStart()
 			if yyl164 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl164, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct164 == codecSelferValueTypeArray1234 {
 			yyl164 := r.ReadArrayStart()
 			if yyl164 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl164, d)
 			}
@@ -1936,8 +2082,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys165Slc = r.DecodeBytes(yys165Slc, true, true)
 		yys165 := string(yys165Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys165 {
 		case "observedGeneration":
 			if r.TryDecodeAsNil() {
@@ -2008,9 +2156,7 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 			z.DecStructFieldNotFound(-1, yys165)
 		} // end switch yys165
 	} // end for yyj165
-	if !yyhl165 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -2027,9 +2173,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ObservedGeneration != nil {
 			x.ObservedGeneration = nil
@@ -2052,9 +2199,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.LastScaleTime != nil {
 			x.LastScaleTime = nil
@@ -2082,9 +2230,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CurrentReplicas = 0
 	} else {
@@ -2097,9 +2246,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DesiredReplicas = 0
 	} else {
@@ -2112,9 +2262,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CurrentCPUUtilizationPercentage != nil {
 			x.CurrentCPUUtilizationPercentage = nil
@@ -2140,9 +2291,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if yyb174 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj174-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -2167,18 +2319,21 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq184[2] = true
 			yyq184[3] = true
 			yyq184[4] = true
+			var yynn184 int
 			if yyr184 || yy2arr184 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn184 int = 0
+				yynn184 = 0
 				for _, b := range yyq184 {
 					if b {
 						yynn184++
 					}
 				}
 				r.EncodeMapStart(yynn184)
+				yynn184 = 0
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[0] {
 					yym186 := z.EncBinary()
 					_ = yym186
@@ -2191,7 +2346,9 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym187 := z.EncBinary()
 					_ = yym187
 					if false {
@@ -2201,6 +2358,7 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[1] {
 					yym189 := z.EncBinary()
 					_ = yym189
@@ -2213,7 +2371,9 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym190 := z.EncBinary()
 					_ = yym190
 					if false {
@@ -2223,6 +2383,7 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[2] {
 					yy192 := &x.ObjectMeta
 					yy192.CodecEncodeSelf(e)
@@ -2231,12 +2392,15 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy193 := &x.ObjectMeta
 					yy193.CodecEncodeSelf(e)
 				}
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[3] {
 					yy195 := &x.Spec
 					yy195.CodecEncodeSelf(e)
@@ -2245,12 +2409,15 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy196 := &x.Spec
 					yy196.CodecEncodeSelf(e)
 				}
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[4] {
 					yy198 := &x.Status
 					yy198.CodecEncodeSelf(e)
@@ -2259,13 +2426,17 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy199 := &x.Status
 					yy199.CodecEncodeSelf(e)
 				}
 			}
-			if yysep184 {
-				r.EncodeEnd()
+			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -2280,17 +2451,18 @@ func (x *HorizontalPodAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct201 := r.ContainerType()
+		if yyct201 == codecSelferValueTypeMap1234 {
 			yyl201 := r.ReadMapStart()
 			if yyl201 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl201, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct201 == codecSelferValueTypeArray1234 {
 			yyl201 := r.ReadArrayStart()
 			if yyl201 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl201, d)
 			}
@@ -2317,8 +2489,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys202Slc = r.DecodeBytes(yys202Slc, true, true)
 		yys202 := string(yys202Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys202 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -2357,9 +2531,7 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			z.DecStructFieldNotFound(-1, yys202)
 		} // end switch yys202
 	} // end for yyj202
-	if !yyhl202 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -2376,9 +2548,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -2391,9 +2564,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -2406,9 +2580,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -2422,9 +2597,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = HorizontalPodAutoscalerSpec{}
 	} else {
@@ -2438,9 +2614,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = HorizontalPodAutoscalerStatus{}
 	} else {
@@ -2457,9 +2634,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if yyb208 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj208-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -2482,18 +2660,21 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq215[0] = x.Kind != ""
 			yyq215[1] = x.APIVersion != ""
 			yyq215[2] = true
+			var yynn215 int
 			if yyr215 || yy2arr215 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn215 int = 1
+				yynn215 = 1
 				for _, b := range yyq215 {
 					if b {
 						yynn215++
 					}
 				}
 				r.EncodeMapStart(yynn215)
+				yynn215 = 0
 			}
 			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq215[0] {
 					yym217 := z.EncBinary()
 					_ = yym217
@@ -2506,7 +2687,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq215[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym218 := z.EncBinary()
 					_ = yym218
 					if false {
@@ -2516,6 +2699,7 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq215[1] {
 					yym220 := z.EncBinary()
 					_ = yym220
@@ -2528,7 +2712,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq215[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym221 := z.EncBinary()
 					_ = yym221
 					if false {
@@ -2538,6 +2724,7 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq215[2] {
 					yy223 := &x.ListMeta
 					yym224 := z.EncBinary()
@@ -2552,7 +2739,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq215[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy225 := &x.ListMeta
 					yym226 := z.EncBinary()
 					_ = yym226
@@ -2564,6 +2753,7 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -2575,7 +2765,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -2587,8 +2779,10 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep215 {
-				r.EncodeEnd()
+			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -2603,17 +2797,18 @@ func (x *HorizontalPodAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct231 := r.ContainerType()
+		if yyct231 == codecSelferValueTypeMap1234 {
 			yyl231 := r.ReadMapStart()
 			if yyl231 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl231, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct231 == codecSelferValueTypeArray1234 {
 			yyl231 := r.ReadArrayStart()
 			if yyl231 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl231, d)
 			}
@@ -2640,8 +2835,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys232Slc = r.DecodeBytes(yys232Slc, true, true)
 		yys232 := string(yys232Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys232 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -2684,9 +2881,7 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 			z.DecStructFieldNotFound(-1, yys232)
 		} // end switch yys232
 	} // end for yyj232
-	if !yyhl232 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -2703,9 +2898,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		yyb239 = r.CheckBreak()
 	}
 	if yyb239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -2718,9 +2914,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		yyb239 = r.CheckBreak()
 	}
 	if yyb239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -2733,9 +2930,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		yyb239 = r.CheckBreak()
 	}
 	if yyb239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -2755,9 +2953,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		yyb239 = r.CheckBreak()
 	}
 	if yyb239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -2779,9 +2978,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		if yyb239 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj239-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -2806,18 +3006,21 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq247[2] = true
 			yyq247[3] = x.Description != ""
 			yyq247[4] = len(x.Versions) != 0
+			var yynn247 int
 			if yyr247 || yy2arr247 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn247 int = 0
+				yynn247 = 0
 				for _, b := range yyq247 {
 					if b {
 						yynn247++
 					}
 				}
 				r.EncodeMapStart(yynn247)
+				yynn247 = 0
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[0] {
 					yym249 := z.EncBinary()
 					_ = yym249
@@ -2830,7 +3033,9 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym250 := z.EncBinary()
 					_ = yym250
 					if false {
@@ -2840,6 +3045,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[1] {
 					yym252 := z.EncBinary()
 					_ = yym252
@@ -2852,7 +3058,9 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym253 := z.EncBinary()
 					_ = yym253
 					if false {
@@ -2862,6 +3070,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[2] {
 					yy255 := &x.ObjectMeta
 					yy255.CodecEncodeSelf(e)
@@ -2870,12 +3079,15 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy256 := &x.ObjectMeta
 					yy256.CodecEncodeSelf(e)
 				}
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[3] {
 					yym258 := z.EncBinary()
 					_ = yym258
@@ -2888,7 +3100,9 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("description"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym259 := z.EncBinary()
 					_ = yym259
 					if false {
@@ -2898,6 +3112,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[4] {
 					if x.Versions == nil {
 						r.EncodeNil()
@@ -2914,7 +3129,9 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("versions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
@@ -2927,8 +3144,10 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep247 {
-				r.EncodeEnd()
+			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -2943,17 +3162,18 @@ func (x *ThirdPartyResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct264 := r.ContainerType()
+		if yyct264 == codecSelferValueTypeMap1234 {
 			yyl264 := r.ReadMapStart()
 			if yyl264 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl264, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct264 == codecSelferValueTypeArray1234 {
 			yyl264 := r.ReadArrayStart()
 			if yyl264 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl264, d)
 			}
@@ -2980,8 +3200,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys265Slc = r.DecodeBytes(yys265Slc, true, true)
 		yys265 := string(yys265Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys265 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -3024,9 +3246,7 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys265)
 		} // end switch yys265
 	} // end for yyj265
-	if !yyhl265 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3043,9 +3263,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -3058,9 +3279,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -3073,9 +3295,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -3089,9 +3312,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Description = ""
 	} else {
@@ -3104,9 +3328,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Versions = nil
 	} else {
@@ -3128,9 +3353,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb272 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj272-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3153,18 +3379,21 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq280[0] = x.Kind != ""
 			yyq280[1] = x.APIVersion != ""
 			yyq280[2] = true
+			var yynn280 int
 			if yyr280 || yy2arr280 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn280 int = 1
+				yynn280 = 1
 				for _, b := range yyq280 {
 					if b {
 						yynn280++
 					}
 				}
 				r.EncodeMapStart(yynn280)
+				yynn280 = 0
 			}
 			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq280[0] {
 					yym282 := z.EncBinary()
 					_ = yym282
@@ -3177,7 +3406,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq280[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym283 := z.EncBinary()
 					_ = yym283
 					if false {
@@ -3187,6 +3418,7 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq280[1] {
 					yym285 := z.EncBinary()
 					_ = yym285
@@ -3199,7 +3431,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq280[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym286 := z.EncBinary()
 					_ = yym286
 					if false {
@@ -3209,6 +3443,7 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq280[2] {
 					yy288 := &x.ListMeta
 					yym289 := z.EncBinary()
@@ -3223,7 +3458,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq280[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy290 := &x.ListMeta
 					yym291 := z.EncBinary()
 					_ = yym291
@@ -3235,6 +3472,7 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -3246,7 +3484,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -3258,8 +3498,10 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep280 {
-				r.EncodeEnd()
+			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3274,17 +3516,18 @@ func (x *ThirdPartyResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct296 := r.ContainerType()
+		if yyct296 == codecSelferValueTypeMap1234 {
 			yyl296 := r.ReadMapStart()
 			if yyl296 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl296, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct296 == codecSelferValueTypeArray1234 {
 			yyl296 := r.ReadArrayStart()
 			if yyl296 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl296, d)
 			}
@@ -3311,8 +3554,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys297Slc = r.DecodeBytes(yys297Slc, true, true)
 		yys297 := string(yys297Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys297 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -3355,9 +3600,7 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys297)
 		} // end switch yys297
 	} // end for yyj297
-	if !yyhl297 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3374,9 +3617,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb304 = r.CheckBreak()
 	}
 	if yyb304 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -3389,9 +3633,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb304 = r.CheckBreak()
 	}
 	if yyb304 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -3404,9 +3649,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb304 = r.CheckBreak()
 	}
 	if yyb304 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -3426,9 +3672,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb304 = r.CheckBreak()
 	}
 	if yyb304 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -3450,9 +3697,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb304 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj304-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3474,18 +3722,21 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr312 bool = false
 			yyq312[0] = x.Name != ""
 			yyq312[1] = x.APIGroup != ""
+			var yynn312 int
 			if yyr312 || yy2arr312 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn312 int = 0
+				yynn312 = 0
 				for _, b := range yyq312 {
 					if b {
 						yynn312++
 					}
 				}
 				r.EncodeMapStart(yynn312)
+				yynn312 = 0
 			}
 			if yyr312 || yy2arr312 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq312[0] {
 					yym314 := z.EncBinary()
 					_ = yym314
@@ -3498,7 +3749,9 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq312[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym315 := z.EncBinary()
 					_ = yym315
 					if false {
@@ -3508,6 +3761,7 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr312 || yy2arr312 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq312[1] {
 					yym317 := z.EncBinary()
 					_ = yym317
@@ -3520,7 +3774,9 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq312[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiGroup"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym318 := z.EncBinary()
 					_ = yym318
 					if false {
@@ -3529,8 +3785,10 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep312 {
-				r.EncodeEnd()
+			if yyr312 || yy2arr312 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3545,17 +3803,18 @@ func (x *APIVersion) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct320 := r.ContainerType()
+		if yyct320 == codecSelferValueTypeMap1234 {
 			yyl320 := r.ReadMapStart()
 			if yyl320 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl320, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct320 == codecSelferValueTypeArray1234 {
 			yyl320 := r.ReadArrayStart()
 			if yyl320 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl320, d)
 			}
@@ -3582,8 +3841,10 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys321Slc = r.DecodeBytes(yys321Slc, true, true)
 		yys321 := string(yys321Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys321 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -3601,9 +3862,7 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys321)
 		} // end switch yys321
 	} // end for yyj321
-	if !yyhl321 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3620,9 +3879,10 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb324 = r.CheckBreak()
 	}
 	if yyb324 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -3635,9 +3895,10 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb324 = r.CheckBreak()
 	}
 	if yyb324 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIGroup = ""
 	} else {
@@ -3653,9 +3914,10 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb324 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj324-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3679,18 +3941,21 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq328[1] = x.APIVersion != ""
 			yyq328[2] = true
 			yyq328[3] = len(x.Data) != 0
+			var yynn328 int
 			if yyr328 || yy2arr328 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn328 int = 0
+				yynn328 = 0
 				for _, b := range yyq328 {
 					if b {
 						yynn328++
 					}
 				}
 				r.EncodeMapStart(yynn328)
+				yynn328 = 0
 			}
 			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq328[0] {
 					yym330 := z.EncBinary()
 					_ = yym330
@@ -3703,7 +3968,9 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq328[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym331 := z.EncBinary()
 					_ = yym331
 					if false {
@@ -3713,6 +3980,7 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq328[1] {
 					yym333 := z.EncBinary()
 					_ = yym333
@@ -3725,7 +3993,9 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq328[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym334 := z.EncBinary()
 					_ = yym334
 					if false {
@@ -3735,6 +4005,7 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq328[2] {
 					yy336 := &x.ObjectMeta
 					yy336.CodecEncodeSelf(e)
@@ -3743,12 +4014,15 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq328[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy337 := &x.ObjectMeta
 					yy337.CodecEncodeSelf(e)
 				}
 			}
 			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq328[3] {
 					if x.Data == nil {
 						r.EncodeNil()
@@ -3765,7 +4039,9 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq328[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
@@ -3778,8 +4054,10 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep328 {
-				r.EncodeEnd()
+			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3794,17 +4072,18 @@ func (x *ThirdPartyResourceData) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct342 := r.ContainerType()
+		if yyct342 == codecSelferValueTypeMap1234 {
 			yyl342 := r.ReadMapStart()
 			if yyl342 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl342, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct342 == codecSelferValueTypeArray1234 {
 			yyl342 := r.ReadArrayStart()
 			if yyl342 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl342, d)
 			}
@@ -3831,8 +4110,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
 		yys343 := string(yys343Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys343 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -3869,9 +4150,7 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys343)
 		} // end switch yys343
 	} // end for yyj343
-	if !yyhl343 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3888,9 +4167,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb349 = r.CheckBreak()
 	}
 	if yyb349 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -3903,9 +4183,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb349 = r.CheckBreak()
 	}
 	if yyb349 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -3918,9 +4199,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb349 = r.CheckBreak()
 	}
 	if yyb349 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -3934,9 +4216,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb349 = r.CheckBreak()
 	}
 	if yyb349 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
@@ -3958,9 +4241,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb349 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj349-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3985,18 +4269,21 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq356[2] = true
 			yyq356[3] = true
 			yyq356[4] = true
+			var yynn356 int
 			if yyr356 || yy2arr356 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn356 int = 0
+				yynn356 = 0
 				for _, b := range yyq356 {
 					if b {
 						yynn356++
 					}
 				}
 				r.EncodeMapStart(yynn356)
+				yynn356 = 0
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[0] {
 					yym358 := z.EncBinary()
 					_ = yym358
@@ -4009,7 +4296,9 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym359 := z.EncBinary()
 					_ = yym359
 					if false {
@@ -4019,6 +4308,7 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[1] {
 					yym361 := z.EncBinary()
 					_ = yym361
@@ -4031,7 +4321,9 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym362 := z.EncBinary()
 					_ = yym362
 					if false {
@@ -4041,6 +4333,7 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[2] {
 					yy364 := &x.ObjectMeta
 					yy364.CodecEncodeSelf(e)
@@ -4049,12 +4342,15 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy365 := &x.ObjectMeta
 					yy365.CodecEncodeSelf(e)
 				}
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[3] {
 					yy367 := &x.Spec
 					yy367.CodecEncodeSelf(e)
@@ -4063,12 +4359,15 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy368 := &x.Spec
 					yy368.CodecEncodeSelf(e)
 				}
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[4] {
 					yy370 := &x.Status
 					yy370.CodecEncodeSelf(e)
@@ -4077,13 +4376,17 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy371 := &x.Status
 					yy371.CodecEncodeSelf(e)
 				}
 			}
-			if yysep356 {
-				r.EncodeEnd()
+			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4098,17 +4401,18 @@ func (x *Deployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct373 := r.ContainerType()
+		if yyct373 == codecSelferValueTypeMap1234 {
 			yyl373 := r.ReadMapStart()
 			if yyl373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl373, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct373 == codecSelferValueTypeArray1234 {
 			yyl373 := r.ReadArrayStart()
 			if yyl373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl373, d)
 			}
@@ -4135,8 +4439,10 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys374Slc = r.DecodeBytes(yys374Slc, true, true)
 		yys374 := string(yys374Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys374 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -4175,9 +4481,7 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys374)
 		} // end switch yys374
 	} // end for yyj374
-	if !yyhl374 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -4194,9 +4498,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -4209,9 +4514,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -4224,9 +4530,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -4240,9 +4547,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = DeploymentSpec{}
 	} else {
@@ -4256,9 +4564,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = DeploymentStatus{}
 	} else {
@@ -4275,9 +4584,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb380 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj380-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -4301,18 +4611,21 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq387[1] = len(x.Selector) != 0
 			yyq387[3] = true
 			yyq387[4] = x.UniqueLabelKey != ""
+			var yynn387 int
 			if yyr387 || yy2arr387 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn387 int = 1
+				yynn387 = 1
 				for _, b := range yyq387 {
 					if b {
 						yynn387++
 					}
 				}
 				r.EncodeMapStart(yynn387)
+				yynn387 = 0
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq387[0] {
 					yym389 := z.EncBinary()
 					_ = yym389
@@ -4325,7 +4638,9 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq387[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym390 := z.EncBinary()
 					_ = yym390
 					if false {
@@ -4335,6 +4650,7 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq387[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -4351,7 +4667,9 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq387[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -4365,14 +4683,18 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy395 := &x.Template
 				yy395.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy396 := &x.Template
 				yy396.CodecEncodeSelf(e)
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq387[3] {
 					yy398 := &x.Strategy
 					yy398.CodecEncodeSelf(e)
@@ -4381,12 +4703,15 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq387[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("strategy"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy399 := &x.Strategy
 					yy399.CodecEncodeSelf(e)
 				}
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq387[4] {
 					yym401 := z.EncBinary()
 					_ = yym401
@@ -4399,7 +4724,9 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq387[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym402 := z.EncBinary()
 					_ = yym402
 					if false {
@@ -4408,8 +4735,10 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep387 {
-				r.EncodeEnd()
+			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4424,17 +4753,18 @@ func (x *DeploymentSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct404 := r.ContainerType()
+		if yyct404 == codecSelferValueTypeMap1234 {
 			yyl404 := r.ReadMapStart()
 			if yyl404 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl404, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct404 == codecSelferValueTypeArray1234 {
 			yyl404 := r.ReadArrayStart()
 			if yyl404 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl404, d)
 			}
@@ -4461,8 +4791,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys405Slc = r.DecodeBytes(yys405Slc, true, true)
 		yys405 := string(yys405Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys405 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -4506,9 +4838,7 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys405)
 		} // end switch yys405
 	} // end for yyj405
-	if !yyhl405 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -4525,9 +4855,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb412 = r.CheckBreak()
 	}
 	if yyb412 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -4540,9 +4871,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb412 = r.CheckBreak()
 	}
 	if yyb412 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
@@ -4561,9 +4893,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb412 = r.CheckBreak()
 	}
 	if yyb412 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
@@ -4577,9 +4910,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb412 = r.CheckBreak()
 	}
 	if yyb412 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Strategy = DeploymentStrategy{}
 	} else {
@@ -4593,9 +4927,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb412 = r.CheckBreak()
 	}
 	if yyb412 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.UniqueLabelKey = ""
 	} else {
@@ -4611,9 +4946,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb412 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj412-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -4635,18 +4971,21 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr420 bool = false
 			yyq420[0] = x.Type != ""
 			yyq420[1] = x.RollingUpdate != nil
+			var yynn420 int
 			if yyr420 || yy2arr420 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn420 int = 0
+				yynn420 = 0
 				for _, b := range yyq420 {
 					if b {
 						yynn420++
 					}
 				}
 				r.EncodeMapStart(yynn420)
+				yynn420 = 0
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq420[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
@@ -4654,11 +4993,14 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq420[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
 			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq420[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
@@ -4670,7 +5012,9 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq420[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -4678,8 +5022,10 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep420 {
-				r.EncodeEnd()
+			if yyr420 || yy2arr420 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4694,17 +5040,18 @@ func (x *DeploymentStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct424 := r.ContainerType()
+		if yyct424 == codecSelferValueTypeMap1234 {
 			yyl424 := r.ReadMapStart()
 			if yyl424 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl424, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct424 == codecSelferValueTypeArray1234 {
 			yyl424 := r.ReadArrayStart()
 			if yyl424 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl424, d)
 			}
@@ -4731,8 +5078,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys425Slc = r.DecodeBytes(yys425Slc, true, true)
 		yys425 := string(yys425Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys425 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -4755,9 +5104,7 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys425)
 		} // end switch yys425
 	} // end for yyj425
-	if !yyhl425 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -4774,9 +5121,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb428 = r.CheckBreak()
 	}
 	if yyb428 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -4789,9 +5137,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb428 = r.CheckBreak()
 	}
 	if yyb428 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RollingUpdate != nil {
 			x.RollingUpdate = nil
@@ -4812,9 +5161,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb428 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj428-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x DeploymentStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -4863,18 +5213,21 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq434[0] = true
 			yyq434[1] = true
 			yyq434[2] = x.MinReadySeconds != 0
+			var yynn434 int
 			if yyr434 || yy2arr434 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn434 int = 0
+				yynn434 = 0
 				for _, b := range yyq434 {
 					if b {
 						yynn434++
 					}
 				}
 				r.EncodeMapStart(yynn434)
+				yynn434 = 0
 			}
 			if yyr434 || yy2arr434 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq434[0] {
 					yy436 := &x.MaxUnavailable
 					yym437 := z.EncBinary()
@@ -4891,7 +5244,9 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq434[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy438 := &x.MaxUnavailable
 					yym439 := z.EncBinary()
 					_ = yym439
@@ -4905,6 +5260,7 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr434 || yy2arr434 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq434[1] {
 					yy441 := &x.MaxSurge
 					yym442 := z.EncBinary()
@@ -4921,7 +5277,9 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq434[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy443 := &x.MaxSurge
 					yym444 := z.EncBinary()
 					_ = yym444
@@ -4935,6 +5293,7 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr434 || yy2arr434 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq434[2] {
 					yym446 := z.EncBinary()
 					_ = yym446
@@ -4947,7 +5306,9 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq434[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym447 := z.EncBinary()
 					_ = yym447
 					if false {
@@ -4956,8 +5317,10 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep434 {
-				r.EncodeEnd()
+			if yyr434 || yy2arr434 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4972,17 +5335,18 @@ func (x *RollingUpdateDeployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct449 := r.ContainerType()
+		if yyct449 == codecSelferValueTypeMap1234 {
 			yyl449 := r.ReadMapStart()
 			if yyl449 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl449, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct449 == codecSelferValueTypeArray1234 {
 			yyl449 := r.ReadArrayStart()
 			if yyl449 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl449, d)
 			}
@@ -5009,8 +5373,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys450Slc = r.DecodeBytes(yys450Slc, true, true)
 		yys450 := string(yys450Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys450 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
@@ -5052,9 +5418,7 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			z.DecStructFieldNotFound(-1, yys450)
 		} // end switch yys450
 	} // end for yyj450
-	if !yyhl450 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5071,9 +5435,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb456 = r.CheckBreak()
 	}
 	if yyb456 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MaxUnavailable = pkg6_intstr.IntOrString{}
 	} else {
@@ -5095,9 +5460,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb456 = r.CheckBreak()
 	}
 	if yyb456 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MaxSurge = pkg6_intstr.IntOrString{}
 	} else {
@@ -5119,9 +5485,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb456 = r.CheckBreak()
 	}
 	if yyb456 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MinReadySeconds = 0
 	} else {
@@ -5137,9 +5504,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if yyb456 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj456-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5161,18 +5529,21 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr463 bool = false
 			yyq463[0] = x.Replicas != 0
 			yyq463[1] = x.UpdatedReplicas != 0
+			var yynn463 int
 			if yyr463 || yy2arr463 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn463 int = 0
+				yynn463 = 0
 				for _, b := range yyq463 {
 					if b {
 						yynn463++
 					}
 				}
 				r.EncodeMapStart(yynn463)
+				yynn463 = 0
 			}
 			if yyr463 || yy2arr463 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq463[0] {
 					yym465 := z.EncBinary()
 					_ = yym465
@@ -5185,7 +5556,9 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq463[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym466 := z.EncBinary()
 					_ = yym466
 					if false {
@@ -5195,6 +5568,7 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr463 || yy2arr463 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq463[1] {
 					yym468 := z.EncBinary()
 					_ = yym468
@@ -5207,7 +5581,9 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq463[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("updatedReplicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym469 := z.EncBinary()
 					_ = yym469
 					if false {
@@ -5216,8 +5592,10 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep463 {
-				r.EncodeEnd()
+			if yyr463 || yy2arr463 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5232,17 +5610,18 @@ func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct471 := r.ContainerType()
+		if yyct471 == codecSelferValueTypeMap1234 {
 			yyl471 := r.ReadMapStart()
 			if yyl471 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl471, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct471 == codecSelferValueTypeArray1234 {
 			yyl471 := r.ReadArrayStart()
 			if yyl471 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl471, d)
 			}
@@ -5269,8 +5648,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys472Slc = r.DecodeBytes(yys472Slc, true, true)
 		yys472 := string(yys472Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys472 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -5288,9 +5669,7 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys472)
 		} // end switch yys472
 	} // end for yyj472
-	if !yyhl472 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5307,9 +5686,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb475 = r.CheckBreak()
 	}
 	if yyb475 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -5322,9 +5702,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb475 = r.CheckBreak()
 	}
 	if yyb475 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.UpdatedReplicas = 0
 	} else {
@@ -5340,9 +5721,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if yyb475 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj475-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5365,18 +5747,21 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq479[0] = x.Kind != ""
 			yyq479[1] = x.APIVersion != ""
 			yyq479[2] = true
+			var yynn479 int
 			if yyr479 || yy2arr479 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn479 int = 1
+				yynn479 = 1
 				for _, b := range yyq479 {
 					if b {
 						yynn479++
 					}
 				}
 				r.EncodeMapStart(yynn479)
+				yynn479 = 0
 			}
 			if yyr479 || yy2arr479 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq479[0] {
 					yym481 := z.EncBinary()
 					_ = yym481
@@ -5389,7 +5774,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq479[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym482 := z.EncBinary()
 					_ = yym482
 					if false {
@@ -5399,6 +5786,7 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr479 || yy2arr479 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq479[1] {
 					yym484 := z.EncBinary()
 					_ = yym484
@@ -5411,7 +5799,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq479[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym485 := z.EncBinary()
 					_ = yym485
 					if false {
@@ -5421,6 +5811,7 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr479 || yy2arr479 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq479[2] {
 					yy487 := &x.ListMeta
 					yym488 := z.EncBinary()
@@ -5435,7 +5826,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq479[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy489 := &x.ListMeta
 					yym490 := z.EncBinary()
 					_ = yym490
@@ -5447,6 +5840,7 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr479 || yy2arr479 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -5458,7 +5852,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -5470,8 +5866,10 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep479 {
-				r.EncodeEnd()
+			if yyr479 || yy2arr479 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5486,17 +5884,18 @@ func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct495 := r.ContainerType()
+		if yyct495 == codecSelferValueTypeMap1234 {
 			yyl495 := r.ReadMapStart()
 			if yyl495 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl495, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct495 == codecSelferValueTypeArray1234 {
 			yyl495 := r.ReadArrayStart()
 			if yyl495 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl495, d)
 			}
@@ -5523,8 +5922,10 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys496Slc = r.DecodeBytes(yys496Slc, true, true)
 		yys496 := string(yys496Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys496 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -5567,9 +5968,7 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys496)
 		} // end switch yys496
 	} // end for yyj496
-	if !yyhl496 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5586,9 +5985,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb503 = r.CheckBreak()
 	}
 	if yyb503 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -5601,9 +6001,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb503 = r.CheckBreak()
 	}
 	if yyb503 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -5616,9 +6017,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb503 = r.CheckBreak()
 	}
 	if yyb503 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -5638,9 +6040,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb503 = r.CheckBreak()
 	}
 	if yyb503 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -5662,9 +6065,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb503 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj503-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5686,18 +6090,21 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr511 bool = false
 			yyq511[0] = x.Selector != nil
 			yyq511[1] = x.Template != nil
+			var yynn511 int
 			if yyr511 || yy2arr511 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn511 int = 0
+				yynn511 = 0
 				for _, b := range yyq511 {
 					if b {
 						yynn511++
 					}
 				}
 				r.EncodeMapStart(yynn511)
+				yynn511 = 0
 			}
 			if yyr511 || yy2arr511 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq511[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -5709,7 +6116,9 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq511[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -5718,6 +6127,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr511 || yy2arr511 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq511[1] {
 					if x.Template == nil {
 						r.EncodeNil()
@@ -5729,7 +6139,9 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq511[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -5737,8 +6149,10 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep511 {
-				r.EncodeEnd()
+			if yyr511 || yy2arr511 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5753,17 +6167,18 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct515 := r.ContainerType()
+		if yyct515 == codecSelferValueTypeMap1234 {
 			yyl515 := r.ReadMapStart()
 			if yyl515 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl515, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct515 == codecSelferValueTypeArray1234 {
 			yyl515 := r.ReadArrayStart()
 			if yyl515 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl515, d)
 			}
@@ -5790,8 +6205,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys516Slc = r.DecodeBytes(yys516Slc, true, true)
 		yys516 := string(yys516Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys516 {
 		case "selector":
 			if r.TryDecodeAsNil() {
@@ -5819,9 +6236,7 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys516)
 		} // end switch yys516
 	} // end for yyj516
-	if !yyhl516 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5838,9 +6253,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb519 = r.CheckBreak()
 	}
 	if yyb519 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Selector != nil {
 			x.Selector = nil
@@ -5858,9 +6274,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb519 = r.CheckBreak()
 	}
 	if yyb519 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Template != nil {
 			x.Template = nil
@@ -5881,9 +6298,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb519 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj519-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5903,18 +6321,21 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq523 [3]bool
 			_, _, _ = yysep523, yyq523, yy2arr523
 			const yyr523 bool = false
+			var yynn523 int
 			if yyr523 || yy2arr523 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn523 int = 3
+				yynn523 = 3
 				for _, b := range yyq523 {
 					if b {
 						yynn523++
 					}
 				}
 				r.EncodeMapStart(yynn523)
+				yynn523 = 0
 			}
 			if yyr523 || yy2arr523 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym525 := z.EncBinary()
 				_ = yym525
 				if false {
@@ -5922,7 +6343,9 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym526 := z.EncBinary()
 				_ = yym526
 				if false {
@@ -5931,6 +6354,7 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr523 || yy2arr523 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym528 := z.EncBinary()
 				_ = yym528
 				if false {
@@ -5938,7 +6362,9 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym529 := z.EncBinary()
 				_ = yym529
 				if false {
@@ -5947,6 +6373,7 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr523 || yy2arr523 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym531 := z.EncBinary()
 				_ = yym531
 				if false {
@@ -5954,7 +6381,9 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym532 := z.EncBinary()
 				_ = yym532
 				if false {
@@ -5962,8 +6391,10 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yysep523 {
-				r.EncodeEnd()
+			if yyr523 || yy2arr523 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5978,17 +6409,18 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct534 := r.ContainerType()
+		if yyct534 == codecSelferValueTypeMap1234 {
 			yyl534 := r.ReadMapStart()
 			if yyl534 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl534, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct534 == codecSelferValueTypeArray1234 {
 			yyl534 := r.ReadArrayStart()
 			if yyl534 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl534, d)
 			}
@@ -6015,8 +6447,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys535Slc = r.DecodeBytes(yys535Slc, true, true)
 		yys535 := string(yys535Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys535 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
@@ -6040,9 +6474,7 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys535)
 		} // end switch yys535
 	} // end for yyj535
-	if !yyhl535 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6059,9 +6491,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb539 = r.CheckBreak()
 	}
 	if yyb539 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CurrentNumberScheduled = 0
 	} else {
@@ -6074,9 +6507,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb539 = r.CheckBreak()
 	}
 	if yyb539 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NumberMisscheduled = 0
 	} else {
@@ -6089,9 +6523,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb539 = r.CheckBreak()
 	}
 	if yyb539 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DesiredNumberScheduled = 0
 	} else {
@@ -6107,9 +6542,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb539 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj539-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6134,18 +6570,21 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq544[2] = true
 			yyq544[3] = true
 			yyq544[4] = true
+			var yynn544 int
 			if yyr544 || yy2arr544 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn544 int = 0
+				yynn544 = 0
 				for _, b := range yyq544 {
 					if b {
 						yynn544++
 					}
 				}
 				r.EncodeMapStart(yynn544)
+				yynn544 = 0
 			}
 			if yyr544 || yy2arr544 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq544[0] {
 					yym546 := z.EncBinary()
 					_ = yym546
@@ -6158,7 +6597,9 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq544[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym547 := z.EncBinary()
 					_ = yym547
 					if false {
@@ -6168,6 +6609,7 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr544 || yy2arr544 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq544[1] {
 					yym549 := z.EncBinary()
 					_ = yym549
@@ -6180,7 +6622,9 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq544[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym550 := z.EncBinary()
 					_ = yym550
 					if false {
@@ -6190,6 +6634,7 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr544 || yy2arr544 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq544[2] {
 					yy552 := &x.ObjectMeta
 					yy552.CodecEncodeSelf(e)
@@ -6198,12 +6643,15 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq544[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy553 := &x.ObjectMeta
 					yy553.CodecEncodeSelf(e)
 				}
 			}
 			if yyr544 || yy2arr544 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq544[3] {
 					yy555 := &x.Spec
 					yy555.CodecEncodeSelf(e)
@@ -6212,12 +6660,15 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq544[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy556 := &x.Spec
 					yy556.CodecEncodeSelf(e)
 				}
 			}
 			if yyr544 || yy2arr544 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq544[4] {
 					yy558 := &x.Status
 					yy558.CodecEncodeSelf(e)
@@ -6226,13 +6677,17 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq544[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy559 := &x.Status
 					yy559.CodecEncodeSelf(e)
 				}
 			}
-			if yysep544 {
-				r.EncodeEnd()
+			if yyr544 || yy2arr544 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6247,17 +6702,18 @@ func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct561 := r.ContainerType()
+		if yyct561 == codecSelferValueTypeMap1234 {
 			yyl561 := r.ReadMapStart()
 			if yyl561 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl561, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct561 == codecSelferValueTypeArray1234 {
 			yyl561 := r.ReadArrayStart()
 			if yyl561 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl561, d)
 			}
@@ -6284,8 +6740,10 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys562Slc = r.DecodeBytes(yys562Slc, true, true)
 		yys562 := string(yys562Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys562 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -6324,9 +6782,7 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys562)
 		} // end switch yys562
 	} // end for yyj562
-	if !yyhl562 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6343,9 +6799,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb568 = r.CheckBreak()
 	}
 	if yyb568 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -6358,9 +6815,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb568 = r.CheckBreak()
 	}
 	if yyb568 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -6373,9 +6831,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb568 = r.CheckBreak()
 	}
 	if yyb568 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -6389,9 +6848,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb568 = r.CheckBreak()
 	}
 	if yyb568 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = DaemonSetSpec{}
 	} else {
@@ -6405,9 +6865,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb568 = r.CheckBreak()
 	}
 	if yyb568 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = DaemonSetStatus{}
 	} else {
@@ -6424,9 +6885,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb568 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj568-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6449,18 +6911,21 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq575[0] = x.Kind != ""
 			yyq575[1] = x.APIVersion != ""
 			yyq575[2] = true
+			var yynn575 int
 			if yyr575 || yy2arr575 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn575 int = 1
+				yynn575 = 1
 				for _, b := range yyq575 {
 					if b {
 						yynn575++
 					}
 				}
 				r.EncodeMapStart(yynn575)
+				yynn575 = 0
 			}
 			if yyr575 || yy2arr575 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq575[0] {
 					yym577 := z.EncBinary()
 					_ = yym577
@@ -6473,7 +6938,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq575[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym578 := z.EncBinary()
 					_ = yym578
 					if false {
@@ -6483,6 +6950,7 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr575 || yy2arr575 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq575[1] {
 					yym580 := z.EncBinary()
 					_ = yym580
@@ -6495,7 +6963,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq575[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym581 := z.EncBinary()
 					_ = yym581
 					if false {
@@ -6505,6 +6975,7 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr575 || yy2arr575 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq575[2] {
 					yy583 := &x.ListMeta
 					yym584 := z.EncBinary()
@@ -6519,7 +6990,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq575[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy585 := &x.ListMeta
 					yym586 := z.EncBinary()
 					_ = yym586
@@ -6531,6 +7004,7 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr575 || yy2arr575 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6542,7 +7016,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6554,8 +7030,10 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep575 {
-				r.EncodeEnd()
+			if yyr575 || yy2arr575 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6570,17 +7048,18 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct591 := r.ContainerType()
+		if yyct591 == codecSelferValueTypeMap1234 {
 			yyl591 := r.ReadMapStart()
 			if yyl591 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl591, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct591 == codecSelferValueTypeArray1234 {
 			yyl591 := r.ReadArrayStart()
 			if yyl591 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl591, d)
 			}
@@ -6607,8 +7086,10 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys592Slc = r.DecodeBytes(yys592Slc, true, true)
 		yys592 := string(yys592Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys592 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -6651,9 +7132,7 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys592)
 		} // end switch yys592
 	} // end for yyj592
-	if !yyhl592 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6670,9 +7149,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb599 = r.CheckBreak()
 	}
 	if yyb599 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -6685,9 +7165,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb599 = r.CheckBreak()
 	}
 	if yyb599 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -6700,9 +7181,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb599 = r.CheckBreak()
 	}
 	if yyb599 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -6722,9 +7204,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb599 = r.CheckBreak()
 	}
 	if yyb599 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -6746,9 +7229,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb599 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj599-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6771,18 +7255,21 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq607[0] = x.Kind != ""
 			yyq607[1] = x.APIVersion != ""
 			yyq607[2] = true
+			var yynn607 int
 			if yyr607 || yy2arr607 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn607 int = 1
+				yynn607 = 1
 				for _, b := range yyq607 {
 					if b {
 						yynn607++
 					}
 				}
 				r.EncodeMapStart(yynn607)
+				yynn607 = 0
 			}
 			if yyr607 || yy2arr607 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq607[0] {
 					yym609 := z.EncBinary()
 					_ = yym609
@@ -6795,7 +7282,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq607[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym610 := z.EncBinary()
 					_ = yym610
 					if false {
@@ -6805,6 +7294,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr607 || yy2arr607 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq607[1] {
 					yym612 := z.EncBinary()
 					_ = yym612
@@ -6817,7 +7307,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq607[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym613 := z.EncBinary()
 					_ = yym613
 					if false {
@@ -6827,6 +7319,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr607 || yy2arr607 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq607[2] {
 					yy615 := &x.ListMeta
 					yym616 := z.EncBinary()
@@ -6841,7 +7334,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq607[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy617 := &x.ListMeta
 					yym618 := z.EncBinary()
 					_ = yym618
@@ -6853,6 +7348,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr607 || yy2arr607 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6864,7 +7360,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6876,8 +7374,10 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep607 {
-				r.EncodeEnd()
+			if yyr607 || yy2arr607 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6892,17 +7392,18 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct623 := r.ContainerType()
+		if yyct623 == codecSelferValueTypeMap1234 {
 			yyl623 := r.ReadMapStart()
 			if yyl623 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl623, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct623 == codecSelferValueTypeArray1234 {
 			yyl623 := r.ReadArrayStart()
 			if yyl623 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl623, d)
 			}
@@ -6929,8 +7430,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys624Slc = r.DecodeBytes(yys624Slc, true, true)
 		yys624 := string(yys624Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys624 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -6973,9 +7476,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			z.DecStructFieldNotFound(-1, yys624)
 		} // end switch yys624
 	} // end for yyj624
-	if !yyhl624 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6992,9 +7493,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		yyb631 = r.CheckBreak()
 	}
 	if yyb631 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -7007,9 +7509,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		yyb631 = r.CheckBreak()
 	}
 	if yyb631 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -7022,9 +7525,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		yyb631 = r.CheckBreak()
 	}
 	if yyb631 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -7044,9 +7548,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		yyb631 = r.CheckBreak()
 	}
 	if yyb631 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -7068,9 +7573,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		if yyb631 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj631-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7095,18 +7601,21 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq639[2] = true
 			yyq639[3] = true
 			yyq639[4] = true
+			var yynn639 int
 			if yyr639 || yy2arr639 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn639 int = 0
+				yynn639 = 0
 				for _, b := range yyq639 {
 					if b {
 						yynn639++
 					}
 				}
 				r.EncodeMapStart(yynn639)
+				yynn639 = 0
 			}
 			if yyr639 || yy2arr639 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq639[0] {
 					yym641 := z.EncBinary()
 					_ = yym641
@@ -7119,7 +7628,9 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq639[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym642 := z.EncBinary()
 					_ = yym642
 					if false {
@@ -7129,6 +7640,7 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr639 || yy2arr639 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq639[1] {
 					yym644 := z.EncBinary()
 					_ = yym644
@@ -7141,7 +7653,9 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq639[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym645 := z.EncBinary()
 					_ = yym645
 					if false {
@@ -7151,6 +7665,7 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr639 || yy2arr639 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq639[2] {
 					yy647 := &x.ObjectMeta
 					yy647.CodecEncodeSelf(e)
@@ -7159,12 +7674,15 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq639[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy648 := &x.ObjectMeta
 					yy648.CodecEncodeSelf(e)
 				}
 			}
 			if yyr639 || yy2arr639 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq639[3] {
 					yy650 := &x.Spec
 					yy650.CodecEncodeSelf(e)
@@ -7173,12 +7691,15 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq639[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy651 := &x.Spec
 					yy651.CodecEncodeSelf(e)
 				}
 			}
 			if yyr639 || yy2arr639 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq639[4] {
 					yy653 := &x.Status
 					yy653.CodecEncodeSelf(e)
@@ -7187,13 +7708,17 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq639[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy654 := &x.Status
 					yy654.CodecEncodeSelf(e)
 				}
 			}
-			if yysep639 {
-				r.EncodeEnd()
+			if yyr639 || yy2arr639 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7208,17 +7733,18 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct656 := r.ContainerType()
+		if yyct656 == codecSelferValueTypeMap1234 {
 			yyl656 := r.ReadMapStart()
 			if yyl656 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl656, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct656 == codecSelferValueTypeArray1234 {
 			yyl656 := r.ReadArrayStart()
 			if yyl656 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl656, d)
 			}
@@ -7245,8 +7771,10 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys657Slc = r.DecodeBytes(yys657Slc, true, true)
 		yys657 := string(yys657Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys657 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -7285,9 +7813,7 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys657)
 		} // end switch yys657
 	} // end for yyj657
-	if !yyhl657 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7304,9 +7830,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb663 = r.CheckBreak()
 	}
 	if yyb663 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -7319,9 +7846,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb663 = r.CheckBreak()
 	}
 	if yyb663 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -7334,9 +7862,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb663 = r.CheckBreak()
 	}
 	if yyb663 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -7350,9 +7879,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb663 = r.CheckBreak()
 	}
 	if yyb663 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = JobSpec{}
 	} else {
@@ -7366,9 +7896,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb663 = r.CheckBreak()
 	}
 	if yyb663 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = JobStatus{}
 	} else {
@@ -7385,9 +7916,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb663 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj663-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7410,18 +7942,21 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq670[0] = x.Kind != ""
 			yyq670[1] = x.APIVersion != ""
 			yyq670[2] = true
+			var yynn670 int
 			if yyr670 || yy2arr670 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn670 int = 1
+				yynn670 = 1
 				for _, b := range yyq670 {
 					if b {
 						yynn670++
 					}
 				}
 				r.EncodeMapStart(yynn670)
+				yynn670 = 0
 			}
 			if yyr670 || yy2arr670 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq670[0] {
 					yym672 := z.EncBinary()
 					_ = yym672
@@ -7434,7 +7969,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq670[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym673 := z.EncBinary()
 					_ = yym673
 					if false {
@@ -7444,6 +7981,7 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr670 || yy2arr670 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq670[1] {
 					yym675 := z.EncBinary()
 					_ = yym675
@@ -7456,7 +7994,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq670[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym676 := z.EncBinary()
 					_ = yym676
 					if false {
@@ -7466,6 +8006,7 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr670 || yy2arr670 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq670[2] {
 					yy678 := &x.ListMeta
 					yym679 := z.EncBinary()
@@ -7480,7 +8021,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq670[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy680 := &x.ListMeta
 					yym681 := z.EncBinary()
 					_ = yym681
@@ -7492,6 +8035,7 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr670 || yy2arr670 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -7503,7 +8047,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -7515,8 +8061,10 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep670 {
-				r.EncodeEnd()
+			if yyr670 || yy2arr670 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7531,17 +8079,18 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct686 := r.ContainerType()
+		if yyct686 == codecSelferValueTypeMap1234 {
 			yyl686 := r.ReadMapStart()
 			if yyl686 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl686, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct686 == codecSelferValueTypeArray1234 {
 			yyl686 := r.ReadArrayStart()
 			if yyl686 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl686, d)
 			}
@@ -7568,8 +8117,10 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys687Slc = r.DecodeBytes(yys687Slc, true, true)
 		yys687 := string(yys687Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys687 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -7612,9 +8163,7 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys687)
 		} // end switch yys687
 	} // end for yyj687
-	if !yyhl687 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7631,9 +8180,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb694 = r.CheckBreak()
 	}
 	if yyb694 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -7646,9 +8196,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb694 = r.CheckBreak()
 	}
 	if yyb694 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -7661,9 +8212,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb694 = r.CheckBreak()
 	}
 	if yyb694 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -7683,9 +8235,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb694 = r.CheckBreak()
 	}
 	if yyb694 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -7707,9 +8260,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb694 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj694-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7732,18 +8286,21 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq702[0] = x.Parallelism != nil
 			yyq702[1] = x.Completions != nil
 			yyq702[2] = x.Selector != nil
+			var yynn702 int
 			if yyr702 || yy2arr702 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn702 int = 1
+				yynn702 = 1
 				for _, b := range yyq702 {
 					if b {
 						yynn702++
 					}
 				}
 				r.EncodeMapStart(yynn702)
+				yynn702 = 0
 			}
 			if yyr702 || yy2arr702 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq702[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
@@ -7761,7 +8318,9 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq702[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
@@ -7776,6 +8335,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr702 || yy2arr702 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq702[1] {
 					if x.Completions == nil {
 						r.EncodeNil()
@@ -7793,7 +8353,9 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq702[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
@@ -7808,6 +8370,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr702 || yy2arr702 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq702[2] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -7819,7 +8382,9 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq702[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -7828,15 +8393,20 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr702 || yy2arr702 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy715 := &x.Template
 				yy715.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy716 := &x.Template
 				yy716.CodecEncodeSelf(e)
 			}
-			if yysep702 {
-				r.EncodeEnd()
+			if yyr702 || yy2arr702 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7851,17 +8421,18 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct718 := r.ContainerType()
+		if yyct718 == codecSelferValueTypeMap1234 {
 			yyl718 := r.ReadMapStart()
 			if yyl718 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl718, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct718 == codecSelferValueTypeArray1234 {
 			yyl718 := r.ReadArrayStart()
 			if yyl718 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl718, d)
 			}
@@ -7888,8 +8459,10 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys719Slc = r.DecodeBytes(yys719Slc, true, true)
 		yys719 := string(yys719Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys719 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
@@ -7945,9 +8518,7 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys719)
 		} // end switch yys719
 	} // end for yyj719
-	if !yyhl719 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7964,9 +8535,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb726 = r.CheckBreak()
 	}
 	if yyb726 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Parallelism != nil {
 			x.Parallelism = nil
@@ -7989,9 +8561,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb726 = r.CheckBreak()
 	}
 	if yyb726 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Completions != nil {
 			x.Completions = nil
@@ -8014,9 +8587,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb726 = r.CheckBreak()
 	}
 	if yyb726 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Selector != nil {
 			x.Selector = nil
@@ -8034,9 +8608,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb726 = r.CheckBreak()
 	}
 	if yyb726 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
@@ -8053,9 +8628,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb726 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj726-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8081,18 +8657,21 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq734[3] = x.Active != 0
 			yyq734[4] = x.Succeeded != 0
 			yyq734[5] = x.Failed != 0
+			var yynn734 int
 			if yyr734 || yy2arr734 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn734 int = 0
+				yynn734 = 0
 				for _, b := range yyq734 {
 					if b {
 						yynn734++
 					}
 				}
 				r.EncodeMapStart(yynn734)
+				yynn734 = 0
 			}
 			if yyr734 || yy2arr734 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq734[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
@@ -8109,7 +8688,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq734[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
@@ -8123,6 +8704,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr734 || yy2arr734 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq734[1] {
 					if x.StartTime == nil {
 						r.EncodeNil()
@@ -8144,7 +8726,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq734[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
@@ -8163,6 +8747,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr734 || yy2arr734 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq734[2] {
 					if x.CompletionTime == nil {
 						r.EncodeNil()
@@ -8184,7 +8769,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq734[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
@@ -8203,6 +8790,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr734 || yy2arr734 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq734[3] {
 					yym745 := z.EncBinary()
 					_ = yym745
@@ -8215,7 +8803,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq734[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym746 := z.EncBinary()
 					_ = yym746
 					if false {
@@ -8225,6 +8815,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr734 || yy2arr734 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq734[4] {
 					yym748 := z.EncBinary()
 					_ = yym748
@@ -8237,7 +8828,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq734[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym749 := z.EncBinary()
 					_ = yym749
 					if false {
@@ -8247,6 +8840,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr734 || yy2arr734 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq734[5] {
 					yym751 := z.EncBinary()
 					_ = yym751
@@ -8259,7 +8853,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq734[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym752 := z.EncBinary()
 					_ = yym752
 					if false {
@@ -8268,8 +8864,10 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep734 {
-				r.EncodeEnd()
+			if yyr734 || yy2arr734 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8284,17 +8882,18 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct754 := r.ContainerType()
+		if yyct754 == codecSelferValueTypeMap1234 {
 			yyl754 := r.ReadMapStart()
 			if yyl754 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl754, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct754 == codecSelferValueTypeArray1234 {
 			yyl754 := r.ReadArrayStart()
 			if yyl754 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl754, d)
 			}
@@ -8321,8 +8920,10 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys755Slc = r.DecodeBytes(yys755Slc, true, true)
 		yys755 := string(yys755Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys755 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
@@ -8400,9 +9001,7 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys755)
 		} // end switch yys755
 	} // end for yyj755
-	if !yyhl755 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8419,9 +9018,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb765 = r.CheckBreak()
 	}
 	if yyb765 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
@@ -8440,9 +9040,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb765 = r.CheckBreak()
 	}
 	if yyb765 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.StartTime != nil {
 			x.StartTime = nil
@@ -8470,9 +9071,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb765 = r.CheckBreak()
 	}
 	if yyb765 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CompletionTime != nil {
 			x.CompletionTime = nil
@@ -8500,9 +9102,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb765 = r.CheckBreak()
 	}
 	if yyb765 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Active = 0
 	} else {
@@ -8515,9 +9118,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb765 = r.CheckBreak()
 	}
 	if yyb765 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Succeeded = 0
 	} else {
@@ -8530,9 +9134,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb765 = r.CheckBreak()
 	}
 	if yyb765 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Failed = 0
 	} else {
@@ -8548,9 +9153,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb765 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj765-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8600,24 +9206,30 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq778[3] = true
 			yyq778[4] = x.Reason != ""
 			yyq778[5] = x.Message != ""
+			var yynn778 int
 			if yyr778 || yy2arr778 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn778 int = 2
+				yynn778 = 2
 				for _, b := range yyq778 {
 					if b {
 						yynn778++
 					}
 				}
 				r.EncodeMapStart(yynn778)
+				yynn778 = 0
 			}
 			if yyr778 || yy2arr778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr778 || yy2arr778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym781 := z.EncBinary()
 				_ = yym781
 				if false {
@@ -8626,7 +9238,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym782 := z.EncBinary()
 				_ = yym782
 				if false {
@@ -8636,6 +9250,7 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr778 || yy2arr778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq778[2] {
 					yy784 := &x.LastProbeTime
 					yym785 := z.EncBinary()
@@ -8654,7 +9269,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq778[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy786 := &x.LastProbeTime
 					yym787 := z.EncBinary()
 					_ = yym787
@@ -8670,6 +9287,7 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr778 || yy2arr778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq778[3] {
 					yy789 := &x.LastTransitionTime
 					yym790 := z.EncBinary()
@@ -8688,7 +9306,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq778[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy791 := &x.LastTransitionTime
 					yym792 := z.EncBinary()
 					_ = yym792
@@ -8704,6 +9324,7 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr778 || yy2arr778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq778[4] {
 					yym794 := z.EncBinary()
 					_ = yym794
@@ -8716,7 +9337,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq778[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym795 := z.EncBinary()
 					_ = yym795
 					if false {
@@ -8726,6 +9349,7 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr778 || yy2arr778 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq778[5] {
 					yym797 := z.EncBinary()
 					_ = yym797
@@ -8738,7 +9362,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq778[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym798 := z.EncBinary()
 					_ = yym798
 					if false {
@@ -8747,8 +9373,10 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep778 {
-				r.EncodeEnd()
+			if yyr778 || yy2arr778 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8763,17 +9391,18 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct800 := r.ContainerType()
+		if yyct800 == codecSelferValueTypeMap1234 {
 			yyl800 := r.ReadMapStart()
 			if yyl800 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl800, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct800 == codecSelferValueTypeArray1234 {
 			yyl800 := r.ReadArrayStart()
 			if yyl800 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl800, d)
 			}
@@ -8800,8 +9429,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys801Slc = r.DecodeBytes(yys801Slc, true, true)
 		yys801 := string(yys801Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys801 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -8865,9 +9496,7 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys801)
 		} // end switch yys801
 	} // end for yyj801
-	if !yyhl801 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8884,9 +9513,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb810 = r.CheckBreak()
 	}
 	if yyb810 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -8899,9 +9529,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb810 = r.CheckBreak()
 	}
 	if yyb810 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ""
 	} else {
@@ -8914,9 +9545,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb810 = r.CheckBreak()
 	}
 	if yyb810 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
@@ -8940,9 +9572,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb810 = r.CheckBreak()
 	}
 	if yyb810 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
@@ -8966,9 +9599,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb810 = r.CheckBreak()
 	}
 	if yyb810 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -8981,9 +9615,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb810 = r.CheckBreak()
 	}
 	if yyb810 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -8999,9 +9634,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb810 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj810-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9026,18 +9662,21 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq820[2] = true
 			yyq820[3] = true
 			yyq820[4] = true
+			var yynn820 int
 			if yyr820 || yy2arr820 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn820 int = 0
+				yynn820 = 0
 				for _, b := range yyq820 {
 					if b {
 						yynn820++
 					}
 				}
 				r.EncodeMapStart(yynn820)
+				yynn820 = 0
 			}
 			if yyr820 || yy2arr820 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq820[0] {
 					yym822 := z.EncBinary()
 					_ = yym822
@@ -9050,7 +9689,9 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq820[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym823 := z.EncBinary()
 					_ = yym823
 					if false {
@@ -9060,6 +9701,7 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr820 || yy2arr820 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq820[1] {
 					yym825 := z.EncBinary()
 					_ = yym825
@@ -9072,7 +9714,9 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq820[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym826 := z.EncBinary()
 					_ = yym826
 					if false {
@@ -9082,6 +9726,7 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr820 || yy2arr820 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq820[2] {
 					yy828 := &x.ObjectMeta
 					yy828.CodecEncodeSelf(e)
@@ -9090,12 +9735,15 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq820[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy829 := &x.ObjectMeta
 					yy829.CodecEncodeSelf(e)
 				}
 			}
 			if yyr820 || yy2arr820 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq820[3] {
 					yy831 := &x.Spec
 					yy831.CodecEncodeSelf(e)
@@ -9104,12 +9752,15 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq820[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy832 := &x.Spec
 					yy832.CodecEncodeSelf(e)
 				}
 			}
 			if yyr820 || yy2arr820 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq820[4] {
 					yy834 := &x.Status
 					yy834.CodecEncodeSelf(e)
@@ -9118,13 +9769,17 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq820[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy835 := &x.Status
 					yy835.CodecEncodeSelf(e)
 				}
 			}
-			if yysep820 {
-				r.EncodeEnd()
+			if yyr820 || yy2arr820 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9139,17 +9794,18 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct837 := r.ContainerType()
+		if yyct837 == codecSelferValueTypeMap1234 {
 			yyl837 := r.ReadMapStart()
 			if yyl837 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl837, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct837 == codecSelferValueTypeArray1234 {
 			yyl837 := r.ReadArrayStart()
 			if yyl837 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl837, d)
 			}
@@ -9176,8 +9832,10 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys838Slc = r.DecodeBytes(yys838Slc, true, true)
 		yys838 := string(yys838Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys838 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -9216,9 +9874,7 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys838)
 		} // end switch yys838
 	} // end for yyj838
-	if !yyhl838 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9235,9 +9891,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb844 = r.CheckBreak()
 	}
 	if yyb844 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -9250,9 +9907,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb844 = r.CheckBreak()
 	}
 	if yyb844 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -9265,9 +9923,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb844 = r.CheckBreak()
 	}
 	if yyb844 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -9281,9 +9940,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb844 = r.CheckBreak()
 	}
 	if yyb844 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
@@ -9297,9 +9957,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb844 = r.CheckBreak()
 	}
 	if yyb844 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
@@ -9316,9 +9977,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb844 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj844-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9341,18 +10003,21 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq851[0] = x.Kind != ""
 			yyq851[1] = x.APIVersion != ""
 			yyq851[2] = true
+			var yynn851 int
 			if yyr851 || yy2arr851 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn851 int = 1
+				yynn851 = 1
 				for _, b := range yyq851 {
 					if b {
 						yynn851++
 					}
 				}
 				r.EncodeMapStart(yynn851)
+				yynn851 = 0
 			}
 			if yyr851 || yy2arr851 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq851[0] {
 					yym853 := z.EncBinary()
 					_ = yym853
@@ -9365,7 +10030,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq851[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym854 := z.EncBinary()
 					_ = yym854
 					if false {
@@ -9375,6 +10042,7 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr851 || yy2arr851 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq851[1] {
 					yym856 := z.EncBinary()
 					_ = yym856
@@ -9387,7 +10055,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq851[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym857 := z.EncBinary()
 					_ = yym857
 					if false {
@@ -9397,6 +10067,7 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr851 || yy2arr851 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq851[2] {
 					yy859 := &x.ListMeta
 					yym860 := z.EncBinary()
@@ -9411,7 +10082,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq851[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy861 := &x.ListMeta
 					yym862 := z.EncBinary()
 					_ = yym862
@@ -9423,6 +10096,7 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr851 || yy2arr851 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -9434,7 +10108,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -9446,8 +10122,10 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep851 {
-				r.EncodeEnd()
+			if yyr851 || yy2arr851 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9462,17 +10140,18 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct867 := r.ContainerType()
+		if yyct867 == codecSelferValueTypeMap1234 {
 			yyl867 := r.ReadMapStart()
 			if yyl867 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl867, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct867 == codecSelferValueTypeArray1234 {
 			yyl867 := r.ReadArrayStart()
 			if yyl867 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl867, d)
 			}
@@ -9499,8 +10178,10 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys868Slc = r.DecodeBytes(yys868Slc, true, true)
 		yys868 := string(yys868Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys868 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -9543,9 +10224,7 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys868)
 		} // end switch yys868
 	} // end for yyj868
-	if !yyhl868 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9562,9 +10241,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb875 = r.CheckBreak()
 	}
 	if yyb875 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -9577,9 +10257,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb875 = r.CheckBreak()
 	}
 	if yyb875 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -9592,9 +10273,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb875 = r.CheckBreak()
 	}
 	if yyb875 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -9614,9 +10296,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb875 = r.CheckBreak()
 	}
 	if yyb875 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -9638,9 +10321,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb875 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj875-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9662,18 +10346,21 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr883 bool = false
 			yyq883[0] = x.Backend != nil
 			yyq883[1] = len(x.Rules) != 0
+			var yynn883 int
 			if yyr883 || yy2arr883 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn883 int = 0
+				yynn883 = 0
 				for _, b := range yyq883 {
 					if b {
 						yynn883++
 					}
 				}
 				r.EncodeMapStart(yynn883)
+				yynn883 = 0
 			}
 			if yyr883 || yy2arr883 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq883[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
@@ -9685,7 +10372,9 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq883[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -9694,6 +10383,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr883 || yy2arr883 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq883[1] {
 					if x.Rules == nil {
 						r.EncodeNil()
@@ -9710,7 +10400,9 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq883[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
@@ -9723,8 +10415,10 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep883 {
-				r.EncodeEnd()
+			if yyr883 || yy2arr883 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9739,17 +10433,18 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct889 := r.ContainerType()
+		if yyct889 == codecSelferValueTypeMap1234 {
 			yyl889 := r.ReadMapStart()
 			if yyl889 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl889, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct889 == codecSelferValueTypeArray1234 {
 			yyl889 := r.ReadArrayStart()
 			if yyl889 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl889, d)
 			}
@@ -9776,8 +10471,10 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys890Slc = r.DecodeBytes(yys890Slc, true, true)
 		yys890 := string(yys890Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys890 {
 		case "backend":
 			if r.TryDecodeAsNil() {
@@ -9806,9 +10503,7 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys890)
 		} // end switch yys890
 	} // end for yyj890
-	if !yyhl890 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9825,9 +10520,10 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb894 = r.CheckBreak()
 	}
 	if yyb894 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Backend != nil {
 			x.Backend = nil
@@ -9845,9 +10541,10 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb894 = r.CheckBreak()
 	}
 	if yyb894 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
@@ -9869,9 +10566,10 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb894 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj894-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9892,18 +10590,21 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep899, yyq899, yy2arr899
 			const yyr899 bool = false
 			yyq899[0] = true
+			var yynn899 int
 			if yyr899 || yy2arr899 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn899 int = 0
+				yynn899 = 0
 				for _, b := range yyq899 {
 					if b {
 						yynn899++
 					}
 				}
 				r.EncodeMapStart(yynn899)
+				yynn899 = 0
 			}
 			if yyr899 || yy2arr899 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq899[0] {
 					yy901 := &x.LoadBalancer
 					yy901.CodecEncodeSelf(e)
@@ -9912,13 +10613,17 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq899[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy902 := &x.LoadBalancer
 					yy902.CodecEncodeSelf(e)
 				}
 			}
-			if yysep899 {
-				r.EncodeEnd()
+			if yyr899 || yy2arr899 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9933,17 +10638,18 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct904 := r.ContainerType()
+		if yyct904 == codecSelferValueTypeMap1234 {
 			yyl904 := r.ReadMapStart()
 			if yyl904 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl904, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct904 == codecSelferValueTypeArray1234 {
 			yyl904 := r.ReadArrayStart()
 			if yyl904 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl904, d)
 			}
@@ -9970,8 +10676,10 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys905Slc = r.DecodeBytes(yys905Slc, true, true)
 		yys905 := string(yys905Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys905 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
@@ -9984,9 +10692,7 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys905)
 		} // end switch yys905
 	} // end for yyj905
-	if !yyhl905 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10003,9 +10709,10 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb907 = r.CheckBreak()
 	}
 	if yyb907 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 	} else {
@@ -10022,9 +10729,10 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb907 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj907-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10046,18 +10754,21 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr910 bool = false
 			yyq910[0] = x.Host != ""
 			yyq910[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			var yynn910 int
 			if yyr910 || yy2arr910 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn910 int = 0
+				yynn910 = 0
 				for _, b := range yyq910 {
 					if b {
 						yynn910++
 					}
 				}
 				r.EncodeMapStart(yynn910)
+				yynn910 = 0
 			}
 			if yyr910 || yy2arr910 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq910[0] {
 					yym912 := z.EncBinary()
 					_ = yym912
@@ -10070,7 +10781,9 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq910[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym913 := z.EncBinary()
 					_ = yym913
 					if false {
@@ -10089,6 +10802,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn914 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq910[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
@@ -10101,7 +10815,9 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq910[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn914 {
 						r.EncodeNil()
 					} else {
@@ -10113,8 +10829,10 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep910 {
-				r.EncodeEnd()
+			if yyr910 || yy2arr910 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10129,17 +10847,18 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct916 := r.ContainerType()
+		if yyct916 == codecSelferValueTypeMap1234 {
 			yyl916 := r.ReadMapStart()
 			if yyl916 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl916, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct916 == codecSelferValueTypeArray1234 {
 			yyl916 := r.ReadArrayStart()
 			if yyl916 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl916, d)
 			}
@@ -10166,8 +10885,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys917Slc = r.DecodeBytes(yys917Slc, true, true)
 		yys917 := string(yys917Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys917 {
 		case "host":
 			if r.TryDecodeAsNil() {
@@ -10193,9 +10914,7 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys917)
 		} // end switch yys917
 	} // end for yyj917
-	if !yyhl917 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10212,13 +10931,17 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb920 = r.CheckBreak()
 	}
 	if yyb920 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Host = ""
 	} else {
 		x.Host = string(r.DecodeString())
+	}
+	if x.IngressRuleValue.HTTP == nil {
+		x.IngressRuleValue.HTTP = new(HTTPIngressRuleValue)
 	}
 	yyj920++
 	if yyhl920 {
@@ -10227,9 +10950,10 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb920 = r.CheckBreak()
 	}
 	if yyb920 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HTTP != nil {
 			x.HTTP = nil
@@ -10250,9 +10974,10 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb920 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj920-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10273,18 +10998,21 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep924, yyq924, yy2arr924
 			const yyr924 bool = false
 			yyq924[0] = x.HTTP != nil
+			var yynn924 int
 			if yyr924 || yy2arr924 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn924 int = 0
+				yynn924 = 0
 				for _, b := range yyq924 {
 					if b {
 						yynn924++
 					}
 				}
 				r.EncodeMapStart(yynn924)
+				yynn924 = 0
 			}
 			if yyr924 || yy2arr924 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq924[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
@@ -10296,7 +11024,9 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq924[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -10304,8 +11034,10 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep924 {
-				r.EncodeEnd()
+			if yyr924 || yy2arr924 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10320,17 +11052,18 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct927 := r.ContainerType()
+		if yyct927 == codecSelferValueTypeMap1234 {
 			yyl927 := r.ReadMapStart()
 			if yyl927 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl927, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct927 == codecSelferValueTypeArray1234 {
 			yyl927 := r.ReadArrayStart()
 			if yyl927 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl927, d)
 			}
@@ -10357,8 +11090,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys928Slc = r.DecodeBytes(yys928Slc, true, true)
 		yys928 := string(yys928Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys928 {
 		case "http":
 			if r.TryDecodeAsNil() {
@@ -10375,9 +11110,7 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys928)
 		} // end switch yys928
 	} // end for yyj928
-	if !yyhl928 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10394,9 +11127,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb930 = r.CheckBreak()
 	}
 	if yyb930 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HTTP != nil {
 			x.HTTP = nil
@@ -10417,9 +11151,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if yyb930 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj930-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10439,18 +11174,21 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq933 [1]bool
 			_, _, _ = yysep933, yyq933, yy2arr933
 			const yyr933 bool = false
+			var yynn933 int
 			if yyr933 || yy2arr933 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn933 int = 1
+				yynn933 = 1
 				for _, b := range yyq933 {
 					if b {
 						yynn933++
 					}
 				}
 				r.EncodeMapStart(yynn933)
+				yynn933 = 0
 			}
 			if yyr933 || yy2arr933 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
@@ -10462,7 +11200,9 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("paths"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
@@ -10474,8 +11214,10 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep933 {
-				r.EncodeEnd()
+			if yyr933 || yy2arr933 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10490,17 +11232,18 @@ func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct938 := r.ContainerType()
+		if yyct938 == codecSelferValueTypeMap1234 {
 			yyl938 := r.ReadMapStart()
 			if yyl938 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl938, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct938 == codecSelferValueTypeArray1234 {
 			yyl938 := r.ReadArrayStart()
 			if yyl938 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl938, d)
 			}
@@ -10527,8 +11270,10 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys939Slc = r.DecodeBytes(yys939Slc, true, true)
 		yys939 := string(yys939Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys939 {
 		case "paths":
 			if r.TryDecodeAsNil() {
@@ -10546,9 +11291,7 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys939)
 		} // end switch yys939
 	} // end for yyj939
-	if !yyhl939 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10565,9 +11308,10 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb942 = r.CheckBreak()
 	}
 	if yyb942 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Paths = nil
 	} else {
@@ -10589,9 +11333,10 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb942 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj942-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10612,18 +11357,21 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep946, yyq946, yy2arr946
 			const yyr946 bool = false
 			yyq946[0] = x.Path != ""
+			var yynn946 int
 			if yyr946 || yy2arr946 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn946 int = 1
+				yynn946 = 1
 				for _, b := range yyq946 {
 					if b {
 						yynn946++
 					}
 				}
 				r.EncodeMapStart(yynn946)
+				yynn946 = 0
 			}
 			if yyr946 || yy2arr946 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq946[0] {
 					yym948 := z.EncBinary()
 					_ = yym948
@@ -10636,7 +11384,9 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq946[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym949 := z.EncBinary()
 					_ = yym949
 					if false {
@@ -10646,15 +11396,20 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr946 || yy2arr946 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy951 := &x.Backend
 				yy951.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("backend"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy952 := &x.Backend
 				yy952.CodecEncodeSelf(e)
 			}
-			if yysep946 {
-				r.EncodeEnd()
+			if yyr946 || yy2arr946 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10669,17 +11424,18 @@ func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct954 := r.ContainerType()
+		if yyct954 == codecSelferValueTypeMap1234 {
 			yyl954 := r.ReadMapStart()
 			if yyl954 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl954, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct954 == codecSelferValueTypeArray1234 {
 			yyl954 := r.ReadArrayStart()
 			if yyl954 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl954, d)
 			}
@@ -10706,8 +11462,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys955Slc = r.DecodeBytes(yys955Slc, true, true)
 		yys955 := string(yys955Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys955 {
 		case "path":
 			if r.TryDecodeAsNil() {
@@ -10726,9 +11484,7 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys955)
 		} // end switch yys955
 	} // end for yyj955
-	if !yyhl955 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10745,9 +11501,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb958 = r.CheckBreak()
 	}
 	if yyb958 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -10760,9 +11517,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb958 = r.CheckBreak()
 	}
 	if yyb958 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Backend = IngressBackend{}
 	} else {
@@ -10779,9 +11537,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb958 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj958-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10801,18 +11560,21 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq962 [2]bool
 			_, _, _ = yysep962, yyq962, yy2arr962
 			const yyr962 bool = false
+			var yynn962 int
 			if yyr962 || yy2arr962 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn962 int = 2
+				yynn962 = 2
 				for _, b := range yyq962 {
 					if b {
 						yynn962++
 					}
 				}
 				r.EncodeMapStart(yynn962)
+				yynn962 = 0
 			}
 			if yyr962 || yy2arr962 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym964 := z.EncBinary()
 				_ = yym964
 				if false {
@@ -10820,7 +11582,9 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym965 := z.EncBinary()
 				_ = yym965
 				if false {
@@ -10829,6 +11593,7 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr962 || yy2arr962 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy967 := &x.ServicePort
 				yym968 := z.EncBinary()
 				_ = yym968
@@ -10840,7 +11605,9 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy967)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy969 := &x.ServicePort
 				yym970 := z.EncBinary()
 				_ = yym970
@@ -10852,8 +11619,10 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy969)
 				}
 			}
-			if yysep962 {
-				r.EncodeEnd()
+			if yyr962 || yy2arr962 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10868,17 +11637,18 @@ func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct972 := r.ContainerType()
+		if yyct972 == codecSelferValueTypeMap1234 {
 			yyl972 := r.ReadMapStart()
 			if yyl972 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl972, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct972 == codecSelferValueTypeArray1234 {
 			yyl972 := r.ReadArrayStart()
 			if yyl972 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl972, d)
 			}
@@ -10905,8 +11675,10 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys973Slc = r.DecodeBytes(yys973Slc, true, true)
 		yys973 := string(yys973Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys973 {
 		case "serviceName":
 			if r.TryDecodeAsNil() {
@@ -10933,9 +11705,7 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys973)
 		} // end switch yys973
 	} // end for yyj973
-	if !yyhl973 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10952,9 +11722,10 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb977 = r.CheckBreak()
 	}
 	if yyb977 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ServiceName = ""
 	} else {
@@ -10967,9 +11738,10 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb977 = r.CheckBreak()
 	}
 	if yyb977 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ServicePort = pkg6_intstr.IntOrString{}
 	} else {
@@ -10994,9 +11766,10 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb977 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj977-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11042,24 +11815,30 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq984 [2]bool
 			_, _, _ = yysep984, yyq984, yy2arr984
 			const yyr984 bool = false
+			var yynn984 int
 			if yyr984 || yy2arr984 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn984 int = 2
+				yynn984 = 2
 				for _, b := range yyq984 {
 					if b {
 						yynn984++
 					}
 				}
 				r.EncodeMapStart(yynn984)
+				yynn984 = 0
 			}
 			if yyr984 || yy2arr984 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Resource.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("resource"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Resource.CodecEncodeSelf(e)
 			}
 			if yyr984 || yy2arr984 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym987 := z.EncBinary()
 				_ = yym987
 				if false {
@@ -11067,7 +11846,9 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym988 := z.EncBinary()
 				_ = yym988
 				if false {
@@ -11075,8 +11856,10 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yysep984 {
-				r.EncodeEnd()
+			if yyr984 || yy2arr984 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11091,17 +11874,18 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct990 := r.ContainerType()
+		if yyct990 == codecSelferValueTypeMap1234 {
 			yyl990 := r.ReadMapStart()
 			if yyl990 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl990, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct990 == codecSelferValueTypeArray1234 {
 			yyl990 := r.ReadArrayStart()
 			if yyl990 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl990, d)
 			}
@@ -11128,8 +11912,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys991Slc = r.DecodeBytes(yys991Slc, true, true)
 		yys991 := string(yys991Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys991 {
 		case "resource":
 			if r.TryDecodeAsNil() {
@@ -11147,9 +11933,7 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys991)
 		} // end switch yys991
 	} // end for yyj991
-	if !yyhl991 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11166,9 +11950,10 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb994 = r.CheckBreak()
 	}
 	if yyb994 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Resource = ""
 	} else {
@@ -11181,9 +11966,10 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb994 = r.CheckBreak()
 	}
 	if yyb994 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Value = 0
 	} else {
@@ -11199,9 +11985,10 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb994 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj994-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11221,18 +12008,21 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq998 [3]bool
 			_, _, _ = yysep998, yyq998, yy2arr998
 			const yyr998 bool = false
+			var yynn998 int
 			if yyr998 || yy2arr998 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn998 int = 3
+				yynn998 = 3
 				for _, b := range yyq998 {
 					if b {
 						yynn998++
 					}
 				}
 				r.EncodeMapStart(yynn998)
+				yynn998 = 0
 			}
 			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1000 := z.EncBinary()
 				_ = yym1000
 				if false {
@@ -11240,7 +12030,9 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1001 := z.EncBinary()
 				_ = yym1001
 				if false {
@@ -11249,6 +12041,7 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1003 := z.EncBinary()
 				_ = yym1003
 				if false {
@@ -11256,7 +12049,9 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1004 := z.EncBinary()
 				_ = yym1004
 				if false {
@@ -11265,6 +12060,7 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
@@ -11276,7 +12072,9 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
@@ -11288,8 +12086,10 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep998 {
-				r.EncodeEnd()
+			if yyr998 || yy2arr998 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11304,17 +12104,18 @@ func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1009 := r.ContainerType()
+		if yyct1009 == codecSelferValueTypeMap1234 {
 			yyl1009 := r.ReadMapStart()
 			if yyl1009 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1009, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1009 == codecSelferValueTypeArray1234 {
 			yyl1009 := r.ReadArrayStart()
 			if yyl1009 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1009, d)
 			}
@@ -11341,8 +12142,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1010Slc = r.DecodeBytes(yys1010Slc, true, true)
 		yys1010 := string(yys1010Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1010 {
 		case "minNodes":
 			if r.TryDecodeAsNil() {
@@ -11372,9 +12175,7 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1010)
 		} // end switch yys1010
 	} // end for yyj1010
-	if !yyhl1010 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11391,9 +12192,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1015 = r.CheckBreak()
 	}
 	if yyb1015 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MinNodes = 0
 	} else {
@@ -11406,9 +12208,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1015 = r.CheckBreak()
 	}
 	if yyb1015 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MaxNodes = 0
 	} else {
@@ -11421,9 +12224,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1015 = r.CheckBreak()
 	}
 	if yyb1015 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetUtilization = nil
 	} else {
@@ -11445,9 +12249,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1015 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1015-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11471,18 +12276,21 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1021[1] = x.APIVersion != ""
 			yyq1021[2] = true
 			yyq1021[3] = true
+			var yynn1021 int
 			if yyr1021 || yy2arr1021 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1021 int = 0
+				yynn1021 = 0
 				for _, b := range yyq1021 {
 					if b {
 						yynn1021++
 					}
 				}
 				r.EncodeMapStart(yynn1021)
+				yynn1021 = 0
 			}
 			if yyr1021 || yy2arr1021 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1021[0] {
 					yym1023 := z.EncBinary()
 					_ = yym1023
@@ -11495,7 +12303,9 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1021[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1024 := z.EncBinary()
 					_ = yym1024
 					if false {
@@ -11505,6 +12315,7 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1021 || yy2arr1021 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1021[1] {
 					yym1026 := z.EncBinary()
 					_ = yym1026
@@ -11517,7 +12328,9 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1021[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1027 := z.EncBinary()
 					_ = yym1027
 					if false {
@@ -11527,6 +12340,7 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1021 || yy2arr1021 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1021[2] {
 					yy1029 := &x.ObjectMeta
 					yy1029.CodecEncodeSelf(e)
@@ -11535,12 +12349,15 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1021[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1030 := &x.ObjectMeta
 					yy1030.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1021 || yy2arr1021 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1021[3] {
 					yy1032 := &x.Spec
 					yy1032.CodecEncodeSelf(e)
@@ -11549,13 +12366,17 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1021[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1033 := &x.Spec
 					yy1033.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1021 {
-				r.EncodeEnd()
+			if yyr1021 || yy2arr1021 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11570,17 +12391,18 @@ func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1035 := r.ContainerType()
+		if yyct1035 == codecSelferValueTypeMap1234 {
 			yyl1035 := r.ReadMapStart()
 			if yyl1035 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1035, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1035 == codecSelferValueTypeArray1234 {
 			yyl1035 := r.ReadArrayStart()
 			if yyl1035 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1035, d)
 			}
@@ -11607,8 +12429,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1036Slc = r.DecodeBytes(yys1036Slc, true, true)
 		yys1036 := string(yys1036Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1036 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -11640,9 +12464,7 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			z.DecStructFieldNotFound(-1, yys1036)
 		} // end switch yys1036
 	} // end for yyj1036
-	if !yyhl1036 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11659,9 +12481,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb1041 = r.CheckBreak()
 	}
 	if yyb1041 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -11674,9 +12497,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb1041 = r.CheckBreak()
 	}
 	if yyb1041 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -11689,9 +12513,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb1041 = r.CheckBreak()
 	}
 	if yyb1041 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -11705,9 +12530,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb1041 = r.CheckBreak()
 	}
 	if yyb1041 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ClusterAutoscalerSpec{}
 	} else {
@@ -11724,9 +12550,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if yyb1041 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1041-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11749,18 +12576,21 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1047[0] = x.Kind != ""
 			yyq1047[1] = x.APIVersion != ""
 			yyq1047[2] = true
+			var yynn1047 int
 			if yyr1047 || yy2arr1047 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1047 int = 1
+				yynn1047 = 1
 				for _, b := range yyq1047 {
 					if b {
 						yynn1047++
 					}
 				}
 				r.EncodeMapStart(yynn1047)
+				yynn1047 = 0
 			}
 			if yyr1047 || yy2arr1047 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1047[0] {
 					yym1049 := z.EncBinary()
 					_ = yym1049
@@ -11773,7 +12603,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1047[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1050 := z.EncBinary()
 					_ = yym1050
 					if false {
@@ -11783,6 +12615,7 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1047 || yy2arr1047 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1047[1] {
 					yym1052 := z.EncBinary()
 					_ = yym1052
@@ -11795,7 +12628,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1047[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1053 := z.EncBinary()
 					_ = yym1053
 					if false {
@@ -11805,6 +12640,7 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1047 || yy2arr1047 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1047[2] {
 					yy1055 := &x.ListMeta
 					yym1056 := z.EncBinary()
@@ -11819,7 +12655,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1047[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1057 := &x.ListMeta
 					yym1058 := z.EncBinary()
 					_ = yym1058
@@ -11831,6 +12669,7 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1047 || yy2arr1047 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -11842,7 +12681,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -11854,8 +12695,10 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1047 {
-				r.EncodeEnd()
+			if yyr1047 || yy2arr1047 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11870,17 +12713,18 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1063 := r.ContainerType()
+		if yyct1063 == codecSelferValueTypeMap1234 {
 			yyl1063 := r.ReadMapStart()
 			if yyl1063 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1063, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1063 == codecSelferValueTypeArray1234 {
 			yyl1063 := r.ReadArrayStart()
 			if yyl1063 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1063, d)
 			}
@@ -11907,8 +12751,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1064Slc = r.DecodeBytes(yys1064Slc, true, true)
 		yys1064 := string(yys1064Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1064 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -11951,9 +12797,7 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1064)
 		} // end switch yys1064
 	} // end for yyj1064
-	if !yyhl1064 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11970,9 +12814,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1071 = r.CheckBreak()
 	}
 	if yyb1071 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -11985,9 +12830,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1071 = r.CheckBreak()
 	}
 	if yyb1071 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -12000,9 +12846,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1071 = r.CheckBreak()
 	}
 	if yyb1071 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -12022,9 +12869,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1071 = r.CheckBreak()
 	}
 	if yyb1071 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -12046,9 +12894,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1071 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1071-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12070,18 +12919,21 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1079 bool = false
 			yyq1079[0] = len(x.MatchLabels) != 0
 			yyq1079[1] = len(x.MatchExpressions) != 0
+			var yynn1079 int
 			if yyr1079 || yy2arr1079 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1079 int = 0
+				yynn1079 = 0
 				for _, b := range yyq1079 {
 					if b {
 						yynn1079++
 					}
 				}
 				r.EncodeMapStart(yynn1079)
+				yynn1079 = 0
 			}
 			if yyr1079 || yy2arr1079 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1079[0] {
 					if x.MatchLabels == nil {
 						r.EncodeNil()
@@ -12098,7 +12950,9 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1079[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
@@ -12112,6 +12966,7 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1079 || yy2arr1079 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1079[1] {
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
@@ -12128,7 +12983,9 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1079[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
@@ -12141,8 +12998,10 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1079 {
-				r.EncodeEnd()
+			if yyr1079 || yy2arr1079 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12157,17 +13016,18 @@ func (x *PodSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1087 := r.ContainerType()
+		if yyct1087 == codecSelferValueTypeMap1234 {
 			yyl1087 := r.ReadMapStart()
 			if yyl1087 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1087, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1087 == codecSelferValueTypeArray1234 {
 			yyl1087 := r.ReadArrayStart()
 			if yyl1087 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1087, d)
 			}
@@ -12194,8 +13054,10 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1088Slc = r.DecodeBytes(yys1088Slc, true, true)
 		yys1088 := string(yys1088Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1088 {
 		case "matchLabels":
 			if r.TryDecodeAsNil() {
@@ -12225,9 +13087,7 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1088)
 		} // end switch yys1088
 	} // end for yyj1088
-	if !yyhl1088 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12244,9 +13104,10 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1093 = r.CheckBreak()
 	}
 	if yyb1093 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MatchLabels = nil
 	} else {
@@ -12265,9 +13126,10 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1093 = r.CheckBreak()
 	}
 	if yyb1093 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MatchExpressions = nil
 	} else {
@@ -12289,9 +13151,10 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1093 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1093-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12312,18 +13175,21 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1099, yyq1099, yy2arr1099
 			const yyr1099 bool = false
 			yyq1099[2] = len(x.Values) != 0
+			var yynn1099 int
 			if yyr1099 || yy2arr1099 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1099 int = 2
+				yynn1099 = 2
 				for _, b := range yyq1099 {
 					if b {
 						yynn1099++
 					}
 				}
 				r.EncodeMapStart(yynn1099)
+				yynn1099 = 0
 			}
 			if yyr1099 || yy2arr1099 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1101 := z.EncBinary()
 				_ = yym1101
 				if false {
@@ -12331,7 +13197,9 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1102 := z.EncBinary()
 				_ = yym1102
 				if false {
@@ -12340,12 +13208,16 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1099 || yy2arr1099 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Operator.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("operator"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Operator.CodecEncodeSelf(e)
 			}
 			if yyr1099 || yy2arr1099 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1099[2] {
 					if x.Values == nil {
 						r.EncodeNil()
@@ -12362,7 +13234,9 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1099[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("values"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
@@ -12375,8 +13249,10 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1099 {
-				r.EncodeEnd()
+			if yyr1099 || yy2arr1099 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12391,17 +13267,18 @@ func (x *PodSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1108 := r.ContainerType()
+		if yyct1108 == codecSelferValueTypeMap1234 {
 			yyl1108 := r.ReadMapStart()
 			if yyl1108 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1108, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1108 == codecSelferValueTypeArray1234 {
 			yyl1108 := r.ReadArrayStart()
 			if yyl1108 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1108, d)
 			}
@@ -12428,8 +13305,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1109Slc = r.DecodeBytes(yys1109Slc, true, true)
 		yys1109 := string(yys1109Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1109 {
 		case "key":
 			if r.TryDecodeAsNil() {
@@ -12459,9 +13338,7 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys1109)
 		} // end switch yys1109
 	} // end for yyj1109
-	if !yyhl1109 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12478,9 +13355,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb1114 = r.CheckBreak()
 	}
 	if yyb1114 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Key = ""
 	} else {
@@ -12493,9 +13371,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb1114 = r.CheckBreak()
 	}
 	if yyb1114 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Operator = ""
 	} else {
@@ -12508,9 +13387,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb1114 = r.CheckBreak()
 	}
 	if yyb1114 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Values = nil
 	} else {
@@ -12532,9 +13412,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb1114 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1114-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PodSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12569,10 +13450,11 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1121 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1122 := &yyv1121
 		yy1122.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutoscaler, d *codec1978.Decoder) {
@@ -12582,39 +13464,44 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 
 	yyv1123 := *v
 	yyh1123, yyl1123 := z.DecSliceHelperStart()
-
-	var yyrr1123, yyrl1123 int
-	var yyc1123, yyrt1123 bool
-	_, _, _ = yyc1123, yyrt1123, yyrl1123
-	yyrr1123 = yyl1123
-
-	if yyv1123 == nil {
-		if yyrl1123, yyrt1123 = z.DecInferLen(yyl1123, z.DecBasicHandle().MaxInitLen, 320); yyrt1123 {
-			yyrr1123 = yyrl1123
-		}
-		yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
-		yyc1123 = true
-	}
-
+	var yyc1123 bool
 	if yyl1123 == 0 {
-		if len(yyv1123) != 0 {
+		if yyv1123 == nil {
+			yyv1123 = []HorizontalPodAutoscaler{}
+			yyc1123 = true
+		} else if len(yyv1123) != 0 {
 			yyv1123 = yyv1123[:0]
 			yyc1123 = true
 		}
 	} else if yyl1123 > 0 {
-
+		var yyrr1123, yyrl1123 int
+		var yyrt1123 bool
 		if yyl1123 > cap(yyv1123) {
-			yyrl1123, yyrt1123 = z.DecInferLen(yyl1123, z.DecBasicHandle().MaxInitLen, 320)
-			yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
-			yyc1123 = true
 
+			yyrg1123 := len(yyv1123) > 0
+			yyv21123 := yyv1123
+			yyrl1123, yyrt1123 = z.DecInferLen(yyl1123, z.DecBasicHandle().MaxInitLen, 320)
+			if yyrt1123 {
+				if yyrl1123 <= cap(yyv1123) {
+					yyv1123 = yyv1123[:yyrl1123]
+				} else {
+					yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
+				}
+			} else {
+				yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
+			}
+			yyc1123 = true
 			yyrr1123 = len(yyv1123)
+			if yyrg1123 {
+				copy(yyv1123, yyv21123)
+			}
 		} else if yyl1123 != len(yyv1123) {
 			yyv1123 = yyv1123[:yyl1123]
 			yyc1123 = true
 		}
 		yyj1123 := 0
 		for ; yyj1123 < yyrr1123; yyj1123++ {
+			yyh1123.ElemContainerState(yyj1123)
 			if r.TryDecodeAsNil() {
 				yyv1123[yyj1123] = HorizontalPodAutoscaler{}
 			} else {
@@ -12626,6 +13513,7 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 		if yyrt1123 {
 			for ; yyj1123 < yyl1123; yyj1123++ {
 				yyv1123 = append(yyv1123, HorizontalPodAutoscaler{})
+				yyh1123.ElemContainerState(yyj1123)
 				if r.TryDecodeAsNil() {
 					yyv1123[yyj1123] = HorizontalPodAutoscaler{}
 				} else {
@@ -12637,12 +13525,14 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 		}
 
 	} else {
-		for yyj1123 := 0; !r.CheckBreak(); yyj1123++ {
+		yyj1123 := 0
+		for ; !r.CheckBreak(); yyj1123++ {
+
 			if yyj1123 >= len(yyv1123) {
 				yyv1123 = append(yyv1123, HorizontalPodAutoscaler{}) // var yyz1123 HorizontalPodAutoscaler
 				yyc1123 = true
 			}
-
+			yyh1123.ElemContainerState(yyj1123)
 			if yyj1123 < len(yyv1123) {
 				if r.TryDecodeAsNil() {
 					yyv1123[yyj1123] = HorizontalPodAutoscaler{}
@@ -12656,12 +13546,18 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		yyh1123.End()
+		if yyj1123 < len(yyv1123) {
+			yyv1123 = yyv1123[:yyj1123]
+			yyc1123 = true
+		} else if yyj1123 == 0 && yyv1123 == nil {
+			yyv1123 = []HorizontalPodAutoscaler{}
+			yyc1123 = true
+		}
 	}
+	yyh1123.End()
 	if yyc1123 {
 		*v = yyv1123
 	}
-
 }
 
 func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder) {
@@ -12670,10 +13566,11 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1127 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1128 := &yyv1127
 		yy1128.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decoder) {
@@ -12683,39 +13580,44 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 
 	yyv1129 := *v
 	yyh1129, yyl1129 := z.DecSliceHelperStart()
-
-	var yyrr1129, yyrl1129 int
-	var yyc1129, yyrt1129 bool
-	_, _, _ = yyc1129, yyrt1129, yyrl1129
-	yyrr1129 = yyl1129
-
-	if yyv1129 == nil {
-		if yyrl1129, yyrt1129 = z.DecInferLen(yyl1129, z.DecBasicHandle().MaxInitLen, 32); yyrt1129 {
-			yyrr1129 = yyrl1129
-		}
-		yyv1129 = make([]APIVersion, yyrl1129)
-		yyc1129 = true
-	}
-
+	var yyc1129 bool
 	if yyl1129 == 0 {
-		if len(yyv1129) != 0 {
+		if yyv1129 == nil {
+			yyv1129 = []APIVersion{}
+			yyc1129 = true
+		} else if len(yyv1129) != 0 {
 			yyv1129 = yyv1129[:0]
 			yyc1129 = true
 		}
 	} else if yyl1129 > 0 {
-
+		var yyrr1129, yyrl1129 int
+		var yyrt1129 bool
 		if yyl1129 > cap(yyv1129) {
-			yyrl1129, yyrt1129 = z.DecInferLen(yyl1129, z.DecBasicHandle().MaxInitLen, 32)
-			yyv1129 = make([]APIVersion, yyrl1129)
-			yyc1129 = true
 
+			yyrg1129 := len(yyv1129) > 0
+			yyv21129 := yyv1129
+			yyrl1129, yyrt1129 = z.DecInferLen(yyl1129, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt1129 {
+				if yyrl1129 <= cap(yyv1129) {
+					yyv1129 = yyv1129[:yyrl1129]
+				} else {
+					yyv1129 = make([]APIVersion, yyrl1129)
+				}
+			} else {
+				yyv1129 = make([]APIVersion, yyrl1129)
+			}
+			yyc1129 = true
 			yyrr1129 = len(yyv1129)
+			if yyrg1129 {
+				copy(yyv1129, yyv21129)
+			}
 		} else if yyl1129 != len(yyv1129) {
 			yyv1129 = yyv1129[:yyl1129]
 			yyc1129 = true
 		}
 		yyj1129 := 0
 		for ; yyj1129 < yyrr1129; yyj1129++ {
+			yyh1129.ElemContainerState(yyj1129)
 			if r.TryDecodeAsNil() {
 				yyv1129[yyj1129] = APIVersion{}
 			} else {
@@ -12727,6 +13629,7 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 		if yyrt1129 {
 			for ; yyj1129 < yyl1129; yyj1129++ {
 				yyv1129 = append(yyv1129, APIVersion{})
+				yyh1129.ElemContainerState(yyj1129)
 				if r.TryDecodeAsNil() {
 					yyv1129[yyj1129] = APIVersion{}
 				} else {
@@ -12738,12 +13641,14 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 		}
 
 	} else {
-		for yyj1129 := 0; !r.CheckBreak(); yyj1129++ {
+		yyj1129 := 0
+		for ; !r.CheckBreak(); yyj1129++ {
+
 			if yyj1129 >= len(yyv1129) {
 				yyv1129 = append(yyv1129, APIVersion{}) // var yyz1129 APIVersion
 				yyc1129 = true
 			}
-
+			yyh1129.ElemContainerState(yyj1129)
 			if yyj1129 < len(yyv1129) {
 				if r.TryDecodeAsNil() {
 					yyv1129[yyj1129] = APIVersion{}
@@ -12757,12 +13662,18 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		yyh1129.End()
+		if yyj1129 < len(yyv1129) {
+			yyv1129 = yyv1129[:yyj1129]
+			yyc1129 = true
+		} else if yyj1129 == 0 && yyv1129 == nil {
+			yyv1129 = []APIVersion{}
+			yyc1129 = true
+		}
 	}
+	yyh1129.End()
 	if yyc1129 {
 		*v = yyv1129
 	}
-
 }
 
 func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *codec1978.Encoder) {
@@ -12771,10 +13682,11 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1133 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1134 := &yyv1133
 		yy1134.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *codec1978.Decoder) {
@@ -12784,39 +13696,44 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 
 	yyv1135 := *v
 	yyh1135, yyl1135 := z.DecSliceHelperStart()
-
-	var yyrr1135, yyrl1135 int
-	var yyc1135, yyrt1135 bool
-	_, _, _ = yyc1135, yyrt1135, yyrl1135
-	yyrr1135 = yyl1135
-
-	if yyv1135 == nil {
-		if yyrl1135, yyrt1135 = z.DecInferLen(yyl1135, z.DecBasicHandle().MaxInitLen, 232); yyrt1135 {
-			yyrr1135 = yyrl1135
-		}
-		yyv1135 = make([]ThirdPartyResource, yyrl1135)
-		yyc1135 = true
-	}
-
+	var yyc1135 bool
 	if yyl1135 == 0 {
-		if len(yyv1135) != 0 {
+		if yyv1135 == nil {
+			yyv1135 = []ThirdPartyResource{}
+			yyc1135 = true
+		} else if len(yyv1135) != 0 {
 			yyv1135 = yyv1135[:0]
 			yyc1135 = true
 		}
 	} else if yyl1135 > 0 {
-
+		var yyrr1135, yyrl1135 int
+		var yyrt1135 bool
 		if yyl1135 > cap(yyv1135) {
-			yyrl1135, yyrt1135 = z.DecInferLen(yyl1135, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1135 = make([]ThirdPartyResource, yyrl1135)
-			yyc1135 = true
 
+			yyrg1135 := len(yyv1135) > 0
+			yyv21135 := yyv1135
+			yyrl1135, yyrt1135 = z.DecInferLen(yyl1135, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1135 {
+				if yyrl1135 <= cap(yyv1135) {
+					yyv1135 = yyv1135[:yyrl1135]
+				} else {
+					yyv1135 = make([]ThirdPartyResource, yyrl1135)
+				}
+			} else {
+				yyv1135 = make([]ThirdPartyResource, yyrl1135)
+			}
+			yyc1135 = true
 			yyrr1135 = len(yyv1135)
+			if yyrg1135 {
+				copy(yyv1135, yyv21135)
+			}
 		} else if yyl1135 != len(yyv1135) {
 			yyv1135 = yyv1135[:yyl1135]
 			yyc1135 = true
 		}
 		yyj1135 := 0
 		for ; yyj1135 < yyrr1135; yyj1135++ {
+			yyh1135.ElemContainerState(yyj1135)
 			if r.TryDecodeAsNil() {
 				yyv1135[yyj1135] = ThirdPartyResource{}
 			} else {
@@ -12828,6 +13745,7 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 		if yyrt1135 {
 			for ; yyj1135 < yyl1135; yyj1135++ {
 				yyv1135 = append(yyv1135, ThirdPartyResource{})
+				yyh1135.ElemContainerState(yyj1135)
 				if r.TryDecodeAsNil() {
 					yyv1135[yyj1135] = ThirdPartyResource{}
 				} else {
@@ -12839,12 +13757,14 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 		}
 
 	} else {
-		for yyj1135 := 0; !r.CheckBreak(); yyj1135++ {
+		yyj1135 := 0
+		for ; !r.CheckBreak(); yyj1135++ {
+
 			if yyj1135 >= len(yyv1135) {
 				yyv1135 = append(yyv1135, ThirdPartyResource{}) // var yyz1135 ThirdPartyResource
 				yyc1135 = true
 			}
-
+			yyh1135.ElemContainerState(yyj1135)
 			if yyj1135 < len(yyv1135) {
 				if r.TryDecodeAsNil() {
 					yyv1135[yyj1135] = ThirdPartyResource{}
@@ -12858,12 +13778,18 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		yyh1135.End()
+		if yyj1135 < len(yyv1135) {
+			yyv1135 = yyv1135[:yyj1135]
+			yyc1135 = true
+		} else if yyj1135 == 0 && yyv1135 == nil {
+			yyv1135 = []ThirdPartyResource{}
+			yyc1135 = true
+		}
 	}
+	yyh1135.End()
 	if yyc1135 {
 		*v = yyv1135
 	}
-
 }
 
 func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder) {
@@ -12872,10 +13798,11 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1139 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1140 := &yyv1139
 		yy1140.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decoder) {
@@ -12885,39 +13812,44 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 
 	yyv1141 := *v
 	yyh1141, yyl1141 := z.DecSliceHelperStart()
-
-	var yyrr1141, yyrl1141 int
-	var yyc1141, yyrt1141 bool
-	_, _, _ = yyc1141, yyrt1141, yyrl1141
-	yyrr1141 = yyl1141
-
-	if yyv1141 == nil {
-		if yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592); yyrt1141 {
-			yyrr1141 = yyrl1141
-		}
-		yyv1141 = make([]Deployment, yyrl1141)
-		yyc1141 = true
-	}
-
+	var yyc1141 bool
 	if yyl1141 == 0 {
-		if len(yyv1141) != 0 {
+		if yyv1141 == nil {
+			yyv1141 = []Deployment{}
+			yyc1141 = true
+		} else if len(yyv1141) != 0 {
 			yyv1141 = yyv1141[:0]
 			yyc1141 = true
 		}
 	} else if yyl1141 > 0 {
-
+		var yyrr1141, yyrl1141 int
+		var yyrt1141 bool
 		if yyl1141 > cap(yyv1141) {
-			yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592)
-			yyv1141 = make([]Deployment, yyrl1141)
-			yyc1141 = true
 
+			yyrg1141 := len(yyv1141) > 0
+			yyv21141 := yyv1141
+			yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592)
+			if yyrt1141 {
+				if yyrl1141 <= cap(yyv1141) {
+					yyv1141 = yyv1141[:yyrl1141]
+				} else {
+					yyv1141 = make([]Deployment, yyrl1141)
+				}
+			} else {
+				yyv1141 = make([]Deployment, yyrl1141)
+			}
+			yyc1141 = true
 			yyrr1141 = len(yyv1141)
+			if yyrg1141 {
+				copy(yyv1141, yyv21141)
+			}
 		} else if yyl1141 != len(yyv1141) {
 			yyv1141 = yyv1141[:yyl1141]
 			yyc1141 = true
 		}
 		yyj1141 := 0
 		for ; yyj1141 < yyrr1141; yyj1141++ {
+			yyh1141.ElemContainerState(yyj1141)
 			if r.TryDecodeAsNil() {
 				yyv1141[yyj1141] = Deployment{}
 			} else {
@@ -12929,6 +13861,7 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 		if yyrt1141 {
 			for ; yyj1141 < yyl1141; yyj1141++ {
 				yyv1141 = append(yyv1141, Deployment{})
+				yyh1141.ElemContainerState(yyj1141)
 				if r.TryDecodeAsNil() {
 					yyv1141[yyj1141] = Deployment{}
 				} else {
@@ -12940,12 +13873,14 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 		}
 
 	} else {
-		for yyj1141 := 0; !r.CheckBreak(); yyj1141++ {
+		yyj1141 := 0
+		for ; !r.CheckBreak(); yyj1141++ {
+
 			if yyj1141 >= len(yyv1141) {
 				yyv1141 = append(yyv1141, Deployment{}) // var yyz1141 Deployment
 				yyc1141 = true
 			}
-
+			yyh1141.ElemContainerState(yyj1141)
 			if yyj1141 < len(yyv1141) {
 				if r.TryDecodeAsNil() {
 					yyv1141[yyj1141] = Deployment{}
@@ -12959,12 +13894,18 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		yyh1141.End()
+		if yyj1141 < len(yyv1141) {
+			yyv1141 = yyv1141[:yyj1141]
+			yyc1141 = true
+		} else if yyj1141 == 0 && yyv1141 == nil {
+			yyv1141 = []Deployment{}
+			yyc1141 = true
+		}
 	}
+	yyh1141.End()
 	if yyc1141 {
 		*v = yyv1141
 	}
-
 }
 
 func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) {
@@ -12973,10 +13914,11 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1145 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1146 := &yyv1145
 		yy1146.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder) {
@@ -12986,39 +13928,44 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 
 	yyv1147 := *v
 	yyh1147, yyl1147 := z.DecSliceHelperStart()
-
-	var yyrr1147, yyrl1147 int
-	var yyc1147, yyrt1147 bool
-	_, _, _ = yyc1147, yyrt1147, yyrl1147
-	yyrr1147 = yyl1147
-
-	if yyv1147 == nil {
-		if yyrl1147, yyrt1147 = z.DecInferLen(yyl1147, z.DecBasicHandle().MaxInitLen, 232); yyrt1147 {
-			yyrr1147 = yyrl1147
-		}
-		yyv1147 = make([]DaemonSet, yyrl1147)
-		yyc1147 = true
-	}
-
+	var yyc1147 bool
 	if yyl1147 == 0 {
-		if len(yyv1147) != 0 {
+		if yyv1147 == nil {
+			yyv1147 = []DaemonSet{}
+			yyc1147 = true
+		} else if len(yyv1147) != 0 {
 			yyv1147 = yyv1147[:0]
 			yyc1147 = true
 		}
 	} else if yyl1147 > 0 {
-
+		var yyrr1147, yyrl1147 int
+		var yyrt1147 bool
 		if yyl1147 > cap(yyv1147) {
-			yyrl1147, yyrt1147 = z.DecInferLen(yyl1147, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1147 = make([]DaemonSet, yyrl1147)
-			yyc1147 = true
 
+			yyrg1147 := len(yyv1147) > 0
+			yyv21147 := yyv1147
+			yyrl1147, yyrt1147 = z.DecInferLen(yyl1147, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1147 {
+				if yyrl1147 <= cap(yyv1147) {
+					yyv1147 = yyv1147[:yyrl1147]
+				} else {
+					yyv1147 = make([]DaemonSet, yyrl1147)
+				}
+			} else {
+				yyv1147 = make([]DaemonSet, yyrl1147)
+			}
+			yyc1147 = true
 			yyrr1147 = len(yyv1147)
+			if yyrg1147 {
+				copy(yyv1147, yyv21147)
+			}
 		} else if yyl1147 != len(yyv1147) {
 			yyv1147 = yyv1147[:yyl1147]
 			yyc1147 = true
 		}
 		yyj1147 := 0
 		for ; yyj1147 < yyrr1147; yyj1147++ {
+			yyh1147.ElemContainerState(yyj1147)
 			if r.TryDecodeAsNil() {
 				yyv1147[yyj1147] = DaemonSet{}
 			} else {
@@ -13030,6 +13977,7 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 		if yyrt1147 {
 			for ; yyj1147 < yyl1147; yyj1147++ {
 				yyv1147 = append(yyv1147, DaemonSet{})
+				yyh1147.ElemContainerState(yyj1147)
 				if r.TryDecodeAsNil() {
 					yyv1147[yyj1147] = DaemonSet{}
 				} else {
@@ -13041,12 +13989,14 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 		}
 
 	} else {
-		for yyj1147 := 0; !r.CheckBreak(); yyj1147++ {
+		yyj1147 := 0
+		for ; !r.CheckBreak(); yyj1147++ {
+
 			if yyj1147 >= len(yyv1147) {
 				yyv1147 = append(yyv1147, DaemonSet{}) // var yyz1147 DaemonSet
 				yyc1147 = true
 			}
-
+			yyh1147.ElemContainerState(yyj1147)
 			if yyj1147 < len(yyv1147) {
 				if r.TryDecodeAsNil() {
 					yyv1147[yyj1147] = DaemonSet{}
@@ -13060,12 +14010,18 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		yyh1147.End()
+		if yyj1147 < len(yyv1147) {
+			yyv1147 = yyv1147[:yyj1147]
+			yyc1147 = true
+		} else if yyj1147 == 0 && yyv1147 == nil {
+			yyv1147 = []DaemonSet{}
+			yyc1147 = true
+		}
 	}
+	yyh1147.End()
 	if yyc1147 {
 		*v = yyv1147
 	}
-
 }
 
 func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceData, e *codec1978.Encoder) {
@@ -13074,10 +14030,11 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1151 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1152 := &yyv1151
 		yy1152.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceData, d *codec1978.Decoder) {
@@ -13087,39 +14044,44 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 
 	yyv1153 := *v
 	yyh1153, yyl1153 := z.DecSliceHelperStart()
-
-	var yyrr1153, yyrl1153 int
-	var yyc1153, yyrt1153 bool
-	_, _, _ = yyc1153, yyrt1153, yyrl1153
-	yyrr1153 = yyl1153
-
-	if yyv1153 == nil {
-		if yyrl1153, yyrt1153 = z.DecInferLen(yyl1153, z.DecBasicHandle().MaxInitLen, 216); yyrt1153 {
-			yyrr1153 = yyrl1153
-		}
-		yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
-		yyc1153 = true
-	}
-
+	var yyc1153 bool
 	if yyl1153 == 0 {
-		if len(yyv1153) != 0 {
+		if yyv1153 == nil {
+			yyv1153 = []ThirdPartyResourceData{}
+			yyc1153 = true
+		} else if len(yyv1153) != 0 {
 			yyv1153 = yyv1153[:0]
 			yyc1153 = true
 		}
 	} else if yyl1153 > 0 {
-
+		var yyrr1153, yyrl1153 int
+		var yyrt1153 bool
 		if yyl1153 > cap(yyv1153) {
-			yyrl1153, yyrt1153 = z.DecInferLen(yyl1153, z.DecBasicHandle().MaxInitLen, 216)
-			yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
-			yyc1153 = true
 
+			yyrg1153 := len(yyv1153) > 0
+			yyv21153 := yyv1153
+			yyrl1153, yyrt1153 = z.DecInferLen(yyl1153, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt1153 {
+				if yyrl1153 <= cap(yyv1153) {
+					yyv1153 = yyv1153[:yyrl1153]
+				} else {
+					yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
+				}
+			} else {
+				yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
+			}
+			yyc1153 = true
 			yyrr1153 = len(yyv1153)
+			if yyrg1153 {
+				copy(yyv1153, yyv21153)
+			}
 		} else if yyl1153 != len(yyv1153) {
 			yyv1153 = yyv1153[:yyl1153]
 			yyc1153 = true
 		}
 		yyj1153 := 0
 		for ; yyj1153 < yyrr1153; yyj1153++ {
+			yyh1153.ElemContainerState(yyj1153)
 			if r.TryDecodeAsNil() {
 				yyv1153[yyj1153] = ThirdPartyResourceData{}
 			} else {
@@ -13131,6 +14093,7 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 		if yyrt1153 {
 			for ; yyj1153 < yyl1153; yyj1153++ {
 				yyv1153 = append(yyv1153, ThirdPartyResourceData{})
+				yyh1153.ElemContainerState(yyj1153)
 				if r.TryDecodeAsNil() {
 					yyv1153[yyj1153] = ThirdPartyResourceData{}
 				} else {
@@ -13142,12 +14105,14 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 		}
 
 	} else {
-		for yyj1153 := 0; !r.CheckBreak(); yyj1153++ {
+		yyj1153 := 0
+		for ; !r.CheckBreak(); yyj1153++ {
+
 			if yyj1153 >= len(yyv1153) {
 				yyv1153 = append(yyv1153, ThirdPartyResourceData{}) // var yyz1153 ThirdPartyResourceData
 				yyc1153 = true
 			}
-
+			yyh1153.ElemContainerState(yyj1153)
 			if yyj1153 < len(yyv1153) {
 				if r.TryDecodeAsNil() {
 					yyv1153[yyj1153] = ThirdPartyResourceData{}
@@ -13161,12 +14126,18 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		yyh1153.End()
+		if yyj1153 < len(yyv1153) {
+			yyv1153 = yyv1153[:yyj1153]
+			yyc1153 = true
+		} else if yyj1153 == 0 && yyv1153 == nil {
+			yyv1153 = []ThirdPartyResourceData{}
+			yyc1153 = true
+		}
 	}
+	yyh1153.End()
 	if yyc1153 {
 		*v = yyv1153
 	}
-
 }
 
 func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
@@ -13175,10 +14146,11 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1157 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1158 := &yyv1157
 		yy1158.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
@@ -13188,39 +14160,44 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 
 	yyv1159 := *v
 	yyh1159, yyl1159 := z.DecSliceHelperStart()
-
-	var yyrr1159, yyrl1159 int
-	var yyc1159, yyrt1159 bool
-	_, _, _ = yyc1159, yyrt1159, yyrl1159
-	yyrr1159 = yyl1159
-
-	if yyv1159 == nil {
-		if yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608); yyrt1159 {
-			yyrr1159 = yyrl1159
-		}
-		yyv1159 = make([]Job, yyrl1159)
-		yyc1159 = true
-	}
-
+	var yyc1159 bool
 	if yyl1159 == 0 {
-		if len(yyv1159) != 0 {
+		if yyv1159 == nil {
+			yyv1159 = []Job{}
+			yyc1159 = true
+		} else if len(yyv1159) != 0 {
 			yyv1159 = yyv1159[:0]
 			yyc1159 = true
 		}
 	} else if yyl1159 > 0 {
-
+		var yyrr1159, yyrl1159 int
+		var yyrt1159 bool
 		if yyl1159 > cap(yyv1159) {
-			yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608)
-			yyv1159 = make([]Job, yyrl1159)
-			yyc1159 = true
 
+			yyrg1159 := len(yyv1159) > 0
+			yyv21159 := yyv1159
+			yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608)
+			if yyrt1159 {
+				if yyrl1159 <= cap(yyv1159) {
+					yyv1159 = yyv1159[:yyrl1159]
+				} else {
+					yyv1159 = make([]Job, yyrl1159)
+				}
+			} else {
+				yyv1159 = make([]Job, yyrl1159)
+			}
+			yyc1159 = true
 			yyrr1159 = len(yyv1159)
+			if yyrg1159 {
+				copy(yyv1159, yyv21159)
+			}
 		} else if yyl1159 != len(yyv1159) {
 			yyv1159 = yyv1159[:yyl1159]
 			yyc1159 = true
 		}
 		yyj1159 := 0
 		for ; yyj1159 < yyrr1159; yyj1159++ {
+			yyh1159.ElemContainerState(yyj1159)
 			if r.TryDecodeAsNil() {
 				yyv1159[yyj1159] = Job{}
 			} else {
@@ -13232,6 +14209,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 		if yyrt1159 {
 			for ; yyj1159 < yyl1159; yyj1159++ {
 				yyv1159 = append(yyv1159, Job{})
+				yyh1159.ElemContainerState(yyj1159)
 				if r.TryDecodeAsNil() {
 					yyv1159[yyj1159] = Job{}
 				} else {
@@ -13243,12 +14221,14 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj1159 := 0; !r.CheckBreak(); yyj1159++ {
+		yyj1159 := 0
+		for ; !r.CheckBreak(); yyj1159++ {
+
 			if yyj1159 >= len(yyv1159) {
 				yyv1159 = append(yyv1159, Job{}) // var yyz1159 Job
 				yyc1159 = true
 			}
-
+			yyh1159.ElemContainerState(yyj1159)
 			if yyj1159 < len(yyv1159) {
 				if r.TryDecodeAsNil() {
 					yyv1159[yyj1159] = Job{}
@@ -13262,12 +14242,18 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1159.End()
+		if yyj1159 < len(yyv1159) {
+			yyv1159 = yyv1159[:yyj1159]
+			yyc1159 = true
+		} else if yyj1159 == 0 && yyv1159 == nil {
+			yyv1159 = []Job{}
+			yyc1159 = true
+		}
 	}
+	yyh1159.End()
 	if yyc1159 {
 		*v = yyv1159
 	}
-
 }
 
 func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Encoder) {
@@ -13276,10 +14262,11 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1163 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1164 := &yyv1163
 		yy1164.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.Decoder) {
@@ -13289,39 +14276,44 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 
 	yyv1165 := *v
 	yyh1165, yyl1165 := z.DecSliceHelperStart()
-
-	var yyrr1165, yyrl1165 int
-	var yyc1165, yyrt1165 bool
-	_, _, _ = yyc1165, yyrt1165, yyrl1165
-	yyrr1165 = yyl1165
-
-	if yyv1165 == nil {
-		if yyrl1165, yyrt1165 = z.DecInferLen(yyl1165, z.DecBasicHandle().MaxInitLen, 112); yyrt1165 {
-			yyrr1165 = yyrl1165
-		}
-		yyv1165 = make([]JobCondition, yyrl1165)
-		yyc1165 = true
-	}
-
+	var yyc1165 bool
 	if yyl1165 == 0 {
-		if len(yyv1165) != 0 {
+		if yyv1165 == nil {
+			yyv1165 = []JobCondition{}
+			yyc1165 = true
+		} else if len(yyv1165) != 0 {
 			yyv1165 = yyv1165[:0]
 			yyc1165 = true
 		}
 	} else if yyl1165 > 0 {
-
+		var yyrr1165, yyrl1165 int
+		var yyrt1165 bool
 		if yyl1165 > cap(yyv1165) {
-			yyrl1165, yyrt1165 = z.DecInferLen(yyl1165, z.DecBasicHandle().MaxInitLen, 112)
-			yyv1165 = make([]JobCondition, yyrl1165)
-			yyc1165 = true
 
+			yyrg1165 := len(yyv1165) > 0
+			yyv21165 := yyv1165
+			yyrl1165, yyrt1165 = z.DecInferLen(yyl1165, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt1165 {
+				if yyrl1165 <= cap(yyv1165) {
+					yyv1165 = yyv1165[:yyrl1165]
+				} else {
+					yyv1165 = make([]JobCondition, yyrl1165)
+				}
+			} else {
+				yyv1165 = make([]JobCondition, yyrl1165)
+			}
+			yyc1165 = true
 			yyrr1165 = len(yyv1165)
+			if yyrg1165 {
+				copy(yyv1165, yyv21165)
+			}
 		} else if yyl1165 != len(yyv1165) {
 			yyv1165 = yyv1165[:yyl1165]
 			yyc1165 = true
 		}
 		yyj1165 := 0
 		for ; yyj1165 < yyrr1165; yyj1165++ {
+			yyh1165.ElemContainerState(yyj1165)
 			if r.TryDecodeAsNil() {
 				yyv1165[yyj1165] = JobCondition{}
 			} else {
@@ -13333,6 +14325,7 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 		if yyrt1165 {
 			for ; yyj1165 < yyl1165; yyj1165++ {
 				yyv1165 = append(yyv1165, JobCondition{})
+				yyh1165.ElemContainerState(yyj1165)
 				if r.TryDecodeAsNil() {
 					yyv1165[yyj1165] = JobCondition{}
 				} else {
@@ -13344,12 +14337,14 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 		}
 
 	} else {
-		for yyj1165 := 0; !r.CheckBreak(); yyj1165++ {
+		yyj1165 := 0
+		for ; !r.CheckBreak(); yyj1165++ {
+
 			if yyj1165 >= len(yyv1165) {
 				yyv1165 = append(yyv1165, JobCondition{}) // var yyz1165 JobCondition
 				yyc1165 = true
 			}
-
+			yyh1165.ElemContainerState(yyj1165)
 			if yyj1165 < len(yyv1165) {
 				if r.TryDecodeAsNil() {
 					yyv1165[yyj1165] = JobCondition{}
@@ -13363,12 +14358,18 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		yyh1165.End()
+		if yyj1165 < len(yyv1165) {
+			yyv1165 = yyv1165[:yyj1165]
+			yyc1165 = true
+		} else if yyj1165 == 0 && yyv1165 == nil {
+			yyv1165 = []JobCondition{}
+			yyc1165 = true
+		}
 	}
+	yyh1165.End()
 	if yyc1165 {
 		*v = yyv1165
 	}
-
 }
 
 func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
@@ -13377,10 +14378,11 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1169 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1170 := &yyv1169
 		yy1170.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
@@ -13390,39 +14392,44 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 
 	yyv1171 := *v
 	yyh1171, yyl1171 := z.DecSliceHelperStart()
-
-	var yyrr1171, yyrl1171 int
-	var yyc1171, yyrt1171 bool
-	_, _, _ = yyc1171, yyrt1171, yyrl1171
-	yyrr1171 = yyl1171
-
-	if yyv1171 == nil {
-		if yyrl1171, yyrt1171 = z.DecInferLen(yyl1171, z.DecBasicHandle().MaxInitLen, 248); yyrt1171 {
-			yyrr1171 = yyrl1171
-		}
-		yyv1171 = make([]Ingress, yyrl1171)
-		yyc1171 = true
-	}
-
+	var yyc1171 bool
 	if yyl1171 == 0 {
-		if len(yyv1171) != 0 {
+		if yyv1171 == nil {
+			yyv1171 = []Ingress{}
+			yyc1171 = true
+		} else if len(yyv1171) != 0 {
 			yyv1171 = yyv1171[:0]
 			yyc1171 = true
 		}
 	} else if yyl1171 > 0 {
-
+		var yyrr1171, yyrl1171 int
+		var yyrt1171 bool
 		if yyl1171 > cap(yyv1171) {
-			yyrl1171, yyrt1171 = z.DecInferLen(yyl1171, z.DecBasicHandle().MaxInitLen, 248)
-			yyv1171 = make([]Ingress, yyrl1171)
-			yyc1171 = true
 
+			yyrg1171 := len(yyv1171) > 0
+			yyv21171 := yyv1171
+			yyrl1171, yyrt1171 = z.DecInferLen(yyl1171, z.DecBasicHandle().MaxInitLen, 248)
+			if yyrt1171 {
+				if yyrl1171 <= cap(yyv1171) {
+					yyv1171 = yyv1171[:yyrl1171]
+				} else {
+					yyv1171 = make([]Ingress, yyrl1171)
+				}
+			} else {
+				yyv1171 = make([]Ingress, yyrl1171)
+			}
+			yyc1171 = true
 			yyrr1171 = len(yyv1171)
+			if yyrg1171 {
+				copy(yyv1171, yyv21171)
+			}
 		} else if yyl1171 != len(yyv1171) {
 			yyv1171 = yyv1171[:yyl1171]
 			yyc1171 = true
 		}
 		yyj1171 := 0
 		for ; yyj1171 < yyrr1171; yyj1171++ {
+			yyh1171.ElemContainerState(yyj1171)
 			if r.TryDecodeAsNil() {
 				yyv1171[yyj1171] = Ingress{}
 			} else {
@@ -13434,6 +14441,7 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 		if yyrt1171 {
 			for ; yyj1171 < yyl1171; yyj1171++ {
 				yyv1171 = append(yyv1171, Ingress{})
+				yyh1171.ElemContainerState(yyj1171)
 				if r.TryDecodeAsNil() {
 					yyv1171[yyj1171] = Ingress{}
 				} else {
@@ -13445,12 +14453,14 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj1171 := 0; !r.CheckBreak(); yyj1171++ {
+		yyj1171 := 0
+		for ; !r.CheckBreak(); yyj1171++ {
+
 			if yyj1171 >= len(yyv1171) {
 				yyv1171 = append(yyv1171, Ingress{}) // var yyz1171 Ingress
 				yyc1171 = true
 			}
-
+			yyh1171.ElemContainerState(yyj1171)
 			if yyj1171 < len(yyv1171) {
 				if r.TryDecodeAsNil() {
 					yyv1171[yyj1171] = Ingress{}
@@ -13464,12 +14474,18 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1171.End()
+		if yyj1171 < len(yyv1171) {
+			yyv1171 = yyv1171[:yyj1171]
+			yyc1171 = true
+		} else if yyj1171 == 0 && yyv1171 == nil {
+			yyv1171 = []Ingress{}
+			yyc1171 = true
+		}
 	}
+	yyh1171.End()
 	if yyc1171 {
 		*v = yyv1171
 	}
-
 }
 
 func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encoder) {
@@ -13478,10 +14494,11 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1175 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1176 := &yyv1175
 		yy1176.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Decoder) {
@@ -13491,39 +14508,44 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 
 	yyv1177 := *v
 	yyh1177, yyl1177 := z.DecSliceHelperStart()
-
-	var yyrr1177, yyrl1177 int
-	var yyc1177, yyrt1177 bool
-	_, _, _ = yyc1177, yyrt1177, yyrl1177
-	yyrr1177 = yyl1177
-
-	if yyv1177 == nil {
-		if yyrl1177, yyrt1177 = z.DecInferLen(yyl1177, z.DecBasicHandle().MaxInitLen, 24); yyrt1177 {
-			yyrr1177 = yyrl1177
-		}
-		yyv1177 = make([]IngressRule, yyrl1177)
-		yyc1177 = true
-	}
-
+	var yyc1177 bool
 	if yyl1177 == 0 {
-		if len(yyv1177) != 0 {
+		if yyv1177 == nil {
+			yyv1177 = []IngressRule{}
+			yyc1177 = true
+		} else if len(yyv1177) != 0 {
 			yyv1177 = yyv1177[:0]
 			yyc1177 = true
 		}
 	} else if yyl1177 > 0 {
-
+		var yyrr1177, yyrl1177 int
+		var yyrt1177 bool
 		if yyl1177 > cap(yyv1177) {
-			yyrl1177, yyrt1177 = z.DecInferLen(yyl1177, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1177 = make([]IngressRule, yyrl1177)
-			yyc1177 = true
 
+			yyrg1177 := len(yyv1177) > 0
+			yyv21177 := yyv1177
+			yyrl1177, yyrt1177 = z.DecInferLen(yyl1177, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1177 {
+				if yyrl1177 <= cap(yyv1177) {
+					yyv1177 = yyv1177[:yyrl1177]
+				} else {
+					yyv1177 = make([]IngressRule, yyrl1177)
+				}
+			} else {
+				yyv1177 = make([]IngressRule, yyrl1177)
+			}
+			yyc1177 = true
 			yyrr1177 = len(yyv1177)
+			if yyrg1177 {
+				copy(yyv1177, yyv21177)
+			}
 		} else if yyl1177 != len(yyv1177) {
 			yyv1177 = yyv1177[:yyl1177]
 			yyc1177 = true
 		}
 		yyj1177 := 0
 		for ; yyj1177 < yyrr1177; yyj1177++ {
+			yyh1177.ElemContainerState(yyj1177)
 			if r.TryDecodeAsNil() {
 				yyv1177[yyj1177] = IngressRule{}
 			} else {
@@ -13535,6 +14557,7 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 		if yyrt1177 {
 			for ; yyj1177 < yyl1177; yyj1177++ {
 				yyv1177 = append(yyv1177, IngressRule{})
+				yyh1177.ElemContainerState(yyj1177)
 				if r.TryDecodeAsNil() {
 					yyv1177[yyj1177] = IngressRule{}
 				} else {
@@ -13546,12 +14569,14 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj1177 := 0; !r.CheckBreak(); yyj1177++ {
+		yyj1177 := 0
+		for ; !r.CheckBreak(); yyj1177++ {
+
 			if yyj1177 >= len(yyv1177) {
 				yyv1177 = append(yyv1177, IngressRule{}) // var yyz1177 IngressRule
 				yyc1177 = true
 			}
-
+			yyh1177.ElemContainerState(yyj1177)
 			if yyj1177 < len(yyv1177) {
 				if r.TryDecodeAsNil() {
 					yyv1177[yyj1177] = IngressRule{}
@@ -13565,12 +14590,18 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		yyh1177.End()
+		if yyj1177 < len(yyv1177) {
+			yyv1177 = yyv1177[:yyj1177]
+			yyc1177 = true
+		} else if yyj1177 == 0 && yyv1177 == nil {
+			yyv1177 = []IngressRule{}
+			yyc1177 = true
+		}
 	}
+	yyh1177.End()
 	if yyc1177 {
 		*v = yyv1177
 	}
-
 }
 
 func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec1978.Encoder) {
@@ -13579,10 +14610,11 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1181 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1182 := &yyv1181
 		yy1182.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1978.Decoder) {
@@ -13592,39 +14624,44 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 
 	yyv1183 := *v
 	yyh1183, yyl1183 := z.DecSliceHelperStart()
-
-	var yyrr1183, yyrl1183 int
-	var yyc1183, yyrt1183 bool
-	_, _, _ = yyc1183, yyrt1183, yyrl1183
-	yyrr1183 = yyl1183
-
-	if yyv1183 == nil {
-		if yyrl1183, yyrt1183 = z.DecInferLen(yyl1183, z.DecBasicHandle().MaxInitLen, 64); yyrt1183 {
-			yyrr1183 = yyrl1183
-		}
-		yyv1183 = make([]HTTPIngressPath, yyrl1183)
-		yyc1183 = true
-	}
-
+	var yyc1183 bool
 	if yyl1183 == 0 {
-		if len(yyv1183) != 0 {
+		if yyv1183 == nil {
+			yyv1183 = []HTTPIngressPath{}
+			yyc1183 = true
+		} else if len(yyv1183) != 0 {
 			yyv1183 = yyv1183[:0]
 			yyc1183 = true
 		}
 	} else if yyl1183 > 0 {
-
+		var yyrr1183, yyrl1183 int
+		var yyrt1183 bool
 		if yyl1183 > cap(yyv1183) {
-			yyrl1183, yyrt1183 = z.DecInferLen(yyl1183, z.DecBasicHandle().MaxInitLen, 64)
-			yyv1183 = make([]HTTPIngressPath, yyrl1183)
-			yyc1183 = true
 
+			yyrg1183 := len(yyv1183) > 0
+			yyv21183 := yyv1183
+			yyrl1183, yyrt1183 = z.DecInferLen(yyl1183, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt1183 {
+				if yyrl1183 <= cap(yyv1183) {
+					yyv1183 = yyv1183[:yyrl1183]
+				} else {
+					yyv1183 = make([]HTTPIngressPath, yyrl1183)
+				}
+			} else {
+				yyv1183 = make([]HTTPIngressPath, yyrl1183)
+			}
+			yyc1183 = true
 			yyrr1183 = len(yyv1183)
+			if yyrg1183 {
+				copy(yyv1183, yyv21183)
+			}
 		} else if yyl1183 != len(yyv1183) {
 			yyv1183 = yyv1183[:yyl1183]
 			yyc1183 = true
 		}
 		yyj1183 := 0
 		for ; yyj1183 < yyrr1183; yyj1183++ {
+			yyh1183.ElemContainerState(yyj1183)
 			if r.TryDecodeAsNil() {
 				yyv1183[yyj1183] = HTTPIngressPath{}
 			} else {
@@ -13636,6 +14673,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		if yyrt1183 {
 			for ; yyj1183 < yyl1183; yyj1183++ {
 				yyv1183 = append(yyv1183, HTTPIngressPath{})
+				yyh1183.ElemContainerState(yyj1183)
 				if r.TryDecodeAsNil() {
 					yyv1183[yyj1183] = HTTPIngressPath{}
 				} else {
@@ -13647,12 +14685,14 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		}
 
 	} else {
-		for yyj1183 := 0; !r.CheckBreak(); yyj1183++ {
+		yyj1183 := 0
+		for ; !r.CheckBreak(); yyj1183++ {
+
 			if yyj1183 >= len(yyv1183) {
 				yyv1183 = append(yyv1183, HTTPIngressPath{}) // var yyz1183 HTTPIngressPath
 				yyc1183 = true
 			}
-
+			yyh1183.ElemContainerState(yyj1183)
 			if yyj1183 < len(yyv1183) {
 				if r.TryDecodeAsNil() {
 					yyv1183[yyj1183] = HTTPIngressPath{}
@@ -13666,12 +14706,18 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		yyh1183.End()
+		if yyj1183 < len(yyv1183) {
+			yyv1183 = yyv1183[:yyj1183]
+			yyc1183 = true
+		} else if yyj1183 == 0 && yyv1183 == nil {
+			yyv1183 = []HTTPIngressPath{}
+			yyc1183 = true
+		}
 	}
+	yyh1183.End()
 	if yyc1183 {
 		*v = yyv1183
 	}
-
 }
 
 func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec1978.Encoder) {
@@ -13680,10 +14726,11 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1187 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1188 := &yyv1187
 		yy1188.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1978.Decoder) {
@@ -13693,39 +14740,44 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 
 	yyv1189 := *v
 	yyh1189, yyl1189 := z.DecSliceHelperStart()
-
-	var yyrr1189, yyrl1189 int
-	var yyc1189, yyrt1189 bool
-	_, _, _ = yyc1189, yyrt1189, yyrl1189
-	yyrr1189 = yyl1189
-
-	if yyv1189 == nil {
-		if yyrl1189, yyrt1189 = z.DecInferLen(yyl1189, z.DecBasicHandle().MaxInitLen, 24); yyrt1189 {
-			yyrr1189 = yyrl1189
-		}
-		yyv1189 = make([]NodeUtilization, yyrl1189)
-		yyc1189 = true
-	}
-
+	var yyc1189 bool
 	if yyl1189 == 0 {
-		if len(yyv1189) != 0 {
+		if yyv1189 == nil {
+			yyv1189 = []NodeUtilization{}
+			yyc1189 = true
+		} else if len(yyv1189) != 0 {
 			yyv1189 = yyv1189[:0]
 			yyc1189 = true
 		}
 	} else if yyl1189 > 0 {
-
+		var yyrr1189, yyrl1189 int
+		var yyrt1189 bool
 		if yyl1189 > cap(yyv1189) {
-			yyrl1189, yyrt1189 = z.DecInferLen(yyl1189, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1189 = make([]NodeUtilization, yyrl1189)
-			yyc1189 = true
 
+			yyrg1189 := len(yyv1189) > 0
+			yyv21189 := yyv1189
+			yyrl1189, yyrt1189 = z.DecInferLen(yyl1189, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1189 {
+				if yyrl1189 <= cap(yyv1189) {
+					yyv1189 = yyv1189[:yyrl1189]
+				} else {
+					yyv1189 = make([]NodeUtilization, yyrl1189)
+				}
+			} else {
+				yyv1189 = make([]NodeUtilization, yyrl1189)
+			}
+			yyc1189 = true
 			yyrr1189 = len(yyv1189)
+			if yyrg1189 {
+				copy(yyv1189, yyv21189)
+			}
 		} else if yyl1189 != len(yyv1189) {
 			yyv1189 = yyv1189[:yyl1189]
 			yyc1189 = true
 		}
 		yyj1189 := 0
 		for ; yyj1189 < yyrr1189; yyj1189++ {
+			yyh1189.ElemContainerState(yyj1189)
 			if r.TryDecodeAsNil() {
 				yyv1189[yyj1189] = NodeUtilization{}
 			} else {
@@ -13737,6 +14789,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		if yyrt1189 {
 			for ; yyj1189 < yyl1189; yyj1189++ {
 				yyv1189 = append(yyv1189, NodeUtilization{})
+				yyh1189.ElemContainerState(yyj1189)
 				if r.TryDecodeAsNil() {
 					yyv1189[yyj1189] = NodeUtilization{}
 				} else {
@@ -13748,12 +14801,14 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		}
 
 	} else {
-		for yyj1189 := 0; !r.CheckBreak(); yyj1189++ {
+		yyj1189 := 0
+		for ; !r.CheckBreak(); yyj1189++ {
+
 			if yyj1189 >= len(yyv1189) {
 				yyv1189 = append(yyv1189, NodeUtilization{}) // var yyz1189 NodeUtilization
 				yyc1189 = true
 			}
-
+			yyh1189.ElemContainerState(yyj1189)
 			if yyj1189 < len(yyv1189) {
 				if r.TryDecodeAsNil() {
 					yyv1189[yyj1189] = NodeUtilization{}
@@ -13767,12 +14822,18 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		yyh1189.End()
+		if yyj1189 < len(yyv1189) {
+			yyv1189 = yyv1189[:yyj1189]
+			yyc1189 = true
+		} else if yyj1189 == 0 && yyv1189 == nil {
+			yyv1189 = []NodeUtilization{}
+			yyc1189 = true
+		}
 	}
+	yyh1189.End()
 	if yyc1189 {
 		*v = yyv1189
 	}
-
 }
 
 func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *codec1978.Encoder) {
@@ -13781,10 +14842,11 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1193 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1194 := &yyv1193
 		yy1194.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *codec1978.Decoder) {
@@ -13794,39 +14856,44 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 
 	yyv1195 := *v
 	yyh1195, yyl1195 := z.DecSliceHelperStart()
-
-	var yyrr1195, yyrl1195 int
-	var yyc1195, yyrt1195 bool
-	_, _, _ = yyc1195, yyrt1195, yyrl1195
-	yyrr1195 = yyl1195
-
-	if yyv1195 == nil {
-		if yyrl1195, yyrt1195 = z.DecInferLen(yyl1195, z.DecBasicHandle().MaxInitLen, 232); yyrt1195 {
-			yyrr1195 = yyrl1195
-		}
-		yyv1195 = make([]ClusterAutoscaler, yyrl1195)
-		yyc1195 = true
-	}
-
+	var yyc1195 bool
 	if yyl1195 == 0 {
-		if len(yyv1195) != 0 {
+		if yyv1195 == nil {
+			yyv1195 = []ClusterAutoscaler{}
+			yyc1195 = true
+		} else if len(yyv1195) != 0 {
 			yyv1195 = yyv1195[:0]
 			yyc1195 = true
 		}
 	} else if yyl1195 > 0 {
-
+		var yyrr1195, yyrl1195 int
+		var yyrt1195 bool
 		if yyl1195 > cap(yyv1195) {
-			yyrl1195, yyrt1195 = z.DecInferLen(yyl1195, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1195 = make([]ClusterAutoscaler, yyrl1195)
-			yyc1195 = true
 
+			yyrg1195 := len(yyv1195) > 0
+			yyv21195 := yyv1195
+			yyrl1195, yyrt1195 = z.DecInferLen(yyl1195, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1195 {
+				if yyrl1195 <= cap(yyv1195) {
+					yyv1195 = yyv1195[:yyrl1195]
+				} else {
+					yyv1195 = make([]ClusterAutoscaler, yyrl1195)
+				}
+			} else {
+				yyv1195 = make([]ClusterAutoscaler, yyrl1195)
+			}
+			yyc1195 = true
 			yyrr1195 = len(yyv1195)
+			if yyrg1195 {
+				copy(yyv1195, yyv21195)
+			}
 		} else if yyl1195 != len(yyv1195) {
 			yyv1195 = yyv1195[:yyl1195]
 			yyc1195 = true
 		}
 		yyj1195 := 0
 		for ; yyj1195 < yyrr1195; yyj1195++ {
+			yyh1195.ElemContainerState(yyj1195)
 			if r.TryDecodeAsNil() {
 				yyv1195[yyj1195] = ClusterAutoscaler{}
 			} else {
@@ -13838,6 +14905,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		if yyrt1195 {
 			for ; yyj1195 < yyl1195; yyj1195++ {
 				yyv1195 = append(yyv1195, ClusterAutoscaler{})
+				yyh1195.ElemContainerState(yyj1195)
 				if r.TryDecodeAsNil() {
 					yyv1195[yyj1195] = ClusterAutoscaler{}
 				} else {
@@ -13849,12 +14917,14 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		}
 
 	} else {
-		for yyj1195 := 0; !r.CheckBreak(); yyj1195++ {
+		yyj1195 := 0
+		for ; !r.CheckBreak(); yyj1195++ {
+
 			if yyj1195 >= len(yyv1195) {
 				yyv1195 = append(yyv1195, ClusterAutoscaler{}) // var yyz1195 ClusterAutoscaler
 				yyc1195 = true
 			}
-
+			yyh1195.ElemContainerState(yyj1195)
 			if yyj1195 < len(yyv1195) {
 				if r.TryDecodeAsNil() {
 					yyv1195[yyj1195] = ClusterAutoscaler{}
@@ -13868,12 +14938,18 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		yyh1195.End()
+		if yyj1195 < len(yyv1195) {
+			yyv1195 = yyv1195[:yyj1195]
+			yyc1195 = true
+		} else if yyj1195 == 0 && yyv1195 == nil {
+			yyv1195 = []ClusterAutoscaler{}
+			yyc1195 = true
+		}
 	}
+	yyh1195.End()
 	if yyc1195 {
 		*v = yyv1195
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePodSelectorRequirement(v []PodSelectorRequirement, e *codec1978.Encoder) {
@@ -13882,10 +14958,11 @@ func (x codecSelfer1234) encSlicePodSelectorRequirement(v []PodSelectorRequireme
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1199 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1200 := &yyv1199
 		yy1200.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirement, d *codec1978.Decoder) {
@@ -13895,39 +14972,44 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 
 	yyv1201 := *v
 	yyh1201, yyl1201 := z.DecSliceHelperStart()
-
-	var yyrr1201, yyrl1201 int
-	var yyc1201, yyrt1201 bool
-	_, _, _ = yyc1201, yyrt1201, yyrl1201
-	yyrr1201 = yyl1201
-
-	if yyv1201 == nil {
-		if yyrl1201, yyrt1201 = z.DecInferLen(yyl1201, z.DecBasicHandle().MaxInitLen, 56); yyrt1201 {
-			yyrr1201 = yyrl1201
-		}
-		yyv1201 = make([]PodSelectorRequirement, yyrl1201)
-		yyc1201 = true
-	}
-
+	var yyc1201 bool
 	if yyl1201 == 0 {
-		if len(yyv1201) != 0 {
+		if yyv1201 == nil {
+			yyv1201 = []PodSelectorRequirement{}
+			yyc1201 = true
+		} else if len(yyv1201) != 0 {
 			yyv1201 = yyv1201[:0]
 			yyc1201 = true
 		}
 	} else if yyl1201 > 0 {
-
+		var yyrr1201, yyrl1201 int
+		var yyrt1201 bool
 		if yyl1201 > cap(yyv1201) {
-			yyrl1201, yyrt1201 = z.DecInferLen(yyl1201, z.DecBasicHandle().MaxInitLen, 56)
-			yyv1201 = make([]PodSelectorRequirement, yyrl1201)
-			yyc1201 = true
 
+			yyrg1201 := len(yyv1201) > 0
+			yyv21201 := yyv1201
+			yyrl1201, yyrt1201 = z.DecInferLen(yyl1201, z.DecBasicHandle().MaxInitLen, 56)
+			if yyrt1201 {
+				if yyrl1201 <= cap(yyv1201) {
+					yyv1201 = yyv1201[:yyrl1201]
+				} else {
+					yyv1201 = make([]PodSelectorRequirement, yyrl1201)
+				}
+			} else {
+				yyv1201 = make([]PodSelectorRequirement, yyrl1201)
+			}
+			yyc1201 = true
 			yyrr1201 = len(yyv1201)
+			if yyrg1201 {
+				copy(yyv1201, yyv21201)
+			}
 		} else if yyl1201 != len(yyv1201) {
 			yyv1201 = yyv1201[:yyl1201]
 			yyc1201 = true
 		}
 		yyj1201 := 0
 		for ; yyj1201 < yyrr1201; yyj1201++ {
+			yyh1201.ElemContainerState(yyj1201)
 			if r.TryDecodeAsNil() {
 				yyv1201[yyj1201] = PodSelectorRequirement{}
 			} else {
@@ -13939,6 +15021,7 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 		if yyrt1201 {
 			for ; yyj1201 < yyl1201; yyj1201++ {
 				yyv1201 = append(yyv1201, PodSelectorRequirement{})
+				yyh1201.ElemContainerState(yyj1201)
 				if r.TryDecodeAsNil() {
 					yyv1201[yyj1201] = PodSelectorRequirement{}
 				} else {
@@ -13950,12 +15033,14 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 		}
 
 	} else {
-		for yyj1201 := 0; !r.CheckBreak(); yyj1201++ {
+		yyj1201 := 0
+		for ; !r.CheckBreak(); yyj1201++ {
+
 			if yyj1201 >= len(yyv1201) {
 				yyv1201 = append(yyv1201, PodSelectorRequirement{}) // var yyz1201 PodSelectorRequirement
 				yyc1201 = true
 			}
-
+			yyh1201.ElemContainerState(yyj1201)
 			if yyj1201 < len(yyv1201) {
 				if r.TryDecodeAsNil() {
 					yyv1201[yyj1201] = PodSelectorRequirement{}
@@ -13969,10 +15054,16 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 			}
 
 		}
-		yyh1201.End()
+		if yyj1201 < len(yyv1201) {
+			yyv1201 = yyv1201[:yyj1201]
+			yyc1201 = true
+		} else if yyj1201 == 0 && yyv1201 == nil {
+			yyv1201 = []PodSelectorRequirement{}
+			yyc1201 = true
+		}
 	}
+	yyh1201.End()
 	if yyc1201 {
 		*v = yyv1201
 	}
-
 }

--- a/pkg/apis/extensions/v1beta1/types.generated.go
+++ b/pkg/apis/extensions/v1beta1/types.generated.go
@@ -37,10 +37,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -51,10 +59,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -87,18 +95,21 @@ func (x *ScaleSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			yyq2[0] = x.Replicas != 0
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2 int = 0
+				yynn2 = 0
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -111,7 +122,9 @@ func (x *ScaleSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -120,8 +133,10 @@ func (x *ScaleSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -136,17 +151,18 @@ func (x *ScaleSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct7 := r.ContainerType()
+		if yyct7 == codecSelferValueTypeMap1234 {
 			yyl7 := r.ReadMapStart()
 			if yyl7 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl7, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct7 == codecSelferValueTypeArray1234 {
 			yyl7 := r.ReadArrayStart()
 			if yyl7 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl7, d)
 			}
@@ -173,8 +189,10 @@ func (x *ScaleSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys8Slc = r.DecodeBytes(yys8Slc, true, true)
 		yys8 := string(yys8Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys8 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -186,9 +204,7 @@ func (x *ScaleSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys8)
 		} // end switch yys8
 	} // end for yyj8
-	if !yyhl8 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ScaleSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -205,9 +221,10 @@ func (x *ScaleSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb10 = r.CheckBreak()
 	}
 	if yyb10 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -223,9 +240,10 @@ func (x *ScaleSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb10 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj10-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -246,18 +264,21 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep13, yyq13, yy2arr13
 			const yyr13 bool = false
 			yyq13[1] = len(x.Selector) != 0
+			var yynn13 int
 			if yyr13 || yy2arr13 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn13 int = 1
+				yynn13 = 1
 				for _, b := range yyq13 {
 					if b {
 						yynn13++
 					}
 				}
 				r.EncodeMapStart(yynn13)
+				yynn13 = 0
 			}
 			if yyr13 || yy2arr13 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym15 := z.EncBinary()
 				_ = yym15
 				if false {
@@ -265,7 +286,9 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym16 := z.EncBinary()
 				_ = yym16
 				if false {
@@ -274,6 +297,7 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr13 || yy2arr13 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq13[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -290,7 +314,9 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq13[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -303,8 +329,10 @@ func (x *ScaleStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep13 {
-				r.EncodeEnd()
+			if yyr13 || yy2arr13 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -319,17 +347,18 @@ func (x *ScaleStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct21 := r.ContainerType()
+		if yyct21 == codecSelferValueTypeMap1234 {
 			yyl21 := r.ReadMapStart()
 			if yyl21 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl21, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct21 == codecSelferValueTypeArray1234 {
 			yyl21 := r.ReadArrayStart()
 			if yyl21 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl21, d)
 			}
@@ -356,8 +385,10 @@ func (x *ScaleStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys22Slc = r.DecodeBytes(yys22Slc, true, true)
 		yys22 := string(yys22Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys22 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -381,9 +412,7 @@ func (x *ScaleStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys22)
 		} // end switch yys22
 	} // end for yyj22
-	if !yyhl22 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ScaleStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -400,9 +429,10 @@ func (x *ScaleStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb26 = r.CheckBreak()
 	}
 	if yyb26 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -415,9 +445,10 @@ func (x *ScaleStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb26 = r.CheckBreak()
 	}
 	if yyb26 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
@@ -439,9 +470,10 @@ func (x *ScaleStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb26 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj26-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -466,18 +498,21 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq31[2] = true
 			yyq31[3] = true
 			yyq31[4] = true
+			var yynn31 int
 			if yyr31 || yy2arr31 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn31 int = 0
+				yynn31 = 0
 				for _, b := range yyq31 {
 					if b {
 						yynn31++
 					}
 				}
 				r.EncodeMapStart(yynn31)
+				yynn31 = 0
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[0] {
 					yym33 := z.EncBinary()
 					_ = yym33
@@ -490,7 +525,9 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym34 := z.EncBinary()
 					_ = yym34
 					if false {
@@ -500,6 +537,7 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[1] {
 					yym36 := z.EncBinary()
 					_ = yym36
@@ -512,7 +550,9 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym37 := z.EncBinary()
 					_ = yym37
 					if false {
@@ -522,6 +562,7 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[2] {
 					yy39 := &x.ObjectMeta
 					yy39.CodecEncodeSelf(e)
@@ -530,12 +571,15 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy40 := &x.ObjectMeta
 					yy40.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[3] {
 					yy42 := &x.Spec
 					yy42.CodecEncodeSelf(e)
@@ -544,12 +588,15 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy43 := &x.Spec
 					yy43.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[4] {
 					yy45 := &x.Status
 					yy45.CodecEncodeSelf(e)
@@ -558,13 +605,17 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq31[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy46 := &x.Status
 					yy46.CodecEncodeSelf(e)
 				}
 			}
-			if yysep31 {
-				r.EncodeEnd()
+			if yyr31 || yy2arr31 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -579,17 +630,18 @@ func (x *Scale) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct48 := r.ContainerType()
+		if yyct48 == codecSelferValueTypeMap1234 {
 			yyl48 := r.ReadMapStart()
 			if yyl48 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl48, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct48 == codecSelferValueTypeArray1234 {
 			yyl48 := r.ReadArrayStart()
 			if yyl48 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl48, d)
 			}
@@ -616,8 +668,10 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys49Slc = r.DecodeBytes(yys49Slc, true, true)
 		yys49 := string(yys49Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys49 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -656,9 +710,7 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys49)
 		} // end switch yys49
 	} // end for yyj49
-	if !yyhl49 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -675,9 +727,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -690,9 +743,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -705,9 +759,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
@@ -721,9 +776,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ScaleSpec{}
 	} else {
@@ -737,9 +793,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb55 = r.CheckBreak()
 	}
 	if yyb55 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ScaleStatus{}
 	} else {
@@ -756,9 +813,10 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb55 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj55-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -780,18 +838,21 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr62 bool = false
 			yyq62[0] = x.Kind != ""
 			yyq62[1] = x.APIVersion != ""
+			var yynn62 int
 			if yyr62 || yy2arr62 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn62 int = 0
+				yynn62 = 0
 				for _, b := range yyq62 {
 					if b {
 						yynn62++
 					}
 				}
 				r.EncodeMapStart(yynn62)
+				yynn62 = 0
 			}
 			if yyr62 || yy2arr62 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq62[0] {
 					yym64 := z.EncBinary()
 					_ = yym64
@@ -804,7 +865,9 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq62[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym65 := z.EncBinary()
 					_ = yym65
 					if false {
@@ -814,6 +877,7 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr62 || yy2arr62 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq62[1] {
 					yym67 := z.EncBinary()
 					_ = yym67
@@ -826,7 +890,9 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq62[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym68 := z.EncBinary()
 					_ = yym68
 					if false {
@@ -835,8 +901,10 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep62 {
-				r.EncodeEnd()
+			if yyr62 || yy2arr62 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -851,17 +919,18 @@ func (x *ReplicationControllerDummy) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct70 := r.ContainerType()
+		if yyct70 == codecSelferValueTypeMap1234 {
 			yyl70 := r.ReadMapStart()
 			if yyl70 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl70, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct70 == codecSelferValueTypeArray1234 {
 			yyl70 := r.ReadArrayStart()
 			if yyl70 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl70, d)
 			}
@@ -888,8 +957,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys71Slc = r.DecodeBytes(yys71Slc, true, true)
 		yys71 := string(yys71Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys71 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -907,9 +978,7 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 			z.DecStructFieldNotFound(-1, yys71)
 		} // end switch yys71
 	} // end for yyj71
-	if !yyhl71 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -926,9 +995,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 		yyb74 = r.CheckBreak()
 	}
 	if yyb74 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -941,9 +1011,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 		yyb74 = r.CheckBreak()
 	}
 	if yyb74 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -959,9 +1030,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 		if yyb74 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj74-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -985,18 +1057,21 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq78[1] = x.Name != ""
 			yyq78[2] = x.APIVersion != ""
 			yyq78[3] = x.Subresource != ""
+			var yynn78 int
 			if yyr78 || yy2arr78 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn78 int = 0
+				yynn78 = 0
 				for _, b := range yyq78 {
 					if b {
 						yynn78++
 					}
 				}
 				r.EncodeMapStart(yynn78)
+				yynn78 = 0
 			}
 			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq78[0] {
 					yym80 := z.EncBinary()
 					_ = yym80
@@ -1009,7 +1084,9 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq78[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym81 := z.EncBinary()
 					_ = yym81
 					if false {
@@ -1019,6 +1096,7 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq78[1] {
 					yym83 := z.EncBinary()
 					_ = yym83
@@ -1031,7 +1109,9 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq78[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym84 := z.EncBinary()
 					_ = yym84
 					if false {
@@ -1041,6 +1121,7 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq78[2] {
 					yym86 := z.EncBinary()
 					_ = yym86
@@ -1053,7 +1134,9 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq78[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym87 := z.EncBinary()
 					_ = yym87
 					if false {
@@ -1063,6 +1146,7 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq78[3] {
 					yym89 := z.EncBinary()
 					_ = yym89
@@ -1075,7 +1159,9 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq78[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("subresource"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym90 := z.EncBinary()
 					_ = yym90
 					if false {
@@ -1084,8 +1170,10 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep78 {
-				r.EncodeEnd()
+			if yyr78 || yy2arr78 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1100,17 +1188,18 @@ func (x *SubresourceReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct92 := r.ContainerType()
+		if yyct92 == codecSelferValueTypeMap1234 {
 			yyl92 := r.ReadMapStart()
 			if yyl92 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl92, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct92 == codecSelferValueTypeArray1234 {
 			yyl92 := r.ReadArrayStart()
 			if yyl92 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl92, d)
 			}
@@ -1137,8 +1226,10 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys93Slc = r.DecodeBytes(yys93Slc, true, true)
 		yys93 := string(yys93Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys93 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -1168,9 +1259,7 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys93)
 		} // end switch yys93
 	} // end for yyj93
-	if !yyhl93 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -1187,9 +1276,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb98 = r.CheckBreak()
 	}
 	if yyb98 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -1202,9 +1292,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb98 = r.CheckBreak()
 	}
 	if yyb98 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -1217,9 +1308,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb98 = r.CheckBreak()
 	}
 	if yyb98 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -1232,9 +1324,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb98 = r.CheckBreak()
 	}
 	if yyb98 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Subresource = ""
 	} else {
@@ -1250,9 +1343,10 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb98 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj98-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -1272,18 +1366,21 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq104 [1]bool
 			_, _, _ = yysep104, yyq104, yy2arr104
 			const yyr104 bool = false
+			var yynn104 int
 			if yyr104 || yy2arr104 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn104 int = 1
+				yynn104 = 1
 				for _, b := range yyq104 {
 					if b {
 						yynn104++
 					}
 				}
 				r.EncodeMapStart(yynn104)
+				yynn104 = 0
 			}
 			if yyr104 || yy2arr104 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym106 := z.EncBinary()
 				_ = yym106
 				if false {
@@ -1291,7 +1388,9 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("targetPercentage"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym107 := z.EncBinary()
 				_ = yym107
 				if false {
@@ -1299,8 +1398,10 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			}
-			if yysep104 {
-				r.EncodeEnd()
+			if yyr104 || yy2arr104 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1315,17 +1416,18 @@ func (x *CPUTargetUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct109 := r.ContainerType()
+		if yyct109 == codecSelferValueTypeMap1234 {
 			yyl109 := r.ReadMapStart()
 			if yyl109 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl109, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct109 == codecSelferValueTypeArray1234 {
 			yyl109 := r.ReadArrayStart()
 			if yyl109 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl109, d)
 			}
@@ -1352,8 +1454,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys110Slc = r.DecodeBytes(yys110Slc, true, true)
 		yys110 := string(yys110Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys110 {
 		case "targetPercentage":
 			if r.TryDecodeAsNil() {
@@ -1365,9 +1469,7 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys110)
 		} // end switch yys110
 	} // end for yyj110
-	if !yyhl110 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -1384,9 +1486,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb112 = r.CheckBreak()
 	}
 	if yyb112 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetPercentage = 0
 	} else {
@@ -1402,9 +1505,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb112 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj112-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -1426,26 +1530,32 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr115 bool = false
 			yyq115[1] = x.MinReplicas != nil
 			yyq115[3] = x.CPUUtilization != nil
+			var yynn115 int
 			if yyr115 || yy2arr115 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn115 int = 2
+				yynn115 = 2
 				for _, b := range yyq115 {
 					if b {
 						yynn115++
 					}
 				}
 				r.EncodeMapStart(yynn115)
+				yynn115 = 0
 			}
 			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy117 := &x.ScaleRef
 				yy117.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("scaleRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy118 := &x.ScaleRef
 				yy118.CodecEncodeSelf(e)
 			}
 			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq115[1] {
 					if x.MinReplicas == nil {
 						r.EncodeNil()
@@ -1463,7 +1573,9 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq115[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("minReplicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
@@ -1478,6 +1590,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym125 := z.EncBinary()
 				_ = yym125
 				if false {
@@ -1485,7 +1598,9 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("maxReplicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym126 := z.EncBinary()
 				_ = yym126
 				if false {
@@ -1494,6 +1609,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq115[3] {
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
@@ -1505,7 +1621,9 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq115[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("cpuUtilization"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
 					} else {
@@ -1513,8 +1631,10 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep115 {
-				r.EncodeEnd()
+			if yyr115 || yy2arr115 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1529,17 +1649,18 @@ func (x *HorizontalPodAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct129 := r.ContainerType()
+		if yyct129 == codecSelferValueTypeMap1234 {
 			yyl129 := r.ReadMapStart()
 			if yyl129 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl129, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct129 == codecSelferValueTypeArray1234 {
 			yyl129 := r.ReadArrayStart()
 			if yyl129 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl129, d)
 			}
@@ -1566,8 +1687,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys130Slc = r.DecodeBytes(yys130Slc, true, true)
 		yys130 := string(yys130Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys130 {
 		case "scaleRef":
 			if r.TryDecodeAsNil() {
@@ -1613,9 +1736,7 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 			z.DecStructFieldNotFound(-1, yys130)
 		} // end switch yys130
 	} // end for yyj130
-	if !yyhl130 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -1632,9 +1753,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		yyb136 = r.CheckBreak()
 	}
 	if yyb136 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ScaleRef = SubresourceReference{}
 	} else {
@@ -1648,9 +1770,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		yyb136 = r.CheckBreak()
 	}
 	if yyb136 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.MinReplicas != nil {
 			x.MinReplicas = nil
@@ -1673,9 +1796,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		yyb136 = r.CheckBreak()
 	}
 	if yyb136 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MaxReplicas = 0
 	} else {
@@ -1688,9 +1812,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		yyb136 = r.CheckBreak()
 	}
 	if yyb136 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CPUUtilization != nil {
 			x.CPUUtilization = nil
@@ -1711,9 +1836,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		if yyb136 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj136-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -1736,18 +1862,21 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq143[0] = x.ObservedGeneration != nil
 			yyq143[1] = x.LastScaleTime != nil
 			yyq143[4] = x.CurrentCPUUtilizationPercentage != nil
+			var yynn143 int
 			if yyr143 || yy2arr143 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn143 int = 2
+				yynn143 = 2
 				for _, b := range yyq143 {
 					if b {
 						yynn143++
 					}
 				}
 				r.EncodeMapStart(yynn143)
+				yynn143 = 0
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq143[0] {
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
@@ -1765,7 +1894,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq143[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
@@ -1780,6 +1911,7 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq143[1] {
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
@@ -1801,7 +1933,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq143[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastScaleTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
@@ -1820,6 +1954,7 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym153 := z.EncBinary()
 				_ = yym153
 				if false {
@@ -1827,7 +1962,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("currentReplicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym154 := z.EncBinary()
 				_ = yym154
 				if false {
@@ -1836,6 +1973,7 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym156 := z.EncBinary()
 				_ = yym156
 				if false {
@@ -1843,7 +1981,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("desiredReplicas"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym157 := z.EncBinary()
 				_ = yym157
 				if false {
@@ -1852,6 +1992,7 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq143[4] {
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
@@ -1869,7 +2010,9 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq143[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("currentCPUUtilizationPercentage"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
@@ -1883,8 +2026,10 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep143 {
-				r.EncodeEnd()
+			if yyr143 || yy2arr143 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1899,17 +2044,18 @@ func (x *HorizontalPodAutoscalerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct164 := r.ContainerType()
+		if yyct164 == codecSelferValueTypeMap1234 {
 			yyl164 := r.ReadMapStart()
 			if yyl164 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl164, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct164 == codecSelferValueTypeArray1234 {
 			yyl164 := r.ReadArrayStart()
 			if yyl164 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl164, d)
 			}
@@ -1936,8 +2082,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys165Slc = r.DecodeBytes(yys165Slc, true, true)
 		yys165 := string(yys165Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys165 {
 		case "observedGeneration":
 			if r.TryDecodeAsNil() {
@@ -2008,9 +2156,7 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 			z.DecStructFieldNotFound(-1, yys165)
 		} // end switch yys165
 	} // end for yyj165
-	if !yyhl165 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -2027,9 +2173,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.ObservedGeneration != nil {
 			x.ObservedGeneration = nil
@@ -2052,9 +2199,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.LastScaleTime != nil {
 			x.LastScaleTime = nil
@@ -2082,9 +2230,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CurrentReplicas = 0
 	} else {
@@ -2097,9 +2246,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DesiredReplicas = 0
 	} else {
@@ -2112,9 +2262,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		yyb174 = r.CheckBreak()
 	}
 	if yyb174 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CurrentCPUUtilizationPercentage != nil {
 			x.CurrentCPUUtilizationPercentage = nil
@@ -2140,9 +2291,10 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if yyb174 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj174-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -2167,18 +2319,21 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq184[2] = true
 			yyq184[3] = true
 			yyq184[4] = true
+			var yynn184 int
 			if yyr184 || yy2arr184 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn184 int = 0
+				yynn184 = 0
 				for _, b := range yyq184 {
 					if b {
 						yynn184++
 					}
 				}
 				r.EncodeMapStart(yynn184)
+				yynn184 = 0
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[0] {
 					yym186 := z.EncBinary()
 					_ = yym186
@@ -2191,7 +2346,9 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym187 := z.EncBinary()
 					_ = yym187
 					if false {
@@ -2201,6 +2358,7 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[1] {
 					yym189 := z.EncBinary()
 					_ = yym189
@@ -2213,7 +2371,9 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym190 := z.EncBinary()
 					_ = yym190
 					if false {
@@ -2223,6 +2383,7 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[2] {
 					yy192 := &x.ObjectMeta
 					yy192.CodecEncodeSelf(e)
@@ -2231,12 +2392,15 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy193 := &x.ObjectMeta
 					yy193.CodecEncodeSelf(e)
 				}
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[3] {
 					yy195 := &x.Spec
 					yy195.CodecEncodeSelf(e)
@@ -2245,12 +2409,15 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy196 := &x.Spec
 					yy196.CodecEncodeSelf(e)
 				}
 			}
 			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq184[4] {
 					yy198 := &x.Status
 					yy198.CodecEncodeSelf(e)
@@ -2259,13 +2426,17 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq184[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy199 := &x.Status
 					yy199.CodecEncodeSelf(e)
 				}
 			}
-			if yysep184 {
-				r.EncodeEnd()
+			if yyr184 || yy2arr184 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -2280,17 +2451,18 @@ func (x *HorizontalPodAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct201 := r.ContainerType()
+		if yyct201 == codecSelferValueTypeMap1234 {
 			yyl201 := r.ReadMapStart()
 			if yyl201 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl201, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct201 == codecSelferValueTypeArray1234 {
 			yyl201 := r.ReadArrayStart()
 			if yyl201 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl201, d)
 			}
@@ -2317,8 +2489,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys202Slc = r.DecodeBytes(yys202Slc, true, true)
 		yys202 := string(yys202Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys202 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -2357,9 +2531,7 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			z.DecStructFieldNotFound(-1, yys202)
 		} // end switch yys202
 	} // end for yyj202
-	if !yyhl202 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -2376,9 +2548,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -2391,9 +2564,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -2406,9 +2580,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
@@ -2422,9 +2597,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = HorizontalPodAutoscalerSpec{}
 	} else {
@@ -2438,9 +2614,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb208 = r.CheckBreak()
 	}
 	if yyb208 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = HorizontalPodAutoscalerStatus{}
 	} else {
@@ -2457,9 +2634,10 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if yyb208 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj208-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -2482,18 +2660,21 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq215[0] = x.Kind != ""
 			yyq215[1] = x.APIVersion != ""
 			yyq215[2] = true
+			var yynn215 int
 			if yyr215 || yy2arr215 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn215 int = 1
+				yynn215 = 1
 				for _, b := range yyq215 {
 					if b {
 						yynn215++
 					}
 				}
 				r.EncodeMapStart(yynn215)
+				yynn215 = 0
 			}
 			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq215[0] {
 					yym217 := z.EncBinary()
 					_ = yym217
@@ -2506,7 +2687,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq215[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym218 := z.EncBinary()
 					_ = yym218
 					if false {
@@ -2516,6 +2699,7 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq215[1] {
 					yym220 := z.EncBinary()
 					_ = yym220
@@ -2528,7 +2712,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq215[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym221 := z.EncBinary()
 					_ = yym221
 					if false {
@@ -2538,6 +2724,7 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq215[2] {
 					yy223 := &x.ListMeta
 					yym224 := z.EncBinary()
@@ -2552,7 +2739,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq215[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy225 := &x.ListMeta
 					yym226 := z.EncBinary()
 					_ = yym226
@@ -2564,6 +2753,7 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -2575,7 +2765,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -2587,8 +2779,10 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep215 {
-				r.EncodeEnd()
+			if yyr215 || yy2arr215 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -2603,17 +2797,18 @@ func (x *HorizontalPodAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct231 := r.ContainerType()
+		if yyct231 == codecSelferValueTypeMap1234 {
 			yyl231 := r.ReadMapStart()
 			if yyl231 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl231, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct231 == codecSelferValueTypeArray1234 {
 			yyl231 := r.ReadArrayStart()
 			if yyl231 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl231, d)
 			}
@@ -2640,8 +2835,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys232Slc = r.DecodeBytes(yys232Slc, true, true)
 		yys232 := string(yys232Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys232 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -2684,9 +2881,7 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 			z.DecStructFieldNotFound(-1, yys232)
 		} // end switch yys232
 	} // end for yyj232
-	if !yyhl232 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -2703,9 +2898,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		yyb239 = r.CheckBreak()
 	}
 	if yyb239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -2718,9 +2914,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		yyb239 = r.CheckBreak()
 	}
 	if yyb239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -2733,9 +2930,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		yyb239 = r.CheckBreak()
 	}
 	if yyb239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -2755,9 +2953,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		yyb239 = r.CheckBreak()
 	}
 	if yyb239 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -2779,9 +2978,10 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		if yyb239 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj239-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -2806,18 +3006,21 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq247[2] = true
 			yyq247[3] = x.Description != ""
 			yyq247[4] = len(x.Versions) != 0
+			var yynn247 int
 			if yyr247 || yy2arr247 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn247 int = 0
+				yynn247 = 0
 				for _, b := range yyq247 {
 					if b {
 						yynn247++
 					}
 				}
 				r.EncodeMapStart(yynn247)
+				yynn247 = 0
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[0] {
 					yym249 := z.EncBinary()
 					_ = yym249
@@ -2830,7 +3033,9 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym250 := z.EncBinary()
 					_ = yym250
 					if false {
@@ -2840,6 +3045,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[1] {
 					yym252 := z.EncBinary()
 					_ = yym252
@@ -2852,7 +3058,9 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym253 := z.EncBinary()
 					_ = yym253
 					if false {
@@ -2862,6 +3070,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[2] {
 					yy255 := &x.ObjectMeta
 					yy255.CodecEncodeSelf(e)
@@ -2870,12 +3079,15 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy256 := &x.ObjectMeta
 					yy256.CodecEncodeSelf(e)
 				}
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[3] {
 					yym258 := z.EncBinary()
 					_ = yym258
@@ -2888,7 +3100,9 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("description"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym259 := z.EncBinary()
 					_ = yym259
 					if false {
@@ -2898,6 +3112,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq247[4] {
 					if x.Versions == nil {
 						r.EncodeNil()
@@ -2914,7 +3129,9 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq247[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("versions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
@@ -2927,8 +3144,10 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep247 {
-				r.EncodeEnd()
+			if yyr247 || yy2arr247 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -2943,17 +3162,18 @@ func (x *ThirdPartyResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct264 := r.ContainerType()
+		if yyct264 == codecSelferValueTypeMap1234 {
 			yyl264 := r.ReadMapStart()
 			if yyl264 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl264, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct264 == codecSelferValueTypeArray1234 {
 			yyl264 := r.ReadArrayStart()
 			if yyl264 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl264, d)
 			}
@@ -2980,8 +3200,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys265Slc = r.DecodeBytes(yys265Slc, true, true)
 		yys265 := string(yys265Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys265 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -3024,9 +3246,7 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys265)
 		} // end switch yys265
 	} // end for yyj265
-	if !yyhl265 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3043,9 +3263,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -3058,9 +3279,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -3073,9 +3295,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
@@ -3089,9 +3312,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Description = ""
 	} else {
@@ -3104,9 +3328,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb272 = r.CheckBreak()
 	}
 	if yyb272 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Versions = nil
 	} else {
@@ -3128,9 +3353,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb272 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj272-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3153,18 +3379,21 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq280[0] = x.Kind != ""
 			yyq280[1] = x.APIVersion != ""
 			yyq280[2] = true
+			var yynn280 int
 			if yyr280 || yy2arr280 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn280 int = 1
+				yynn280 = 1
 				for _, b := range yyq280 {
 					if b {
 						yynn280++
 					}
 				}
 				r.EncodeMapStart(yynn280)
+				yynn280 = 0
 			}
 			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq280[0] {
 					yym282 := z.EncBinary()
 					_ = yym282
@@ -3177,7 +3406,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq280[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym283 := z.EncBinary()
 					_ = yym283
 					if false {
@@ -3187,6 +3418,7 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq280[1] {
 					yym285 := z.EncBinary()
 					_ = yym285
@@ -3199,7 +3431,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq280[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym286 := z.EncBinary()
 					_ = yym286
 					if false {
@@ -3209,6 +3443,7 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq280[2] {
 					yy288 := &x.ListMeta
 					yym289 := z.EncBinary()
@@ -3223,7 +3458,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq280[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy290 := &x.ListMeta
 					yym291 := z.EncBinary()
 					_ = yym291
@@ -3235,6 +3472,7 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -3246,7 +3484,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -3258,8 +3498,10 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep280 {
-				r.EncodeEnd()
+			if yyr280 || yy2arr280 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3274,17 +3516,18 @@ func (x *ThirdPartyResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct296 := r.ContainerType()
+		if yyct296 == codecSelferValueTypeMap1234 {
 			yyl296 := r.ReadMapStart()
 			if yyl296 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl296, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct296 == codecSelferValueTypeArray1234 {
 			yyl296 := r.ReadArrayStart()
 			if yyl296 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl296, d)
 			}
@@ -3311,8 +3554,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys297Slc = r.DecodeBytes(yys297Slc, true, true)
 		yys297 := string(yys297Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys297 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -3355,9 +3600,7 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys297)
 		} // end switch yys297
 	} // end for yyj297
-	if !yyhl297 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3374,9 +3617,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb304 = r.CheckBreak()
 	}
 	if yyb304 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -3389,9 +3633,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb304 = r.CheckBreak()
 	}
 	if yyb304 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -3404,9 +3649,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb304 = r.CheckBreak()
 	}
 	if yyb304 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -3426,9 +3672,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb304 = r.CheckBreak()
 	}
 	if yyb304 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -3450,9 +3697,10 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb304 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj304-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3474,18 +3722,21 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr312 bool = false
 			yyq312[0] = x.Name != ""
 			yyq312[1] = x.APIGroup != ""
+			var yynn312 int
 			if yyr312 || yy2arr312 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn312 int = 0
+				yynn312 = 0
 				for _, b := range yyq312 {
 					if b {
 						yynn312++
 					}
 				}
 				r.EncodeMapStart(yynn312)
+				yynn312 = 0
 			}
 			if yyr312 || yy2arr312 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq312[0] {
 					yym314 := z.EncBinary()
 					_ = yym314
@@ -3498,7 +3749,9 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq312[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym315 := z.EncBinary()
 					_ = yym315
 					if false {
@@ -3508,6 +3761,7 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr312 || yy2arr312 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq312[1] {
 					yym317 := z.EncBinary()
 					_ = yym317
@@ -3520,7 +3774,9 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq312[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiGroup"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym318 := z.EncBinary()
 					_ = yym318
 					if false {
@@ -3529,8 +3785,10 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep312 {
-				r.EncodeEnd()
+			if yyr312 || yy2arr312 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3545,17 +3803,18 @@ func (x *APIVersion) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct320 := r.ContainerType()
+		if yyct320 == codecSelferValueTypeMap1234 {
 			yyl320 := r.ReadMapStart()
 			if yyl320 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl320, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct320 == codecSelferValueTypeArray1234 {
 			yyl320 := r.ReadArrayStart()
 			if yyl320 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl320, d)
 			}
@@ -3582,8 +3841,10 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys321Slc = r.DecodeBytes(yys321Slc, true, true)
 		yys321 := string(yys321Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys321 {
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -3601,9 +3862,7 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys321)
 		} // end switch yys321
 	} // end for yyj321
-	if !yyhl321 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3620,9 +3879,10 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb324 = r.CheckBreak()
 	}
 	if yyb324 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Name = ""
 	} else {
@@ -3635,9 +3895,10 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb324 = r.CheckBreak()
 	}
 	if yyb324 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIGroup = ""
 	} else {
@@ -3653,9 +3914,10 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb324 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj324-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3679,18 +3941,21 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq328[1] = x.APIVersion != ""
 			yyq328[2] = true
 			yyq328[3] = len(x.Data) != 0
+			var yynn328 int
 			if yyr328 || yy2arr328 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn328 int = 0
+				yynn328 = 0
 				for _, b := range yyq328 {
 					if b {
 						yynn328++
 					}
 				}
 				r.EncodeMapStart(yynn328)
+				yynn328 = 0
 			}
 			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq328[0] {
 					yym330 := z.EncBinary()
 					_ = yym330
@@ -3703,7 +3968,9 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq328[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym331 := z.EncBinary()
 					_ = yym331
 					if false {
@@ -3713,6 +3980,7 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq328[1] {
 					yym333 := z.EncBinary()
 					_ = yym333
@@ -3725,7 +3993,9 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq328[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym334 := z.EncBinary()
 					_ = yym334
 					if false {
@@ -3735,6 +4005,7 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq328[2] {
 					yy336 := &x.ObjectMeta
 					yy336.CodecEncodeSelf(e)
@@ -3743,12 +4014,15 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq328[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy337 := &x.ObjectMeta
 					yy337.CodecEncodeSelf(e)
 				}
 			}
 			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq328[3] {
 					if x.Data == nil {
 						r.EncodeNil()
@@ -3765,7 +4039,9 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq328[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
@@ -3778,8 +4054,10 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep328 {
-				r.EncodeEnd()
+			if yyr328 || yy2arr328 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -3794,17 +4072,18 @@ func (x *ThirdPartyResourceData) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct342 := r.ContainerType()
+		if yyct342 == codecSelferValueTypeMap1234 {
 			yyl342 := r.ReadMapStart()
 			if yyl342 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl342, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct342 == codecSelferValueTypeArray1234 {
 			yyl342 := r.ReadArrayStart()
 			if yyl342 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl342, d)
 			}
@@ -3831,8 +4110,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
 		yys343 := string(yys343Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys343 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -3869,9 +4150,7 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys343)
 		} // end switch yys343
 	} // end for yyj343
-	if !yyhl343 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -3888,9 +4167,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb349 = r.CheckBreak()
 	}
 	if yyb349 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -3903,9 +4183,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb349 = r.CheckBreak()
 	}
 	if yyb349 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -3918,9 +4199,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb349 = r.CheckBreak()
 	}
 	if yyb349 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
@@ -3934,9 +4216,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb349 = r.CheckBreak()
 	}
 	if yyb349 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
@@ -3958,9 +4241,10 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb349 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj349-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -3985,18 +4269,21 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq356[2] = true
 			yyq356[3] = true
 			yyq356[4] = true
+			var yynn356 int
 			if yyr356 || yy2arr356 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn356 int = 0
+				yynn356 = 0
 				for _, b := range yyq356 {
 					if b {
 						yynn356++
 					}
 				}
 				r.EncodeMapStart(yynn356)
+				yynn356 = 0
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[0] {
 					yym358 := z.EncBinary()
 					_ = yym358
@@ -4009,7 +4296,9 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym359 := z.EncBinary()
 					_ = yym359
 					if false {
@@ -4019,6 +4308,7 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[1] {
 					yym361 := z.EncBinary()
 					_ = yym361
@@ -4031,7 +4321,9 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym362 := z.EncBinary()
 					_ = yym362
 					if false {
@@ -4041,6 +4333,7 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[2] {
 					yy364 := &x.ObjectMeta
 					yy364.CodecEncodeSelf(e)
@@ -4049,12 +4342,15 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy365 := &x.ObjectMeta
 					yy365.CodecEncodeSelf(e)
 				}
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[3] {
 					yy367 := &x.Spec
 					yy367.CodecEncodeSelf(e)
@@ -4063,12 +4359,15 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy368 := &x.Spec
 					yy368.CodecEncodeSelf(e)
 				}
 			}
 			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq356[4] {
 					yy370 := &x.Status
 					yy370.CodecEncodeSelf(e)
@@ -4077,13 +4376,17 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq356[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy371 := &x.Status
 					yy371.CodecEncodeSelf(e)
 				}
 			}
-			if yysep356 {
-				r.EncodeEnd()
+			if yyr356 || yy2arr356 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4098,17 +4401,18 @@ func (x *Deployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct373 := r.ContainerType()
+		if yyct373 == codecSelferValueTypeMap1234 {
 			yyl373 := r.ReadMapStart()
 			if yyl373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl373, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct373 == codecSelferValueTypeArray1234 {
 			yyl373 := r.ReadArrayStart()
 			if yyl373 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl373, d)
 			}
@@ -4135,8 +4439,10 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys374Slc = r.DecodeBytes(yys374Slc, true, true)
 		yys374 := string(yys374Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys374 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -4175,9 +4481,7 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys374)
 		} // end switch yys374
 	} // end for yyj374
-	if !yyhl374 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -4194,9 +4498,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -4209,9 +4514,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -4224,9 +4530,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
@@ -4240,9 +4547,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = DeploymentSpec{}
 	} else {
@@ -4256,9 +4564,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb380 = r.CheckBreak()
 	}
 	if yyb380 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = DeploymentStatus{}
 	} else {
@@ -4275,9 +4584,10 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb380 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj380-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -4301,18 +4611,21 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq387[1] = len(x.Selector) != 0
 			yyq387[3] = true
 			yyq387[4] = x.UniqueLabelKey != nil
+			var yynn387 int
 			if yyr387 || yy2arr387 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn387 int = 1
+				yynn387 = 1
 				for _, b := range yyq387 {
 					if b {
 						yynn387++
 					}
 				}
 				r.EncodeMapStart(yynn387)
+				yynn387 = 0
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq387[0] {
 					if x.Replicas == nil {
 						r.EncodeNil()
@@ -4330,7 +4643,9 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq387[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
@@ -4345,6 +4660,7 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq387[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -4361,7 +4677,9 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq387[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -4375,14 +4693,18 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy397 := &x.Template
 				yy397.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy398 := &x.Template
 				yy398.CodecEncodeSelf(e)
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq387[3] {
 					yy400 := &x.Strategy
 					yy400.CodecEncodeSelf(e)
@@ -4391,12 +4713,15 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq387[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("strategy"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy401 := &x.Strategy
 					yy401.CodecEncodeSelf(e)
 				}
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq387[4] {
 					if x.UniqueLabelKey == nil {
 						r.EncodeNil()
@@ -4414,7 +4739,9 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq387[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.UniqueLabelKey == nil {
 						r.EncodeNil()
 					} else {
@@ -4428,8 +4755,10 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep387 {
-				r.EncodeEnd()
+			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4444,17 +4773,18 @@ func (x *DeploymentSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct408 := r.ContainerType()
+		if yyct408 == codecSelferValueTypeMap1234 {
 			yyl408 := r.ReadMapStart()
 			if yyl408 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl408, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct408 == codecSelferValueTypeArray1234 {
 			yyl408 := r.ReadArrayStart()
 			if yyl408 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl408, d)
 			}
@@ -4481,8 +4811,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys409Slc = r.DecodeBytes(yys409Slc, true, true)
 		yys409 := string(yys409Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys409 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -4546,9 +4878,7 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys409)
 		} // end switch yys409
 	} // end for yyj409
-	if !yyhl409 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -4565,9 +4895,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb418 = r.CheckBreak()
 	}
 	if yyb418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Replicas != nil {
 			x.Replicas = nil
@@ -4590,9 +4921,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb418 = r.CheckBreak()
 	}
 	if yyb418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
@@ -4611,9 +4943,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb418 = r.CheckBreak()
 	}
 	if yyb418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_v1.PodTemplateSpec{}
 	} else {
@@ -4627,9 +4960,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb418 = r.CheckBreak()
 	}
 	if yyb418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Strategy = DeploymentStrategy{}
 	} else {
@@ -4643,9 +4977,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb418 = r.CheckBreak()
 	}
 	if yyb418 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.UniqueLabelKey != nil {
 			x.UniqueLabelKey = nil
@@ -4671,9 +5006,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb418 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj418-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -4695,18 +5031,21 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr428 bool = false
 			yyq428[0] = x.Type != ""
 			yyq428[1] = x.RollingUpdate != nil
+			var yynn428 int
 			if yyr428 || yy2arr428 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn428 int = 0
+				yynn428 = 0
 				for _, b := range yyq428 {
 					if b {
 						yynn428++
 					}
 				}
 				r.EncodeMapStart(yynn428)
+				yynn428 = 0
 			}
 			if yyr428 || yy2arr428 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq428[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
@@ -4714,11 +5053,14 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq428[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
 			if yyr428 || yy2arr428 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq428[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
@@ -4730,7 +5072,9 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq428[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -4738,8 +5082,10 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep428 {
-				r.EncodeEnd()
+			if yyr428 || yy2arr428 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -4754,17 +5100,18 @@ func (x *DeploymentStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct432 := r.ContainerType()
+		if yyct432 == codecSelferValueTypeMap1234 {
 			yyl432 := r.ReadMapStart()
 			if yyl432 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl432, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct432 == codecSelferValueTypeArray1234 {
 			yyl432 := r.ReadArrayStart()
 			if yyl432 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl432, d)
 			}
@@ -4791,8 +5138,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys433Slc = r.DecodeBytes(yys433Slc, true, true)
 		yys433 := string(yys433Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys433 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -4815,9 +5164,7 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			z.DecStructFieldNotFound(-1, yys433)
 		} // end switch yys433
 	} // end for yyj433
-	if !yyhl433 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -4834,9 +5181,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb436 = r.CheckBreak()
 	}
 	if yyb436 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -4849,9 +5197,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		yyb436 = r.CheckBreak()
 	}
 	if yyb436 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.RollingUpdate != nil {
 			x.RollingUpdate = nil
@@ -4872,9 +5221,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if yyb436 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj436-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x DeploymentStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -4923,18 +5273,21 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq442[0] = x.MaxUnavailable != nil
 			yyq442[1] = x.MaxSurge != nil
 			yyq442[2] = x.MinReadySeconds != 0
+			var yynn442 int
 			if yyr442 || yy2arr442 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn442 int = 0
+				yynn442 = 0
 				for _, b := range yyq442 {
 					if b {
 						yynn442++
 					}
 				}
 				r.EncodeMapStart(yynn442)
+				yynn442 = 0
 			}
 			if yyr442 || yy2arr442 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq442[0] {
 					if x.MaxUnavailable == nil {
 						r.EncodeNil()
@@ -4954,7 +5307,9 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq442[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MaxUnavailable == nil {
 						r.EncodeNil()
 					} else {
@@ -4971,6 +5326,7 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr442 || yy2arr442 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq442[1] {
 					if x.MaxSurge == nil {
 						r.EncodeNil()
@@ -4990,7 +5346,9 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq442[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MaxSurge == nil {
 						r.EncodeNil()
 					} else {
@@ -5007,6 +5365,7 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr442 || yy2arr442 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq442[2] {
 					yym450 := z.EncBinary()
 					_ = yym450
@@ -5019,7 +5378,9 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq442[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym451 := z.EncBinary()
 					_ = yym451
 					if false {
@@ -5028,8 +5389,10 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep442 {
-				r.EncodeEnd()
+			if yyr442 || yy2arr442 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5044,17 +5407,18 @@ func (x *RollingUpdateDeployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct453 := r.ContainerType()
+		if yyct453 == codecSelferValueTypeMap1234 {
 			yyl453 := r.ReadMapStart()
 			if yyl453 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl453, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct453 == codecSelferValueTypeArray1234 {
 			yyl453 := r.ReadArrayStart()
 			if yyl453 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl453, d)
 			}
@@ -5081,8 +5445,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys454Slc = r.DecodeBytes(yys454Slc, true, true)
 		yys454 := string(yys454Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys454 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
@@ -5132,9 +5498,7 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			z.DecStructFieldNotFound(-1, yys454)
 		} // end switch yys454
 	} // end for yyj454
-	if !yyhl454 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5151,9 +5515,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb460 = r.CheckBreak()
 	}
 	if yyb460 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.MaxUnavailable != nil {
 			x.MaxUnavailable = nil
@@ -5179,9 +5544,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb460 = r.CheckBreak()
 	}
 	if yyb460 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.MaxSurge != nil {
 			x.MaxSurge = nil
@@ -5207,9 +5573,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		yyb460 = r.CheckBreak()
 	}
 	if yyb460 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MinReadySeconds = 0
 	} else {
@@ -5225,9 +5592,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if yyb460 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj460-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5249,18 +5617,21 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr467 bool = false
 			yyq467[0] = x.Replicas != 0
 			yyq467[1] = x.UpdatedReplicas != 0
+			var yynn467 int
 			if yyr467 || yy2arr467 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn467 int = 0
+				yynn467 = 0
 				for _, b := range yyq467 {
 					if b {
 						yynn467++
 					}
 				}
 				r.EncodeMapStart(yynn467)
+				yynn467 = 0
 			}
 			if yyr467 || yy2arr467 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq467[0] {
 					yym469 := z.EncBinary()
 					_ = yym469
@@ -5273,7 +5644,9 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq467[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym470 := z.EncBinary()
 					_ = yym470
 					if false {
@@ -5283,6 +5656,7 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr467 || yy2arr467 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq467[1] {
 					yym472 := z.EncBinary()
 					_ = yym472
@@ -5295,7 +5669,9 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq467[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("updatedReplicas"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym473 := z.EncBinary()
 					_ = yym473
 					if false {
@@ -5304,8 +5680,10 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep467 {
-				r.EncodeEnd()
+			if yyr467 || yy2arr467 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5320,17 +5698,18 @@ func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct475 := r.ContainerType()
+		if yyct475 == codecSelferValueTypeMap1234 {
 			yyl475 := r.ReadMapStart()
 			if yyl475 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl475, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct475 == codecSelferValueTypeArray1234 {
 			yyl475 := r.ReadArrayStart()
 			if yyl475 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl475, d)
 			}
@@ -5357,8 +5736,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys476Slc = r.DecodeBytes(yys476Slc, true, true)
 		yys476 := string(yys476Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys476 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
@@ -5376,9 +5757,7 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys476)
 		} // end switch yys476
 	} // end for yyj476
-	if !yyhl476 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5395,9 +5774,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb479 = r.CheckBreak()
 	}
 	if yyb479 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
@@ -5410,9 +5790,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb479 = r.CheckBreak()
 	}
 	if yyb479 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.UpdatedReplicas = 0
 	} else {
@@ -5428,9 +5809,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if yyb479 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj479-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5453,18 +5835,21 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq483[0] = x.Kind != ""
 			yyq483[1] = x.APIVersion != ""
 			yyq483[2] = true
+			var yynn483 int
 			if yyr483 || yy2arr483 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn483 int = 1
+				yynn483 = 1
 				for _, b := range yyq483 {
 					if b {
 						yynn483++
 					}
 				}
 				r.EncodeMapStart(yynn483)
+				yynn483 = 0
 			}
 			if yyr483 || yy2arr483 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq483[0] {
 					yym485 := z.EncBinary()
 					_ = yym485
@@ -5477,7 +5862,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq483[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym486 := z.EncBinary()
 					_ = yym486
 					if false {
@@ -5487,6 +5874,7 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr483 || yy2arr483 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq483[1] {
 					yym488 := z.EncBinary()
 					_ = yym488
@@ -5499,7 +5887,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq483[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym489 := z.EncBinary()
 					_ = yym489
 					if false {
@@ -5509,6 +5899,7 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr483 || yy2arr483 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq483[2] {
 					yy491 := &x.ListMeta
 					yym492 := z.EncBinary()
@@ -5523,7 +5914,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq483[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy493 := &x.ListMeta
 					yym494 := z.EncBinary()
 					_ = yym494
@@ -5535,6 +5928,7 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr483 || yy2arr483 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -5546,7 +5940,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -5558,8 +5954,10 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep483 {
-				r.EncodeEnd()
+			if yyr483 || yy2arr483 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5574,17 +5972,18 @@ func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct499 := r.ContainerType()
+		if yyct499 == codecSelferValueTypeMap1234 {
 			yyl499 := r.ReadMapStart()
 			if yyl499 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl499, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct499 == codecSelferValueTypeArray1234 {
 			yyl499 := r.ReadArrayStart()
 			if yyl499 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl499, d)
 			}
@@ -5611,8 +6010,10 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys500Slc = r.DecodeBytes(yys500Slc, true, true)
 		yys500 := string(yys500Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys500 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -5655,9 +6056,7 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys500)
 		} // end switch yys500
 	} // end for yyj500
-	if !yyhl500 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5674,9 +6073,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb507 = r.CheckBreak()
 	}
 	if yyb507 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -5689,9 +6089,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb507 = r.CheckBreak()
 	}
 	if yyb507 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -5704,9 +6105,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb507 = r.CheckBreak()
 	}
 	if yyb507 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -5726,9 +6128,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb507 = r.CheckBreak()
 	}
 	if yyb507 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -5750,9 +6153,10 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb507 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj507-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5774,18 +6178,21 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr515 bool = false
 			yyq515[0] = x.Selector != nil
 			yyq515[1] = x.Template != nil
+			var yynn515 int
 			if yyr515 || yy2arr515 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn515 int = 0
+				yynn515 = 0
 				for _, b := range yyq515 {
 					if b {
 						yynn515++
 					}
 				}
 				r.EncodeMapStart(yynn515)
+				yynn515 = 0
 			}
 			if yyr515 || yy2arr515 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq515[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -5797,7 +6204,9 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq515[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -5806,6 +6215,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr515 || yy2arr515 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq515[1] {
 					if x.Template == nil {
 						r.EncodeNil()
@@ -5817,7 +6227,9 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq515[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -5825,8 +6237,10 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep515 {
-				r.EncodeEnd()
+			if yyr515 || yy2arr515 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -5841,17 +6255,18 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct519 := r.ContainerType()
+		if yyct519 == codecSelferValueTypeMap1234 {
 			yyl519 := r.ReadMapStart()
 			if yyl519 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl519, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct519 == codecSelferValueTypeArray1234 {
 			yyl519 := r.ReadArrayStart()
 			if yyl519 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl519, d)
 			}
@@ -5878,8 +6293,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys520Slc = r.DecodeBytes(yys520Slc, true, true)
 		yys520 := string(yys520Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys520 {
 		case "selector":
 			if r.TryDecodeAsNil() {
@@ -5907,9 +6324,7 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys520)
 		} // end switch yys520
 	} // end for yyj520
-	if !yyhl520 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -5926,9 +6341,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb523 = r.CheckBreak()
 	}
 	if yyb523 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Selector != nil {
 			x.Selector = nil
@@ -5946,9 +6362,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb523 = r.CheckBreak()
 	}
 	if yyb523 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Template != nil {
 			x.Template = nil
@@ -5969,9 +6386,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb523 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj523-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -5991,18 +6409,21 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq527 [3]bool
 			_, _, _ = yysep527, yyq527, yy2arr527
 			const yyr527 bool = false
+			var yynn527 int
 			if yyr527 || yy2arr527 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn527 int = 3
+				yynn527 = 3
 				for _, b := range yyq527 {
 					if b {
 						yynn527++
 					}
 				}
 				r.EncodeMapStart(yynn527)
+				yynn527 = 0
 			}
 			if yyr527 || yy2arr527 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym529 := z.EncBinary()
 				_ = yym529
 				if false {
@@ -6010,7 +6431,9 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym530 := z.EncBinary()
 				_ = yym530
 				if false {
@@ -6019,6 +6442,7 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr527 || yy2arr527 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym532 := z.EncBinary()
 				_ = yym532
 				if false {
@@ -6026,7 +6450,9 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym533 := z.EncBinary()
 				_ = yym533
 				if false {
@@ -6035,6 +6461,7 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr527 || yy2arr527 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym535 := z.EncBinary()
 				_ = yym535
 				if false {
@@ -6042,7 +6469,9 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym536 := z.EncBinary()
 				_ = yym536
 				if false {
@@ -6050,8 +6479,10 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yysep527 {
-				r.EncodeEnd()
+			if yyr527 || yy2arr527 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6066,17 +6497,18 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct538 := r.ContainerType()
+		if yyct538 == codecSelferValueTypeMap1234 {
 			yyl538 := r.ReadMapStart()
 			if yyl538 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl538, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct538 == codecSelferValueTypeArray1234 {
 			yyl538 := r.ReadArrayStart()
 			if yyl538 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl538, d)
 			}
@@ -6103,8 +6535,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys539Slc = r.DecodeBytes(yys539Slc, true, true)
 		yys539 := string(yys539Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys539 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
@@ -6128,9 +6562,7 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys539)
 		} // end switch yys539
 	} // end for yyj539
-	if !yyhl539 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6147,9 +6579,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb543 = r.CheckBreak()
 	}
 	if yyb543 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.CurrentNumberScheduled = 0
 	} else {
@@ -6162,9 +6595,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb543 = r.CheckBreak()
 	}
 	if yyb543 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.NumberMisscheduled = 0
 	} else {
@@ -6177,9 +6611,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb543 = r.CheckBreak()
 	}
 	if yyb543 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.DesiredNumberScheduled = 0
 	} else {
@@ -6195,9 +6630,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb543 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj543-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6222,18 +6658,21 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq548[2] = true
 			yyq548[3] = true
 			yyq548[4] = true
+			var yynn548 int
 			if yyr548 || yy2arr548 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn548 int = 0
+				yynn548 = 0
 				for _, b := range yyq548 {
 					if b {
 						yynn548++
 					}
 				}
 				r.EncodeMapStart(yynn548)
+				yynn548 = 0
 			}
 			if yyr548 || yy2arr548 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq548[0] {
 					yym550 := z.EncBinary()
 					_ = yym550
@@ -6246,7 +6685,9 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq548[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym551 := z.EncBinary()
 					_ = yym551
 					if false {
@@ -6256,6 +6697,7 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr548 || yy2arr548 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq548[1] {
 					yym553 := z.EncBinary()
 					_ = yym553
@@ -6268,7 +6710,9 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq548[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym554 := z.EncBinary()
 					_ = yym554
 					if false {
@@ -6278,6 +6722,7 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr548 || yy2arr548 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq548[2] {
 					yy556 := &x.ObjectMeta
 					yy556.CodecEncodeSelf(e)
@@ -6286,12 +6731,15 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq548[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy557 := &x.ObjectMeta
 					yy557.CodecEncodeSelf(e)
 				}
 			}
 			if yyr548 || yy2arr548 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq548[3] {
 					yy559 := &x.Spec
 					yy559.CodecEncodeSelf(e)
@@ -6300,12 +6748,15 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq548[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy560 := &x.Spec
 					yy560.CodecEncodeSelf(e)
 				}
 			}
 			if yyr548 || yy2arr548 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq548[4] {
 					yy562 := &x.Status
 					yy562.CodecEncodeSelf(e)
@@ -6314,13 +6765,17 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq548[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy563 := &x.Status
 					yy563.CodecEncodeSelf(e)
 				}
 			}
-			if yysep548 {
-				r.EncodeEnd()
+			if yyr548 || yy2arr548 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6335,17 +6790,18 @@ func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct565 := r.ContainerType()
+		if yyct565 == codecSelferValueTypeMap1234 {
 			yyl565 := r.ReadMapStart()
 			if yyl565 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl565, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct565 == codecSelferValueTypeArray1234 {
 			yyl565 := r.ReadArrayStart()
 			if yyl565 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl565, d)
 			}
@@ -6372,8 +6828,10 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys566Slc = r.DecodeBytes(yys566Slc, true, true)
 		yys566 := string(yys566Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys566 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -6412,9 +6870,7 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys566)
 		} // end switch yys566
 	} // end for yyj566
-	if !yyhl566 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6431,9 +6887,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb572 = r.CheckBreak()
 	}
 	if yyb572 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -6446,9 +6903,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb572 = r.CheckBreak()
 	}
 	if yyb572 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -6461,9 +6919,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb572 = r.CheckBreak()
 	}
 	if yyb572 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
@@ -6477,9 +6936,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb572 = r.CheckBreak()
 	}
 	if yyb572 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = DaemonSetSpec{}
 	} else {
@@ -6493,9 +6953,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb572 = r.CheckBreak()
 	}
 	if yyb572 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = DaemonSetStatus{}
 	} else {
@@ -6512,9 +6973,10 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb572 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj572-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6537,18 +6999,21 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq579[0] = x.Kind != ""
 			yyq579[1] = x.APIVersion != ""
 			yyq579[2] = true
+			var yynn579 int
 			if yyr579 || yy2arr579 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn579 int = 1
+				yynn579 = 1
 				for _, b := range yyq579 {
 					if b {
 						yynn579++
 					}
 				}
 				r.EncodeMapStart(yynn579)
+				yynn579 = 0
 			}
 			if yyr579 || yy2arr579 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq579[0] {
 					yym581 := z.EncBinary()
 					_ = yym581
@@ -6561,7 +7026,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq579[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym582 := z.EncBinary()
 					_ = yym582
 					if false {
@@ -6571,6 +7038,7 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr579 || yy2arr579 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq579[1] {
 					yym584 := z.EncBinary()
 					_ = yym584
@@ -6583,7 +7051,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq579[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym585 := z.EncBinary()
 					_ = yym585
 					if false {
@@ -6593,6 +7063,7 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr579 || yy2arr579 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq579[2] {
 					yy587 := &x.ListMeta
 					yym588 := z.EncBinary()
@@ -6607,7 +7078,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq579[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy589 := &x.ListMeta
 					yym590 := z.EncBinary()
 					_ = yym590
@@ -6619,6 +7092,7 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr579 || yy2arr579 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6630,7 +7104,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6642,8 +7118,10 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep579 {
-				r.EncodeEnd()
+			if yyr579 || yy2arr579 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6658,17 +7136,18 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct595 := r.ContainerType()
+		if yyct595 == codecSelferValueTypeMap1234 {
 			yyl595 := r.ReadMapStart()
 			if yyl595 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl595, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct595 == codecSelferValueTypeArray1234 {
 			yyl595 := r.ReadArrayStart()
 			if yyl595 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl595, d)
 			}
@@ -6695,8 +7174,10 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys596Slc = r.DecodeBytes(yys596Slc, true, true)
 		yys596 := string(yys596Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys596 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -6739,9 +7220,7 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys596)
 		} // end switch yys596
 	} // end for yyj596
-	if !yyhl596 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -6758,9 +7237,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb603 = r.CheckBreak()
 	}
 	if yyb603 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -6773,9 +7253,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb603 = r.CheckBreak()
 	}
 	if yyb603 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -6788,9 +7269,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb603 = r.CheckBreak()
 	}
 	if yyb603 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -6810,9 +7292,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb603 = r.CheckBreak()
 	}
 	if yyb603 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -6834,9 +7317,10 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb603 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj603-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -6859,18 +7343,21 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq611[0] = x.Kind != ""
 			yyq611[1] = x.APIVersion != ""
 			yyq611[2] = true
+			var yynn611 int
 			if yyr611 || yy2arr611 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn611 int = 1
+				yynn611 = 1
 				for _, b := range yyq611 {
 					if b {
 						yynn611++
 					}
 				}
 				r.EncodeMapStart(yynn611)
+				yynn611 = 0
 			}
 			if yyr611 || yy2arr611 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq611[0] {
 					yym613 := z.EncBinary()
 					_ = yym613
@@ -6883,7 +7370,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq611[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym614 := z.EncBinary()
 					_ = yym614
 					if false {
@@ -6893,6 +7382,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr611 || yy2arr611 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq611[1] {
 					yym616 := z.EncBinary()
 					_ = yym616
@@ -6905,7 +7395,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq611[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym617 := z.EncBinary()
 					_ = yym617
 					if false {
@@ -6915,6 +7407,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr611 || yy2arr611 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq611[2] {
 					yy619 := &x.ListMeta
 					yym620 := z.EncBinary()
@@ -6929,7 +7422,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq611[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy621 := &x.ListMeta
 					yym622 := z.EncBinary()
 					_ = yym622
@@ -6941,6 +7436,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr611 || yy2arr611 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6952,7 +7448,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -6964,8 +7462,10 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep611 {
-				r.EncodeEnd()
+			if yyr611 || yy2arr611 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -6980,17 +7480,18 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct627 := r.ContainerType()
+		if yyct627 == codecSelferValueTypeMap1234 {
 			yyl627 := r.ReadMapStart()
 			if yyl627 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl627, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct627 == codecSelferValueTypeArray1234 {
 			yyl627 := r.ReadArrayStart()
 			if yyl627 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl627, d)
 			}
@@ -7017,8 +7518,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys628Slc = r.DecodeBytes(yys628Slc, true, true)
 		yys628 := string(yys628Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys628 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -7061,9 +7564,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			z.DecStructFieldNotFound(-1, yys628)
 		} // end switch yys628
 	} // end for yyj628
-	if !yyhl628 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7080,9 +7581,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		yyb635 = r.CheckBreak()
 	}
 	if yyb635 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -7095,9 +7597,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		yyb635 = r.CheckBreak()
 	}
 	if yyb635 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -7110,9 +7613,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		yyb635 = r.CheckBreak()
 	}
 	if yyb635 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -7132,9 +7636,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		yyb635 = r.CheckBreak()
 	}
 	if yyb635 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -7156,9 +7661,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		if yyb635 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj635-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7183,18 +7689,21 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq643[2] = true
 			yyq643[3] = true
 			yyq643[4] = true
+			var yynn643 int
 			if yyr643 || yy2arr643 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn643 int = 0
+				yynn643 = 0
 				for _, b := range yyq643 {
 					if b {
 						yynn643++
 					}
 				}
 				r.EncodeMapStart(yynn643)
+				yynn643 = 0
 			}
 			if yyr643 || yy2arr643 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq643[0] {
 					yym645 := z.EncBinary()
 					_ = yym645
@@ -7207,7 +7716,9 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq643[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym646 := z.EncBinary()
 					_ = yym646
 					if false {
@@ -7217,6 +7728,7 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr643 || yy2arr643 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq643[1] {
 					yym648 := z.EncBinary()
 					_ = yym648
@@ -7229,7 +7741,9 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq643[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym649 := z.EncBinary()
 					_ = yym649
 					if false {
@@ -7239,6 +7753,7 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr643 || yy2arr643 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq643[2] {
 					yy651 := &x.ObjectMeta
 					yy651.CodecEncodeSelf(e)
@@ -7247,12 +7762,15 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq643[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy652 := &x.ObjectMeta
 					yy652.CodecEncodeSelf(e)
 				}
 			}
 			if yyr643 || yy2arr643 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq643[3] {
 					yy654 := &x.Spec
 					yy654.CodecEncodeSelf(e)
@@ -7261,12 +7779,15 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq643[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy655 := &x.Spec
 					yy655.CodecEncodeSelf(e)
 				}
 			}
 			if yyr643 || yy2arr643 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq643[4] {
 					yy657 := &x.Status
 					yy657.CodecEncodeSelf(e)
@@ -7275,13 +7796,17 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq643[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy658 := &x.Status
 					yy658.CodecEncodeSelf(e)
 				}
 			}
-			if yysep643 {
-				r.EncodeEnd()
+			if yyr643 || yy2arr643 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7296,17 +7821,18 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct660 := r.ContainerType()
+		if yyct660 == codecSelferValueTypeMap1234 {
 			yyl660 := r.ReadMapStart()
 			if yyl660 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl660, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct660 == codecSelferValueTypeArray1234 {
 			yyl660 := r.ReadArrayStart()
 			if yyl660 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl660, d)
 			}
@@ -7333,8 +7859,10 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys661Slc = r.DecodeBytes(yys661Slc, true, true)
 		yys661 := string(yys661Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys661 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -7373,9 +7901,7 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys661)
 		} // end switch yys661
 	} // end for yyj661
-	if !yyhl661 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7392,9 +7918,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb667 = r.CheckBreak()
 	}
 	if yyb667 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -7407,9 +7934,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb667 = r.CheckBreak()
 	}
 	if yyb667 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -7422,9 +7950,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb667 = r.CheckBreak()
 	}
 	if yyb667 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
@@ -7438,9 +7967,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb667 = r.CheckBreak()
 	}
 	if yyb667 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = JobSpec{}
 	} else {
@@ -7454,9 +7984,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb667 = r.CheckBreak()
 	}
 	if yyb667 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = JobStatus{}
 	} else {
@@ -7473,9 +8004,10 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb667 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj667-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7498,18 +8030,21 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq674[0] = x.Kind != ""
 			yyq674[1] = x.APIVersion != ""
 			yyq674[2] = true
+			var yynn674 int
 			if yyr674 || yy2arr674 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn674 int = 1
+				yynn674 = 1
 				for _, b := range yyq674 {
 					if b {
 						yynn674++
 					}
 				}
 				r.EncodeMapStart(yynn674)
+				yynn674 = 0
 			}
 			if yyr674 || yy2arr674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq674[0] {
 					yym676 := z.EncBinary()
 					_ = yym676
@@ -7522,7 +8057,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq674[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym677 := z.EncBinary()
 					_ = yym677
 					if false {
@@ -7532,6 +8069,7 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr674 || yy2arr674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq674[1] {
 					yym679 := z.EncBinary()
 					_ = yym679
@@ -7544,7 +8082,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq674[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym680 := z.EncBinary()
 					_ = yym680
 					if false {
@@ -7554,6 +8094,7 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr674 || yy2arr674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq674[2] {
 					yy682 := &x.ListMeta
 					yym683 := z.EncBinary()
@@ -7568,7 +8109,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq674[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy684 := &x.ListMeta
 					yym685 := z.EncBinary()
 					_ = yym685
@@ -7580,6 +8123,7 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr674 || yy2arr674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -7591,7 +8135,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -7603,8 +8149,10 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep674 {
-				r.EncodeEnd()
+			if yyr674 || yy2arr674 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7619,17 +8167,18 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct690 := r.ContainerType()
+		if yyct690 == codecSelferValueTypeMap1234 {
 			yyl690 := r.ReadMapStart()
 			if yyl690 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl690, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct690 == codecSelferValueTypeArray1234 {
 			yyl690 := r.ReadArrayStart()
 			if yyl690 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl690, d)
 			}
@@ -7656,8 +8205,10 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys691Slc = r.DecodeBytes(yys691Slc, true, true)
 		yys691 := string(yys691Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys691 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -7700,9 +8251,7 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys691)
 		} // end switch yys691
 	} // end for yyj691
-	if !yyhl691 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -7719,9 +8268,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb698 = r.CheckBreak()
 	}
 	if yyb698 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -7734,9 +8284,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb698 = r.CheckBreak()
 	}
 	if yyb698 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -7749,9 +8300,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb698 = r.CheckBreak()
 	}
 	if yyb698 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -7771,9 +8323,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb698 = r.CheckBreak()
 	}
 	if yyb698 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -7795,9 +8348,10 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb698 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj698-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -7820,18 +8374,21 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq706[0] = x.Parallelism != nil
 			yyq706[1] = x.Completions != nil
 			yyq706[2] = x.Selector != nil
+			var yynn706 int
 			if yyr706 || yy2arr706 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn706 int = 1
+				yynn706 = 1
 				for _, b := range yyq706 {
 					if b {
 						yynn706++
 					}
 				}
 				r.EncodeMapStart(yynn706)
+				yynn706 = 0
 			}
 			if yyr706 || yy2arr706 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq706[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
@@ -7849,7 +8406,9 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq706[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
@@ -7864,6 +8423,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr706 || yy2arr706 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq706[1] {
 					if x.Completions == nil {
 						r.EncodeNil()
@@ -7881,7 +8441,9 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq706[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
@@ -7896,6 +8458,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr706 || yy2arr706 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq706[2] {
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -7907,7 +8470,9 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq706[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -7916,15 +8481,20 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr706 || yy2arr706 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy719 := &x.Template
 				yy719.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy720 := &x.Template
 				yy720.CodecEncodeSelf(e)
 			}
-			if yysep706 {
-				r.EncodeEnd()
+			if yyr706 || yy2arr706 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -7939,17 +8509,18 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct722 := r.ContainerType()
+		if yyct722 == codecSelferValueTypeMap1234 {
 			yyl722 := r.ReadMapStart()
 			if yyl722 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl722, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct722 == codecSelferValueTypeArray1234 {
 			yyl722 := r.ReadArrayStart()
 			if yyl722 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl722, d)
 			}
@@ -7976,8 +8547,10 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys723Slc = r.DecodeBytes(yys723Slc, true, true)
 		yys723 := string(yys723Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys723 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
@@ -8033,9 +8606,7 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys723)
 		} // end switch yys723
 	} // end for yyj723
-	if !yyhl723 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8052,9 +8623,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb730 = r.CheckBreak()
 	}
 	if yyb730 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Parallelism != nil {
 			x.Parallelism = nil
@@ -8077,9 +8649,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb730 = r.CheckBreak()
 	}
 	if yyb730 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Completions != nil {
 			x.Completions = nil
@@ -8102,9 +8675,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb730 = r.CheckBreak()
 	}
 	if yyb730 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Selector != nil {
 			x.Selector = nil
@@ -8122,9 +8696,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb730 = r.CheckBreak()
 	}
 	if yyb730 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_v1.PodTemplateSpec{}
 	} else {
@@ -8141,9 +8716,10 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb730 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj730-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8169,18 +8745,21 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq738[3] = x.Active != 0
 			yyq738[4] = x.Succeeded != 0
 			yyq738[5] = x.Failed != 0
+			var yynn738 int
 			if yyr738 || yy2arr738 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn738 int = 0
+				yynn738 = 0
 				for _, b := range yyq738 {
 					if b {
 						yynn738++
 					}
 				}
 				r.EncodeMapStart(yynn738)
+				yynn738 = 0
 			}
 			if yyr738 || yy2arr738 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq738[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
@@ -8197,7 +8776,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq738[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
@@ -8211,6 +8792,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr738 || yy2arr738 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq738[1] {
 					if x.StartTime == nil {
 						r.EncodeNil()
@@ -8232,7 +8814,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq738[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
@@ -8251,6 +8835,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr738 || yy2arr738 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq738[2] {
 					if x.CompletionTime == nil {
 						r.EncodeNil()
@@ -8272,7 +8857,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq738[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
@@ -8291,6 +8878,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr738 || yy2arr738 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq738[3] {
 					yym749 := z.EncBinary()
 					_ = yym749
@@ -8303,7 +8891,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq738[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym750 := z.EncBinary()
 					_ = yym750
 					if false {
@@ -8313,6 +8903,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr738 || yy2arr738 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq738[4] {
 					yym752 := z.EncBinary()
 					_ = yym752
@@ -8325,7 +8916,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq738[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym753 := z.EncBinary()
 					_ = yym753
 					if false {
@@ -8335,6 +8928,7 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr738 || yy2arr738 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq738[5] {
 					yym755 := z.EncBinary()
 					_ = yym755
@@ -8347,7 +8941,9 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq738[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym756 := z.EncBinary()
 					_ = yym756
 					if false {
@@ -8356,8 +8952,10 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep738 {
-				r.EncodeEnd()
+			if yyr738 || yy2arr738 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8372,17 +8970,18 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct758 := r.ContainerType()
+		if yyct758 == codecSelferValueTypeMap1234 {
 			yyl758 := r.ReadMapStart()
 			if yyl758 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl758, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct758 == codecSelferValueTypeArray1234 {
 			yyl758 := r.ReadArrayStart()
 			if yyl758 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl758, d)
 			}
@@ -8409,8 +9008,10 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys759Slc = r.DecodeBytes(yys759Slc, true, true)
 		yys759 := string(yys759Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys759 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
@@ -8488,9 +9089,7 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys759)
 		} // end switch yys759
 	} // end for yyj759
-	if !yyhl759 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8507,9 +9106,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb769 = r.CheckBreak()
 	}
 	if yyb769 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
@@ -8528,9 +9128,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb769 = r.CheckBreak()
 	}
 	if yyb769 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.StartTime != nil {
 			x.StartTime = nil
@@ -8558,9 +9159,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb769 = r.CheckBreak()
 	}
 	if yyb769 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.CompletionTime != nil {
 			x.CompletionTime = nil
@@ -8588,9 +9190,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb769 = r.CheckBreak()
 	}
 	if yyb769 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Active = 0
 	} else {
@@ -8603,9 +9206,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb769 = r.CheckBreak()
 	}
 	if yyb769 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Succeeded = 0
 	} else {
@@ -8618,9 +9222,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb769 = r.CheckBreak()
 	}
 	if yyb769 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Failed = 0
 	} else {
@@ -8636,9 +9241,10 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb769 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj769-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -8688,24 +9294,30 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq782[3] = true
 			yyq782[4] = x.Reason != ""
 			yyq782[5] = x.Message != ""
+			var yynn782 int
 			if yyr782 || yy2arr782 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn782 int = 2
+				yynn782 = 2
 				for _, b := range yyq782 {
 					if b {
 						yynn782++
 					}
 				}
 				r.EncodeMapStart(yynn782)
+				yynn782 = 0
 			}
 			if yyr782 || yy2arr782 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
 			if yyr782 || yy2arr782 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym785 := z.EncBinary()
 				_ = yym785
 				if false {
@@ -8714,7 +9326,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym786 := z.EncBinary()
 				_ = yym786
 				if false {
@@ -8724,6 +9338,7 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr782 || yy2arr782 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq782[2] {
 					yy788 := &x.LastProbeTime
 					yym789 := z.EncBinary()
@@ -8742,7 +9357,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq782[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy790 := &x.LastProbeTime
 					yym791 := z.EncBinary()
 					_ = yym791
@@ -8758,6 +9375,7 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr782 || yy2arr782 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq782[3] {
 					yy793 := &x.LastTransitionTime
 					yym794 := z.EncBinary()
@@ -8776,7 +9394,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq782[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy795 := &x.LastTransitionTime
 					yym796 := z.EncBinary()
 					_ = yym796
@@ -8792,6 +9412,7 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr782 || yy2arr782 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq782[4] {
 					yym798 := z.EncBinary()
 					_ = yym798
@@ -8804,7 +9425,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq782[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym799 := z.EncBinary()
 					_ = yym799
 					if false {
@@ -8814,6 +9437,7 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr782 || yy2arr782 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq782[5] {
 					yym801 := z.EncBinary()
 					_ = yym801
@@ -8826,7 +9450,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq782[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym802 := z.EncBinary()
 					_ = yym802
 					if false {
@@ -8835,8 +9461,10 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep782 {
-				r.EncodeEnd()
+			if yyr782 || yy2arr782 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -8851,17 +9479,18 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct804 := r.ContainerType()
+		if yyct804 == codecSelferValueTypeMap1234 {
 			yyl804 := r.ReadMapStart()
 			if yyl804 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl804, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct804 == codecSelferValueTypeArray1234 {
 			yyl804 := r.ReadArrayStart()
 			if yyl804 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl804, d)
 			}
@@ -8888,8 +9517,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys805Slc = r.DecodeBytes(yys805Slc, true, true)
 		yys805 := string(yys805Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys805 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -8953,9 +9584,7 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys805)
 		} // end switch yys805
 	} // end for yyj805
-	if !yyhl805 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -8972,9 +9601,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb814 = r.CheckBreak()
 	}
 	if yyb814 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
@@ -8987,9 +9617,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb814 = r.CheckBreak()
 	}
 	if yyb814 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = ""
 	} else {
@@ -9002,9 +9633,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb814 = r.CheckBreak()
 	}
 	if yyb814 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
@@ -9028,9 +9660,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb814 = r.CheckBreak()
 	}
 	if yyb814 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
@@ -9054,9 +9687,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb814 = r.CheckBreak()
 	}
 	if yyb814 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Reason = ""
 	} else {
@@ -9069,9 +9703,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb814 = r.CheckBreak()
 	}
 	if yyb814 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Message = ""
 	} else {
@@ -9087,9 +9722,10 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb814 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj814-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9114,18 +9750,21 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq824[2] = true
 			yyq824[3] = true
 			yyq824[4] = true
+			var yynn824 int
 			if yyr824 || yy2arr824 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn824 int = 0
+				yynn824 = 0
 				for _, b := range yyq824 {
 					if b {
 						yynn824++
 					}
 				}
 				r.EncodeMapStart(yynn824)
+				yynn824 = 0
 			}
 			if yyr824 || yy2arr824 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq824[0] {
 					yym826 := z.EncBinary()
 					_ = yym826
@@ -9138,7 +9777,9 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq824[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym827 := z.EncBinary()
 					_ = yym827
 					if false {
@@ -9148,6 +9789,7 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr824 || yy2arr824 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq824[1] {
 					yym829 := z.EncBinary()
 					_ = yym829
@@ -9160,7 +9802,9 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq824[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym830 := z.EncBinary()
 					_ = yym830
 					if false {
@@ -9170,6 +9814,7 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr824 || yy2arr824 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq824[2] {
 					yy832 := &x.ObjectMeta
 					yy832.CodecEncodeSelf(e)
@@ -9178,12 +9823,15 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq824[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy833 := &x.ObjectMeta
 					yy833.CodecEncodeSelf(e)
 				}
 			}
 			if yyr824 || yy2arr824 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq824[3] {
 					yy835 := &x.Spec
 					yy835.CodecEncodeSelf(e)
@@ -9192,12 +9840,15 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq824[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy836 := &x.Spec
 					yy836.CodecEncodeSelf(e)
 				}
 			}
 			if yyr824 || yy2arr824 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq824[4] {
 					yy838 := &x.Status
 					yy838.CodecEncodeSelf(e)
@@ -9206,13 +9857,17 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq824[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy839 := &x.Status
 					yy839.CodecEncodeSelf(e)
 				}
 			}
-			if yysep824 {
-				r.EncodeEnd()
+			if yyr824 || yy2arr824 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9227,17 +9882,18 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct841 := r.ContainerType()
+		if yyct841 == codecSelferValueTypeMap1234 {
 			yyl841 := r.ReadMapStart()
 			if yyl841 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl841, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct841 == codecSelferValueTypeArray1234 {
 			yyl841 := r.ReadArrayStart()
 			if yyl841 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl841, d)
 			}
@@ -9264,8 +9920,10 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys842Slc = r.DecodeBytes(yys842Slc, true, true)
 		yys842 := string(yys842Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys842 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -9304,9 +9962,7 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys842)
 		} // end switch yys842
 	} // end for yyj842
-	if !yyhl842 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9323,9 +9979,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb848 = r.CheckBreak()
 	}
 	if yyb848 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -9338,9 +9995,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb848 = r.CheckBreak()
 	}
 	if yyb848 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -9353,9 +10011,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb848 = r.CheckBreak()
 	}
 	if yyb848 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
@@ -9369,9 +10028,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb848 = r.CheckBreak()
 	}
 	if yyb848 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
@@ -9385,9 +10045,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb848 = r.CheckBreak()
 	}
 	if yyb848 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
@@ -9404,9 +10065,10 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb848 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj848-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9429,18 +10091,21 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq855[0] = x.Kind != ""
 			yyq855[1] = x.APIVersion != ""
 			yyq855[2] = true
+			var yynn855 int
 			if yyr855 || yy2arr855 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn855 int = 1
+				yynn855 = 1
 				for _, b := range yyq855 {
 					if b {
 						yynn855++
 					}
 				}
 				r.EncodeMapStart(yynn855)
+				yynn855 = 0
 			}
 			if yyr855 || yy2arr855 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq855[0] {
 					yym857 := z.EncBinary()
 					_ = yym857
@@ -9453,7 +10118,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq855[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym858 := z.EncBinary()
 					_ = yym858
 					if false {
@@ -9463,6 +10130,7 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr855 || yy2arr855 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq855[1] {
 					yym860 := z.EncBinary()
 					_ = yym860
@@ -9475,7 +10143,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq855[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym861 := z.EncBinary()
 					_ = yym861
 					if false {
@@ -9485,6 +10155,7 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr855 || yy2arr855 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq855[2] {
 					yy863 := &x.ListMeta
 					yym864 := z.EncBinary()
@@ -9499,7 +10170,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq855[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy865 := &x.ListMeta
 					yym866 := z.EncBinary()
 					_ = yym866
@@ -9511,6 +10184,7 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr855 || yy2arr855 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -9522,7 +10196,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -9534,8 +10210,10 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep855 {
-				r.EncodeEnd()
+			if yyr855 || yy2arr855 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9550,17 +10228,18 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct871 := r.ContainerType()
+		if yyct871 == codecSelferValueTypeMap1234 {
 			yyl871 := r.ReadMapStart()
 			if yyl871 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl871, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct871 == codecSelferValueTypeArray1234 {
 			yyl871 := r.ReadArrayStart()
 			if yyl871 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl871, d)
 			}
@@ -9587,8 +10266,10 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys872Slc = r.DecodeBytes(yys872Slc, true, true)
 		yys872 := string(yys872Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys872 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -9631,9 +10312,7 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys872)
 		} // end switch yys872
 	} // end for yyj872
-	if !yyhl872 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9650,9 +10329,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb879 = r.CheckBreak()
 	}
 	if yyb879 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -9665,9 +10345,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb879 = r.CheckBreak()
 	}
 	if yyb879 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -9680,9 +10361,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb879 = r.CheckBreak()
 	}
 	if yyb879 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -9702,9 +10384,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb879 = r.CheckBreak()
 	}
 	if yyb879 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -9726,9 +10409,10 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb879 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj879-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9750,18 +10434,21 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr887 bool = false
 			yyq887[0] = x.Backend != nil
 			yyq887[1] = len(x.Rules) != 0
+			var yynn887 int
 			if yyr887 || yy2arr887 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn887 int = 0
+				yynn887 = 0
 				for _, b := range yyq887 {
 					if b {
 						yynn887++
 					}
 				}
 				r.EncodeMapStart(yynn887)
+				yynn887 = 0
 			}
 			if yyr887 || yy2arr887 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq887[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
@@ -9773,7 +10460,9 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq887[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -9782,6 +10471,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr887 || yy2arr887 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq887[1] {
 					if x.Rules == nil {
 						r.EncodeNil()
@@ -9798,7 +10488,9 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq887[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
@@ -9811,8 +10503,10 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep887 {
-				r.EncodeEnd()
+			if yyr887 || yy2arr887 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -9827,17 +10521,18 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct893 := r.ContainerType()
+		if yyct893 == codecSelferValueTypeMap1234 {
 			yyl893 := r.ReadMapStart()
 			if yyl893 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl893, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct893 == codecSelferValueTypeArray1234 {
 			yyl893 := r.ReadArrayStart()
 			if yyl893 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl893, d)
 			}
@@ -9864,8 +10559,10 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys894Slc = r.DecodeBytes(yys894Slc, true, true)
 		yys894 := string(yys894Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys894 {
 		case "backend":
 			if r.TryDecodeAsNil() {
@@ -9894,9 +10591,7 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys894)
 		} // end switch yys894
 	} // end for yyj894
-	if !yyhl894 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -9913,9 +10608,10 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb898 = r.CheckBreak()
 	}
 	if yyb898 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.Backend != nil {
 			x.Backend = nil
@@ -9933,9 +10629,10 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb898 = r.CheckBreak()
 	}
 	if yyb898 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
@@ -9957,9 +10654,10 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb898 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj898-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -9980,18 +10678,21 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep903, yyq903, yy2arr903
 			const yyr903 bool = false
 			yyq903[0] = true
+			var yynn903 int
 			if yyr903 || yy2arr903 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn903 int = 0
+				yynn903 = 0
 				for _, b := range yyq903 {
 					if b {
 						yynn903++
 					}
 				}
 				r.EncodeMapStart(yynn903)
+				yynn903 = 0
 			}
 			if yyr903 || yy2arr903 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq903[0] {
 					yy905 := &x.LoadBalancer
 					yy905.CodecEncodeSelf(e)
@@ -10000,13 +10701,17 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq903[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy906 := &x.LoadBalancer
 					yy906.CodecEncodeSelf(e)
 				}
 			}
-			if yysep903 {
-				r.EncodeEnd()
+			if yyr903 || yy2arr903 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10021,17 +10726,18 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct908 := r.ContainerType()
+		if yyct908 == codecSelferValueTypeMap1234 {
 			yyl908 := r.ReadMapStart()
 			if yyl908 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl908, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct908 == codecSelferValueTypeArray1234 {
 			yyl908 := r.ReadArrayStart()
 			if yyl908 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl908, d)
 			}
@@ -10058,8 +10764,10 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys909Slc = r.DecodeBytes(yys909Slc, true, true)
 		yys909 := string(yys909Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys909 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
@@ -10072,9 +10780,7 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys909)
 		} // end switch yys909
 	} // end for yyj909
-	if !yyhl909 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10091,9 +10797,10 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb911 = r.CheckBreak()
 	}
 	if yyb911 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_v1.LoadBalancerStatus{}
 	} else {
@@ -10110,9 +10817,10 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb911 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj911-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10134,18 +10842,21 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr914 bool = false
 			yyq914[0] = x.Host != ""
 			yyq914[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			var yynn914 int
 			if yyr914 || yy2arr914 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn914 int = 0
+				yynn914 = 0
 				for _, b := range yyq914 {
 					if b {
 						yynn914++
 					}
 				}
 				r.EncodeMapStart(yynn914)
+				yynn914 = 0
 			}
 			if yyr914 || yy2arr914 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq914[0] {
 					yym916 := z.EncBinary()
 					_ = yym916
@@ -10158,7 +10869,9 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq914[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym917 := z.EncBinary()
 					_ = yym917
 					if false {
@@ -10177,6 +10890,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 				if yyn918 {
 					r.EncodeNil()
 				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 					if yyq914[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
@@ -10189,7 +10903,9 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq914[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if yyn918 {
 						r.EncodeNil()
 					} else {
@@ -10201,8 +10917,10 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep914 {
-				r.EncodeEnd()
+			if yyr914 || yy2arr914 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10217,17 +10935,18 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct920 := r.ContainerType()
+		if yyct920 == codecSelferValueTypeMap1234 {
 			yyl920 := r.ReadMapStart()
 			if yyl920 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl920, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct920 == codecSelferValueTypeArray1234 {
 			yyl920 := r.ReadArrayStart()
 			if yyl920 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl920, d)
 			}
@@ -10254,8 +10973,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys921Slc = r.DecodeBytes(yys921Slc, true, true)
 		yys921 := string(yys921Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys921 {
 		case "host":
 			if r.TryDecodeAsNil() {
@@ -10281,9 +11002,7 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys921)
 		} // end switch yys921
 	} // end for yyj921
-	if !yyhl921 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10300,13 +11019,17 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb924 = r.CheckBreak()
 	}
 	if yyb924 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Host = ""
 	} else {
 		x.Host = string(r.DecodeString())
+	}
+	if x.IngressRuleValue.HTTP == nil {
+		x.IngressRuleValue.HTTP = new(HTTPIngressRuleValue)
 	}
 	yyj924++
 	if yyhl924 {
@@ -10315,9 +11038,10 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb924 = r.CheckBreak()
 	}
 	if yyb924 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HTTP != nil {
 			x.HTTP = nil
@@ -10338,9 +11062,10 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb924 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj924-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10361,18 +11086,21 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep928, yyq928, yy2arr928
 			const yyr928 bool = false
 			yyq928[0] = x.HTTP != nil
+			var yynn928 int
 			if yyr928 || yy2arr928 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn928 int = 0
+				yynn928 = 0
 				for _, b := range yyq928 {
 					if b {
 						yynn928++
 					}
 				}
 				r.EncodeMapStart(yynn928)
+				yynn928 = 0
 			}
 			if yyr928 || yy2arr928 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq928[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
@@ -10384,7 +11112,9 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq928[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -10392,8 +11122,10 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep928 {
-				r.EncodeEnd()
+			if yyr928 || yy2arr928 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10408,17 +11140,18 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct931 := r.ContainerType()
+		if yyct931 == codecSelferValueTypeMap1234 {
 			yyl931 := r.ReadMapStart()
 			if yyl931 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl931, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct931 == codecSelferValueTypeArray1234 {
 			yyl931 := r.ReadArrayStart()
 			if yyl931 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl931, d)
 			}
@@ -10445,8 +11178,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys932Slc = r.DecodeBytes(yys932Slc, true, true)
 		yys932 := string(yys932Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys932 {
 		case "http":
 			if r.TryDecodeAsNil() {
@@ -10463,9 +11198,7 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys932)
 		} // end switch yys932
 	} // end for yyj932
-	if !yyhl932 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10482,9 +11215,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb934 = r.CheckBreak()
 	}
 	if yyb934 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		if x.HTTP != nil {
 			x.HTTP = nil
@@ -10505,9 +11239,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if yyb934 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj934-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10527,18 +11262,21 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq937 [1]bool
 			_, _, _ = yysep937, yyq937, yy2arr937
 			const yyr937 bool = false
+			var yynn937 int
 			if yyr937 || yy2arr937 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn937 int = 1
+				yynn937 = 1
 				for _, b := range yyq937 {
 					if b {
 						yynn937++
 					}
 				}
 				r.EncodeMapStart(yynn937)
+				yynn937 = 0
 			}
 			if yyr937 || yy2arr937 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
@@ -10550,7 +11288,9 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("paths"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
@@ -10562,8 +11302,10 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep937 {
-				r.EncodeEnd()
+			if yyr937 || yy2arr937 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10578,17 +11320,18 @@ func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct942 := r.ContainerType()
+		if yyct942 == codecSelferValueTypeMap1234 {
 			yyl942 := r.ReadMapStart()
 			if yyl942 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl942, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct942 == codecSelferValueTypeArray1234 {
 			yyl942 := r.ReadArrayStart()
 			if yyl942 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl942, d)
 			}
@@ -10615,8 +11358,10 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys943Slc = r.DecodeBytes(yys943Slc, true, true)
 		yys943 := string(yys943Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys943 {
 		case "paths":
 			if r.TryDecodeAsNil() {
@@ -10634,9 +11379,7 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			z.DecStructFieldNotFound(-1, yys943)
 		} // end switch yys943
 	} // end for yyj943
-	if !yyhl943 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10653,9 +11396,10 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		yyb946 = r.CheckBreak()
 	}
 	if yyb946 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Paths = nil
 	} else {
@@ -10677,9 +11421,10 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		if yyb946 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj946-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10700,18 +11445,21 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep950, yyq950, yy2arr950
 			const yyr950 bool = false
 			yyq950[0] = x.Path != ""
+			var yynn950 int
 			if yyr950 || yy2arr950 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn950 int = 1
+				yynn950 = 1
 				for _, b := range yyq950 {
 					if b {
 						yynn950++
 					}
 				}
 				r.EncodeMapStart(yynn950)
+				yynn950 = 0
 			}
 			if yyr950 || yy2arr950 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq950[0] {
 					yym952 := z.EncBinary()
 					_ = yym952
@@ -10724,7 +11472,9 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq950[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym953 := z.EncBinary()
 					_ = yym953
 					if false {
@@ -10734,15 +11484,20 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr950 || yy2arr950 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy955 := &x.Backend
 				yy955.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("backend"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy956 := &x.Backend
 				yy956.CodecEncodeSelf(e)
 			}
-			if yysep950 {
-				r.EncodeEnd()
+			if yyr950 || yy2arr950 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10757,17 +11512,18 @@ func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct958 := r.ContainerType()
+		if yyct958 == codecSelferValueTypeMap1234 {
 			yyl958 := r.ReadMapStart()
 			if yyl958 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl958, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct958 == codecSelferValueTypeArray1234 {
 			yyl958 := r.ReadArrayStart()
 			if yyl958 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl958, d)
 			}
@@ -10794,8 +11550,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys959Slc = r.DecodeBytes(yys959Slc, true, true)
 		yys959 := string(yys959Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys959 {
 		case "path":
 			if r.TryDecodeAsNil() {
@@ -10814,9 +11572,7 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys959)
 		} // end switch yys959
 	} // end for yyj959
-	if !yyhl959 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -10833,9 +11589,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb962 = r.CheckBreak()
 	}
 	if yyb962 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -10848,9 +11605,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb962 = r.CheckBreak()
 	}
 	if yyb962 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Backend = IngressBackend{}
 	} else {
@@ -10867,9 +11625,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb962 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj962-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -10889,18 +11648,21 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq966 [2]bool
 			_, _, _ = yysep966, yyq966, yy2arr966
 			const yyr966 bool = false
+			var yynn966 int
 			if yyr966 || yy2arr966 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn966 int = 2
+				yynn966 = 2
 				for _, b := range yyq966 {
 					if b {
 						yynn966++
 					}
 				}
 				r.EncodeMapStart(yynn966)
+				yynn966 = 0
 			}
 			if yyr966 || yy2arr966 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym968 := z.EncBinary()
 				_ = yym968
 				if false {
@@ -10908,7 +11670,9 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym969 := z.EncBinary()
 				_ = yym969
 				if false {
@@ -10917,6 +11681,7 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr966 || yy2arr966 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy971 := &x.ServicePort
 				yym972 := z.EncBinary()
 				_ = yym972
@@ -10928,7 +11693,9 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy971)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy973 := &x.ServicePort
 				yym974 := z.EncBinary()
 				_ = yym974
@@ -10940,8 +11707,10 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy973)
 				}
 			}
-			if yysep966 {
-				r.EncodeEnd()
+			if yyr966 || yy2arr966 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -10956,17 +11725,18 @@ func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct976 := r.ContainerType()
+		if yyct976 == codecSelferValueTypeMap1234 {
 			yyl976 := r.ReadMapStart()
 			if yyl976 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl976, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct976 == codecSelferValueTypeArray1234 {
 			yyl976 := r.ReadArrayStart()
 			if yyl976 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl976, d)
 			}
@@ -10993,8 +11763,10 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys977Slc = r.DecodeBytes(yys977Slc, true, true)
 		yys977 := string(yys977Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys977 {
 		case "serviceName":
 			if r.TryDecodeAsNil() {
@@ -11021,9 +11793,7 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys977)
 		} // end switch yys977
 	} // end for yyj977
-	if !yyhl977 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11040,9 +11810,10 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb981 = r.CheckBreak()
 	}
 	if yyb981 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ServiceName = ""
 	} else {
@@ -11055,9 +11826,10 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb981 = r.CheckBreak()
 	}
 	if yyb981 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ServicePort = pkg6_intstr.IntOrString{}
 	} else {
@@ -11082,9 +11854,10 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb981 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj981-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11130,24 +11903,30 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq988 [2]bool
 			_, _, _ = yysep988, yyq988, yy2arr988
 			const yyr988 bool = false
+			var yynn988 int
 			if yyr988 || yy2arr988 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn988 int = 2
+				yynn988 = 2
 				for _, b := range yyq988 {
 					if b {
 						yynn988++
 					}
 				}
 				r.EncodeMapStart(yynn988)
+				yynn988 = 0
 			}
 			if yyr988 || yy2arr988 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Resource.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("resource"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Resource.CodecEncodeSelf(e)
 			}
 			if yyr988 || yy2arr988 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym991 := z.EncBinary()
 				_ = yym991
 				if false {
@@ -11155,7 +11934,9 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym992 := z.EncBinary()
 				_ = yym992
 				if false {
@@ -11163,8 +11944,10 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yysep988 {
-				r.EncodeEnd()
+			if yyr988 || yy2arr988 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11179,17 +11962,18 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct994 := r.ContainerType()
+		if yyct994 == codecSelferValueTypeMap1234 {
 			yyl994 := r.ReadMapStart()
 			if yyl994 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl994, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct994 == codecSelferValueTypeArray1234 {
 			yyl994 := r.ReadArrayStart()
 			if yyl994 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl994, d)
 			}
@@ -11216,8 +12000,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys995Slc = r.DecodeBytes(yys995Slc, true, true)
 		yys995 := string(yys995Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys995 {
 		case "resource":
 			if r.TryDecodeAsNil() {
@@ -11235,9 +12021,7 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys995)
 		} // end switch yys995
 	} // end for yyj995
-	if !yyhl995 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11254,9 +12038,10 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb998 = r.CheckBreak()
 	}
 	if yyb998 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Resource = ""
 	} else {
@@ -11269,9 +12054,10 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb998 = r.CheckBreak()
 	}
 	if yyb998 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Value = 0
 	} else {
@@ -11287,9 +12073,10 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb998 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj998-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11309,18 +12096,21 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1002 [3]bool
 			_, _, _ = yysep1002, yyq1002, yy2arr1002
 			const yyr1002 bool = false
+			var yynn1002 int
 			if yyr1002 || yy2arr1002 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1002 int = 3
+				yynn1002 = 3
 				for _, b := range yyq1002 {
 					if b {
 						yynn1002++
 					}
 				}
 				r.EncodeMapStart(yynn1002)
+				yynn1002 = 0
 			}
 			if yyr1002 || yy2arr1002 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1004 := z.EncBinary()
 				_ = yym1004
 				if false {
@@ -11328,7 +12118,9 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1005 := z.EncBinary()
 				_ = yym1005
 				if false {
@@ -11337,6 +12129,7 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1002 || yy2arr1002 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1007 := z.EncBinary()
 				_ = yym1007
 				if false {
@@ -11344,7 +12137,9 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1008 := z.EncBinary()
 				_ = yym1008
 				if false {
@@ -11353,6 +12148,7 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1002 || yy2arr1002 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
@@ -11364,7 +12160,9 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
@@ -11376,8 +12174,10 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1002 {
-				r.EncodeEnd()
+			if yyr1002 || yy2arr1002 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11392,17 +12192,18 @@ func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1013 := r.ContainerType()
+		if yyct1013 == codecSelferValueTypeMap1234 {
 			yyl1013 := r.ReadMapStart()
 			if yyl1013 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1013, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1013 == codecSelferValueTypeArray1234 {
 			yyl1013 := r.ReadArrayStart()
 			if yyl1013 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1013, d)
 			}
@@ -11429,8 +12230,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1014Slc = r.DecodeBytes(yys1014Slc, true, true)
 		yys1014 := string(yys1014Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1014 {
 		case "minNodes":
 			if r.TryDecodeAsNil() {
@@ -11460,9 +12263,7 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1014)
 		} // end switch yys1014
 	} // end for yyj1014
-	if !yyhl1014 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11479,9 +12280,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1019 = r.CheckBreak()
 	}
 	if yyb1019 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MinNodes = 0
 	} else {
@@ -11494,9 +12296,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1019 = r.CheckBreak()
 	}
 	if yyb1019 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MaxNodes = 0
 	} else {
@@ -11509,9 +12312,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1019 = r.CheckBreak()
 	}
 	if yyb1019 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.TargetUtilization = nil
 	} else {
@@ -11533,9 +12337,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1019 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1019-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11559,18 +12364,21 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1025[1] = x.APIVersion != ""
 			yyq1025[2] = true
 			yyq1025[3] = true
+			var yynn1025 int
 			if yyr1025 || yy2arr1025 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1025 int = 0
+				yynn1025 = 0
 				for _, b := range yyq1025 {
 					if b {
 						yynn1025++
 					}
 				}
 				r.EncodeMapStart(yynn1025)
+				yynn1025 = 0
 			}
 			if yyr1025 || yy2arr1025 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1025[0] {
 					yym1027 := z.EncBinary()
 					_ = yym1027
@@ -11583,7 +12391,9 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1025[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1028 := z.EncBinary()
 					_ = yym1028
 					if false {
@@ -11593,6 +12403,7 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1025 || yy2arr1025 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1025[1] {
 					yym1030 := z.EncBinary()
 					_ = yym1030
@@ -11605,7 +12416,9 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1025[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1031 := z.EncBinary()
 					_ = yym1031
 					if false {
@@ -11615,6 +12428,7 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1025 || yy2arr1025 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1025[2] {
 					yy1033 := &x.ObjectMeta
 					yy1033.CodecEncodeSelf(e)
@@ -11623,12 +12437,15 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1025[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1034 := &x.ObjectMeta
 					yy1034.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1025 || yy2arr1025 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1025[3] {
 					yy1036 := &x.Spec
 					yy1036.CodecEncodeSelf(e)
@@ -11637,13 +12454,17 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1025[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1037 := &x.Spec
 					yy1037.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1025 {
-				r.EncodeEnd()
+			if yyr1025 || yy2arr1025 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11658,17 +12479,18 @@ func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1039 := r.ContainerType()
+		if yyct1039 == codecSelferValueTypeMap1234 {
 			yyl1039 := r.ReadMapStart()
 			if yyl1039 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1039, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1039 == codecSelferValueTypeArray1234 {
 			yyl1039 := r.ReadArrayStart()
 			if yyl1039 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1039, d)
 			}
@@ -11695,8 +12517,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1040Slc = r.DecodeBytes(yys1040Slc, true, true)
 		yys1040 := string(yys1040Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1040 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -11728,9 +12552,7 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			z.DecStructFieldNotFound(-1, yys1040)
 		} // end switch yys1040
 	} // end for yyj1040
-	if !yyhl1040 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -11747,9 +12569,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb1045 = r.CheckBreak()
 	}
 	if yyb1045 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -11762,9 +12585,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb1045 = r.CheckBreak()
 	}
 	if yyb1045 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -11777,9 +12601,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb1045 = r.CheckBreak()
 	}
 	if yyb1045 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
@@ -11793,9 +12618,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		yyb1045 = r.CheckBreak()
 	}
 	if yyb1045 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Spec = ClusterAutoscalerSpec{}
 	} else {
@@ -11812,9 +12638,10 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if yyb1045 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1045-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -11837,18 +12664,21 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1051[0] = x.Kind != ""
 			yyq1051[1] = x.APIVersion != ""
 			yyq1051[2] = true
+			var yynn1051 int
 			if yyr1051 || yy2arr1051 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1051 int = 1
+				yynn1051 = 1
 				for _, b := range yyq1051 {
 					if b {
 						yynn1051++
 					}
 				}
 				r.EncodeMapStart(yynn1051)
+				yynn1051 = 0
 			}
 			if yyr1051 || yy2arr1051 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1051[0] {
 					yym1053 := z.EncBinary()
 					_ = yym1053
@@ -11861,7 +12691,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1051[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1054 := z.EncBinary()
 					_ = yym1054
 					if false {
@@ -11871,6 +12703,7 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1051 || yy2arr1051 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1051[1] {
 					yym1056 := z.EncBinary()
 					_ = yym1056
@@ -11883,7 +12716,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1051[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1057 := z.EncBinary()
 					_ = yym1057
 					if false {
@@ -11893,6 +12728,7 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1051 || yy2arr1051 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1051[2] {
 					yy1059 := &x.ListMeta
 					yym1060 := z.EncBinary()
@@ -11907,7 +12743,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1051[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy1061 := &x.ListMeta
 					yym1062 := z.EncBinary()
 					_ = yym1062
@@ -11919,6 +12757,7 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1051 || yy2arr1051 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -11930,7 +12769,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -11942,8 +12783,10 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1051 {
-				r.EncodeEnd()
+			if yyr1051 || yy2arr1051 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -11958,17 +12801,18 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1067 := r.ContainerType()
+		if yyct1067 == codecSelferValueTypeMap1234 {
 			yyl1067 := r.ReadMapStart()
 			if yyl1067 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1067, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1067 == codecSelferValueTypeArray1234 {
 			yyl1067 := r.ReadArrayStart()
 			if yyl1067 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1067, d)
 			}
@@ -11995,8 +12839,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1068Slc = r.DecodeBytes(yys1068Slc, true, true)
 		yys1068 := string(yys1068Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1068 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -12039,9 +12885,7 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			z.DecStructFieldNotFound(-1, yys1068)
 		} // end switch yys1068
 	} // end for yyj1068
-	if !yyhl1068 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12058,9 +12902,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1075 = r.CheckBreak()
 	}
 	if yyb1075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -12073,9 +12918,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1075 = r.CheckBreak()
 	}
 	if yyb1075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -12088,9 +12934,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1075 = r.CheckBreak()
 	}
 	if yyb1075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -12110,9 +12957,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		yyb1075 = r.CheckBreak()
 	}
 	if yyb1075 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -12134,9 +12982,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if yyb1075 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1075-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12158,18 +13007,21 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr1083 bool = false
 			yyq1083[0] = len(x.MatchLabels) != 0
 			yyq1083[1] = len(x.MatchExpressions) != 0
+			var yynn1083 int
 			if yyr1083 || yy2arr1083 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1083 int = 0
+				yynn1083 = 0
 				for _, b := range yyq1083 {
 					if b {
 						yynn1083++
 					}
 				}
 				r.EncodeMapStart(yynn1083)
+				yynn1083 = 0
 			}
 			if yyr1083 || yy2arr1083 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1083[0] {
 					if x.MatchLabels == nil {
 						r.EncodeNil()
@@ -12186,7 +13038,9 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1083[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
@@ -12200,6 +13054,7 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1083 || yy2arr1083 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1083[1] {
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
@@ -12216,7 +13071,9 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1083[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
@@ -12229,8 +13086,10 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1083 {
-				r.EncodeEnd()
+			if yyr1083 || yy2arr1083 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12245,17 +13104,18 @@ func (x *PodSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1091 := r.ContainerType()
+		if yyct1091 == codecSelferValueTypeMap1234 {
 			yyl1091 := r.ReadMapStart()
 			if yyl1091 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1091, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1091 == codecSelferValueTypeArray1234 {
 			yyl1091 := r.ReadArrayStart()
 			if yyl1091 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1091, d)
 			}
@@ -12282,8 +13142,10 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1092Slc = r.DecodeBytes(yys1092Slc, true, true)
 		yys1092 := string(yys1092Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1092 {
 		case "matchLabels":
 			if r.TryDecodeAsNil() {
@@ -12313,9 +13175,7 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys1092)
 		} // end switch yys1092
 	} // end for yyj1092
-	if !yyhl1092 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12332,9 +13192,10 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1097 = r.CheckBreak()
 	}
 	if yyb1097 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MatchLabels = nil
 	} else {
@@ -12353,9 +13214,10 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb1097 = r.CheckBreak()
 	}
 	if yyb1097 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.MatchExpressions = nil
 	} else {
@@ -12377,9 +13239,10 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb1097 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1097-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12400,18 +13263,21 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep1103, yyq1103, yy2arr1103
 			const yyr1103 bool = false
 			yyq1103[2] = len(x.Values) != 0
+			var yynn1103 int
 			if yyr1103 || yy2arr1103 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1103 int = 2
+				yynn1103 = 2
 				for _, b := range yyq1103 {
 					if b {
 						yynn1103++
 					}
 				}
 				r.EncodeMapStart(yynn1103)
+				yynn1103 = 0
 			}
 			if yyr1103 || yy2arr1103 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym1105 := z.EncBinary()
 				_ = yym1105
 				if false {
@@ -12419,7 +13285,9 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1106 := z.EncBinary()
 				_ = yym1106
 				if false {
@@ -12428,12 +13296,16 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1103 || yy2arr1103 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Operator.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("operator"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Operator.CodecEncodeSelf(e)
 			}
 			if yyr1103 || yy2arr1103 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1103[2] {
 					if x.Values == nil {
 						r.EncodeNil()
@@ -12450,7 +13322,9 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq1103[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("values"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
@@ -12463,8 +13337,10 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1103 {
-				r.EncodeEnd()
+			if yyr1103 || yy2arr1103 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -12479,17 +13355,18 @@ func (x *PodSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct1112 := r.ContainerType()
+		if yyct1112 == codecSelferValueTypeMap1234 {
 			yyl1112 := r.ReadMapStart()
 			if yyl1112 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl1112, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct1112 == codecSelferValueTypeArray1234 {
 			yyl1112 := r.ReadArrayStart()
 			if yyl1112 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl1112, d)
 			}
@@ -12516,8 +13393,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys1113Slc = r.DecodeBytes(yys1113Slc, true, true)
 		yys1113 := string(yys1113Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1113 {
 		case "key":
 			if r.TryDecodeAsNil() {
@@ -12547,9 +13426,7 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			z.DecStructFieldNotFound(-1, yys1113)
 		} // end switch yys1113
 	} // end for yyj1113
-	if !yyhl1113 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -12566,9 +13443,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb1118 = r.CheckBreak()
 	}
 	if yyb1118 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Key = ""
 	} else {
@@ -12581,9 +13459,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb1118 = r.CheckBreak()
 	}
 	if yyb1118 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Operator = ""
 	} else {
@@ -12596,9 +13475,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 		yyb1118 = r.CheckBreak()
 	}
 	if yyb1118 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Values = nil
 	} else {
@@ -12620,9 +13500,10 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if yyb1118 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj1118-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x PodSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -12657,10 +13538,11 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1125 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1126 := &yyv1125
 		yy1126.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutoscaler, d *codec1978.Decoder) {
@@ -12670,39 +13552,44 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 
 	yyv1127 := *v
 	yyh1127, yyl1127 := z.DecSliceHelperStart()
-
-	var yyrr1127, yyrl1127 int
-	var yyc1127, yyrt1127 bool
-	_, _, _ = yyc1127, yyrt1127, yyrl1127
-	yyrr1127 = yyl1127
-
-	if yyv1127 == nil {
-		if yyrl1127, yyrt1127 = z.DecInferLen(yyl1127, z.DecBasicHandle().MaxInitLen, 320); yyrt1127 {
-			yyrr1127 = yyrl1127
-		}
-		yyv1127 = make([]HorizontalPodAutoscaler, yyrl1127)
-		yyc1127 = true
-	}
-
+	var yyc1127 bool
 	if yyl1127 == 0 {
-		if len(yyv1127) != 0 {
+		if yyv1127 == nil {
+			yyv1127 = []HorizontalPodAutoscaler{}
+			yyc1127 = true
+		} else if len(yyv1127) != 0 {
 			yyv1127 = yyv1127[:0]
 			yyc1127 = true
 		}
 	} else if yyl1127 > 0 {
-
+		var yyrr1127, yyrl1127 int
+		var yyrt1127 bool
 		if yyl1127 > cap(yyv1127) {
-			yyrl1127, yyrt1127 = z.DecInferLen(yyl1127, z.DecBasicHandle().MaxInitLen, 320)
-			yyv1127 = make([]HorizontalPodAutoscaler, yyrl1127)
-			yyc1127 = true
 
+			yyrg1127 := len(yyv1127) > 0
+			yyv21127 := yyv1127
+			yyrl1127, yyrt1127 = z.DecInferLen(yyl1127, z.DecBasicHandle().MaxInitLen, 320)
+			if yyrt1127 {
+				if yyrl1127 <= cap(yyv1127) {
+					yyv1127 = yyv1127[:yyrl1127]
+				} else {
+					yyv1127 = make([]HorizontalPodAutoscaler, yyrl1127)
+				}
+			} else {
+				yyv1127 = make([]HorizontalPodAutoscaler, yyrl1127)
+			}
+			yyc1127 = true
 			yyrr1127 = len(yyv1127)
+			if yyrg1127 {
+				copy(yyv1127, yyv21127)
+			}
 		} else if yyl1127 != len(yyv1127) {
 			yyv1127 = yyv1127[:yyl1127]
 			yyc1127 = true
 		}
 		yyj1127 := 0
 		for ; yyj1127 < yyrr1127; yyj1127++ {
+			yyh1127.ElemContainerState(yyj1127)
 			if r.TryDecodeAsNil() {
 				yyv1127[yyj1127] = HorizontalPodAutoscaler{}
 			} else {
@@ -12714,6 +13601,7 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 		if yyrt1127 {
 			for ; yyj1127 < yyl1127; yyj1127++ {
 				yyv1127 = append(yyv1127, HorizontalPodAutoscaler{})
+				yyh1127.ElemContainerState(yyj1127)
 				if r.TryDecodeAsNil() {
 					yyv1127[yyj1127] = HorizontalPodAutoscaler{}
 				} else {
@@ -12725,12 +13613,14 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 		}
 
 	} else {
-		for yyj1127 := 0; !r.CheckBreak(); yyj1127++ {
+		yyj1127 := 0
+		for ; !r.CheckBreak(); yyj1127++ {
+
 			if yyj1127 >= len(yyv1127) {
 				yyv1127 = append(yyv1127, HorizontalPodAutoscaler{}) // var yyz1127 HorizontalPodAutoscaler
 				yyc1127 = true
 			}
-
+			yyh1127.ElemContainerState(yyj1127)
 			if yyj1127 < len(yyv1127) {
 				if r.TryDecodeAsNil() {
 					yyv1127[yyj1127] = HorizontalPodAutoscaler{}
@@ -12744,12 +13634,18 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		yyh1127.End()
+		if yyj1127 < len(yyv1127) {
+			yyv1127 = yyv1127[:yyj1127]
+			yyc1127 = true
+		} else if yyj1127 == 0 && yyv1127 == nil {
+			yyv1127 = []HorizontalPodAutoscaler{}
+			yyc1127 = true
+		}
 	}
+	yyh1127.End()
 	if yyc1127 {
 		*v = yyv1127
 	}
-
 }
 
 func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder) {
@@ -12758,10 +13654,11 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1131 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1132 := &yyv1131
 		yy1132.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decoder) {
@@ -12771,39 +13668,44 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 
 	yyv1133 := *v
 	yyh1133, yyl1133 := z.DecSliceHelperStart()
-
-	var yyrr1133, yyrl1133 int
-	var yyc1133, yyrt1133 bool
-	_, _, _ = yyc1133, yyrt1133, yyrl1133
-	yyrr1133 = yyl1133
-
-	if yyv1133 == nil {
-		if yyrl1133, yyrt1133 = z.DecInferLen(yyl1133, z.DecBasicHandle().MaxInitLen, 32); yyrt1133 {
-			yyrr1133 = yyrl1133
-		}
-		yyv1133 = make([]APIVersion, yyrl1133)
-		yyc1133 = true
-	}
-
+	var yyc1133 bool
 	if yyl1133 == 0 {
-		if len(yyv1133) != 0 {
+		if yyv1133 == nil {
+			yyv1133 = []APIVersion{}
+			yyc1133 = true
+		} else if len(yyv1133) != 0 {
 			yyv1133 = yyv1133[:0]
 			yyc1133 = true
 		}
 	} else if yyl1133 > 0 {
-
+		var yyrr1133, yyrl1133 int
+		var yyrt1133 bool
 		if yyl1133 > cap(yyv1133) {
-			yyrl1133, yyrt1133 = z.DecInferLen(yyl1133, z.DecBasicHandle().MaxInitLen, 32)
-			yyv1133 = make([]APIVersion, yyrl1133)
-			yyc1133 = true
 
+			yyrg1133 := len(yyv1133) > 0
+			yyv21133 := yyv1133
+			yyrl1133, yyrt1133 = z.DecInferLen(yyl1133, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt1133 {
+				if yyrl1133 <= cap(yyv1133) {
+					yyv1133 = yyv1133[:yyrl1133]
+				} else {
+					yyv1133 = make([]APIVersion, yyrl1133)
+				}
+			} else {
+				yyv1133 = make([]APIVersion, yyrl1133)
+			}
+			yyc1133 = true
 			yyrr1133 = len(yyv1133)
+			if yyrg1133 {
+				copy(yyv1133, yyv21133)
+			}
 		} else if yyl1133 != len(yyv1133) {
 			yyv1133 = yyv1133[:yyl1133]
 			yyc1133 = true
 		}
 		yyj1133 := 0
 		for ; yyj1133 < yyrr1133; yyj1133++ {
+			yyh1133.ElemContainerState(yyj1133)
 			if r.TryDecodeAsNil() {
 				yyv1133[yyj1133] = APIVersion{}
 			} else {
@@ -12815,6 +13717,7 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 		if yyrt1133 {
 			for ; yyj1133 < yyl1133; yyj1133++ {
 				yyv1133 = append(yyv1133, APIVersion{})
+				yyh1133.ElemContainerState(yyj1133)
 				if r.TryDecodeAsNil() {
 					yyv1133[yyj1133] = APIVersion{}
 				} else {
@@ -12826,12 +13729,14 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 		}
 
 	} else {
-		for yyj1133 := 0; !r.CheckBreak(); yyj1133++ {
+		yyj1133 := 0
+		for ; !r.CheckBreak(); yyj1133++ {
+
 			if yyj1133 >= len(yyv1133) {
 				yyv1133 = append(yyv1133, APIVersion{}) // var yyz1133 APIVersion
 				yyc1133 = true
 			}
-
+			yyh1133.ElemContainerState(yyj1133)
 			if yyj1133 < len(yyv1133) {
 				if r.TryDecodeAsNil() {
 					yyv1133[yyj1133] = APIVersion{}
@@ -12845,12 +13750,18 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		yyh1133.End()
+		if yyj1133 < len(yyv1133) {
+			yyv1133 = yyv1133[:yyj1133]
+			yyc1133 = true
+		} else if yyj1133 == 0 && yyv1133 == nil {
+			yyv1133 = []APIVersion{}
+			yyc1133 = true
+		}
 	}
+	yyh1133.End()
 	if yyc1133 {
 		*v = yyv1133
 	}
-
 }
 
 func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *codec1978.Encoder) {
@@ -12859,10 +13770,11 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1137 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1138 := &yyv1137
 		yy1138.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *codec1978.Decoder) {
@@ -12872,39 +13784,44 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 
 	yyv1139 := *v
 	yyh1139, yyl1139 := z.DecSliceHelperStart()
-
-	var yyrr1139, yyrl1139 int
-	var yyc1139, yyrt1139 bool
-	_, _, _ = yyc1139, yyrt1139, yyrl1139
-	yyrr1139 = yyl1139
-
-	if yyv1139 == nil {
-		if yyrl1139, yyrt1139 = z.DecInferLen(yyl1139, z.DecBasicHandle().MaxInitLen, 232); yyrt1139 {
-			yyrr1139 = yyrl1139
-		}
-		yyv1139 = make([]ThirdPartyResource, yyrl1139)
-		yyc1139 = true
-	}
-
+	var yyc1139 bool
 	if yyl1139 == 0 {
-		if len(yyv1139) != 0 {
+		if yyv1139 == nil {
+			yyv1139 = []ThirdPartyResource{}
+			yyc1139 = true
+		} else if len(yyv1139) != 0 {
 			yyv1139 = yyv1139[:0]
 			yyc1139 = true
 		}
 	} else if yyl1139 > 0 {
-
+		var yyrr1139, yyrl1139 int
+		var yyrt1139 bool
 		if yyl1139 > cap(yyv1139) {
-			yyrl1139, yyrt1139 = z.DecInferLen(yyl1139, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1139 = make([]ThirdPartyResource, yyrl1139)
-			yyc1139 = true
 
+			yyrg1139 := len(yyv1139) > 0
+			yyv21139 := yyv1139
+			yyrl1139, yyrt1139 = z.DecInferLen(yyl1139, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1139 {
+				if yyrl1139 <= cap(yyv1139) {
+					yyv1139 = yyv1139[:yyrl1139]
+				} else {
+					yyv1139 = make([]ThirdPartyResource, yyrl1139)
+				}
+			} else {
+				yyv1139 = make([]ThirdPartyResource, yyrl1139)
+			}
+			yyc1139 = true
 			yyrr1139 = len(yyv1139)
+			if yyrg1139 {
+				copy(yyv1139, yyv21139)
+			}
 		} else if yyl1139 != len(yyv1139) {
 			yyv1139 = yyv1139[:yyl1139]
 			yyc1139 = true
 		}
 		yyj1139 := 0
 		for ; yyj1139 < yyrr1139; yyj1139++ {
+			yyh1139.ElemContainerState(yyj1139)
 			if r.TryDecodeAsNil() {
 				yyv1139[yyj1139] = ThirdPartyResource{}
 			} else {
@@ -12916,6 +13833,7 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 		if yyrt1139 {
 			for ; yyj1139 < yyl1139; yyj1139++ {
 				yyv1139 = append(yyv1139, ThirdPartyResource{})
+				yyh1139.ElemContainerState(yyj1139)
 				if r.TryDecodeAsNil() {
 					yyv1139[yyj1139] = ThirdPartyResource{}
 				} else {
@@ -12927,12 +13845,14 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 		}
 
 	} else {
-		for yyj1139 := 0; !r.CheckBreak(); yyj1139++ {
+		yyj1139 := 0
+		for ; !r.CheckBreak(); yyj1139++ {
+
 			if yyj1139 >= len(yyv1139) {
 				yyv1139 = append(yyv1139, ThirdPartyResource{}) // var yyz1139 ThirdPartyResource
 				yyc1139 = true
 			}
-
+			yyh1139.ElemContainerState(yyj1139)
 			if yyj1139 < len(yyv1139) {
 				if r.TryDecodeAsNil() {
 					yyv1139[yyj1139] = ThirdPartyResource{}
@@ -12946,12 +13866,18 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		yyh1139.End()
+		if yyj1139 < len(yyv1139) {
+			yyv1139 = yyv1139[:yyj1139]
+			yyc1139 = true
+		} else if yyj1139 == 0 && yyv1139 == nil {
+			yyv1139 = []ThirdPartyResource{}
+			yyc1139 = true
+		}
 	}
+	yyh1139.End()
 	if yyc1139 {
 		*v = yyv1139
 	}
-
 }
 
 func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder) {
@@ -12960,10 +13886,11 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1143 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1144 := &yyv1143
 		yy1144.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decoder) {
@@ -12973,39 +13900,44 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 
 	yyv1145 := *v
 	yyh1145, yyl1145 := z.DecSliceHelperStart()
-
-	var yyrr1145, yyrl1145 int
-	var yyc1145, yyrt1145 bool
-	_, _, _ = yyc1145, yyrt1145, yyrl1145
-	yyrr1145 = yyl1145
-
-	if yyv1145 == nil {
-		if yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 608); yyrt1145 {
-			yyrr1145 = yyrl1145
-		}
-		yyv1145 = make([]Deployment, yyrl1145)
-		yyc1145 = true
-	}
-
+	var yyc1145 bool
 	if yyl1145 == 0 {
-		if len(yyv1145) != 0 {
+		if yyv1145 == nil {
+			yyv1145 = []Deployment{}
+			yyc1145 = true
+		} else if len(yyv1145) != 0 {
 			yyv1145 = yyv1145[:0]
 			yyc1145 = true
 		}
 	} else if yyl1145 > 0 {
-
+		var yyrr1145, yyrl1145 int
+		var yyrt1145 bool
 		if yyl1145 > cap(yyv1145) {
-			yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 608)
-			yyv1145 = make([]Deployment, yyrl1145)
-			yyc1145 = true
 
+			yyrg1145 := len(yyv1145) > 0
+			yyv21145 := yyv1145
+			yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 608)
+			if yyrt1145 {
+				if yyrl1145 <= cap(yyv1145) {
+					yyv1145 = yyv1145[:yyrl1145]
+				} else {
+					yyv1145 = make([]Deployment, yyrl1145)
+				}
+			} else {
+				yyv1145 = make([]Deployment, yyrl1145)
+			}
+			yyc1145 = true
 			yyrr1145 = len(yyv1145)
+			if yyrg1145 {
+				copy(yyv1145, yyv21145)
+			}
 		} else if yyl1145 != len(yyv1145) {
 			yyv1145 = yyv1145[:yyl1145]
 			yyc1145 = true
 		}
 		yyj1145 := 0
 		for ; yyj1145 < yyrr1145; yyj1145++ {
+			yyh1145.ElemContainerState(yyj1145)
 			if r.TryDecodeAsNil() {
 				yyv1145[yyj1145] = Deployment{}
 			} else {
@@ -13017,6 +13949,7 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 		if yyrt1145 {
 			for ; yyj1145 < yyl1145; yyj1145++ {
 				yyv1145 = append(yyv1145, Deployment{})
+				yyh1145.ElemContainerState(yyj1145)
 				if r.TryDecodeAsNil() {
 					yyv1145[yyj1145] = Deployment{}
 				} else {
@@ -13028,12 +13961,14 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 		}
 
 	} else {
-		for yyj1145 := 0; !r.CheckBreak(); yyj1145++ {
+		yyj1145 := 0
+		for ; !r.CheckBreak(); yyj1145++ {
+
 			if yyj1145 >= len(yyv1145) {
 				yyv1145 = append(yyv1145, Deployment{}) // var yyz1145 Deployment
 				yyc1145 = true
 			}
-
+			yyh1145.ElemContainerState(yyj1145)
 			if yyj1145 < len(yyv1145) {
 				if r.TryDecodeAsNil() {
 					yyv1145[yyj1145] = Deployment{}
@@ -13047,12 +13982,18 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		yyh1145.End()
+		if yyj1145 < len(yyv1145) {
+			yyv1145 = yyv1145[:yyj1145]
+			yyc1145 = true
+		} else if yyj1145 == 0 && yyv1145 == nil {
+			yyv1145 = []Deployment{}
+			yyc1145 = true
+		}
 	}
+	yyh1145.End()
 	if yyc1145 {
 		*v = yyv1145
 	}
-
 }
 
 func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) {
@@ -13061,10 +14002,11 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1149 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1150 := &yyv1149
 		yy1150.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder) {
@@ -13074,39 +14016,44 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 
 	yyv1151 := *v
 	yyh1151, yyl1151 := z.DecSliceHelperStart()
-
-	var yyrr1151, yyrl1151 int
-	var yyc1151, yyrt1151 bool
-	_, _, _ = yyc1151, yyrt1151, yyrl1151
-	yyrr1151 = yyl1151
-
-	if yyv1151 == nil {
-		if yyrl1151, yyrt1151 = z.DecInferLen(yyl1151, z.DecBasicHandle().MaxInitLen, 232); yyrt1151 {
-			yyrr1151 = yyrl1151
-		}
-		yyv1151 = make([]DaemonSet, yyrl1151)
-		yyc1151 = true
-	}
-
+	var yyc1151 bool
 	if yyl1151 == 0 {
-		if len(yyv1151) != 0 {
+		if yyv1151 == nil {
+			yyv1151 = []DaemonSet{}
+			yyc1151 = true
+		} else if len(yyv1151) != 0 {
 			yyv1151 = yyv1151[:0]
 			yyc1151 = true
 		}
 	} else if yyl1151 > 0 {
-
+		var yyrr1151, yyrl1151 int
+		var yyrt1151 bool
 		if yyl1151 > cap(yyv1151) {
-			yyrl1151, yyrt1151 = z.DecInferLen(yyl1151, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1151 = make([]DaemonSet, yyrl1151)
-			yyc1151 = true
 
+			yyrg1151 := len(yyv1151) > 0
+			yyv21151 := yyv1151
+			yyrl1151, yyrt1151 = z.DecInferLen(yyl1151, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1151 {
+				if yyrl1151 <= cap(yyv1151) {
+					yyv1151 = yyv1151[:yyrl1151]
+				} else {
+					yyv1151 = make([]DaemonSet, yyrl1151)
+				}
+			} else {
+				yyv1151 = make([]DaemonSet, yyrl1151)
+			}
+			yyc1151 = true
 			yyrr1151 = len(yyv1151)
+			if yyrg1151 {
+				copy(yyv1151, yyv21151)
+			}
 		} else if yyl1151 != len(yyv1151) {
 			yyv1151 = yyv1151[:yyl1151]
 			yyc1151 = true
 		}
 		yyj1151 := 0
 		for ; yyj1151 < yyrr1151; yyj1151++ {
+			yyh1151.ElemContainerState(yyj1151)
 			if r.TryDecodeAsNil() {
 				yyv1151[yyj1151] = DaemonSet{}
 			} else {
@@ -13118,6 +14065,7 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 		if yyrt1151 {
 			for ; yyj1151 < yyl1151; yyj1151++ {
 				yyv1151 = append(yyv1151, DaemonSet{})
+				yyh1151.ElemContainerState(yyj1151)
 				if r.TryDecodeAsNil() {
 					yyv1151[yyj1151] = DaemonSet{}
 				} else {
@@ -13129,12 +14077,14 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 		}
 
 	} else {
-		for yyj1151 := 0; !r.CheckBreak(); yyj1151++ {
+		yyj1151 := 0
+		for ; !r.CheckBreak(); yyj1151++ {
+
 			if yyj1151 >= len(yyv1151) {
 				yyv1151 = append(yyv1151, DaemonSet{}) // var yyz1151 DaemonSet
 				yyc1151 = true
 			}
-
+			yyh1151.ElemContainerState(yyj1151)
 			if yyj1151 < len(yyv1151) {
 				if r.TryDecodeAsNil() {
 					yyv1151[yyj1151] = DaemonSet{}
@@ -13148,12 +14098,18 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		yyh1151.End()
+		if yyj1151 < len(yyv1151) {
+			yyv1151 = yyv1151[:yyj1151]
+			yyc1151 = true
+		} else if yyj1151 == 0 && yyv1151 == nil {
+			yyv1151 = []DaemonSet{}
+			yyc1151 = true
+		}
 	}
+	yyh1151.End()
 	if yyc1151 {
 		*v = yyv1151
 	}
-
 }
 
 func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceData, e *codec1978.Encoder) {
@@ -13162,10 +14118,11 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1155 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1156 := &yyv1155
 		yy1156.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceData, d *codec1978.Decoder) {
@@ -13175,39 +14132,44 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 
 	yyv1157 := *v
 	yyh1157, yyl1157 := z.DecSliceHelperStart()
-
-	var yyrr1157, yyrl1157 int
-	var yyc1157, yyrt1157 bool
-	_, _, _ = yyc1157, yyrt1157, yyrl1157
-	yyrr1157 = yyl1157
-
-	if yyv1157 == nil {
-		if yyrl1157, yyrt1157 = z.DecInferLen(yyl1157, z.DecBasicHandle().MaxInitLen, 216); yyrt1157 {
-			yyrr1157 = yyrl1157
-		}
-		yyv1157 = make([]ThirdPartyResourceData, yyrl1157)
-		yyc1157 = true
-	}
-
+	var yyc1157 bool
 	if yyl1157 == 0 {
-		if len(yyv1157) != 0 {
+		if yyv1157 == nil {
+			yyv1157 = []ThirdPartyResourceData{}
+			yyc1157 = true
+		} else if len(yyv1157) != 0 {
 			yyv1157 = yyv1157[:0]
 			yyc1157 = true
 		}
 	} else if yyl1157 > 0 {
-
+		var yyrr1157, yyrl1157 int
+		var yyrt1157 bool
 		if yyl1157 > cap(yyv1157) {
-			yyrl1157, yyrt1157 = z.DecInferLen(yyl1157, z.DecBasicHandle().MaxInitLen, 216)
-			yyv1157 = make([]ThirdPartyResourceData, yyrl1157)
-			yyc1157 = true
 
+			yyrg1157 := len(yyv1157) > 0
+			yyv21157 := yyv1157
+			yyrl1157, yyrt1157 = z.DecInferLen(yyl1157, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt1157 {
+				if yyrl1157 <= cap(yyv1157) {
+					yyv1157 = yyv1157[:yyrl1157]
+				} else {
+					yyv1157 = make([]ThirdPartyResourceData, yyrl1157)
+				}
+			} else {
+				yyv1157 = make([]ThirdPartyResourceData, yyrl1157)
+			}
+			yyc1157 = true
 			yyrr1157 = len(yyv1157)
+			if yyrg1157 {
+				copy(yyv1157, yyv21157)
+			}
 		} else if yyl1157 != len(yyv1157) {
 			yyv1157 = yyv1157[:yyl1157]
 			yyc1157 = true
 		}
 		yyj1157 := 0
 		for ; yyj1157 < yyrr1157; yyj1157++ {
+			yyh1157.ElemContainerState(yyj1157)
 			if r.TryDecodeAsNil() {
 				yyv1157[yyj1157] = ThirdPartyResourceData{}
 			} else {
@@ -13219,6 +14181,7 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 		if yyrt1157 {
 			for ; yyj1157 < yyl1157; yyj1157++ {
 				yyv1157 = append(yyv1157, ThirdPartyResourceData{})
+				yyh1157.ElemContainerState(yyj1157)
 				if r.TryDecodeAsNil() {
 					yyv1157[yyj1157] = ThirdPartyResourceData{}
 				} else {
@@ -13230,12 +14193,14 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 		}
 
 	} else {
-		for yyj1157 := 0; !r.CheckBreak(); yyj1157++ {
+		yyj1157 := 0
+		for ; !r.CheckBreak(); yyj1157++ {
+
 			if yyj1157 >= len(yyv1157) {
 				yyv1157 = append(yyv1157, ThirdPartyResourceData{}) // var yyz1157 ThirdPartyResourceData
 				yyc1157 = true
 			}
-
+			yyh1157.ElemContainerState(yyj1157)
 			if yyj1157 < len(yyv1157) {
 				if r.TryDecodeAsNil() {
 					yyv1157[yyj1157] = ThirdPartyResourceData{}
@@ -13249,12 +14214,18 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		yyh1157.End()
+		if yyj1157 < len(yyv1157) {
+			yyv1157 = yyv1157[:yyj1157]
+			yyc1157 = true
+		} else if yyj1157 == 0 && yyv1157 == nil {
+			yyv1157 = []ThirdPartyResourceData{}
+			yyc1157 = true
+		}
 	}
+	yyh1157.End()
 	if yyc1157 {
 		*v = yyv1157
 	}
-
 }
 
 func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
@@ -13263,10 +14234,11 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1161 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1162 := &yyv1161
 		yy1162.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
@@ -13276,39 +14248,44 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 
 	yyv1163 := *v
 	yyh1163, yyl1163 := z.DecSliceHelperStart()
-
-	var yyrr1163, yyrl1163 int
-	var yyc1163, yyrt1163 bool
-	_, _, _ = yyc1163, yyrt1163, yyrl1163
-	yyrr1163 = yyl1163
-
-	if yyv1163 == nil {
-		if yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 632); yyrt1163 {
-			yyrr1163 = yyrl1163
-		}
-		yyv1163 = make([]Job, yyrl1163)
-		yyc1163 = true
-	}
-
+	var yyc1163 bool
 	if yyl1163 == 0 {
-		if len(yyv1163) != 0 {
+		if yyv1163 == nil {
+			yyv1163 = []Job{}
+			yyc1163 = true
+		} else if len(yyv1163) != 0 {
 			yyv1163 = yyv1163[:0]
 			yyc1163 = true
 		}
 	} else if yyl1163 > 0 {
-
+		var yyrr1163, yyrl1163 int
+		var yyrt1163 bool
 		if yyl1163 > cap(yyv1163) {
-			yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 632)
-			yyv1163 = make([]Job, yyrl1163)
-			yyc1163 = true
 
+			yyrg1163 := len(yyv1163) > 0
+			yyv21163 := yyv1163
+			yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 632)
+			if yyrt1163 {
+				if yyrl1163 <= cap(yyv1163) {
+					yyv1163 = yyv1163[:yyrl1163]
+				} else {
+					yyv1163 = make([]Job, yyrl1163)
+				}
+			} else {
+				yyv1163 = make([]Job, yyrl1163)
+			}
+			yyc1163 = true
 			yyrr1163 = len(yyv1163)
+			if yyrg1163 {
+				copy(yyv1163, yyv21163)
+			}
 		} else if yyl1163 != len(yyv1163) {
 			yyv1163 = yyv1163[:yyl1163]
 			yyc1163 = true
 		}
 		yyj1163 := 0
 		for ; yyj1163 < yyrr1163; yyj1163++ {
+			yyh1163.ElemContainerState(yyj1163)
 			if r.TryDecodeAsNil() {
 				yyv1163[yyj1163] = Job{}
 			} else {
@@ -13320,6 +14297,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 		if yyrt1163 {
 			for ; yyj1163 < yyl1163; yyj1163++ {
 				yyv1163 = append(yyv1163, Job{})
+				yyh1163.ElemContainerState(yyj1163)
 				if r.TryDecodeAsNil() {
 					yyv1163[yyj1163] = Job{}
 				} else {
@@ -13331,12 +14309,14 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj1163 := 0; !r.CheckBreak(); yyj1163++ {
+		yyj1163 := 0
+		for ; !r.CheckBreak(); yyj1163++ {
+
 			if yyj1163 >= len(yyv1163) {
 				yyv1163 = append(yyv1163, Job{}) // var yyz1163 Job
 				yyc1163 = true
 			}
-
+			yyh1163.ElemContainerState(yyj1163)
 			if yyj1163 < len(yyv1163) {
 				if r.TryDecodeAsNil() {
 					yyv1163[yyj1163] = Job{}
@@ -13350,12 +14330,18 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1163.End()
+		if yyj1163 < len(yyv1163) {
+			yyv1163 = yyv1163[:yyj1163]
+			yyc1163 = true
+		} else if yyj1163 == 0 && yyv1163 == nil {
+			yyv1163 = []Job{}
+			yyc1163 = true
+		}
 	}
+	yyh1163.End()
 	if yyc1163 {
 		*v = yyv1163
 	}
-
 }
 
 func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Encoder) {
@@ -13364,10 +14350,11 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1167 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1168 := &yyv1167
 		yy1168.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.Decoder) {
@@ -13377,39 +14364,44 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 
 	yyv1169 := *v
 	yyh1169, yyl1169 := z.DecSliceHelperStart()
-
-	var yyrr1169, yyrl1169 int
-	var yyc1169, yyrt1169 bool
-	_, _, _ = yyc1169, yyrt1169, yyrl1169
-	yyrr1169 = yyl1169
-
-	if yyv1169 == nil {
-		if yyrl1169, yyrt1169 = z.DecInferLen(yyl1169, z.DecBasicHandle().MaxInitLen, 112); yyrt1169 {
-			yyrr1169 = yyrl1169
-		}
-		yyv1169 = make([]JobCondition, yyrl1169)
-		yyc1169 = true
-	}
-
+	var yyc1169 bool
 	if yyl1169 == 0 {
-		if len(yyv1169) != 0 {
+		if yyv1169 == nil {
+			yyv1169 = []JobCondition{}
+			yyc1169 = true
+		} else if len(yyv1169) != 0 {
 			yyv1169 = yyv1169[:0]
 			yyc1169 = true
 		}
 	} else if yyl1169 > 0 {
-
+		var yyrr1169, yyrl1169 int
+		var yyrt1169 bool
 		if yyl1169 > cap(yyv1169) {
-			yyrl1169, yyrt1169 = z.DecInferLen(yyl1169, z.DecBasicHandle().MaxInitLen, 112)
-			yyv1169 = make([]JobCondition, yyrl1169)
-			yyc1169 = true
 
+			yyrg1169 := len(yyv1169) > 0
+			yyv21169 := yyv1169
+			yyrl1169, yyrt1169 = z.DecInferLen(yyl1169, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt1169 {
+				if yyrl1169 <= cap(yyv1169) {
+					yyv1169 = yyv1169[:yyrl1169]
+				} else {
+					yyv1169 = make([]JobCondition, yyrl1169)
+				}
+			} else {
+				yyv1169 = make([]JobCondition, yyrl1169)
+			}
+			yyc1169 = true
 			yyrr1169 = len(yyv1169)
+			if yyrg1169 {
+				copy(yyv1169, yyv21169)
+			}
 		} else if yyl1169 != len(yyv1169) {
 			yyv1169 = yyv1169[:yyl1169]
 			yyc1169 = true
 		}
 		yyj1169 := 0
 		for ; yyj1169 < yyrr1169; yyj1169++ {
+			yyh1169.ElemContainerState(yyj1169)
 			if r.TryDecodeAsNil() {
 				yyv1169[yyj1169] = JobCondition{}
 			} else {
@@ -13421,6 +14413,7 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 		if yyrt1169 {
 			for ; yyj1169 < yyl1169; yyj1169++ {
 				yyv1169 = append(yyv1169, JobCondition{})
+				yyh1169.ElemContainerState(yyj1169)
 				if r.TryDecodeAsNil() {
 					yyv1169[yyj1169] = JobCondition{}
 				} else {
@@ -13432,12 +14425,14 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 		}
 
 	} else {
-		for yyj1169 := 0; !r.CheckBreak(); yyj1169++ {
+		yyj1169 := 0
+		for ; !r.CheckBreak(); yyj1169++ {
+
 			if yyj1169 >= len(yyv1169) {
 				yyv1169 = append(yyv1169, JobCondition{}) // var yyz1169 JobCondition
 				yyc1169 = true
 			}
-
+			yyh1169.ElemContainerState(yyj1169)
 			if yyj1169 < len(yyv1169) {
 				if r.TryDecodeAsNil() {
 					yyv1169[yyj1169] = JobCondition{}
@@ -13451,12 +14446,18 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		yyh1169.End()
+		if yyj1169 < len(yyv1169) {
+			yyv1169 = yyv1169[:yyj1169]
+			yyc1169 = true
+		} else if yyj1169 == 0 && yyv1169 == nil {
+			yyv1169 = []JobCondition{}
+			yyc1169 = true
+		}
 	}
+	yyh1169.End()
 	if yyc1169 {
 		*v = yyv1169
 	}
-
 }
 
 func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
@@ -13465,10 +14466,11 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1173 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1174 := &yyv1173
 		yy1174.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
@@ -13478,39 +14480,44 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 
 	yyv1175 := *v
 	yyh1175, yyl1175 := z.DecSliceHelperStart()
-
-	var yyrr1175, yyrl1175 int
-	var yyc1175, yyrt1175 bool
-	_, _, _ = yyc1175, yyrt1175, yyrl1175
-	yyrr1175 = yyl1175
-
-	if yyv1175 == nil {
-		if yyrl1175, yyrt1175 = z.DecInferLen(yyl1175, z.DecBasicHandle().MaxInitLen, 248); yyrt1175 {
-			yyrr1175 = yyrl1175
-		}
-		yyv1175 = make([]Ingress, yyrl1175)
-		yyc1175 = true
-	}
-
+	var yyc1175 bool
 	if yyl1175 == 0 {
-		if len(yyv1175) != 0 {
+		if yyv1175 == nil {
+			yyv1175 = []Ingress{}
+			yyc1175 = true
+		} else if len(yyv1175) != 0 {
 			yyv1175 = yyv1175[:0]
 			yyc1175 = true
 		}
 	} else if yyl1175 > 0 {
-
+		var yyrr1175, yyrl1175 int
+		var yyrt1175 bool
 		if yyl1175 > cap(yyv1175) {
-			yyrl1175, yyrt1175 = z.DecInferLen(yyl1175, z.DecBasicHandle().MaxInitLen, 248)
-			yyv1175 = make([]Ingress, yyrl1175)
-			yyc1175 = true
 
+			yyrg1175 := len(yyv1175) > 0
+			yyv21175 := yyv1175
+			yyrl1175, yyrt1175 = z.DecInferLen(yyl1175, z.DecBasicHandle().MaxInitLen, 248)
+			if yyrt1175 {
+				if yyrl1175 <= cap(yyv1175) {
+					yyv1175 = yyv1175[:yyrl1175]
+				} else {
+					yyv1175 = make([]Ingress, yyrl1175)
+				}
+			} else {
+				yyv1175 = make([]Ingress, yyrl1175)
+			}
+			yyc1175 = true
 			yyrr1175 = len(yyv1175)
+			if yyrg1175 {
+				copy(yyv1175, yyv21175)
+			}
 		} else if yyl1175 != len(yyv1175) {
 			yyv1175 = yyv1175[:yyl1175]
 			yyc1175 = true
 		}
 		yyj1175 := 0
 		for ; yyj1175 < yyrr1175; yyj1175++ {
+			yyh1175.ElemContainerState(yyj1175)
 			if r.TryDecodeAsNil() {
 				yyv1175[yyj1175] = Ingress{}
 			} else {
@@ -13522,6 +14529,7 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 		if yyrt1175 {
 			for ; yyj1175 < yyl1175; yyj1175++ {
 				yyv1175 = append(yyv1175, Ingress{})
+				yyh1175.ElemContainerState(yyj1175)
 				if r.TryDecodeAsNil() {
 					yyv1175[yyj1175] = Ingress{}
 				} else {
@@ -13533,12 +14541,14 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj1175 := 0; !r.CheckBreak(); yyj1175++ {
+		yyj1175 := 0
+		for ; !r.CheckBreak(); yyj1175++ {
+
 			if yyj1175 >= len(yyv1175) {
 				yyv1175 = append(yyv1175, Ingress{}) // var yyz1175 Ingress
 				yyc1175 = true
 			}
-
+			yyh1175.ElemContainerState(yyj1175)
 			if yyj1175 < len(yyv1175) {
 				if r.TryDecodeAsNil() {
 					yyv1175[yyj1175] = Ingress{}
@@ -13552,12 +14562,18 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1175.End()
+		if yyj1175 < len(yyv1175) {
+			yyv1175 = yyv1175[:yyj1175]
+			yyc1175 = true
+		} else if yyj1175 == 0 && yyv1175 == nil {
+			yyv1175 = []Ingress{}
+			yyc1175 = true
+		}
 	}
+	yyh1175.End()
 	if yyc1175 {
 		*v = yyv1175
 	}
-
 }
 
 func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encoder) {
@@ -13566,10 +14582,11 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1179 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1180 := &yyv1179
 		yy1180.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Decoder) {
@@ -13579,39 +14596,44 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 
 	yyv1181 := *v
 	yyh1181, yyl1181 := z.DecSliceHelperStart()
-
-	var yyrr1181, yyrl1181 int
-	var yyc1181, yyrt1181 bool
-	_, _, _ = yyc1181, yyrt1181, yyrl1181
-	yyrr1181 = yyl1181
-
-	if yyv1181 == nil {
-		if yyrl1181, yyrt1181 = z.DecInferLen(yyl1181, z.DecBasicHandle().MaxInitLen, 24); yyrt1181 {
-			yyrr1181 = yyrl1181
-		}
-		yyv1181 = make([]IngressRule, yyrl1181)
-		yyc1181 = true
-	}
-
+	var yyc1181 bool
 	if yyl1181 == 0 {
-		if len(yyv1181) != 0 {
+		if yyv1181 == nil {
+			yyv1181 = []IngressRule{}
+			yyc1181 = true
+		} else if len(yyv1181) != 0 {
 			yyv1181 = yyv1181[:0]
 			yyc1181 = true
 		}
 	} else if yyl1181 > 0 {
-
+		var yyrr1181, yyrl1181 int
+		var yyrt1181 bool
 		if yyl1181 > cap(yyv1181) {
-			yyrl1181, yyrt1181 = z.DecInferLen(yyl1181, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1181 = make([]IngressRule, yyrl1181)
-			yyc1181 = true
 
+			yyrg1181 := len(yyv1181) > 0
+			yyv21181 := yyv1181
+			yyrl1181, yyrt1181 = z.DecInferLen(yyl1181, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1181 {
+				if yyrl1181 <= cap(yyv1181) {
+					yyv1181 = yyv1181[:yyrl1181]
+				} else {
+					yyv1181 = make([]IngressRule, yyrl1181)
+				}
+			} else {
+				yyv1181 = make([]IngressRule, yyrl1181)
+			}
+			yyc1181 = true
 			yyrr1181 = len(yyv1181)
+			if yyrg1181 {
+				copy(yyv1181, yyv21181)
+			}
 		} else if yyl1181 != len(yyv1181) {
 			yyv1181 = yyv1181[:yyl1181]
 			yyc1181 = true
 		}
 		yyj1181 := 0
 		for ; yyj1181 < yyrr1181; yyj1181++ {
+			yyh1181.ElemContainerState(yyj1181)
 			if r.TryDecodeAsNil() {
 				yyv1181[yyj1181] = IngressRule{}
 			} else {
@@ -13623,6 +14645,7 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 		if yyrt1181 {
 			for ; yyj1181 < yyl1181; yyj1181++ {
 				yyv1181 = append(yyv1181, IngressRule{})
+				yyh1181.ElemContainerState(yyj1181)
 				if r.TryDecodeAsNil() {
 					yyv1181[yyj1181] = IngressRule{}
 				} else {
@@ -13634,12 +14657,14 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 		}
 
 	} else {
-		for yyj1181 := 0; !r.CheckBreak(); yyj1181++ {
+		yyj1181 := 0
+		for ; !r.CheckBreak(); yyj1181++ {
+
 			if yyj1181 >= len(yyv1181) {
 				yyv1181 = append(yyv1181, IngressRule{}) // var yyz1181 IngressRule
 				yyc1181 = true
 			}
-
+			yyh1181.ElemContainerState(yyj1181)
 			if yyj1181 < len(yyv1181) {
 				if r.TryDecodeAsNil() {
 					yyv1181[yyj1181] = IngressRule{}
@@ -13653,12 +14678,18 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		yyh1181.End()
+		if yyj1181 < len(yyv1181) {
+			yyv1181 = yyv1181[:yyj1181]
+			yyc1181 = true
+		} else if yyj1181 == 0 && yyv1181 == nil {
+			yyv1181 = []IngressRule{}
+			yyc1181 = true
+		}
 	}
+	yyh1181.End()
 	if yyc1181 {
 		*v = yyv1181
 	}
-
 }
 
 func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec1978.Encoder) {
@@ -13667,10 +14698,11 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1185 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1186 := &yyv1185
 		yy1186.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1978.Decoder) {
@@ -13680,39 +14712,44 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 
 	yyv1187 := *v
 	yyh1187, yyl1187 := z.DecSliceHelperStart()
-
-	var yyrr1187, yyrl1187 int
-	var yyc1187, yyrt1187 bool
-	_, _, _ = yyc1187, yyrt1187, yyrl1187
-	yyrr1187 = yyl1187
-
-	if yyv1187 == nil {
-		if yyrl1187, yyrt1187 = z.DecInferLen(yyl1187, z.DecBasicHandle().MaxInitLen, 64); yyrt1187 {
-			yyrr1187 = yyrl1187
-		}
-		yyv1187 = make([]HTTPIngressPath, yyrl1187)
-		yyc1187 = true
-	}
-
+	var yyc1187 bool
 	if yyl1187 == 0 {
-		if len(yyv1187) != 0 {
+		if yyv1187 == nil {
+			yyv1187 = []HTTPIngressPath{}
+			yyc1187 = true
+		} else if len(yyv1187) != 0 {
 			yyv1187 = yyv1187[:0]
 			yyc1187 = true
 		}
 	} else if yyl1187 > 0 {
-
+		var yyrr1187, yyrl1187 int
+		var yyrt1187 bool
 		if yyl1187 > cap(yyv1187) {
-			yyrl1187, yyrt1187 = z.DecInferLen(yyl1187, z.DecBasicHandle().MaxInitLen, 64)
-			yyv1187 = make([]HTTPIngressPath, yyrl1187)
-			yyc1187 = true
 
+			yyrg1187 := len(yyv1187) > 0
+			yyv21187 := yyv1187
+			yyrl1187, yyrt1187 = z.DecInferLen(yyl1187, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt1187 {
+				if yyrl1187 <= cap(yyv1187) {
+					yyv1187 = yyv1187[:yyrl1187]
+				} else {
+					yyv1187 = make([]HTTPIngressPath, yyrl1187)
+				}
+			} else {
+				yyv1187 = make([]HTTPIngressPath, yyrl1187)
+			}
+			yyc1187 = true
 			yyrr1187 = len(yyv1187)
+			if yyrg1187 {
+				copy(yyv1187, yyv21187)
+			}
 		} else if yyl1187 != len(yyv1187) {
 			yyv1187 = yyv1187[:yyl1187]
 			yyc1187 = true
 		}
 		yyj1187 := 0
 		for ; yyj1187 < yyrr1187; yyj1187++ {
+			yyh1187.ElemContainerState(yyj1187)
 			if r.TryDecodeAsNil() {
 				yyv1187[yyj1187] = HTTPIngressPath{}
 			} else {
@@ -13724,6 +14761,7 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		if yyrt1187 {
 			for ; yyj1187 < yyl1187; yyj1187++ {
 				yyv1187 = append(yyv1187, HTTPIngressPath{})
+				yyh1187.ElemContainerState(yyj1187)
 				if r.TryDecodeAsNil() {
 					yyv1187[yyj1187] = HTTPIngressPath{}
 				} else {
@@ -13735,12 +14773,14 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 		}
 
 	} else {
-		for yyj1187 := 0; !r.CheckBreak(); yyj1187++ {
+		yyj1187 := 0
+		for ; !r.CheckBreak(); yyj1187++ {
+
 			if yyj1187 >= len(yyv1187) {
 				yyv1187 = append(yyv1187, HTTPIngressPath{}) // var yyz1187 HTTPIngressPath
 				yyc1187 = true
 			}
-
+			yyh1187.ElemContainerState(yyj1187)
 			if yyj1187 < len(yyv1187) {
 				if r.TryDecodeAsNil() {
 					yyv1187[yyj1187] = HTTPIngressPath{}
@@ -13754,12 +14794,18 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		yyh1187.End()
+		if yyj1187 < len(yyv1187) {
+			yyv1187 = yyv1187[:yyj1187]
+			yyc1187 = true
+		} else if yyj1187 == 0 && yyv1187 == nil {
+			yyv1187 = []HTTPIngressPath{}
+			yyc1187 = true
+		}
 	}
+	yyh1187.End()
 	if yyc1187 {
 		*v = yyv1187
 	}
-
 }
 
 func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec1978.Encoder) {
@@ -13768,10 +14814,11 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1191 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1192 := &yyv1191
 		yy1192.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1978.Decoder) {
@@ -13781,39 +14828,44 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 
 	yyv1193 := *v
 	yyh1193, yyl1193 := z.DecSliceHelperStart()
-
-	var yyrr1193, yyrl1193 int
-	var yyc1193, yyrt1193 bool
-	_, _, _ = yyc1193, yyrt1193, yyrl1193
-	yyrr1193 = yyl1193
-
-	if yyv1193 == nil {
-		if yyrl1193, yyrt1193 = z.DecInferLen(yyl1193, z.DecBasicHandle().MaxInitLen, 24); yyrt1193 {
-			yyrr1193 = yyrl1193
-		}
-		yyv1193 = make([]NodeUtilization, yyrl1193)
-		yyc1193 = true
-	}
-
+	var yyc1193 bool
 	if yyl1193 == 0 {
-		if len(yyv1193) != 0 {
+		if yyv1193 == nil {
+			yyv1193 = []NodeUtilization{}
+			yyc1193 = true
+		} else if len(yyv1193) != 0 {
 			yyv1193 = yyv1193[:0]
 			yyc1193 = true
 		}
 	} else if yyl1193 > 0 {
-
+		var yyrr1193, yyrl1193 int
+		var yyrt1193 bool
 		if yyl1193 > cap(yyv1193) {
-			yyrl1193, yyrt1193 = z.DecInferLen(yyl1193, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1193 = make([]NodeUtilization, yyrl1193)
-			yyc1193 = true
 
+			yyrg1193 := len(yyv1193) > 0
+			yyv21193 := yyv1193
+			yyrl1193, yyrt1193 = z.DecInferLen(yyl1193, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1193 {
+				if yyrl1193 <= cap(yyv1193) {
+					yyv1193 = yyv1193[:yyrl1193]
+				} else {
+					yyv1193 = make([]NodeUtilization, yyrl1193)
+				}
+			} else {
+				yyv1193 = make([]NodeUtilization, yyrl1193)
+			}
+			yyc1193 = true
 			yyrr1193 = len(yyv1193)
+			if yyrg1193 {
+				copy(yyv1193, yyv21193)
+			}
 		} else if yyl1193 != len(yyv1193) {
 			yyv1193 = yyv1193[:yyl1193]
 			yyc1193 = true
 		}
 		yyj1193 := 0
 		for ; yyj1193 < yyrr1193; yyj1193++ {
+			yyh1193.ElemContainerState(yyj1193)
 			if r.TryDecodeAsNil() {
 				yyv1193[yyj1193] = NodeUtilization{}
 			} else {
@@ -13825,6 +14877,7 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		if yyrt1193 {
 			for ; yyj1193 < yyl1193; yyj1193++ {
 				yyv1193 = append(yyv1193, NodeUtilization{})
+				yyh1193.ElemContainerState(yyj1193)
 				if r.TryDecodeAsNil() {
 					yyv1193[yyj1193] = NodeUtilization{}
 				} else {
@@ -13836,12 +14889,14 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 		}
 
 	} else {
-		for yyj1193 := 0; !r.CheckBreak(); yyj1193++ {
+		yyj1193 := 0
+		for ; !r.CheckBreak(); yyj1193++ {
+
 			if yyj1193 >= len(yyv1193) {
 				yyv1193 = append(yyv1193, NodeUtilization{}) // var yyz1193 NodeUtilization
 				yyc1193 = true
 			}
-
+			yyh1193.ElemContainerState(yyj1193)
 			if yyj1193 < len(yyv1193) {
 				if r.TryDecodeAsNil() {
 					yyv1193[yyj1193] = NodeUtilization{}
@@ -13855,12 +14910,18 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		yyh1193.End()
+		if yyj1193 < len(yyv1193) {
+			yyv1193 = yyv1193[:yyj1193]
+			yyc1193 = true
+		} else if yyj1193 == 0 && yyv1193 == nil {
+			yyv1193 = []NodeUtilization{}
+			yyc1193 = true
+		}
 	}
+	yyh1193.End()
 	if yyc1193 {
 		*v = yyv1193
 	}
-
 }
 
 func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *codec1978.Encoder) {
@@ -13869,10 +14930,11 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1197 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1198 := &yyv1197
 		yy1198.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *codec1978.Decoder) {
@@ -13882,39 +14944,44 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 
 	yyv1199 := *v
 	yyh1199, yyl1199 := z.DecSliceHelperStart()
-
-	var yyrr1199, yyrl1199 int
-	var yyc1199, yyrt1199 bool
-	_, _, _ = yyc1199, yyrt1199, yyrl1199
-	yyrr1199 = yyl1199
-
-	if yyv1199 == nil {
-		if yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232); yyrt1199 {
-			yyrr1199 = yyrl1199
-		}
-		yyv1199 = make([]ClusterAutoscaler, yyrl1199)
-		yyc1199 = true
-	}
-
+	var yyc1199 bool
 	if yyl1199 == 0 {
-		if len(yyv1199) != 0 {
+		if yyv1199 == nil {
+			yyv1199 = []ClusterAutoscaler{}
+			yyc1199 = true
+		} else if len(yyv1199) != 0 {
 			yyv1199 = yyv1199[:0]
 			yyc1199 = true
 		}
 	} else if yyl1199 > 0 {
-
+		var yyrr1199, yyrl1199 int
+		var yyrt1199 bool
 		if yyl1199 > cap(yyv1199) {
-			yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1199 = make([]ClusterAutoscaler, yyrl1199)
-			yyc1199 = true
 
+			yyrg1199 := len(yyv1199) > 0
+			yyv21199 := yyv1199
+			yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1199 {
+				if yyrl1199 <= cap(yyv1199) {
+					yyv1199 = yyv1199[:yyrl1199]
+				} else {
+					yyv1199 = make([]ClusterAutoscaler, yyrl1199)
+				}
+			} else {
+				yyv1199 = make([]ClusterAutoscaler, yyrl1199)
+			}
+			yyc1199 = true
 			yyrr1199 = len(yyv1199)
+			if yyrg1199 {
+				copy(yyv1199, yyv21199)
+			}
 		} else if yyl1199 != len(yyv1199) {
 			yyv1199 = yyv1199[:yyl1199]
 			yyc1199 = true
 		}
 		yyj1199 := 0
 		for ; yyj1199 < yyrr1199; yyj1199++ {
+			yyh1199.ElemContainerState(yyj1199)
 			if r.TryDecodeAsNil() {
 				yyv1199[yyj1199] = ClusterAutoscaler{}
 			} else {
@@ -13926,6 +14993,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		if yyrt1199 {
 			for ; yyj1199 < yyl1199; yyj1199++ {
 				yyv1199 = append(yyv1199, ClusterAutoscaler{})
+				yyh1199.ElemContainerState(yyj1199)
 				if r.TryDecodeAsNil() {
 					yyv1199[yyj1199] = ClusterAutoscaler{}
 				} else {
@@ -13937,12 +15005,14 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 		}
 
 	} else {
-		for yyj1199 := 0; !r.CheckBreak(); yyj1199++ {
+		yyj1199 := 0
+		for ; !r.CheckBreak(); yyj1199++ {
+
 			if yyj1199 >= len(yyv1199) {
 				yyv1199 = append(yyv1199, ClusterAutoscaler{}) // var yyz1199 ClusterAutoscaler
 				yyc1199 = true
 			}
-
+			yyh1199.ElemContainerState(yyj1199)
 			if yyj1199 < len(yyv1199) {
 				if r.TryDecodeAsNil() {
 					yyv1199[yyj1199] = ClusterAutoscaler{}
@@ -13956,12 +15026,18 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		yyh1199.End()
+		if yyj1199 < len(yyv1199) {
+			yyv1199 = yyv1199[:yyj1199]
+			yyc1199 = true
+		} else if yyj1199 == 0 && yyv1199 == nil {
+			yyv1199 = []ClusterAutoscaler{}
+			yyc1199 = true
+		}
 	}
+	yyh1199.End()
 	if yyc1199 {
 		*v = yyv1199
 	}
-
 }
 
 func (x codecSelfer1234) encSlicePodSelectorRequirement(v []PodSelectorRequirement, e *codec1978.Encoder) {
@@ -13970,10 +15046,11 @@ func (x codecSelfer1234) encSlicePodSelectorRequirement(v []PodSelectorRequireme
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1203 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy1204 := &yyv1203
 		yy1204.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirement, d *codec1978.Decoder) {
@@ -13983,39 +15060,44 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 
 	yyv1205 := *v
 	yyh1205, yyl1205 := z.DecSliceHelperStart()
-
-	var yyrr1205, yyrl1205 int
-	var yyc1205, yyrt1205 bool
-	_, _, _ = yyc1205, yyrt1205, yyrl1205
-	yyrr1205 = yyl1205
-
-	if yyv1205 == nil {
-		if yyrl1205, yyrt1205 = z.DecInferLen(yyl1205, z.DecBasicHandle().MaxInitLen, 56); yyrt1205 {
-			yyrr1205 = yyrl1205
-		}
-		yyv1205 = make([]PodSelectorRequirement, yyrl1205)
-		yyc1205 = true
-	}
-
+	var yyc1205 bool
 	if yyl1205 == 0 {
-		if len(yyv1205) != 0 {
+		if yyv1205 == nil {
+			yyv1205 = []PodSelectorRequirement{}
+			yyc1205 = true
+		} else if len(yyv1205) != 0 {
 			yyv1205 = yyv1205[:0]
 			yyc1205 = true
 		}
 	} else if yyl1205 > 0 {
-
+		var yyrr1205, yyrl1205 int
+		var yyrt1205 bool
 		if yyl1205 > cap(yyv1205) {
-			yyrl1205, yyrt1205 = z.DecInferLen(yyl1205, z.DecBasicHandle().MaxInitLen, 56)
-			yyv1205 = make([]PodSelectorRequirement, yyrl1205)
-			yyc1205 = true
 
+			yyrg1205 := len(yyv1205) > 0
+			yyv21205 := yyv1205
+			yyrl1205, yyrt1205 = z.DecInferLen(yyl1205, z.DecBasicHandle().MaxInitLen, 56)
+			if yyrt1205 {
+				if yyrl1205 <= cap(yyv1205) {
+					yyv1205 = yyv1205[:yyrl1205]
+				} else {
+					yyv1205 = make([]PodSelectorRequirement, yyrl1205)
+				}
+			} else {
+				yyv1205 = make([]PodSelectorRequirement, yyrl1205)
+			}
+			yyc1205 = true
 			yyrr1205 = len(yyv1205)
+			if yyrg1205 {
+				copy(yyv1205, yyv21205)
+			}
 		} else if yyl1205 != len(yyv1205) {
 			yyv1205 = yyv1205[:yyl1205]
 			yyc1205 = true
 		}
 		yyj1205 := 0
 		for ; yyj1205 < yyrr1205; yyj1205++ {
+			yyh1205.ElemContainerState(yyj1205)
 			if r.TryDecodeAsNil() {
 				yyv1205[yyj1205] = PodSelectorRequirement{}
 			} else {
@@ -14027,6 +15109,7 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 		if yyrt1205 {
 			for ; yyj1205 < yyl1205; yyj1205++ {
 				yyv1205 = append(yyv1205, PodSelectorRequirement{})
+				yyh1205.ElemContainerState(yyj1205)
 				if r.TryDecodeAsNil() {
 					yyv1205[yyj1205] = PodSelectorRequirement{}
 				} else {
@@ -14038,12 +15121,14 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 		}
 
 	} else {
-		for yyj1205 := 0; !r.CheckBreak(); yyj1205++ {
+		yyj1205 := 0
+		for ; !r.CheckBreak(); yyj1205++ {
+
 			if yyj1205 >= len(yyv1205) {
 				yyv1205 = append(yyv1205, PodSelectorRequirement{}) // var yyz1205 PodSelectorRequirement
 				yyc1205 = true
 			}
-
+			yyh1205.ElemContainerState(yyj1205)
 			if yyj1205 < len(yyv1205) {
 				if r.TryDecodeAsNil() {
 					yyv1205[yyj1205] = PodSelectorRequirement{}
@@ -14057,10 +15142,16 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 			}
 
 		}
-		yyh1205.End()
+		if yyj1205 < len(yyv1205) {
+			yyv1205 = yyv1205[:yyj1205]
+			yyc1205 = true
+		} else if yyj1205 == 0 && yyv1205 == nil {
+			yyv1205 = []PodSelectorRequirement{}
+			yyc1205 = true
+		}
 	}
+	yyh1205.End()
 	if yyc1205 {
 		*v = yyv1205
 	}
-
 }

--- a/pkg/apis/metrics/types.generated.go
+++ b/pkg/apis/metrics/types.generated.go
@@ -31,10 +31,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -45,10 +53,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -76,18 +84,21 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2 bool = false
 			yyq2[0] = x.Kind != ""
 			yyq2[1] = x.APIVersion != ""
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2 int = 0
+				yynn2 = 0
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -100,7 +111,9 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -110,6 +123,7 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
@@ -122,7 +136,9 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
@@ -131,8 +147,10 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -147,17 +165,18 @@ func (x *RawNode) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct10 := r.ContainerType()
+		if yyct10 == codecSelferValueTypeMap1234 {
 			yyl10 := r.ReadMapStart()
 			if yyl10 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl10, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct10 == codecSelferValueTypeArray1234 {
 			yyl10 := r.ReadArrayStart()
 			if yyl10 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl10, d)
 			}
@@ -184,8 +203,10 @@ func (x *RawNode) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys11Slc = r.DecodeBytes(yys11Slc, true, true)
 		yys11 := string(yys11Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys11 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -203,9 +224,7 @@ func (x *RawNode) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys11)
 		} // end switch yys11
 	} // end for yyj11
-	if !yyhl11 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -222,9 +241,10 @@ func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb14 = r.CheckBreak()
 	}
 	if yyb14 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -237,9 +257,10 @@ func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb14 = r.CheckBreak()
 	}
 	if yyb14 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -255,9 +276,10 @@ func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb14 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj14-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -279,18 +301,21 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr18 bool = false
 			yyq18[0] = x.Kind != ""
 			yyq18[1] = x.APIVersion != ""
+			var yynn18 int
 			if yyr18 || yy2arr18 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn18 int = 0
+				yynn18 = 0
 				for _, b := range yyq18 {
 					if b {
 						yynn18++
 					}
 				}
 				r.EncodeMapStart(yynn18)
+				yynn18 = 0
 			}
 			if yyr18 || yy2arr18 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq18[0] {
 					yym20 := z.EncBinary()
 					_ = yym20
@@ -303,7 +328,9 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq18[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym21 := z.EncBinary()
 					_ = yym21
 					if false {
@@ -313,6 +340,7 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr18 || yy2arr18 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq18[1] {
 					yym23 := z.EncBinary()
 					_ = yym23
@@ -325,7 +353,9 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq18[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym24 := z.EncBinary()
 					_ = yym24
 					if false {
@@ -334,8 +364,10 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep18 {
-				r.EncodeEnd()
+			if yyr18 || yy2arr18 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -350,17 +382,18 @@ func (x *RawPod) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct26 := r.ContainerType()
+		if yyct26 == codecSelferValueTypeMap1234 {
 			yyl26 := r.ReadMapStart()
 			if yyl26 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl26, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct26 == codecSelferValueTypeArray1234 {
 			yyl26 := r.ReadArrayStart()
 			if yyl26 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl26, d)
 			}
@@ -387,8 +420,10 @@ func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys27Slc = r.DecodeBytes(yys27Slc, true, true)
 		yys27 := string(yys27Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys27 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -406,9 +441,7 @@ func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys27)
 		} // end switch yys27
 	} // end for yyj27
-	if !yyhl27 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -425,9 +458,10 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb30 = r.CheckBreak()
 	}
 	if yyb30 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -440,9 +474,10 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb30 = r.CheckBreak()
 	}
 	if yyb30 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -458,7 +493,8 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb30 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj30-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }

--- a/pkg/apis/metrics/v1alpha1/types.generated.go
+++ b/pkg/apis/metrics/v1alpha1/types.generated.go
@@ -31,10 +31,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -45,10 +53,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -76,18 +84,21 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2 bool = false
 			yyq2[0] = x.Kind != ""
 			yyq2[1] = x.APIVersion != ""
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2 int = 0
+				yynn2 = 0
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -100,7 +111,9 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -110,6 +123,7 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
@@ -122,7 +136,9 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
@@ -131,8 +147,10 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -147,17 +165,18 @@ func (x *RawNode) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct10 := r.ContainerType()
+		if yyct10 == codecSelferValueTypeMap1234 {
 			yyl10 := r.ReadMapStart()
 			if yyl10 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl10, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct10 == codecSelferValueTypeArray1234 {
 			yyl10 := r.ReadArrayStart()
 			if yyl10 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl10, d)
 			}
@@ -184,8 +203,10 @@ func (x *RawNode) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys11Slc = r.DecodeBytes(yys11Slc, true, true)
 		yys11 := string(yys11Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys11 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -203,9 +224,7 @@ func (x *RawNode) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys11)
 		} // end switch yys11
 	} // end for yyj11
-	if !yyhl11 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -222,9 +241,10 @@ func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb14 = r.CheckBreak()
 	}
 	if yyb14 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -237,9 +257,10 @@ func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb14 = r.CheckBreak()
 	}
 	if yyb14 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -255,9 +276,10 @@ func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb14 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj14-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -279,18 +301,21 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr18 bool = false
 			yyq18[0] = x.Kind != ""
 			yyq18[1] = x.APIVersion != ""
+			var yynn18 int
 			if yyr18 || yy2arr18 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn18 int = 0
+				yynn18 = 0
 				for _, b := range yyq18 {
 					if b {
 						yynn18++
 					}
 				}
 				r.EncodeMapStart(yynn18)
+				yynn18 = 0
 			}
 			if yyr18 || yy2arr18 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq18[0] {
 					yym20 := z.EncBinary()
 					_ = yym20
@@ -303,7 +328,9 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq18[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym21 := z.EncBinary()
 					_ = yym21
 					if false {
@@ -313,6 +340,7 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr18 || yy2arr18 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq18[1] {
 					yym23 := z.EncBinary()
 					_ = yym23
@@ -325,7 +353,9 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq18[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym24 := z.EncBinary()
 					_ = yym24
 					if false {
@@ -334,8 +364,10 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep18 {
-				r.EncodeEnd()
+			if yyr18 || yy2arr18 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -350,17 +382,18 @@ func (x *RawPod) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct26 := r.ContainerType()
+		if yyct26 == codecSelferValueTypeMap1234 {
 			yyl26 := r.ReadMapStart()
 			if yyl26 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl26, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct26 == codecSelferValueTypeArray1234 {
 			yyl26 := r.ReadArrayStart()
 			if yyl26 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl26, d)
 			}
@@ -387,8 +420,10 @@ func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys27Slc = r.DecodeBytes(yys27Slc, true, true)
 		yys27 := string(yys27Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys27 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -406,9 +441,7 @@ func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys27)
 		} // end switch yys27
 	} // end for yyj27
-	if !yyhl27 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -425,9 +458,10 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb30 = r.CheckBreak()
 	}
 	if yyb30 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -440,9 +474,10 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb30 = r.CheckBreak()
 	}
 	if yyb30 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -458,7 +493,8 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb30 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj30-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }

--- a/pkg/apiserver/testing/types.generated.go
+++ b/pkg/apiserver/testing/types.generated.go
@@ -34,10 +34,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -48,10 +56,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -84,18 +92,21 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2[1] = x.APIVersion != ""
 			yyq2[3] = x.Other != ""
 			yyq2[4] = len(x.Labels) != 0
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2 int = 1
+				yynn2 = 1
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -108,7 +119,9 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -118,6 +131,7 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
@@ -130,7 +144,9 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
@@ -140,14 +156,18 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy10 := &x.ObjectMeta
 				yy10.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy11 := &x.ObjectMeta
 				yy11.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[3] {
 					yym13 := z.EncBinary()
 					_ = yym13
@@ -160,7 +180,9 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("other"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym14 := z.EncBinary()
 					_ = yym14
 					if false {
@@ -170,6 +192,7 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[4] {
 					if x.Labels == nil {
 						r.EncodeNil()
@@ -186,7 +209,9 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("labels"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
@@ -199,8 +224,10 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -215,17 +242,18 @@ func (x *Simple) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct19 := r.ContainerType()
+		if yyct19 == codecSelferValueTypeMap1234 {
 			yyl19 := r.ReadMapStart()
 			if yyl19 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl19, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct19 == codecSelferValueTypeArray1234 {
 			yyl19 := r.ReadArrayStart()
 			if yyl19 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl19, d)
 			}
@@ -252,8 +280,10 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys20Slc = r.DecodeBytes(yys20Slc, true, true)
 		yys20 := string(yys20Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys20 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -296,9 +326,7 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys20)
 		} // end switch yys20
 	} // end for yyj20
-	if !yyhl20 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -315,9 +343,10 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb27 = r.CheckBreak()
 	}
 	if yyb27 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -330,9 +359,10 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb27 = r.CheckBreak()
 	}
 	if yyb27 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -345,9 +375,10 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb27 = r.CheckBreak()
 	}
 	if yyb27 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -361,9 +392,10 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb27 = r.CheckBreak()
 	}
 	if yyb27 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Other = ""
 	} else {
@@ -376,9 +408,10 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb27 = r.CheckBreak()
 	}
 	if yyb27 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
@@ -400,9 +433,10 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb27 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj27-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -426,18 +460,21 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq35[1] = x.APIVersion != ""
 			yyq35[3] = x.Other != ""
 			yyq35[4] = len(x.Labels) != 0
+			var yynn35 int
 			if yyr35 || yy2arr35 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn35 int = 1
+				yynn35 = 1
 				for _, b := range yyq35 {
 					if b {
 						yynn35++
 					}
 				}
 				r.EncodeMapStart(yynn35)
+				yynn35 = 0
 			}
 			if yyr35 || yy2arr35 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq35[0] {
 					yym37 := z.EncBinary()
 					_ = yym37
@@ -450,7 +487,9 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq35[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym38 := z.EncBinary()
 					_ = yym38
 					if false {
@@ -460,6 +499,7 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr35 || yy2arr35 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq35[1] {
 					yym40 := z.EncBinary()
 					_ = yym40
@@ -472,7 +512,9 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq35[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym41 := z.EncBinary()
 					_ = yym41
 					if false {
@@ -482,14 +524,18 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr35 || yy2arr35 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy43 := &x.ObjectMeta
 				yy43.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy44 := &x.ObjectMeta
 				yy44.CodecEncodeSelf(e)
 			}
 			if yyr35 || yy2arr35 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq35[3] {
 					yym46 := z.EncBinary()
 					_ = yym46
@@ -502,7 +548,9 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq35[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("other"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym47 := z.EncBinary()
 					_ = yym47
 					if false {
@@ -512,6 +560,7 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr35 || yy2arr35 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq35[4] {
 					if x.Labels == nil {
 						r.EncodeNil()
@@ -528,7 +577,9 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq35[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("labels"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
@@ -541,8 +592,10 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep35 {
-				r.EncodeEnd()
+			if yyr35 || yy2arr35 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -557,17 +610,18 @@ func (x *SimpleRoot) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct52 := r.ContainerType()
+		if yyct52 == codecSelferValueTypeMap1234 {
 			yyl52 := r.ReadMapStart()
 			if yyl52 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl52, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct52 == codecSelferValueTypeArray1234 {
 			yyl52 := r.ReadArrayStart()
 			if yyl52 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl52, d)
 			}
@@ -594,8 +648,10 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys53Slc = r.DecodeBytes(yys53Slc, true, true)
 		yys53 := string(yys53Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys53 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -638,9 +694,7 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys53)
 		} // end switch yys53
 	} // end for yyj53
-	if !yyhl53 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -657,9 +711,10 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb60 = r.CheckBreak()
 	}
 	if yyb60 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -672,9 +727,10 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb60 = r.CheckBreak()
 	}
 	if yyb60 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -687,9 +743,10 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb60 = r.CheckBreak()
 	}
 	if yyb60 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -703,9 +760,10 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb60 = r.CheckBreak()
 	}
 	if yyb60 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Other = ""
 	} else {
@@ -718,9 +776,10 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb60 = r.CheckBreak()
 	}
 	if yyb60 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
@@ -742,9 +801,10 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb60 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj60-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -766,18 +826,21 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr68 bool = false
 			yyq68[0] = x.Kind != ""
 			yyq68[1] = x.APIVersion != ""
+			var yynn68 int
 			if yyr68 || yy2arr68 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn68 int = 3
+				yynn68 = 3
 				for _, b := range yyq68 {
 					if b {
 						yynn68++
 					}
 				}
 				r.EncodeMapStart(yynn68)
+				yynn68 = 0
 			}
 			if yyr68 || yy2arr68 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq68[0] {
 					yym70 := z.EncBinary()
 					_ = yym70
@@ -790,7 +853,9 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq68[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym71 := z.EncBinary()
 					_ = yym71
 					if false {
@@ -800,6 +865,7 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr68 || yy2arr68 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq68[1] {
 					yym73 := z.EncBinary()
 					_ = yym73
@@ -812,7 +878,9 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq68[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym74 := z.EncBinary()
 					_ = yym74
 					if false {
@@ -822,6 +890,7 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr68 || yy2arr68 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym76 := z.EncBinary()
 				_ = yym76
 				if false {
@@ -829,7 +898,9 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param1))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("param1"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym77 := z.EncBinary()
 				_ = yym77
 				if false {
@@ -838,6 +909,7 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr68 || yy2arr68 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym79 := z.EncBinary()
 				_ = yym79
 				if false {
@@ -845,7 +917,9 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param2))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("param2"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym80 := z.EncBinary()
 				_ = yym80
 				if false {
@@ -854,6 +928,7 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr68 || yy2arr68 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym82 := z.EncBinary()
 				_ = yym82
 				if false {
@@ -861,7 +936,9 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("atAPath"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym83 := z.EncBinary()
 				_ = yym83
 				if false {
@@ -869,8 +946,10 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yysep68 {
-				r.EncodeEnd()
+			if yyr68 || yy2arr68 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -885,17 +964,18 @@ func (x *SimpleGetOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct85 := r.ContainerType()
+		if yyct85 == codecSelferValueTypeMap1234 {
 			yyl85 := r.ReadMapStart()
 			if yyl85 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl85, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct85 == codecSelferValueTypeArray1234 {
 			yyl85 := r.ReadArrayStart()
 			if yyl85 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl85, d)
 			}
@@ -922,8 +1002,10 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys86Slc = r.DecodeBytes(yys86Slc, true, true)
 		yys86 := string(yys86Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys86 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -959,9 +1041,7 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys86)
 		} // end switch yys86
 	} // end for yyj86
-	if !yyhl86 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -978,9 +1058,10 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb92 = r.CheckBreak()
 	}
 	if yyb92 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -993,9 +1074,10 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb92 = r.CheckBreak()
 	}
 	if yyb92 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -1008,9 +1090,10 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb92 = r.CheckBreak()
 	}
 	if yyb92 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Param1 = ""
 	} else {
@@ -1023,9 +1106,10 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb92 = r.CheckBreak()
 	}
 	if yyb92 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Param2 = ""
 	} else {
@@ -1038,9 +1122,10 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		yyb92 = r.CheckBreak()
 	}
 	if yyb92 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
@@ -1056,9 +1141,10 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if yyb92 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj92-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -1081,18 +1167,21 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq99[0] = x.Kind != ""
 			yyq99[1] = x.APIVersion != ""
 			yyq99[3] = len(x.Items) != 0
+			var yynn99 int
 			if yyr99 || yy2arr99 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn99 int = 1
+				yynn99 = 1
 				for _, b := range yyq99 {
 					if b {
 						yynn99++
 					}
 				}
 				r.EncodeMapStart(yynn99)
+				yynn99 = 0
 			}
 			if yyr99 || yy2arr99 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq99[0] {
 					yym101 := z.EncBinary()
 					_ = yym101
@@ -1105,7 +1194,9 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq99[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym102 := z.EncBinary()
 					_ = yym102
 					if false {
@@ -1115,6 +1206,7 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr99 || yy2arr99 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq99[1] {
 					yym104 := z.EncBinary()
 					_ = yym104
@@ -1127,7 +1219,9 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq99[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym105 := z.EncBinary()
 					_ = yym105
 					if false {
@@ -1137,6 +1231,7 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr99 || yy2arr99 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy107 := &x.ListMeta
 				yym108 := z.EncBinary()
 				_ = yym108
@@ -1146,7 +1241,9 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(yy107)
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy109 := &x.ListMeta
 				yym110 := z.EncBinary()
 				_ = yym110
@@ -1157,6 +1254,7 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr99 || yy2arr99 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq99[3] {
 					if x.Items == nil {
 						r.EncodeNil()
@@ -1173,7 +1271,9 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq99[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
@@ -1186,8 +1286,10 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep99 {
-				r.EncodeEnd()
+			if yyr99 || yy2arr99 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -1202,17 +1304,18 @@ func (x *SimpleList) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct115 := r.ContainerType()
+		if yyct115 == codecSelferValueTypeMap1234 {
 			yyl115 := r.ReadMapStart()
 			if yyl115 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl115, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct115 == codecSelferValueTypeArray1234 {
 			yyl115 := r.ReadArrayStart()
 			if yyl115 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl115, d)
 			}
@@ -1239,8 +1342,10 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys116Slc = r.DecodeBytes(yys116Slc, true, true)
 		yys116 := string(yys116Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys116 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -1283,9 +1388,7 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys116)
 		} // end switch yys116
 	} // end for yyj116
-	if !yyhl116 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -1302,9 +1405,10 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb123 = r.CheckBreak()
 	}
 	if yyb123 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -1317,9 +1421,10 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb123 = r.CheckBreak()
 	}
 	if yyb123 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -1332,9 +1437,10 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb123 = r.CheckBreak()
 	}
 	if yyb123 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
@@ -1354,9 +1460,10 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb123 = r.CheckBreak()
 	}
 	if yyb123 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -1378,9 +1485,10 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb123 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj123-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) encSliceSimple(v []Simple, e *codec1978.Encoder) {
@@ -1389,10 +1497,11 @@ func (x codecSelfer1234) encSliceSimple(v []Simple, e *codec1978.Encoder) {
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv130 := range v {
+		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 		yy131 := &yyv130
 		yy131.CodecEncodeSelf(e)
 	}
-	r.EncodeEnd()
+	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
 func (x codecSelfer1234) decSliceSimple(v *[]Simple, d *codec1978.Decoder) {
@@ -1402,39 +1511,44 @@ func (x codecSelfer1234) decSliceSimple(v *[]Simple, d *codec1978.Decoder) {
 
 	yyv132 := *v
 	yyh132, yyl132 := z.DecSliceHelperStart()
-
-	var yyrr132, yyrl132 int
-	var yyc132, yyrt132 bool
-	_, _, _ = yyc132, yyrt132, yyrl132
-	yyrr132 = yyl132
-
-	if yyv132 == nil {
-		if yyrl132, yyrt132 = z.DecInferLen(yyl132, z.DecBasicHandle().MaxInitLen, 216); yyrt132 {
-			yyrr132 = yyrl132
-		}
-		yyv132 = make([]Simple, yyrl132)
-		yyc132 = true
-	}
-
+	var yyc132 bool
 	if yyl132 == 0 {
-		if len(yyv132) != 0 {
+		if yyv132 == nil {
+			yyv132 = []Simple{}
+			yyc132 = true
+		} else if len(yyv132) != 0 {
 			yyv132 = yyv132[:0]
 			yyc132 = true
 		}
 	} else if yyl132 > 0 {
-
+		var yyrr132, yyrl132 int
+		var yyrt132 bool
 		if yyl132 > cap(yyv132) {
-			yyrl132, yyrt132 = z.DecInferLen(yyl132, z.DecBasicHandle().MaxInitLen, 216)
-			yyv132 = make([]Simple, yyrl132)
-			yyc132 = true
 
+			yyrg132 := len(yyv132) > 0
+			yyv2132 := yyv132
+			yyrl132, yyrt132 = z.DecInferLen(yyl132, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt132 {
+				if yyrl132 <= cap(yyv132) {
+					yyv132 = yyv132[:yyrl132]
+				} else {
+					yyv132 = make([]Simple, yyrl132)
+				}
+			} else {
+				yyv132 = make([]Simple, yyrl132)
+			}
+			yyc132 = true
 			yyrr132 = len(yyv132)
+			if yyrg132 {
+				copy(yyv132, yyv2132)
+			}
 		} else if yyl132 != len(yyv132) {
 			yyv132 = yyv132[:yyl132]
 			yyc132 = true
 		}
 		yyj132 := 0
 		for ; yyj132 < yyrr132; yyj132++ {
+			yyh132.ElemContainerState(yyj132)
 			if r.TryDecodeAsNil() {
 				yyv132[yyj132] = Simple{}
 			} else {
@@ -1446,6 +1560,7 @@ func (x codecSelfer1234) decSliceSimple(v *[]Simple, d *codec1978.Decoder) {
 		if yyrt132 {
 			for ; yyj132 < yyl132; yyj132++ {
 				yyv132 = append(yyv132, Simple{})
+				yyh132.ElemContainerState(yyj132)
 				if r.TryDecodeAsNil() {
 					yyv132[yyj132] = Simple{}
 				} else {
@@ -1457,12 +1572,14 @@ func (x codecSelfer1234) decSliceSimple(v *[]Simple, d *codec1978.Decoder) {
 		}
 
 	} else {
-		for yyj132 := 0; !r.CheckBreak(); yyj132++ {
+		yyj132 := 0
+		for ; !r.CheckBreak(); yyj132++ {
+
 			if yyj132 >= len(yyv132) {
 				yyv132 = append(yyv132, Simple{}) // var yyz132 Simple
 				yyc132 = true
 			}
-
+			yyh132.ElemContainerState(yyj132)
 			if yyj132 < len(yyv132) {
 				if r.TryDecodeAsNil() {
 					yyv132[yyj132] = Simple{}
@@ -1476,10 +1593,16 @@ func (x codecSelfer1234) decSliceSimple(v *[]Simple, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh132.End()
+		if yyj132 < len(yyv132) {
+			yyv132 = yyv132[:yyj132]
+			yyc132 = true
+		} else if yyj132 == 0 && yyv132 == nil {
+			yyv132 = []Simple{}
+			yyc132 = true
+		}
 	}
+	yyh132.End()
 	if yyc132 {
 		*v = yyv132
 	}
-
 }

--- a/pkg/kubectl/testing/types.generated.go
+++ b/pkg/kubectl/testing/types.generated.go
@@ -34,10 +34,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -48,10 +56,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -83,18 +91,21 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2[0] = x.Kind != ""
 			yyq2[1] = x.APIVersion != ""
 			yyq2[2] = true
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2 int = 4
+				yynn2 = 4
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -107,7 +118,9 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -117,6 +130,7 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
@@ -129,7 +143,9 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
@@ -139,6 +155,7 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[2] {
 					yy10 := &x.ObjectMeta
 					yy10.CodecEncodeSelf(e)
@@ -147,12 +164,15 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yy11 := &x.ObjectMeta
 					yy11.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym13 := z.EncBinary()
 				_ = yym13
 				if false {
@@ -160,7 +180,9 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Key"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym14 := z.EncBinary()
 				_ = yym14
 				if false {
@@ -169,6 +191,7 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Map == nil {
 					r.EncodeNil()
 				} else {
@@ -180,7 +203,9 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Map"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.Map == nil {
 					r.EncodeNil()
 				} else {
@@ -193,6 +218,7 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.StringList == nil {
 					r.EncodeNil()
 				} else {
@@ -204,7 +230,9 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("StringList"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.StringList == nil {
 					r.EncodeNil()
 				} else {
@@ -217,6 +245,7 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.IntList == nil {
 					r.EncodeNil()
 				} else {
@@ -228,7 +257,9 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("IntList"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				if x.IntList == nil {
 					r.EncodeNil()
 				} else {
@@ -240,8 +271,10 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -256,17 +289,18 @@ func (x *TestStruct) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct25 := r.ContainerType()
+		if yyct25 == codecSelferValueTypeMap1234 {
 			yyl25 := r.ReadMapStart()
 			if yyl25 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl25, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct25 == codecSelferValueTypeArray1234 {
 			yyl25 := r.ReadArrayStart()
 			if yyl25 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl25, d)
 			}
@@ -293,8 +327,10 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys26Slc = r.DecodeBytes(yys26Slc, true, true)
 		yys26 := string(yys26Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys26 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -361,9 +397,7 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys26)
 		} // end switch yys26
 	} // end for yyj26
-	if !yyhl26 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -380,9 +414,10 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb37 = r.CheckBreak()
 	}
 	if yyb37 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -395,9 +430,10 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb37 = r.CheckBreak()
 	}
 	if yyb37 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -410,9 +446,10 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb37 = r.CheckBreak()
 	}
 	if yyb37 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -426,9 +463,10 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb37 = r.CheckBreak()
 	}
 	if yyb37 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Key = ""
 	} else {
@@ -441,9 +479,10 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb37 = r.CheckBreak()
 	}
 	if yyb37 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Map = nil
 	} else {
@@ -462,9 +501,10 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb37 = r.CheckBreak()
 	}
 	if yyb37 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.StringList = nil
 	} else {
@@ -483,9 +523,10 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb37 = r.CheckBreak()
 	}
 	if yyb37 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.IntList = nil
 	} else {
@@ -507,7 +548,8 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb37 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj37-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }

--- a/pkg/storage/testing/types.generated.go
+++ b/pkg/storage/testing/types.generated.go
@@ -34,10 +34,18 @@ import (
 )
 
 const (
-	codecSelferC_UTF81234         = 1
-	codecSelferC_RAW1234          = 0
+	// ----- content types ----
+	codecSelferC_UTF81234 = 1
+	codecSelferC_RAW1234  = 0
+	// ----- value types used ----
 	codecSelferValueTypeArray1234 = 10
 	codecSelferValueTypeMap1234   = 9
+	// ----- containerStateValues ----
+	codecSelfer_containerMapKey1234    = 2
+	codecSelfer_containerMapValue1234  = 3
+	codecSelfer_containerMapEnd1234    = 4
+	codecSelfer_containerArrayElem1234 = 6
+	codecSelfer_containerArrayEnd1234  = 7
 )
 
 var (
@@ -48,10 +56,10 @@ var (
 type codecSelfer1234 struct{}
 
 func init() {
-	if codec1978.GenVersion != 4 {
+	if codec1978.GenVersion != 5 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			4, codec1978.GenVersion, file)
+			5, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -82,18 +90,21 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			const yyr2 bool = false
 			yyq2[0] = x.Kind != ""
 			yyq2[1] = x.APIVersion != ""
+			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2 int = 2
+				yynn2 = 2
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
 					}
 				}
 				r.EncodeMapStart(yynn2)
+				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
@@ -106,7 +117,9 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
@@ -116,6 +129,7 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
@@ -128,7 +142,9 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
@@ -138,14 +154,18 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yy10 := &x.ObjectMeta
 				yy10.CodecEncodeSelf(e)
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yy11 := &x.ObjectMeta
 				yy11.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				yym13 := z.EncBinary()
 				_ = yym13
 				if false {
@@ -153,7 +173,9 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Value))
 				}
 			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym14 := z.EncBinary()
 				_ = yym14
 				if false {
@@ -161,8 +183,10 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Value))
 				}
 			}
-			if yysep2 {
-				r.EncodeEnd()
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 			}
 		}
 	}
@@ -177,17 +201,18 @@ func (x *TestResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
+		yyct16 := r.ContainerType()
+		if yyct16 == codecSelferValueTypeMap1234 {
 			yyl16 := r.ReadMapStart()
 			if yyl16 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
 				x.codecDecodeSelfFromMap(yyl16, d)
 			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+		} else if yyct16 == codecSelferValueTypeArray1234 {
 			yyl16 := r.ReadArrayStart()
 			if yyl16 == 0 {
-				r.ReadEnd()
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				x.codecDecodeSelfFromArray(yyl16, d)
 			}
@@ -214,8 +239,10 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
 		yys17Slc = r.DecodeBytes(yys17Slc, true, true)
 		yys17 := string(yys17Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys17 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -246,9 +273,7 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys17)
 		} // end switch yys17
 	} // end for yyj17
-	if !yyhl17 {
-		r.ReadEnd()
-	}
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
@@ -265,9 +290,10 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb22 = r.CheckBreak()
 	}
 	if yyb22 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -280,9 +306,10 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb22 = r.CheckBreak()
 	}
 	if yyb22 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -295,9 +322,10 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb22 = r.CheckBreak()
 	}
 	if yyb22 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
@@ -311,9 +339,10 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb22 = r.CheckBreak()
 	}
 	if yyb22 {
-		r.ReadEnd()
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
 		x.Value = 0
 	} else {
@@ -329,7 +358,8 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb22 {
 			break
 		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj22-1, "")
 	}
-	r.ReadEnd()
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }


### PR DESCRIPTION
Note, that these three dependencies needs to be updated in a single PR, because k8s, go-etcd and etcd are using ugorji and we can't have incompatible versions of it in different dependencies.

Fix #16361
