### PR TITLE
Added flag to bypass binary checks in CanSupport

### DIFF
--- a/pkg/controller/persistentvolume/persistentvolume_recycler_controller.go
+++ b/pkg/controller/persistentvolume/persistentvolume_recycler_controller.go
@@ -129,6 +129,9 @@ func (recycler *PersistentVolumeRecycler) handleRecycle(pv *api.PersistentVolume
 	nextPhase := currentPhase
 
 	spec := volume.NewSpecFromPersistentVolume(pv, false)
+	// checking for binaries when running in master may fail when the master
+	// is running in a container and/or is not configured like a node.
+	spec.BypassBinaryChecks = true
 	plugin, err := recycler.pluginMgr.FindRecyclablePluginBySpec(spec)
 	if err != nil {
 		return fmt.Errorf("Could not find recyclable volume plugin for spec: %+v", err)

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -89,6 +89,12 @@ func (plugin *nfsPlugin) CanSupport(spec *volume.Spec) bool {
 	if (spec.Volume != nil && spec.Volume.NFS == nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.NFS == nil) {
 		return false
 	}
+
+	// PV Controller running in master may not have the required binaries.
+	if spec.BypassBinaryChecks {
+		return true
+	}
+
 	// see if /sbin/mount.nfs* is there
 	return hasNFSMount()
 }

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -169,6 +169,8 @@ type Spec struct {
 	Volume           *api.Volume
 	PersistentVolume *api.PersistentVolume
 	ReadOnly         bool
+	// used in CanSupport to tell a plugin to perform checks for existing binaries.
+	BypassBinaryChecks bool
 }
 
 // Name returns the name of either Volume or PersistentVolume, one of which must not be nil.


### PR DESCRIPTION
Partial fix of https://github.com/kubernetes/kubernetes/issues/16727

This allows the recycler to find the correct plugin.  Still requires containerized kubelet fix.

@pmorie @thockin @jsafrane 
