### PR TITLE
Revert 16032 -- NFS CanSupport -- breaks PV Recycler

### DIFF
--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -19,12 +19,10 @@ package nfs
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
 
@@ -68,29 +66,9 @@ func (plugin *nfsPlugin) Name() string {
 	return nfsPluginName
 }
 
-func hasNFSMount() bool {
-	exe := exec.New()
-	switch runtime.GOOS {
-	case "linux":
-		cmd1 := exe.Command("/bin/ls", "/sbin/mount.nfs")
-		_, err1 := cmd1.CombinedOutput()
-		cmd2 := exe.Command("/bin/ls", "/sbin/mount.nfs4")
-		_, err2 := cmd2.CombinedOutput()
-		return (err1 == nil || err2 == nil)
-	case "darwin":
-		cmd := exe.Command("/bin/ls", "/sbin/mount_nfs")
-		_, err := cmd.CombinedOutput()
-		return err == nil
-	}
-	return false
-}
-
 func (plugin *nfsPlugin) CanSupport(spec *volume.Spec) bool {
-	if (spec.Volume != nil && spec.Volume.NFS == nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.NFS == nil) {
-		return false
-	}
-	// see if /sbin/mount.nfs* is there
-	return hasNFSMount()
+	return (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.NFS != nil) ||
+		(spec.Volume != nil && spec.Volume.NFS != nil)
 }
 
 func (plugin *nfsPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -38,15 +38,11 @@ func TestCanSupport(t *testing.T) {
 	if plug.Name() != "kubernetes.io/nfs" {
 		t.Errorf("Wrong name: %s", plug.Name())
 	}
-	foundMount := hasNFSMount()
-	if plug.CanSupport(&volume.Spec{Volume: &api.Volume{VolumeSource: api.VolumeSource{NFS: &api.NFSVolumeSource{}}}}) != foundMount {
+	if !plug.CanSupport(&volume.Spec{Volume: &api.Volume{VolumeSource: api.VolumeSource{NFS: &api.NFSVolumeSource{}}}}) {
 		t.Errorf("Expected true")
 	}
-	if plug.CanSupport(&volume.Spec{PersistentVolume: &api.PersistentVolume{Spec: api.PersistentVolumeSpec{PersistentVolumeSource: api.PersistentVolumeSource{NFS: &api.NFSVolumeSource{}}}}}) != foundMount {
+	if !plug.CanSupport(&volume.Spec{PersistentVolume: &api.PersistentVolume{Spec: api.PersistentVolumeSpec{PersistentVolumeSource: api.PersistentVolumeSource{NFS: &api.NFSVolumeSource{}}}}}) {
 		t.Errorf("Expected true")
-	}
-	if plug.CanSupport(&volume.Spec{PersistentVolume: &api.PersistentVolume{Spec: api.PersistentVolumeSpec{PersistentVolumeSource: api.PersistentVolumeSource{}}}}) {
-		t.Errorf("Expected false")
 	}
 	if plug.CanSupport(&volume.Spec{Volume: &api.Volume{VolumeSource: api.VolumeSource{}}}) {
 		t.Errorf("Expected false")
@@ -67,10 +63,6 @@ func TestGetAccessModes(t *testing.T) {
 }
 
 func TestRecycler(t *testing.T) {
-	if foundMount := hasNFSMount(); !foundMount {
-		// FindRecyclablePluginBySpec will test CanSupport() but mount helper is absent
-		return
-	}
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins([]volume.VolumePlugin{&nfsPlugin{nil, newMockRecycler, volume.VolumeConfig{}}}, volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
 


### PR DESCRIPTION
This reverts commit 1b3a88dc8702920576436c43ab5c08218017a39b from https://github.com/kubernetes/kubernetes/pull/16032

See issue: https://github.com/kubernetes/kubernetes/issues/16727

The checks in hasNFSMount fail in kube-controller-manager (master doesn't have the same configuration as the nodes) and in containerized kubelet (doesn't have the same visibility as non-container kubelet).

@pmorie @rootfs @smarterclayton @childsb 
