### PR TITLE
Fixes for codecgen

### DIFF
--- a/hack/update-codecgen.sh
+++ b/hack/update-codecgen.sh
@@ -19,6 +19,10 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::setup_env
+
 cd "${KUBE_ROOT}"
 
 generated_files=$(
@@ -40,14 +44,6 @@ function cleanup {
 trap cleanup EXIT
 CODECGEN="${PWD}/codecgen_binary"
 godep go build -o "${CODECGEN}" github.com/ugorji/go/codec/codecgen
-
-# Running codecgen fails if some of the files doesn't compile.
-# Thus (since all the files are completely auto-generated and
-# not required for the code to be compilable, we first remove
-# them and the regenerate them.
-for generated_file in ${generated_files}; do
-	rm -f "${generated_file}"
-done
 
 for generated_file in ${generated_files}; do
   initial_dir=${PWD}


### PR DESCRIPTION
1. Setup go environment to use godeps for codecgen (rather than local go sources)
2. Don't remove generated files prior to regenerating them

I don't know why the second fix is necessary, but codecgen generates different output depending on whether the generated file exists. A sample of the differences (from https://github.com/kubernetes/kubernetes/pull/15967) can be seen here: https://gist.github.com/timstclair/cb26775ed0a89e6467cb

cc/ @wojtek-t 
