### PR TITLE
Remove unhelpful output when jsonpath and template printers fail to print

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1541,11 +1541,11 @@ func (p *TemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		// It is way easier to debug this stuff when it shows up in
 		// stdout instead of just stdin. So in addition to returning
 		// a nice error, also print useful stuff with the writer.
-		fmt.Fprintf(w, "Error executing template: %v\n", err)
-		fmt.Fprintf(w, "template was:\n\t%v\n", p.rawTemplate)
-		fmt.Fprintf(w, "raw data was:\n\t%v\n", string(data))
-		fmt.Fprintf(w, "object given to template engine was:\n\t%+v\n", out)
-		return fmt.Errorf("error executing template '%v': '%v'\n----data----\n%+v\n", p.rawTemplate, err, out)
+		fmt.Fprintf(w, "Error executing template: %v. Printing more information for debugging the template:\n", err)
+		fmt.Fprintf(w, "\ttemplate was:\n\t\t%v\n", p.rawTemplate)
+		fmt.Fprintf(w, "\traw data was:\n\t\t%v\n", string(data))
+		fmt.Fprintf(w, "\tobject given to template engine was:\n\t\t%+v\n\n", out)
+		return fmt.Errorf("error executing template %q: %v", p.rawTemplate, err)
 	}
 	return nil
 }
@@ -1692,10 +1692,10 @@ func (j *JSONPathPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	}
 
 	if err := j.JSONPath.Execute(w, queryObj); err != nil {
-		fmt.Fprintf(w, "Error executing template: %v\n", err)
-		fmt.Fprintf(w, "template was:\n\t%v\n", j.rawTemplate)
-		fmt.Fprintf(w, "object given to jsonpath engine was:\n\t%#v\n", queryObj)
-		return fmt.Errorf("error executing jsonpath '%v': '%v'\n----data----\n%+v\n", j.rawTemplate, err, obj)
+		fmt.Fprintf(w, "Error executing template: %v. Printing more information for debugging the template:\n", err)
+		fmt.Fprintf(w, "\ttemplate was:\n\t\t%v\n", j.rawTemplate)
+		fmt.Fprintf(w, "\tobject given to jsonpath engine was:\n\t\t%#v\n\n", queryObj)
+		return fmt.Errorf("error executing jsonpath %q: %v\n", j.rawTemplate, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #16708 

Now the error message becomes:

``` console
$  kubectl get no -o jsonpath="{.name}"
Error executing template: name is not found. Printing more information for debugging the template:
    template was:
        {.name}
    object given to jsonpath engine was:
        map[string]interface {}{"apiVersion":"v1", "metadata":map[string]interface {}{}, "items":[]interface {}{map[string]interface {}{"kind":"Node", "apiVersion":"v1", "metadata":map[string]interface {}{"labels":map[string]interface {}{"kubernetes.io/hostname":"127.0.0.1"}, "name":"127.0.0.1", "selfLink":"/api/v1/nodes/127.0.0.1", "uid":"ba0ef736-827f-11e5-a731-64510658e388", "resourceVersion":"19", "creationTimestamp":"2015-11-03T23:07:59Z"}, "spec":map[string]interface {}{"externalID":"127.0.0.1"}, "status":map[string]interface {}{"capacity":map[string]interface {}{"cpu":"12", "memory":"32840052Ki", "pods":"40"}, "conditions":[]interface {}{map[string]interface {}{"type":"Ready", "status":"True", "lastHeartbeatTime":"2015-11-03T23:07:59Z", "lastTransitionTime":"2015-11-03T23:07:59Z", "reason":"KubeletReady", "message":"kubelet is posting ready status"}, map[string]interface {}{"lastTransitionTime":"2015-11-03T23:07:59Z", "reason":"KubeletHasSufficientDisk", "message":"kubelet has sufficient disk space available", "type":"OutOfDisk", "status":"False", "lastHeartbeatTime":"2015-11-03T23:07:59Z"}}, "addresses":[]interface {}{map[string]interface {}{"type":"LegacyHostIP", "address":"127.0.0.1"}, map[string]interface {}{"type":"InternalIP", "address":"127.0.0.1"}}, "daemonEndpoints":map[string]interface {}{"kubeletEndpoint":map[string]interface {}{"Port":10250}}, "nodeInfo":map[string]interface {}{"osImage":"Ubuntu 14.04.3 LTS", "containerRuntimeVersion":"docker://1.9.0", "kubeletVersion":"v1.2.0-alpha.3.30+a78b2e0a9f63ec-dirty", "kubeProxyVersion":"v1.2.0-alpha.3.30+a78b2e0a9f63ec-dirty", "machineID":"e7696f0e50125bc3edd6c05955f0a2fd", "systemUUID":"7873D17C-CD83-11E4-9C43-BC0000060000", "bootID":"c4ae516b-9a9b-4687-af01-2ed4e7e1245c", "kernelVersion":"3.13.0-65-generic"}}}}, "kind":"List"}

error: error executing jsonpath "{.name}": name is not found
```

cc @kubernetes/kubectl @kubernetes/goog-ux @lavalamp @mikedanese 
