### PR TITLE
Create Jenkins project for scalability tests on 1.1

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -396,6 +396,28 @@ case ${JOB_NAME} in
     TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
     ;;
 
+  # Runs the performance/scalability tests on GCE using the latest 1.1 ci
+  # release. A larger cluster is used.
+  kubernetes-e2e-gce-scalability-1.1)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-scalability-1.1"}
+    : ${E2E_NETWORK:="e2e-scalability-1-1"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Performance\ssuite"}
+    : ${JENKINS_PUBLISHED_VERSION:="ci/latest-1.1"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-scalability-1-1"}
+    : ${KUBE_GCS_STAGING_PATH_SUFFIX:="scalability-1.1"}
+    : ${PROJECT:="k8s-e2e-gce-scalability-1-1"}
+    # Override GCE defaults.
+    E2E_ZONE="us-east1-b"
+    MASTER_SIZE="n1-standard-4"
+    MINION_SIZE="n1-standard-2"
+    MINION_DISK_SIZE="50GB"
+    NUM_MINIONS="100"
+    # Reduce logs verbosity
+    TEST_CLUSTER_LOG_LEVEL="--v=2"
+    # Increase resync period to simulate production
+    TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+    ;;
+
   # Sets up the GCE soak cluster weekly using the latest CI release.
   kubernetes-soak-weekly-deploy-gce)
     : ${E2E_CLUSTER_NAME:="gce-soak-weekly"}


### PR DESCRIPTION
I haven't tested this yet but will do so momentarily.

This gets us closer to full test coverage for 1.1, though we're probably not at 100% e2es yet.

@kubernetes/goog-testing 
