### PR TITLE
move assignment into for loop

### DIFF
--- a/pkg/controller/daemon/controller.go
+++ b/pkg/controller/daemon/controller.go
@@ -411,12 +411,12 @@ func storeDaemonSetStatus(dsClient client.DaemonSetInterface, ds *extensions.Dae
 		return nil
 	}
 
-	ds.Status.DesiredNumberScheduled = desiredNumberScheduled
-	ds.Status.CurrentNumberScheduled = currentNumberScheduled
-	ds.Status.NumberMisscheduled = numberMisscheduled
-
 	var updateErr, getErr error
 	for i := 0; i <= StatusUpdateRetries; i++ {
+		ds.Status.DesiredNumberScheduled = desiredNumberScheduled
+		ds.Status.CurrentNumberScheduled = currentNumberScheduled
+		ds.Status.NumberMisscheduled = numberMisscheduled
+
 		_, updateErr = dsClient.UpdateStatus(ds)
 		if updateErr == nil {
 			// successful update


### PR DESCRIPTION
I submit a PR https://github.com/kubernetes/kubernetes/pull/15944 several weeks ago to move assignment statement out of loop, hoping to improve efficiency. However, I am wrong, if there was a update conflict, `ds` gets refetched below, which means the status set outside the loop is lost, calling `UpdateStatus(ds)` then becomes a no-op, which is not correct.

@liggitt Great thanks for pointing out this.

I am sorry to not read the existing code carefully.
