### PR TITLE
Automated cherry pick of #16761 upstream release 1.1

### DIFF
--- a/cluster/saltbase/salt/README.md
+++ b/cluster/saltbase/salt/README.md
@@ -10,7 +10,6 @@ Key: M = Config applies to master, n = config applies to nodes
 
 Config                                              | GCE   | Vagrant | AWS |
 ----------------------------------------------------|-------|---------|-----|
-[cadvisor](cadvisor/)                               | M n   | M n     | M n |
 [debian-auto-upgrades](debian-auto-upgrades/)       | M n   | M n     | M n |
 [docker](docker/)                                   | M n   | M n     | M n |
 [etcd](etcd/)                                       | M     | M       | M   |
@@ -24,8 +23,7 @@ Config                                              | GCE   | Vagrant | AWS |
 [kube-scheduler](kube-scheduler/)                   | M     | M       | M   |
 [kubelet](kubelet/)                                 | M n   | M n     | M n |
 [logrotate](logrotate/)                             | M n   |   n     | M n |
-[monit](monit/)                                     | M n   | M n     | M n |
-[nginx](nginx/)                                     | M     | M       | M   |
+[supervisord](supervisor/)                          | M n   | M n     | M n |
 [static-routes](static-routes/) (vsphere only)      |       |         |     |
 [base](base.sls)                                    | M n   | M n     | M n |
 [kube-client-tools](kube-client-tools.sls)          | M     | M       | M   |

--- a/docs/admin/cluster-components.md
+++ b/docs/admin/cluster-components.md
@@ -113,9 +113,9 @@ network rules on the host and performing connection forwarding.
 
 `rkt` is supported experimentally as an alternative to docker.
 
-### monit
+### supervisord
 
-`monit` is a lightweight process babysitting system for keeping kubelet and docker
+`supervisord` is a lightweight process babysitting system for keeping kubelet and docker
 running.
 
 

--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -350,7 +350,7 @@ options, you may have a Docker-created bridge and iptables rules.  You may want 
 as follows before proceeding to configure Docker for Kubernetes.
 
 ```sh
-iptables -t nat -F 
+iptables -t nat -F
 ifconfig docker0 down
 brctl delbr docker0
 ```
@@ -474,7 +474,7 @@ traffic to the internet, but have no problem with them inside your GCE Project.
 
 - Enable auto-upgrades for your OS package manager, if desired.
 - Configure log rotation for all node components (e.g. using [logrotate](http://linux.die.net/man/8/logrotate)).
-- Setup liveness-monitoring (e.g. using [monit](http://linux.die.net/man/1/monit)).
+- Setup liveness-monitoring (e.g. using [supervisord](http://supervisord.org/)).
 - Setup volume plugin support (optional)
   - Install any client binaries for optional volume types, such as `glusterfs-client` for GlusterFS
     volumes.


### PR DESCRIPTION
Replace monit with supervisord in documentation. #16761

This will fix the docs on the release branch. 
