### PR TITLE
Check some errors that we were letting slip silently by.

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -317,6 +317,7 @@ var _ = Describe("Services", func() {
 
 		defer func() { expectNoError(stopServeHostnameService(c, ns, "service1")) }()
 		podNames1, svc1IP, err := startServeHostnameService(c, ns, "service1", servicePort, numPods)
+		Expect(err).NotTo(HaveOccurred())
 
 		hosts, err := NodeSSHHosts(c)
 		Expect(err).NotTo(HaveOccurred())
@@ -339,6 +340,7 @@ var _ = Describe("Services", func() {
 		// Create a new service and check if it's not reusing IP.
 		defer func() { expectNoError(stopServeHostnameService(c, ns, "service2")) }()
 		podNames2, svc2IP, err := startServeHostnameService(c, ns, "service2", servicePort, numPods)
+		Expect(err).NotTo(HaveOccurred())
 
 		if svc1IP == svc2IP {
 			Failf("VIPs conflict: %v", svc1IP)


### PR DESCRIPTION
@ihmccreery @ixdy @quinton-hoole 

@kubernetes/goog-testing 
