### PR TITLE
Fix running mesos-docker configuration on Darwin

### DIFF
--- a/cluster/mesos/docker/km/build.sh
+++ b/cluster/mesos/docker/km/build.sh
@@ -41,8 +41,11 @@ find-binary() {
 
 km_path=$(find-binary km linux/amd64)
 if [ -z "$km_path" ]; then
-  echo "Failed to find km binary" 1>&2
-  exit 1
+  km_path=$(find-binary km darwin/amd64)
+  if [ -z "$km_path" ]; then
+    echo "Failed to find km binary" 1>&2
+    exit 1
+  fi
 fi
 kube_bin_path=$(dirname ${km_path})
 common_bin_path=$(cd ${script_dir}/../common/bin && pwd -P)


### PR DESCRIPTION
When following https://github.com/kubernetes/kubernetes/blob/master/docs/getting-started-guides/mesos-docker.md guide on Mac, kubernetes builds binaries under Darwin platform, therefore km/build.sh can't find km binary because it was only looking for Linux. This change makes it also look for Darwin binaries too.
