### PR TITLE
Modify request.go to use exponential backoff 

### DIFF
--- a/pkg/client/unversioned/fake/fake.go
+++ b/pkg/client/unversioned/fake/fake.go
@@ -50,23 +50,23 @@ type RESTClient struct {
 }
 
 func (c *RESTClient) Get() *unversioned.Request {
-	return unversioned.NewRequest(c, "GET", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+	return unversioned.NewRequest(c, "GET", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec, nil)
 }
 
 func (c *RESTClient) Put() *unversioned.Request {
-	return unversioned.NewRequest(c, "PUT", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+	return unversioned.NewRequest(c, "PUT", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec, nil)
 }
 
 func (c *RESTClient) Patch(_ api.PatchType) *unversioned.Request {
-	return unversioned.NewRequest(c, "PATCH", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+	return unversioned.NewRequest(c, "PATCH", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec, nil)
 }
 
 func (c *RESTClient) Post() *unversioned.Request {
-	return unversioned.NewRequest(c, "POST", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+	return unversioned.NewRequest(c, "POST", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec, nil)
 }
 
 func (c *RESTClient) Delete() *unversioned.Request {
-	return unversioned.NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+	return unversioned.NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec, nil)
 }
 
 func (c *RESTClient) Do(req *http.Request) (*http.Response, error) {

--- a/pkg/client/unversioned/request_test.go
+++ b/pkg/client/unversioned/request_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"
@@ -270,7 +271,7 @@ func TestResultIntoWithErrReturnsErr(t *testing.T) {
 
 func TestURLTemplate(t *testing.T) {
 	uri, _ := url.Parse("http://localhost")
-	r := NewRequest(nil, "POST", uri, "test", nil)
+	r := NewRequest(nil, "POST", uri, "test", nil, nil)
 	r.Prefix("pre1").Resource("r1").Namespace("ns").Name("nm").Param("p0", "v0")
 	full := r.URL()
 	if full.String() != "http://localhost/pre1/namespaces/ns/r1/nm?p0=v0" {
@@ -331,7 +332,7 @@ func TestTransformResponse(t *testing.T) {
 		{Response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader(invalid))}, Data: invalid},
 	}
 	for i, test := range testCases {
-		r := NewRequest(nil, "", uri, testapi.Default.Version(), testapi.Default.Codec())
+		r := NewRequest(nil, "", uri, testapi.Default.Version(), testapi.Default.Codec(), nil)
 		if test.Response.Body == nil {
 			test.Response.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
 		}
@@ -550,6 +551,8 @@ func TestRequestWatch(t *testing.T) {
 		},
 	}
 	for i, testCase := range testCases {
+		glog.Infof("testcase %v", testCase.Request)
+		testCase.Request.backoffMgr = &NoBackoff{}
 		watch, err := testCase.Request.Watch()
 		hasErr := err != nil
 		if hasErr != testCase.Err {
@@ -612,6 +615,7 @@ func TestRequestStream(t *testing.T) {
 		},
 	}
 	for i, testCase := range testCases {
+		testCase.Request.backoffMgr = &NoBackoff{}
 		body, err := testCase.Request.Stream()
 		hasErr := err != nil
 		if hasErr != testCase.Err {
@@ -681,6 +685,7 @@ func TestRequestDo(t *testing.T) {
 		},
 	}
 	for i, testCase := range testCases {
+		testCase.Request.backoffMgr = &NoBackoff{}
 		body, err := testCase.Request.Do().Raw()
 		hasErr := err != nil
 		if hasErr != testCase.Err {
@@ -728,6 +733,39 @@ func TestDoRequestNewWay(t *testing.T) {
 	fakeHandler.ValidateRequest(t, requestURL, "POST", &reqBody)
 	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
 		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+//This test assumes that the client implementation backs off exponentially, for an individual request.
+func TestBackoffLifecycle(t *testing.T) {
+	count := 0
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		count++
+		t.Logf("attempt %d", count)
+		//requests "1" and "2" both fail.
+		if count == 5 || count == 9 {
+			w.WriteHeader(http.StatusOK)
+			return
+		} else {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			return
+		}
+	}))
+	defer testServer.Close()
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+
+	//Test backoff recovery and increase.  This correlates to the constants
+	//which are used in the server implementation returning StatusOK above.
+	seconds := []int{0, 1, 2, 4, 8, 0, 1, 2, 4, 0}
+	request := c.Verb("POST").Prefix("backofftest").Suffix("abc")
+	for _, sec := range seconds {
+		start := time.Now()
+		request.DoRaw()
+		finish := time.Since(start)
+		glog.Infof("%v finished in %v", sec, finish)
+		if finish < time.Duration(sec)*time.Second || finish >= time.Duration(sec+5)*time.Second {
+			t.Fatalf("%v not in range %v", finish, sec)
+		}
 	}
 }
 

--- a/pkg/client/unversioned/restclient.go
+++ b/pkg/client/unversioned/restclient.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -89,10 +90,11 @@ func (c *RESTClient) Verb(verb string) *Request {
 	if c.Throttle != nil {
 		c.Throttle.Accept()
 	}
+	backoff := &URLBackoff{Backoff: util.NewBackOff(1*time.Second, 120*time.Second)}
 	if c.Client == nil {
-		return NewRequest(nil, verb, c.baseURL, c.apiVersion, c.Codec)
+		return NewRequest(nil, verb, c.baseURL, c.apiVersion, c.Codec, backoff)
 	}
-	return NewRequest(c.Client, verb, c.baseURL, c.apiVersion, c.Codec)
+	return NewRequest(c.Client, verb, c.baseURL, c.apiVersion, c.Codec, backoff)
 }
 
 // Post begins a POST request. Short for c.Verb("POST").


### PR DESCRIPTION
commit 1 HTTP Client request metrics: consolidating + client->server endpoint label.
commit 2 Exp backoff, first pass
commit 3 Adding jitter to backoff
commit 4 Updated request with unit tests
commit 5 getting tests to pass by adding disable hook
commit 6 recovery, modified backoff to use backoff.go instead of custom imp.  wrapped in URLBackoff for decoupling
commit 7 testing for Random int updates
commit 8 testing for backoff unit tests
