### PR TITLE
Drop the beta for GCR v2 images.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -101,7 +101,7 @@ readonly KUBE_DOCKER_WRAPPED_BINARIES=(
 
 # The set of addons images that should be prepopulated
 readonly KUBE_ADDON_PATHS=(
-  beta.gcr.io/google_containers/pause:2.0
+  gcr.io/google_containers/pause:2.0
   gcr.io/google_containers/kube-registry-proxy:0.3
 )
 

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -5,9 +5,9 @@ TAG = 2.0
 
 build:
 	./prepare.sh
-	docker build -t beta.gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push:	build
-	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=gcr.io push gcr.io/google_containers/$(IMAGE):$(TAG)
 
 all:	push

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -34,7 +34,7 @@ spec:
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data
-        - image: beta.gcr.io/google_containers/heapster_grafana:v2.1.1
+        - image: gcr.io/google_containers/heapster_grafana:v2.1.1
           name: grafana
           env:
           resources:

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -4,7 +4,7 @@ IMAGE = fluentd-elasticsearch
 TAG = 1.12
 
 build:	
-	docker build -t beta.gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push:	
-	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=gcr.io push gcr.io/google_containers/$(IMAGE):$(TAG)

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: fluentd-elasticsearch
-    image: beta.gcr.io/google_containers/fluentd-elasticsearch:1.12
+    image: gcr.io/google_containers/fluentd-elasticsearch:1.12
     resources:
       limits:
         cpu: 100m

--- a/docs/admin/kubelet.md
+++ b/docs/admin/kubelet.md
@@ -114,7 +114,7 @@ kubelet
       --node-status-update-frequency=10s: Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller. Default: 10s
       --oom-score-adj=-999: The oom-score-adj value for kubelet process. Values must be within the range [-1000, 1000]
       --pod-cidr="": The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.
-      --pod-infra-container-image="beta.gcr.io/google_containers/pause:2.0": The image whose network/ipc namespaces containers in each pod will use.
+      --pod-infra-container-image="gcr.io/google_containers/pause:2.0": The image whose network/ipc namespaces containers in each pod will use.
       --port=10250: The port for the Kubelet to serve on. Note that "kubectl logs" will not work if you set this flag.
       --read-only-port=10255: The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)
       --really-crash-for-testing[=false]: If true, when panics occur crash. Intended for testing.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -40,7 +40,7 @@ import (
 const (
 	PodInfraContainerName  = leaky.PodInfraContainerName
 	DockerPrefix           = "docker://"
-	PodInfraContainerImage = "beta.gcr.io/google_containers/pause:2.0"
+	PodInfraContainerImage = "gcr.io/google_containers/pause:2.0"
 	LogSuffix              = "log"
 )
 

--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -147,7 +147,7 @@ func ReserveCpu(f *Framework, id string, millicores int) {
 		Name:       id,
 		Namespace:  f.Namespace.Name,
 		Timeout:    10 * time.Minute,
-		Image:      "beta.gcr.io/google_containers/pause:2.0",
+		Image:      "gcr.io/google_containers/pause:2.0",
 		Replicas:   millicores / 100,
 		CpuRequest: 100,
 	}
@@ -161,7 +161,7 @@ func ReserveMemory(f *Framework, id string, megabytes int) {
 		Name:       id,
 		Namespace:  f.Namespace.Name,
 		Timeout:    10 * time.Minute,
-		Image:      "beta.gcr.io/google_containers/pause:2.0",
+		Image:      "gcr.io/google_containers/pause:2.0",
 		Replicas:   megabytes / 500,
 		MemRequest: 500 * 1024 * 1024,
 	}

--- a/test/e2e/container_probe.go
+++ b/test/e2e/container_probe.go
@@ -117,7 +117,7 @@ func makePodSpec(readinessProbe, livenessProbe *api.Probe) *api.Pod {
 					ReadinessProbe: readinessProbe,
 				}, {
 					Name:  "test-noprobe",
-					Image: "beta.gcr.io/google_containers/pause:2.0",
+					Image: "gcr.io/google_containers/pause:2.0",
 				},
 			},
 		},

--- a/test/e2e/daemon_restart.go
+++ b/test/e2e/daemon_restart.go
@@ -208,7 +208,7 @@ var _ = Describe("DaemonRestart", func() {
 			Client:      framework.Client,
 			Name:        rcName,
 			Namespace:   ns,
-			Image:       "beta.gcr.io/google_containers/pause:2.0",
+			Image:       "gcr.io/google_containers/pause:2.0",
 			Replicas:    numPods,
 			CreatedPods: &[]*api.Pod{},
 		}

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -186,7 +186,7 @@ var _ = Describe("Density", func() {
 			expectNoError(err)
 			defer fileHndl.Close()
 			config := RCConfig{Client: c,
-				Image:                "beta.gcr.io/google_containers/pause:2.0",
+				Image:                "gcr.io/google_containers/pause:2.0",
 				Name:                 RCName,
 				Namespace:            ns,
 				PollInterval:         itArg.interval,
@@ -316,7 +316,7 @@ var _ = Describe("Density", func() {
 				}
 				for i := 1; i <= nodeCount; i++ {
 					name := additionalPodsPrefix + "-" + strconv.Itoa(i)
-					go createRunningPod(&wg, c, name, ns, "beta.gcr.io/google_containers/pause:2.0", podLabels)
+					go createRunningPod(&wg, c, name, ns, "gcr.io/google_containers/pause:2.0", podLabels)
 					time.Sleep(200 * time.Millisecond)
 				}
 				wg.Wait()

--- a/test/e2e/etcd_failure.go
+++ b/test/e2e/etcd_failure.go
@@ -47,7 +47,7 @@ var _ = Describe("Etcd failure", func() {
 			Client:    framework.Client,
 			Name:      "baz",
 			Namespace: framework.Namespace.Name,
-			Image:     "beta.gcr.io/google_containers/pause:2.0",
+			Image:     "gcr.io/google_containers/pause:2.0",
 			Replicas:  1,
 		})).NotTo(HaveOccurred())
 	})

--- a/test/e2e/garbage_collector.go
+++ b/test/e2e/garbage_collector.go
@@ -73,7 +73,7 @@ func createTerminatingPod(f *Framework) (*api.Pod, error) {
 			Containers: []api.Container{
 				{
 					Name:  string(uuid),
-					Image: "beta.gcr.io/google_containers/busybox",
+					Image: "gcr.io/google_containers/busybox",
 				},
 			},
 		},

--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -130,7 +130,7 @@ var _ = Describe("kubelet", func() {
 					Client:    framework.Client,
 					Name:      rcName,
 					Namespace: framework.Namespace.Name,
-					Image:     "beta.gcr.io/google_containers/pause:2.0",
+					Image:     "gcr.io/google_containers/pause:2.0",
 					Replicas:  totalPods,
 				})).NotTo(HaveOccurred())
 				// Perform a sanity check so that we know all desired pods are

--- a/test/e2e/kubelet_perf.go
+++ b/test/e2e/kubelet_perf.go
@@ -61,7 +61,7 @@ func runResourceTrackingTest(framework *Framework, podsPerNode int, nodeNames se
 		Client:    framework.Client,
 		Name:      rcName,
 		Namespace: framework.Namespace.Name,
-		Image:     "beta.gcr.io/google_containers/pause:2.0",
+		Image:     "gcr.io/google_containers/pause:2.0",
 		Replicas:  totalPods,
 	})).NotTo(HaveOccurred())
 

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -219,7 +219,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "test",
-						Image: "beta.gcr.io/google_containers/pause:2.0",
+						Image: "gcr.io/google_containers/pause:2.0",
 					},
 				},
 			},
@@ -244,7 +244,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "nginx",
-						Image: "beta.gcr.io/google_containers/pause:2.0",
+						Image: "gcr.io/google_containers/pause:2.0",
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								api.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -230,7 +230,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  "",
-						Image: "beta.gcr.io/google_containers/pause:2.0",
+						Image: "gcr.io/google_containers/pause:2.0",
 					},
 				},
 			},
@@ -249,7 +249,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "beta.gcr.io/google_containers/pause:2.0",
+						Image: "gcr.io/google_containers/pause:2.0",
 					},
 				},
 			},
@@ -308,7 +308,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  "",
-						Image: "beta.gcr.io/google_containers/pause:2.0",
+						Image: "gcr.io/google_containers/pause:2.0",
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								"cpu": *resource.NewMilliQuantity(milliCpuPerPod, "DecimalSI"),
@@ -332,7 +332,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "beta.gcr.io/google_containers/pause:2.0",
+						Image: "gcr.io/google_containers/pause:2.0",
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								"cpu": *resource.NewMilliQuantity(milliCpuPerPod, "DecimalSI"),
@@ -372,7 +372,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "beta.gcr.io/google_containers/pause:2.0",
+						Image: "gcr.io/google_containers/pause:2.0",
 					},
 				},
 				NodeSelector: map[string]string{
@@ -408,7 +408,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "beta.gcr.io/google_containers/pause:2.0",
+						Image: "gcr.io/google_containers/pause:2.0",
 					},
 				},
 			},
@@ -446,7 +446,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  labelPodName,
-						Image: "beta.gcr.io/google_containers/pause:2.0",
+						Image: "gcr.io/google_containers/pause:2.0",
 					},
 				},
 				NodeSelector: map[string]string{

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1074,7 +1074,7 @@ func createPodOrFail(c *client.Client, ns, name string, labels map[string]string
 			Containers: []api.Container{
 				{
 					Name:  "test",
-					Image: "beta.gcr.io/google_containers/pause:2.0",
+					Image: "gcr.io/google_containers/pause:2.0",
 					Ports: containerPorts,
 				},
 			},

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -119,7 +119,7 @@ var _ = Describe("Service endpoints latency", func() {
 func runServiceLatencies(f *Framework, inParallel, total int) (output []time.Duration, err error) {
 	cfg := RCConfig{
 		Client:       f.Client,
-		Image:        "beta.gcr.io/google_containers/pause:2.0",
+		Image:        "gcr.io/google_containers/pause:2.0",
 		Name:         "svc-latency-rc",
 		Namespace:    f.Namespace.Name,
 		Replicas:     1,


### PR DESCRIPTION
`beta.gcr.io` is no longer needed to pull through v2.
