### PR TITLE
Move around an error check so that we still print out events.

### DIFF
--- a/test/e2e/daemon_restart.go
+++ b/test/e2e/daemon_restart.go
@@ -202,9 +202,9 @@ var _ = Describe("DaemonRestart", func() {
 	})
 
 	AfterEach(func() {
+		defer framework.afterEach()
 		close(stopCh)
 		expectNoError(DeleteRC(framework.Client, ns, rcName))
-		framework.afterEach()
 	})
 
 	It("Controller Manager should not create/delete replicas across restart", func() {


### PR DESCRIPTION
We should do something similar at HEAD.  We need events to help debug e2e test failures.

@ixdy @quinton-hoole @ihmccreery 

@kubernetes/goog-testing 
