### PR TITLE
Improve examples/https-nginx dependency management

### DIFF
--- a/examples/https-nginx/Makefile
+++ b/examples/https-nginx/Makefile
@@ -11,7 +11,7 @@ keys:
 	openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $(KEY) -out $(CERT) -subj "/CN=nginxsvc/O=nginxsvc"
 
 secret:
-	CGO_ENABLED=0 GOOS=linux go run -a -installsuffix cgo -ldflags '-w' make_secret.go -crt $(CERT) -key $(KEY) > $(SECRET)
+	godep go run make_secret.go -crt $(CERT) -key $(KEY) > $(SECRET)
 
 container:
 	docker build -t $(PREFIX):$(TAG) .


### PR DESCRIPTION
The https-nginx example is a little bit painful for a beginner to get through.  I believe most of that pain can be attributed to the one line changed in this PR.

The problems with it are twofold:
1. Explicitly compiling for Linux instead of compiling for the native architecture of the machine the user is working on.  (So, as is, this example fails on Mac OS, for instance.)
2. Not using any dependency management.  This requires a user to issue numerous `go get` commands, and even that doesn't guarantee they get the same dependency versions that are vendored in `/Godeps` at the root of the project.  (In the event that a dependency does not respect semver, it doesn't even guarantee that they get _compatible_ versions.)

The easy fix for this is to make the `secret` task use godep.
