### PR TITLE
Label nodes with Zone information, if available

### DIFF
--- a/pkg/api/unversioned/well_known_labels.go
+++ b/pkg/api/unversioned/well_known_labels.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+const LabelZoneFailureDomain = "kubernetes.io/zone-failure-domain"
+const LabelZoneRegion = "kubernetes.io/zone-region"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -901,6 +901,23 @@ func (kl *Kubelet) initialNodeStatus() (*api.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// If the cloud has zone information, label the node with the zone information
+		zones, ok := kl.cloud.Zones()
+		if ok {
+			zone, err := zones.GetZone()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get zone from cloud provider: %v", err)
+			}
+			if zone.FailureDomain != "" {
+				glog.Infof("Adding node label from cloud provider: %s=%s", unversioned.LabelZoneFailureDomain, zone.FailureDomain)
+				node.ObjectMeta.Labels[unversioned.LabelZoneFailureDomain] = zone.FailureDomain
+			}
+			if zone.Region != "" {
+				glog.Infof("Adding node label from cloud provider: %s=%s", unversioned.LabelZoneRegion, zone.Region)
+				node.ObjectMeta.Labels[unversioned.LabelZoneRegion] = zone.Region
+			}
+		}
 	} else {
 		node.Spec.ExternalID = kl.hostname
 	}


### PR DESCRIPTION
This lays the groundwork for simple multizone capabilities.

In a cloud environment, nodes are typically created by the kubelet
registering with the API server.  When creating a new node, we now query
the cloudprovider to see if it can provide Zone information, and if so
we add some well-known labels to the Node we are creating.
