### PR TITLE
component status: nil error should return empty string

### DIFF
--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -88,7 +88,7 @@ func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList)
 func testComponentStatusData() *api.ComponentStatusList {
 	good := api.ComponentStatus{
 		Conditions: []api.ComponentCondition{
-			{Type: api.ComponentHealthy, Status: api.ConditionTrue, Message: "ok", Error: "nil"},
+			{Type: api.ComponentHealthy, Status: api.ConditionTrue, Message: "ok"},
 		},
 		ObjectMeta: api.ObjectMeta{Name: "servergood"},
 	}

--- a/pkg/registry/componentstatus/rest.go
+++ b/pkg/registry/componentstatus/rest.go
@@ -85,11 +85,9 @@ func ToConditionStatus(s probe.Result) api.ConditionStatus {
 func (rs *REST) getComponentStatus(name string, server apiserver.Server) *api.ComponentStatus {
 	transport := rs.rt
 	status, msg, err := server.DoServerCheck(transport)
-	var errorMsg string
+	errorMsg := ""
 	if err != nil {
 		errorMsg = err.Error()
-	} else {
-		errorMsg = "nil"
 	}
 
 	c := &api.ComponentCondition{

--- a/pkg/registry/componentstatus/rest_test.go
+++ b/pkg/registry/componentstatus/rest_test.go
@@ -81,7 +81,7 @@ func TestList_NoError(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	expect := &api.ComponentStatusList{
-		Items: []api.ComponentStatus{*(createTestStatus("test1", api.ConditionTrue, "ok", "nil"))},
+		Items: []api.ComponentStatus{*(createTestStatus("test1", api.ConditionTrue, "ok", ""))},
 	}
 	if e, a := expect, got; !reflect.DeepEqual(e, a) {
 		t.Errorf("Got unexpected object. Diff: %s", util.ObjectDiff(e, a))
@@ -124,7 +124,7 @@ func TestGet_NoError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	expect := createTestStatus("test1", api.ConditionTrue, "ok", "nil")
+	expect := createTestStatus("test1", api.ConditionTrue, "ok", "")
 	if e, a := expect, got; !reflect.DeepEqual(e, a) {
 		t.Errorf("Got unexpected object. Diff: %s", util.ObjectDiff(e, a))
 	}


### PR DESCRIPTION
Fixed #16721 

If error is nil, it should return empty string instead of \"nil\".
JSON marshalling will omit empty error in such case.
