### PR TITLE
Automated cherry pick of #15519 #15737 #15793 upstream release 1.1

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -437,31 +437,6 @@ function ensure-temp-dir {
   fi
 }
 
-# Verify and find the various tar files that we are going to use on the server.
-#
-# Vars set:
-#   SERVER_BINARY_TAR
-#   SALT_TAR
-function find-release-tars {
-  SERVER_BINARY_TAR="${KUBE_ROOT}/server/kubernetes-server-linux-amd64.tar.gz"
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    SERVER_BINARY_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-server-linux-amd64.tar.gz"
-  fi
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    echo "!!! Cannot find kubernetes-server-linux-amd64.tar.gz"
-    exit 1
-  fi
-
-  SALT_TAR="${KUBE_ROOT}/server/kubernetes-salt.tar.gz"
-  if [[ ! -f "$SALT_TAR" ]]; then
-    SALT_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-salt.tar.gz"
-  fi
-  if [[ ! -f "$SALT_TAR" ]]; then
-    echo "!!! Cannot find kubernetes-salt.tar.gz"
-    exit 1
-  fi
-}
-
 # Take the local tar files and upload them to S3.  They will then be
 # downloaded by the master as part of the start up script for the master.
 #

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -260,10 +260,10 @@ function set_binary_version() {
 # use local dev binaries.
 #
 # Assumed vars:
+#   KUBE_VERSION
 #   KUBE_VERSION_REGEX
 #   KUBE_CI_VERSION_REGEX
 # Vars set:
-#   KUBE_TAR_URL
 #   KUBE_TAR_HASH
 #   SERVER_BINARY_TAR_URL
 #   SERVER_BINARY_TAR_HASH
@@ -274,36 +274,27 @@ function tars_from_version() {
     find-release-tars
     upload-server-tars
   elif [[ ${KUBE_VERSION} =~ ${KUBE_VERSION_REGEX} ]]; then
-    KUBE_TAR_URL="https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes.tar.gz"
     SERVER_BINARY_TAR_URL="https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes-server-linux-amd64.tar.gz"
     SALT_TAR_URL="https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes-salt.tar.gz"
   elif [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then
-    KUBE_TAR_URL="https://storage.googleapis.com/kubernetes-release/ci/${KUBE_VERSION}/kubernetes.tar.gz"
     SERVER_BINARY_TAR_URL="https://storage.googleapis.com/kubernetes-release/ci/${KUBE_VERSION}/kubernetes-server-linux-amd64.tar.gz"
     SALT_TAR_URL="https://storage.googleapis.com/kubernetes-release/ci/${KUBE_VERSION}/kubernetes-salt.tar.gz"
   else
     echo "Version doesn't match regexp" >&2
     exit 1
   fi
-  until KUBE_TAR_HASH=$(curl --fail --silent "${KUBE_TAR_URL}.sha1"); do
+  if ! SERVER_BINARY_TAR_HASH=$(curl -Ss --fail "${SERVER_BINARY_TAR_URL}.sha1"); then
     echo "Failure trying to curl release .sha1"
-  done
-  until SERVER_BINARY_TAR_HASH=$(curl --fail --silent "${SERVER_BINARY_TAR_URL}.sha1"); do
-    echo "Failure trying to curl release .sha1"
-  done
-  until SALT_TAR_HASH=$(curl --fail --silent "${SALT_TAR_URL}.sha1"); do
-    echo "Failure trying to curl Salt tar .sha1"
-  done
-
-  if ! curl -Ss --range 0-1 "${KUBE_TAR_URL}" >&/dev/null; then
-    echo "Can't find release at ${KUBE_TAR_URL}" >&2
-    exit 1
   fi
-  if ! curl -Ss --range 0-1 "${SERVER_BINARY_TAR_URL}" >&/dev/null; then
+  if ! SALT_TAR_HASH=$(curl -Ss --fail "${SALT_TAR_URL}.sha1"); then
+    echo "Failure trying to curl Salt tar .sha1"
+  fi
+
+  if ! curl -Ss --head "${SERVER_BINARY_TAR_URL}" >&/dev/null; then
     echo "Can't find release at ${SERVER_BINARY_TAR_URL}" >&2
     exit 1
   fi
-  if ! curl -Ss --range 0-1 "${SALT_TAR_URL}" >&/dev/null; then
+  if ! curl -Ss --head "${SALT_TAR_URL}" >&/dev/null; then
     echo "Can't find Salt tar at ${SALT_TAR_URL}" >&2
     exit 1
   fi

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -309,3 +309,29 @@ function tars_from_version() {
   fi
 }
 
+# Verify and find the various tar files that we are going to use on the server.
+#
+# Assumed vars:
+#   KUBE_ROOT
+# Vars set:
+#   SERVER_BINARY_TAR
+#   SALT_TAR
+function find-release-tars() {
+  SERVER_BINARY_TAR="${KUBE_ROOT}/server/kubernetes-server-linux-amd64.tar.gz"
+  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
+    SERVER_BINARY_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-server-linux-amd64.tar.gz"
+  fi
+  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
+    echo "!!! Cannot find kubernetes-server-linux-amd64.tar.gz" >&2
+    exit 1
+  fi
+
+  SALT_TAR="${KUBE_ROOT}/server/kubernetes-salt.tar.gz"
+  if [[ ! -f "$SALT_TAR" ]]; then
+    SALT_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-salt.tar.gz"
+  fi
+  if [[ ! -f "$SALT_TAR" ]]; then
+    echo "!!! Cannot find kubernetes-salt.tar.gz" >&2
+    exit 1
+  fi
+}

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -34,29 +34,38 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 function usage() {
   echo "!!! EXPERIMENTAL !!!"
   echo ""
-  echo "${0} [-M|-N|-P] -l | <release or continuous integration version> | [latest_stable|latest_release|latest_ci]"
+  echo "${0} [-M|-N|-P] -l | <version number or publication>"
   echo "  Upgrades master and nodes by default"
   echo "  -M:  Upgrade master only"
   echo "  -N:  Upgrade nodes only"
   echo "  -P:  Node upgrade prerequisites only (create a new instance template)"
   echo "  -l:  Use local(dev) binaries"
   echo ""
+  echo '  Version number or publication is either a proper version number'
+  echo '  (e.g. "v1.0.6", "v1.2.0-alpha.1.881+376438b69c7612") or a version'
+  echo '  publication of the form <bucket>/<version> (e.g. "release/stable",'
+  echo '  "ci/latest-1").  Some common ones are:'
+  echo '    - "release/stable"'
+  echo '    - "release/latest"'
+  echo '    - "ci/latest"'
+  echo '  See the docs on getting builds for more information about version publication.'
+  echo ""
   echo "(... Fetching current release versions ...)"
   echo ""
 
   # NOTE: IF YOU CHANGE THE FOLLOWING LIST, ALSO UPDATE test/e2e/cluster_upgrade.go
-  local latest_release
-  local latest_stable
-  local latest_ci
+  local release_stable
+  local release_latest
+  local ci_latest
 
-  latest_stable=$(gsutil cat gs://kubernetes-release/release/stable.txt)
-  latest_release=$(gsutil cat gs://kubernetes-release/release/latest.txt)
-  latest_ci=$(gsutil cat gs://kubernetes-release/ci/latest.txt)
+  release_stable=$(gsutil cat gs://kubernetes-release/release/stable.txt)
+  release_latest=$(gsutil cat gs://kubernetes-release/release/latest.txt)
+  ci_latest=$(gsutil cat gs://kubernetes-release/ci/latest.txt)
 
-  echo "To upgrade to:"
-  echo "  latest stable:  ${0} ${latest_stable}"
-  echo "  latest release: ${0} ${latest_release}"
-  echo "  latest ci:      ${0} ${latest_ci}"
+  echo "Right now, versions are as follows:"
+  echo "  release/stable: ${0} ${release_stable}"
+  echo "  release/latest: ${0} ${release_latest}"
+  echo "  ci/latest:      ${0} ${ci_latest}"
 }
 
 function upgrade-master() {

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -40,13 +40,6 @@ KUBE_SKIP_UPDATE=${KUBE_SKIP_UPDATE-"n"}
 # simultaneously (e.g. on Jenkins).
 KUBE_GCS_STAGING_PATH_SUFFIX=${KUBE_GCS_STAGING_PATH_SUFFIX-""}
 
-# VERSION_REGEX matches things like "v0.13.1"
-readonly KUBE_VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
-
-# CI_VERSION_REGEX matches things like "v0.14.1-341-ge0c9d9e"
-readonly KUBE_CI_VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-(.*)$"
-
-
 function join_csv {
   local IFS=','; echo "$*";
 }

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -93,31 +93,6 @@ function ensure-temp-dir {
   fi
 }
 
-# Verify and find the various tar files that we are going to use on the server.
-#
-# Vars set:
-#   SERVER_BINARY_TAR
-#   SALT_TAR
-function find-release-tars {
-  SERVER_BINARY_TAR="${KUBE_ROOT}/server/kubernetes-server-linux-amd64.tar.gz"
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    SERVER_BINARY_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-server-linux-amd64.tar.gz"
-  fi
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    echo "!!! Cannot find kubernetes-server-linux-amd64.tar.gz"
-    exit 1
-  fi
-
-  SALT_TAR="${KUBE_ROOT}/server/kubernetes-salt.tar.gz"
-  if [[ ! -f "$SALT_TAR" ]]; then
-    SALT_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-salt.tar.gz"
-  fi
-  if [[ ! -f "$SALT_TAR" ]]; then
-    echo "!!! Cannot find kubernetes-salt.tar.gz"
-    exit 1
-  fi
-}
-
 # Use the gcloud defaults to find the project.  If it is already set in the
 # environment then go with that.
 #

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -250,17 +250,6 @@ function kube-down {
   destroy-network
 }
 
-function find-release-tars {
-  SERVER_BINARY_TAR="${KUBE_ROOT}/server/kubernetes-server-linux-amd64.tar.gz"
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    SERVER_BINARY_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-server-linux-amd64.tar.gz"
-  fi
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    echo "!!! Cannot find kubernetes-server-linux-amd64.tar.gz"
-    exit 1
-  fi
-}
-
 # The kubernetes binaries are pushed to a host directory which is exposed to the VM
 function upload-server-tars {
   tar -x -C "$POOL_PATH/kubernetes" -f "$SERVER_BINARY_TAR" kubernetes

--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -66,19 +66,6 @@ rax-ssh-key() {
   fi
 }
 
-find-release-tars() {
-  SERVER_BINARY_TAR="${KUBE_ROOT}/server/kubernetes-server-linux-amd64.tar.gz"
-  RELEASE_DIR="${KUBE_ROOT}/server/"
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    SERVER_BINARY_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-server-linux-amd64.tar.gz"
-    RELEASE_DIR="${KUBE_ROOT}/_output/release-tars/"
-  fi
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    echo "!!! Cannot find kubernetes-server-linux-amd64.tar.gz"
-    exit 1
-  fi
-}
-
 rackspace-set-vars() {
 
   CLOUDFILES_CONTAINER="kubernetes-releases-${OS_USERNAME}"
@@ -114,7 +101,7 @@ ensure_dev_container() {
 copy_dev_tarballs() {
 
   echo "cluster/rackspace/util.sh: Uploading to Cloud Files"
-  ${SWIFTLY_CMD} put -i ${RELEASE_DIR}/kubernetes-server-linux-amd64.tar.gz \
+  ${SWIFTLY_CMD} put -i ${SERVER_BINARY_TAR} \
   ${CLOUDFILES_CONTAINER}/${CONTAINER_PREFIX}/kubernetes-server-linux-amd64.tar.gz > /dev/null 2>&1
 
   echo "Release pushed."

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -126,31 +126,6 @@ function ensure-temp-dir {
   fi
 }
 
-# Verify and find the various tar files that we are going to use on the server.
-#
-# Vars set:
-#   SERVER_BINARY_TAR
-#   SALT_TAR
-function find-release-tars {
-  SERVER_BINARY_TAR="${KUBE_ROOT}/server/kubernetes-server-linux-amd64.tar.gz"
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    SERVER_BINARY_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-server-linux-amd64.tar.gz"
-  fi
-  if [[ ! -f "$SERVER_BINARY_TAR" ]]; then
-    echo "!!! Cannot find kubernetes-server-linux-amd64.tar.gz"
-    exit 1
-  fi
-
-  SALT_TAR="${KUBE_ROOT}/server/kubernetes-salt.tar.gz"
-  if [[ ! -f "$SALT_TAR" ]]; then
-    SALT_TAR="${KUBE_ROOT}/_output/release-tars/kubernetes-salt.tar.gz"
-  fi
-  if [[ ! -f "$SALT_TAR" ]]; then
-    echo "!!! Cannot find kubernetes-salt.tar.gz"
-    exit 1
-  fi
-}
-
 # Take the local tar files and upload them to the master.
 #
 # Assumed vars:

--- a/docs/admin/cluster-management.md
+++ b/docs/admin/cluster-management.md
@@ -46,16 +46,7 @@ The node upgrade process is user-initiated and is described in the [GKE document
 
 Upgrades on open source Google Compute Engine (GCE) clusters are controlled by the ```cluster/gce/upgrade.sh``` script.
 
-Its usage is as follows:
-
-```console
-cluster/gce/upgrade.sh [-M|-N|-P] -l | <release or continuous integration version> | [latest_stable|latest_release|latest_ci]
-  Upgrades master and nodes by default
-  -M:  Upgrade master only
-  -N:  Upgrade nodes only
-  -P:  Node upgrade prerequisites only (create a new instance template)
-  -l:  Use local(dev) binaries
-```
+Get its usage by running `cluster/gce/upgrade.sh -h`.
 
 For example, to upgrade just your master to a specific version (v1.0.2):
 
@@ -66,7 +57,7 @@ cluster/gce/upgrade.sh -M v1.0.2
 Alternatively, to upgrade your entire cluster to the latest stable release:
 
 ```console
-cluster/gce/upgrade.sh latest_stable
+cluster/gce/upgrade.sh release/stable
 ```
 
 ### Other platforms

--- a/docs/devel/getting-builds.md
+++ b/docs/devel/getting-builds.md
@@ -7,17 +7,27 @@
 
 You can use [hack/get-build.sh](http://releases.k8s.io/release-1.1/hack/get-build.sh) to or use as a reference on how to get the most recent builds with curl. With `get-build.sh` you can grab the most recent stable build, the most recent release candidate, or the most recent build to pass our ci and gce e2e tests (essentially a nightly build).
 
-```console
-usage:
-  ./hack/get-build.sh [stable|release|latest|latest-green]
+Run `./hack/get-build.sh -h` for its usage.
 
-        stable:        latest stable version
-        release:       latest release candidate
-        latest:        latest ci build
-        latest-green:  latest ci build to pass gce e2e
+For example, to get a build at a specific version (v1.0.2):
+
+```console
+./hack/get-build.sh v1.0.2
 ```
 
-You can also use the gsutil tool to explore the Google Cloud Storage release bucket. Here are some examples:
+Alternatively, to get the latest stable release:
+
+```console
+./hack/get-build.sh release/stable
+```
+
+Finally, you can just print the latest or stable version:
+
+```console
+./hack/get-build.sh -v ci/latest
+```
+
+You can also use the gsutil tool to explore the Google Cloud Storage release buckets. Here are some examples:
 
 ```sh
 gsutil cat gs://kubernetes-release/ci/latest.txt          # output the latest ci version number

--- a/hack/get-build.sh
+++ b/hack/get-build.sh
@@ -18,53 +18,59 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+source "${KUBE_ROOT}/cluster/common.sh"
+
 declare -r KUBE_RELEASE_BUCKET_URL="https://storage.googleapis.com/kubernetes-release"
 declare -r KUBE_TAR_NAME="kubernetes.tar.gz"
 
 usage() {
-	echo "usage:
-  $0 [stable|release|latest|latest-green]
-
-        stable:        latest stable version
-        release:       latest release candidate
-        latest:        latest ci build
-        latest-green:  latest ci build to pass gce e2e"
+  echo "${0} [-v] <version number or publication>"
+  echo "  -v:  Don't get tars, just print the version number"
+  echo ""
+  echo '  Version number or publication is either a proper version number'
+  echo '  (e.g. "v1.0.6", "v1.2.0-alpha.1.881+376438b69c7612") or a version'
+  echo '  publication of the form <bucket>/<version> (e.g. "release/stable",'
+  echo '  "ci/latest-1").  Some common ones are:'
+  echo '    - "release/stable"'
+  echo '    - "release/latest"'
+  echo '    - "ci/latest"'
+  echo '  See the docs on getting builds for more information about version'
+  echo '  publication.'
 }
+
+print_version=false
+
+while getopts ":vh" opt; do
+  case ${opt} in
+    v)
+      print_version="true"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
 
 if [[ $# -ne 1 ]]; then
     usage
     exit 1
 fi
 
-case "$1" in
-  "latest")
-    # latest ci version is written in the latest.txt in the /ci dir
-    KUBE_TAR_RELATIVE_PATH="ci"
-    KUBE_VERSION_FILE="latest.txt"
-    ;;
-  "latest-green")
-    # latest ci version to pass gce e2e is written in the latest-green.txt in the /ci dir
-    KUBE_TAR_RELATIVE_PATH="ci"
-    KUBE_VERSION_FILE="latest-green.txt"
-    ;;
-  "stable")
-    # latest stable release version is written in the stable.txt file in the /release dir
-    KUBE_TAR_RELATIVE_PATH="release"
-    KUBE_VERSION_FILE="stable.txt"
-    ;;
-  "release")
-    # latest release candidate version is written in latest.txt in the /release dir
-    KUBE_TAR_RELATIVE_PATH="release"
-    KUBE_VERSION_FILE="latest.txt"
-    ;;
-  *)
-    usage
-    exit 1
-    ;;
-esac
+set_binary_version ${1}
 
-KUBE_BINARY_DIRECTORY="${KUBE_RELEASE_BUCKET_URL}/${KUBE_TAR_RELATIVE_PATH}"
-KUBE_VERSION=$(curl --silent --fail "${KUBE_BINARY_DIRECTORY}/${KUBE_VERSION_FILE}")
-KUBE_BINARY_PATH="${KUBE_BINARY_DIRECTORY}/${KUBE_VERSION}/${KUBE_TAR_NAME}"
-
-curl --fail -o kubernetes-${KUBE_VERSION}.tar.gz "${KUBE_BINARY_PATH}"
+if [[ "${print_version}" == "true" ]]; then
+  echo "${KUBE_VERSION}"
+else
+  echo "Using version at ${1}: ${KUBE_VERSION}" >&2
+  tars_from_version
+  curl --fail -o kubernetes-${KUBE_VERSION}.tar.gz "${KUBE_TAR_URL}"
+fi

--- a/hack/get-build.sh
+++ b/hack/get-build.sh
@@ -71,6 +71,12 @@ if [[ "${print_version}" == "true" ]]; then
   echo "${KUBE_VERSION}"
 else
   echo "Using version at ${1}: ${KUBE_VERSION}" >&2
-  tars_from_version
-  curl --fail -o kubernetes-${KUBE_VERSION}.tar.gz "${KUBE_TAR_URL}"
+  if [[ ${KUBE_VERSION} =~ ${KUBE_VERSION_REGEX} ]]; then
+    curl --fail -o kubernetes-${KUBE_VERSION}.tar.gz "https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes.tar.gz"
+  elif [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then
+    curl --fail -o kubernetes-${KUBE_VERSION}.tar.gz "https://storage.googleapis.com/kubernetes-release/ci/${KUBE_VERSION}/kubernetes.tar.gz"
+  else
+    echo "Version doesn't match regexp" >&2
+    exit 1
+  fi
 fi

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -89,6 +89,7 @@ readonly KUBE_TEST_PORTABLE=(
   test/images/network-tester/service.json
   hack/e2e.go
   hack/e2e-internal
+  hack/get-build.sh
   hack/ginkgo-e2e.sh
   hack/lib
 )

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -79,7 +79,7 @@ func init() {
 
 	flag.StringVar(&cloudConfig.ClusterTag, "cluster-tag", "", "Tag used to identify resources.  Only required if provider is aws.")
 	flag.IntVar(&testContext.MinStartupPods, "minStartupPods", 0, "The number of pods which we need to see in 'Running' state with a 'Ready' condition of true, before we try running tests. This is useful in any cluster which needs some base pod-based services running before it can be used.")
-	flag.StringVar(&testContext.UpgradeTarget, "upgrade-target", "latest_ci", "Version to upgrade to (e.g. 'latest_stable', 'latest_release', 'latest_ci', '0.19.1', '0.19.1-669-gabac8c8') if doing an upgrade test.")
+	flag.StringVar(&testContext.UpgradeTarget, "upgrade-target", "ci/latest", "Version to upgrade to (e.g. 'release/stable', 'release/latest', 'ci/latest', '0.19.1', '0.19.1-669-gabac8c8') if doing an upgrade test.")
 	flag.StringVar(&testContext.PrometheusPushGateway, "prom-push-gateway", "", "The URL to prometheus gateway, so that metrics can be pushed during e2es and scraped by prometheus. Typically something like 127.0.0.1:9091.")
 	flag.BoolVar(&testContext.VerifyServiceAccount, "e2e-verify-service-account", true, "If true tests will verify the service account before running.")
 }


### PR DESCRIPTION
These changes are needed so that GKE upgrades work properly in the release-1.1 branch.
