### PR TITLE
Print clue for getting command prompt

### DIFF
--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -182,6 +182,7 @@ func (p *AttachOptions) Run() error {
 					if err != nil {
 						glog.Fatal(err)
 					}
+					fmt.Fprintln(p.Out, "\nHit enter for command prompt")
 					// this handles a clean exit, where the command finished
 					defer term.RestoreTerminal(inFd, oldState)
 


### PR DESCRIPTION
Ref #16742

after PR, the result  `kubectl run date -i --tty --restart=Never --image=busybox -- /bin/sh`  as follows:

```
Waiting for pod default/date to be running, status is Pending, pod ready: false

Hit enter for command prompt

```
