### PR TITLE
Workaround docker-pull issues with examples/cluster-dns

### DIFF
--- a/examples/cluster-dns/dns-backend-rc.yaml
+++ b/examples/cluster-dns/dns-backend-rc.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: dns-backend
-          image: ddysher/dns-backend
+          image: gcr.io/google_containers/example-dns-backend:v1
           ports:
             - name: backend-port
               containerPort: 8000

--- a/examples/cluster-dns/dns-frontend-pod.yaml
+++ b/examples/cluster-dns/dns-frontend-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: dns-frontend
-      image: ddysher/dns-frontend
+      image: gcr.io/google_containers/example-dns-frontend:v1
       command:
         - python
         - client.py

--- a/examples/cluster-dns/images/backend/Dockerfile
+++ b/examples/cluster-dns/images/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-slim
 
 COPY . /dns-backend
 WORKDIR /dns-backend

--- a/examples/cluster-dns/images/backend/Makefile
+++ b/examples/cluster-dns/images/backend/Makefile
@@ -1,0 +1,13 @@
+TAG = v1
+PREFIX = gcr.io/google_containers
+IMAGE = example-dns-backend
+
+all: push
+
+image:
+	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
+
+push: image
+	gcloud docker push $(PREFIX)/$(IMAGE)
+
+clean:

--- a/examples/cluster-dns/images/frontend/Dockerfile
+++ b/examples/cluster-dns/images/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-slim
 
 RUN pip install requests
 

--- a/examples/cluster-dns/images/frontend/Makefile
+++ b/examples/cluster-dns/images/frontend/Makefile
@@ -1,0 +1,13 @@
+TAG = v1
+PREFIX = gcr.io/google_containers
+IMAGE = example-dns-frontend
+
+all: push
+
+image:
+	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
+
+push: image
+	gcloud docker push $(PREFIX)/$(IMAGE)
+
+clean:


### PR DESCRIPTION
The cluster-dns example is used as conformance test in `tests/e2e/examples.go`. The dns-frontend image often triggers a docker-pull freeze (which is independent of k8s), but block conformance testing.

This PR
- changes the base image to `python:2.7-slim` which is only 30% the original size
- changes the docker registry to gcr.io

**NOTE**: tests will fail until the images are pushed to gcr.io. The Dockerfiles are in `examples/cluster-dns/images`
