### PR TITLE
AWS: Always use an elastic IP for the master

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -77,9 +77,9 @@ POLL_SLEEP_INTERVAL=3
 SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET
 CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.244.0.0/16}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
-# If set to Elastic IP, master instance will be associated with this IP.
-# If set to auto, a new Elastic IP will be acquired
-# Otherwise amazon-given public ip will be used (it'll change with reboot).
+# If set to an Elastic IP address, master instance will be associated with this IP.
+# Otherwise a new Elastic IP will be acquired
+# (We used to accept 'auto' to mean 'allocate elastic ip', but now that is the default)
 MASTER_RESERVED_IP="${MASTER_RESERVED_IP:-}"
 RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 ENABLE_EXPERIMENTAL_API="${KUBE_ENABLE_EXPERIMENTAL_API:-false}"

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -75,9 +75,9 @@ POLL_SLEEP_INTERVAL=3
 SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET
 CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.245.0.0/16}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
-# If set to Elastic IP, master instance will be associated with this IP.
-# If set to auto, a new Elastic IP will be acquired
-# Otherwise amazon-given public ip will be used (it'll change with reboot).
+# If set to an Elastic IP address, master instance will be associated with this IP.
+# Otherwise a new Elastic IP will be acquired
+# (We used to accept 'auto' to mean 'allocate elastic ip', but now that is the default)
 MASTER_RESERVED_IP="${MASTER_RESERVED_IP:-}"
 RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 ENABLE_EXPERIMENTAL_API="${KUBE_ENABLE_EXPERIMENTAL_API:-false}"


### PR DESCRIPTION
If we don't assign the master an elastic IP, when we restart it the IP
changes and the SSL certs break and users must update their
configurations.

So always create an elastic IP for the master (unless an IP is specified
in MASTER_RESERVED_IP, in which case use that)

Fix #16469
