### PR TITLE
Make verify-generated-docs work inside docker.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -416,6 +416,7 @@ function kube::build::source_targets() {
   local targets=(
     api
     build
+    cluster
     cmd
     docs
     examples
@@ -425,9 +426,12 @@ function kube::build::source_targets() {
     LICENSE
     pkg
     plugin
+    DESIGN.md
     README.md
     test
     third_party
+    contrib/completions/bash/kubectl
+    .generated_docs
   )
   if [ -n "${KUBERNETES_CONTRIB:-}" ]; then
     for contrib in "${KUBERNETES_CONTRIB}"; do


### PR DESCRIPTION
Add a few missing files to the docker tarball.

Before:

<pre>
% build/run.sh hack/verify-generated-docs.sh
+++ [1106 10:10:55] Verifying Prerequisites....
+++ [1106 10:10:56] Building Docker image kube-build:cross.
+++ [1106 10:10:59] Building Docker image kube-build:build-0343d9fca5.
+++ [1106 10:11:04] Running build command....
+++ [1106 18:11:05] Building go targets for linux/amd64:
    cmd/gendocs
    cmd/genkubedocs
    cmd/genman
    cmd/genbashcomp
    cmd/mungedocs
+++ [1106 18:11:29] Placing binaries
/go/src/k8s.io/kubernetes/docs/admin/cluster-large.md
----
md-links:
contents were modified

/go/src/k8s.io/kubernetes/docs/design/aws_under_the_hood.md
----
md-links:
"../../cluster/aws/templates/iam/kubernetes-master-policy.json": target not found

/go/src/k8s.io/kubernetes/docs/getting-started-guides/docker-multinode/deployDNS.md
----
md-links:
contents were modified

/go/src/k8s.io/kubernetes/docs/getting-started-guides/juju.md
----
md-links:
contents were modified

/go/src/k8s.io/kubernetes/docs/getting-started-guides/locally.md
----
md-links:
contents were modified

/go/src/k8s.io/kubernetes/docs/getting-started-guides/logging.md
----
md-links:
"../../cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml?raw=true": target not found

sync-examples:
open cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml: no such file or directory

/go/src/k8s.io/kubernetes/docs/getting-started-guides/rkt/README.md
----
md-links:
contents were modified

/go/src/k8s.io/kubernetes/docs/getting-started-guides/scratch.md
----
md-links:
contents were modified

/go/src/k8s.io/kubernetes/docs/getting-started-guides/ubuntu-calico.md
----
md-links:
contents were modified

/go/src/k8s.io/kubernetes/docs/user-guide/monitoring.md
----
md-links:
contents were modified

/go/src/k8s.io/kubernetes/docs/user-guide/ui.md
----
kubectl-dash-f:
44: target file "cluster/addons/kube-ui/kube-ui-rc.yaml" does not exist
45: target file "cluster/addons/kube-ui/kube-ui-svc.yaml" does not exist

FAIL: changes needed but not made due to --verify
/go/src/k8s.io/kubernetes/docs/ is out of date. Please run hack/update-generated-docs.sh
!!! Error in hack/verify-generated-docs.sh:28
  '"${KUBE_ROOT}/hack/after-build/verify-generated-docs.sh" "$@"' exited with status 1
Call stack:
  1: hack/verify-generated-docs.sh:28 main(...)
Exiting with status 1
!!! Error in build/../build/common.sh:556
  '"${docker_cmd[@]}" "$@"' exited with status 1
Call stack:
  1: build/../build/common.sh:556 kube::build::run_build_command(...)
  2: build/run.sh:30 main(...)
Exiting with status 1
zsh: exit 1     build/run.sh hack/verify-generated-docs.sh
</pre>


After:

<pre>
% build/run.sh hack/verify-generated-docs.sh
+++ [1106 10:12:27] Verifying Prerequisites....
+++ [1106 10:12:28] Building Docker image kube-build:cross.
+++ [1106 10:12:30] Building Docker image kube-build:build-0343d9fca5.
+++ [1106 10:12:35] Running build command....
+++ [1106 18:12:36] Building go targets for linux/amd64:
    cmd/gendocs
    cmd/genkubedocs
    cmd/genman
    cmd/genbashcomp
    cmd/mungedocs
+++ [1106 18:12:37] Placing binaries
Generated docs are up to date.
+++ [1106 10:12:42] Running build command....
+++ [1106 10:12:43] Output directory is local.  No need to copy results out.
</pre>
