### PR TITLE
Cleanup for versioning

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -24,11 +24,17 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 DEFAULT_KUBECONFIG="${HOME}/.kube/config"
 
-# KUBE_VERSION_REGEX matches things like "v1.2.3"
-KUBE_VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+# KUBE_RELEASE_VERSION_REGEX matches things like "v1.2.3" or "v1.2.3-alpha.4"
+#
+# NOTE This must match the version_regex in build/common.sh
+# kube::release::parse_and_validate_release_version()
+KUBE_RELEASE_VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-(beta|alpha)\\.(0|[1-9][0-9]*))?$"
 
-# KUBE_CI_VERSION_REGEX matches things like "v1.2.3-alpha.4.56+abcdefg"
-KUBE_CI_VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-(.*)$"
+# KUBE_CI_VERSION_REGEX matches things like "v1.2.3-alpha.4.56+abcdefg" This
+#
+# NOTE This must match the version_regex in build/common.sh
+# kube::release::parse_and_validate_ci_version()
+KUBE_CI_VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-(beta|alpha)\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)\\+[-0-9a-z]*)?$"
 
 
 # Generate kubeconfig data for the created cluster.
@@ -261,7 +267,7 @@ function set_binary_version() {
 #
 # Assumed vars:
 #   KUBE_VERSION
-#   KUBE_VERSION_REGEX
+#   KUBE_RELEASE_VERSION_REGEX
 #   KUBE_CI_VERSION_REGEX
 # Vars set:
 #   KUBE_TAR_HASH
@@ -273,7 +279,7 @@ function tars_from_version() {
   if [[ -z "${KUBE_VERSION-}" ]]; then
     find-release-tars
     upload-server-tars
-  elif [[ ${KUBE_VERSION} =~ ${KUBE_VERSION_REGEX} ]]; then
+  elif [[ ${KUBE_VERSION} =~ ${KUBE_RELEASE_VERSION_REGEX} ]]; then
     SERVER_BINARY_TAR_URL="https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes-server-linux-amd64.tar.gz"
     SALT_TAR_URL="https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes-salt.tar.gz"
   elif [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then

--- a/docs/devel/releasing.md
+++ b/docs/devel/releasing.md
@@ -178,8 +178,8 @@ release/cut-official-release.sh "${VER}" "${GITHASH}"
 
 This will do a dry run of:
 
-1. do a series of commits on the release branch for `vX.Y.Z-beta`;
-1. mark the `vX.Y.Z-beta` tag at the beta version commit;
+1. do a series of commits on the release branch for `vX.Y.Z-beta.W`;
+1. mark the `vX.Y.Z-beta.W` tag at the beta version commit;
 1. prompt you to do the remainder of the work, including building the
    appropriate binaries and pushing them to the appropriate places.
 
@@ -209,9 +209,9 @@ This will do a dry run of:
 
 1. do a series of commits on the branch for `vX.Y.Z`;
 1. mark the `vX.Y.Z` tag at the release version commit;
-1. do a series of commits on the branch for `vX.Y.(Z+1)-beta` on top of the
+1. do a series of commits on the branch for `vX.Y.(Z+1)-beta.0` on top of the
    previous commits;
-1. mark the `vX.Y.(Z+1)-beta` tag at the beta version commit;
+1. mark the `vX.Y.(Z+1)-beta.0` tag at the beta version commit;
 1. prompt you to do the remainder of the work, including building the
    appropriate binaries and pushing them to the appropriate places.
 
@@ -245,8 +245,8 @@ This will do a dry run of:
 
 1. mark the `vX.(Y+1).0-alpha.0` tag at the given git hash on `master`;
 1. fork a new branch `release-X.Y` off of `master` at the given git hash;
-1. do a series of commits on the branch for `vX.Y.0-beta`;
-1. mark the `vX.Y.0-beta` tag at the beta version commit;
+1. do a series of commits on the branch for `vX.Y.0-beta.0`;
+1. mark the `vX.Y.0-beta.0` tag at the beta version commit;
 1. prompt you to do the remainder of the work, including building the
    appropriate binaries and pushing them to the appropriate places.
 


### PR DESCRIPTION
A few last cleanup issues for versioning changes:
- Properly find pre-releases in the `release` GCS bucket in `cluster/`, and
- Add versioned beta language to `releasing.md`.
