### PR TITLE
Update libvirt-coreos.md with an option to change the qemu user to have access to the storage pool

### DIFF
--- a/docs/getting-started-guides/libvirt-coreos.md
+++ b/docs/getting-started-guides/libvirt-coreos.md
@@ -144,6 +144,7 @@ In order to fix that issue, you have several possibilities:
   * writable by your user;
   * accessible by the qemu user.
 * Grant the qemu user access to the storage pool.
+* Edit `/etc/libvirt/qemu.conf` to run under that user, that have access to the storage pool (not recommended for production usage).
 
 On Arch:
 


### PR DESCRIPTION
Trying to access the storage pool while running the `kube-up.sh` command one may notice the following error:

```
error: Failed to create domain from /tmp/tmp.cJF1SE15Rd
error: internal error: process exited while connecting to monitor: qemu-system-x86_64: -drive file=/opt/kubernetes/cluster/libvirt-coreos/libvirt_storage_pool/kubernetes-minion-1.img,if=none,id=drive-virtio-disk0,format=qcow2: could not open disk image /opt/kubernetes/cluster/libvirt-coreos/libvirt_storage_pool/kubernetes-minion-1.img: Could not open '/opt/kubernetes/cluster/libvirt-coreos/libvirt_storage_pool/kubernetes-minion-1.img': Permission denied
```

One more alternative to run kubernetes libvirt-based cluster without any issues while accessing the storage pool - is to change user, that runs `libvirt/qemu` processes.

This fix might be used only as a workaround for solving this issue on non-production environments, it has been tested only for testing purposes.
