### PR TITLE
Secrets in containerized Kubelet get mangled due to 'echo'

### DIFF
--- a/pkg/util/io/writer.go
+++ b/pkg/util/io/writer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package io
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -49,6 +50,7 @@ func (writer *StdWriter) WriteFile(filename string, data []byte, perm os.FileMod
 type NsenterWriter struct {
 }
 
+// TODO: should take a writer, not []byte
 func (writer *NsenterWriter) WriteFile(filename string, data []byte, perm os.FileMode) error {
 	cmd := "nsenter"
 	base_args := []string{
@@ -56,10 +58,11 @@ func (writer *NsenterWriter) WriteFile(filename string, data []byte, perm os.Fil
 		"--",
 	}
 
-	echo_args := append(base_args, "sh", "-c",
-		fmt.Sprintf("echo %q | cat > %s", data, filename))
+	echo_args := append(base_args, "sh", "-c", fmt.Sprintf("cat > %s", filename))
 	glog.V(5).Infof("Command to write data to file: %v %v", cmd, echo_args)
-	outputBytes, err := exec.Command(cmd, echo_args...).CombinedOutput()
+	command := exec.Command(cmd, echo_args...)
+	command.Stdin = bytes.NewBuffer(data)
+	outputBytes, err := command.CombinedOutput()
 	if err != nil {
 		glog.Errorf("Output from writing to %q: %v", filename, string(outputBytes))
 		return err


### PR DESCRIPTION
Change to stream over stdin to 'cat', and avoid the mangling of 'echo'.

Result was that 'ca.crt' in every container in kubelet was:

```
--- BEGIN CERTIFICATE ---\n08uo089uuxaetunhsnhtaoeusnhoue\n...
```

rather than having proper newlines.  Would have horribly broken binary files as well.
