### PR TITLE
Add an environment variable override for AWS ssh keys

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1785,6 +1785,12 @@ func getSigner(provider string) (ssh.Signer, error) {
 	case "gce", "gke":
 		keyfile = "google_compute_engine"
 	case "aws":
+		// If there is an env. variable override, use that.
+		aws_keyfile := os.Getenv("AWS_SSH_KEY")
+		if len(aws_keyfile) != 0 {
+			return util.MakePrivateKeySignerFromFile(aws_keyfile)
+		}
+		// Otherwise revert to home dir
 		keyfile = "kube_aws_rsa"
 	default:
 		return nil, fmt.Errorf("getSigner(...) not implemented for %s", provider)


### PR DESCRIPTION
@ixdy @ihmccreery @quinton-hoole @zmerlynn @justinsb 

Ref #15137

This is needed to make SSH-based tests work from Jenkins, since Jenkins set `$HOME` to be the workspace directory, but the AWS key is in `~/jenkins/...`

If this goes green, I'm just going to merge.
