### PR TITLE
don't print resources twice in kubectl get

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -259,6 +259,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 			if err := printer.PrintObj(objs[ix], w); err != nil {
 				return err
 			}
+			continue
 		}
 		if err := printer.PrintObj(objs[ix], out); err != nil {
 			return err


### PR DESCRIPTION
Fixes #16973

cc @kubernetes/kubectl @brendandburns 
