### PR TITLE
MESOS: Add MESOS_DOCKER_DUMP_LOGS to enforce log dumping

### DIFF
--- a/cluster/mesos/docker/config-default.sh
+++ b/cluster/mesos/docker/config-default.sh
@@ -66,3 +66,6 @@ DOCKER_DAEMON_ARGS="${DOCKER_DAEMON_ARGS:---log-level=error}"
 # Force a dump of the logs into ${MESOS_DOCKER_WORK_DIR}/log on kube-down.sh. By
 # default this only happens when kube-up.sh fails.
 MESOS_DOCKER_DUMP_LOGS="${MESOS_DOCKER_DUMP_LOGS:-false}"
+
+# Skip rebuilding the involved docker containers on kube-up.sh.
+MESOS_DOCKER_SKIP_BUILD="${MESOS_DOCKER_SKIP_BUILD:-false}"

--- a/cluster/mesos/docker/config-default.sh
+++ b/cluster/mesos/docker/config-default.sh
@@ -62,3 +62,7 @@ MESOS_DOCKER_WORK_DIR="${MESOS_DOCKER_WORK_DIR:-${HOME}/tmp/kubernetes}"
 
 # Arguments to pass to docker-engine running on the mesos-slave-dind containers.
 DOCKER_DAEMON_ARGS="${DOCKER_DAEMON_ARGS:---log-level=error}"
+
+# Force a dump of the logs into ${MESOS_DOCKER_WORK_DIR}/log on kube-down.sh. By
+# default this only happens when kube-up.sh fails.
+MESOS_DOCKER_DUMP_LOGS="${MESOS_DOCKER_DUMP_LOGS:-false}"

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -317,6 +317,9 @@ function validate-cluster {
 
 # Delete a kubernetes cluster
 function kube-down {
+  if [ "${MESOS_DOCKER_DUMP_LOGS:-false}" == "true" ]; then
+    cluster::mesos::docker::dump_logs "${MESOS_DOCKER_WORK_DIR}/log"
+  fi
   echo "Stopping ${KUBERNETES_PROVIDER} cluster" 1>&2
   # Since restoring a stopped cluster is not yet supported, use the nuclear option
   cluster::mesos::docker::docker_compose kill

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -317,7 +317,7 @@ function validate-cluster {
 
 # Delete a kubernetes cluster
 function kube-down {
-  if [ "${MESOS_DOCKER_DUMP_LOGS:-false}" == "true" ]; then
+  if [ "${MESOS_DOCKER_DUMP_LOGS}" == "true" ]; then
     cluster::mesos::docker::dump_logs "${MESOS_DOCKER_WORK_DIR}/log"
   fi
   echo "Stopping ${KUBERNETES_PROVIDER} cluster" 1>&2

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -267,7 +267,7 @@ function kube-up {
   echo "Pulling Docker images" 1>&2
   cluster::mesos::docker::docker_compose_lazy_pull
 
-  if [ "${MESOS_DOCKER_SKIP_BUILD:-false}" != "true" ]; then
+  if [ "${MESOS_DOCKER_SKIP_BUILD}" != "true" ]; then
     echo "Building Docker images" 1>&2
     # TODO: version images (k8s version, git sha, and dirty state) to avoid re-building them every time.
     "${provider_root}/km/build.sh"


### PR DESCRIPTION
For e2e testing debugging we need the logs. This PR adds the MESOS_DOCKER_DUMP_LOGS variable which can be passed to kube-down to dump the logs (in the same way as in kube-up on error).
