### PR TITLE
resource consumer - prevent consumeCPU/Mem processes from becoming zombies upon exit

### DIFF
--- a/test/images/resource-consumer/utils.go
+++ b/test/images/resource-consumer/utils.go
@@ -34,7 +34,7 @@ func ConsumeCPU(millicores int, durationSec int) {
 	arg1 := fmt.Sprintf("-millicores=%d", millicores)
 	arg2 := fmt.Sprintf("-duration-sec=%d", durationSec)
 	consumeCPU := exec.Command(consumeCPUBinary, arg1, arg2)
-	consumeCPU.Start()
+	consumeCPU.Run()
 }
 
 func ConsumeMem(megabytes int, durationSec int) {
@@ -43,7 +43,7 @@ func ConsumeMem(megabytes int, durationSec int) {
 	durationSecString := strconv.Itoa(durationSec)
 	// creating new consume memory process
 	consumeMem := exec.Command(consumeMemBinary, "-m", "1", "--vm-bytes", megabytesString, "--vm-hang", "0", "-t", durationSecString)
-	consumeMem.Start()
+	consumeMem.Run()
 }
 
 func GetCurrentStatus() {


### PR DESCRIPTION
While looking into issue #16425, I noticed that the consumeCPU and consumeMem processes remain as zombies once they exit, and pile up. This is because `Wait()` is not called on the corresponding `exec.cmd`s. While I'm sure this is not the cause for issue #16425, I still thought this should be straightened out.
