### PR TITLE
bug-fix: nodecontroller will update node status even if it not change

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -663,7 +663,7 @@ func (nc *NodeController) tryUpdateNodeStatus(node *api.Node) (time.Duration, ap
 			}
 		}
 
-		if !api.Semantic.DeepEqual(nc.getCondition(&node.Status, api.NodeReady), lastReadyCondition) {
+		if !api.Semantic.DeepEqual(nc.getCondition(&node.Status, api.NodeReady), &lastReadyCondition) {
 			if _, err = nc.kubeClient.Nodes().UpdateStatus(node); err != nil {
 				glog.Errorf("Error updating node %s: %v", node.Name, err)
 				return gracePeriod, lastReadyCondition, readyCondition, err


### PR DESCRIPTION
We found cpu usage of apiserver often fluctuates, after close scrutiny we found even if all node status remains unchanged, node controller will send a lot of requests to apiserver to update node status.

It turns out that the statement `api.Semantic.DeepEqual(nc.getCondition(&node.Status, api.NodeReady), lastReadyCondition)` will always be `false`, since one of its parameter is pointer, but another not.

Such a bug could make node controller send a lot of unnecessary update requests to apiserver, and make cpu usage of apiserver fluctuates.
