### PR TITLE
fix client cache for different versions

### DIFF
--- a/pkg/kubectl/cmd/util/clientcache.go
+++ b/pkg/kubectl/cmd/util/clientcache.go
@@ -68,6 +68,11 @@ func (c *ClientCache) ClientConfigForVersion(version string) (*client.Config, er
 	client.SetKubernetesDefaults(&config)
 	c.configs[version] = &config
 
+	// `version` does not necessarily equal `config.Version`.  However, we know that we call this method again with
+	// `config.Version`, we should get the the config we've just built.
+	configCopy := config
+	c.configs[config.Version] = &configCopy
+
 	return &config, nil
 }
 


### PR DESCRIPTION
When we negotiate for "", we get back "v1", but later when the resource builder gets a "v1" `RESTClient` for its objects, the negotiation happens a second time.  This fills in the cache as its known.
