### PR TITLE
Unnecessary updates to ResourceQuota when doing UPDATE

### DIFF
--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -168,6 +168,12 @@ func (q *quota) Admit(a admission.Attributes) (err error) {
 // Return true if the usage must be recorded prior to admitting the new resource
 // Return an error if the operation should not pass admission control
 func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, client client.Interface) (bool, error) {
+	// on update, the only resource that can modify the value of a quota is pods
+	// so if your not a pod, we exit quickly
+	if a.GetOperation() == admission.Update && a.GetResource() != "pods" {
+		return false, nil
+	}
+
 	var errs []error
 	dirty := true
 	set := map[api.ResourceName]bool{}


### PR DESCRIPTION
Admission control was recording that the quota was dirty during UPDATE operations for resource types that were not pods.  This results in unnecessary edits to the quota document when doing normal UPDATE operations to other resources (even when not tracked by quota).

For example, if a namespace had a quota, an update to the Service.Spec or the ReplicationController.Spec resulted in unnecessary edits to the quota document because the quota was just performing object counts.

This did not impact UPDATE_STATUS operations or anything that was a sub-resource action.

/cc @liggitt 
