### PR TITLE
Fix Calico docs with correct 1.1 binary URL

### DIFF
--- a/docs/getting-started-guides/ubuntu-calico.md
+++ b/docs/getting-started-guides/ubuntu-calico.md
@@ -75,7 +75,7 @@ We'll use the `kubelet` to bootstrap the Kubernetes master processes as containe
 
 ```
 # Get the Kubernetes Release.
-wget https://github.com/kubernetes/kubernetes/releases/download/v1.1.0/kubernetes.tar.gz
+wget https://github.com/kubernetes/kubernetes/releases/download/v1.1.1/kubernetes.tar.gz
 
 # Extract the Kubernetes binaries.
 tar -xf kubernetes.tar.gz


### PR DESCRIPTION
I think this should get cherry-picked onto the 1.1 branch too, not sure what the process is for updating docs on already-cut releases?
