### PR TITLE
Add hostexec test image

### DIFF
--- a/test/images/hostexec/Dockerfile
+++ b/test/images/hostexec/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.2
+
+run apk --update add curl netcat-openbsd iproute2 && rm -rf /var/cache/apk/*
+
+# wait forever
+CMD rm -f /fifo && mkfifo /fifo && exec cat </fifo

--- a/test/images/hostexec/Makefile
+++ b/test/images/hostexec/Makefile
@@ -1,0 +1,16 @@
+.PHONY: all image push clean
+
+TAG = 1.2
+PREFIX = gcr.io/google_containers
+
+
+all: push
+
+image:
+	docker build -t $(PREFIX)/hostexec:$(TAG) .
+
+push: image
+	gcloud docker push $(PREFIX)/hostexec:$(TAG)
+
+clean:
+	rm -f hostexec

--- a/test/images/hostexec/pod.yaml
+++ b/test/images/hostexec/pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostexec
+  labels:
+    app: hostexec
+spec:
+  containers:
+  - name: hostexec
+    image: gcr.io/google_containers/hostexec:1.2
+  securityContext:
+    hostNetwork: true


### PR DESCRIPTION
Add test/images/hostexec container which is to be deployed in net=host mode.

This is a preparation for https://github.com/kubernetes/kubernetes/pull/15777

_NOTE_: `gcr.io/google_containers/hostexec:1.2` must be built in test/images/hostexec before merging
