### PR TITLE
edit: Make environment variables composable

### DIFF
--- a/docs/man/man1/kubectl-edit.1
+++ b/docs/man/man1/kubectl-edit.1
@@ -17,8 +17,8 @@ Edit a resource from the default editor.
 
 .PP
 The edit command allows you to directly edit any API resource you can retrieve via the
-command line tools. It will open the editor defined by your KUBE\_EDITOR, GIT\_EDITOR,
-or EDITOR environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
+command line tools. It will open the editor defined by your KUBE\_EDITOR, or EDITOR
+environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
 You can edit multiple objects, although changes are applied one at a time. The command
 accepts filenames as well as command line arguments, although the files you point to must
 be previously saved versions of resources.

--- a/docs/user-guide/kubectl/kubectl_edit.md
+++ b/docs/user-guide/kubectl/kubectl_edit.md
@@ -41,8 +41,8 @@ Edit a resource on the server
 Edit a resource from the default editor.
 
 The edit command allows you to directly edit any API resource you can retrieve via the
-command line tools. It will open the editor defined by your KUBE_EDITOR, GIT_EDITOR,
-or EDITOR environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
+command line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR
+environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
 You can edit multiple objects, although changes are applied one at a time. The command
 accepts filenames as well as command line arguments, although the files you point to must
 be previously saved versions of resources.

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -46,9 +46,9 @@ const (
 	editLong = `Edit a resource from the default editor.
 
 The edit command allows you to directly edit any API resource you can retrieve via the
-command line tools. It will open the editor defined by your KUBE_EDITOR, GIT_EDITOR,
-or EDITOR environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
-You can edit multiple objects, although changes are applied one at a time. The command 
+command line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR
+environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
+You can edit multiple objects, although changes are applied one at a time. The command
 accepts filenames as well as command line arguments, although the files you point to must
 be previously saved versions of resources.
 
@@ -148,7 +148,7 @@ func RunEdit(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 	}
 
 	windowsLineEndings := cmdutil.GetFlagBool(cmd, "windows-line-endings")
-	edit := editor.NewDefaultEditor()
+	edit := editor.NewDefaultEditor(f.EditorEnvs())
 	defaultVersion := cmdutil.OutputVersionFromGroupVersion(cmd, clientConfig.GroupVersion)
 	results := editResults{}
 	for {

--- a/pkg/kubectl/cmd/util/editor/editor.go
+++ b/pkg/kubectl/cmd/util/editor/editor.go
@@ -53,8 +53,8 @@ type Editor struct {
 // the proper command line. If the provided editor has no spaces, or no quotes,
 // it is treated as a bare command to be loaded. Otherwise, the string will
 // be passed to the user's shell for execution.
-func NewDefaultEditor() Editor {
-	args, shell := defaultEnvEditor()
+func NewDefaultEditor(envs []string) Editor {
+	args, shell := defaultEnvEditor(envs)
 	return Editor{
 		Args:  args,
 		Shell: shell,
@@ -73,8 +73,16 @@ func defaultEnvShell() []string {
 	return []string{shell, flag}
 }
 
-func defaultEnvEditor() ([]string, bool) {
-	editor := os.Getenv("EDITOR")
+func defaultEnvEditor(envs []string) ([]string, bool) {
+	var editor string
+	for _, env := range envs {
+		if len(env) > 0 {
+			editor = os.Getenv(env)
+		}
+		if len(editor) > 0 {
+			break
+		}
+	}
 	if len(editor) == 0 {
 		editor = platformize(defaultEditor, windowsEditor)
 	}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -101,6 +101,10 @@ type Factory struct {
 	CanBeAutoscaled func(kind string) error
 	// AttachablePodForObject returns the pod to which to attach given an object.
 	AttachablePodForObject func(object runtime.Object) (*api.Pod, error)
+	// EditorEnvs returns a group of environment variables that the edit command
+	// can range over in order to determine if the user has specified an editor
+	// of their choice.
+	EditorEnvs func() []string
 }
 
 // NewFactory creates a factory with the default Kubernetes resources defined
@@ -330,6 +334,9 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				}
 				return nil, fmt.Errorf("cannot attach to %s: not implemented", kind)
 			}
+		},
+		EditorEnvs: func() []string {
+			return []string{"KUBE_EDITOR", "EDITOR"}
 		},
 	}
 }


### PR DESCRIPTION
It also adds support for KUBE_EDITOR which was already advertised in the edit usage message.

@kubernetes/kubectl 
