### PR TITLE
wait for 10s before controller manager fails when api-server is not up

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -314,8 +314,11 @@ func (s *CMServer) Run(_ []string) error {
 	// important when we start apiserver and controller manager at the same time.
 	var versionStrings []string
 	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
-		versionStrings, err = client.ServerAPIVersions(kubeconfig)
-		return err == nil, err
+		if versionStrings, err = client.ServerAPIVersions(kubeconfig); err == nil {
+			return true, nil
+		}
+		glog.Errorf("Failed to get api versions from server: %v", err)
+		return false, nil
 	})
 	if err != nil {
 		glog.Fatalf("Failed to get api versions from server: %v", err)


### PR DESCRIPTION
This patch tries to fix #17109, yet it's a guess simply based on comment :-/ And i haven't tested it myself.

`pollImmediateInternal`, called by `PollImmediate`, fails immediately when `condition` returns an error, which i believe is the trouble maker.

/cc @ddysher @WIZARD-CXY
