### PR TITLE
[ubuntu] delete secrets consumed by pods when kube-down

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -136,6 +136,7 @@ function tear_down_alive_resources() {
   "${kubectl}" delete pods --all || true
   "${kubectl}" delete svc --all || true
   "${kubectl}" delete pvc --all || true
+  "${kubectl}" delete secret --all || true 
 }
 
 # Gets username, password for the current-context in kubeconfig, if they exist.


### PR DESCRIPTION
Seems that `kubelet` does not handle volume (unmount) for `/var/lib/kubelet` when it deletes pods. And we still get following when conducting `kube-down`

```
$ rm -rf /var/lib/kubelet
rm: cannot remove ‘/var/lib/kubelet/pods/24c42a99-8818-11e5-b321-005056b45392/volumes/kubernetes.io~secret/default-token-t6sw8’: Device or resource busy
```

Seems that deleting secrets roughly would fix this, even a new one would be generated at once. 

```
$ kubectl delete pods --all
pod "busybox-pure" deleted
$ mount | grep /var/lib/kubelet
tmpfs on /var/lib/kubelet/pods/0fdbe466-88e6-11e5-8ff2-f8bc1298bf7c/volumes/kubernetes.io~secret/default-token-nc2xz type tmpfs (rw)
$ kubectl delete secrets --all
secret "default-token-nc2xz" deleted
$ mount | grep /var/lib/kubelet
(nil)
```

Dive deep down what `kubelet` would do when it deletes pods helps more though.
/cc @resouer @WIZARD-CXY
