### PR TITLE
Fix wrong terminal output for vagrant.md

### DIFF
--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -284,7 +284,10 @@ my-nginx-xql4j   1/1       Running   0          1m
 
 $ ./cluster/kubectl.sh get services
 NAME              CLUSTER_IP       EXTERNAL_IP       PORT(S)       SELECTOR               AGE
-my-nginx          10.0.0.1         <none>            80/TCP        run=my-nginx           1h
+
+$ ./cluster/kubectl.sh get replicationcontrollers
+CONTROLLER   CONTAINER(S)   IMAGE(S)   SELECTOR       REPLICAS   AGE
+my-nginx     my-nginx       nginx      run=my-nginx   3          1m
 ```
 
 We did not start any services, hence there are none listed. But we see three replicas displayed properly.


### PR DESCRIPTION
According to the description below `We did not start any services, hence there are none listed. But we see three replicas displayed properly.`

The original terminal output example was wrong and misleading.
