### PR TITLE
Add socat command to hyperkube image

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -7,6 +7,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     ca-certificates \
     file \
     util-linux \
+    socat \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
     && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
This is needed for port forwarding to work in kubelet.

Fixes #17157
