### PR TITLE
use GroupVersion in APIGroupVersion for api installer

### DIFF
--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -56,6 +56,15 @@ func ParseGroupVersion(gv string) (GroupVersion, error) {
 	}
 }
 
+func ParseGroupVersionOrDie(gv string) GroupVersion {
+	ret, err := ParseGroupVersion(gv)
+	if err != nil {
+		panic(err)
+	}
+
+	return ret
+}
+
 // MarshalJSON implements the json.Marshaller interface.
 func (gv GroupVersion) MarshalJSON() ([]byte, error) {
 	s := gv.String()

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -95,7 +95,7 @@ func TestProxy(t *testing.T) {
 			server           *httptest.Server
 			proxyTestPattern string
 		}{
-			{namespaceServer, "/api/version2/proxy/namespaces/" + item.reqNamespace + "/foo/id" + item.path},
+			{namespaceServer, "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/proxy/namespaces/" + item.reqNamespace + "/foo/id" + item.path},
 		}
 
 		for _, serverPattern := range serverPatterns {
@@ -212,7 +212,7 @@ func TestProxyUpgrade(t *testing.T) {
 		server := httptest.NewServer(namespaceHandler)
 		defer server.Close()
 
-		ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/api/version2/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
+		ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/"+prefix+"/"+newGroupVersion.Group+"/"+newGroupVersion.Version+"/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
 		if err != nil {
 			t.Errorf("%s: websocket dial err: %s", k, err)
 			continue
@@ -276,7 +276,7 @@ func TestRedirectOnMissingTrailingSlash(t *testing.T) {
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
-		proxyTestPattern := "/api/version2/proxy/namespaces/ns/foo/id" + item.path
+		proxyTestPattern := "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/proxy/namespaces/ns/foo/id" + item.path
 		req, err := http.NewRequest(
 			"GET",
 			server.URL+proxyTestPattern+"?"+item.query,

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -62,7 +62,7 @@ func TestWatchWebsocket(t *testing.T) {
 
 	dest, _ := url.Parse(server.URL)
 	dest.Scheme = "ws" // Required by websocket, though the server never sees it.
-	dest.Path = "/api/version/watch/simples"
+	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	ws, err := websocket.Dial(dest.String(), "", "http://localhost")
@@ -114,7 +114,7 @@ func TestWatchHTTP(t *testing.T) {
 	client := http.Client{}
 
 	dest, _ := url.Parse(server.URL)
-	dest.Path = "/api/version/watch/simples"
+	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	request, err := http.NewRequest("GET", dest.String(), nil)
@@ -178,8 +178,8 @@ func TestWatchParamParsing(t *testing.T) {
 
 	dest, _ := url.Parse(server.URL)
 
-	rootPath := "/api/" + testVersion + "/watch/simples"
-	namespacedPath := "/api/" + testVersion + "/watch/namespaces/other/simpleroots"
+	rootPath := "/" + prefix + "/" + testVersion + "/watch/simples"
+	namespacedPath := "/" + prefix + "/" + testVersion + "/watch/namespaces/other/simpleroots"
 
 	table := []struct {
 		path            string
@@ -286,7 +286,7 @@ func TestWatchProtocolSelection(t *testing.T) {
 	client := http.Client{}
 
 	dest, _ := url.Parse(server.URL)
-	dest.Path = "/api/version/watch/simples"
+	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	table := []struct {
@@ -358,7 +358,7 @@ func TestWatchHTTPTimeout(t *testing.T) {
 
 	// Setup a client
 	dest, _ := url.Parse(s.URL)
-	dest.Path = "/api/" + newVersion + "/simple"
+	dest.Path = "/" + prefix + "/" + newVersion + "/simple"
 	dest.RawQuery = "watch=true"
 
 	req, _ := http.NewRequest("GET", dest.String(), nil)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -670,8 +670,8 @@ func (m *Master) init(c *Config) {
 		}
 		expAPIVersions := []unversioned.GroupVersionForDiscovery{
 			{
-				GroupVersion: expVersion.Version,
-				Version:      apiutil.GetVersion(expVersion.Version),
+				GroupVersion: expVersion.GroupVersion.String(),
+				Version:      expVersion.GroupVersion.Version,
 			},
 		}
 		storageVersion, found := c.StorageVersions[g.Group]
@@ -685,7 +685,7 @@ func (m *Master) init(c *Config) {
 		}
 		apiserver.AddGroupWebService(m.handlerContainer, c.APIGroupPrefix+"/"+latest.GroupOrDie("extensions").Group, group)
 		allGroups = append(allGroups, group)
-		apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newRequestInfoResolver(), []string{expVersion.Version})
+		apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newRequestInfoResolver(), []string{expVersion.GroupVersion.String()})
 	}
 
 	// This should be done after all groups are registered
@@ -892,7 +892,7 @@ func (m *Master) api_v1() *apiserver.APIGroupVersion {
 	}
 	version := m.defaultAPIGroupVersion()
 	version.Storage = storage
-	version.Version = "v1"
+	version.GroupVersion = unversioned.GroupVersion{Version: "v1"}
 	version.Codec = v1.Codec
 	return version
 }
@@ -1005,7 +1005,7 @@ func (m *Master) InstallThirdPartyResource(rsrc *expapi.ThirdPartyResource) erro
 	}
 	apiserver.AddGroupWebService(m.handlerContainer, path, apiGroup)
 	m.addThirdPartyResourceStorage(path, thirdparty.Storage[strings.ToLower(kind)+"s"].(*thirdpartyresourcedataetcd.REST))
-	apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newRequestInfoResolver(), []string{thirdparty.Version})
+	apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newRequestInfoResolver(), []string{thirdparty.GroupVersion.String()})
 	return nil
 }
 
@@ -1018,20 +1018,22 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 		strings.ToLower(kind) + "s": resourceStorage,
 	}
 
+	serverGroupVersion := unversioned.ParseGroupVersionOrDie(latest.GroupOrDie("").GroupVersion)
+
 	return &apiserver.APIGroupVersion{
 		Root:                apiRoot,
-		Version:             apiutil.GetGroupVersion(group, version),
+		GroupVersion:        unversioned.GroupVersion{Group: group, Version: version},
 		RequestInfoResolver: m.newRequestInfoResolver(),
 
 		Creater:   thirdpartyresourcedata.NewObjectCreator(group, version, api.Scheme),
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,
 
-		Mapper:        thirdpartyresourcedata.NewMapper(latest.GroupOrDie("extensions").RESTMapper, kind, version, group),
-		Codec:         thirdpartyresourcedata.NewCodec(latest.GroupOrDie("extensions").Codec, kind),
-		Linker:        latest.GroupOrDie("extensions").SelfLinker,
-		Storage:       storage,
-		ServerVersion: latest.GroupOrDie("").GroupVersion,
+		Mapper:             thirdpartyresourcedata.NewMapper(latest.GroupOrDie("extensions").RESTMapper, kind, version, group),
+		Codec:              thirdpartyresourcedata.NewCodec(latest.GroupOrDie("extensions").Codec, kind),
+		Linker:             latest.GroupOrDie("extensions").SelfLinker,
+		Storage:            storage,
+		ServerGroupVersion: &serverGroupVersion,
 
 		Context: m.requestContextMapper,
 
@@ -1106,6 +1108,7 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 	}
 
 	extensionsGroup := latest.GroupOrDie("extensions")
+	serverGroupVersion := unversioned.ParseGroupVersionOrDie(latest.GroupOrDie("").GroupVersion)
 
 	return &apiserver.APIGroupVersion{
 		Root:                m.apiGroupPrefix,
@@ -1115,12 +1118,12 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,
 
-		Mapper:        extensionsGroup.RESTMapper,
-		Codec:         extensionsGroup.Codec,
-		Linker:        extensionsGroup.SelfLinker,
-		Storage:       storage,
-		Version:       extensionsGroup.GroupVersion,
-		ServerVersion: latest.GroupOrDie("").GroupVersion,
+		Mapper:             extensionsGroup.RESTMapper,
+		Codec:              extensionsGroup.Codec,
+		Linker:             extensionsGroup.SelfLinker,
+		Storage:            storage,
+		GroupVersion:       unversioned.ParseGroupVersionOrDie(extensionsGroup.GroupVersion),
+		ServerGroupVersion: &serverGroupVersion,
 
 		Admit:   m.admissionControl,
 		Context: m.requestContextMapper,

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -175,7 +175,7 @@ func TestFindExternalAddress(t *testing.T) {
 func TestApi_v1(t *testing.T) {
 	master, _, assert := setUp(t)
 	version := master.api_v1()
-	assert.Equal("v1", version.Version, "Version was not v1: %s", version.Version)
+	assert.Equal(unversioned.GroupVersion{Version: "v1"}, version.GroupVersion, "Version was not v1: %s", version.GroupVersion)
 	assert.Equal(v1.Codec, version.Codec, "version.Codec was not for v1: %s", version.Codec)
 	for k, v := range master.storage {
 		assert.Contains(version.Storage, v, "Value %s not found (key: %s)", k, v)
@@ -322,12 +322,14 @@ func TestDefaultAPIGroupVersion(t *testing.T) {
 func TestExpapi(t *testing.T) {
 	master, config, assert := setUp(t)
 
+	extensionsGroupMeta := latest.GroupOrDie("extensions")
+
 	expAPIGroup := master.experimental(&config)
 	assert.Equal(expAPIGroup.Root, master.apiGroupPrefix)
-	assert.Equal(expAPIGroup.Mapper, latest.GroupOrDie("extensions").RESTMapper)
-	assert.Equal(expAPIGroup.Codec, latest.GroupOrDie("extensions").Codec)
-	assert.Equal(expAPIGroup.Linker, latest.GroupOrDie("extensions").SelfLinker)
-	assert.Equal(expAPIGroup.Version, latest.GroupOrDie("extensions").GroupVersion)
+	assert.Equal(expAPIGroup.Mapper, extensionsGroupMeta.RESTMapper)
+	assert.Equal(expAPIGroup.Codec, extensionsGroupMeta.Codec)
+	assert.Equal(expAPIGroup.Linker, extensionsGroupMeta.SelfLinker)
+	assert.Equal(expAPIGroup.GroupVersion, unversioned.GroupVersion{Group: extensionsGroupMeta.Group, Version: extensionsGroupMeta.Version})
 }
 
 // TestGetNodeAddresses verifies that proper results are returned


### PR DESCRIPTION
This starts to pick away at using `GroupVersion` to represent a `GroupVersion`.  I'm changing one type, rippling out one part removed (maybe two) and then converting at the edges.  It will help keep the pulls small and manageable as we move forward.

@liggitt @caesarxuchao
