### PR TITLE
Fixed minor error in docs for namespaces

### DIFF
--- a/docs/user-guide/namespaces.md
+++ b/docs/user-guide/namespaces.md
@@ -99,7 +99,9 @@ $ export CONTEXT=$(kubectl config view | grep current-context | awk '{print $2}'
 Then update the default namespace:
 
 ```console
-$ kubectl config set-context $(CONTEXT) --namespace=<insert-namespace-name-here>
+$ kubectl config set-context $CONTEXT --namespace=<insert-namespace-name-here>
+# Validate it
+$ kubectl config view | grep namespace:
 ```
 
 ## Namespaces and DNS


### PR DESCRIPTION
I found a minor error in [namespaces](https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/namespaces.md) docs.

You need to remove the braces around CONTEXT to get it work otherwise you will get an error:

``` Bash
$ export CONTEXT=$(kubectl config view | grep current-context | awk '{print $2}')
$ kubectl config set-context $(CONTEXT) --namespace=default
zsh: command not found: CONTEXT
# or with bash
bash: CONTEXT: command not found
```
