### PR TITLE
Enable serviceaccounts for the docker-multinode deployment

### DIFF
--- a/cluster/images/hyperkube/master-multi.json
+++ b/cluster/images/hyperkube/master-multi.json
@@ -12,10 +12,17 @@
               "/hyperkube",
               "controller-manager",
               "--master=127.0.0.1:8080",
-              "--terminated-pod-gc-threshold=100",
+              "--service-account-private-key-file=/srv/kubernetes/server.key",
+              "--root-ca-file=/srv/kubernetes/ca.crt",
               "--min-resync-period=3m",
               "--v=2"
-        ]
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
     },
     {
       "name": "apiserver",
@@ -27,8 +34,21 @@
               "--insecure-bind-address=0.0.0.0",
               "--etcd-servers=http://127.0.0.1:4001",
               "--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota",
-              "--v=2"
-        ]
+              "--client-ca-file=/srv/kubernetes/ca.crt",
+              "--basic-auth-file=/srv/kubernetes/basic_auth.csv",
+              "--min-request-timeout=300",
+              "--tls-cert-file=/srv/kubernetes/server.cert",
+              "--tls-private-key-file=/srv/kubernetes/server.key",
+              "--token-auth-file=/srv/kubernetes/known_tokens.csv",
+              "--allow-privileged=true",
+              "--v=4"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
     },
     {
       "name": "scheduler",
@@ -39,6 +59,25 @@
               "--master=127.0.0.1:8080",
               "--v=2"
         ]
+    },
+    {
+      "name": "setup",
+      "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+      "command": [
+              "/setup-files.sh"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/data"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "name": "data",
+      "emptyDir": {}
     }
   ]
  }

--- a/cluster/images/hyperkube/master.json
+++ b/cluster/images/hyperkube/master.json
@@ -12,11 +12,11 @@
               "/hyperkube",
               "controller-manager",
               "--master=127.0.0.1:8080",
-              "--min-resync-period=3m",
               "--service-account-private-key-file=/srv/kubernetes/server.key",
               "--root-ca-file=/srv/kubernetes/ca.crt",
+              "--min-resync-period=3m",
               "--v=2"
-        ],
+      ],
       "volumeMounts": [
         {
           "name": "data",
@@ -33,7 +33,7 @@
               "--service-cluster-ip-range=10.0.0.1/24",
               "--insecure-bind-address=127.0.0.1",
               "--etcd-servers=http://127.0.0.1:4001",
-              "--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,SecurityContextDeny,ResourceQuota",
+              "--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota",
               "--client-ca-file=/srv/kubernetes/ca.crt",
               "--basic-auth-file=/srv/kubernetes/basic_auth.csv",
               "--min-request-timeout=300",
@@ -42,7 +42,7 @@
               "--token-auth-file=/srv/kubernetes/known_tokens.csv",
               "--allow-privileged=true",
               "--v=4"
-        ],
+      ],
       "volumeMounts": [
         {
           "name": "data",

--- a/cluster/images/hyperkube/turnup.sh
+++ b/cluster/images/hyperkube/turnup.sh
@@ -20,6 +20,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+K8S_VERSION=${K8S_VERSION:-"1.1.3"}
+
 docker run \
   --volume=/:/rootfs:ro \
   --volume=/sys:/sys:ro \


### PR DESCRIPTION
Ref: #16987
Depends on: #13791, which is merged to HEAD and included at least in `v1.2.0-xxx` releases.

This change enables `ServiceAccount` `secret` creation, when running with dockerized kubelet.
It enables `apiserver` `--admission-control=ServiceAccount`, so that kubelet mounts the `/var/run/secrets/kubernetes.io` that containers use.

As said in #16987:

> A new version of the hyperkube image should also be built.
> Before this patch could be merged, a v1.2.0-alpha.3 hyperkube image must be pushed to gcr.io.
> Just now curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.3/bin/linux/amd64/hyperkube doesn't exist.
> Ref: [Makefile](https://github.com/kubernetes/kubernetes/blob/master/cluster/images/hyperkube/Makefile)

Results:

```
$ kubectl get serviceaccounts
NAME      SECRETS   AGE
default   1         2m

$ kubectl get secrets
NAME                  TYPE                                  DATA      AGE
default-token-1b0wy   kubernetes.io/service-account-token   2         2m

$ kubectl exec -it busybox -- ls /var/run/secrets/kubernetes.io/serviceaccount
ca.crt  token
```
