### PR TITLE
MESOS: increase dind loop device size to 10GB

### DIFF
--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -52,6 +52,7 @@ mesosslave:
   - MESOS_SWITCH_USER=0
   - MESOS_CONTAINERIZERS=docker,mesos
   - MESOS_ISOLATION=cgroups/cpu,cgroups/mem
+  - VAR_LIB_DOCKER_SIZE=10
   - DOCKER_DAEMON_ARGS
   links:
   - etcd


### PR DESCRIPTION
For the conformance tests 5 GB turned out to be not enough.
