### PR TITLE
use GroupVersion in RESTMapping

### DIFF
--- a/pkg/api/install/install_test.go
+++ b/pkg/api/install/install_test.go
@@ -78,12 +78,16 @@ func TestRESTMapper(t *testing.T) {
 		t.Errorf("unexpected version mapping: %s %s %v", v, k, err)
 	}
 
-	if m, err := latest.GroupOrDie("").RESTMapper.RESTMapping("PodTemplate", ""); err != nil || m.APIVersion != "v1" || m.Resource != "podtemplates" {
+	expectedGroupVersion := unversioned.GroupVersion{Version: "v1"}
+
+	if m, err := latest.GroupOrDie("").RESTMapper.RESTMapping("PodTemplate", ""); err != nil || m.GroupVersionKind.GroupVersion() != expectedGroupVersion || m.Resource != "podtemplates" {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
 	for _, version := range latest.GroupOrDie("").Versions {
-		mapping, err := latest.GroupOrDie("").RESTMapper.RESTMapping("ReplicationController", version)
+		currGroupVersion := unversioned.GroupVersion{Version: version}
+
+		mapping, err := latest.GroupOrDie("").RESTMapper.RESTMapping("ReplicationController", currGroupVersion.String())
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -91,11 +95,11 @@ func TestRESTMapper(t *testing.T) {
 		if mapping.Resource != "replicationControllers" && mapping.Resource != "replicationcontrollers" {
 			t.Errorf("incorrect resource name: %#v", mapping)
 		}
-		if mapping.APIVersion != version {
+		if mapping.GroupVersionKind.GroupVersion() != currGroupVersion {
 			t.Errorf("incorrect version: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("").InterfacesFor(version)
+		interfaces, _ := latest.GroupOrDie("").InterfacesFor(currGroupVersion.String())
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/api/meta/interfaces.go
+++ b/pkg/api/meta/interfaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package meta
 
 import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
 )
@@ -124,10 +125,8 @@ type RESTScope interface {
 type RESTMapping struct {
 	// Resource is a string representing the name of this resource as a REST client would see it
 	Resource string
-	// APIVersion represents the APIVersion that represents the resource as presented. It is provided
-	// for convenience for passing around a consistent mapping.
-	APIVersion string
-	Kind       string
+
+	GroupVersionKind unversioned.GroupVersionKind
 
 	// Scope contains the information needed to deal with REST Resources that are in a resource hierarchy
 	Scope RESTScope

--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -56,6 +56,15 @@ func ParseGroupVersion(gv string) (GroupVersion, error) {
 	}
 }
 
+func ParseGroupVersionOrDie(gv string) GroupVersion {
+	ret, err := ParseGroupVersion(gv)
+	if err != nil {
+		panic(err)
+	}
+
+	return ret
+}
+
 // MarshalJSON implements the json.Marshaller interface.
 func (gv GroupVersion) MarshalJSON() ([]byte, error) {
 	s := gv.String()

--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -22,7 +22,26 @@ import (
 	"strings"
 )
 
-// TODO: We need to remove the GroupVersion in types.go. We use the name GroupVersion here temporarily.
+// GroupVersionKind unambiguously identifies a kind.  It doesn't anonymously include GroupVersion
+// to avoid automatic coersion.  It doesn't use a GroupVersion to avoid custom marshalling
+type GroupVersionKind struct {
+	Group   string
+	Version string
+	Kind    string
+}
+
+func NewGroupVersionKind(gv GroupVersion, kind string) GroupVersionKind {
+	return GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: kind}
+}
+
+func (gvk GroupVersionKind) GroupVersion() GroupVersion {
+	return GroupVersion{Group: gvk.Group, Version: gvk.Version}
+}
+
+func (gvk *GroupVersionKind) String() string {
+	return gvk.Group + "/" + gvk.Version + ", Kind=" + gvk.Kind
+}
+
 // GroupVersion contains the "group" and the "version", which uniquely identifies the API.
 type GroupVersion struct {
 	Group   string
@@ -31,7 +50,7 @@ type GroupVersion struct {
 
 // String puts "group" and "version" into a single "group/version" string. For the legacy v1
 // it returns "v1".
-func (gv *GroupVersion) String() string {
+func (gv GroupVersion) String() string {
 	// special case of "v1" for backward compatibility
 	if gv.Group == "" && gv.Version == "v1" {
 		return gv.Version

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -95,7 +95,7 @@ func TestProxy(t *testing.T) {
 			server           *httptest.Server
 			proxyTestPattern string
 		}{
-			{namespaceServer, "/api/version2/proxy/namespaces/" + item.reqNamespace + "/foo/id" + item.path},
+			{namespaceServer, "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/proxy/namespaces/" + item.reqNamespace + "/foo/id" + item.path},
 		}
 
 		for _, serverPattern := range serverPatterns {
@@ -212,7 +212,7 @@ func TestProxyUpgrade(t *testing.T) {
 		server := httptest.NewServer(namespaceHandler)
 		defer server.Close()
 
-		ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/api/version2/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
+		ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/"+prefix+"/"+newGroupVersion.Group+"/"+newGroupVersion.Version+"/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
 		if err != nil {
 			t.Errorf("%s: websocket dial err: %s", k, err)
 			continue
@@ -276,7 +276,7 @@ func TestRedirectOnMissingTrailingSlash(t *testing.T) {
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
-		proxyTestPattern := "/api/version2/proxy/namespaces/ns/foo/id" + item.path
+		proxyTestPattern := "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/proxy/namespaces/ns/foo/id" + item.path
 		req, err := http.NewRequest(
 			"GET",
 			server.URL+proxyTestPattern+"?"+item.query,

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -62,7 +62,7 @@ func TestWatchWebsocket(t *testing.T) {
 
 	dest, _ := url.Parse(server.URL)
 	dest.Scheme = "ws" // Required by websocket, though the server never sees it.
-	dest.Path = "/api/version/watch/simples"
+	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	ws, err := websocket.Dial(dest.String(), "", "http://localhost")
@@ -114,7 +114,7 @@ func TestWatchHTTP(t *testing.T) {
 	client := http.Client{}
 
 	dest, _ := url.Parse(server.URL)
-	dest.Path = "/api/version/watch/simples"
+	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	request, err := http.NewRequest("GET", dest.String(), nil)
@@ -178,8 +178,8 @@ func TestWatchParamParsing(t *testing.T) {
 
 	dest, _ := url.Parse(server.URL)
 
-	rootPath := "/api/" + testVersion + "/watch/simples"
-	namespacedPath := "/api/" + testVersion + "/watch/namespaces/other/simpleroots"
+	rootPath := "/" + prefix + "/" + testVersion + "/watch/simples"
+	namespacedPath := "/" + prefix + "/" + testVersion + "/watch/namespaces/other/simpleroots"
 
 	table := []struct {
 		path            string
@@ -286,7 +286,7 @@ func TestWatchProtocolSelection(t *testing.T) {
 	client := http.Client{}
 
 	dest, _ := url.Parse(server.URL)
-	dest.Path = "/api/version/watch/simples"
+	dest.Path = "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
 	dest.RawQuery = ""
 
 	table := []struct {
@@ -358,7 +358,7 @@ func TestWatchHTTPTimeout(t *testing.T) {
 
 	// Setup a client
 	dest, _ := url.Parse(s.URL)
-	dest.Path = "/api/" + newVersion + "/simple"
+	dest.Path = "/" + prefix + "/" + newVersion + "/simple"
 	dest.RawQuery = "watch=true"
 
 	req, _ := http.NewRequest("GET", dest.String(), nil)

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -178,8 +178,8 @@ func TestWatchParamParsing(t *testing.T) {
 
 	dest, _ := url.Parse(server.URL)
 
-	rootPath := "/" + prefix + "/" + testVersion + "/watch/simples"
-	namespacedPath := "/" + prefix + "/" + testVersion + "/watch/namespaces/other/simpleroots"
+	rootPath := "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/simples"
+	namespacedPath := "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/namespaces/other/simpleroots"
 
 	table := []struct {
 		path            string
@@ -358,13 +358,13 @@ func TestWatchHTTPTimeout(t *testing.T) {
 
 	// Setup a client
 	dest, _ := url.Parse(s.URL)
-	dest.Path = "/" + prefix + "/" + newVersion + "/simple"
+	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/simple"
 	dest.RawQuery = "watch=true"
 
 	req, _ := http.NewRequest("GET", dest.String(), nil)
 	client := http.Client{}
 	resp, err := client.Do(req)
-	watcher.Add(&apiservertesting.Simple{TypeMeta: unversioned.TypeMeta{APIVersion: newVersion}})
+	watcher.Add(&apiservertesting.Simple{TypeMeta: unversioned.TypeMeta{APIVersion: newGroupVersion.String()}})
 
 	// Make sure we can actually watch an endpoint
 	decoder := json.NewDecoder(resp.Body)

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -96,7 +96,7 @@ func RunAutoscale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 	}
 	info := infos[0]
 	mapping := info.ResourceMapping()
-	if err := f.CanBeAutoscaled(mapping.Kind); err != nil {
+	if err := f.CanBeAutoscaled(mapping.GroupVersionKind.Kind); err != nil {
 		return err
 	}
 
@@ -111,9 +111,9 @@ func RunAutoscale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 	name := info.Name
 	params["default-name"] = name
 
-	params["scaleRef-kind"] = mapping.Kind
+	params["scaleRef-kind"] = mapping.GroupVersionKind.Kind
 	params["scaleRef-name"] = name
-	params["scaleRef-apiVersion"] = mapping.APIVersion
+	params["scaleRef-apiVersion"] = mapping.GroupVersionKind.GroupVersion().String()
 
 	if err = kubectl.ValidateParams(names, params); err != nil {
 		return err

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -76,23 +76,27 @@ func versionErrIfFalse(b bool) error {
 	return versionErr
 }
 
+var validVersion = testapi.Default.Version()
+var internalGV = unversioned.GroupVersion{Group: "apitest", Version: ""}
+var unlikelyGV = unversioned.GroupVersion{Group: "apitest", Version: "unlikelyversion"}
+var validVersionGV = unversioned.GroupVersion{Group: "apitest", Version: validVersion}
+
 func newExternalScheme() (*runtime.Scheme, meta.RESTMapper, runtime.Codec) {
 	scheme := runtime.NewScheme()
-	scheme.AddKnownTypeWithName("", "Type", &internalType{})
-	scheme.AddKnownTypeWithName("unlikelyversion", "Type", &externalType{})
+	scheme.AddKnownTypeWithName(internalGV.Version, "Type", &internalType{})
+	scheme.AddKnownTypeWithName(unlikelyGV.String(), "Type", &externalType{})
 	//This tests that kubectl will not confuse the external scheme with the internal scheme, even when they accidentally have versions of the same name.
-	scheme.AddKnownTypeWithName(testapi.Default.Version(), "Type", &ExternalType2{})
+	scheme.AddKnownTypeWithName(validVersionGV.String(), "Type", &ExternalType2{})
 
-	codec := runtime.CodecFor(scheme, "unlikelyversion")
-	validVersion := testapi.Default.Version()
-	mapper := meta.NewDefaultRESTMapper("apitest", []string{"unlikelyversion", validVersion}, func(version string) (*meta.VersionInterfaces, error) {
+	codec := runtime.CodecFor(scheme, unlikelyGV.String())
+	mapper := meta.NewDefaultRESTMapper("apitest", []string{unlikelyGV.String(), validVersionGV.String()}, func(version string) (*meta.VersionInterfaces, error) {
 		return &meta.VersionInterfaces{
 			Codec:            runtime.CodecFor(scheme, version),
 			ObjectConvertor:  scheme,
 			MetadataAccessor: meta.NewAccessor(),
-		}, versionErrIfFalse(version == validVersion || version == "unlikelyversion")
+		}, versionErrIfFalse(version == validVersionGV.String() || version == unlikelyGV.String())
 	})
-	for _, version := range []string{"unlikelyversion", validVersion} {
+	for _, version := range []string{unlikelyGV.String(), validVersionGV.String()} {
 		for kind := range scheme.KnownTypes(version) {
 			mixedCase := false
 			scope := meta.RESTScopeNamespace

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -120,7 +120,7 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	}
 	info := infos[0]
 	mapping := info.ResourceMapping()
-	if err := f.CanBeExposed(mapping.Kind); err != nil {
+	if err := f.CanBeExposed(mapping.GroupVersionKind.Kind); err != nil {
 		return err
 	}
 	// Get the input object
@@ -187,7 +187,7 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	}
 
 	if inline := cmdutil.GetFlagString(cmd, "overrides"); len(inline) > 0 {
-		object, err = cmdutil.Merge(object, inline, mapping.Kind)
+		object, err = cmdutil.Merge(object, inline, mapping.GroupVersionKind.Kind)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -159,19 +159,19 @@ func TestGetUnknownSchemaObjectListGeneric(t *testing.T) {
 		"handles specific version": {
 			outputVersion:   testapi.Default.Version(),
 			listVersion:     testapi.Default.Version(),
-			testtypeVersion: "unlikelyversion",
+			testtypeVersion: unlikelyGV.String(),
 			rcVersion:       testapi.Default.Version(),
 		},
 		"handles second specific version": {
 			outputVersion:   "unlikelyversion",
 			listVersion:     testapi.Default.Version(),
-			testtypeVersion: "unlikelyversion",
+			testtypeVersion: unlikelyGV.String(),
 			rcVersion:       testapi.Default.Version(), // see expected behavior 3b
 		},
 		"handles common version": {
 			outputVersion:   testapi.Default.Version(),
 			listVersion:     testapi.Default.Version(),
-			testtypeVersion: "unlikelyversion",
+			testtypeVersion: unlikelyGV.String(),
 			rcVersion:       testapi.Default.Version(),
 		},
 	}
@@ -198,6 +198,7 @@ func TestGetUnknownSchemaObjectListGeneric(t *testing.T) {
 		cmd := NewCmdGet(f, buf)
 		cmd.SetOutput(buf)
 		cmd.Flags().Set("output", "json")
+
 		cmd.Flags().Set("output-version", test.outputVersion)
 		err := RunGet(f, buf, cmd, []string{"type/foo", "replicationcontrollers/foo"}, &GetOptions{})
 		if err != nil {

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -382,8 +383,9 @@ func isReplicasDefaulted(info *resource.Info) bool {
 		// was unable to recover versioned info
 		return false
 	}
-	switch info.Mapping.APIVersion {
-	case "v1":
+
+	switch info.Mapping.GroupVersionKind.GroupVersion() {
+	case unversioned.GroupVersion{Version: "v1"}:
 		if rc, ok := info.VersionedObject.(*v1.ReplicationController); ok {
 			return rc.Spec.Replicas == nil
 		}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -148,7 +148,7 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			if err != nil {
 				return nil, err
 			}
-			client, err := clients.ClientForVersion(mapping.APIVersion)
+			client, err := clients.ClientForVersion(mapping.GroupVersionKind.GroupVersion().String())
 			if err != nil {
 				return nil, err
 			}
@@ -165,11 +165,11 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			if err != nil {
 				return nil, err
 			}
-			client, err := clients.ClientForVersion(mapping.APIVersion)
+			client, err := clients.ClientForVersion(mapping.GroupVersionKind.GroupVersion().String())
 			if err != nil {
 				return nil, err
 			}
-			if describer, ok := kubectl.DescriberFor(group, mapping.Kind, client); ok {
+			if describer, ok := kubectl.DescriberFor(group, mapping.GroupVersionKind.Kind, client); ok {
 				return describer, nil
 			}
 			return nil, fmt.Errorf("no description has been implemented for %q", mapping.Kind)
@@ -242,18 +242,18 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			}
 		},
 		Scaler: func(mapping *meta.RESTMapping) (kubectl.Scaler, error) {
-			client, err := clients.ClientForVersion(mapping.APIVersion)
+			client, err := clients.ClientForVersion(mapping.GroupVersionKind.GroupVersion().String())
 			if err != nil {
 				return nil, err
 			}
-			return kubectl.ScalerFor(mapping.Kind, client)
+			return kubectl.ScalerFor(mapping.GroupVersionKind.Kind, client)
 		},
 		Reaper: func(mapping *meta.RESTMapping) (kubectl.Reaper, error) {
-			client, err := clients.ClientForVersion(mapping.APIVersion)
+			client, err := clients.ClientForVersion(mapping.GroupVersionKind.GroupVersion().String())
 			if err != nil {
 				return nil, err
 			}
-			return kubectl.ReaperFor(mapping.Kind, client)
+			return kubectl.ReaperFor(mapping.GroupVersionKind.Kind, client)
 		},
 		Validator: func(validate bool, cacheDir string) (validation.Schema, error) {
 			if validate {
@@ -581,12 +581,12 @@ func (f *Factory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMappin
 
 		version := OutputVersion(cmd, defaultVersion)
 		if len(version) == 0 {
-			version = mapping.APIVersion
+			version = mapping.GroupVersionKind.GroupVersion().String()
 		}
 		if len(version) == 0 {
 			return nil, fmt.Errorf("you must specify an output-version when using this output format")
 		}
-		printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version, mapping.APIVersion)
+		printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version, mapping.GroupVersionKind.GroupVersion().String())
 	} else {
 		// Some callers do not have "label-columns" so we can't use the GetFlagStringSlice() helper
 		columnLabel, err := cmd.Flags().GetStringSlice("label-columns")

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -470,7 +470,7 @@ func TestResourceByNameWithoutRequireObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if mapping.Kind != "Pod" || mapping.Resource != "pods" {
+	if mapping.GroupVersionKind.Kind != "Pod" || mapping.Resource != "pods" {
 		t.Errorf("unexpected resource mapping: %#v", mapping)
 	}
 }

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -254,7 +254,7 @@ func AsVersionedObjects(infos []*Info, version string) ([]runtime.Object, error)
 			}
 		}
 
-		converted, err := tryConvert(info.Mapping.ObjectConvertor, info.Object, version, info.Mapping.APIVersion)
+		converted, err := tryConvert(info.Mapping.ObjectConvertor, info.Object, version, info.Mapping.GroupVersionKind.GroupVersion().String())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubectl/resource/selector.go
+++ b/pkg/kubectl/resource/selector.go
@@ -45,7 +45,7 @@ func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace string,
 
 // Visit implements Visitor
 func (r *Selector) Visit(fn VisitorFunc) error {
-	list, err := NewHelper(r.Client, r.Mapping).List(r.Namespace, r.ResourceMapping().APIVersion, r.Selector)
+	list, err := NewHelper(r.Client, r.Mapping).List(r.Namespace, r.ResourceMapping().GroupVersionKind.GroupVersion().String(), r.Selector)
 	if err != nil {
 		if errors.IsBadRequest(err) || errors.IsNotFound(err) {
 			if r.Selector.Empty() {
@@ -70,7 +70,7 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 }
 
 func (r *Selector) Watch(resourceVersion string) (watch.Interface, error) {
-	return NewHelper(r.Client, r.Mapping).Watch(r.Namespace, resourceVersion, r.ResourceMapping().APIVersion, r.Selector)
+	return NewHelper(r.Client, r.Mapping).Watch(r.Namespace, resourceVersion, r.ResourceMapping().GroupVersionKind.GroupVersion().String(), r.Selector)
 }
 
 // ResourceMapping returns the mapping for this resource and implements ResourceMapping

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -670,8 +670,8 @@ func (m *Master) init(c *Config) {
 		}
 		expAPIVersions := []unversioned.GroupVersionForDiscovery{
 			{
-				GroupVersion: expVersion.Version,
-				Version:      apiutil.GetVersion(expVersion.Version),
+				GroupVersion: expVersion.GroupVersion.String(),
+				Version:      expVersion.GroupVersion.Version,
 			},
 		}
 		storageVersion, found := c.StorageVersions[g.Group]
@@ -685,7 +685,7 @@ func (m *Master) init(c *Config) {
 		}
 		apiserver.AddGroupWebService(m.handlerContainer, c.APIGroupPrefix+"/"+latest.GroupOrDie("extensions").Group, group)
 		allGroups = append(allGroups, group)
-		apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newRequestInfoResolver(), []string{expVersion.Version})
+		apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newRequestInfoResolver(), []string{expVersion.GroupVersion.String()})
 	}
 
 	// This should be done after all groups are registered
@@ -892,7 +892,7 @@ func (m *Master) api_v1() *apiserver.APIGroupVersion {
 	}
 	version := m.defaultAPIGroupVersion()
 	version.Storage = storage
-	version.Version = "v1"
+	version.GroupVersion = unversioned.GroupVersion{Version: "v1"}
 	version.Codec = v1.Codec
 	return version
 }
@@ -1005,7 +1005,7 @@ func (m *Master) InstallThirdPartyResource(rsrc *expapi.ThirdPartyResource) erro
 	}
 	apiserver.AddGroupWebService(m.handlerContainer, path, apiGroup)
 	m.addThirdPartyResourceStorage(path, thirdparty.Storage[strings.ToLower(kind)+"s"].(*thirdpartyresourcedataetcd.REST))
-	apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newRequestInfoResolver(), []string{thirdparty.Version})
+	apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newRequestInfoResolver(), []string{thirdparty.GroupVersion.String()})
 	return nil
 }
 
@@ -1018,20 +1018,22 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 		strings.ToLower(kind) + "s": resourceStorage,
 	}
 
+	serverGroupVersion := unversioned.ParseGroupVersionOrDie(latest.GroupOrDie("").GroupVersion)
+
 	return &apiserver.APIGroupVersion{
 		Root:                apiRoot,
-		Version:             apiutil.GetGroupVersion(group, version),
+		GroupVersion:        unversioned.GroupVersion{Group: group, Version: version},
 		RequestInfoResolver: m.newRequestInfoResolver(),
 
 		Creater:   thirdpartyresourcedata.NewObjectCreator(group, version, api.Scheme),
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,
 
-		Mapper:        thirdpartyresourcedata.NewMapper(latest.GroupOrDie("extensions").RESTMapper, kind, version, group),
-		Codec:         thirdpartyresourcedata.NewCodec(latest.GroupOrDie("extensions").Codec, kind),
-		Linker:        latest.GroupOrDie("extensions").SelfLinker,
-		Storage:       storage,
-		ServerVersion: latest.GroupOrDie("").GroupVersion,
+		Mapper:             thirdpartyresourcedata.NewMapper(latest.GroupOrDie("extensions").RESTMapper, kind, version, group),
+		Codec:              thirdpartyresourcedata.NewCodec(latest.GroupOrDie("extensions").Codec, kind),
+		Linker:             latest.GroupOrDie("extensions").SelfLinker,
+		Storage:            storage,
+		ServerGroupVersion: &serverGroupVersion,
 
 		Context: m.requestContextMapper,
 
@@ -1106,6 +1108,7 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 	}
 
 	extensionsGroup := latest.GroupOrDie("extensions")
+	serverGroupVersion := unversioned.ParseGroupVersionOrDie(latest.GroupOrDie("").GroupVersion)
 
 	return &apiserver.APIGroupVersion{
 		Root:                m.apiGroupPrefix,
@@ -1115,12 +1118,12 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,
 
-		Mapper:        extensionsGroup.RESTMapper,
-		Codec:         extensionsGroup.Codec,
-		Linker:        extensionsGroup.SelfLinker,
-		Storage:       storage,
-		Version:       extensionsGroup.GroupVersion,
-		ServerVersion: latest.GroupOrDie("").GroupVersion,
+		Mapper:             extensionsGroup.RESTMapper,
+		Codec:              extensionsGroup.Codec,
+		Linker:             extensionsGroup.SelfLinker,
+		Storage:            storage,
+		GroupVersion:       unversioned.ParseGroupVersionOrDie(extensionsGroup.GroupVersion),
+		ServerGroupVersion: &serverGroupVersion,
 
 		Admit:   m.admissionControl,
 		Context: m.requestContextMapper,

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -175,7 +175,7 @@ func TestFindExternalAddress(t *testing.T) {
 func TestApi_v1(t *testing.T) {
 	master, _, assert := setUp(t)
 	version := master.api_v1()
-	assert.Equal("v1", version.Version, "Version was not v1: %s", version.Version)
+	assert.Equal(unversioned.GroupVersion{Version: "v1"}, version.GroupVersion, "Version was not v1: %s", version.GroupVersion)
 	assert.Equal(v1.Codec, version.Codec, "version.Codec was not for v1: %s", version.Codec)
 	for k, v := range master.storage {
 		assert.Contains(version.Storage, v, "Value %s not found (key: %s)", k, v)
@@ -322,12 +322,14 @@ func TestDefaultAPIGroupVersion(t *testing.T) {
 func TestExpapi(t *testing.T) {
 	master, config, assert := setUp(t)
 
+	extensionsGroupMeta := latest.GroupOrDie("extensions")
+
 	expAPIGroup := master.experimental(&config)
 	assert.Equal(expAPIGroup.Root, master.apiGroupPrefix)
-	assert.Equal(expAPIGroup.Mapper, latest.GroupOrDie("extensions").RESTMapper)
-	assert.Equal(expAPIGroup.Codec, latest.GroupOrDie("extensions").Codec)
-	assert.Equal(expAPIGroup.Linker, latest.GroupOrDie("extensions").SelfLinker)
-	assert.Equal(expAPIGroup.Version, latest.GroupOrDie("extensions").GroupVersion)
+	assert.Equal(expAPIGroup.Mapper, extensionsGroupMeta.RESTMapper)
+	assert.Equal(expAPIGroup.Codec, extensionsGroupMeta.Codec)
+	assert.Equal(expAPIGroup.Linker, extensionsGroupMeta.SelfLinker)
+	assert.Equal(expAPIGroup.GroupVersion, unversioned.GroupVersion{Group: extensionsGroupMeta.Group, Version: extensionsGroupMeta.Version})
 }
 
 // TestGetNodeAddresses verifies that proper results are returned


### PR DESCRIPTION
This converts the internals of the `RESTMapping` object to use a `GroupVersionKind` to unambiguously reference a particular kind.  The actual code expected to speak "group/version" to a `RESTMapper`, so this updates the internal tests to do the same thing.

I also eliminated the `testVersion` and `newVersion` from the `apiserver_test.go` file.

@caesarxuchao @liggitt 

@liggitt I think its your turn.  I'll rebase once the first pull merges.
