### PR TITLE
Don't use ginkgo.focus for ci-reboot

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -689,7 +689,7 @@ case ${JOB_NAME} in
           ${REBOOT_SKIP_TESTS[@]:+${REBOOT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          ) --ginkgo.focus=Reboot"}
+          )"}
     ;;
 
   kubernetes-e2e-gke-1.1)


### PR DESCRIPTION
focus is whitelist, we want to run unflaky, unslow tests along with
reboot to verify cluster functionality before/after.
