### PR TITLE
 kubelet: add RawPodStatus and related functions

### DIFF
--- a/pkg/kubelet/container/fake_runtime.go
+++ b/pkg/kubelet/container/fake_runtime.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/volume"
 )
@@ -36,6 +37,7 @@ type FakeRuntime struct {
 	AllPodList        []*Pod
 	ImageList         []Image
 	PodStatus         api.PodStatus
+	RawPodStatus      RawPodStatus
 	StartedPods       []string
 	KilledPods        []string
 	StartedContainers []string
@@ -226,6 +228,24 @@ func (f *FakeRuntime) GetPodStatus(*api.Pod) (*api.PodStatus, error) {
 	defer f.Unlock()
 
 	f.CalledFunctions = append(f.CalledFunctions, "GetPodStatus")
+	status := f.PodStatus
+	return &status, f.Err
+}
+
+func (f *FakeRuntime) GetRawPodStatus(uid types.UID, name, namespace string) (*RawPodStatus, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	f.CalledFunctions = append(f.CalledFunctions, "GetRawPodStatus")
+	status := f.RawPodStatus
+	return &status, f.Err
+}
+
+func (f *FakeRuntime) ConvertRawToPodStatus(_ *api.Pod, _ *RawPodStatus) (*api.PodStatus, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	f.CalledFunctions = append(f.CalledFunctions, "ConvertRawToPodStatus")
 	status := f.PodStatus
 	return &status, f.Err
 }

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -2095,3 +2095,11 @@ func (dm *DockerManager) GetNetNs(containerID kubecontainer.ContainerID) (string
 func (dm *DockerManager) GarbageCollect(gcPolicy kubecontainer.ContainerGCPolicy) error {
 	return dm.containerGC.GarbageCollect(gcPolicy)
 }
+
+func (dm *DockerManager) GetRawPodStatus(uid types.UID, name, namespace string) (*kubecontainer.RawPodStatus, error) {
+	return nil, fmt.Errorf("Not implemented yet")
+}
+
+func (dm *DockerManager) ConvertRawToPodStatus(_ *api.Pod, _ *kubecontainer.RawPodStatus) (*api.PodStatus, error) {
+	return nil, fmt.Errorf("Not implemented yet")
+}

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1410,3 +1410,11 @@ func (r *Runtime) RemoveImage(image kubecontainer.ImageSpec) error {
 	}
 	return nil
 }
+
+func (r *Runtime) GetRawPodStatus(uid types.UID, name, namespace string) (*kubecontainer.RawPodStatus, error) {
+	return nil, fmt.Errorf("Not implemented yet")
+}
+
+func (r *Runtime) ConvertRawToPodStatus(_ *api.Pod, _ *kubecontainer.RawPodStatus) (*api.PodStatus, error) {
+	return nil, fmt.Errorf("Not implemented yet")
+}


### PR DESCRIPTION
RawPodStatus will be the internal status of the pod that kubelet relies on for syncing
This PR only adds the type and functions. The followup PRs will start implementing them.

This is part of #12619.
