### PR TITLE
Install libapparmor1 in kubekins-test image

### DIFF
--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -42,5 +42,5 @@ docker run --rm=true \
   -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
   -v "${KUBE_JUNIT_REPORT_DIR}":/workspace/artifacts \
   --env REPO_DIR="${REPO_DIR}" \
-  -i gcr.io/google_containers/kubekins-test:0.2 \
+  -i gcr.io/google_containers/kubekins-test:0.3 \
   bash -c "cd kubernetes && ./hack/jenkins/test-dockerized.sh"

--- a/hack/jenkins/test-image/Dockerfile
+++ b/hack/jenkins/test-image/Dockerfile
@@ -24,7 +24,8 @@ ENV TERM                    xterm
 WORKDIR /workspace
 
 RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y rsync
-RUN apt-get install -y file
+# libapparmor1 is needed for docker-in-docker.
+RUN apt-get install -y file libapparmor1
 RUN mkdir -p /go/src/k8s.io/kubernetes
 RUN ln -s /go/src/k8s.io/kubernetes /workspace/kubernetes
 

--- a/hack/jenkins/test-image/Makefile
+++ b/hack/jenkins/test-image/Makefile
@@ -1,6 +1,6 @@
 all: push
 
-TAG = 0.2
+TAG = 0.3
 
 container:
 	docker build -t gcr.io/google_containers/kubekins-test .


### PR DESCRIPTION
Recent versions of Docker are dynamically linked, so when we run the verification tests in the kubekins-test image, docker-in-docker fails, due to a missing shared library:

```
docker: error while loading shared libraries: libapparmor.so.1: cannot open shared object file: No such file or directory
!!! Error in ./hack/update-api-reference-docs.sh:53
  'docker run -u $(id -u) --rm -v $V1_TMP_IN_HOST:/output:z -v ${SWAGGER_PATH}:/swagger-source:z gcr.io/google_containers/gen-swagger-docs:v4 v1 https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/v1/register.go' exited with status 127
Call stack:
  1: ./hack/update-api-reference-docs.sh:53 main(...)
Exiting with status 1
!!! Error in ./hack/../hack/verify-api-reference-docs.sh:34
  '"./hack/update-api-reference-docs.sh" "${OUTPUT_DIR}"' exited with status 1
Call stack:
  1: ./hack/../hack/verify-api-reference-docs.sh:34 main(...)
Exiting with status 1
FAILED
```

Per https://github.com/docker/docker/issues/15024 it seems this is WAI, and the workarounds are to either include the library dependency in the docker mount or install the library in the container. The latter seemed less fragile for now.

I've tested this locally, but I haven't pushed a new image (yet), so this will fail on PR Jenkins. If you're happy with the changes, I'll push the image to gcr.io, then re-run unit tests to verify everything is still good.

@kubernetes/goog-testing 
