### PR TITLE
Update CentOS manual instructions to use virt7-docker-common-release

### DIFF
--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -61,36 +61,19 @@ centos-minion = 192.168.121.65
 
 **Prepare the hosts:**
 
-* Create virt7-testing repo on all hosts - centos-{master,minion} with following information.
+* Create a virt7-docker-common-release repo on all hosts - centos-{master,minion} with following information.
 
 ```
-[virt7-testing]
-name=virt7-testing
-baseurl=http://cbs.centos.org/repos/virt7-testing/x86_64/os/
+[virt7-docker-common-release]
+name=virt7-docker-common-release
+baseurl=http://cbs.centos.org/repos/virt7-docker-common-release/x86_64/os/
 gpgcheck=0
 ```
 
 * Install Kubernetes on all hosts - centos-{master,minion}.  This will also pull in etcd, docker, and cadvisor.
 
 ```sh
-yum -y install --enablerepo=virt7-testing kubernetes
-```
-
-* Note * Using etcd-0.4.6-7 (This is temporary update in documentation)
-
-If you do not get etcd-0.4.6-7 installed with virt7-testing repo,
-
-In the current virt7-testing repo, the etcd package is updated which causes service failure. To avoid this,
-
-```sh
-yum erase etcd
-```
-
-It will uninstall the current available etcd package
-
-```sh
-yum install http://cbs.centos.org/kojifiles/packages/etcd/0.4.6/7.el7.centos/x86_64/etcd-0.4.6-7.el7.centos.x86_64.rpm
-yum -y install --enablerepo=virt7-testing kubernetes
+yum -y install --enablerepo=virt7-docker-common-release kubernetes
 ```
 
 * Add master and node to /etc/hosts on all machines (not needed if hostnames already in DNS)


### PR DESCRIPTION
Just sync the documentation up since the latest [virt7-docker-common-release](http://cbs.centos.org/koji/packages?tagID=112) has newer packages that work together.

Tested this on a single node Centos 7.1 node with the following packages and it all works well so far:

```
$ sudo yum list -q docker etcd kubernetes flannel
Installed Packages
docker.x86_64                                1.8.2-7.el7.centos                                  @extras
etcd.x86_64                                  2.1.1-2.el7                                         @extras
flannel.x86_64                               0.2.0-10.el7                                        @extras
kubernetes.x86_64                            1.1.0-0.4.git2bfa9a1.el7                            @virt7-docker-common-release
```

Would this be worth backporting to the `release-1.1` branch, given Centos's propensity to live in the past...
