### PR TITLE
Update get-kube.sh with libvirt provider

### DIFF
--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -28,6 +28,8 @@
 #   * export KUBERNETES_PROVIDER=gke; wget -q -O - https://get.k8s.io | bash
 #  Amazon EC2
 #   * export KUBERNETES_PROVIDER=aws; wget -q -O - https://get.k8s.io | bash
+#  Libvirt (with CoreOS as a guest operating system)
+#   * export KUBERNETES_PROVIDER=libvirt-coreos; wget -q -O - https://get.k8s.io | bash
 #  Vagrant (local virtual machines)
 #   * export KUBERNETES_PROVIDER=vagrant; wget -q -O - https://get.k8s.io | bash
 #  VMWare VSphere


### PR DESCRIPTION
Update get-kube.sh with libvirt provider (with CoreOS as a guest operating system) - https://github.com/kubernetes/kubernetes/blob/master/docs/getting-started-guides/libvirt-coreos.md
