### PR TITLE
jenkins: Skip a flaky test for Trusty release jobs

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -224,10 +224,16 @@ GCE_SOAK_CONTINUOUS_SKIP_TESTS=(
 GCE_RELEASE_SKIP_TESTS=(
     )
 
-# TODO(wonderfly): Delete this once
-# https://github.com/kubernetes/kubernetes/issues/12689 is fixed.
 TRUSTY_SKIP_TESTS=(
+    # TODO(wonderfly): Remove this once
+    # https://github.com/kubernetes/kubernetes/issues/12689 is fixed.
     "Services.*should\swork\safter\srestarting\skube-proxy"
+    # This test was broken and fixed after v1.1.1 release cut. As Trusty release
+    # tests pin to the latest release version of k8s, we'd have to wait till
+    # next release to pick up the fix.
+    # https://github.com/kubernetes/kubernetes/pull/14603
+    # TODO(wonderfly): Remove this once v1.1.2 is out.
+    "Kubelet\sregular\sresource\susage\stracking\sover\s30m0s\swith\s0\spods\sper\snode"
 )
 
 # Define environment variables based on the Jenkins project name.


### PR DESCRIPTION
The "Kubelet regular resource usage tracking over 30m0s with 0 pods per node"
was broken and fixed after the v1.1.1 cut, by pull request #14603. Trusty
release jobs always pin to the latest release version of k8s, so we would have
to wait until next 1.1 release to pick up the fix. Temporarily skipping that
test for Trusty jobs now.

@ixdy @andyzheng0831 
