### PR TITLE
Parallel build logic should work against available memory, not total memory

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -415,12 +415,12 @@ kube::golang::build_binaries_for_platform() {
   done
 }
 
-# Return approximate physical memory in gigabytes.
+# Return approximate physical memory available in gigabytes.
 kube::golang::get_physmem() {
   local mem
 
   # Linux, in kb
-  if mem=$(grep MemTotal /proc/meminfo | awk '{ print $2 }'); then
+  if mem=$(grep MemAvailable /proc/meminfo | awk '{ print $2 }'); then
     echo $(( ${mem} / 1048576 ))
     return
   fi


### PR DESCRIPTION
The existing logic would lock up my development laptop.  A better solution to know when to do parallel builds is to look at available memory and not total memory.  Often, I have other things going on in my laptop, so its not safe to assume it has all 11G.

In essence, the current behavior would often break up my development flow.
