### PR TITLE
Fix generation of master `minion.d/grains.conf`.

### DIFF
--- a/cluster/aws/templates/salt-master.sh
+++ b/cluster/aws/templates/salt-master.sh
@@ -33,7 +33,7 @@ function env_to_salt {
   local value=${!env_key}
   if [[ -n "${value}" ]]; then
     # Note this is yaml, so indentation matters
-    cat <<EOF # >>/etc/salt/minion.d/grains.conf
+    cat <<EOF >>/etc/salt/minion.d/grains.conf
   ${key}: '$(echo "${value}" | sed -e "s/'/''/g")'
 EOF
   fi


### PR DESCRIPTION
Remove a comment that disabled the redirection of output destined for `/etc/salt/minion.d/grains.conf`. Must have been a commented added to debug the generation of the line; to view it on `STDOUT`.
