### PR TITLE
Small readability improvements in Kubelet

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -17,9 +17,6 @@ limitations under the License.
 // Package app makes it easy to create a kubelet server for various contexts.
 package app
 
-// Note: if you change code in this file, you might need to change code in
-// contrib/mesos/pkg/executor/service/.
-
 import (
 	"crypto/tls"
 	"fmt"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -16,9 +16,6 @@ limitations under the License.
 
 package kubelet
 
-// Note: if you change code in this file, you might need to change code in
-// contrib/mesos/pkg/executor/.
-
 import (
 	"bytes"
 	"errors"
@@ -205,7 +202,7 @@ func NewMainKubelet(
 	configureCBR0 bool,
 	podCIDR string,
 	reconcileCIDR bool,
-	pods int,
+	maxPods int,
 	dockerExecHandler dockertools.ExecHandler,
 	resolverConfig string,
 	cpuCFSQuota bool,
@@ -315,7 +312,7 @@ func NewMainKubelet(
 		writer:                         writer,
 		configureCBR0:                  configureCBR0,
 		reconcileCIDR:                  reconcileCIDR,
-		pods:                           pods,
+		maxPods:                        maxPods,
 		syncLoopMonitor:                util.AtomicValue{},
 		resolverConfig:                 resolverConfig,
 		cpuCFSQuota:                    cpuCFSQuota,
@@ -606,8 +603,8 @@ type Kubelet struct {
 	configureCBR0 bool
 	reconcileCIDR bool
 
-	// Number of Pods which can be run by this Kubelet
-	pods int
+	// Maximum Number of Pods which can be run by this Kubelet
+	maxPods int
 
 	// Monitor Kubelet's sync loop
 	syncLoopMonitor util.AtomicValue
@@ -2602,7 +2599,7 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 		node.Status.Capacity = api.ResourceList{
 			api.ResourceCPU:    *resource.NewMilliQuantity(0, resource.DecimalSI),
 			api.ResourceMemory: resource.MustParse("0Gi"),
-			api.ResourcePods:   *resource.NewQuantity(int64(kl.pods), resource.DecimalSI),
+			api.ResourcePods:   *resource.NewQuantity(int64(kl.maxPods), resource.DecimalSI),
 		}
 		glog.Errorf("Error getting machine info: %v", err)
 	} else {
@@ -2610,7 +2607,7 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 		node.Status.NodeInfo.SystemUUID = info.SystemUUID
 		node.Status.Capacity = cadvisor.CapacityFromMachineInfo(info)
 		node.Status.Capacity[api.ResourcePods] = *resource.NewQuantity(
-			int64(kl.pods), resource.DecimalSI)
+			int64(kl.maxPods), resource.DecimalSI)
 		if node.Status.NodeInfo.BootID != "" &&
 			node.Status.NodeInfo.BootID != info.BootID {
 			// TODO: This requires a transaction, either both node status is updated


### PR DESCRIPTION
Rename kubelet variable pods to maxPods in kubelet pkg to match corresponding maxPods variable in cmd/kubelet/server.go.

Remove comment requesting modification of mesos contrib file, dependencies such as this are maintained in unit tests
