### PR TITLE
Convert external int fields to uint32 or int32 as appropriate

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -13544,17 +13544,17 @@
      },
      "initialDelaySeconds": {
       "type": "integer",
-      "format": "int64",
+      "format": "int32",
       "description": "Number of seconds after the container has started before liveness probes are initiated. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
      },
      "timeoutSeconds": {
       "type": "integer",
-      "format": "int64",
+      "format": "int32",
       "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
      },
      "periodSeconds": {
       "type": "integer",
-      "format": "int64",
+      "format": "int32",
       "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1."
      },
      "successThreshold": {

--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -3784,17 +3784,17 @@
      },
      "initialDelaySeconds": {
       "type": "integer",
-      "format": "int64",
+      "format": "int32",
       "description": "Number of seconds after the container has started before liveness probes are initiated. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
      },
      "timeoutSeconds": {
       "type": "integer",
-      "format": "int64",
+      "format": "int32",
       "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
      },
      "periodSeconds": {
       "type": "integer",
-      "format": "int64",
+      "format": "int32",
       "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1."
      },
      "successThreshold": {

--- a/contrib/mesos/pkg/service/endpoints_controller.go
+++ b/contrib/mesos/pkg/service/endpoints_controller.go
@@ -430,8 +430,8 @@ func findPort(pod *api.Pod, svcPort *api.ServicePort) (int, int, error) {
 		p := portName.IntVal
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {
-				if port.ContainerPort == p && port.Protocol == svcPort.Protocol {
-					hostPort, err := findMappedPort(pod, port.Protocol, p)
+				if port.ContainerPort == int(p) && port.Protocol == svcPort.Protocol {
+					hostPort, err := findMappedPort(pod, port.Protocol, int(p))
 					return hostPort, port.ContainerPort, err
 				}
 			}

--- a/contrib/mesos/pkg/service/endpoints_controller.go
+++ b/contrib/mesos/pkg/service/endpoints_controller.go
@@ -427,11 +427,11 @@ func findPort(pod *api.Pod, svcPort *api.ServicePort) (int, int, error) {
 		// it actually maps to a host-port assigned to the pod. upstream
 		// doesn't check this and happily returns the container port spec'd
 		// in the service, but that doesn't align w/ mesos port mgmt.
-		p := portName.IntVal
+		p := portName.IntValue()
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {
-				if port.ContainerPort == int(p) && port.Protocol == svcPort.Protocol {
-					hostPort, err := findMappedPort(pod, port.Protocol, int(p))
+				if port.ContainerPort == p && port.Protocol == svcPort.Protocol {
+					hostPort, err := findMappedPort(pod, port.Protocol, p)
 					return hostPort, port.ContainerPort, err
 				}
 			}

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -3302,21 +3302,21 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <td class="tableblock halign-left valign-top"><p class="tableblock">initialDelaySeconds</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after the container has started before liveness probes are initiated. More info: <a href="http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">timeoutSeconds</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: <a href="http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">periodSeconds</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -3068,21 +3068,21 @@ The resulting set of endpoints can be viewed as:<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock">initialDelaySeconds</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after the container has started before liveness probes are initiated. More info: <a href="http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">timeoutSeconds</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: <a href="http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">periodSeconds</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>

--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -224,7 +224,7 @@ func NewServerTimeout(kind, operation string, retryAfterSeconds int) error {
 		Details: &unversioned.StatusDetails{
 			Kind:              kind,
 			Name:              operation,
-			RetryAfterSeconds: retryAfterSeconds,
+			RetryAfterSeconds: int32(retryAfterSeconds),
 		},
 		Message: fmt.Sprintf("The %s operation against %s could not be completed at this time, please try again.", operation, kind),
 	}}
@@ -252,7 +252,7 @@ func NewTimeoutError(message string, retryAfterSeconds int) error {
 		Reason:  unversioned.StatusReasonTimeout,
 		Message: fmt.Sprintf("Timeout: %s", message),
 		Details: &unversioned.StatusDetails{
-			RetryAfterSeconds: retryAfterSeconds,
+			RetryAfterSeconds: int32(retryAfterSeconds),
 		},
 	}}
 }
@@ -318,14 +318,14 @@ func NewGenericServerResponse(code int, verb, kind, name, serverMessage string, 
 	}
 	return &StatusError{unversioned.Status{
 		Status: unversioned.StatusFailure,
-		Code:   code,
+		Code:   int32(code),
 		Reason: reason,
 		Details: &unversioned.StatusDetails{
 			Kind: kind,
 			Name: name,
 
 			Causes:            causes,
-			RetryAfterSeconds: retryAfterSeconds,
+			RetryAfterSeconds: int32(retryAfterSeconds),
 		},
 		Message: message,
 	}}
@@ -410,7 +410,7 @@ func SuggestsClientDelay(err error) (int, bool) {
 		if t.Status().Details != nil {
 			switch t.Status().Reason {
 			case unversioned.StatusReasonServerTimeout, unversioned.StatusReasonTimeout:
-				return t.Status().Details.RetryAfterSeconds, true
+				return int(t.Status().Details.RetryAfterSeconds), true
 			}
 		}
 	}

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -110,8 +110,13 @@ func TestSpecificKind(t *testing.T) {
 	api.Scheme.Log(t)
 	defer api.Scheme.Log(nil)
 
-	kind := "Pod"
-	doRoundTripTest(kind, t)
+	kind := "JobList"
+	for i := 0; i < *fuzzIters; i++ {
+		doRoundTripTest(kind, t)
+		if t.Failed() {
+			break
+		}
+	}
 }
 
 func TestList(t *testing.T) {
@@ -142,6 +147,9 @@ func TestRoundTripTypes(t *testing.T) {
 		// Try a few times, since runTest uses random values.
 		for i := 0; i < *fuzzIters; i++ {
 			doRoundTripTest(kind, t)
+			if t.Failed() {
+				break
+			}
 		}
 	}
 }

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -110,7 +110,7 @@ func TestSpecificKind(t *testing.T) {
 	api.Scheme.Log(t)
 	defer api.Scheme.Log(nil)
 
-	kind := "JobList"
+	kind := "Pod"
 	for i := 0; i < *fuzzIters; i++ {
 		doRoundTripTest(kind, t)
 		if t.Failed() {

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -375,7 +375,7 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			c.FuzzNoCustom(s) // fuzz self without calling this function again
 			minReplicas := int(c.Rand.Int31())
 			s.MinReplicas = &minReplicas
-			s.CPUUtilization = &extensions.CPUTargetUtilization{TargetPercentage: int(c.Int31())}
+			s.CPUUtilization = &extensions.CPUTargetUtilization{TargetPercentage: int(int32(c.RandUint64()))}
 		},
 	)
 	return f

--- a/pkg/api/types.generated.go
+++ b/pkg/api/types.generated.go
@@ -14302,19 +14302,19 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.InitialDelaySeconds = 0
 			} else {
-				x.InitialDelaySeconds = int64(r.DecodeInt(64))
+				x.InitialDelaySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		case "timeoutSeconds":
 			if r.TryDecodeAsNil() {
 				x.TimeoutSeconds = 0
 			} else {
-				x.TimeoutSeconds = int64(r.DecodeInt(64))
+				x.TimeoutSeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		case "periodSeconds":
 			if r.TryDecodeAsNil() {
 				x.PeriodSeconds = 0
 			} else {
-				x.PeriodSeconds = int64(r.DecodeInt(64))
+				x.PeriodSeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		case "successThreshold":
 			if r.TryDecodeAsNil() {
@@ -14428,7 +14428,7 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.InitialDelaySeconds = 0
 	} else {
-		x.InitialDelaySeconds = int64(r.DecodeInt(64))
+		x.InitialDelaySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	yyj1028++
 	if yyhl1028 {
@@ -14444,7 +14444,7 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.TimeoutSeconds = 0
 	} else {
-		x.TimeoutSeconds = int64(r.DecodeInt(64))
+		x.TimeoutSeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	yyj1028++
 	if yyhl1028 {
@@ -14460,7 +14460,7 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.PeriodSeconds = 0
 	} else {
-		x.PeriodSeconds = int64(r.DecodeInt(64))
+		x.PeriodSeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	yyj1028++
 	if yyhl1028 {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -719,11 +719,11 @@ type Probe struct {
 	// The action taken to determine the health of a container
 	Handler `json:",inline"`
 	// Length of time before health checking is activated.  In seconds.
-	InitialDelaySeconds int64 `json:"initialDelaySeconds,omitempty"`
+	InitialDelaySeconds int `json:"initialDelaySeconds,omitempty"`
 	// Length of time before health checking times out.  In seconds.
-	TimeoutSeconds int64 `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
 	// How often (in seconds) to perform the probe.
-	PeriodSeconds int64 `json:"periodSeconds,omitempty"`
+	PeriodSeconds int `json:"periodSeconds,omitempty"`
 	// Minimum consecutive successes for the probe to be considered successful after having failed.
 	// Must be 1 for liveness.
 	SuccessThreshold int `json:"successThreshold,omitempty"`

--- a/pkg/api/unversioned/types.go
+++ b/pkg/api/unversioned/types.go
@@ -99,7 +99,7 @@ type Status struct {
 	// the reason type.
 	Details *StatusDetails `json:"details,omitempty"`
 	// Suggested HTTP return code for this status, 0 if not set.
-	Code int `json:"code,omitempty"`
+	Code int32 `json:"code,omitempty"`
 }
 
 // StatusDetails is a set of additional properties that MAY be set by the
@@ -120,7 +120,7 @@ type StatusDetails struct {
 	// failure. Not all StatusReasons may provide detailed causes.
 	Causes []StatusCause `json:"causes,omitempty"`
 	// If specified, the time in seconds before the operation should be retried.
-	RetryAfterSeconds int `json:"retryAfterSeconds,omitempty"`
+	RetryAfterSeconds int32 `json:"retryAfterSeconds,omitempty"`
 }
 
 // Values of Status.Status
@@ -204,7 +204,7 @@ const (
 	// Details (optional):
 	//   "kind" string - the kind attribute of the resource being acted on.
 	//   "id"   string - the operation that is being attempted.
-	//   "retryAfterSeconds" int - the number of seconds before the operation should be retried
+	//   "retryAfterSeconds" int32 - the number of seconds before the operation should be retried
 	// Status code 500
 	StatusReasonServerTimeout StatusReason = "ServerTimeout"
 
@@ -214,7 +214,7 @@ const (
 	// The request might succeed with an increased value of timeout param. The client *should*
 	// wait at least the number of seconds specified by the retryAfterSeconds field.
 	// Details (optional):
-	//   "retryAfterSeconds" int - the number of seconds before the operation should be retried
+	//   "retryAfterSeconds" int32 - the number of seconds before the operation should be retried
 	// Status code 504
 	StatusReasonTimeout StatusReason = "Timeout"
 

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -180,8 +180,8 @@ func convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *a
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationControllerSpec))(in)
 	}
-	out.Replicas = new(int)
-	*out.Replicas = in.Replicas
+	out.Replicas = new(int32)
+	*out.Replicas = int32(in.Replicas)
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {
@@ -213,7 +213,7 @@ func convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *R
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerSpec))(in)
 	}
-	out.Replicas = *in.Replicas
+	out.Replicas = int(*in.Replicas)
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -33,7 +33,7 @@ func autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStore
 	}
 	out.VolumeID = in.VolumeID
 	out.FSType = in.FSType
-	out.Partition = in.Partition
+	out.Partition = int32(in.Partition)
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -307,8 +307,8 @@ func autoconvert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, ou
 		defaulting.(func(*api.ContainerPort))(in)
 	}
 	out.Name = in.Name
-	out.HostPort = in.HostPort
-	out.ContainerPort = in.ContainerPort
+	out.HostPort = int32(in.HostPort)
+	out.ContainerPort = int32(in.ContainerPort)
 	out.Protocol = Protocol(in.Protocol)
 	out.HostIP = in.HostIP
 	return nil
@@ -371,8 +371,8 @@ func autoconvert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ContainerStateTerminated))(in)
 	}
-	out.ExitCode = in.ExitCode
-	out.Signal = in.Signal
+	out.ExitCode = int32(in.ExitCode)
+	out.Signal = int32(in.Signal)
 	out.Reason = in.Reason
 	out.Message = in.Message
 	if err := s.Convert(&in.StartedAt, &out.StartedAt, 0); err != nil {
@@ -414,7 +414,7 @@ func autoconvert_api_ContainerStatus_To_v1_ContainerStatus(in *api.ContainerStat
 		return err
 	}
 	out.Ready = in.Ready
-	out.RestartCount = in.RestartCount
+	out.RestartCount = int32(in.RestartCount)
 	out.Image = in.Image
 	out.ImageID = in.ImageID
 	out.ContainerID = in.ContainerID
@@ -429,7 +429,7 @@ func autoconvert_api_DaemonEndpoint_To_v1_DaemonEndpoint(in *api.DaemonEndpoint,
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DaemonEndpoint))(in)
 	}
-	out.Port = in.Port
+	out.Port = int32(in.Port)
 	return nil
 }
 
@@ -530,7 +530,7 @@ func autoconvert_api_EndpointPort_To_v1_EndpointPort(in *api.EndpointPort, out *
 		defaulting.(func(*api.EndpointPort))(in)
 	}
 	out.Name = in.Name
-	out.Port = in.Port
+	out.Port = int32(in.Port)
 	out.Protocol = Protocol(in.Protocol)
 	return nil
 }
@@ -698,7 +698,7 @@ func autoconvert_api_Event_To_v1_Event(in *api.Event, out *Event, s conversion.S
 	if err := s.Convert(&in.LastTimestamp, &out.LastTimestamp, 0); err != nil {
 		return err
 	}
-	out.Count = in.Count
+	out.Count = int32(in.Count)
 	out.Type = in.Type
 	return nil
 }
@@ -779,8 +779,8 @@ func autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource,
 		out.TargetWWNs = nil
 	}
 	if in.Lun != nil {
-		out.Lun = new(int)
-		*out.Lun = *in.Lun
+		out.Lun = new(int32)
+		*out.Lun = int32(*in.Lun)
 	} else {
 		out.Lun = nil
 	}
@@ -811,7 +811,7 @@ func autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolume
 	}
 	out.PDName = in.PDName
 	out.FSType = in.FSType
-	out.Partition = in.Partition
+	out.Partition = int32(in.Partition)
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -917,7 +917,7 @@ func autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolu
 	}
 	out.TargetPortal = in.TargetPortal
 	out.IQN = in.IQN
-	out.Lun = in.Lun
+	out.Lun = int32(in.Lun)
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
 	return nil
@@ -2215,11 +2215,11 @@ func autoconvert_api_Probe_To_v1_Probe(in *api.Probe, out *Probe, s conversion.S
 	if err := convert_api_Handler_To_v1_Handler(&in.Handler, &out.Handler, s); err != nil {
 		return err
 	}
-	out.InitialDelaySeconds = in.InitialDelaySeconds
-	out.TimeoutSeconds = in.TimeoutSeconds
-	out.PeriodSeconds = in.PeriodSeconds
-	out.SuccessThreshold = in.SuccessThreshold
-	out.FailureThreshold = in.FailureThreshold
+	out.InitialDelaySeconds = int32(in.InitialDelaySeconds)
+	out.TimeoutSeconds = int32(in.TimeoutSeconds)
+	out.PeriodSeconds = int32(in.PeriodSeconds)
+	out.SuccessThreshold = int32(in.SuccessThreshold)
+	out.FailureThreshold = int32(in.FailureThreshold)
 	return nil
 }
 
@@ -2361,7 +2361,7 @@ func autoconvert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStat
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationControllerStatus))(in)
 	}
-	out.Replicas = in.Replicas
+	out.Replicas = int32(in.Replicas)
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
@@ -2779,11 +2779,11 @@ func autoconvert_api_ServicePort_To_v1_ServicePort(in *api.ServicePort, out *Ser
 	}
 	out.Name = in.Name
 	out.Protocol = Protocol(in.Protocol)
-	out.Port = in.Port
+	out.Port = int32(in.Port)
 	if err := s.Convert(&in.TargetPort, &out.TargetPort, 0); err != nil {
 		return err
 	}
-	out.NodePort = in.NodePort
+	out.NodePort = int32(in.NodePort)
 	return nil
 }
 
@@ -3058,7 +3058,7 @@ func autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStore
 	}
 	out.VolumeID = in.VolumeID
 	out.FSType = in.FSType
-	out.Partition = in.Partition
+	out.Partition = int(in.Partition)
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -3332,8 +3332,8 @@ func autoconvert_v1_ContainerPort_To_api_ContainerPort(in *ContainerPort, out *a
 		defaulting.(func(*ContainerPort))(in)
 	}
 	out.Name = in.Name
-	out.HostPort = in.HostPort
-	out.ContainerPort = in.ContainerPort
+	out.HostPort = int(in.HostPort)
+	out.ContainerPort = int(in.ContainerPort)
 	out.Protocol = api.Protocol(in.Protocol)
 	out.HostIP = in.HostIP
 	return nil
@@ -3396,8 +3396,8 @@ func autoconvert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ContainerStateTerminated))(in)
 	}
-	out.ExitCode = in.ExitCode
-	out.Signal = in.Signal
+	out.ExitCode = int(in.ExitCode)
+	out.Signal = int(in.Signal)
 	out.Reason = in.Reason
 	out.Message = in.Message
 	if err := s.Convert(&in.StartedAt, &out.StartedAt, 0); err != nil {
@@ -3439,7 +3439,7 @@ func autoconvert_v1_ContainerStatus_To_api_ContainerStatus(in *ContainerStatus, 
 		return err
 	}
 	out.Ready = in.Ready
-	out.RestartCount = in.RestartCount
+	out.RestartCount = int(in.RestartCount)
 	out.Image = in.Image
 	out.ImageID = in.ImageID
 	out.ContainerID = in.ContainerID
@@ -3454,7 +3454,7 @@ func autoconvert_v1_DaemonEndpoint_To_api_DaemonEndpoint(in *DaemonEndpoint, out
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DaemonEndpoint))(in)
 	}
-	out.Port = in.Port
+	out.Port = int(in.Port)
 	return nil
 }
 
@@ -3555,7 +3555,7 @@ func autoconvert_v1_EndpointPort_To_api_EndpointPort(in *EndpointPort, out *api.
 		defaulting.(func(*EndpointPort))(in)
 	}
 	out.Name = in.Name
-	out.Port = in.Port
+	out.Port = int(in.Port)
 	out.Protocol = api.Protocol(in.Protocol)
 	return nil
 }
@@ -3723,7 +3723,7 @@ func autoconvert_v1_Event_To_api_Event(in *Event, out *api.Event, s conversion.S
 	if err := s.Convert(&in.LastTimestamp, &out.LastTimestamp, 0); err != nil {
 		return err
 	}
-	out.Count = in.Count
+	out.Count = int(in.Count)
 	out.Type = in.Type
 	return nil
 }
@@ -3805,7 +3805,7 @@ func autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out
 	}
 	if in.Lun != nil {
 		out.Lun = new(int)
-		*out.Lun = *in.Lun
+		*out.Lun = int(*in.Lun)
 	} else {
 		out.Lun = nil
 	}
@@ -3836,7 +3836,7 @@ func autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolume
 	}
 	out.PDName = in.PDName
 	out.FSType = in.FSType
-	out.Partition = in.Partition
+	out.Partition = int(in.Partition)
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -3942,7 +3942,7 @@ func autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *ISCSIVolumeSo
 	}
 	out.TargetPortal = in.TargetPortal
 	out.IQN = in.IQN
-	out.Lun = in.Lun
+	out.Lun = int(in.Lun)
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
 	return nil
@@ -5272,11 +5272,11 @@ func autoconvert_v1_Probe_To_api_Probe(in *Probe, out *api.Probe, s conversion.S
 	if err := convert_v1_Handler_To_api_Handler(&in.Handler, &out.Handler, s); err != nil {
 		return err
 	}
-	out.InitialDelaySeconds = in.InitialDelaySeconds
-	out.TimeoutSeconds = in.TimeoutSeconds
-	out.PeriodSeconds = in.PeriodSeconds
-	out.SuccessThreshold = in.SuccessThreshold
-	out.FailureThreshold = in.FailureThreshold
+	out.InitialDelaySeconds = int(in.InitialDelaySeconds)
+	out.TimeoutSeconds = int(in.TimeoutSeconds)
+	out.PeriodSeconds = int(in.PeriodSeconds)
+	out.SuccessThreshold = int(in.SuccessThreshold)
+	out.FailureThreshold = int(in.FailureThreshold)
 	return nil
 }
 
@@ -5416,7 +5416,7 @@ func autoconvert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStat
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerStatus))(in)
 	}
-	out.Replicas = in.Replicas
+	out.Replicas = int(in.Replicas)
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
@@ -5834,11 +5834,11 @@ func autoconvert_v1_ServicePort_To_api_ServicePort(in *ServicePort, out *api.Ser
 	}
 	out.Name = in.Name
 	out.Protocol = api.Protocol(in.Protocol)
-	out.Port = in.Port
+	out.Port = int(in.Port)
 	if err := s.Convert(&in.TargetPort, &out.TargetPort, 0); err != nil {
 		return err
 	}
-	out.NodePort = in.NodePort
+	out.NodePort = int(in.NodePort)
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -597,7 +597,7 @@ func deepCopy_v1_FCVolumeSource(in FCVolumeSource, out *FCVolumeSource, c *conve
 		out.TargetWWNs = nil
 	}
 	if in.Lun != nil {
-		out.Lun = new(int)
+		out.Lun = new(int32)
 		*out.Lun = *in.Lun
 	} else {
 		out.Lun = nil
@@ -1803,7 +1803,7 @@ func deepCopy_v1_ReplicationControllerList(in ReplicationControllerList, out *Re
 
 func deepCopy_v1_ReplicationControllerSpec(in ReplicationControllerSpec, out *ReplicationControllerSpec, c *conversion.Cloner) error {
 	if in.Replicas != nil {
-		out.Replicas = new(int)
+		out.Replicas = new(int32)
 		*out.Replicas = *in.Replicas
 	} else {
 		out.Replicas = nil

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -41,7 +41,7 @@ func addDefaultingFuncs() {
 				}
 			}
 			if obj.Spec.Replicas == nil {
-				obj.Spec.Replicas = new(int)
+				obj.Spec.Replicas = new(int32)
 				*obj.Spec.Replicas = 1
 			}
 		},
@@ -85,7 +85,7 @@ func addDefaultingFuncs() {
 					sp.Protocol = ProtocolTCP
 				}
 				if sp.TargetPort == intstr.FromInt(0) || sp.TargetPort == intstr.FromString("") {
-					sp.TargetPort = intstr.FromInt(sp.Port)
+					sp.TargetPort = intstr.FromInt(int(sp.Port))
 				}
 			}
 		},

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -156,8 +156,8 @@ func TestSetDefaultReplicationController(t *testing.T) {
 	}
 }
 
-func newInt(val int) *int {
-	p := new(int)
+func newInt(val int32) *int32 {
+	p := new(int32)
 	*p = val
 	return p
 }
@@ -165,7 +165,7 @@ func newInt(val int) *int {
 func TestSetDefaultReplicationControllerReplicas(t *testing.T) {
 	tests := []struct {
 		rc             versioned.ReplicationController
-		expectReplicas int
+		expectReplicas int32
 	}{
 		{
 			rc: versioned.ReplicationController{
@@ -345,13 +345,13 @@ func TestSetDefaultServicePort(t *testing.T) {
 	if out.Spec.Ports[0].Protocol != versioned.ProtocolTCP {
 		t.Errorf("Expected protocol %s, got %s", versioned.ProtocolTCP, out.Spec.Ports[0].Protocol)
 	}
-	if out.Spec.Ports[0].TargetPort != intstr.FromInt(in.Spec.Ports[0].Port) {
+	if out.Spec.Ports[0].TargetPort != intstr.FromInt(int(in.Spec.Ports[0].Port)) {
 		t.Errorf("Expected port %v, got %v", in.Spec.Ports[0].Port, out.Spec.Ports[0].TargetPort)
 	}
 	if out.Spec.Ports[1].Protocol != versioned.ProtocolTCP {
 		t.Errorf("Expected protocol %s, got %s", versioned.ProtocolTCP, out.Spec.Ports[1].Protocol)
 	}
-	if out.Spec.Ports[1].TargetPort != intstr.FromInt(in.Spec.Ports[1].Port) {
+	if out.Spec.Ports[1].TargetPort != intstr.FromInt(int(in.Spec.Ports[1].Port)) {
 		t.Errorf("Expected port %v, got %v", in.Spec.Ports[1].Port, out.Spec.Ports[1].TargetPort)
 	}
 }
@@ -367,7 +367,7 @@ func TestSetDefaultNamespace(t *testing.T) {
 }
 
 func TestSetDefaultPodSpecHostNetwork(t *testing.T) {
-	portNum := 8080
+	portNum := int32(8080)
 	s := versioned.PodSpec{}
 	s.HostNetwork = true
 	s.Containers = []versioned.Container{

--- a/pkg/api/v1/types.generated.go
+++ b/pkg/api/v1/types.generated.go
@@ -9838,7 +9838,7 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromMap(l int, d *codec19
 			if r.TryDecodeAsNil() {
 				x.Partition = 0
 			} else {
-				x.Partition = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Partition = int32(r.DecodeInt(32))
 			}
 		case "readOnly":
 			if r.TryDecodeAsNil() {
@@ -9906,7 +9906,7 @@ func (x *GCEPersistentDiskVolumeSource) codecDecodeSelfFromArray(l int, d *codec
 	if r.TryDecodeAsNil() {
 		x.Partition = 0
 	} else {
-		x.Partition = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Partition = int32(r.DecodeInt(32))
 	}
 	yyj674++
 	if yyhl674 {
@@ -10137,7 +10137,7 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromMap(l int, d *code
 			if r.TryDecodeAsNil() {
 				x.Partition = 0
 			} else {
-				x.Partition = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Partition = int32(r.DecodeInt(32))
 			}
 		case "readOnly":
 			if r.TryDecodeAsNil() {
@@ -10205,7 +10205,7 @@ func (x *AWSElasticBlockStoreVolumeSource) codecDecodeSelfFromArray(l int, d *co
 	if r.TryDecodeAsNil() {
 		x.Partition = 0
 	} else {
-		x.Partition = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Partition = int32(r.DecodeInt(32))
 	}
 	yyj700++
 	if yyhl700 {
@@ -11064,7 +11064,7 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.Lun = 0
 			} else {
-				x.Lun = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Lun = int32(r.DecodeInt(32))
 			}
 		case "fsType":
 			if r.TryDecodeAsNil() {
@@ -11138,7 +11138,7 @@ func (x *ISCSIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	if r.TryDecodeAsNil() {
 		x.Lun = 0
 	} else {
-		x.Lun = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Lun = int32(r.DecodeInt(32))
 	}
 	yyj778++
 	if yyhl778 {
@@ -11399,13 +11399,13 @@ func (x *FCVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 			} else {
 				if x.Lun == nil {
-					x.Lun = new(int)
+					x.Lun = new(int32)
 				}
 				yym806 := z.DecBinary()
 				_ = yym806
 				if false {
 				} else {
-					*((*int)(x.Lun)) = int(r.DecodeInt(codecSelferBitsize1234))
+					*((*int32)(x.Lun)) = int32(r.DecodeInt(32))
 				}
 			}
 		case "fsType":
@@ -11473,13 +11473,13 @@ func (x *FCVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 	} else {
 		if x.Lun == nil {
-			x.Lun = new(int)
+			x.Lun = new(int32)
 		}
 		yym813 := z.DecBinary()
 		_ = yym813
 		if false {
 		} else {
-			*((*int)(x.Lun)) = int(r.DecodeInt(codecSelferBitsize1234))
+			*((*int32)(x.Lun)) = int32(r.DecodeInt(32))
 		}
 	}
 	yyj809++
@@ -11744,13 +11744,13 @@ func (x *ContainerPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.HostPort = 0
 			} else {
-				x.HostPort = int(r.DecodeInt(codecSelferBitsize1234))
+				x.HostPort = int32(r.DecodeInt(32))
 			}
 		case "containerPort":
 			if r.TryDecodeAsNil() {
 				x.ContainerPort = 0
 			} else {
-				x.ContainerPort = int(r.DecodeInt(codecSelferBitsize1234))
+				x.ContainerPort = int32(r.DecodeInt(32))
 			}
 		case "protocol":
 			if r.TryDecodeAsNil() {
@@ -11808,7 +11808,7 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.HostPort = 0
 	} else {
-		x.HostPort = int(r.DecodeInt(codecSelferBitsize1234))
+		x.HostPort = int32(r.DecodeInt(32))
 	}
 	yyj839++
 	if yyhl839 {
@@ -11824,7 +11824,7 @@ func (x *ContainerPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ContainerPort = 0
 	} else {
-		x.ContainerPort = int(r.DecodeInt(codecSelferBitsize1234))
+		x.ContainerPort = int32(r.DecodeInt(32))
 	}
 	yyj839++
 	if yyhl839 {
@@ -13877,31 +13877,31 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.InitialDelaySeconds = 0
 			} else {
-				x.InitialDelaySeconds = int64(r.DecodeInt(64))
+				x.InitialDelaySeconds = int32(r.DecodeInt(32))
 			}
 		case "timeoutSeconds":
 			if r.TryDecodeAsNil() {
 				x.TimeoutSeconds = 0
 			} else {
-				x.TimeoutSeconds = int64(r.DecodeInt(64))
+				x.TimeoutSeconds = int32(r.DecodeInt(32))
 			}
 		case "periodSeconds":
 			if r.TryDecodeAsNil() {
 				x.PeriodSeconds = 0
 			} else {
-				x.PeriodSeconds = int64(r.DecodeInt(64))
+				x.PeriodSeconds = int32(r.DecodeInt(32))
 			}
 		case "successThreshold":
 			if r.TryDecodeAsNil() {
 				x.SuccessThreshold = 0
 			} else {
-				x.SuccessThreshold = int(r.DecodeInt(codecSelferBitsize1234))
+				x.SuccessThreshold = int32(r.DecodeInt(32))
 			}
 		case "failureThreshold":
 			if r.TryDecodeAsNil() {
 				x.FailureThreshold = 0
 			} else {
-				x.FailureThreshold = int(r.DecodeInt(codecSelferBitsize1234))
+				x.FailureThreshold = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys990)
@@ -14003,7 +14003,7 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.InitialDelaySeconds = 0
 	} else {
-		x.InitialDelaySeconds = int64(r.DecodeInt(64))
+		x.InitialDelaySeconds = int32(r.DecodeInt(32))
 	}
 	yyj999++
 	if yyhl999 {
@@ -14019,7 +14019,7 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.TimeoutSeconds = 0
 	} else {
-		x.TimeoutSeconds = int64(r.DecodeInt(64))
+		x.TimeoutSeconds = int32(r.DecodeInt(32))
 	}
 	yyj999++
 	if yyhl999 {
@@ -14035,7 +14035,7 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.PeriodSeconds = 0
 	} else {
-		x.PeriodSeconds = int64(r.DecodeInt(64))
+		x.PeriodSeconds = int32(r.DecodeInt(32))
 	}
 	yyj999++
 	if yyhl999 {
@@ -14051,7 +14051,7 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.SuccessThreshold = 0
 	} else {
-		x.SuccessThreshold = int(r.DecodeInt(codecSelferBitsize1234))
+		x.SuccessThreshold = int32(r.DecodeInt(32))
 	}
 	yyj999++
 	if yyhl999 {
@@ -14067,7 +14067,7 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.FailureThreshold = 0
 	} else {
-		x.FailureThreshold = int(r.DecodeInt(codecSelferBitsize1234))
+		x.FailureThreshold = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj999++
@@ -16967,13 +16967,13 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromMap(l int, d *codec1978.De
 			if r.TryDecodeAsNil() {
 				x.ExitCode = 0
 			} else {
-				x.ExitCode = int(r.DecodeInt(codecSelferBitsize1234))
+				x.ExitCode = int32(r.DecodeInt(32))
 			}
 		case "signal":
 			if r.TryDecodeAsNil() {
 				x.Signal = 0
 			} else {
-				x.Signal = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Signal = int32(r.DecodeInt(32))
 			}
 		case "reason":
 			if r.TryDecodeAsNil() {
@@ -17055,7 +17055,7 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 	if r.TryDecodeAsNil() {
 		x.ExitCode = 0
 	} else {
-		x.ExitCode = int(r.DecodeInt(codecSelferBitsize1234))
+		x.ExitCode = int32(r.DecodeInt(32))
 	}
 	yyj1239++
 	if yyhl1239 {
@@ -17071,7 +17071,7 @@ func (x *ContainerStateTerminated) codecDecodeSelfFromArray(l int, d *codec1978.
 	if r.TryDecodeAsNil() {
 		x.Signal = 0
 	} else {
-		x.Signal = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Signal = int32(r.DecodeInt(32))
 	}
 	yyj1239++
 	if yyhl1239 {
@@ -17758,7 +17758,7 @@ func (x *ContainerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.RestartCount = 0
 			} else {
-				x.RestartCount = int(r.DecodeInt(codecSelferBitsize1234))
+				x.RestartCount = int32(r.DecodeInt(32))
 			}
 		case "image":
 			if r.TryDecodeAsNil() {
@@ -17872,7 +17872,7 @@ func (x *ContainerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	if r.TryDecodeAsNil() {
 		x.RestartCount = 0
 	} else {
-		x.RestartCount = int(r.DecodeInt(codecSelferBitsize1234))
+		x.RestartCount = int32(r.DecodeInt(32))
 	}
 	yyj1301++
 	if yyhl1301 {
@@ -22539,13 +22539,13 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				}
 			} else {
 				if x.Replicas == nil {
-					x.Replicas = new(int)
+					x.Replicas = new(int32)
 				}
 				yym1720 := z.DecBinary()
 				_ = yym1720
 				if false {
 				} else {
-					*((*int)(x.Replicas)) = int(r.DecodeInt(codecSelferBitsize1234))
+					*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
 				}
 			}
 		case "selector":
@@ -22602,13 +22602,13 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		}
 	} else {
 		if x.Replicas == nil {
-			x.Replicas = new(int)
+			x.Replicas = new(int32)
 		}
 		yym1726 := z.DecBinary()
 		_ = yym1726
 		if false {
 		} else {
-			*((*int)(x.Replicas)) = int(r.DecodeInt(codecSelferBitsize1234))
+			*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
 		}
 	}
 	yyj1724++
@@ -22810,7 +22810,7 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
 			} else {
-				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Replicas = int32(r.DecodeInt(32))
 			}
 		case "observedGeneration":
 			if r.TryDecodeAsNil() {
@@ -22846,7 +22846,7 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
-		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Replicas = int32(r.DecodeInt(32))
 	}
 	yyj1743++
 	if yyhl1743 {
@@ -24974,7 +24974,7 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Port = 0
 			} else {
-				x.Port = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Port = int32(r.DecodeInt(32))
 			}
 		case "targetPort":
 			if r.TryDecodeAsNil() {
@@ -24995,7 +24995,7 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.NodePort = 0
 			} else {
-				x.NodePort = int(r.DecodeInt(codecSelferBitsize1234))
+				x.NodePort = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1922)
@@ -25057,7 +25057,7 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Port = 0
 	} else {
-		x.Port = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Port = int32(r.DecodeInt(32))
 	}
 	yyj1929++
 	if yyhl1929 {
@@ -25098,7 +25098,7 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.NodePort = 0
 	} else {
-		x.NodePort = int(r.DecodeInt(codecSelferBitsize1234))
+		x.NodePort = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj1929++
@@ -27567,7 +27567,7 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Port = 0
 			} else {
-				x.Port = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Port = int32(r.DecodeInt(32))
 			}
 		case "protocol":
 			if r.TryDecodeAsNil() {
@@ -27619,7 +27619,7 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Port = 0
 	} else {
-		x.Port = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Port = int32(r.DecodeInt(32))
 	}
 	yyj2150++
 	if yyhl2150 {
@@ -28424,7 +28424,7 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Port = 0
 			} else {
-				x.Port = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Port = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2219)
@@ -28454,7 +28454,7 @@ func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Port = 0
 	} else {
-		x.Port = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Port = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj2221++
@@ -36653,7 +36653,7 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Count = 0
 			} else {
-				x.Count = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Count = int32(r.DecodeInt(32))
 			}
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -36858,7 +36858,7 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Count = 0
 	} else {
-		x.Count = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Count = int32(r.DecodeInt(32))
 	}
 	yyj2952++
 	if yyhl2952 {
@@ -43625,7 +43625,7 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 
 			yyrg3511 := len(yyv3511) > 0
 			yyv23511 := yyv3511
-			yyrl3511, yyrt3511 = z.DecInferLen(yyl3511, z.DecBasicHandle().MaxInitLen, 64)
+			yyrl3511, yyrt3511 = z.DecInferLen(yyl3511, z.DecBasicHandle().MaxInitLen, 56)
 			if yyrt3511 {
 				if yyrl3511 <= cap(yyv3511) {
 					yyv3511 = yyv3511[:yyrl3511]
@@ -44437,7 +44437,7 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 
 			yyrg3553 := len(yyv3553) > 0
 			yyv23553 := yyv3553
-			yyrl3553, yyrt3553 = z.DecInferLen(yyl3553, z.DecBasicHandle().MaxInitLen, 128)
+			yyrl3553, yyrt3553 = z.DecInferLen(yyl3553, z.DecBasicHandle().MaxInitLen, 120)
 			if yyrt3553 {
 				if yyrl3553 <= cap(yyv3553) {
 					yyv3553 = yyv3553[:yyrl3553]

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -635,7 +635,7 @@ type GCEPersistentDiskVolumeSource struct {
 	// Examples: For volume /dev/sda1, you specify the partition as "1".
 	// Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk
-	Partition int `json:"partition,omitempty"`
+	Partition int32 `json:"partition,omitempty"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk
@@ -661,7 +661,7 @@ type AWSElasticBlockStoreVolumeSource struct {
 	// If omitted, the default is to mount by volume name.
 	// Examples: For volume /dev/sda1, you specify the partition as "1".
 	// Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-	Partition int `json:"partition,omitempty"`
+	Partition int32 `json:"partition,omitempty"`
 	// Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
 	// If omitted, the default is "false".
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore
@@ -709,7 +709,7 @@ type ISCSIVolumeSource struct {
 	// Target iSCSI Qualified Name.
 	IQN string `json:"iqn"`
 	// iSCSI target lun number.
-	Lun int `json:"lun"`
+	Lun int32 `json:"lun"`
 	// Filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs".
@@ -726,7 +726,7 @@ type FCVolumeSource struct {
 	// Required: FC target world wide names (WWNs)
 	TargetWWNs []string `json:"targetWWNs"`
 	// Required: FC target lun number
-	Lun *int `json:"lun"`
+	Lun *int32 `json:"lun"`
 	// Required: Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs"
@@ -747,10 +747,10 @@ type ContainerPort struct {
 	// If specified, this must be a valid port number, 0 < x < 65536.
 	// If HostNetwork is specified, this must match ContainerPort.
 	// Most containers do not need this.
-	HostPort int `json:"hostPort,omitempty"`
+	HostPort int32 `json:"hostPort,omitempty"`
 	// Number of port to expose on the pod's IP address.
 	// This must be a valid port number, 0 < x < 65536.
-	ContainerPort int `json:"containerPort"`
+	ContainerPort int32 `json:"containerPort"`
 	// Protocol for port. Must be UDP or TCP.
 	// Defaults to "TCP".
 	Protocol Protocol `json:"protocol,omitempty"`
@@ -853,20 +853,20 @@ type Probe struct {
 	Handler `json:",inline"`
 	// Number of seconds after the container has started before liveness probes are initiated.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes
-	InitialDelaySeconds int64 `json:"initialDelaySeconds,omitempty"`
+	InitialDelaySeconds int32 `json:"initialDelaySeconds,omitempty"`
 	// Number of seconds after which the probe times out.
 	// Defaults to 1 second. Minimum value is 1.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes
-	TimeoutSeconds int64 `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds int32 `json:"timeoutSeconds,omitempty"`
 	// How often (in seconds) to perform the probe.
 	// Default to 10 seconds. Minimum value is 1.
-	PeriodSeconds int64 `json:"periodSeconds,omitempty"`
+	PeriodSeconds int32 `json:"periodSeconds,omitempty"`
 	// Minimum consecutive successes for the probe to be considered successful after having failed.
 	// Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-	SuccessThreshold int `json:"successThreshold,omitempty"`
+	SuccessThreshold int32 `json:"successThreshold,omitempty"`
 	// Minimum consecutive failures for the probe to be considered failed after having succeeded.
 	// Defaults to 3. Minimum value is 1.
-	FailureThreshold int `json:"failureThreshold,omitempty"`
+	FailureThreshold int32 `json:"failureThreshold,omitempty"`
 }
 
 // PullPolicy describes a policy for if/when to pull a container image
@@ -1064,9 +1064,9 @@ type ContainerStateRunning struct {
 // ContainerStateTerminated is a terminated state of a container.
 type ContainerStateTerminated struct {
 	// Exit status from the last termination of the container
-	ExitCode int `json:"exitCode"`
+	ExitCode int32 `json:"exitCode"`
 	// Signal from the last termination of the container
-	Signal int `json:"signal,omitempty"`
+	Signal int32 `json:"signal,omitempty"`
 	// (brief) reason from the last termination of the container
 	Reason string `json:"reason,omitempty"`
 	// Message regarding the last termination of the container
@@ -1106,7 +1106,7 @@ type ContainerStatus struct {
 	// the number of dead containers that have not yet been removed.
 	// Note that this is calculated from dead containers. But those containers are subject to
 	// garbage collection. This value will get capped at 5 by GC.
-	RestartCount int `json:"restartCount"`
+	RestartCount int32 `json:"restartCount"`
 	// The image the container is running.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/images.md
 	// TODO(dchen1107): Which image the container is running with?
@@ -1423,7 +1423,7 @@ type ReplicationControllerSpec struct {
 	// This is a pointer to distinguish between explicit zero and unspecified.
 	// Defaults to 1.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller
-	Replicas *int `json:"replicas,omitempty"`
+	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Selector is a label query over pods that should match the Replicas count.
 	// If Selector is empty, it is defaulted to the labels present on the Pod template.
@@ -1448,7 +1448,7 @@ type ReplicationControllerSpec struct {
 type ReplicationControllerStatus struct {
 	// Replicas is the most recently oberved number of replicas.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller
-	Replicas int `json:"replicas"`
+	Replicas int32 `json:"replicas"`
 
 	// ObservedGeneration reflects the generation of the most recently observed replication controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
@@ -1612,7 +1612,7 @@ type ServicePort struct {
 	Protocol Protocol `json:"protocol,omitempty"`
 
 	// The port that will be exposed by this service.
-	Port int `json:"port"`
+	Port int32 `json:"port"`
 
 	// Number or name of the port to access on the pods targeted by the service.
 	// Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
@@ -1628,7 +1628,7 @@ type ServicePort struct {
 	// if unused or else creation of the service will fail.
 	// Default is to auto-allocate a port if the ServiceType of this Service requires one.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#type--nodeport
-	NodePort int `json:"nodePort,omitempty"`
+	NodePort int32 `json:"nodePort,omitempty"`
 }
 
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
@@ -1771,7 +1771,7 @@ type EndpointPort struct {
 	Name string `json:"name,omitempty"`
 
 	// The port number of the endpoint.
-	Port int `json:"port"`
+	Port int32 `json:"port"`
 
 	// The IP protocol for this port.
 	// Must be UDP or TCP.
@@ -1807,7 +1807,7 @@ type NodeSpec struct {
 // DaemonEndpoint contains information about a single Daemon endpoint.
 type DaemonEndpoint struct {
 	// Port number of the given endpoint.
-	Port int `json:port`
+	Port int32 `json:port`
 }
 
 // NodeDaemonEndpoints lists ports opened by daemons running on the Node.
@@ -2258,7 +2258,7 @@ type Event struct {
 	LastTimestamp unversioned.Time `json:"lastTimestamp,omitempty"`
 
 	// The number of times this event has occurred.
-	Count int `json:"count,omitempty"`
+	Count int32 `json:"count,omitempty"`
 
 	// Type of this event (Normal, Warning), new types could be added in the future
 	Type string `json:"type,omitempty"`

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -880,8 +880,9 @@ func validateProbe(probe *api.Probe) validation.ErrorList {
 		return allErrs
 	}
 	allErrs = append(allErrs, validateHandler(&probe.Handler)...)
-	allErrs = append(allErrs, ValidatePositiveField(probe.InitialDelaySeconds, "initialDelaySeconds")...)
-	allErrs = append(allErrs, ValidatePositiveField(probe.TimeoutSeconds, "timeoutSeconds")...)
+
+	allErrs = append(allErrs, ValidatePositiveField(int64(probe.InitialDelaySeconds), "initialDelaySeconds")...)
+	allErrs = append(allErrs, ValidatePositiveField(int64(probe.TimeoutSeconds), "timeoutSeconds")...)
 	allErrs = append(allErrs, ValidatePositiveField(int64(probe.PeriodSeconds), "periodSeconds")...)
 	allErrs = append(allErrs, ValidatePositiveField(int64(probe.SuccessThreshold), "successThreshold")...)
 	allErrs = append(allErrs, ValidatePositiveField(int64(probe.FailureThreshold), "failureThreshold")...)
@@ -932,7 +933,7 @@ func validateHTTPGetAction(http *api.HTTPGetAction) validation.ErrorList {
 	if len(http.Path) == 0 {
 		allErrors = append(allErrors, validation.NewRequiredError("path"))
 	}
-	if http.Port.Type == intstr.Int && !validation.IsValidPortNum(http.Port.IntVal) {
+	if http.Port.Type == intstr.Int && !validation.IsValidPortNum(http.Port.IntValue()) {
 		allErrors = append(allErrors, validation.NewInvalidError("port", http.Port, PortRangeErrorMsg))
 	} else if http.Port.Type == intstr.String && !validation.IsValidPortName(http.Port.StrVal) {
 		allErrors = append(allErrors, validation.NewInvalidError("port", http.Port.StrVal, PortNameErrorMsg))
@@ -946,7 +947,7 @@ func validateHTTPGetAction(http *api.HTTPGetAction) validation.ErrorList {
 
 func validateTCPSocketAction(tcp *api.TCPSocketAction) validation.ErrorList {
 	allErrors := validation.ErrorList{}
-	if tcp.Port.Type == intstr.Int && !validation.IsValidPortNum(tcp.Port.IntVal) {
+	if tcp.Port.Type == intstr.Int && !validation.IsValidPortNum(tcp.Port.IntValue()) {
 		allErrors = append(allErrors, validation.NewInvalidError("port", tcp.Port, PortRangeErrorMsg))
 	} else if tcp.Port.Type == intstr.String && !validation.IsValidPortName(tcp.Port.StrVal) {
 		allErrors = append(allErrors, validation.NewInvalidError("port", tcp.Port.StrVal, PortNameErrorMsg))
@@ -1333,7 +1334,7 @@ func validateServicePort(sp *api.ServicePort, requireName bool, allNames *sets.S
 		allErrs = append(allErrs, validation.NewNotSupportedError("protocol", sp.Protocol, supportedPortProtocols.List()))
 	}
 
-	if sp.TargetPort.Type == intstr.Int && !validation.IsValidPortNum(sp.TargetPort.IntVal) {
+	if sp.TargetPort.Type == intstr.Int && !validation.IsValidPortNum(sp.TargetPort.IntValue()) {
 		allErrs = append(allErrs, validation.NewInvalidError("targetPort", sp.TargetPort, PortRangeErrorMsg))
 	}
 	if sp.TargetPort.Type == intstr.String && !validation.IsValidPortName(sp.TargetPort.StrVal) {

--- a/pkg/apis/componentconfig/v1alpha1/conversion_generated.go
+++ b/pkg/apis/componentconfig/v1alpha1/conversion_generated.go
@@ -36,24 +36,24 @@ func autoconvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyCon
 	out.BindAddress = in.BindAddress
 	out.CleanupIPTables = in.CleanupIPTables
 	out.HealthzBindAddress = in.HealthzBindAddress
-	out.HealthzPort = in.HealthzPort
+	out.HealthzPort = int32(in.HealthzPort)
 	out.HostnameOverride = in.HostnameOverride
-	out.IPTablesSyncePeriodSeconds = in.IPTablesSyncePeriodSeconds
-	out.KubeAPIBurst = in.KubeAPIBurst
-	out.KubeAPIQPS = in.KubeAPIQPS
+	out.IPTablesSyncePeriodSeconds = int32(in.IPTablesSyncePeriodSeconds)
+	out.KubeAPIBurst = int32(in.KubeAPIBurst)
+	out.KubeAPIQPS = int32(in.KubeAPIQPS)
 	out.KubeconfigPath = in.KubeconfigPath
 	out.MasqueradeAll = in.MasqueradeAll
 	out.Master = in.Master
 	if in.OOMScoreAdj != nil {
-		out.OOMScoreAdj = new(int)
-		*out.OOMScoreAdj = *in.OOMScoreAdj
+		out.OOMScoreAdj = new(int32)
+		*out.OOMScoreAdj = int32(*in.OOMScoreAdj)
 	} else {
 		out.OOMScoreAdj = nil
 	}
 	out.Mode = ProxyMode(in.Mode)
 	out.PortRange = in.PortRange
 	out.ResourceContainer = in.ResourceContainer
-	out.UDPTimeoutMilliseconds = in.UDPTimeoutMilliseconds
+	out.UDPTimeoutMilliseconds = int32(in.UDPTimeoutMilliseconds)
 	return nil
 }
 
@@ -71,24 +71,24 @@ func autoconvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyCon
 	out.BindAddress = in.BindAddress
 	out.CleanupIPTables = in.CleanupIPTables
 	out.HealthzBindAddress = in.HealthzBindAddress
-	out.HealthzPort = in.HealthzPort
+	out.HealthzPort = int(in.HealthzPort)
 	out.HostnameOverride = in.HostnameOverride
-	out.IPTablesSyncePeriodSeconds = in.IPTablesSyncePeriodSeconds
-	out.KubeAPIBurst = in.KubeAPIBurst
-	out.KubeAPIQPS = in.KubeAPIQPS
+	out.IPTablesSyncePeriodSeconds = int(in.IPTablesSyncePeriodSeconds)
+	out.KubeAPIBurst = int(in.KubeAPIBurst)
+	out.KubeAPIQPS = int(in.KubeAPIQPS)
 	out.KubeconfigPath = in.KubeconfigPath
 	out.MasqueradeAll = in.MasqueradeAll
 	out.Master = in.Master
 	if in.OOMScoreAdj != nil {
 		out.OOMScoreAdj = new(int)
-		*out.OOMScoreAdj = *in.OOMScoreAdj
+		*out.OOMScoreAdj = int(*in.OOMScoreAdj)
 	} else {
 		out.OOMScoreAdj = nil
 	}
 	out.Mode = componentconfig.ProxyMode(in.Mode)
 	out.PortRange = in.PortRange
 	out.ResourceContainer = in.ResourceContainer
-	out.UDPTimeoutMilliseconds = in.UDPTimeoutMilliseconds
+	out.UDPTimeoutMilliseconds = int(in.UDPTimeoutMilliseconds)
 	return nil
 }
 

--- a/pkg/apis/componentconfig/v1alpha1/deep_copy_generated.go
+++ b/pkg/apis/componentconfig/v1alpha1/deep_copy_generated.go
@@ -46,7 +46,7 @@ func deepCopy_v1alpha1_KubeProxyConfiguration(in KubeProxyConfiguration, out *Ku
 	out.MasqueradeAll = in.MasqueradeAll
 	out.Master = in.Master
 	if in.OOMScoreAdj != nil {
-		out.OOMScoreAdj = new(int)
+		out.OOMScoreAdj = new(int32)
 		*out.OOMScoreAdj = *in.OOMScoreAdj
 	} else {
 		out.OOMScoreAdj = nil

--- a/pkg/apis/componentconfig/v1alpha1/defaults.go
+++ b/pkg/apis/componentconfig/v1alpha1/defaults.go
@@ -34,7 +34,7 @@ func addDefaultingFuncs() {
 				obj.HealthzBindAddress = "127.0.0.1"
 			}
 			if obj.OOMScoreAdj == nil {
-				temp := qos.KubeProxyOOMScoreAdj
+				temp := int32(qos.KubeProxyOOMScoreAdj)
 				obj.OOMScoreAdj = &temp
 			}
 			if obj.IPTablesSyncePeriodSeconds == 0 {

--- a/pkg/apis/componentconfig/v1alpha1/types.generated.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.generated.go
@@ -546,7 +546,7 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.HealthzPort = 0
 			} else {
-				x.HealthzPort = int(r.DecodeInt(codecSelferBitsize1234))
+				x.HealthzPort = int32(r.DecodeInt(32))
 			}
 		case "hostnameOverride":
 			if r.TryDecodeAsNil() {
@@ -558,19 +558,19 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.IPTablesSyncePeriodSeconds = 0
 			} else {
-				x.IPTablesSyncePeriodSeconds = int(r.DecodeInt(codecSelferBitsize1234))
+				x.IPTablesSyncePeriodSeconds = int32(r.DecodeInt(32))
 			}
 		case "kubeAPIBurst":
 			if r.TryDecodeAsNil() {
 				x.KubeAPIBurst = 0
 			} else {
-				x.KubeAPIBurst = int(r.DecodeInt(codecSelferBitsize1234))
+				x.KubeAPIBurst = int32(r.DecodeInt(32))
 			}
 		case "kubeAPIQPS":
 			if r.TryDecodeAsNil() {
 				x.KubeAPIQPS = 0
 			} else {
-				x.KubeAPIQPS = int(r.DecodeInt(codecSelferBitsize1234))
+				x.KubeAPIQPS = int32(r.DecodeInt(32))
 			}
 		case "kubeconfigPath":
 			if r.TryDecodeAsNil() {
@@ -597,13 +597,13 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				}
 			} else {
 				if x.OOMScoreAdj == nil {
-					x.OOMScoreAdj = new(int)
+					x.OOMScoreAdj = new(int32)
 				}
 				yym74 := z.DecBinary()
 				_ = yym74
 				if false {
 				} else {
-					*((*int)(x.OOMScoreAdj)) = int(r.DecodeInt(codecSelferBitsize1234))
+					*((*int32)(x.OOMScoreAdj)) = int32(r.DecodeInt(32))
 				}
 			}
 		case "mode":
@@ -628,7 +628,7 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.UDPTimeoutMilliseconds = 0
 			} else {
-				x.UDPTimeoutMilliseconds = int(r.DecodeInt(codecSelferBitsize1234))
+				x.UDPTimeoutMilliseconds = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys59)
@@ -738,7 +738,7 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.HealthzPort = 0
 	} else {
-		x.HealthzPort = int(r.DecodeInt(codecSelferBitsize1234))
+		x.HealthzPort = int32(r.DecodeInt(32))
 	}
 	yyj79++
 	if yyhl79 {
@@ -770,7 +770,7 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.IPTablesSyncePeriodSeconds = 0
 	} else {
-		x.IPTablesSyncePeriodSeconds = int(r.DecodeInt(codecSelferBitsize1234))
+		x.IPTablesSyncePeriodSeconds = int32(r.DecodeInt(32))
 	}
 	yyj79++
 	if yyhl79 {
@@ -786,7 +786,7 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.KubeAPIBurst = 0
 	} else {
-		x.KubeAPIBurst = int(r.DecodeInt(codecSelferBitsize1234))
+		x.KubeAPIBurst = int32(r.DecodeInt(32))
 	}
 	yyj79++
 	if yyhl79 {
@@ -802,7 +802,7 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.KubeAPIQPS = 0
 	} else {
-		x.KubeAPIQPS = int(r.DecodeInt(codecSelferBitsize1234))
+		x.KubeAPIQPS = int32(r.DecodeInt(32))
 	}
 	yyj79++
 	if yyhl79 {
@@ -869,13 +869,13 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		}
 	} else {
 		if x.OOMScoreAdj == nil {
-			x.OOMScoreAdj = new(int)
+			x.OOMScoreAdj = new(int32)
 		}
 		yym94 := z.DecBinary()
 		_ = yym94
 		if false {
 		} else {
-			*((*int)(x.OOMScoreAdj)) = int(r.DecodeInt(codecSelferBitsize1234))
+			*((*int32)(x.OOMScoreAdj)) = int32(r.DecodeInt(32))
 		}
 	}
 	yyj79++
@@ -940,7 +940,7 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.UDPTimeoutMilliseconds = 0
 	} else {
-		x.UDPTimeoutMilliseconds = int(r.DecodeInt(codecSelferBitsize1234))
+		x.UDPTimeoutMilliseconds = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj79++

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -21,22 +21,22 @@ import "k8s.io/kubernetes/pkg/api/unversioned"
 type KubeProxyConfiguration struct {
 	unversioned.TypeMeta
 
-	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces)
+	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0 for all int32erfaces)
 	BindAddress string `json:"bindAddress"`
 	// cleanupIPTables
 	CleanupIPTables bool `json:"cleanupIPTables"`
-	// healthzBindAddress is the IP address for the health check server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)
+	// healthzBindAddress is the IP address for the health check server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all int32erfaces)
 	HealthzBindAddress string `json:"healthzBindAddress"`
 	// healthzPort is the port to bind the health check server. Use 0 to disable.
-	HealthzPort int `json:"healthzPort"`
+	HealthzPort int32 `json:"healthzPort"`
 	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride"`
 	// iptablesSyncPeriodSeconds is the period that iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.
-	IPTablesSyncePeriodSeconds int `json:"iptablesSyncPeriodSeconds"`
+	IPTablesSyncePeriodSeconds int32 `json:"iptablesSyncPeriodSeconds"`
 	// kubeAPIBurst is the burst to use while talking with kubernetes apiserver
-	KubeAPIBurst int `json:"kubeAPIBurst"`
+	KubeAPIBurst int32 `json:"kubeAPIBurst"`
 	// kubeAPIQPS is the max QPS to use while talking with kubernetes apiserver
-	KubeAPIQPS int `json:"kubeAPIQPS"`
+	KubeAPIQPS int32 `json:"kubeAPIQPS"`
 	// kubeconfigPath is the path to the kubeconfig file with authorization information (the master location is set by the master flag).
 	KubeconfigPath string `json:"kubeconfigPath"`
 	// masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.
@@ -44,7 +44,7 @@ type KubeProxyConfiguration struct {
 	// master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master"`
 	// oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]
-	OOMScoreAdj *int `json:"oomScoreAdj"`
+	OOMScoreAdj *int32 `json:"oomScoreAdj"`
 	// mode specifies which proxy mode to use.
 	Mode ProxyMode `json:"mode"`
 	// portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.
@@ -52,7 +52,7 @@ type KubeProxyConfiguration struct {
 	// resourceContainer is the bsolute name of the resource-only container to create and run the Kube-proxy in (Default: /kube-proxy).
 	ResourceContainer string `json:"resourceContainer"`
 	// udpTimeoutMilliseconds is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxyMode=userspace.
-	UDPTimeoutMilliseconds int `json:"udpTimeoutMilliseconds"`
+	UDPTimeoutMilliseconds int32 `json:"udpTimeoutMilliseconds"`
 }
 
 // Currently two modes of proxying are available: 'userspace' (older, stable) or 'iptables' (experimental). If blank, look at the Node object on the Kubernetes API and respect the 'net.experimental.kubernetes.io/proxy-mode' annotation if provided.  Otherwise use the best-available proxy (currently userspace, but may change in future versions).  If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.

--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -203,8 +203,8 @@ func convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensions.
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DeploymentSpec))(in)
 	}
-	out.Replicas = new(int)
-	*out.Replicas = in.Replicas
+	out.Replicas = new(int32)
+	*out.Replicas = int32(in.Replicas)
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {
@@ -229,7 +229,7 @@ func convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *DeploymentS
 		defaulting.(func(*DeploymentSpec))(in)
 	}
 	if in.Replicas != nil {
-		out.Replicas = *in.Replicas
+		out.Replicas = int(*in.Replicas)
 	}
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
@@ -299,7 +299,7 @@ func convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployme
 	if err := s.Convert(&in.MaxSurge, out.MaxSurge, 0); err != nil {
 		return err
 	}
-	out.MinReadySeconds = in.MinReadySeconds
+	out.MinReadySeconds = int32(in.MinReadySeconds)
 	return nil
 }
 
@@ -313,7 +313,7 @@ func convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployme
 	if err := s.Convert(in.MaxSurge, &out.MaxSurge, 0); err != nil {
 		return err
 	}
-	out.MinReadySeconds = in.MinReadySeconds
+	out.MinReadySeconds = int(in.MinReadySeconds)
 	return nil
 }
 

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -34,7 +34,7 @@ func autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStore
 	}
 	out.VolumeID = in.VolumeID
 	out.FSType = in.FSType
-	out.Partition = in.Partition
+	out.Partition = int32(in.Partition)
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -219,8 +219,8 @@ func autoconvert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, ou
 		defaulting.(func(*api.ContainerPort))(in)
 	}
 	out.Name = in.Name
-	out.HostPort = in.HostPort
-	out.ContainerPort = in.ContainerPort
+	out.HostPort = int32(in.HostPort)
+	out.ContainerPort = int32(in.ContainerPort)
 	out.Protocol = v1.Protocol(in.Protocol)
 	out.HostIP = in.HostIP
 	return nil
@@ -350,8 +350,8 @@ func autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource,
 		out.TargetWWNs = nil
 	}
 	if in.Lun != nil {
-		out.Lun = new(int)
-		*out.Lun = *in.Lun
+		out.Lun = new(int32)
+		*out.Lun = int32(*in.Lun)
 	} else {
 		out.Lun = nil
 	}
@@ -382,7 +382,7 @@ func autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolume
 	}
 	out.PDName = in.PDName
 	out.FSType = in.FSType
-	out.Partition = in.Partition
+	out.Partition = int32(in.Partition)
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -488,7 +488,7 @@ func autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolu
 	}
 	out.TargetPortal = in.TargetPortal
 	out.IQN = in.IQN
-	out.Lun = in.Lun
+	out.Lun = int32(in.Lun)
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
 	return nil
@@ -753,11 +753,11 @@ func autoconvert_api_Probe_To_v1_Probe(in *api.Probe, out *v1.Probe, s conversio
 	if err := convert_api_Handler_To_v1_Handler(&in.Handler, &out.Handler, s); err != nil {
 		return err
 	}
-	out.InitialDelaySeconds = in.InitialDelaySeconds
-	out.TimeoutSeconds = in.TimeoutSeconds
-	out.PeriodSeconds = in.PeriodSeconds
-	out.SuccessThreshold = in.SuccessThreshold
-	out.FailureThreshold = in.FailureThreshold
+	out.InitialDelaySeconds = int32(in.InitialDelaySeconds)
+	out.TimeoutSeconds = int32(in.TimeoutSeconds)
+	out.PeriodSeconds = int32(in.PeriodSeconds)
+	out.SuccessThreshold = int32(in.SuccessThreshold)
+	out.FailureThreshold = int32(in.FailureThreshold)
 	return nil
 }
 
@@ -1093,7 +1093,7 @@ func autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStore
 	}
 	out.VolumeID = in.VolumeID
 	out.FSType = in.FSType
-	out.Partition = in.Partition
+	out.Partition = int(in.Partition)
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -1278,8 +1278,8 @@ func autoconvert_v1_ContainerPort_To_api_ContainerPort(in *v1.ContainerPort, out
 		defaulting.(func(*v1.ContainerPort))(in)
 	}
 	out.Name = in.Name
-	out.HostPort = in.HostPort
-	out.ContainerPort = in.ContainerPort
+	out.HostPort = int(in.HostPort)
+	out.ContainerPort = int(in.ContainerPort)
 	out.Protocol = api.Protocol(in.Protocol)
 	out.HostIP = in.HostIP
 	return nil
@@ -1410,7 +1410,7 @@ func autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *v1.FCVolumeSource, 
 	}
 	if in.Lun != nil {
 		out.Lun = new(int)
-		*out.Lun = *in.Lun
+		*out.Lun = int(*in.Lun)
 	} else {
 		out.Lun = nil
 	}
@@ -1441,7 +1441,7 @@ func autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolume
 	}
 	out.PDName = in.PDName
 	out.FSType = in.FSType
-	out.Partition = in.Partition
+	out.Partition = int(in.Partition)
 	out.ReadOnly = in.ReadOnly
 	return nil
 }
@@ -1547,7 +1547,7 @@ func autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *v1.ISCSIVolum
 	}
 	out.TargetPortal = in.TargetPortal
 	out.IQN = in.IQN
-	out.Lun = in.Lun
+	out.Lun = int(in.Lun)
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
 	return nil
@@ -1816,11 +1816,11 @@ func autoconvert_v1_Probe_To_api_Probe(in *v1.Probe, out *api.Probe, s conversio
 	if err := convert_v1_Handler_To_api_Handler(&in.Handler, &out.Handler, s); err != nil {
 		return err
 	}
-	out.InitialDelaySeconds = in.InitialDelaySeconds
-	out.TimeoutSeconds = in.TimeoutSeconds
-	out.PeriodSeconds = in.PeriodSeconds
-	out.SuccessThreshold = in.SuccessThreshold
-	out.FailureThreshold = in.FailureThreshold
+	out.InitialDelaySeconds = int(in.InitialDelaySeconds)
+	out.TimeoutSeconds = int(in.TimeoutSeconds)
+	out.PeriodSeconds = int(in.PeriodSeconds)
+	out.SuccessThreshold = int(in.SuccessThreshold)
+	out.FailureThreshold = int(in.FailureThreshold)
 	return nil
 }
 
@@ -2167,7 +2167,7 @@ func autoconvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.CPUTargetUtilization))(in)
 	}
-	out.TargetPercentage = in.TargetPercentage
+	out.TargetPercentage = int32(in.TargetPercentage)
 	return nil
 }
 
@@ -2226,8 +2226,8 @@ func autoconvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSp
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ClusterAutoscalerSpec))(in)
 	}
-	out.MinNodes = in.MinNodes
-	out.MaxNodes = in.MaxNodes
+	out.MinNodes = int32(in.MinNodes)
+	out.MaxNodes = int32(in.MaxNodes)
 	if in.TargetUtilization != nil {
 		out.TargetUtilization = make([]NodeUtilization, len(in.TargetUtilization))
 		for i := range in.TargetUtilization {
@@ -2326,9 +2326,9 @@ func autoconvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *exten
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DaemonSetStatus))(in)
 	}
-	out.CurrentNumberScheduled = in.CurrentNumberScheduled
-	out.NumberMisscheduled = in.NumberMisscheduled
-	out.DesiredNumberScheduled = in.DesiredNumberScheduled
+	out.CurrentNumberScheduled = int32(in.CurrentNumberScheduled)
+	out.NumberMisscheduled = int32(in.NumberMisscheduled)
+	out.DesiredNumberScheduled = int32(in.DesiredNumberScheduled)
 	return nil
 }
 
@@ -2417,8 +2417,8 @@ func autoconvert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(in *ext
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DeploymentStatus))(in)
 	}
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
+	out.Replicas = int32(in.Replicas)
+	out.UpdatedReplicas = int32(in.UpdatedReplicas)
 	return nil
 }
 
@@ -2536,12 +2536,12 @@ func autoconvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPod
 		return err
 	}
 	if in.MinReplicas != nil {
-		out.MinReplicas = new(int)
-		*out.MinReplicas = *in.MinReplicas
+		out.MinReplicas = new(int32)
+		*out.MinReplicas = int32(*in.MinReplicas)
 	} else {
 		out.MinReplicas = nil
 	}
-	out.MaxReplicas = in.MaxReplicas
+	out.MaxReplicas = int32(in.MaxReplicas)
 	if in.CPUUtilization != nil {
 		out.CPUUtilization = new(CPUTargetUtilization)
 		if err := convert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in.CPUUtilization, out.CPUUtilization, s); err != nil {
@@ -2574,11 +2574,11 @@ func autoconvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalP
 	} else {
 		out.LastScaleTime = nil
 	}
-	out.CurrentReplicas = in.CurrentReplicas
-	out.DesiredReplicas = in.DesiredReplicas
+	out.CurrentReplicas = int32(in.CurrentReplicas)
+	out.DesiredReplicas = int32(in.DesiredReplicas)
 	if in.CurrentCPUUtilizationPercentage != nil {
-		out.CurrentCPUUtilizationPercentage = new(int)
-		*out.CurrentCPUUtilizationPercentage = *in.CurrentCPUUtilizationPercentage
+		out.CurrentCPUUtilizationPercentage = new(int32)
+		*out.CurrentCPUUtilizationPercentage = int32(*in.CurrentCPUUtilizationPercentage)
 	} else {
 		out.CurrentCPUUtilizationPercentage = nil
 	}
@@ -2807,14 +2807,14 @@ func autoconvert_extensions_JobSpec_To_v1beta1_JobSpec(in *extensions.JobSpec, o
 		defaulting.(func(*extensions.JobSpec))(in)
 	}
 	if in.Parallelism != nil {
-		out.Parallelism = new(int)
-		*out.Parallelism = *in.Parallelism
+		out.Parallelism = new(int32)
+		*out.Parallelism = int32(*in.Parallelism)
 	} else {
 		out.Parallelism = nil
 	}
 	if in.Completions != nil {
-		out.Completions = new(int)
-		*out.Completions = *in.Completions
+		out.Completions = new(int32)
+		*out.Completions = int32(*in.Completions)
 	} else {
 		out.Completions = nil
 	}
@@ -2864,9 +2864,9 @@ func autoconvert_extensions_JobStatus_To_v1beta1_JobStatus(in *extensions.JobSta
 	} else {
 		out.CompletionTime = nil
 	}
-	out.Active = in.Active
-	out.Succeeded = in.Succeeded
-	out.Failed = in.Failed
+	out.Active = int32(in.Active)
+	out.Succeeded = int32(in.Succeeded)
+	out.Failed = int32(in.Failed)
 	return nil
 }
 
@@ -2961,7 +2961,7 @@ func autoconvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDepl
 	if err := s.Convert(&in.MaxSurge, &out.MaxSurge, 0); err != nil {
 		return err
 	}
-	out.MinReadySeconds = in.MinReadySeconds
+	out.MinReadySeconds = int32(in.MinReadySeconds)
 	return nil
 }
 
@@ -2992,7 +2992,7 @@ func autoconvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in *extensions.ScaleS
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ScaleSpec))(in)
 	}
-	out.Replicas = in.Replicas
+	out.Replicas = int32(in.Replicas)
 	return nil
 }
 
@@ -3004,7 +3004,7 @@ func autoconvert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(in *extensions.Sc
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ScaleStatus))(in)
 	}
-	out.Replicas = in.Replicas
+	out.Replicas = int32(in.Replicas)
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {
@@ -3154,7 +3154,7 @@ func autoconvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*CPUTargetUtilization))(in)
 	}
-	out.TargetPercentage = in.TargetPercentage
+	out.TargetPercentage = int(in.TargetPercentage)
 	return nil
 }
 
@@ -3213,8 +3213,8 @@ func autoconvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSp
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ClusterAutoscalerSpec))(in)
 	}
-	out.MinNodes = in.MinNodes
-	out.MaxNodes = in.MaxNodes
+	out.MinNodes = int(in.MinNodes)
+	out.MaxNodes = int(in.MaxNodes)
 	if in.TargetUtilization != nil {
 		out.TargetUtilization = make([]extensions.NodeUtilization, len(in.TargetUtilization))
 		for i := range in.TargetUtilization {
@@ -3313,9 +3313,9 @@ func autoconvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in *Daemo
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DaemonSetStatus))(in)
 	}
-	out.CurrentNumberScheduled = in.CurrentNumberScheduled
-	out.NumberMisscheduled = in.NumberMisscheduled
-	out.DesiredNumberScheduled = in.DesiredNumberScheduled
+	out.CurrentNumberScheduled = int(in.CurrentNumberScheduled)
+	out.NumberMisscheduled = int(in.NumberMisscheduled)
+	out.DesiredNumberScheduled = int(in.DesiredNumberScheduled)
 	return nil
 }
 
@@ -3400,8 +3400,8 @@ func autoconvert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(in *Dep
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeploymentStatus))(in)
 	}
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
+	out.Replicas = int(in.Replicas)
+	out.UpdatedReplicas = int(in.UpdatedReplicas)
 	return nil
 }
 
@@ -3504,11 +3504,11 @@ func autoconvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPod
 	}
 	if in.MinReplicas != nil {
 		out.MinReplicas = new(int)
-		*out.MinReplicas = *in.MinReplicas
+		*out.MinReplicas = int(*in.MinReplicas)
 	} else {
 		out.MinReplicas = nil
 	}
-	out.MaxReplicas = in.MaxReplicas
+	out.MaxReplicas = int(in.MaxReplicas)
 	if in.CPUUtilization != nil {
 		out.CPUUtilization = new(extensions.CPUTargetUtilization)
 		if err := convert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in.CPUUtilization, out.CPUUtilization, s); err != nil {
@@ -3541,11 +3541,11 @@ func autoconvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalP
 	} else {
 		out.LastScaleTime = nil
 	}
-	out.CurrentReplicas = in.CurrentReplicas
-	out.DesiredReplicas = in.DesiredReplicas
+	out.CurrentReplicas = int(in.CurrentReplicas)
+	out.DesiredReplicas = int(in.DesiredReplicas)
 	if in.CurrentCPUUtilizationPercentage != nil {
 		out.CurrentCPUUtilizationPercentage = new(int)
-		*out.CurrentCPUUtilizationPercentage = *in.CurrentCPUUtilizationPercentage
+		*out.CurrentCPUUtilizationPercentage = int(*in.CurrentCPUUtilizationPercentage)
 	} else {
 		out.CurrentCPUUtilizationPercentage = nil
 	}
@@ -3775,13 +3775,13 @@ func autoconvert_v1beta1_JobSpec_To_extensions_JobSpec(in *JobSpec, out *extensi
 	}
 	if in.Parallelism != nil {
 		out.Parallelism = new(int)
-		*out.Parallelism = *in.Parallelism
+		*out.Parallelism = int(*in.Parallelism)
 	} else {
 		out.Parallelism = nil
 	}
 	if in.Completions != nil {
 		out.Completions = new(int)
-		*out.Completions = *in.Completions
+		*out.Completions = int(*in.Completions)
 	} else {
 		out.Completions = nil
 	}
@@ -3831,9 +3831,9 @@ func autoconvert_v1beta1_JobStatus_To_extensions_JobStatus(in *JobStatus, out *e
 	} else {
 		out.CompletionTime = nil
 	}
-	out.Active = in.Active
-	out.Succeeded = in.Succeeded
-	out.Failed = in.Failed
+	out.Active = int(in.Active)
+	out.Succeeded = int(in.Succeeded)
+	out.Failed = int(in.Failed)
 	return nil
 }
 
@@ -3924,7 +3924,7 @@ func autoconvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDepl
 	}
 	// in.MaxUnavailable has no peer in out
 	// in.MaxSurge has no peer in out
-	out.MinReadySeconds = in.MinReadySeconds
+	out.MinReadySeconds = int(in.MinReadySeconds)
 	return nil
 }
 
@@ -3955,7 +3955,7 @@ func autoconvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(in *ScaleSpec, out *e
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ScaleSpec))(in)
 	}
-	out.Replicas = in.Replicas
+	out.Replicas = int(in.Replicas)
 	return nil
 }
 
@@ -3967,7 +3967,7 @@ func autoconvert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(in *ScaleStatus, 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ScaleStatus))(in)
 	}
-	out.Replicas = in.Replicas
+	out.Replicas = int(in.Replicas)
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {

--- a/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -300,7 +300,7 @@ func deepCopy_v1_FCVolumeSource(in v1.FCVolumeSource, out *v1.FCVolumeSource, c 
 		out.TargetWWNs = nil
 	}
 	if in.Lun != nil {
-		out.Lun = new(int)
+		out.Lun = new(int32)
 		*out.Lun = *in.Lun
 	} else {
 		out.Lun = nil
@@ -1046,7 +1046,7 @@ func deepCopy_v1beta1_DeploymentList(in DeploymentList, out *DeploymentList, c *
 
 func deepCopy_v1beta1_DeploymentSpec(in DeploymentSpec, out *DeploymentSpec, c *conversion.Cloner) error {
 	if in.Replicas != nil {
-		out.Replicas = new(int)
+		out.Replicas = new(int32)
 		*out.Replicas = *in.Replicas
 	} else {
 		out.Replicas = nil
@@ -1156,7 +1156,7 @@ func deepCopy_v1beta1_HorizontalPodAutoscalerSpec(in HorizontalPodAutoscalerSpec
 		return err
 	}
 	if in.MinReplicas != nil {
-		out.MinReplicas = new(int)
+		out.MinReplicas = new(int32)
 		*out.MinReplicas = *in.MinReplicas
 	} else {
 		out.MinReplicas = nil
@@ -1191,7 +1191,7 @@ func deepCopy_v1beta1_HorizontalPodAutoscalerStatus(in HorizontalPodAutoscalerSt
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
 	if in.CurrentCPUUtilizationPercentage != nil {
-		out.CurrentCPUUtilizationPercentage = new(int)
+		out.CurrentCPUUtilizationPercentage = new(int32)
 		*out.CurrentCPUUtilizationPercentage = *in.CurrentCPUUtilizationPercentage
 	} else {
 		out.CurrentCPUUtilizationPercentage = nil
@@ -1344,13 +1344,13 @@ func deepCopy_v1beta1_JobList(in JobList, out *JobList, c *conversion.Cloner) er
 
 func deepCopy_v1beta1_JobSpec(in JobSpec, out *JobSpec, c *conversion.Cloner) error {
 	if in.Parallelism != nil {
-		out.Parallelism = new(int)
+		out.Parallelism = new(int32)
 		*out.Parallelism = *in.Parallelism
 	} else {
 		out.Parallelism = nil
 	}
 	if in.Completions != nil {
-		out.Completions = new(int)
+		out.Completions = new(int32)
 		*out.Completions = *in.Completions
 	} else {
 		out.Completions = nil

--- a/pkg/apis/extensions/v1beta1/defaults.go
+++ b/pkg/apis/extensions/v1beta1/defaults.go
@@ -59,7 +59,7 @@ func addDefaultingFuncs() {
 			}
 			// Set DeploymentSpec.Replicas to 1 if it is not set.
 			if obj.Spec.Replicas == nil {
-				obj.Spec.Replicas = new(int)
+				obj.Spec.Replicas = new(int32)
 				*obj.Spec.Replicas = 1
 			}
 			strategy := &obj.Spec.Strategy
@@ -102,7 +102,7 @@ func addDefaultingFuncs() {
 				}
 			}
 			if obj.Spec.Completions == nil {
-				completions := 1
+				completions := int32(1)
 				obj.Spec.Completions = &completions
 			}
 			if obj.Spec.Parallelism == nil {
@@ -111,7 +111,7 @@ func addDefaultingFuncs() {
 		},
 		func(obj *HorizontalPodAutoscaler) {
 			if obj.Spec.MinReplicas == nil {
-				minReplicas := 1
+				minReplicas := int32(1)
 				obj.Spec.MinReplicas = &minReplicas
 			}
 			if obj.Spec.CPUUtilization == nil {

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -294,9 +294,9 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 	return obj3
 }
 
-func newInt(val int) *int {
-	p := new(int)
-	*p = val
+func newInt(val int) *int32 {
+	p := new(int32)
+	*p = int32(val)
 	return p
 }
 

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -105,7 +105,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			original: &Deployment{},
 			expected: &Deployment{
 				Spec: DeploymentSpec{
-					Replicas: newInt(1),
+					Replicas: newInt32(1),
 					Strategy: DeploymentStrategy{
 						Type: RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &RollingUpdateDeployment{
@@ -121,7 +121,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &Deployment{
 				Spec: DeploymentSpec{
-					Replicas: newInt(5),
+					Replicas: newInt32(5),
 					Strategy: DeploymentStrategy{
 						RollingUpdate: &RollingUpdateDeployment{
 							MaxSurge: &differentIntOrString,
@@ -131,7 +131,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &Deployment{
 				Spec: DeploymentSpec{
-					Replicas: newInt(5),
+					Replicas: newInt32(5),
 					Strategy: DeploymentStrategy{
 						Type: RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &RollingUpdateDeployment{
@@ -147,7 +147,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &Deployment{
 				Spec: DeploymentSpec{
-					Replicas: newInt(5),
+					Replicas: newInt32(5),
 					Strategy: DeploymentStrategy{
 						Type: RecreateDeploymentStrategyType,
 					},
@@ -155,7 +155,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &Deployment{
 				Spec: DeploymentSpec{
-					Replicas: newInt(5),
+					Replicas: newInt32(5),
 					Strategy: DeploymentStrategy{
 						Type: RecreateDeploymentStrategyType,
 					},
@@ -167,7 +167,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &Deployment{
 				Spec: DeploymentSpec{
-					Replicas: newInt(5),
+					Replicas: newInt32(5),
 					Strategy: DeploymentStrategy{
 						Type: RecreateDeploymentStrategyType,
 					},
@@ -176,7 +176,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &Deployment{
 				Spec: DeploymentSpec{
-					Replicas: newInt(5),
+					Replicas: newInt32(5),
 					Strategy: DeploymentStrategy{
 						Type: RecreateDeploymentStrategyType,
 					},
@@ -208,8 +208,8 @@ func TestSetDefaultJob(t *testing.T) {
 			Selector: &PodSelector{
 				MatchLabels: map[string]string{"job": "selector"},
 			},
-			Completions: newInt(1),
-			Parallelism: newInt(1),
+			Completions: newInt32(1),
+			Parallelism: newInt32(1),
 		},
 	}
 	tests := []*Job{
@@ -234,7 +234,7 @@ func TestSetDefaultJob(t *testing.T) {
 		// selector from template labels, completions set explicitly, parallelism - default
 		{
 			Spec: JobSpec{
-				Completions: newInt(1),
+				Completions: newInt32(1),
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{"job": "selector"},
@@ -245,7 +245,7 @@ func TestSetDefaultJob(t *testing.T) {
 		// selector from template labels, completions - default, parallelism set explicitly
 		{
 			Spec: JobSpec{
-				Parallelism: newInt(1),
+				Parallelism: newInt32(1),
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{"job": "selector"},
@@ -294,9 +294,9 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 	return obj3
 }
 
-func newInt(val int) *int32 {
+func newInt32(val int32) *int32 {
 	p := new(int32)
-	*p = int32(val)
+	*p = val
 	return p
 }
 

--- a/pkg/apis/extensions/v1beta1/types.generated.go
+++ b/pkg/apis/extensions/v1beta1/types.generated.go
@@ -198,7 +198,7 @@ func (x *ScaleSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
 			} else {
-				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Replicas = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys8)
@@ -228,7 +228,7 @@ func (x *ScaleSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
-		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Replicas = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj10++
@@ -394,7 +394,7 @@ func (x *ScaleStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
 			} else {
-				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Replicas = int32(r.DecodeInt(32))
 			}
 		case "selector":
 			if r.TryDecodeAsNil() {
@@ -436,7 +436,7 @@ func (x *ScaleStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
-		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Replicas = int32(r.DecodeInt(32))
 	}
 	yyj26++
 	if yyhl26 {
@@ -1463,7 +1463,7 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			if r.TryDecodeAsNil() {
 				x.TargetPercentage = 0
 			} else {
-				x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
+				x.TargetPercentage = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys110)
@@ -1493,7 +1493,7 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.TargetPercentage = 0
 	} else {
-		x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
+		x.TargetPercentage = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj112++
@@ -1706,20 +1706,20 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				}
 			} else {
 				if x.MinReplicas == nil {
-					x.MinReplicas = new(int)
+					x.MinReplicas = new(int32)
 				}
 				yym133 := z.DecBinary()
 				_ = yym133
 				if false {
 				} else {
-					*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
+					*((*int32)(x.MinReplicas)) = int32(r.DecodeInt(32))
 				}
 			}
 		case "maxReplicas":
 			if r.TryDecodeAsNil() {
 				x.MaxReplicas = 0
 			} else {
-				x.MaxReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+				x.MaxReplicas = int32(r.DecodeInt(32))
 			}
 		case "cpuUtilization":
 			if r.TryDecodeAsNil() {
@@ -1780,13 +1780,13 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		}
 	} else {
 		if x.MinReplicas == nil {
-			x.MinReplicas = new(int)
+			x.MinReplicas = new(int32)
 		}
 		yym139 := z.DecBinary()
 		_ = yym139
 		if false {
 		} else {
-			*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
+			*((*int32)(x.MinReplicas)) = int32(r.DecodeInt(32))
 		}
 	}
 	yyj136++
@@ -1803,7 +1803,7 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	if r.TryDecodeAsNil() {
 		x.MaxReplicas = 0
 	} else {
-		x.MaxReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+		x.MaxReplicas = int32(r.DecodeInt(32))
 	}
 	yyj136++
 	if yyhl136 {
@@ -2128,13 +2128,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 			if r.TryDecodeAsNil() {
 				x.CurrentReplicas = 0
 			} else {
-				x.CurrentReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+				x.CurrentReplicas = int32(r.DecodeInt(32))
 			}
 		case "desiredReplicas":
 			if r.TryDecodeAsNil() {
 				x.DesiredReplicas = 0
 			} else {
-				x.DesiredReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+				x.DesiredReplicas = int32(r.DecodeInt(32))
 			}
 		case "currentCPUUtilizationPercentage":
 			if r.TryDecodeAsNil() {
@@ -2143,13 +2143,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				}
 			} else {
 				if x.CurrentCPUUtilizationPercentage == nil {
-					x.CurrentCPUUtilizationPercentage = new(int)
+					x.CurrentCPUUtilizationPercentage = new(int32)
 				}
 				yym173 := z.DecBinary()
 				_ = yym173
 				if false {
 				} else {
-					*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
+					*((*int32)(x.CurrentCPUUtilizationPercentage)) = int32(r.DecodeInt(32))
 				}
 			}
 		default:
@@ -2237,7 +2237,7 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	if r.TryDecodeAsNil() {
 		x.CurrentReplicas = 0
 	} else {
-		x.CurrentReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+		x.CurrentReplicas = int32(r.DecodeInt(32))
 	}
 	yyj174++
 	if yyhl174 {
@@ -2253,7 +2253,7 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	if r.TryDecodeAsNil() {
 		x.DesiredReplicas = 0
 	} else {
-		x.DesiredReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+		x.DesiredReplicas = int32(r.DecodeInt(32))
 	}
 	yyj174++
 	if yyhl174 {
@@ -2272,13 +2272,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		}
 	} else {
 		if x.CurrentCPUUtilizationPercentage == nil {
-			x.CurrentCPUUtilizationPercentage = new(int)
+			x.CurrentCPUUtilizationPercentage = new(int32)
 		}
 		yym182 := z.DecBinary()
 		_ = yym182
 		if false {
 		} else {
-			*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
+			*((*int32)(x.CurrentCPUUtilizationPercentage)) = int32(r.DecodeInt(32))
 		}
 	}
 	for {
@@ -4823,13 +4823,13 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 			} else {
 				if x.Replicas == nil {
-					x.Replicas = new(int)
+					x.Replicas = new(int32)
 				}
 				yym411 := z.DecBinary()
 				_ = yym411
 				if false {
 				} else {
-					*((*int)(x.Replicas)) = int(r.DecodeInt(codecSelferBitsize1234))
+					*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
 				}
 			}
 		case "selector":
@@ -4905,13 +4905,13 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 	} else {
 		if x.Replicas == nil {
-			x.Replicas = new(int)
+			x.Replicas = new(int32)
 		}
 		yym420 := z.DecBinary()
 		_ = yym420
 		if false {
 		} else {
-			*((*int)(x.Replicas)) = int(r.DecodeInt(codecSelferBitsize1234))
+			*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
 		}
 	}
 	yyj418++
@@ -5492,7 +5492,7 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			if r.TryDecodeAsNil() {
 				x.MinReadySeconds = 0
 			} else {
-				x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
+				x.MinReadySeconds = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys454)
@@ -5580,7 +5580,7 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	if r.TryDecodeAsNil() {
 		x.MinReadySeconds = 0
 	} else {
-		x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
+		x.MinReadySeconds = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj460++
@@ -5745,13 +5745,13 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
 			} else {
-				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Replicas = int32(r.DecodeInt(32))
 			}
 		case "updatedReplicas":
 			if r.TryDecodeAsNil() {
 				x.UpdatedReplicas = 0
 			} else {
-				x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+				x.UpdatedReplicas = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys476)
@@ -5781,7 +5781,7 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	if r.TryDecodeAsNil() {
 		x.Replicas = 0
 	} else {
-		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Replicas = int32(r.DecodeInt(32))
 	}
 	yyj479++
 	if yyhl479 {
@@ -5797,7 +5797,7 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	if r.TryDecodeAsNil() {
 		x.UpdatedReplicas = 0
 	} else {
-		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+		x.UpdatedReplicas = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj479++
@@ -6544,19 +6544,19 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
 			} else {
-				x.CurrentNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
+				x.CurrentNumberScheduled = int32(r.DecodeInt(32))
 			}
 		case "numberMisscheduled":
 			if r.TryDecodeAsNil() {
 				x.NumberMisscheduled = 0
 			} else {
-				x.NumberMisscheduled = int(r.DecodeInt(codecSelferBitsize1234))
+				x.NumberMisscheduled = int32(r.DecodeInt(32))
 			}
 		case "desiredNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.DesiredNumberScheduled = 0
 			} else {
-				x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
+				x.DesiredNumberScheduled = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys539)
@@ -6586,7 +6586,7 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	if r.TryDecodeAsNil() {
 		x.CurrentNumberScheduled = 0
 	} else {
-		x.CurrentNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
+		x.CurrentNumberScheduled = int32(r.DecodeInt(32))
 	}
 	yyj543++
 	if yyhl543 {
@@ -6602,7 +6602,7 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	if r.TryDecodeAsNil() {
 		x.NumberMisscheduled = 0
 	} else {
-		x.NumberMisscheduled = int(r.DecodeInt(codecSelferBitsize1234))
+		x.NumberMisscheduled = int32(r.DecodeInt(32))
 	}
 	yyj543++
 	if yyhl543 {
@@ -6618,7 +6618,7 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	if r.TryDecodeAsNil() {
 		x.DesiredNumberScheduled = 0
 	} else {
-		x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
+		x.DesiredNumberScheduled = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj543++
@@ -8559,13 +8559,13 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 			} else {
 				if x.Parallelism == nil {
-					x.Parallelism = new(int)
+					x.Parallelism = new(int32)
 				}
 				yym725 := z.DecBinary()
 				_ = yym725
 				if false {
 				} else {
-					*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
+					*((*int32)(x.Parallelism)) = int32(r.DecodeInt(32))
 				}
 			}
 		case "completions":
@@ -8575,13 +8575,13 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 			} else {
 				if x.Completions == nil {
-					x.Completions = new(int)
+					x.Completions = new(int32)
 				}
 				yym727 := z.DecBinary()
 				_ = yym727
 				if false {
 				} else {
-					*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
+					*((*int32)(x.Completions)) = int32(r.DecodeInt(32))
 				}
 			}
 		case "selector":
@@ -8633,13 +8633,13 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 	} else {
 		if x.Parallelism == nil {
-			x.Parallelism = new(int)
+			x.Parallelism = new(int32)
 		}
 		yym732 := z.DecBinary()
 		_ = yym732
 		if false {
 		} else {
-			*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
+			*((*int32)(x.Parallelism)) = int32(r.DecodeInt(32))
 		}
 	}
 	yyj730++
@@ -8659,13 +8659,13 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 	} else {
 		if x.Completions == nil {
-			x.Completions = new(int)
+			x.Completions = new(int32)
 		}
 		yym734 := z.DecBinary()
 		_ = yym734
 		if false {
 		} else {
-			*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
+			*((*int32)(x.Completions)) = int32(r.DecodeInt(32))
 		}
 	}
 	yyj730++
@@ -9071,19 +9071,19 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Active = 0
 			} else {
-				x.Active = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Active = int32(r.DecodeInt(32))
 			}
 		case "succeeded":
 			if r.TryDecodeAsNil() {
 				x.Succeeded = 0
 			} else {
-				x.Succeeded = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Succeeded = int32(r.DecodeInt(32))
 			}
 		case "failed":
 			if r.TryDecodeAsNil() {
 				x.Failed = 0
 			} else {
-				x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
+				x.Failed = int32(r.DecodeInt(32))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys759)
@@ -9197,7 +9197,7 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Active = 0
 	} else {
-		x.Active = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Active = int32(r.DecodeInt(32))
 	}
 	yyj769++
 	if yyhl769 {
@@ -9213,7 +9213,7 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Succeeded = 0
 	} else {
-		x.Succeeded = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Succeeded = int32(r.DecodeInt(32))
 	}
 	yyj769++
 	if yyhl769 {
@@ -9229,7 +9229,7 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Failed = 0
 	} else {
-		x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
+		x.Failed = int32(r.DecodeInt(32))
 	}
 	for {
 		yyj769++
@@ -12239,13 +12239,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.MinNodes = 0
 			} else {
-				x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
+				x.MinNodes = int32(r.DecodeInt(32))
 			}
 		case "maxNodes":
 			if r.TryDecodeAsNil() {
 				x.MaxNodes = 0
 			} else {
-				x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
+				x.MaxNodes = int32(r.DecodeInt(32))
 			}
 		case "target":
 			if r.TryDecodeAsNil() {
@@ -12287,7 +12287,7 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.MinNodes = 0
 	} else {
-		x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
+		x.MinNodes = int32(r.DecodeInt(32))
 	}
 	yyj1019++
 	if yyhl1019 {
@@ -12303,7 +12303,7 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.MaxNodes = 0
 	} else {
-		x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
+		x.MaxNodes = int32(r.DecodeInt(32))
 	}
 	yyj1019++
 	if yyhl1019 {
@@ -13568,7 +13568,7 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 
 			yyrg1127 := len(yyv1127) > 0
 			yyv21127 := yyv1127
-			yyrl1127, yyrt1127 = z.DecInferLen(yyl1127, z.DecBasicHandle().MaxInitLen, 320)
+			yyrl1127, yyrt1127 = z.DecInferLen(yyl1127, z.DecBasicHandle().MaxInitLen, 312)
 			if yyrt1127 {
 				if yyrl1127 <= cap(yyv1127) {
 					yyv1127 = yyv1127[:yyrl1127]
@@ -13916,7 +13916,7 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 
 			yyrg1145 := len(yyv1145) > 0
 			yyv21145 := yyv1145
-			yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 608)
+			yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 600)
 			if yyrt1145 {
 				if yyrl1145 <= cap(yyv1145) {
 					yyv1145 = yyv1145[:yyrl1145]
@@ -14032,7 +14032,7 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 
 			yyrg1151 := len(yyv1151) > 0
 			yyv21151 := yyv1151
-			yyrl1151, yyrt1151 = z.DecInferLen(yyl1151, z.DecBasicHandle().MaxInitLen, 232)
+			yyrl1151, yyrt1151 = z.DecInferLen(yyl1151, z.DecBasicHandle().MaxInitLen, 224)
 			if yyrt1151 {
 				if yyrl1151 <= cap(yyv1151) {
 					yyv1151 = yyv1151[:yyrl1151]
@@ -14264,7 +14264,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 
 			yyrg1163 := len(yyv1163) > 0
 			yyv21163 := yyv1163
-			yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 632)
+			yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 624)
 			if yyrt1163 {
 				if yyrl1163 <= cap(yyv1163) {
 					yyv1163 = yyv1163[:yyrl1163]
@@ -14960,7 +14960,7 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 
 			yyrg1199 := len(yyv1199) > 0
 			yyv21199 := yyv1199
-			yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232)
+			yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 224)
 			if yyrt1199 {
 				if yyrl1199 <= cap(yyv1199) {
 					yyv1199 = yyv1199[:yyrl1199]

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -25,13 +25,13 @@ import (
 // describes the attributes of a scale subresource
 type ScaleSpec struct {
 	// desired number of instances for the scaled object.
-	Replicas int `json:"replicas,omitempty"`
+	Replicas int32 `json:"replicas,omitempty"`
 }
 
 // represents the current status of a scale subresource.
 type ScaleStatus struct {
 	// actual number of observed instances of the scaled object.
-	Replicas int `json:"replicas"`
+	Replicas int32 `json:"replicas"`
 
 	// label query over pods that should match the replicas count. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors
 	Selector map[string]string `json:"selector,omitempty"`
@@ -70,7 +70,7 @@ type SubresourceReference struct {
 type CPUTargetUtilization struct {
 	// fraction of the requested CPU that should be utilized/used,
 	// e.g. 70 means that 70% of the requested CPU should be in use.
-	TargetPercentage int `json:"targetPercentage"`
+	TargetPercentage int32 `json:"targetPercentage"`
 }
 
 // specification of a horizontal pod autoscaler.
@@ -79,9 +79,9 @@ type HorizontalPodAutoscalerSpec struct {
 	// and will set the desired number of pods by modifying its spec.
 	ScaleRef SubresourceReference `json:"scaleRef"`
 	// lower limit for the number of pods that can be set by the autoscaler, default 1.
-	MinReplicas *int `json:"minReplicas,omitempty"`
+	MinReplicas *int32 `json:"minReplicas,omitempty"`
 	// upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
-	MaxReplicas int `json:"maxReplicas"`
+	MaxReplicas int32 `json:"maxReplicas"`
 	// target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
 	// if not specified it defaults to the target CPU utilization at 80% of the requested resources.
 	CPUUtilization *CPUTargetUtilization `json:"cpuUtilization,omitempty"`
@@ -97,14 +97,14 @@ type HorizontalPodAutoscalerStatus struct {
 	LastScaleTime *unversioned.Time `json:"lastScaleTime,omitempty"`
 
 	// current number of replicas of pods managed by this autoscaler.
-	CurrentReplicas int `json:"currentReplicas"`
+	CurrentReplicas int32 `json:"currentReplicas"`
 
 	// desired number of replicas of pods managed by this autoscaler.
-	DesiredReplicas int `json:"desiredReplicas"`
+	DesiredReplicas int32 `json:"desiredReplicas"`
 
 	// current average CPU utilization over all pods, represented as a percentage of requested CPU,
 	// e.g. 70 means that an average pod is using now 70% of its requested CPU.
-	CurrentCPUUtilizationPercentage *int `json:"currentCPUUtilizationPercentage,omitempty"`
+	CurrentCPUUtilizationPercentage *int32 `json:"currentCPUUtilizationPercentage,omitempty"`
 }
 
 // configuration of a horizontal pod autoscaler.
@@ -192,7 +192,7 @@ type Deployment struct {
 type DeploymentSpec struct {
 	// Number of desired pods. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
-	Replicas *int `json:"replicas,omitempty"`
+	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Label selector for pods. Existing ReplicationControllers whose pods are
 	// selected by this will be the ones affected by this deployment.
@@ -268,16 +268,16 @@ type RollingUpdateDeployment struct {
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing, for it to be considered available.
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	MinReadySeconds int `json:"minReadySeconds,omitempty"`
+	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
 }
 
 // DeploymentStatus is the most recently observed status of the Deployment.
 type DeploymentStatus struct {
 	// Total number of non-terminated pods targeted by this deployment (their labels match the selector).
-	Replicas int `json:"replicas,omitempty"`
+	Replicas int32 `json:"replicas,omitempty"`
 
 	// Total number of non-terminated pods targeted by this deployment that have the desired template spec.
-	UpdatedReplicas int `json:"updatedReplicas,omitempty"`
+	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
 }
 
 // DeploymentList is a list of Deployments.
@@ -311,17 +311,17 @@ type DaemonSetStatus struct {
 	// CurrentNumberScheduled is the number of nodes that are running at least 1
 	// daemon pod and are supposed to run the daemon pod.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/daemon.md
-	CurrentNumberScheduled int `json:"currentNumberScheduled"`
+	CurrentNumberScheduled int32 `json:"currentNumberScheduled"`
 
 	// NumberMisscheduled is the number of nodes that are running the daemon pod, but are
 	// not supposed to run the daemon pod.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/daemon.md
-	NumberMisscheduled int `json:"numberMisscheduled"`
+	NumberMisscheduled int32 `json:"numberMisscheduled"`
 
 	// DesiredNumberScheduled is the total number of nodes that should be running the daemon
 	// pod (including nodes correctly running the daemon pod).
 	// More info: http://releases.k8s.io/HEAD/docs/admin/daemon.md
-	DesiredNumberScheduled int `json:"desiredNumberScheduled"`
+	DesiredNumberScheduled int32 `json:"desiredNumberScheduled"`
 }
 
 // DaemonSet represents the configuration of a daemon set.
@@ -400,12 +400,12 @@ type JobSpec struct {
 	// be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
 	// i.e. when the work left to do is less than max parallelism.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/jobs.md
-	Parallelism *int `json:"parallelism,omitempty"`
+	Parallelism *int32 `json:"parallelism,omitempty"`
 
 	// Completions specifies the desired number of successfully finished pods the
 	// job should be run with. Defaults to 1.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/jobs.md
-	Completions *int `json:"completions,omitempty"`
+	Completions *int32 `json:"completions,omitempty"`
 
 	// Selector is a label query over pods that should match the pod count.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors
@@ -435,13 +435,13 @@ type JobStatus struct {
 	CompletionTime *unversioned.Time `json:"completionTime,omitempty"`
 
 	// Active is the number of actively running pods.
-	Active int `json:"active,omitempty"`
+	Active int32 `json:"active,omitempty"`
 
 	// Succeeded is the number of pods which reached Phase Succeeded.
-	Succeeded int `json:"succeeded,omitempty"`
+	Succeeded int32 `json:"succeeded,omitempty"`
 
 	// Failed is the number of pods which reached Phase Failed.
-	Failed int `json:"failed,omitempty"`
+	Failed int32 `json:"failed,omitempty"`
 }
 
 type JobConditionType string
@@ -621,10 +621,10 @@ type NodeUtilization struct {
 // Configuration of the Cluster Autoscaler
 type ClusterAutoscalerSpec struct {
 	// Minimum number of nodes that the cluster should have.
-	MinNodes int `json:"minNodes"`
+	MinNodes int32 `json:"minNodes"`
 
 	// Maximum number of nodes that the cluster should have.
-	MaxNodes int `json:"maxNodes"`
+	MaxNodes int32 `json:"maxNodes"`
 
 	// Target average utilization of the cluster nodes. New nodes will be added if one of the
 	// targets is exceeded. Cluster size will be decreased if the current utilization is too low

--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -249,7 +249,7 @@ func getIntOrPercentValue(intOrStringValue intstr.IntOrString) int {
 	if isPercent {
 		return value
 	}
-	return intOrStringValue.IntVal
+	return intOrStringValue.IntValue()
 }
 
 func IsNotMoreThan100Percent(intOrStringValue intstr.IntOrString, fieldName string) validation.ErrorList {
@@ -525,7 +525,7 @@ func validateIngressBackend(backend *extensions.IngressBackend) validation.Error
 		if !validation.IsValidPortName(backend.ServicePort.StrVal) {
 			allErrs = append(allErrs, validation.NewInvalidError("servicePort", backend.ServicePort.StrVal, apivalidation.PortNameErrorMsg))
 		}
-	} else if !validation.IsValidPortNum(backend.ServicePort.IntVal) {
+	} else if !validation.IsValidPortNum(backend.ServicePort.IntValue()) {
 		allErrs = append(allErrs, validation.NewInvalidError("servicePort", backend.ServicePort, apivalidation.PortRangeErrorMsg))
 	}
 	return allErrs

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -420,8 +420,9 @@ func prettyJSON(codec runtime.Codec, object runtime.Object, w http.ResponseWrite
 // errorJSON renders an error to the response. Returns the HTTP status code of the error.
 func errorJSON(err error, codec runtime.Codec, w http.ResponseWriter) int {
 	status := errToAPIStatus(err)
-	writeJSON(status.Code, codec, status, w, true)
-	return status.Code
+	code := int(status.Code)
+	writeJSON(code, codec, status, w, true)
+	return code
 }
 
 // errorJSONFatal renders an error to the response, and if codec fails will render plaintext.
@@ -429,16 +430,17 @@ func errorJSON(err error, codec runtime.Codec, w http.ResponseWriter) int {
 func errorJSONFatal(err error, codec runtime.Codec, w http.ResponseWriter) int {
 	util.HandleError(fmt.Errorf("apiserver was unable to write a JSON response: %v", err))
 	status := errToAPIStatus(err)
+	code := int(status.Code)
 	output, err := codec.Encode(status)
 	if err != nil {
-		w.WriteHeader(status.Code)
+		w.WriteHeader(code)
 		fmt.Fprintf(w, "%s: %s", status.Reason, status.Message)
-		return status.Code
+		return code
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status.Code)
+	w.WriteHeader(code)
 	w.Write(output)
-	return status.Code
+	return code
 }
 
 // writeRawJSON writes a non-API object in JSON.

--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -62,7 +62,7 @@ func errToAPIStatus(err error) *unversioned.Status {
 		util.HandleError(fmt.Errorf("apiserver received an error that is not an unversioned.Status: %v", err))
 		return &unversioned.Status{
 			Status:  unversioned.StatusFailure,
-			Code:    status,
+			Code:    int32(status),
 			Reason:  unversioned.StatusReasonUnknown,
 			Message: err.Error(),
 		}

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -109,8 +109,9 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		httplog.LogOf(req, w).Addf("Error getting ResourceLocation: %v", err)
 		status := errToAPIStatus(err)
-		writeJSON(status.Code, r.codec, status, w, true)
-		httpCode = status.Code
+		code := int(status.Code)
+		writeJSON(code, r.codec, status, w, true)
+		httpCode = code
 		return
 	}
 	if location == nil {
@@ -144,9 +145,10 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	newReq, err := http.NewRequest(req.Method, location.String(), req.Body)
 	if err != nil {
 		status := errToAPIStatus(err)
-		writeJSON(status.Code, r.codec, status, w, true)
+		code := int(status.Code)
+		writeJSON(code, r.codec, status, w, true)
 		notFound(w, req)
-		httpCode = status.Code
+		httpCode = code
 		return
 	}
 	httpCode = http.StatusOK
@@ -211,7 +213,8 @@ func (r *ProxyHandler) tryUpgrade(w http.ResponseWriter, req, newReq *http.Reque
 	backendConn, err := proxyutil.DialURL(location, transport)
 	if err != nil {
 		status := errToAPIStatus(err)
-		writeJSON(status.Code, r.codec, status, w, true)
+		code := int(status.Code)
+		writeJSON(code, r.codec, status, w, true)
 		return true
 	}
 	defer backendConn.Close()
@@ -222,14 +225,16 @@ func (r *ProxyHandler) tryUpgrade(w http.ResponseWriter, req, newReq *http.Reque
 	requestHijackedConn, _, err := w.(http.Hijacker).Hijack()
 	if err != nil {
 		status := errToAPIStatus(err)
-		writeJSON(status.Code, r.codec, status, w, true)
+		code := int(status.Code)
+		writeJSON(code, r.codec, status, w, true)
 		return true
 	}
 	defer requestHijackedConn.Close()
 
 	if err = newReq.Write(backendConn); err != nil {
 		status := errToAPIStatus(err)
-		writeJSON(status.Code, r.codec, status, w, true)
+		code := int(status.Code)
+		writeJSON(code, r.codec, status, w, true)
 		return true
 	}
 

--- a/pkg/client/unversioned/request_test.go
+++ b/pkg/client/unversioned/request_test.go
@@ -347,7 +347,7 @@ func TestTransformResponse(t *testing.T) {
 				t.Errorf("%d: response should have been transformable into APIStatus: %v", i, err)
 				continue
 			}
-			if status.Status().Code != test.Response.StatusCode {
+			if int(status.Status().Code) != test.Response.StatusCode {
 				t.Errorf("%d: status code did not match response: %#v", i, status.Status())
 			}
 		}

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -419,7 +419,7 @@ func findPort(pod *api.Pod, svcPort *api.ServicePort) (int, error) {
 			}
 		}
 	case intstr.Int:
-		return portName.IntVal, nil
+		return portName.IntValue(), nil
 	}
 
 	return 0, fmt.Errorf("no suitable port for manifest: %s", pod.UID)

--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -489,7 +489,7 @@ func extractMaxValue(field intstr.IntOrString, name string, value int) (int, err
 		if field.IntVal < 0 {
 			return 0, fmt.Errorf("%s must be >= 0", name)
 		}
-		return field.IntVal, nil
+		return field.IntValue(), nil
 	case intstr.String:
 		s := strings.Replace(field.StrVal, "%", "", -1)
 		v, err := strconv.Atoi(s)

--- a/pkg/kubectl/sorting_printer_test.go
+++ b/pkg/kubectl/sorting_printer_test.go
@@ -33,7 +33,7 @@ func encodeOrDie(obj runtime.Object) []byte {
 }
 
 func TestSortingPrinter(t *testing.T) {
-	intPtr := func(val int) *int { return &val }
+	intPtr := func(val int32) *int32 { return &val }
 
 	a := &api.Pod{
 		ObjectMeta: api.ObjectMeta{

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -68,19 +68,17 @@ func (hr *HandlerRunner) Run(containerID kubecontainer.ContainerID, pod *api.Pod
 // port is found, an error is returned.
 func resolvePort(portReference intstr.IntOrString, container *api.Container) (int, error) {
 	if portReference.Type == intstr.Int {
-		return portReference.IntVal, nil
-	} else {
-		portName := portReference.StrVal
-		port, err := strconv.Atoi(portName)
-		if err == nil {
-			return port, nil
+		return portReference.IntValue(), nil
+	}
+	portName := portReference.StrVal
+	port, err := strconv.Atoi(portName)
+	if err == nil {
+		return port, nil
+	}
+	for _, portSpec := range container.Ports {
+		if portSpec.Name == portName {
+			return portSpec.ContainerPort, nil
 		}
-		for _, portSpec := range container.Ports {
-			if portSpec.Name == portName {
-				return portSpec.ContainerPort, nil
-			}
-		}
-
 	}
 	return -1, fmt.Errorf("couldn't find port: %v in %v", portReference, container)
 }

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -163,7 +163,7 @@ func extractPort(param intstr.IntOrString, container api.Container) (int, error)
 	var err error
 	switch param.Type {
 	case intstr.Int:
-		port = param.IntVal
+		port = param.IntValue()
 	case intstr.String:
 		if port, err = findPortByName(container, param.StrVal); err != nil {
 			// Last ditch effort - maybe it was an int stored as string?

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -163,7 +163,7 @@ func (w *worker) doProbe() (keepGoing bool) {
 			w.pod.Spec.RestartPolicy != api.RestartPolicyNever
 	}
 
-	if int64(time.Since(c.State.Running.StartedAt.Time).Seconds()) < w.spec.InitialDelaySeconds {
+	if int(time.Since(c.State.Running.StartedAt.Time).Seconds()) < w.spec.InitialDelaySeconds {
 		return true
 	}
 

--- a/pkg/runtime/conversion_generator.go
+++ b/pkg/runtime/conversion_generator.go
@@ -111,6 +111,22 @@ func (g *conversionGenerator) GenerateConversionsForType(gv unversioned.GroupVer
 	return nil
 }
 
+// primitiveConversion returns true if the two types can be converted via a cast.
+func primitiveConversion(inType, outType reflect.Type) (string, bool) {
+	switch inType.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		switch outType.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+			reflect.Float32, reflect.Float64:
+			return outType.Name(), true
+		}
+	}
+	return "", false
+}
+
 func (g *conversionGenerator) generateConversionsBetween(inType, outType reflect.Type) error {
 	existingConversion := g.scheme.Converter().HasConversionFunc(inType, outType) && g.scheme.Converter().HasConversionFunc(outType, inType)
 
@@ -123,6 +139,10 @@ func (g *conversionGenerator) generateConversionsBetween(inType, outType reflect
 	}
 	if inType == outType {
 		// Don't generate conversion methods for the same type.
+		return nil
+	}
+
+	if _, ok := primitiveConversion(inType, outType); ok {
 		return nil
 	}
 

--- a/pkg/util/intstr/intstr.go
+++ b/pkg/util/intstr/intstr.go
@@ -28,6 +28,7 @@ import (
 // JSON or YAML marshalling and unmarshalling, it produces or consumes the
 // inner type.  This allows you to have, for example, a JSON field that can
 // accept a name or number.
+// TODO: Rename to Int32OrString
 type IntOrString struct {
 	Type   Type
 	IntVal int32
@@ -42,7 +43,10 @@ const (
 	String             // The IntOrString holds a string.
 )
 
-// FromInt creates an IntOrString object with an int value.
+// FromInt creates an IntOrString object with an int32 value. It is
+// your responsibility not to call this method with a value greater
+// than int32.
+// TODO: convert to (val int32)
 func FromInt(val int) IntOrString {
 	return IntOrString{Type: Int, IntVal: int32(val)}
 }
@@ -70,7 +74,7 @@ func (intstr *IntOrString) String() string {
 	return strconv.Itoa(intstr.IntValue())
 }
 
-// IntValue returns the IntVal cast as int32 if type Int, or if
+// IntValue returns the IntVal if type Int, or if
 // it is a String, will attempt a conversion to int.
 func (intstr *IntOrString) IntValue() int {
 	if intstr.Type == String {

--- a/pkg/util/intstr/intstr.go
+++ b/pkg/util/intstr/intstr.go
@@ -24,13 +24,13 @@ import (
 	"github.com/google/gofuzz"
 )
 
-// IntOrString is a type that can hold an int or a string.  When used in
+// IntOrString is a type that can hold an int32 or a string.  When used in
 // JSON or YAML marshalling and unmarshalling, it produces or consumes the
 // inner type.  This allows you to have, for example, a JSON field that can
 // accept a name or number.
 type IntOrString struct {
 	Type   Type
-	IntVal int
+	IntVal int32
 	StrVal string
 }
 
@@ -44,7 +44,7 @@ const (
 
 // FromInt creates an IntOrString object with an int value.
 func FromInt(val int) IntOrString {
-	return IntOrString{Type: Int, IntVal: val}
+	return IntOrString{Type: Int, IntVal: int32(val)}
 }
 
 // FromString creates an IntOrString object with a string value.
@@ -67,7 +67,17 @@ func (intstr *IntOrString) String() string {
 	if intstr.Type == String {
 		return intstr.StrVal
 	}
-	return strconv.Itoa(intstr.IntVal)
+	return strconv.Itoa(intstr.IntValue())
+}
+
+// IntValue returns the IntVal cast as int32 if type Int, or if
+// it is a String, will attempt a conversion to int.
+func (intstr *IntOrString) IntValue() int {
+	if intstr.Type == String {
+		i, _ := strconv.Atoi(intstr.StrVal)
+		return i
+	}
+	return int(intstr.IntVal)
 }
 
 // MarshalJSON implements the json.Marshaller interface.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -136,14 +136,14 @@ func Until(f func(), period time.Duration, stopCh <-chan struct{}) {
 func GetIntOrPercentValue(intOrStr *intstr.IntOrString) (int, bool, error) {
 	switch intOrStr.Type {
 	case intstr.Int:
-		return intOrStr.IntVal, false, nil
+		return intOrStr.IntValue(), false, nil
 	case intstr.String:
 		s := strings.Replace(intOrStr.StrVal, "%", "", -1)
 		v, err := strconv.Atoi(s)
 		if err != nil {
 			return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
 		}
-		return v, true, nil
+		return int(v), true, nil
 	}
 	return 0, false, fmt.Errorf("invalid value: neither int nor percentage")
 }

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -616,7 +616,7 @@ var _ = Describe("Kubectl client", func() {
 				if port.Port != servicePort {
 					Failf("Wrong service port: %d", port.Port)
 				}
-				if port.TargetPort.IntVal != redisPort {
+				if port.TargetPort.IntValue() != redisPort {
 					Failf("Wrong target port: %d")
 				}
 			}


### PR DESCRIPTION
Downgrades prober to int32 externally (not waiting 40 years for a pod to be ready)

Fuzzer is currently broken (internal int is not a valid fuzz target) which has to be fixed prior to merging this.

Addresses some possible problems from #17095.  Main motivation is that this is required for protobuf support because we can't have ambiguous external types.
