### PR TITLE
Fix the petstore example test with iptables proxy

### DIFF
--- a/examples/k8petstore/k8petstore-loadbalancer.sh
+++ b/examples/k8petstore/k8petstore-loadbalancer.sh
@@ -253,7 +253,7 @@ function pollfor {
   do
       ### Just testing that the front end comes up.  Not sure how to test total entries etc... (yet)
       echo "Trying curl ... $PUBLIC_IP:3000 , attempt $i . expect a few failures while pulling images... "
-      curl "$PUBLIC_IP:3000" > result
+      curl --connect-timeout 1 "$PUBLIC_IP:3000" > result
       cat result
       cat result | grep -q "k8-bps"
       if [ $? -eq 0 ]; then
@@ -279,7 +279,7 @@ function tests {
     for i in `seq 1 $_SECONDS`;
      do
         echo "curl : $PUBLIC_IP:3000 , $i of $_SECONDS"
-        curr_cnt="`curl "$PUBLIC_IP:3000/llen"`" 
+        curr_cnt="`curl --connect-timeout 1 "$PUBLIC_IP:3000/llen"`" 
         ### Write CSV File of # of trials / total transcations.
         echo "$i $curr_cnt" >> result
         echo "total transactions so far : $curr_cnt"

--- a/examples/k8petstore/k8petstore-nodeport.sh
+++ b/examples/k8petstore/k8petstore-nodeport.sh
@@ -270,8 +270,8 @@ function pollfor {
   for i in `seq 1 150`;
   do
       ### Just testing that the front end comes up.  Not sure how to test total entries etc... (yet)
-      echo "Trying curl ... $PUBLIC_IP:3000 , attempt $i . expect a few failures while pulling images... "
-      curl "$TEST_IP:$NODE_PORT" > result
+      echo "Trying curl frontend:3000 via $TEST_IP:$NODE_PORT, attempt ${i}. Expect a few failures while pulling images... "
+      curl --connect-timeout 1 "$TEST_IP:$NODE_PORT" > result
       cat result
       cat result | grep -q "k8-bps"
       if [ $? -eq 0 ]; then
@@ -296,7 +296,7 @@ function tests {
     for i in `seq 1 $_SECONDS`;
      do
         echo "curl : $TEST_IP:$NODE_PORT , $i of $_SECONDS"
-        curr_cnt="`curl "$TEST_IP:$NODE_PORT/llen"`"
+        curr_cnt="`curl --connect-timeout 1 "$TEST_IP:$NODE_PORT/llen"`"
         ### Write CSV File of # of trials / total transcations.
         echo "$i $curr_cnt" >> result
         echo "total transactions so far : $curr_cnt"

--- a/examples/k8petstore/k8petstore.sh
+++ b/examples/k8petstore/k8petstore.sh
@@ -237,7 +237,7 @@ function pollfor {
   do
       ### Just testing that the front end comes up.  Not sure how to test total entries etc... (yet)
       echo "Trying curl ... $PUBLIC_IP:3000 , attempt $i . expect a few failures while pulling images... "
-      curl "$PUBLIC_IP:3000" > result
+      curl --connect-timeout 1 "$PUBLIC_IP:3000" > result
       cat result
       cat result | grep -q "k8-bps"
       if [ $? -eq 0 ]; then
@@ -263,7 +263,7 @@ function tests {
     for i in `seq 1 $_SECONDS`;
      do
         echo "curl : $PUBLIC_IP:3000 , $i of $_SECONDS"
-        curr_cnt="`curl "$PUBLIC_IP:3000/llen"`" 
+        curr_cnt="`curl --connect-timeout 1 "$PUBLIC_IP:3000/llen"`" 
         ### Write CSV File of # of trials / total transcations.
         echo "$i $curr_cnt" >> result
         echo "total transactions so far : $curr_cnt"


### PR DESCRIPTION
hypothesis: The old userspace proxier would internally retry connections.  The
new one does not.  When this test comes up, the firewall might not yet be open or
something is causing a long delay and a timeout.  I can't repro this failure
locally, so I am shooting in the dark.  It's sort of plausible.

evidence: I can SSH into the jenkins master that is hung and I can see the hung
curl.  I can run that curl by hand and it works.  I can see that my shell is in
the same netns as that hung curl.
