### PR TITLE
Change htmlpreview links: change HEAD to blob/HEAD, and add "blob" in versioned-docs.sh

### DIFF
--- a/build/versionize-docs.sh
+++ b/build/versionize-docs.sh
@@ -48,7 +48,7 @@ fi
 echo "+++ Versioning documentation and examples"
 
 # Update the docs to match this version.
-HTML_PREVIEW_PREFIX="https://htmlpreview.github.io/\?https://github.com/kubernetes/kubernetes"
+HTML_PREVIEW_PREFIX="https://htmlpreview.github.io/\?https://github.com/kubernetes/kubernetes/blob"
 # Update the include directory in definitions.md and operations.md.
 DIRECTORY_KEY_WORDS="<REPLACE-WITH-RELEASE-VERSION>"
 

--- a/docs/admin/node.md
+++ b/docs/admin/node.md
@@ -257,7 +257,7 @@ on each kubelet where you want to reserve resources.
 
 Node is a top-level resource in the kubernetes REST API. More details about the
 API object can be found at: [Node API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html#_v1_node).
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html#_v1_node).
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/man/man1/kubectl-patch.1
+++ b/docs/man/man1/kubectl-patch.1
@@ -20,7 +20,7 @@ JSON and YAML formats are accepted.
 
 .PP
 Please refer to the models in 
-\[la]https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html\[ra] to find if a field is mutable.
+\[la]https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html\[ra] to find if a field is mutable.
 
 
 .SH OPTIONS

--- a/docs/man/man1/kubectl-replace.1
+++ b/docs/man/man1/kubectl-replace.1
@@ -22,7 +22,7 @@ $ kubectl get TYPE NAME \-o yaml
 
 .PP
 Please refer to the models in 
-\[la]https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html\[ra] to find if a field is mutable.
+\[la]https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html\[ra] to find if a field is mutable.
 
 
 .SH OPTIONS

--- a/docs/user-guide/configuring-containers.md
+++ b/docs/user-guide/configuring-containers.md
@@ -109,7 +109,7 @@ pods/hello-world
 
 `kubectl create --validate` currently warns about problems it detects, but creates the resource anyway, unless a required field is absent or a field value is invalid. Unknown API fields are ignored, so be careful. This pod was created, but with no `command`, which is an optional field, since the image may specify an `Entrypoint`.
 View the [Pod API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html#_v1_pod)
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html#_v1_pod)
 to see the list of valid fields.
 
 ## Environment variables and variable expansion

--- a/docs/user-guide/connecting-applications.md
+++ b/docs/user-guide/connecting-applications.md
@@ -128,7 +128,7 @@ spec:
     app: nginx
 ```
 
-This specification will create a Service which targets TCP port 80 on any Pod with the `app=nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html#_v1_service) to see the list of supported fields in service definition.
+This specification will create a Service which targets TCP port 80 on any Pod with the `app=nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html#_v1_service) to see the list of supported fields in service definition.
 Check your Service:
 
 ```console

--- a/docs/user-guide/deploying-applications.md
+++ b/docs/user-guide/deploying-applications.md
@@ -76,7 +76,7 @@ spec:
 
 Some differences compared to specifying just a pod are that the `kind` is `ReplicationController`, the number of `replicas` desired is specified, and the pod specification is under the `template` field. The names of the pods don’t need to be specified explicitly because they are generated from the name of the replication controller.
 View the [replication controller API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html#_v1_replicationcontroller)
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html#_v1_replicationcontroller)
 to view the list of supported fields.
 
 This replication controller can be created using `create`, just as with pods:

--- a/docs/user-guide/kubectl/kubectl_patch.md
+++ b/docs/user-guide/kubectl/kubectl_patch.md
@@ -42,7 +42,7 @@ Update field(s) of a resource using strategic merge patch
 
 JSON and YAML formats are accepted.
 
-Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.
+Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.
 
 ```
 kubectl patch (-f FILENAME | TYPE NAME) -p PATCH

--- a/docs/user-guide/kubectl/kubectl_replace.md
+++ b/docs/user-guide/kubectl/kubectl_replace.md
@@ -44,7 +44,7 @@ JSON and YAML formats are accepted. If replacing an existing resource, the
 complete resource spec must be provided. This can be obtained by
 $ kubectl get TYPE NAME -o yaml
 
-Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.
+Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.
 
 ```
 kubectl replace -f FILENAME

--- a/docs/user-guide/pods.md
+++ b/docs/user-guide/pods.md
@@ -164,7 +164,7 @@ spec.containers[0].securityContext.privileged: forbidden '<*>(0xc20b222db0)true'
 
 Pod is a top-level resource in the kubernetes REST API. More details about the
 API object can be found at: [Pod API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html#_v1_pod).
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html#_v1_pod).
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/replication-controller.md
+++ b/docs/user-guide/replication-controller.md
@@ -124,7 +124,7 @@ For instance, a service might target all pods with `tier in (frontend), environm
 
 Replication controller is a top-level resource in the kubernetes REST API. More details about the
 API object can be found at: [ReplicationController API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html#_v1_replicationcontroller).
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html#_v1_replicationcontroller).
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/services.md
+++ b/docs/user-guide/services.md
@@ -636,7 +636,7 @@ through a load-balancer, though in those cases the client IP does get altered.
 
 Service is a top-level resource in the kubernetes REST API. More details about the
 API object can be found at: [Service API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html#_v1_service).
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html#_v1_service).
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -40,7 +40,7 @@ const (
 
 JSON and YAML formats are accepted.
 
-Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.`
+Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.`
 	patch_example = `
 # Partially update a node using strategic merge patch
 kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -44,7 +44,7 @@ JSON and YAML formats are accepted. If replacing an existing resource, the
 complete resource spec must be provided. This can be obtained by
 $ kubectl get TYPE NAME -o yaml
 
-Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.`
+Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.`
 	replace_example = `# Replace a pod using the data in pod.json.
 $ kubectl replace -f ./pod.json
 


### PR DESCRIPTION
We want to make the url after the htmlprefix to be valid, so that we can run a link check on that url.
