### PR TITLE
Eliminate a bunch of copies of `api.Node` structs by passing pointers

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities.go
@@ -73,7 +73,7 @@ func getNonzeroRequests(requests *api.ResourceList) (int64, int64) {
 
 // Calculate the resource occupancy on a node.  'node' has information about the resources on the node.
 // 'pods' is a list of pods currently scheduled on the node.
-func calculateResourceOccupancy(pod *api.Pod, node api.Node, pods []*api.Pod) algorithm.HostPriority {
+func calculateResourceOccupancy(pod *api.Pod, node *api.Node, pods []*api.Pod) algorithm.HostPriority {
 	totalMilliCPU := int64(0)
 	totalMemory := int64(0)
 	capacityMilliCPU := node.Status.Capacity.Cpu().MilliValue()
@@ -114,15 +114,13 @@ func calculateResourceOccupancy(pod *api.Pod, node api.Node, pods []*api.Pod) al
 // It calculates the percentage of memory and CPU requested by pods scheduled on the node, and prioritizes
 // based on the minimum of the average of the fraction of requested to capacity.
 // Details: cpu((capacity - sum(requested)) * 10 / capacity) + memory((capacity - sum(requested)) * 10 / capacity) / 2
-func LeastRequestedPriority(pod *api.Pod, podLister algorithm.PodLister, nodeLister algorithm.NodeLister) (algorithm.HostPriorityList, error) {
-	nodes, err := nodeLister.List()
-	if err != nil {
-		return algorithm.HostPriorityList{}, err
-	}
-	podsToMachines, err := predicates.MapPodsToMachines(podLister)
-
+func LeastRequestedPriority(pod *api.Pod, podLister algorithm.PodLister, nodes []*api.Node) (algorithm.HostPriorityList, error) {
 	list := algorithm.HostPriorityList{}
-	for _, node := range nodes.Items {
+	podsToMachines, err := predicates.MapPodsToMachines(podLister)
+	if err != nil {
+		return list, err
+	}
+	for _, node := range nodes {
 		list = append(list, calculateResourceOccupancy(pod, node, podsToMachines[node.Name]))
 	}
 	return list, nil
@@ -144,15 +142,11 @@ func NewNodeLabelPriority(label string, presence bool) algorithm.PriorityFunctio
 // CalculateNodeLabelPriority checks whether a particular label exists on a node or not, regardless of its value.
 // If presence is true, prioritizes nodes that have the specified label, regardless of value.
 // If presence is false, prioritizes nodes that do not have the specified label.
-func (n *NodeLabelPrioritizer) CalculateNodeLabelPriority(pod *api.Pod, podLister algorithm.PodLister, nodeLister algorithm.NodeLister) (algorithm.HostPriorityList, error) {
+func (n *NodeLabelPrioritizer) CalculateNodeLabelPriority(pod *api.Pod, podLister algorithm.PodLister, nodes []*api.Node) (algorithm.HostPriorityList, error) {
 	var score int
-	nodes, err := nodeLister.List()
-	if err != nil {
-		return nil, err
-	}
 
 	labeledNodes := map[string]bool{}
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
 		exists := labels.Set(node.Labels).Has(n.label)
 		labeledNodes[node.Name] = (exists && n.presence) || (!exists && !n.presence)
 	}
@@ -177,21 +171,19 @@ func (n *NodeLabelPrioritizer) CalculateNodeLabelPriority(pod *api.Pod, podListe
 // close the two metrics are to each other.
 // Detail: score = 10 - abs(cpuFraction-memoryFraction)*10. The algorithm is partly inspired by:
 // "Wei Huang et al. An Energy Efficient Virtual Machine Placement Algorithm with Balanced Resource Utilization"
-func BalancedResourceAllocation(pod *api.Pod, podLister algorithm.PodLister, nodeLister algorithm.NodeLister) (algorithm.HostPriorityList, error) {
-	nodes, err := nodeLister.List()
-	if err != nil {
-		return algorithm.HostPriorityList{}, err
-	}
-	podsToMachines, err := predicates.MapPodsToMachines(podLister)
-
+func BalancedResourceAllocation(pod *api.Pod, podLister algorithm.PodLister, nodes []*api.Node) (algorithm.HostPriorityList, error) {
 	list := algorithm.HostPriorityList{}
-	for _, node := range nodes.Items {
+	podsToMachines, err := predicates.MapPodsToMachines(podLister)
+	if err != nil {
+		return list, err
+	}
+	for _, node := range nodes {
 		list = append(list, calculateBalancedResourceAllocation(pod, node, podsToMachines[node.Name]))
 	}
 	return list, nil
 }
 
-func calculateBalancedResourceAllocation(pod *api.Pod, node api.Node, pods []*api.Pod) algorithm.HostPriority {
+func calculateBalancedResourceAllocation(pod *api.Pod, node *api.Node, pods []*api.Pod) algorithm.HostPriority {
 	totalMilliCPU := int64(0)
 	totalMemory := int64(0)
 	score := int(0)

--- a/plugin/pkg/scheduler/algorithm/priorities/priorities_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities_test.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 )
 
-func makeNode(node string, milliCPU, memory int64) api.Node {
-	return api.Node{
+func makeNode(node string, milliCPU, memory int64) *api.Node {
+	return &api.Node{
 		ObjectMeta: api.ObjectMeta{Name: node},
 		Status: api.NodeStatus{
 			Capacity: api.ResourceList{
@@ -88,7 +88,7 @@ func TestZeroRequest(t *testing.T) {
 	tests := []struct {
 		pod   *api.Pod
 		pods  []*api.Pod
-		nodes []api.Node
+		nodes []*api.Node
 		test  string
 	}{
 		// The point of these next two tests is to show you get the same priority for a zero-request pod
@@ -96,7 +96,7 @@ func TestZeroRequest(t *testing.T) {
 		// and when the zero-request pod is the one being scheduled.
 		{
 			pod:   &api.Pod{Spec: noResources},
-			nodes: []api.Node{makeNode("machine1", 1000, defaultMemoryRequest*10), makeNode("machine2", 1000, defaultMemoryRequest*10)},
+			nodes: []*api.Node{makeNode("machine1", 1000, defaultMemoryRequest*10), makeNode("machine2", 1000, defaultMemoryRequest*10)},
 			test:  "test priority of zero-request pod with machine with zero-request pod",
 			pods: []*api.Pod{
 				{Spec: large1}, {Spec: noResources1},
@@ -105,7 +105,7 @@ func TestZeroRequest(t *testing.T) {
 		},
 		{
 			pod:   &api.Pod{Spec: small},
-			nodes: []api.Node{makeNode("machine1", 1000, defaultMemoryRequest*10), makeNode("machine2", 1000, defaultMemoryRequest*10)},
+			nodes: []*api.Node{makeNode("machine1", 1000, defaultMemoryRequest*10), makeNode("machine2", 1000, defaultMemoryRequest*10)},
 			test:  "test priority of nonzero-request pod with machine with zero-request pod",
 			pods: []*api.Pod{
 				{Spec: large1}, {Spec: noResources1},
@@ -115,7 +115,7 @@ func TestZeroRequest(t *testing.T) {
 		// The point of this test is to verify that we're not just getting the same score no matter what we schedule.
 		{
 			pod:   &api.Pod{Spec: large},
-			nodes: []api.Node{makeNode("machine1", 1000, defaultMemoryRequest*10), makeNode("machine2", 1000, defaultMemoryRequest*10)},
+			nodes: []*api.Node{makeNode("machine1", 1000, defaultMemoryRequest*10), makeNode("machine2", 1000, defaultMemoryRequest*10)},
 			test:  "test priority of larger pod with machine with zero-request pod",
 			pods: []*api.Pod{
 				{Spec: large1}, {Spec: noResources1},
@@ -133,7 +133,7 @@ func TestZeroRequest(t *testing.T) {
 			// plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go if you want
 			// to test what's actually in production.
 			[]algorithm.PriorityConfig{{Function: LeastRequestedPriority, Weight: 1}, {Function: BalancedResourceAllocation, Weight: 1}, {Function: NewSelectorSpreadPriority(algorithm.FakeServiceLister([]api.Service{}), algorithm.FakeControllerLister([]api.ReplicationController{})), Weight: 1}},
-			algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}))
+			test.nodes)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -216,7 +216,7 @@ func TestLeastRequested(t *testing.T) {
 	tests := []struct {
 		pod          *api.Pod
 		pods         []*api.Pod
-		nodes        []api.Node
+		nodes        []*api.Node
 		expectedList algorithm.HostPriorityList
 		test         string
 	}{
@@ -233,7 +233,7 @@ func TestLeastRequested(t *testing.T) {
 				Node2 Score: (10 + 10) / 2 = 10
 			*/
 			pod:          &api.Pod{Spec: noResources},
-			nodes:        []api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 10}, {"machine2", 10}},
 			test:         "nothing scheduled, nothing requested",
 		},
@@ -250,7 +250,7 @@ func TestLeastRequested(t *testing.T) {
 				Node2 Score: (5 + 5) / 2 = 5
 			*/
 			pod:          &api.Pod{Spec: cpuAndMemory},
-			nodes:        []api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 3}, {"machine2", 5}},
 			test:         "nothing scheduled, resources requested, differently sized machines",
 		},
@@ -267,7 +267,7 @@ func TestLeastRequested(t *testing.T) {
 				Node2 Score: (10 + 10) / 2 = 10
 			*/
 			pod:          &api.Pod{Spec: noResources},
-			nodes:        []api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 10}, {"machine2", 10}},
 			test:         "no resources requested, pods scheduled",
 			pods: []*api.Pod{
@@ -290,7 +290,7 @@ func TestLeastRequested(t *testing.T) {
 				Node2 Score: (4 + 7.5) / 2 = 5
 			*/
 			pod:          &api.Pod{Spec: noResources},
-			nodes:        []api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
+			nodes:        []*api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 7}, {"machine2", 5}},
 			test:         "no resources requested, pods scheduled with resources",
 			pods: []*api.Pod{
@@ -313,7 +313,7 @@ func TestLeastRequested(t *testing.T) {
 				Node2 Score: (4 + 5) / 2 = 4
 			*/
 			pod:          &api.Pod{Spec: cpuAndMemory},
-			nodes:        []api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
+			nodes:        []*api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 5}, {"machine2", 4}},
 			test:         "resources requested, pods scheduled with resources",
 			pods: []*api.Pod{
@@ -334,7 +334,7 @@ func TestLeastRequested(t *testing.T) {
 				Node2 Score: (4 + 8) / 2 = 6
 			*/
 			pod:          &api.Pod{Spec: cpuAndMemory},
-			nodes:        []api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 50000)},
+			nodes:        []*api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 50000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 5}, {"machine2", 6}},
 			test:         "resources requested, pods scheduled with resources, differently sized machines",
 			pods: []*api.Pod{
@@ -355,7 +355,7 @@ func TestLeastRequested(t *testing.T) {
 				Node2 Score: (0 + 5) / 2 = 2
 			*/
 			pod:          &api.Pod{Spec: cpuOnly},
-			nodes:        []api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 5}, {"machine2", 2}},
 			test:         "requested resources exceed node capacity",
 			pods: []*api.Pod{
@@ -365,7 +365,7 @@ func TestLeastRequested(t *testing.T) {
 		},
 		{
 			pod:          &api.Pod{Spec: noResources},
-			nodes:        []api.Node{makeNode("machine1", 0, 0), makeNode("machine2", 0, 0)},
+			nodes:        []*api.Node{makeNode("machine1", 0, 0), makeNode("machine2", 0, 0)},
 			expectedList: []algorithm.HostPriority{{"machine1", 0}, {"machine2", 0}},
 			test:         "zero node resources, pods scheduled with resources",
 			pods: []*api.Pod{
@@ -376,7 +376,7 @@ func TestLeastRequested(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		list, err := LeastRequestedPriority(test.pod, algorithm.FakePodLister(test.pods), algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}))
+		list, err := LeastRequestedPriority(test.pod, algorithm.FakePodLister(test.pods), test.nodes)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -391,14 +391,14 @@ func TestNewNodeLabelPriority(t *testing.T) {
 	label2 := map[string]string{"bar": "foo"}
 	label3 := map[string]string{"bar": "baz"}
 	tests := []struct {
-		nodes        []api.Node
+		nodes        []*api.Node
 		label        string
 		presence     bool
 		expectedList algorithm.HostPriorityList
 		test         string
 	}{
 		{
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: label3}},
@@ -409,7 +409,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			test:         "no match found, presence true",
 		},
 		{
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: label3}},
@@ -420,7 +420,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			test:         "no match found, presence false",
 		},
 		{
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: label3}},
@@ -431,7 +431,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			test:         "one match found, presence true",
 		},
 		{
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: label3}},
@@ -442,7 +442,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			test:         "one match found, presence false",
 		},
 		{
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: label3}},
@@ -453,7 +453,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			test:         "two matches found, presence true",
 		},
 		{
-			nodes: []api.Node{
+			nodes: []*api.Node{
 				{ObjectMeta: api.ObjectMeta{Name: "machine1", Labels: label1}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine2", Labels: label2}},
 				{ObjectMeta: api.ObjectMeta{Name: "machine3", Labels: label3}},
@@ -470,7 +470,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			label:    test.label,
 			presence: test.presence,
 		}
-		list, err := prioritizer.CalculateNodeLabelPriority(nil, nil, algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}))
+		list, err := prioritizer.CalculateNodeLabelPriority(nil, nil, test.nodes)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -548,7 +548,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 	tests := []struct {
 		pod          *api.Pod
 		pods         []*api.Pod
-		nodes        []api.Node
+		nodes        []*api.Node
 		expectedList algorithm.HostPriorityList
 		test         string
 	}{
@@ -565,7 +565,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 				Node2 Score: 10 - (0-0)*10 = 10
 			*/
 			pod:          &api.Pod{Spec: noResources},
-			nodes:        []api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 10}, {"machine2", 10}},
 			test:         "nothing scheduled, nothing requested",
 		},
@@ -582,7 +582,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 				Node2 Score: 10 - (0.5-0.5)*10 = 10
 			*/
 			pod:          &api.Pod{Spec: cpuAndMemory},
-			nodes:        []api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 7}, {"machine2", 10}},
 			test:         "nothing scheduled, resources requested, differently sized machines",
 		},
@@ -599,7 +599,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 				Node2 Score: 10 - (0-0)*10 = 10
 			*/
 			pod:          &api.Pod{Spec: noResources},
-			nodes:        []api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 10}, {"machine2", 10}},
 			test:         "no resources requested, pods scheduled",
 			pods: []*api.Pod{
@@ -622,7 +622,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 				Node2 Score: 10 - (0.6-0.25)*10 = 6
 			*/
 			pod:          &api.Pod{Spec: noResources},
-			nodes:        []api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
+			nodes:        []*api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 4}, {"machine2", 6}},
 			test:         "no resources requested, pods scheduled with resources",
 			pods: []*api.Pod{
@@ -645,7 +645,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 				Node2 Score: 10 - (0.6-0.5)*10 = 9
 			*/
 			pod:          &api.Pod{Spec: cpuAndMemory},
-			nodes:        []api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
+			nodes:        []*api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 6}, {"machine2", 9}},
 			test:         "resources requested, pods scheduled with resources",
 			pods: []*api.Pod{
@@ -666,7 +666,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 				Node2 Score: 10 - (0.6-0.2)*10 = 6
 			*/
 			pod:          &api.Pod{Spec: cpuAndMemory},
-			nodes:        []api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 50000)},
+			nodes:        []*api.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 50000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 6}, {"machine2", 6}},
 			test:         "resources requested, pods scheduled with resources, differently sized machines",
 			pods: []*api.Pod{
@@ -687,7 +687,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 				Node2 Score: 0
 			*/
 			pod:          &api.Pod{Spec: cpuOnly},
-			nodes:        []api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
+			nodes:        []*api.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []algorithm.HostPriority{{"machine1", 0}, {"machine2", 0}},
 			test:         "requested resources exceed node capacity",
 			pods: []*api.Pod{
@@ -697,7 +697,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 		},
 		{
 			pod:          &api.Pod{Spec: noResources},
-			nodes:        []api.Node{makeNode("machine1", 0, 0), makeNode("machine2", 0, 0)},
+			nodes:        []*api.Node{makeNode("machine1", 0, 0), makeNode("machine2", 0, 0)},
 			expectedList: []algorithm.HostPriority{{"machine1", 0}, {"machine2", 0}},
 			test:         "zero node resources, pods scheduled with resources",
 			pods: []*api.Pod{
@@ -708,7 +708,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		list, err := BalancedResourceAllocation(test.pod, algorithm.FakePodLister(test.pods), algorithm.FakeNodeLister(api.NodeList{Items: test.nodes}))
+		list, err := BalancedResourceAllocation(test.pod, algorithm.FakePodLister(test.pods), test.nodes)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/plugin/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -217,7 +217,7 @@ func TestSelectorSpreadPriority(t *testing.T) {
 
 	for _, test := range tests {
 		selectorSpread := SelectorSpread{serviceLister: algorithm.FakeServiceLister(test.services), controllerLister: algorithm.FakeControllerLister(test.rcs)}
-		list, err := selectorSpread.CalculateSpreadPriority(test.pod, algorithm.FakePodLister(test.pods), algorithm.FakeNodeLister(makeNodeList(test.nodes)))
+		list, err := selectorSpread.CalculateSpreadPriority(test.pod, algorithm.FakePodLister(test.pods), makeNodeList(test.nodes))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -385,7 +385,7 @@ func TestZoneSpreadPriority(t *testing.T) {
 
 	for _, test := range tests {
 		zoneSpread := ServiceAntiAffinity{serviceLister: algorithm.FakeServiceLister(test.services), label: "zone"}
-		list, err := zoneSpread.CalculateAntiAffinityPriority(test.pod, algorithm.FakePodLister(test.pods), algorithm.FakeNodeLister(makeLabeledNodeList(test.nodes)))
+		list, err := zoneSpread.CalculateAntiAffinityPriority(test.pod, algorithm.FakePodLister(test.pods), makeLabeledNodeList(test.nodes))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -398,20 +398,18 @@ func TestZoneSpreadPriority(t *testing.T) {
 	}
 }
 
-func makeLabeledNodeList(nodeMap map[string]map[string]string) (result api.NodeList) {
-	nodes := []api.Node{}
+func makeLabeledNodeList(nodeMap map[string]map[string]string) (result []*api.Node) {
+	nodes := []*api.Node{}
 	for nodeName, labels := range nodeMap {
-		nodes = append(nodes, api.Node{ObjectMeta: api.ObjectMeta{Name: nodeName, Labels: labels}})
+		nodes = append(nodes, &api.Node{ObjectMeta: api.ObjectMeta{Name: nodeName, Labels: labels}})
 	}
-	return api.NodeList{Items: nodes}
+	return nodes
 }
 
-func makeNodeList(nodeNames []string) api.NodeList {
-	result := api.NodeList{
-		Items: make([]api.Node, len(nodeNames)),
-	}
+func makeNodeList(nodeNames []string) []*api.Node {
+	result := []*api.Node{}
 	for ix := range nodeNames {
-		result.Items[ix].Name = nodeNames[ix]
+		result = append(result, &api.Node{ObjectMeta: api.ObjectMeta{Name: nodeNames[ix]}})
 	}
 	return result
 }

--- a/plugin/pkg/scheduler/algorithm/types.go
+++ b/plugin/pkg/scheduler/algorithm/types.go
@@ -46,7 +46,7 @@ func (h HostPriorityList) Swap(i, j int) {
 	h[i], h[j] = h[j], h[i]
 }
 
-type PriorityFunction func(pod *api.Pod, podLister PodLister, nodeLister NodeLister) (HostPriorityList, error)
+type PriorityFunction func(pod *api.Pod, podLister PodLister, nodes []*api.Node) (HostPriorityList, error)
 
 type PriorityConfig struct {
 	Function PriorityFunction

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -104,6 +104,26 @@ func (g *genericScheduler) selectHost(priorityList algorithm.HostPriorityList) (
 	return hosts[ix], nil
 }
 
+func testNodeFit(pod *api.Pod, node *api.Node, machineToPods map[string][]*api.Pod, predicateFuncs map[string]algorithm.FitPredicate) (bool, sets.String, error) {
+	for name, predicate := range predicateFuncs {
+		predicates.FailedResourceType = ""
+		fit, err := predicate(pod, machineToPods[node.Name], node.Name)
+		if err != nil {
+			return false, nil, err
+		}
+		if !fit {
+			failedPredicates := sets.String{}
+			if predicates.FailedResourceType != "" {
+				failedPredicates.Insert(predicates.FailedResourceType)
+				return false, failedPredicates, nil
+			}
+			failedPredicates.Insert(name)
+			return false, failedPredicates, nil
+		}
+	}
+	return true, nil, nil
+}
+
 // Filters the nodes to find the ones that fit based on the given predicate functions
 // Each node is passed through the predicate functions to determine if it is a fit
 func findNodesThatFit(pod *api.Pod, podLister algorithm.PodLister, predicateFuncs map[string]algorithm.FitPredicate, nodes api.NodeList) (api.NodeList, FailedPredicateMap, error) {
@@ -113,30 +133,31 @@ func findNodesThatFit(pod *api.Pod, podLister algorithm.PodLister, predicateFunc
 	if err != nil {
 		return api.NodeList{}, FailedPredicateMap{}, err
 	}
-	for _, node := range nodes.Items {
-		fits := true
-		for name, predicate := range predicateFuncs {
-			predicates.FailedResourceType = ""
-			fit, err := predicate(pod, machineToPods[node.Name], node.Name)
+
+	wait := sync.WaitGroup{}
+	wait.Add(len(nodes.Items))
+	lock := sync.Mutex{}
+	var returnErr error
+	for ix := range nodes.Items {
+		go func(node *api.Node) {
+			defer wait.Done()
+			fits, failedPredicates, err := testNodeFit(pod, node, machineToPods, predicateFuncs)
 			if err != nil {
-				return api.NodeList{}, FailedPredicateMap{}, err
+				// Yes this could clobber other errors, but I don't care
+				returnErr = err
 			}
-			if !fit {
-				fits = false
-				if _, found := failedPredicateMap[node.Name]; !found {
-					failedPredicateMap[node.Name] = sets.String{}
-				}
-				if predicates.FailedResourceType != "" {
-					failedPredicateMap[node.Name].Insert(predicates.FailedResourceType)
-					break
-				}
-				failedPredicateMap[node.Name].Insert(name)
-				break
+			lock.Lock()
+			defer lock.Unlock()
+			if fits {
+				filtered = append(filtered, *node)
+			} else {
+				failedPredicateMap[node.Name] = failedPredicates
 			}
-		}
-		if fits {
-			filtered = append(filtered, node)
-		}
+		}(&nodes.Items[ix])
+	}
+	wait.Wait()
+	if returnErr != nil {
+		return api.NodeList{}, FailedPredicateMap{}, returnErr
 	}
 	return api.NodeList{Items: filtered}, failedPredicateMap, nil
 }
@@ -157,20 +178,37 @@ func PrioritizeNodes(pod *api.Pod, podLister algorithm.PodLister, priorityConfig
 	}
 
 	combinedScores := map[string]int{}
-	for _, priorityConfig := range priorityConfigs {
-		weight := priorityConfig.Weight
-		// skip the priority function if the weight is specified as 0
-		if weight == 0 {
-			continue
-		}
-		priorityFunc := priorityConfig.Function
-		prioritizedList, err := priorityFunc(pod, podLister, nodeLister)
-		if err != nil {
-			return algorithm.HostPriorityList{}, err
-		}
-		for _, hostEntry := range prioritizedList {
-			combinedScores[hostEntry.Host] += hostEntry.Score * weight
-		}
+	// protects combinedScores
+	lock := sync.Mutex{}
+	var returnErr error
+
+	wait := sync.WaitGroup{}
+	wait.Add(len(priorityConfigs))
+
+	for ix := range priorityConfigs {
+		go func(priorityConfig *algorithm.PriorityConfig) {
+			defer wait.Done()
+			weight := priorityConfig.Weight
+			// skip the priority function if the weight is specified as 0
+			if weight == 0 {
+				return
+			}
+			priorityFunc := priorityConfig.Function
+			prioritizedList, err := priorityFunc(pod, podLister, nodeLister)
+			if err != nil {
+				returnErr = err
+			}
+
+			lock.Lock()
+			defer lock.Unlock()
+			for _, hostEntry := range prioritizedList {
+				combinedScores[hostEntry.Host] += hostEntry.Score * weight
+			}
+		}(&priorityConfigs[ix])
+	}
+	wait.Wait()
+	if returnErr != nil {
+		return algorithm.HostPriorityList{}, returnErr
 	}
 	for host, score := range combinedScores {
 		glog.V(10).Infof("Host %s Score %d", host, score)

--- a/plugin/pkg/scheduler/generic_scheduler_test.go
+++ b/plugin/pkg/scheduler/generic_scheduler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scheduler
 
 import (
-	"fmt"
 	"math"
 	"math/rand"
 	"strconv"
@@ -44,14 +43,10 @@ func hasNoPodsPredicate(pod *api.Pod, existingPods []*api.Pod, node string) (boo
 	return len(existingPods) == 0, nil
 }
 
-func numericPriority(pod *api.Pod, podLister algorithm.PodLister, nodeLister algorithm.NodeLister) (algorithm.HostPriorityList, error) {
-	nodes, err := nodeLister.List()
+func numericPriority(pod *api.Pod, podLister algorithm.PodLister, nodes []*api.Node) (algorithm.HostPriorityList, error) {
 	result := []algorithm.HostPriority{}
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to list nodes: %v", err)
-	}
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
 		score, err := strconv.Atoi(node.Name)
 		if err != nil {
 			return nil, err
@@ -64,11 +59,11 @@ func numericPriority(pod *api.Pod, podLister algorithm.PodLister, nodeLister alg
 	return result, nil
 }
 
-func reverseNumericPriority(pod *api.Pod, podLister algorithm.PodLister, nodeLister algorithm.NodeLister) (algorithm.HostPriorityList, error) {
+func reverseNumericPriority(pod *api.Pod, podLister algorithm.PodLister, nodes []*api.Node) (algorithm.HostPriorityList, error) {
 	var maxScore float64
 	minScore := math.MaxFloat64
 	reverseResult := []algorithm.HostPriority{}
-	result, err := numericPriority(pod, podLister, nodeLister)
+	result, err := numericPriority(pod, podLister, nodes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
@davidopp @lavalamp @wojtek-t 

Builds off of https://github.com/kubernetes/kubernetes/pull/17400 please only review the second commit:

https://github.com/kubernetes/kubernetes/commit/eeb44dfd61cbd64391baecd3fa450da306303938
