### PR TITLE
add a way to discover git version from inside a built release

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -909,6 +909,8 @@ function kube::release::package_full_tarball() {
   mkdir -p "${release_stage}/contrib/completions/bash"
   cp "${KUBE_ROOT}/contrib/completions/bash/kubectl" "${release_stage}/contrib/completions/bash"
 
+  echo "${KUBE_GIT_VERSION}" > "${release_stage}/version"
+
   kube::release::clean_cruft
 
   local package_name="${RELEASE_DIR}/kubernetes.tar.gz"

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -332,3 +332,24 @@ function find-release-tars() {
     exit 1
   fi
 }
+
+# Discover the git version of the current build package
+#
+# Assumed vars:
+#   KUBE_ROOT
+# Vars set:
+#   KUBE_GIT_VERSION
+function find-release-version() {
+  KUBE_GIT_VERSION=""
+  if [[ -f "${KUBE_ROOT}/version" ]]; then
+    KUBE_GIT_VERSION="$(cat ${KUBE_ROOT}/version)"
+  fi
+  if [[ -f "${KUBE_ROOT}/_output/full/kubernetes/version" ]]; then
+    KUBE_GIT_VERSION="$(cat ${KUBE_ROOT}/_output/full/kubernetes/version)"
+  fi
+
+  if [[ -z "${KUBE_GIT_VERSION}" ]]; then
+    echo "!!! Cannot find release version"
+    exit 1
+  fi
+}


### PR DESCRIPTION
From scripts in cluster, there is no easy way to discover the build version other than calling out to kubectl which seems like a nuisance. I'm suggesting that we write a version file into the root of the release.
