### PR TITLE
Fix port typo, fix tests

### DIFF
--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -123,7 +123,7 @@ func svcByName(name string, port int) *api.Service {
 				"name": name,
 			},
 			Ports: []api.ServicePort{{
-				Port:       9376,
+				Port:       port,
 				TargetPort: intstr.FromInt(port),
 			}},
 		},


### PR DESCRIPTION
This typo was introduced in https://github.com/kubernetes/kubernetes/pull/14469 and caused the L7 tests in gce-slow to fail. Assigning to Jeff as he's most likely to notice the red. 
