### PR TITLE
Gv decoder

### DIFF
--- a/cmd/genconversion/conversion.go
+++ b/cmd/genconversion/conversion.go
@@ -92,17 +92,25 @@ func main() {
 		glog.Fatalf("Error while writing package line: %v", err)
 	}
 
+	var schemeVersion string
+	if *groupVersion == "" || *groupVersion == "/" {
+		// This occurs when we generate deep-copy for internal version.
+		schemeVersion = ""
+	} else {
+		schemeVersion = *groupVersion
+	}
+
 	versionPath := pkgPath(group, version)
 	generator := kruntime.NewConversionGenerator(api.Scheme.Raw(), versionPath)
 	apiShort := generator.AddImport(path.Join(pkgBase, "api"))
 	generator.AddImport(path.Join(pkgBase, "api/resource"))
 	// TODO(wojtek-t): Change the overwrites to a flag.
 	generator.OverwritePackage(version, "")
-	for _, knownType := range api.Scheme.KnownTypes(*groupVersion) {
+	for _, knownType := range api.Scheme.KnownTypes(schemeVersion) {
 		if knownType.PkgPath() != versionPath {
 			continue
 		}
-		if err := generator.GenerateConversionsForType(version, knownType); err != nil {
+		if err := generator.GenerateConversionsForType(*groupVersion, knownType); err != nil {
 			glog.Errorf("Error while generating conversion functions for %v: %v", knownType, err)
 		}
 	}

--- a/cmd/gendeepcopy/deep_copy.go
+++ b/cmd/gendeepcopy/deep_copy.go
@@ -125,8 +125,9 @@ func main() {
 			generator.OverwritePackage(vals[0], vals[1])
 		}
 	}
+
 	var schemeVersion string
-	if version == "" {
+	if *groupVersion == "" || *groupVersion == "/" {
 		// This occurs when we generate deep-copy for internal version.
 		schemeVersion = ""
 	} else {

--- a/pkg/api/conversion_test.go
+++ b/pkg/api/conversion_test.go
@@ -41,7 +41,7 @@ func BenchmarkPodConversion(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
-		obj, err := scheme.ConvertToVersion(versionedObj, scheme.InternalVersion)
+		obj, err := scheme.ConvertToVersion(versionedObj, scheme.InternalVersions[testapi.Default.Group].String())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
@@ -69,7 +69,7 @@ func BenchmarkNodeConversion(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
-		obj, err := scheme.ConvertToVersion(versionedObj, scheme.InternalVersion)
+		obj, err := scheme.ConvertToVersion(versionedObj, scheme.InternalVersions[testapi.Default.Group].String())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
@@ -97,7 +97,7 @@ func BenchmarkReplicationControllerConversion(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
-		obj, err := scheme.ConvertToVersion(versionedObj, scheme.InternalVersion)
+		obj, err := scheme.ConvertToVersion(versionedObj, scheme.InternalVersions[testapi.Default.Group].String())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -27,6 +27,8 @@ import (
 
 type fakeCodec struct{}
 
+var _ runtime.Decoder = fakeCodec{}
+
 func (fakeCodec) Encode(runtime.Object) ([]byte, error) {
 	return []byte{}, nil
 }
@@ -39,7 +41,7 @@ func (fakeCodec) Decode([]byte) (runtime.Object, error) {
 	return nil, nil
 }
 
-func (fakeCodec) DecodeToVersion([]byte, string) (runtime.Object, error) {
+func (fakeCodec) DecodeToVersion([]byte, unversioned.GroupVersion) (runtime.Object, error) {
 	return nil, nil
 }
 
@@ -47,7 +49,7 @@ func (fakeCodec) DecodeInto([]byte, runtime.Object) error {
 	return nil
 }
 
-func (fakeCodec) DecodeIntoWithSpecifiedVersionKind([]byte, runtime.Object, string, string) error {
+func (fakeCodec) DecodeIntoWithSpecifiedVersionKind([]byte, runtime.Object, unversioned.GroupVersionKind) error {
 	return nil
 }
 

--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -48,6 +48,10 @@ type GroupVersion struct {
 	Version string
 }
 
+func (gv GroupVersion) IsEmpty() bool {
+	return len(gv.Group) == 0 && len(gv.Version) == 0
+}
+
 // String puts "group" and "version" into a single "group/version" string. For the legacy v1
 // it returns "v1".
 func (gv GroupVersion) String() string {

--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -51,6 +51,11 @@ type GroupVersion struct {
 // String puts "group" and "version" into a single "group/version" string. For the legacy v1
 // it returns "v1".
 func (gv GroupVersion) String() string {
+	// special case the internal apiVersion for kube
+	if len(gv.Group) == 0 && len(gv.Version) == 0 {
+		return ""
+	}
+
 	// special case of "v1" for backward compatibility
 	if gv.Group == "" && gv.Version == "v1" {
 		return gv.Version
@@ -62,6 +67,11 @@ func (gv GroupVersion) String() string {
 // ParseGroupVersion turns "group/version" string into a GroupVersion struct. It reports error
 // if it cannot parse the string.
 func ParseGroupVersion(gv string) (GroupVersion, error) {
+	// this can be the internal version for kube
+	if (len(gv) == 0) || (gv == "/") {
+		return GroupVersion{}, nil
+	}
+
 	s := strings.Split(gv, "/")
 	// "v1" is the only special case. Otherwise GroupVersion is expected to contain
 	// one "/" dividing the string into two parts.
@@ -82,6 +92,10 @@ func ParseGroupVersionOrDie(gv string) GroupVersion {
 	}
 
 	return ret
+}
+
+func (gv GroupVersion) WithKind(kind string) GroupVersionKind {
+	return GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: kind}
 }
 
 // MarshalJSON implements the json.Marshaller interface.

--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -56,7 +56,7 @@ func (gv GroupVersion) IsEmpty() bool {
 // it returns "v1".
 func (gv GroupVersion) String() string {
 	// special case the internal apiVersion for kube
-	if len(gv.Group) == 0 && len(gv.Version) == 0 {
+	if gv.IsEmpty() {
 		return ""
 	}
 

--- a/pkg/apis/componentconfig/register.go
+++ b/pkg/apis/componentconfig/register.go
@@ -25,7 +25,8 @@ func init() {
 }
 
 func addKnownTypes() {
-	api.Scheme.AddKnownTypes("",
+	// TODO this will get cleaned up with the scheme types are fixed
+	api.Scheme.AddKnownTypes("componentconfig/",
 		&KubeProxyConfiguration{},
 	)
 }

--- a/pkg/apis/extensions/register.go
+++ b/pkg/apis/extensions/register.go
@@ -27,7 +27,8 @@ func init() {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes() {
-	api.Scheme.AddKnownTypes("",
+	// TODO this gets cleaned up when the types are fixed
+	api.Scheme.AddKnownTypes("extensions/",
 		&ClusterAutoscaler{},
 		&ClusterAutoscalerList{},
 		&Deployment{},

--- a/pkg/apis/metrics/register.go
+++ b/pkg/apis/metrics/register.go
@@ -27,7 +27,8 @@ func init() {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes() {
-	api.Scheme.AddKnownTypes("",
+	// TODO this will get cleaned up with the scheme types are fixed
+	api.Scheme.AddKnownTypes("metrics/",
 		&RawNode{},
 		&RawPod{},
 	)

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -375,11 +375,14 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 	// test/integration/auth_test.go is currently the most comprehensive status code test
 
 	reqScope := RequestScope{
-		ContextFunc:      ctxFn,
-		Creater:          a.group.Creater,
-		Convertor:        a.group.Convertor,
-		Codec:            mapping.Codec,
-		APIVersion:       a.group.GroupVersion.String(),
+		ContextFunc: ctxFn,
+		Creater:     a.group.Creater,
+		Convertor:   a.group.Convertor,
+		Codec:       mapping.Codec,
+		APIVersion:  a.group.GroupVersion.String(),
+		// TODO, this internal version needs to plumbed through from the caller
+		// this works in all the cases we have now
+		InternalVersion:  unversioned.GroupVersion{Group: a.group.GroupVersion.Group},
 		ServerAPIVersion: serverGroupVersion.String(),
 		Resource:         resource,
 		Subresource:      subresource,

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -1705,7 +1705,7 @@ func TestConnectWithOptionsAndPath(t *testing.T) {
 	}
 	opts, ok := connectStorage.receivedConnectOptions.(*apiservertesting.SimpleGetOptions)
 	if !ok {
-		t.Errorf("Unexpected options type: %#v", connectStorage.receivedConnectOptions)
+		t.Fatalf("Unexpected options type: %#v", connectStorage.receivedConnectOptions)
 	}
 	if opts.Param1 != "value1" && opts.Param2 != "value2" {
 		t.Errorf("Unexpected options value: %#v", opts)

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -58,6 +58,7 @@ func convert(obj runtime.Object) (runtime.Object, error) {
 
 // This creates fake API versions, similar to api/latest.go.
 var testAPIGroup = "test.group"
+var testInternalGroupVersion = unversioned.GroupVersion{Group: testAPIGroup, Version: ""}
 var testGroupVersion = unversioned.GroupVersion{Group: testAPIGroup, Version: "version"}
 var newGroupVersion = unversioned.GroupVersion{Group: testAPIGroup, Version: "version2"}
 var prefix = "apis"
@@ -164,8 +165,9 @@ func init() {
 
 	// "internal" version
 	api.Scheme.AddKnownTypes(
-		"", &apiservertesting.Simple{}, &apiservertesting.SimpleList{}, &unversioned.Status{},
+		testInternalGroupVersion.String(), &apiservertesting.Simple{}, &apiservertesting.SimpleList{}, &unversioned.Status{},
 		&api.ListOptions{}, &apiservertesting.SimpleGetOptions{}, &apiservertesting.SimpleRoot{})
+	api.Scheme.AddInternalGroupVersion(testInternalGroupVersion)
 	addGrouplessTypes()
 	addTestTypes()
 	addNewTestTypes()
@@ -1656,7 +1658,7 @@ func TestConnectWithOptions(t *testing.T) {
 	}
 	opts, ok := connectStorage.receivedConnectOptions.(*apiservertesting.SimpleGetOptions)
 	if !ok {
-		t.Errorf("Unexpected options type: %#v", connectStorage.receivedConnectOptions)
+		t.Fatalf("Unexpected options type: %#v", connectStorage.receivedConnectOptions)
 	}
 	if opts.Param1 != "value1" && opts.Param2 != "value2" {
 		t.Errorf("Unexpected options value: %#v", opts)

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -328,7 +328,8 @@ func createHandler(r rest.NamedCreater, scope RequestScope, typer runtime.Object
 		}
 
 		obj := r.New()
-		if err := scope.Codec.DecodeIntoWithSpecifiedVersionKind(body, obj, scope.APIVersion, scope.Kind); err != nil {
+		// TODO this cleans up with proper typing
+		if err := scope.Codec.DecodeIntoWithSpecifiedVersionKind(body, obj, unversioned.ParseGroupVersionOrDie(scope.APIVersion).WithKind(scope.Kind)); err != nil {
 			err = transformDecodeError(typer, err, obj, body)
 			errorJSON(err, scope.Codec, w)
 			return
@@ -561,7 +562,7 @@ func UpdateResource(r rest.Updater, scope RequestScope, typer runtime.ObjectType
 		}
 
 		obj := r.New()
-		if err := scope.Codec.DecodeIntoWithSpecifiedVersionKind(body, obj, scope.APIVersion, scope.Kind); err != nil {
+		if err := scope.Codec.DecodeIntoWithSpecifiedVersionKind(body, obj, unversioned.ParseGroupVersionOrDie(scope.APIVersion).WithKind(scope.Kind)); err != nil {
 			err = transformDecodeError(typer, err, obj, body)
 			errorJSON(err, scope.Codec, w)
 			return

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -72,10 +72,11 @@ type RequestScope struct {
 	Creater   runtime.ObjectCreater
 	Convertor runtime.ObjectConvertor
 
-	Resource    string
-	Subresource string
-	Kind        string
-	APIVersion  string
+	Resource        string
+	Subresource     string
+	Kind            string
+	APIVersion      string
+	InternalVersion unversioned.GroupVersion
 
 	// The version of apiserver resources to use
 	ServerAPIVersion string
@@ -685,7 +686,7 @@ func DeleteResource(r rest.GracefulDeleter, checkBody bool, scope RequestScope, 
 // to use it.
 // TODO: add appropriate structured error responses
 func queryToObject(query url.Values, scope RequestScope, kind string) (runtime.Object, error) {
-	versioned, err := scope.Creater.New(scope.ServerAPIVersion, kind)
+	versioned, err := scope.Creater.New(scope.APIVersion, kind)
 	if err != nil {
 		// programmer error
 		return nil, err
@@ -693,7 +694,7 @@ func queryToObject(query url.Values, scope RequestScope, kind string) (runtime.O
 	if err := scope.Convertor.Convert(&query, versioned); err != nil {
 		return nil, errors.NewBadRequest(err.Error())
 	}
-	out, err := scope.Convertor.ConvertToVersion(versioned, "")
+	out, err := scope.Convertor.ConvertToVersion(versioned, scope.InternalVersion.String())
 	if err != nil {
 		// programmer error
 		return nil, err

--- a/pkg/conversion/decode.go
+++ b/pkg/conversion/decode.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 
 	"github.com/ugorji/go/codec"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 func (s *Scheme) DecodeToVersionedObject(data []byte) (obj interface{}, version, kind string, err error) {
@@ -51,7 +53,8 @@ func (s *Scheme) DecodeToVersionedObject(data []byte) (obj interface{}, version,
 // s.InternalVersion type before being returned. Decode will not decode
 // objects without version set unless InternalVersion is also "".
 func (s *Scheme) Decode(data []byte) (interface{}, error) {
-	return s.DecodeToVersion(data, s.InternalVersion)
+	// TODO this is cleaned up when internal types are fixed
+	return s.DecodeToVersion(data, unversioned.ParseGroupVersionOrDie(s.InternalVersion))
 }
 
 // DecodeToVersion converts a JSON string back into a pointer to an api object.
@@ -59,7 +62,7 @@ func (s *Scheme) Decode(data []byte) (interface{}, error) {
 // technique. The object will be converted, if necessary, into the versioned
 // type before being returned. Decode will not decode objects without version
 // set unless version is also "".
-func (s *Scheme) DecodeToVersion(data []byte, version string) (interface{}, error) {
+func (s *Scheme) DecodeToVersion(data []byte, gv unversioned.GroupVersion) (interface{}, error) {
 	obj, sourceVersion, kind, err := s.DecodeToVersionedObject(data)
 	if err != nil {
 		return nil, err
@@ -70,12 +73,12 @@ func (s *Scheme) DecodeToVersion(data []byte, version string) (interface{}, erro
 	}
 
 	// Convert if needed.
-	if version != sourceVersion {
-		objOut, err := s.NewObject(version, kind)
+	if gv.String() != sourceVersion {
+		objOut, err := s.NewObject(gv.String(), kind)
 		if err != nil {
 			return nil, err
 		}
-		flags, meta := s.generateConvertMeta(sourceVersion, version, obj)
+		flags, meta := s.generateConvertMeta(sourceVersion, gv.String(), obj)
 		if err := s.converter.Convert(obj, objOut, flags, meta); err != nil {
 			return nil, err
 		}
@@ -90,7 +93,7 @@ func (s *Scheme) DecodeToVersion(data []byte, version string) (interface{}, erro
 // If obj's version doesn't match that in data, an attempt will be made to convert
 // data into obj's version.
 func (s *Scheme) DecodeInto(data []byte, obj interface{}) error {
-	return s.DecodeIntoWithSpecifiedVersionKind(data, obj, "", "")
+	return s.DecodeIntoWithSpecifiedVersionKind(data, obj, unversioned.GroupVersionKind{})
 }
 
 // DecodeIntoWithSpecifiedVersionKind compares the passed in specifiedVersion and
@@ -100,7 +103,7 @@ func (s *Scheme) DecodeInto(data []byte, obj interface{}) error {
 // The function then implements the functionality of DecodeInto.
 // If specifiedVersion and specifiedKind are empty, the function degenerates to
 // DecodeInto.
-func (s *Scheme) DecodeIntoWithSpecifiedVersionKind(data []byte, obj interface{}, specifiedVersion, specifiedKind string) error {
+func (s *Scheme) DecodeIntoWithSpecifiedVersionKind(data []byte, obj interface{}, gvk unversioned.GroupVersionKind) error {
 	if len(data) == 0 {
 		return errors.New("empty input")
 	}
@@ -109,16 +112,16 @@ func (s *Scheme) DecodeIntoWithSpecifiedVersionKind(data []byte, obj interface{}
 		return err
 	}
 	if dataVersion == "" {
-		dataVersion = specifiedVersion
+		dataVersion = gvk.GroupVersion().String()
 	}
 	if dataKind == "" {
-		dataKind = specifiedKind
+		dataKind = gvk.Kind
 	}
-	if len(specifiedVersion) > 0 && (dataVersion != specifiedVersion) {
-		return errors.New(fmt.Sprintf("The apiVersion in the data (%s) does not match the specified apiVersion(%s)", dataVersion, specifiedVersion))
+	if (len(gvk.GroupVersion().Group) > 0 || len(gvk.GroupVersion().Version) > 0) && (dataVersion != gvk.GroupVersion().String()) {
+		return errors.New(fmt.Sprintf("The apiVersion in the data (%s) does not match the specified apiVersion(%v)", dataVersion, gvk.GroupVersion()))
 	}
-	if len(specifiedKind) > 0 && (dataKind != specifiedKind) {
-		return errors.New(fmt.Sprintf("The kind in the data (%s) does not match the specified kind(%s)", dataKind, specifiedKind))
+	if len(gvk.Kind) > 0 && (dataKind != gvk.Kind) {
+		return errors.New(fmt.Sprintf("The kind in the data (%s) does not match the specified kind(%v)", dataKind, gvk))
 	}
 
 	objVersion, objKind, err := s.ObjectVersionAndKind(obj)

--- a/pkg/conversion/decode.go
+++ b/pkg/conversion/decode.go
@@ -72,8 +72,8 @@ func (s *Scheme) Decode(data []byte) (interface{}, error) {
 // technique. The object will be converted, if necessary, into the versioned
 // type before being returned. Decode will not decode objects without version
 // set unless version is also "".
-// a GroupVersion with .IsEmpty() == true is means "use the internal version
-// for this group
+// a GroupVersion with .IsEmpty() == true is means "use the internal version for
+// the object's group"
 func (s *Scheme) DecodeToVersion(data []byte, gv unversioned.GroupVersion) (interface{}, error) {
 	obj, sourceVersion, kind, err := s.DecodeToVersionedObject(data)
 	if err != nil {
@@ -144,7 +144,7 @@ func (s *Scheme) DecodeIntoWithSpecifiedVersionKind(data []byte, obj interface{}
 	if dataKind == "" {
 		dataKind = gvk.Kind
 	}
-	if (len(gvk.GroupVersion().Group) > 0 || len(gvk.GroupVersion().Version) > 0) && (dataVersion != gvk.GroupVersion().String()) {
+	if (len(gvk.Group) > 0 || len(gvk.Version) > 0) && (dataVersion != gvk.GroupVersion().String()) {
 		return errors.New(fmt.Sprintf("The apiVersion in the data (%s) does not match the specified apiVersion(%v)", dataVersion, gvk.GroupVersion()))
 	}
 	if len(gvk.Kind) > 0 && (dataKind != gvk.Kind) {

--- a/pkg/conversion/decode.go
+++ b/pkg/conversion/decode.go
@@ -25,18 +25,29 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
-func (s *Scheme) DecodeToVersionedObject(data []byte) (obj interface{}, version, kind string, err error) {
-	version, kind, err = s.DataVersionAndKind(data)
+func (s *Scheme) DecodeToVersionedObject(data []byte) (interface{}, string, string, error) {
+	version, kind, err := s.DataVersionAndKind(data)
 	if err != nil {
-		return
+		return nil, "", "", err
 	}
-	if version == "" && s.InternalVersion != "" {
+
+	gv, err := unversioned.ParseGroupVersion(version)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	internalGV, exists := s.InternalVersions[gv.Group]
+	if !exists {
+		return nil, "", "", fmt.Errorf("no internalVersion specified for %v", gv)
+	}
+
+	if len(gv.Version) == 0 && len(internalGV.Version) != 0 {
 		return nil, "", "", fmt.Errorf("version not set in '%s'", string(data))
 	}
 	if kind == "" {
 		return nil, "", "", fmt.Errorf("kind not set in '%s'", string(data))
 	}
-	obj, err = s.NewObject(version, kind)
+	obj, err := s.NewObject(version, kind)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -44,7 +55,7 @@ func (s *Scheme) DecodeToVersionedObject(data []byte) (obj interface{}, version,
 	if err := codec.NewDecoderBytes(data, new(codec.JsonHandle)).Decode(obj); err != nil {
 		return nil, "", "", err
 	}
-	return
+	return obj, version, kind, nil
 }
 
 // Decode converts a JSON string back into a pointer to an api object.
@@ -53,8 +64,7 @@ func (s *Scheme) DecodeToVersionedObject(data []byte) (obj interface{}, version,
 // s.InternalVersion type before being returned. Decode will not decode
 // objects without version set unless InternalVersion is also "".
 func (s *Scheme) Decode(data []byte) (interface{}, error) {
-	// TODO this is cleaned up when internal types are fixed
-	return s.DecodeToVersion(data, unversioned.ParseGroupVersionOrDie(s.InternalVersion))
+	return s.DecodeToVersion(data, unversioned.GroupVersion{})
 }
 
 // DecodeToVersion converts a JSON string back into a pointer to an api object.
@@ -62,6 +72,8 @@ func (s *Scheme) Decode(data []byte) (interface{}, error) {
 // technique. The object will be converted, if necessary, into the versioned
 // type before being returned. Decode will not decode objects without version
 // set unless version is also "".
+// a GroupVersion with .IsEmpty() == true is means "use the internal version
+// for this group
 func (s *Scheme) DecodeToVersion(data []byte, gv unversioned.GroupVersion) (interface{}, error) {
 	obj, sourceVersion, kind, err := s.DecodeToVersionedObject(data)
 	if err != nil {
@@ -72,8 +84,23 @@ func (s *Scheme) DecodeToVersion(data []byte, gv unversioned.GroupVersion) (inte
 		return nil, err
 	}
 
+	sourceGV, err := unversioned.ParseGroupVersion(sourceVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	// if the gv is empty, then we want the internal version, but the internal version varies by
+	// group.  We can lookup the group now because we have knowledge of the group
+	if gv.IsEmpty() {
+		exists := false
+		gv, exists = s.InternalVersions[sourceGV.Group]
+		if !exists {
+			return nil, fmt.Errorf("no internalVersion specified for %v", gv)
+		}
+	}
+
 	// Convert if needed.
-	if gv.String() != sourceVersion {
+	if gv != sourceGV {
 		objOut, err := s.NewObject(gv.String(), kind)
 		if err != nil {
 			return nil, err

--- a/pkg/conversion/error.go
+++ b/pkg/conversion/error.go
@@ -19,25 +19,27 @@ package conversion
 import (
 	"fmt"
 	"reflect"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 type notRegisteredErr struct {
-	kind    string
-	version string
-	t       reflect.Type
+	gvk unversioned.GroupVersionKind
+	t   reflect.Type
 }
 
 func (k *notRegisteredErr) Error() string {
 	if k.t != nil {
 		return fmt.Sprintf("no kind is registered for the type %v", k.t)
 	}
-	if len(k.kind) == 0 {
-		return fmt.Sprintf("no version %q has been registered", k.version)
+	if len(k.gvk.Kind) == 0 {
+		return fmt.Sprintf("no version %q has been registered", k.gvk.GroupVersion())
 	}
-	if len(k.version) == 0 {
-		return fmt.Sprintf("no kind %q is registered for the default version", k.kind)
+	if len(k.gvk.Version) == 0 {
+		return fmt.Sprintf("no kind %q is registered for the default version of group %q", k.gvk.Kind, k.gvk.Group)
 	}
-	return fmt.Sprintf("no kind %q is registered for version %q", k.kind, k.version)
+
+	return fmt.Sprintf("no kind %q is registered for version %q", k.gvk.Kind, k.gvk.GroupVersion())
 }
 
 // IsNotRegisteredError returns true if the error indicates the provided

--- a/pkg/conversion/meta_test.go
+++ b/pkg/conversion/meta_test.go
@@ -125,9 +125,13 @@ func TestMetaValues(t *testing.T) {
 		Kind       string `json:"kind,omitempty"`
 		TestString string `json:"testString"`
 	}
+	internalGV := unversioned.GroupVersion{Group: "test.group", Version: ""}
+	externalGV := unversioned.GroupVersion{Group: "test.group", Version: "externalVersion"}
+
 	s := NewScheme()
-	s.AddKnownTypeWithName("", "Simple", &InternalSimple{})
-	s.AddKnownTypeWithName("externalVersion", "Simple", &ExternalSimple{})
+	s.InternalVersions[internalGV.Group] = internalGV
+	s.AddKnownTypeWithName(internalGV.String(), "Simple", &InternalSimple{})
+	s.AddKnownTypeWithName(externalGV.String(), "Simple", &ExternalSimple{})
 
 	internalToExternalCalls := 0
 	externalToInternalCalls := 0
@@ -136,10 +140,10 @@ func TestMetaValues(t *testing.T) {
 	err := s.AddConversionFuncs(
 		func(in *InternalSimple, out *ExternalSimple, scope Scope) error {
 			t.Logf("internal -> external")
-			if e, a := "", scope.Meta().SrcVersion; e != a {
+			if e, a := internalGV.String(), scope.Meta().SrcVersion; e != a {
 				t.Fatalf("Expected '%v', got '%v'", e, a)
 			}
-			if e, a := "externalVersion", scope.Meta().DestVersion; e != a {
+			if e, a := externalGV.String(), scope.Meta().DestVersion; e != a {
 				t.Fatalf("Expected '%v', got '%v'", e, a)
 			}
 			scope.Convert(&in.TestString, &out.TestString, 0)
@@ -148,10 +152,10 @@ func TestMetaValues(t *testing.T) {
 		},
 		func(in *ExternalSimple, out *InternalSimple, scope Scope) error {
 			t.Logf("external -> internal")
-			if e, a := "externalVersion", scope.Meta().SrcVersion; e != a {
+			if e, a := externalGV.String(), scope.Meta().SrcVersion; e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
 			}
-			if e, a := "", scope.Meta().DestVersion; e != a {
+			if e, a := internalGV.String(), scope.Meta().DestVersion; e != a {
 				t.Fatalf("Expected '%v', got '%v'", e, a)
 			}
 			scope.Convert(&in.TestString, &out.TestString, 0)
@@ -169,7 +173,7 @@ func TestMetaValues(t *testing.T) {
 	s.Log(t)
 
 	// Test Encode, Decode, and DecodeInto
-	data, err := s.EncodeToVersion(simple, "externalVersion")
+	data, err := s.EncodeToVersion(simple, externalGV.String())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,7 +230,6 @@ func TestMetaValuesUnregisteredConvert(t *testing.T) {
 		TestString string `json:"testString"`
 	}
 	s := NewScheme()
-	s.InternalVersion = ""
 	// We deliberately don't register the types.
 
 	internalToExternalCalls := 0

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -158,14 +158,14 @@ func (s *Scheme) KnownTypes(version string) map[string]reflect.Type {
 
 // NewObject returns a new object of the given version and name,
 // or an error if it hasn't been registered.
-func (s *Scheme) NewObject(versionName, kind string) (interface{}, error) {
-	if types, ok := s.versionMap[versionName]; ok {
+func (s *Scheme) NewObject(gvString, kind string) (interface{}, error) {
+	if types, ok := s.versionMap[gvString]; ok {
 		if t, ok := types[kind]; ok {
 			return reflect.New(t).Interface(), nil
 		}
-		return nil, &notRegisteredErr{kind: kind, version: versionName}
+		return nil, &notRegisteredErr{kind: kind, version: gvString}
 	}
-	return nil, &notRegisteredErr{kind: kind, version: versionName}
+	return nil, &notRegisteredErr{kind: kind, version: gvString}
 }
 
 // AddConversionFuncs adds functions to the list of conversion functions. The given

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -72,10 +72,10 @@ func NewScheme() *Scheme {
 		cloner:        NewCloner(),
 		// TODO remove this hard coded list.  As step one, hardcode it here so this pull doesn't become even bigger
 		InternalVersions: map[string]unversioned.GroupVersion{
-			"":                unversioned.GroupVersion{},
-			"componentconfig": unversioned.GroupVersion{Group: "componentconfig"},
-			"extensions":      unversioned.GroupVersion{Group: "extensions"},
-			"metrics":         unversioned.GroupVersion{Group: "metrics"},
+			"":                {},
+			"componentconfig": {Group: "componentconfig"},
+			"extensions":      {Group: "extensions"},
+			"metrics":         {Group: "metrics"},
 		},
 		MetaFactory: DefaultMetaFactory,
 	}

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -19,6 +19,8 @@ package conversion
 import (
 	"fmt"
 	"reflect"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 // Scheme defines an entire encoding and decoding scheme.
@@ -50,7 +52,9 @@ type Scheme struct {
 
 	// InternalVersion is the default internal version. It is recommended that
 	// you use "" for the internal version.
-	InternalVersion string
+	// TODO logically the InternalVersion is different for every Group, so this structure
+	// must be map
+	InternalVersions map[string]unversioned.GroupVersion
 
 	// MetaInsertionFactory is used to create an object to store and retrieve
 	// the version and kind information for all objects. The default uses the
@@ -61,13 +65,19 @@ type Scheme struct {
 // NewScheme manufactures a new scheme.
 func NewScheme() *Scheme {
 	s := &Scheme{
-		versionMap:      map[string]map[string]reflect.Type{},
-		typeToVersion:   map[reflect.Type]string{},
-		typeToKind:      map[reflect.Type][]string{},
-		converter:       NewConverter(),
-		cloner:          NewCloner(),
-		InternalVersion: "",
-		MetaFactory:     DefaultMetaFactory,
+		versionMap:    map[string]map[string]reflect.Type{},
+		typeToVersion: map[reflect.Type]string{},
+		typeToKind:    map[reflect.Type][]string{},
+		converter:     NewConverter(),
+		cloner:        NewCloner(),
+		// TODO remove this hard coded list.  As step one, hardcode it here so this pull doesn't become even bigger
+		InternalVersions: map[string]unversioned.GroupVersion{
+			"":                unversioned.GroupVersion{},
+			"componentconfig": unversioned.GroupVersion{Group: "componentconfig"},
+			"extensions":      unversioned.GroupVersion{Group: "extensions"},
+			"metrics":         unversioned.GroupVersion{Group: "metrics"},
+		},
+		MetaFactory: DefaultMetaFactory,
 	}
 	s.converter.nameFunc = s.nameFunc
 	return s

--- a/pkg/conversion/scheme.go
+++ b/pkg/conversion/scheme.go
@@ -169,13 +169,21 @@ func (s *Scheme) KnownTypes(version string) map[string]reflect.Type {
 // NewObject returns a new object of the given version and name,
 // or an error if it hasn't been registered.
 func (s *Scheme) NewObject(gvString, kind string) (interface{}, error) {
+	gv, err := unversioned.ParseGroupVersion(gvString)
+	if err != nil {
+		return nil, err
+	}
+	gvk := gv.WithKind(kind)
+
 	if types, ok := s.versionMap[gvString]; ok {
 		if t, ok := types[kind]; ok {
 			return reflect.New(t).Interface(), nil
 		}
-		return nil, &notRegisteredErr{kind: kind, version: gvString}
+
+		return nil, &notRegisteredErr{gvk: gvk}
 	}
-	return nil, &notRegisteredErr{kind: kind, version: gvString}
+
+	return nil, &notRegisteredErr{gvk: gvk}
 }
 
 // AddConversionFuncs adds functions to the list of conversion functions. The given

--- a/pkg/conversion/scheme_test.go
+++ b/pkg/conversion/scheme_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/util"
 
 	"github.com/ghodss/yaml"
@@ -118,7 +119,6 @@ func GetTestScheme() *Scheme {
 	s.AddKnownTypeWithName("v1", "TestType2", &ExternalTestType2{})
 	s.AddKnownTypeWithName("", "TestType3", &TestType1{})
 	s.AddKnownTypeWithName("v1", "TestType3", &ExternalTestType1{})
-	s.InternalVersion = ""
 	s.MetaFactory = testMetaFactory{}
 	return s
 }
@@ -361,7 +361,7 @@ func TestBadJSONRejection(t *testing.T) {
 
 func TestBadJSONRejectionForSetInternalVersion(t *testing.T) {
 	s := GetTestScheme()
-	s.InternalVersion = "v1"
+	s.InternalVersions[""] = unversioned.GroupVersion{Version: "v1"}
 	badJSONs := [][]byte{
 		[]byte(`{"myKindKey":"TestType1"}`), // Missing version
 	}

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -84,7 +84,8 @@ var validVersionGV = unversioned.GroupVersion{Group: "apitest", Version: validVe
 
 func newExternalScheme() (*runtime.Scheme, meta.RESTMapper, runtime.Codec) {
 	scheme := runtime.NewScheme()
-	scheme.AddKnownTypeWithName(internalGV.Version, "Type", &internalType{})
+	scheme.AddInternalGroupVersion(internalGV)
+	scheme.AddKnownTypeWithName(internalGV.String(), "Type", &internalType{})
 	scheme.AddKnownTypeWithName(unlikelyGV.String(), "Type", &externalType{})
 	//This tests that kubectl will not confuse the external scheme with the internal scheme, even when they accidentally have versions of the same name.
 	scheme.AddKnownTypeWithName(validVersionGV.String(), "Type", &ExternalType2{})

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -217,7 +217,7 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 				if err != nil {
 					return err
 				}
-				decodedObj, err := scheme.DecodeToVersion(rawObj, "")
+				decodedObj, err := scheme.DecodeToVersion(rawObj, unversioned.GroupVersion{})
 				if err != nil {
 					return err
 				}

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -153,7 +153,7 @@ func (t *thirdPartyResourceDataCodec) Decode(data []byte) (runtime.Object, error
 	return result, nil
 }
 
-func (t *thirdPartyResourceDataCodec) DecodeToVersion(data []byte, version string) (runtime.Object, error) {
+func (t *thirdPartyResourceDataCodec) DecodeToVersion(data []byte, gv unversioned.GroupVersion) (runtime.Object, error) {
 	// TODO: this is hacky, there must be a better way...
 	obj, err := t.Decode(data)
 	if err != nil {
@@ -163,7 +163,7 @@ func (t *thirdPartyResourceDataCodec) DecodeToVersion(data []byte, version strin
 	if err != nil {
 		return nil, err
 	}
-	return t.delegate.DecodeToVersion(objData, version)
+	return t.delegate.DecodeToVersion(objData, gv)
 }
 
 func (t *thirdPartyResourceDataCodec) DecodeInto(data []byte, obj runtime.Object) error {
@@ -174,14 +174,14 @@ func (t *thirdPartyResourceDataCodec) DecodeInto(data []byte, obj runtime.Object
 	return t.populate(thirdParty, data)
 }
 
-func (t *thirdPartyResourceDataCodec) DecodeIntoWithSpecifiedVersionKind(data []byte, obj runtime.Object, version, kind string) error {
+func (t *thirdPartyResourceDataCodec) DecodeIntoWithSpecifiedVersionKind(data []byte, obj runtime.Object, gvk unversioned.GroupVersionKind) error {
 	thirdParty, ok := obj.(*extensions.ThirdPartyResourceData)
 	if !ok {
 		return fmt.Errorf("unexpected object: %#v", obj)
 	}
 
-	if kind != "ThirdPartyResourceData" {
-		return fmt.Errorf("unexpeceted kind: %s", kind)
+	if gvk.Kind != "ThirdPartyResourceData" {
+		return fmt.Errorf("unexpeceted kind: %s", gvk.Kind)
 	}
 
 	var dataObj interface{}
@@ -193,25 +193,25 @@ func (t *thirdPartyResourceDataCodec) DecodeIntoWithSpecifiedVersionKind(data []
 		return fmt.Errorf("unexpcted object: %#v", dataObj)
 	}
 	if kindObj, found := mapObj["kind"]; !found {
-		mapObj["kind"] = kind
+		mapObj["kind"] = gvk.Kind
 	} else {
 		kindStr, ok := kindObj.(string)
 		if !ok {
 			return fmt.Errorf("unexpected object for 'kind': %v", kindObj)
 		}
 		if kindStr != t.kind {
-			return fmt.Errorf("kind doesn't match, expecting: %s, got %s", kind, kindStr)
+			return fmt.Errorf("kind doesn't match, expecting: %s, got %s", gvk.Kind, kindStr)
 		}
 	}
 	if versionObj, found := mapObj["apiVersion"]; !found {
-		mapObj["apiVersion"] = version
+		mapObj["apiVersion"] = gvk.GroupVersion().String()
 	} else {
 		versionStr, ok := versionObj.(string)
 		if !ok {
 			return fmt.Errorf("unexpected object for 'apiVersion': %v", versionObj)
 		}
-		if versionStr != version {
-			return fmt.Errorf("version doesn't match, expecting: %s, got %s", version, versionStr)
+		if versionStr != gvk.GroupVersion().String() {
+			return fmt.Errorf("version doesn't match, expecting: %v, got %s", gvk.GroupVersion(), versionStr)
 		}
 	}
 

--- a/pkg/runtime/codec.go
+++ b/pkg/runtime/codec.go
@@ -35,6 +35,7 @@ type yamlCodec struct {
 
 // yamlCodec implements Codec
 var _ Codec = yamlCodec{}
+var _ Decoder = yamlCodec{}
 
 // YAMLDecoder adds YAML decoding support to a codec that supports JSON.
 func YAMLDecoder(codec Codec) Codec {
@@ -74,6 +75,8 @@ type codecWrapper struct {
 	ObjectCodec
 	version string
 }
+
+var _ Decoder = &codecWrapper{}
 
 // Encode implements Codec
 func (c *codecWrapper) Encode(obj Object) ([]byte, error) {

--- a/pkg/runtime/conversion_generator.go
+++ b/pkg/runtime/conversion_generator.go
@@ -88,7 +88,8 @@ func (g *conversionGenerator) AddImport(pkg string) string {
 
 func (g *conversionGenerator) GenerateConversionsForType(version string, reflection reflect.Type) error {
 	kind := reflection.Name()
-	internalObj, err := g.scheme.NewObject(g.scheme.InternalVersion, kind)
+	// TODO this is equivalent to what it did before, but it needs to be fixed for the proper group
+	internalObj, err := g.scheme.NewObject(g.scheme.InternalVersions[""].String(), kind)
 	if err != nil {
 		return fmt.Errorf("cannot create an object of type %v in internal version", kind)
 	}

--- a/pkg/runtime/embedded_test.go
+++ b/pkg/runtime/embedded_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 )
@@ -60,11 +61,15 @@ func (*EmbeddedTest) IsAnAPIObject()         {}
 func (*EmbeddedTestExternal) IsAnAPIObject() {}
 
 func TestDecodeEmptyRawExtensionAsObject(t *testing.T) {
-	s := runtime.NewScheme()
-	s.AddKnownTypes("", &ObjectTest{})
-	s.AddKnownTypeWithName("v1test", "ObjectTest", &ObjectTestExternal{})
+	internalGV := unversioned.GroupVersion{Group: "test.group", Version: ""}
+	externalGVK := unversioned.GroupVersionKind{Group: "test.group", Version: "v1test", Kind: "ObjectTest"}
 
-	obj, err := s.Decode([]byte(`{"kind":"ObjectTest","apiVersion":"v1test","items":[{}]}`))
+	s := runtime.NewScheme()
+	s.AddInternalGroupVersion(internalGV)
+	s.AddKnownTypes(internalGV.String(), &ObjectTest{})
+	s.AddKnownTypeWithName(externalGVK.GroupVersion().String(), externalGVK.Kind, &ObjectTestExternal{})
+
+	obj, err := s.Decode([]byte(`{"kind":"` + externalGVK.Kind + `","apiVersion":"` + externalGVK.GroupVersion().String() + `","items":[{}]}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -73,7 +78,7 @@ func TestDecodeEmptyRawExtensionAsObject(t *testing.T) {
 		t.Fatalf("unexpected object: %#v", test.Items[0])
 	}
 
-	obj, err = s.Decode([]byte(`{"kind":"ObjectTest","apiVersion":"v1test","items":[{"kind":"Other","apiVersion":"v1"}]}`))
+	obj, err = s.Decode([]byte(`{"kind":"` + externalGVK.Kind + `","apiVersion":"` + externalGVK.GroupVersion().String() + `","items":[{"kind":"Other","apiVersion":"v1"}]}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,11 +89,15 @@ func TestDecodeEmptyRawExtensionAsObject(t *testing.T) {
 }
 
 func TestArrayOfRuntimeObject(t *testing.T) {
+	internalGV := unversioned.GroupVersion{Group: "test.group", Version: ""}
+	externalGV := unversioned.GroupVersion{Group: "test.group", Version: "v1test"}
+
 	s := runtime.NewScheme()
-	s.AddKnownTypes("", &EmbeddedTest{})
-	s.AddKnownTypeWithName("v1test", "EmbeddedTest", &EmbeddedTestExternal{})
-	s.AddKnownTypes("", &ObjectTest{})
-	s.AddKnownTypeWithName("v1test", "ObjectTest", &ObjectTestExternal{})
+	s.AddInternalGroupVersion(internalGV)
+	s.AddKnownTypes(internalGV.String(), &EmbeddedTest{})
+	s.AddKnownTypeWithName(externalGV.String(), "EmbeddedTest", &EmbeddedTestExternal{})
+	s.AddKnownTypes(internalGV.String(), &ObjectTest{})
+	s.AddKnownTypeWithName(externalGV.String(), "ObjectTest", &ObjectTestExternal{})
 
 	internal := &ObjectTest{
 		Items: []runtime.Object{
@@ -103,7 +112,7 @@ func TestArrayOfRuntimeObject(t *testing.T) {
 			},
 		},
 	}
-	wire, err := s.EncodeToVersion(internal, "v1test")
+	wire, err := s.EncodeToVersion(internal, externalGV.String())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -146,9 +155,14 @@ func TestArrayOfRuntimeObject(t *testing.T) {
 }
 
 func TestEmbeddedObject(t *testing.T) {
+	internalGV := unversioned.GroupVersion{Group: "test.group", Version: ""}
+	externalGV := unversioned.GroupVersion{Group: "test.group", Version: "v1test"}
+	embeddedTestExternalGVK := externalGV.WithKind("EmbeddedTest")
+
 	s := runtime.NewScheme()
-	s.AddKnownTypes("", &EmbeddedTest{})
-	s.AddKnownTypeWithName("v1test", "EmbeddedTest", &EmbeddedTestExternal{})
+	s.AddInternalGroupVersion(internalGV)
+	s.AddKnownTypes(internalGV.String(), &EmbeddedTest{})
+	s.AddKnownTypeWithName(externalGV.String(), embeddedTestExternalGVK.Kind, &EmbeddedTestExternal{})
 
 	outer := &EmbeddedTest{
 		ID: "outer",
@@ -159,7 +173,7 @@ func TestEmbeddedObject(t *testing.T) {
 		},
 	}
 
-	wire, err := s.EncodeToVersion(outer, "v1test")
+	wire, err := s.EncodeToVersion(outer, externalGV.String())
 	if err != nil {
 		t.Fatalf("Unexpected encode error '%v'", err)
 	}
@@ -205,9 +219,14 @@ func TestEmbeddedObject(t *testing.T) {
 
 // TestDeepCopyOfEmbeddedObject checks to make sure that EmbeddedObject's can be passed through DeepCopy with fidelity
 func TestDeepCopyOfEmbeddedObject(t *testing.T) {
+	internalGV := unversioned.GroupVersion{Group: "test.group", Version: ""}
+	externalGV := unversioned.GroupVersion{Group: "test.group", Version: "v1test"}
+	embeddedTestExternalGVK := externalGV.WithKind("EmbeddedTest")
+
 	s := runtime.NewScheme()
-	s.AddKnownTypes("", &EmbeddedTest{})
-	s.AddKnownTypeWithName("v1test", "EmbeddedTest", &EmbeddedTestExternal{})
+	s.AddInternalGroupVersion(internalGV)
+	s.AddKnownTypes(internalGV.String(), &EmbeddedTest{})
+	s.AddKnownTypeWithName(externalGV.String(), embeddedTestExternalGVK.Kind, &EmbeddedTestExternal{})
 
 	original := &EmbeddedTest{
 		ID: "outer",
@@ -218,7 +237,7 @@ func TestDeepCopyOfEmbeddedObject(t *testing.T) {
 		},
 	}
 
-	originalData, err := s.EncodeToVersion(original, "v1test")
+	originalData, err := s.EncodeToVersion(original, externalGV.String())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -229,7 +248,7 @@ func TestDeepCopyOfEmbeddedObject(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	copiedData, err := s.EncodeToVersion(copyOfOriginal.(runtime.Object), "v1test")
+	copiedData, err := s.EncodeToVersion(copyOfOriginal.(runtime.Object), externalGV.String())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -18,6 +18,8 @@ package runtime
 
 import (
 	"io"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 // Codec defines methods for serializing and deserializing API objects.
@@ -30,10 +32,10 @@ type Codec interface {
 type Decoder interface {
 	Decode(data []byte) (Object, error)
 	// TODO: Remove this method?
-	DecodeToVersion(data []byte, version string) (Object, error)
+	DecodeToVersion(data []byte, groupVersion unversioned.GroupVersion) (Object, error)
 	DecodeInto(data []byte, obj Object) error
 	// TODO: Remove this method?
-	DecodeIntoWithSpecifiedVersionKind(data []byte, obj Object, kind, version string) error
+	DecodeIntoWithSpecifiedVersionKind(data []byte, obj Object, groupVersionKind unversioned.GroupVersionKind) error
 
 	// TODO: Add method for processing url parameters.
 	// DecodeParametersInto(parameters url.Values, obj Object) error

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"reflect"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/conversion"
 )
 
@@ -34,6 +35,8 @@ type Scheme struct {
 	// resource field labels in that version to internal version.
 	fieldLabelConversionFuncs map[string]map[string]FieldLabelConversionFunc
 }
+
+var _ Decoder = &Scheme{}
 
 // Function to convert a field selector to internal representation.
 type FieldLabelConversionFunc func(label, value string) (internalLabel, internalValue string, err error)
@@ -456,8 +459,8 @@ func (s *Scheme) Decode(data []byte) (Object, error) {
 // are set by Encode. Only versioned objects (APIVersion != "") are
 // accepted. The object will be converted into the in-memory versioned type
 // requested before being returned.
-func (s *Scheme) DecodeToVersion(data []byte, version string) (Object, error) {
-	obj, err := s.raw.DecodeToVersion(data, version)
+func (s *Scheme) DecodeToVersion(data []byte, gv unversioned.GroupVersion) (Object, error) {
+	obj, err := s.raw.DecodeToVersion(data, gv)
 	if err != nil {
 		return nil, err
 	}
@@ -476,8 +479,8 @@ func (s *Scheme) DecodeInto(data []byte, obj Object) error {
 	return s.raw.DecodeInto(data, obj)
 }
 
-func (s *Scheme) DecodeIntoWithSpecifiedVersionKind(data []byte, obj Object, version, kind string) error {
-	return s.raw.DecodeIntoWithSpecifiedVersionKind(data, obj, version, kind)
+func (s *Scheme) DecodeIntoWithSpecifiedVersionKind(data []byte, obj Object, gvk unversioned.GroupVersionKind) error {
+	return s.raw.DecodeIntoWithSpecifiedVersionKind(data, obj, gvk)
 }
 
 // Copy does a deep copy of an API object.  Useful mostly for tests.

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -44,12 +44,15 @@ func (*InternalSimple) IsAnAPIObject() {}
 func (*ExternalSimple) IsAnAPIObject() {}
 
 func TestScheme(t *testing.T) {
-	internalGVK := unversioned.GroupVersionKind{Group: "test.group", Version: "", Kind: "Simple"}
-	externalGVK := unversioned.GroupVersionKind{Group: "test.group", Version: "externalVersion", Kind: "Simple"}
+	internalGV := unversioned.GroupVersion{Group: "test.group", Version: ""}
+	externalGV := unversioned.GroupVersion{Group: "test.group", Version: "testExternal"}
+	internalGVK := internalGV.WithKind("Simple")
+	externalGVK := externalGV.WithKind("Simple")
 
 	scheme := runtime.NewScheme()
-	scheme.AddKnownTypeWithName(internalGVK.GroupVersion().String(), internalGVK.Kind, &InternalSimple{})
-	scheme.AddKnownTypeWithName(externalGVK.GroupVersion().String(), externalGVK.Kind, &ExternalSimple{})
+	scheme.AddInternalGroupVersion(internalGV)
+	scheme.AddKnownTypeWithName(internalGV.String(), internalGVK.Kind, &InternalSimple{})
+	scheme.AddKnownTypeWithName(externalGV.String(), externalGVK.Kind, &ExternalSimple{})
 
 	// test that scheme is an ObjectTyper
 	var _ runtime.ObjectTyper = scheme
@@ -60,10 +63,10 @@ func TestScheme(t *testing.T) {
 	// Register functions to verify that scope.Meta() gets set correctly.
 	err := scheme.AddConversionFuncs(
 		func(in *InternalSimple, out *ExternalSimple, scope conversion.Scope) error {
-			if e, a := internalGVK.GroupVersion().String(), scope.Meta().SrcVersion; e != a {
+			if e, a := internalGV.String(), scope.Meta().SrcVersion; e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
 			}
-			if e, a := externalGVK.GroupVersion().String(), scope.Meta().DestVersion; e != a {
+			if e, a := externalGV.String(), scope.Meta().DestVersion; e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
 			}
 			scope.Convert(&in.TypeMeta, &out.TypeMeta, 0)
@@ -72,10 +75,10 @@ func TestScheme(t *testing.T) {
 			return nil
 		},
 		func(in *ExternalSimple, out *InternalSimple, scope conversion.Scope) error {
-			if e, a := externalGVK.GroupVersion().String(), scope.Meta().SrcVersion; e != a {
+			if e, a := externalGV.String(), scope.Meta().SrcVersion; e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
 			}
-			if e, a := internalGVK.GroupVersion().String(), scope.Meta().DestVersion; e != a {
+			if e, a := internalGV.String(), scope.Meta().DestVersion; e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)
 			}
 			scope.Convert(&in.TypeMeta, &out.TypeMeta, 0)
@@ -93,11 +96,11 @@ func TestScheme(t *testing.T) {
 
 	// Test Encode, Decode, DecodeInto, and DecodeToVersion
 	obj := runtime.Object(simple)
-	data, err := scheme.EncodeToVersion(obj, "externalVersion")
+	data, err := scheme.EncodeToVersion(obj, externalGV.String())
 	obj2, err2 := scheme.Decode(data)
 	obj3 := &InternalSimple{}
 	err3 := scheme.DecodeInto(data, obj3)
-	obj4, err4 := scheme.DecodeToVersion(data, externalGVK.GroupVersion())
+	obj4, err4 := scheme.DecodeToVersion(data, externalGV)
 	if err != nil || err2 != nil || err3 != nil || err4 != nil {
 		t.Fatalf("Failure: '%v' '%v' '%v' '%v'", err, err2, err3, err4)
 	}
@@ -202,9 +205,13 @@ func (*ExternalOptionalExtensionType) IsAnAPIObject() {}
 func (*InternalOptionalExtensionType) IsAnAPIObject() {}
 
 func TestExternalToInternalMapping(t *testing.T) {
+	internalGV := unversioned.GroupVersion{Group: "test.group", Version: ""}
+	externalGV := unversioned.GroupVersion{Group: "test.group", Version: "testExternal"}
+
 	scheme := runtime.NewScheme()
-	scheme.AddKnownTypeWithName("", "OptionalExtensionType", &InternalOptionalExtensionType{})
-	scheme.AddKnownTypeWithName("testExternal", "OptionalExtensionType", &ExternalOptionalExtensionType{})
+	scheme.AddInternalGroupVersion(internalGV)
+	scheme.AddKnownTypeWithName(internalGV.String(), "OptionalExtensionType", &InternalOptionalExtensionType{})
+	scheme.AddKnownTypeWithName(externalGV.String(), "OptionalExtensionType", &ExternalOptionalExtensionType{})
 
 	table := []struct {
 		obj     runtime.Object
@@ -212,7 +219,7 @@ func TestExternalToInternalMapping(t *testing.T) {
 	}{
 		{
 			&InternalOptionalExtensionType{Extension: runtime.EmbeddedObject{Object: nil}},
-			`{"kind":"OptionalExtensionType","apiVersion":"testExternal"}`,
+			`{"kind":"OptionalExtensionType","apiVersion":"` + externalGV.String() + `"}`,
 		},
 	}
 
@@ -234,15 +241,19 @@ func TestExternalToInternalMapping(t *testing.T) {
 }
 
 func TestExtensionMapping(t *testing.T) {
+	internalGV := unversioned.GroupVersion{Group: "test.group", Version: ""}
+	externalGV := unversioned.GroupVersion{Group: "test.group", Version: "testExternal"}
+
 	scheme := runtime.NewScheme()
-	scheme.AddKnownTypeWithName("", "ExtensionType", &InternalExtensionType{})
-	scheme.AddKnownTypeWithName("", "OptionalExtensionType", &InternalOptionalExtensionType{})
-	scheme.AddKnownTypeWithName("", "A", &ExtensionA{})
-	scheme.AddKnownTypeWithName("", "B", &ExtensionB{})
-	scheme.AddKnownTypeWithName("testExternal", "ExtensionType", &ExternalExtensionType{})
-	scheme.AddKnownTypeWithName("testExternal", "OptionalExtensionType", &ExternalOptionalExtensionType{})
-	scheme.AddKnownTypeWithName("testExternal", "A", &ExtensionA{})
-	scheme.AddKnownTypeWithName("testExternal", "B", &ExtensionB{})
+	scheme.AddInternalGroupVersion(internalGV)
+	scheme.AddKnownTypeWithName(internalGV.String(), "ExtensionType", &InternalExtensionType{})
+	scheme.AddKnownTypeWithName(internalGV.String(), "OptionalExtensionType", &InternalOptionalExtensionType{})
+	scheme.AddKnownTypeWithName(internalGV.String(), "A", &ExtensionA{})
+	scheme.AddKnownTypeWithName(internalGV.String(), "B", &ExtensionB{})
+	scheme.AddKnownTypeWithName(externalGV.String(), "ExtensionType", &ExternalExtensionType{})
+	scheme.AddKnownTypeWithName(externalGV.String(), "OptionalExtensionType", &ExternalOptionalExtensionType{})
+	scheme.AddKnownTypeWithName(externalGV.String(), "A", &ExtensionA{})
+	scheme.AddKnownTypeWithName(externalGV.String(), "B", &ExtensionB{})
 
 	table := []struct {
 		obj     runtime.Object
@@ -250,21 +261,21 @@ func TestExtensionMapping(t *testing.T) {
 	}{
 		{
 			&InternalExtensionType{Extension: runtime.EmbeddedObject{Object: &ExtensionA{TestString: "foo"}}},
-			`{"kind":"ExtensionType","apiVersion":"testExternal","extension":{"kind":"A","testString":"foo"}}
+			`{"kind":"ExtensionType","apiVersion":"` + externalGV.String() + `","extension":{"kind":"A","testString":"foo"}}
 `,
 		}, {
 			&InternalExtensionType{Extension: runtime.EmbeddedObject{Object: &ExtensionB{TestString: "bar"}}},
-			`{"kind":"ExtensionType","apiVersion":"testExternal","extension":{"kind":"B","testString":"bar"}}
+			`{"kind":"ExtensionType","apiVersion":"` + externalGV.String() + `","extension":{"kind":"B","testString":"bar"}}
 `,
 		}, {
 			&InternalExtensionType{Extension: runtime.EmbeddedObject{Object: nil}},
-			`{"kind":"ExtensionType","apiVersion":"testExternal","extension":null}
+			`{"kind":"ExtensionType","apiVersion":"` + externalGV.String() + `","extension":null}
 `,
 		},
 	}
 
 	for _, item := range table {
-		gotEncoded, err := scheme.EncodeToVersion(item.obj, "testExternal")
+		gotEncoded, err := scheme.EncodeToVersion(item.obj, externalGV.String())
 		if err != nil {
 			t.Errorf("unexpected error '%v' (%#v)", err, item.obj)
 		} else if e, a := item.encoded, string(gotEncoded); e != a {
@@ -288,10 +299,14 @@ func TestExtensionMapping(t *testing.T) {
 }
 
 func TestEncode(t *testing.T) {
+	internalGV := unversioned.GroupVersion{Group: "test.group", Version: ""}
+	externalGV := unversioned.GroupVersion{Group: "test.group", Version: "testExternal"}
+
 	scheme := runtime.NewScheme()
-	scheme.AddKnownTypeWithName("", "Simple", &InternalSimple{})
-	scheme.AddKnownTypeWithName("externalVersion", "Simple", &ExternalSimple{})
-	codec := runtime.CodecFor(scheme, "externalVersion")
+	scheme.AddInternalGroupVersion(internalGV)
+	scheme.AddKnownTypeWithName(internalGV.String(), "Simple", &InternalSimple{})
+	scheme.AddKnownTypeWithName(externalGV.String(), "Simple", &ExternalSimple{})
+	codec := runtime.CodecFor(scheme, externalGV.String())
 	test := &InternalSimple{
 		TestString: "I'm the same",
 	}

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/conversion"
 )
 
@@ -29,6 +30,8 @@ import (
 var UnstructuredJSONScheme ObjectDecoder = unstructuredJSONScheme{}
 
 type unstructuredJSONScheme struct{}
+
+var _ Decoder = unstructuredJSONScheme{}
 
 // Recognizes returns true for any version or kind that is specified (internal
 // versions are specifically excluded).
@@ -74,11 +77,11 @@ func (unstructuredJSONScheme) DecodeInto(data []byte, obj Object) error {
 	return nil
 }
 
-func (unstructuredJSONScheme) DecodeIntoWithSpecifiedVersionKind(data []byte, obj Object, kind, version string) error {
+func (unstructuredJSONScheme) DecodeIntoWithSpecifiedVersionKind(data []byte, obj Object, gvk unversioned.GroupVersionKind) error {
 	return nil
 }
 
-func (unstructuredJSONScheme) DecodeToVersion(data []byte, version string) (Object, error) {
+func (unstructuredJSONScheme) DecodeToVersion(data []byte, gv unversioned.GroupVersion) (Object, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
The target of this pull is the `Decoder` interface (`DecodeToVersion` and `DecodeIntoWithSpecifiedVersionKind`).  Everything else is the minimum change needed to make that happen.

ref #17216

@liggitt @caesarxuchao 
