### PR TITLE
Adjust V level for scheduler messages

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities.go
@@ -34,7 +34,7 @@ func calculateScore(requested int64, capacity int64, node string) int {
 		return 0
 	}
 	if requested > capacity {
-		glog.Infof("Combined requested resources %d from existing pods exceeds capacity %d on node %s",
+		glog.V(2).Infof("Combined requested resources %d from existing pods exceeds capacity %d on node %s",
 			requested, capacity, node)
 		return 0
 	}

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -44,7 +44,7 @@ func (f *FitError) Error() string {
 	var reason string
 	// We iterate over all nodes for logging purposes, even though we only return one reason from one node
 	for node, predicateList := range f.FailedPredicates {
-		glog.Infof("Failed to find fit for pod %v on node %s: %s", f.Pod.Name, node, strings.Join(predicateList.List(), ","))
+		glog.V(2).Infof("Failed to find fit for pod %v on node %s: %s", f.Pod.Name, node, strings.Join(predicateList.List(), ","))
 		if len(reason) == 0 {
 			reason, _ = predicateList.PopAny()
 		}


### PR DESCRIPTION
The "Combined requested resources" message becomes excessive as
the cluster fills up.

Put an explicit V(2) on the only other scheduler Infof call that didn't
have V specified already.
