### PR TITLE
Make serviceAccountName a pointer and change defaulting

### DIFF
--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1572,7 +1572,12 @@ func deepCopy_api_PodSpec(in PodSpec, out *PodSpec, c *conversion.Cloner) error 
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+	}
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(PodSecurityContext)

--- a/pkg/api/types.generated.go
+++ b/pkg/api/types.generated.go
@@ -18109,25 +18109,35 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr1420 || yy2arr1420 {
-				yym1443 := z.EncBinary()
-				_ = yym1443
-				if false {
+				if x.ServiceAccountName == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceAccountName))
+					yy1443 := *x.ServiceAccountName
+					yym1444 := z.EncBinary()
+					_ = yym1444
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(yy1443))
+					}
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("serviceAccountName"))
-				yym1444 := z.EncBinary()
-				_ = yym1444
-				if false {
+				if x.ServiceAccountName == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceAccountName))
+					yy1445 := *x.ServiceAccountName
+					yym1446 := z.EncBinary()
+					_ = yym1446
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(yy1445))
+					}
 				}
 			}
 			if yyr1420 || yy2arr1420 {
 				if yyq1420[8] {
-					yym1446 := z.EncBinary()
-					_ = yym1446
+					yym1448 := z.EncBinary()
+					_ = yym1448
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.NodeName))
@@ -18138,8 +18148,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1420[8] {
 					r.EncodeString(codecSelferC_UTF81234, string("nodeName"))
-					yym1447 := z.EncBinary()
-					_ = yym1447
+					yym1449 := z.EncBinary()
+					_ = yym1449
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.NodeName))
@@ -18171,8 +18181,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym1450 := z.EncBinary()
-						_ = yym1450
+						yym1452 := z.EncBinary()
+						_ = yym1452
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -18187,8 +18197,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym1451 := z.EncBinary()
-						_ = yym1451
+						yym1453 := z.EncBinary()
+						_ = yym1453
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -18207,24 +18217,24 @@ func (x *PodSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1452 := z.DecBinary()
-	_ = yym1452
+	yym1454 := z.DecBinary()
+	_ = yym1454
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1453 := r.ReadMapStart()
-			if yyl1453 == 0 {
+			yyl1455 := r.ReadMapStart()
+			if yyl1455 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1453, d)
+				x.codecDecodeSelfFromMap(yyl1455, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1453 := r.ReadArrayStart()
-			if yyl1453 == 0 {
+			yyl1455 := r.ReadArrayStart()
+			if yyl1455 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1453, d)
+				x.codecDecodeSelfFromArray(yyl1455, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -18236,12 +18246,12 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1454Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1454Slc
-	var yyhl1454 bool = l >= 0
-	for yyj1454 := 0; ; yyj1454++ {
-		if yyhl1454 {
-			if yyj1454 >= l {
+	var yys1456Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1456Slc
+	var yyhl1456 bool = l >= 0
+	for yyj1456 := 0; ; yyj1456++ {
+		if yyhl1456 {
+			if yyj1456 >= l {
 				break
 			}
 		} else {
@@ -18249,31 +18259,31 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1454Slc = r.DecodeBytes(yys1454Slc, true, true)
-		yys1454 := string(yys1454Slc)
-		switch yys1454 {
+		yys1456Slc = r.DecodeBytes(yys1456Slc, true, true)
+		yys1456 := string(yys1456Slc)
+		switch yys1456 {
 		case "volumes":
 			if r.TryDecodeAsNil() {
 				x.Volumes = nil
 			} else {
-				yyv1455 := &x.Volumes
-				yym1456 := z.DecBinary()
-				_ = yym1456
+				yyv1457 := &x.Volumes
+				yym1458 := z.DecBinary()
+				_ = yym1458
 				if false {
 				} else {
-					h.decSliceVolume((*[]Volume)(yyv1455), d)
+					h.decSliceVolume((*[]Volume)(yyv1457), d)
 				}
 			}
 		case "containers":
 			if r.TryDecodeAsNil() {
 				x.Containers = nil
 			} else {
-				yyv1457 := &x.Containers
-				yym1458 := z.DecBinary()
-				_ = yym1458
+				yyv1459 := &x.Containers
+				yym1460 := z.DecBinary()
+				_ = yym1460
 				if false {
 				} else {
-					h.decSliceContainer((*[]Container)(yyv1457), d)
+					h.decSliceContainer((*[]Container)(yyv1459), d)
 				}
 			}
 		case "restartPolicy":
@@ -18291,8 +18301,8 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TerminationGracePeriodSeconds == nil {
 					x.TerminationGracePeriodSeconds = new(int64)
 				}
-				yym1461 := z.DecBinary()
-				_ = yym1461
+				yym1463 := z.DecBinary()
+				_ = yym1463
 				if false {
 				} else {
 					*((*int64)(x.TerminationGracePeriodSeconds)) = int64(r.DecodeInt(64))
@@ -18307,8 +18317,8 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.ActiveDeadlineSeconds == nil {
 					x.ActiveDeadlineSeconds = new(int64)
 				}
-				yym1463 := z.DecBinary()
-				_ = yym1463
+				yym1465 := z.DecBinary()
+				_ = yym1465
 				if false {
 				} else {
 					*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
@@ -18324,19 +18334,29 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.NodeSelector = nil
 			} else {
-				yyv1465 := &x.NodeSelector
-				yym1466 := z.DecBinary()
-				_ = yym1466
+				yyv1467 := &x.NodeSelector
+				yym1468 := z.DecBinary()
+				_ = yym1468
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1465, false, d)
+					z.F.DecMapStringStringX(yyv1467, false, d)
 				}
 			}
 		case "serviceAccountName":
 			if r.TryDecodeAsNil() {
-				x.ServiceAccountName = ""
+				if x.ServiceAccountName != nil {
+					x.ServiceAccountName = nil
+				}
 			} else {
-				x.ServiceAccountName = string(r.DecodeString())
+				if x.ServiceAccountName == nil {
+					x.ServiceAccountName = new(string)
+				}
+				yym1470 := z.DecBinary()
+				_ = yym1470
+				if false {
+				} else {
+					*((*string)(x.ServiceAccountName)) = r.DecodeString()
+				}
 			}
 		case "nodeName":
 			if r.TryDecodeAsNil() {
@@ -18359,19 +18379,19 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ImagePullSecrets = nil
 			} else {
-				yyv1470 := &x.ImagePullSecrets
-				yym1471 := z.DecBinary()
-				_ = yym1471
+				yyv1473 := &x.ImagePullSecrets
+				yym1474 := z.DecBinary()
+				_ = yym1474
 				if false {
 				} else {
-					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv1470), d)
+					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv1473), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1454)
-		} // end switch yys1454
-	} // end for yyj1454
-	if !yyhl1454 {
+			z.DecStructFieldNotFound(-1, yys1456)
+		} // end switch yys1456
+	} // end for yyj1456
+	if !yyhl1456 {
 		r.ReadEnd()
 	}
 }
@@ -18380,58 +18400,58 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1472 int
-	var yyb1472 bool
-	var yyhl1472 bool = l >= 0
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	var yyj1475 int
+	var yyb1475 bool
+	var yyhl1475 bool = l >= 0
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Volumes = nil
 	} else {
-		yyv1473 := &x.Volumes
-		yym1474 := z.DecBinary()
-		_ = yym1474
+		yyv1476 := &x.Volumes
+		yym1477 := z.DecBinary()
+		_ = yym1477
 		if false {
 		} else {
-			h.decSliceVolume((*[]Volume)(yyv1473), d)
+			h.decSliceVolume((*[]Volume)(yyv1476), d)
 		}
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Containers = nil
 	} else {
-		yyv1475 := &x.Containers
-		yym1476 := z.DecBinary()
-		_ = yym1476
+		yyv1478 := &x.Containers
+		yym1479 := z.DecBinary()
+		_ = yym1479
 		if false {
 		} else {
-			h.decSliceContainer((*[]Container)(yyv1475), d)
+			h.decSliceContainer((*[]Container)(yyv1478), d)
 		}
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
@@ -18440,13 +18460,13 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.RestartPolicy = RestartPolicy(r.DecodeString())
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
@@ -18458,20 +18478,20 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TerminationGracePeriodSeconds == nil {
 			x.TerminationGracePeriodSeconds = new(int64)
 		}
-		yym1479 := z.DecBinary()
-		_ = yym1479
+		yym1482 := z.DecBinary()
+		_ = yym1482
 		if false {
 		} else {
 			*((*int64)(x.TerminationGracePeriodSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
@@ -18483,20 +18503,20 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.ActiveDeadlineSeconds == nil {
 			x.ActiveDeadlineSeconds = new(int64)
 		}
-		yym1481 := z.DecBinary()
-		_ = yym1481
+		yym1484 := z.DecBinary()
+		_ = yym1484
 		if false {
 		} else {
 			*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
@@ -18505,49 +18525,59 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.DNSPolicy = DNSPolicy(r.DecodeString())
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.NodeSelector = nil
 	} else {
-		yyv1483 := &x.NodeSelector
-		yym1484 := z.DecBinary()
-		_ = yym1484
+		yyv1486 := &x.NodeSelector
+		yym1487 := z.DecBinary()
+		_ = yym1487
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1483, false, d)
+			z.F.DecMapStringStringX(yyv1486, false, d)
 		}
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.ServiceAccountName = ""
+		if x.ServiceAccountName != nil {
+			x.ServiceAccountName = nil
+		}
 	} else {
-		x.ServiceAccountName = string(r.DecodeString())
+		if x.ServiceAccountName == nil {
+			x.ServiceAccountName = new(string)
+		}
+		yym1489 := z.DecBinary()
+		_ = yym1489
+		if false {
+		} else {
+			*((*string)(x.ServiceAccountName)) = r.DecodeString()
+		}
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
@@ -18556,13 +18586,13 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.NodeName = string(r.DecodeString())
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
@@ -18576,38 +18606,38 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.SecurityContext.CodecDecodeSelf(d)
 	}
-	yyj1472++
-	if yyhl1472 {
-		yyb1472 = yyj1472 > l
+	yyj1475++
+	if yyhl1475 {
+		yyb1475 = yyj1475 > l
 	} else {
-		yyb1472 = r.CheckBreak()
+		yyb1475 = r.CheckBreak()
 	}
-	if yyb1472 {
+	if yyb1475 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ImagePullSecrets = nil
 	} else {
-		yyv1488 := &x.ImagePullSecrets
-		yym1489 := z.DecBinary()
-		_ = yym1489
+		yyv1492 := &x.ImagePullSecrets
+		yym1493 := z.DecBinary()
+		_ = yym1493
 		if false {
 		} else {
-			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv1488), d)
+			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv1492), d)
 		}
 	}
 	for {
-		yyj1472++
-		if yyhl1472 {
-			yyb1472 = yyj1472 > l
+		yyj1475++
+		if yyhl1475 {
+			yyb1475 = yyj1475 > l
 		} else {
-			yyb1472 = r.CheckBreak()
+			yyb1475 = r.CheckBreak()
 		}
-		if yyb1472 {
+		if yyb1475 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1472-1, "")
+		z.DecStructFieldNotFound(yyj1475-1, "")
 	}
 	r.ReadEnd()
 }
@@ -18619,83 +18649,83 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1490 := z.EncBinary()
-		_ = yym1490
+		yym1494 := z.EncBinary()
+		_ = yym1494
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1491 := !z.EncBinary()
-			yy2arr1491 := z.EncBasicHandle().StructToArray
-			var yyq1491 [8]bool
-			_, _, _ = yysep1491, yyq1491, yy2arr1491
-			const yyr1491 bool = false
-			yyq1491[0] = x.HostNetwork != false
-			yyq1491[1] = x.HostPID != false
-			yyq1491[2] = x.HostIPC != false
-			yyq1491[3] = x.SELinuxOptions != nil
-			yyq1491[4] = x.RunAsUser != nil
-			yyq1491[5] = x.RunAsNonRoot != nil
-			yyq1491[6] = len(x.SupplementalGroups) != 0
-			yyq1491[7] = x.FSGroup != nil
-			if yyr1491 || yy2arr1491 {
+			yysep1495 := !z.EncBinary()
+			yy2arr1495 := z.EncBasicHandle().StructToArray
+			var yyq1495 [8]bool
+			_, _, _ = yysep1495, yyq1495, yy2arr1495
+			const yyr1495 bool = false
+			yyq1495[0] = x.HostNetwork != false
+			yyq1495[1] = x.HostPID != false
+			yyq1495[2] = x.HostIPC != false
+			yyq1495[3] = x.SELinuxOptions != nil
+			yyq1495[4] = x.RunAsUser != nil
+			yyq1495[5] = x.RunAsNonRoot != nil
+			yyq1495[6] = len(x.SupplementalGroups) != 0
+			yyq1495[7] = x.FSGroup != nil
+			if yyr1495 || yy2arr1495 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1491 int = 0
-				for _, b := range yyq1491 {
+				var yynn1495 int = 0
+				for _, b := range yyq1495 {
 					if b {
-						yynn1491++
+						yynn1495++
 					}
 				}
-				r.EncodeMapStart(yynn1491)
+				r.EncodeMapStart(yynn1495)
 			}
-			if yyr1491 || yy2arr1491 {
-				if yyq1491[0] {
-					yym1493 := z.EncBinary()
-					_ = yym1493
-					if false {
-					} else {
-						r.EncodeBool(bool(x.HostNetwork))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq1491[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("hostNetwork"))
-					yym1494 := z.EncBinary()
-					_ = yym1494
-					if false {
-					} else {
-						r.EncodeBool(bool(x.HostNetwork))
-					}
-				}
-			}
-			if yyr1491 || yy2arr1491 {
-				if yyq1491[1] {
-					yym1496 := z.EncBinary()
-					_ = yym1496
-					if false {
-					} else {
-						r.EncodeBool(bool(x.HostPID))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq1491[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("hostPID"))
+			if yyr1495 || yy2arr1495 {
+				if yyq1495[0] {
 					yym1497 := z.EncBinary()
 					_ = yym1497
 					if false {
 					} else {
+						r.EncodeBool(bool(x.HostNetwork))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq1495[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("hostNetwork"))
+					yym1498 := z.EncBinary()
+					_ = yym1498
+					if false {
+					} else {
+						r.EncodeBool(bool(x.HostNetwork))
+					}
+				}
+			}
+			if yyr1495 || yy2arr1495 {
+				if yyq1495[1] {
+					yym1500 := z.EncBinary()
+					_ = yym1500
+					if false {
+					} else {
+						r.EncodeBool(bool(x.HostPID))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq1495[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("hostPID"))
+					yym1501 := z.EncBinary()
+					_ = yym1501
+					if false {
+					} else {
 						r.EncodeBool(bool(x.HostPID))
 					}
 				}
 			}
-			if yyr1491 || yy2arr1491 {
-				if yyq1491[2] {
-					yym1499 := z.EncBinary()
-					_ = yym1499
+			if yyr1495 || yy2arr1495 {
+				if yyq1495[2] {
+					yym1503 := z.EncBinary()
+					_ = yym1503
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostIPC))
@@ -18704,18 +18734,18 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1491[2] {
+				if yyq1495[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("hostIPC"))
-					yym1500 := z.EncBinary()
-					_ = yym1500
+					yym1504 := z.EncBinary()
+					_ = yym1504
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostIPC))
 					}
 				}
 			}
-			if yyr1491 || yy2arr1491 {
-				if yyq1491[3] {
+			if yyr1495 || yy2arr1495 {
+				if yyq1495[3] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -18725,7 +18755,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1491[3] {
+				if yyq1495[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -18734,133 +18764,133 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1491 || yy2arr1491 {
-				if yyq1491[4] {
+			if yyr1495 || yy2arr1495 {
+				if yyq1495[4] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy1503 := *x.RunAsUser
-						yym1504 := z.EncBinary()
-						_ = yym1504
+						yy1507 := *x.RunAsUser
+						yym1508 := z.EncBinary()
+						_ = yym1508
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1503))
+							r.EncodeInt(int64(yy1507))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1491[4] {
+				if yyq1495[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy1505 := *x.RunAsUser
-						yym1506 := z.EncBinary()
-						_ = yym1506
+						yy1509 := *x.RunAsUser
+						yym1510 := z.EncBinary()
+						_ = yym1510
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1505))
+							r.EncodeInt(int64(yy1509))
 						}
 					}
 				}
 			}
-			if yyr1491 || yy2arr1491 {
-				if yyq1491[5] {
+			if yyr1495 || yy2arr1495 {
+				if yyq1495[5] {
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
-						yy1508 := *x.RunAsNonRoot
-						yym1509 := z.EncBinary()
-						_ = yym1509
-						if false {
-						} else {
-							r.EncodeBool(bool(yy1508))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1491[5] {
-					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
-					if x.RunAsNonRoot == nil {
-						r.EncodeNil()
-					} else {
-						yy1510 := *x.RunAsNonRoot
-						yym1511 := z.EncBinary()
-						_ = yym1511
-						if false {
-						} else {
-							r.EncodeBool(bool(yy1510))
-						}
-					}
-				}
-			}
-			if yyr1491 || yy2arr1491 {
-				if yyq1491[6] {
-					if x.SupplementalGroups == nil {
-						r.EncodeNil()
-					} else {
+						yy1512 := *x.RunAsNonRoot
 						yym1513 := z.EncBinary()
 						_ = yym1513
 						if false {
 						} else {
-							z.F.EncSliceInt64V(x.SupplementalGroups, false, e)
+							r.EncodeBool(bool(yy1512))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1491[6] {
-					r.EncodeString(codecSelferC_UTF81234, string("supplementalGroups"))
-					if x.SupplementalGroups == nil {
+				if yyq1495[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
+					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
-						yym1514 := z.EncBinary()
-						_ = yym1514
+						yy1514 := *x.RunAsNonRoot
+						yym1515 := z.EncBinary()
+						_ = yym1515
 						if false {
 						} else {
-							z.F.EncSliceInt64V(x.SupplementalGroups, false, e)
+							r.EncodeBool(bool(yy1514))
 						}
 					}
 				}
 			}
-			if yyr1491 || yy2arr1491 {
-				if yyq1491[7] {
-					if x.FSGroup == nil {
+			if yyr1495 || yy2arr1495 {
+				if yyq1495[6] {
+					if x.SupplementalGroups == nil {
 						r.EncodeNil()
 					} else {
-						yy1516 := *x.FSGroup
 						yym1517 := z.EncBinary()
 						_ = yym1517
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1516))
+							z.F.EncSliceInt64V(x.SupplementalGroups, false, e)
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1491[7] {
-					r.EncodeString(codecSelferC_UTF81234, string("fsGroup"))
-					if x.FSGroup == nil {
+				if yyq1495[6] {
+					r.EncodeString(codecSelferC_UTF81234, string("supplementalGroups"))
+					if x.SupplementalGroups == nil {
 						r.EncodeNil()
 					} else {
-						yy1518 := *x.FSGroup
-						yym1519 := z.EncBinary()
-						_ = yym1519
+						yym1518 := z.EncBinary()
+						_ = yym1518
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1518))
+							z.F.EncSliceInt64V(x.SupplementalGroups, false, e)
 						}
 					}
 				}
 			}
-			if yysep1491 {
+			if yyr1495 || yy2arr1495 {
+				if yyq1495[7] {
+					if x.FSGroup == nil {
+						r.EncodeNil()
+					} else {
+						yy1520 := *x.FSGroup
+						yym1521 := z.EncBinary()
+						_ = yym1521
+						if false {
+						} else {
+							r.EncodeInt(int64(yy1520))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1495[7] {
+					r.EncodeString(codecSelferC_UTF81234, string("fsGroup"))
+					if x.FSGroup == nil {
+						r.EncodeNil()
+					} else {
+						yy1522 := *x.FSGroup
+						yym1523 := z.EncBinary()
+						_ = yym1523
+						if false {
+						} else {
+							r.EncodeInt(int64(yy1522))
+						}
+					}
+				}
+			}
+			if yysep1495 {
 				r.EncodeEnd()
 			}
 		}
@@ -18871,24 +18901,24 @@ func (x *PodSecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1520 := z.DecBinary()
-	_ = yym1520
+	yym1524 := z.DecBinary()
+	_ = yym1524
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1521 := r.ReadMapStart()
-			if yyl1521 == 0 {
+			yyl1525 := r.ReadMapStart()
+			if yyl1525 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1521, d)
+				x.codecDecodeSelfFromMap(yyl1525, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1521 := r.ReadArrayStart()
-			if yyl1521 == 0 {
+			yyl1525 := r.ReadArrayStart()
+			if yyl1525 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1521, d)
+				x.codecDecodeSelfFromArray(yyl1525, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -18900,12 +18930,12 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1522Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1522Slc
-	var yyhl1522 bool = l >= 0
-	for yyj1522 := 0; ; yyj1522++ {
-		if yyhl1522 {
-			if yyj1522 >= l {
+	var yys1526Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1526Slc
+	var yyhl1526 bool = l >= 0
+	for yyj1526 := 0; ; yyj1526++ {
+		if yyhl1526 {
+			if yyj1526 >= l {
 				break
 			}
 		} else {
@@ -18913,9 +18943,9 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys1522Slc = r.DecodeBytes(yys1522Slc, true, true)
-		yys1522 := string(yys1522Slc)
-		switch yys1522 {
+		yys1526Slc = r.DecodeBytes(yys1526Slc, true, true)
+		yys1526 := string(yys1526Slc)
+		switch yys1526 {
 		case "hostNetwork":
 			if r.TryDecodeAsNil() {
 				x.HostNetwork = false
@@ -18954,8 +18984,8 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.RunAsUser == nil {
 					x.RunAsUser = new(int64)
 				}
-				yym1528 := z.DecBinary()
-				_ = yym1528
+				yym1532 := z.DecBinary()
+				_ = yym1532
 				if false {
 				} else {
 					*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
@@ -18970,8 +19000,8 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.RunAsNonRoot == nil {
 					x.RunAsNonRoot = new(bool)
 				}
-				yym1530 := z.DecBinary()
-				_ = yym1530
+				yym1534 := z.DecBinary()
+				_ = yym1534
 				if false {
 				} else {
 					*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
@@ -18981,12 +19011,12 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.SupplementalGroups = nil
 			} else {
-				yyv1531 := &x.SupplementalGroups
-				yym1532 := z.DecBinary()
-				_ = yym1532
+				yyv1535 := &x.SupplementalGroups
+				yym1536 := z.DecBinary()
+				_ = yym1536
 				if false {
 				} else {
-					z.F.DecSliceInt64X(yyv1531, false, d)
+					z.F.DecSliceInt64X(yyv1535, false, d)
 				}
 			}
 		case "fsGroup":
@@ -18998,18 +19028,18 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.FSGroup == nil {
 					x.FSGroup = new(int64)
 				}
-				yym1534 := z.DecBinary()
-				_ = yym1534
+				yym1538 := z.DecBinary()
+				_ = yym1538
 				if false {
 				} else {
 					*((*int64)(x.FSGroup)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1522)
-		} // end switch yys1522
-	} // end for yyj1522
-	if !yyhl1522 {
+			z.DecStructFieldNotFound(-1, yys1526)
+		} // end switch yys1526
+	} // end for yyj1526
+	if !yyhl1526 {
 		r.ReadEnd()
 	}
 }
@@ -19018,16 +19048,16 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1535 int
-	var yyb1535 bool
-	var yyhl1535 bool = l >= 0
-	yyj1535++
-	if yyhl1535 {
-		yyb1535 = yyj1535 > l
+	var yyj1539 int
+	var yyb1539 bool
+	var yyhl1539 bool = l >= 0
+	yyj1539++
+	if yyhl1539 {
+		yyb1539 = yyj1539 > l
 	} else {
-		yyb1535 = r.CheckBreak()
+		yyb1539 = r.CheckBreak()
 	}
-	if yyb1535 {
+	if yyb1539 {
 		r.ReadEnd()
 		return
 	}
@@ -19036,13 +19066,13 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.HostNetwork = bool(r.DecodeBool())
 	}
-	yyj1535++
-	if yyhl1535 {
-		yyb1535 = yyj1535 > l
+	yyj1539++
+	if yyhl1539 {
+		yyb1539 = yyj1539 > l
 	} else {
-		yyb1535 = r.CheckBreak()
+		yyb1539 = r.CheckBreak()
 	}
-	if yyb1535 {
+	if yyb1539 {
 		r.ReadEnd()
 		return
 	}
@@ -19051,13 +19081,13 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.HostPID = bool(r.DecodeBool())
 	}
-	yyj1535++
-	if yyhl1535 {
-		yyb1535 = yyj1535 > l
+	yyj1539++
+	if yyhl1539 {
+		yyb1539 = yyj1539 > l
 	} else {
-		yyb1535 = r.CheckBreak()
+		yyb1539 = r.CheckBreak()
 	}
-	if yyb1535 {
+	if yyb1539 {
 		r.ReadEnd()
 		return
 	}
@@ -19066,13 +19096,13 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.HostIPC = bool(r.DecodeBool())
 	}
-	yyj1535++
-	if yyhl1535 {
-		yyb1535 = yyj1535 > l
+	yyj1539++
+	if yyhl1539 {
+		yyb1539 = yyj1539 > l
 	} else {
-		yyb1535 = r.CheckBreak()
+		yyb1539 = r.CheckBreak()
 	}
-	if yyb1535 {
+	if yyb1539 {
 		r.ReadEnd()
 		return
 	}
@@ -19086,13 +19116,13 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		}
 		x.SELinuxOptions.CodecDecodeSelf(d)
 	}
-	yyj1535++
-	if yyhl1535 {
-		yyb1535 = yyj1535 > l
+	yyj1539++
+	if yyhl1539 {
+		yyb1539 = yyj1539 > l
 	} else {
-		yyb1535 = r.CheckBreak()
+		yyb1539 = r.CheckBreak()
 	}
-	if yyb1535 {
+	if yyb1539 {
 		r.ReadEnd()
 		return
 	}
@@ -19104,20 +19134,20 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.RunAsUser == nil {
 			x.RunAsUser = new(int64)
 		}
-		yym1541 := z.DecBinary()
-		_ = yym1541
+		yym1545 := z.DecBinary()
+		_ = yym1545
 		if false {
 		} else {
 			*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj1535++
-	if yyhl1535 {
-		yyb1535 = yyj1535 > l
+	yyj1539++
+	if yyhl1539 {
+		yyb1539 = yyj1539 > l
 	} else {
-		yyb1535 = r.CheckBreak()
+		yyb1539 = r.CheckBreak()
 	}
-	if yyb1535 {
+	if yyb1539 {
 		r.ReadEnd()
 		return
 	}
@@ -19129,41 +19159,41 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.RunAsNonRoot == nil {
 			x.RunAsNonRoot = new(bool)
 		}
-		yym1543 := z.DecBinary()
-		_ = yym1543
+		yym1547 := z.DecBinary()
+		_ = yym1547
 		if false {
 		} else {
 			*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 		}
 	}
-	yyj1535++
-	if yyhl1535 {
-		yyb1535 = yyj1535 > l
+	yyj1539++
+	if yyhl1539 {
+		yyb1539 = yyj1539 > l
 	} else {
-		yyb1535 = r.CheckBreak()
+		yyb1539 = r.CheckBreak()
 	}
-	if yyb1535 {
+	if yyb1539 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SupplementalGroups = nil
 	} else {
-		yyv1544 := &x.SupplementalGroups
-		yym1545 := z.DecBinary()
-		_ = yym1545
+		yyv1548 := &x.SupplementalGroups
+		yym1549 := z.DecBinary()
+		_ = yym1549
 		if false {
 		} else {
-			z.F.DecSliceInt64X(yyv1544, false, d)
+			z.F.DecSliceInt64X(yyv1548, false, d)
 		}
 	}
-	yyj1535++
-	if yyhl1535 {
-		yyb1535 = yyj1535 > l
+	yyj1539++
+	if yyhl1539 {
+		yyb1539 = yyj1539 > l
 	} else {
-		yyb1535 = r.CheckBreak()
+		yyb1539 = r.CheckBreak()
 	}
-	if yyb1535 {
+	if yyb1539 {
 		r.ReadEnd()
 		return
 	}
@@ -19175,24 +19205,24 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.FSGroup == nil {
 			x.FSGroup = new(int64)
 		}
-		yym1547 := z.DecBinary()
-		_ = yym1547
+		yym1551 := z.DecBinary()
+		_ = yym1551
 		if false {
 		} else {
 			*((*int64)(x.FSGroup)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj1535++
-		if yyhl1535 {
-			yyb1535 = yyj1535 > l
+		yyj1539++
+		if yyhl1539 {
+			yyb1539 = yyj1539 > l
 		} else {
-			yyb1535 = r.CheckBreak()
+			yyb1539 = r.CheckBreak()
 		}
-		if yyb1535 {
+		if yyb1539 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1535-1, "")
+		z.DecStructFieldNotFound(yyj1539-1, "")
 	}
 	r.ReadEnd()
 }
@@ -19204,54 +19234,54 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1548 := z.EncBinary()
-		_ = yym1548
+		yym1552 := z.EncBinary()
+		_ = yym1552
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1549 := !z.EncBinary()
-			yy2arr1549 := z.EncBasicHandle().StructToArray
-			var yyq1549 [8]bool
-			_, _, _ = yysep1549, yyq1549, yy2arr1549
-			const yyr1549 bool = false
-			yyq1549[0] = x.Phase != ""
-			yyq1549[1] = len(x.Conditions) != 0
-			yyq1549[2] = x.Message != ""
-			yyq1549[3] = x.Reason != ""
-			yyq1549[4] = x.HostIP != ""
-			yyq1549[5] = x.PodIP != ""
-			yyq1549[6] = x.StartTime != nil
-			yyq1549[7] = len(x.ContainerStatuses) != 0
-			if yyr1549 || yy2arr1549 {
+			yysep1553 := !z.EncBinary()
+			yy2arr1553 := z.EncBasicHandle().StructToArray
+			var yyq1553 [8]bool
+			_, _, _ = yysep1553, yyq1553, yy2arr1553
+			const yyr1553 bool = false
+			yyq1553[0] = x.Phase != ""
+			yyq1553[1] = len(x.Conditions) != 0
+			yyq1553[2] = x.Message != ""
+			yyq1553[3] = x.Reason != ""
+			yyq1553[4] = x.HostIP != ""
+			yyq1553[5] = x.PodIP != ""
+			yyq1553[6] = x.StartTime != nil
+			yyq1553[7] = len(x.ContainerStatuses) != 0
+			if yyr1553 || yy2arr1553 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1549 int = 0
-				for _, b := range yyq1549 {
+				var yynn1553 int = 0
+				for _, b := range yyq1553 {
 					if b {
-						yynn1549++
+						yynn1553++
 					}
 				}
-				r.EncodeMapStart(yynn1549)
+				r.EncodeMapStart(yynn1553)
 			}
-			if yyr1549 || yy2arr1549 {
-				if yyq1549[0] {
+			if yyr1553 || yy2arr1553 {
+				if yyq1553[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1549[0] {
+				if yyq1553[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1549 || yy2arr1549 {
-				if yyq1549[1] {
+			if yyr1553 || yy2arr1553 {
+				if yyq1553[1] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym1552 := z.EncBinary()
-						_ = yym1552
+						yym1556 := z.EncBinary()
+						_ = yym1556
 						if false {
 						} else {
 							h.encSlicePodCondition(([]PodCondition)(x.Conditions), e)
@@ -19261,13 +19291,13 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1549[1] {
+				if yyq1553[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym1553 := z.EncBinary()
-						_ = yym1553
+						yym1557 := z.EncBinary()
+						_ = yym1557
 						if false {
 						} else {
 							h.encSlicePodCondition(([]PodCondition)(x.Conditions), e)
@@ -19275,76 +19305,76 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1549 || yy2arr1549 {
-				if yyq1549[2] {
-					yym1555 := z.EncBinary()
-					_ = yym1555
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1549[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym1556 := z.EncBinary()
-					_ = yym1556
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
-				}
-			}
-			if yyr1549 || yy2arr1549 {
-				if yyq1549[3] {
-					yym1558 := z.EncBinary()
-					_ = yym1558
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1549[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+			if yyr1553 || yy2arr1553 {
+				if yyq1553[2] {
 					yym1559 := z.EncBinary()
 					_ = yym1559
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				}
-			}
-			if yyr1549 || yy2arr1549 {
-				if yyq1549[4] {
-					yym1561 := z.EncBinary()
-					_ = yym1561
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.HostIP))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1549[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("hostIP"))
+				if yyq1553[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					yym1560 := z.EncBinary()
+					_ = yym1560
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
+					}
+				}
+			}
+			if yyr1553 || yy2arr1553 {
+				if yyq1553[3] {
 					yym1562 := z.EncBinary()
 					_ = yym1562
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1553[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					yym1563 := z.EncBinary()
+					_ = yym1563
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				}
+			}
+			if yyr1553 || yy2arr1553 {
+				if yyq1553[4] {
+					yym1565 := z.EncBinary()
+					_ = yym1565
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.HostIP))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1553[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("hostIP"))
+					yym1566 := z.EncBinary()
+					_ = yym1566
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.HostIP))
 					}
 				}
 			}
-			if yyr1549 || yy2arr1549 {
-				if yyq1549[5] {
-					yym1564 := z.EncBinary()
-					_ = yym1564
+			if yyr1553 || yy2arr1553 {
+				if yyq1553[5] {
+					yym1568 := z.EncBinary()
+					_ = yym1568
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.PodIP))
@@ -19353,87 +19383,87 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1549[5] {
+				if yyq1553[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("podIP"))
-					yym1565 := z.EncBinary()
-					_ = yym1565
+					yym1569 := z.EncBinary()
+					_ = yym1569
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.PodIP))
 					}
 				}
 			}
-			if yyr1549 || yy2arr1549 {
-				if yyq1549[6] {
+			if yyr1553 || yy2arr1553 {
+				if yyq1553[6] {
 					if x.StartTime == nil {
-						r.EncodeNil()
-					} else {
-						yym1567 := z.EncBinary()
-						_ = yym1567
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym1567 {
-							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym1567 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.StartTime)
-						} else {
-							z.EncFallback(x.StartTime)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1549[6] {
-					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
-					if x.StartTime == nil {
-						r.EncodeNil()
-					} else {
-						yym1568 := z.EncBinary()
-						_ = yym1568
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym1568 {
-							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym1568 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.StartTime)
-						} else {
-							z.EncFallback(x.StartTime)
-						}
-					}
-				}
-			}
-			if yyr1549 || yy2arr1549 {
-				if yyq1549[7] {
-					if x.ContainerStatuses == nil {
-						r.EncodeNil()
-					} else {
-						yym1570 := z.EncBinary()
-						_ = yym1570
-						if false {
-						} else {
-							h.encSliceContainerStatus(([]ContainerStatus)(x.ContainerStatuses), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1549[7] {
-					r.EncodeString(codecSelferC_UTF81234, string("containerStatuses"))
-					if x.ContainerStatuses == nil {
 						r.EncodeNil()
 					} else {
 						yym1571 := z.EncBinary()
 						_ = yym1571
 						if false {
+						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
+						} else if yym1571 {
+							z.EncBinaryMarshal(x.StartTime)
+						} else if !yym1571 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.StartTime)
+						} else {
+							z.EncFallback(x.StartTime)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1553[6] {
+					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
+					if x.StartTime == nil {
+						r.EncodeNil()
+					} else {
+						yym1572 := z.EncBinary()
+						_ = yym1572
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
+						} else if yym1572 {
+							z.EncBinaryMarshal(x.StartTime)
+						} else if !yym1572 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.StartTime)
+						} else {
+							z.EncFallback(x.StartTime)
+						}
+					}
+				}
+			}
+			if yyr1553 || yy2arr1553 {
+				if yyq1553[7] {
+					if x.ContainerStatuses == nil {
+						r.EncodeNil()
+					} else {
+						yym1574 := z.EncBinary()
+						_ = yym1574
+						if false {
+						} else {
+							h.encSliceContainerStatus(([]ContainerStatus)(x.ContainerStatuses), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1553[7] {
+					r.EncodeString(codecSelferC_UTF81234, string("containerStatuses"))
+					if x.ContainerStatuses == nil {
+						r.EncodeNil()
+					} else {
+						yym1575 := z.EncBinary()
+						_ = yym1575
+						if false {
 						} else {
 							h.encSliceContainerStatus(([]ContainerStatus)(x.ContainerStatuses), e)
 						}
 					}
 				}
 			}
-			if yysep1549 {
+			if yysep1553 {
 				r.EncodeEnd()
 			}
 		}
@@ -19444,24 +19474,24 @@ func (x *PodStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1572 := z.DecBinary()
-	_ = yym1572
+	yym1576 := z.DecBinary()
+	_ = yym1576
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1573 := r.ReadMapStart()
-			if yyl1573 == 0 {
+			yyl1577 := r.ReadMapStart()
+			if yyl1577 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1573, d)
+				x.codecDecodeSelfFromMap(yyl1577, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1573 := r.ReadArrayStart()
-			if yyl1573 == 0 {
+			yyl1577 := r.ReadArrayStart()
+			if yyl1577 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1573, d)
+				x.codecDecodeSelfFromArray(yyl1577, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -19473,12 +19503,12 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1574Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1574Slc
-	var yyhl1574 bool = l >= 0
-	for yyj1574 := 0; ; yyj1574++ {
-		if yyhl1574 {
-			if yyj1574 >= l {
+	var yys1578Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1578Slc
+	var yyhl1578 bool = l >= 0
+	for yyj1578 := 0; ; yyj1578++ {
+		if yyhl1578 {
+			if yyj1578 >= l {
 				break
 			}
 		} else {
@@ -19486,9 +19516,9 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1574Slc = r.DecodeBytes(yys1574Slc, true, true)
-		yys1574 := string(yys1574Slc)
-		switch yys1574 {
+		yys1578Slc = r.DecodeBytes(yys1578Slc, true, true)
+		yys1578 := string(yys1578Slc)
+		switch yys1578 {
 		case "phase":
 			if r.TryDecodeAsNil() {
 				x.Phase = ""
@@ -19499,12 +19529,12 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv1576 := &x.Conditions
-				yym1577 := z.DecBinary()
-				_ = yym1577
+				yyv1580 := &x.Conditions
+				yym1581 := z.DecBinary()
+				_ = yym1581
 				if false {
 				} else {
-					h.decSlicePodCondition((*[]PodCondition)(yyv1576), d)
+					h.decSlicePodCondition((*[]PodCondition)(yyv1580), d)
 				}
 			}
 		case "message":
@@ -19540,13 +19570,13 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg2_unversioned.Time)
 				}
-				yym1583 := z.DecBinary()
-				_ = yym1583
+				yym1587 := z.DecBinary()
+				_ = yym1587
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym1583 {
+				} else if yym1587 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym1583 && z.IsJSONHandle() {
+				} else if !yym1587 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -19556,19 +19586,19 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ContainerStatuses = nil
 			} else {
-				yyv1584 := &x.ContainerStatuses
-				yym1585 := z.DecBinary()
-				_ = yym1585
+				yyv1588 := &x.ContainerStatuses
+				yym1589 := z.DecBinary()
+				_ = yym1589
 				if false {
 				} else {
-					h.decSliceContainerStatus((*[]ContainerStatus)(yyv1584), d)
+					h.decSliceContainerStatus((*[]ContainerStatus)(yyv1588), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1574)
-		} // end switch yys1574
-	} // end for yyj1574
-	if !yyhl1574 {
+			z.DecStructFieldNotFound(-1, yys1578)
+		} // end switch yys1578
+	} // end for yyj1578
+	if !yyhl1578 {
 		r.ReadEnd()
 	}
 }
@@ -19577,16 +19607,16 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1586 int
-	var yyb1586 bool
-	var yyhl1586 bool = l >= 0
-	yyj1586++
-	if yyhl1586 {
-		yyb1586 = yyj1586 > l
+	var yyj1590 int
+	var yyb1590 bool
+	var yyhl1590 bool = l >= 0
+	yyj1590++
+	if yyhl1590 {
+		yyb1590 = yyj1590 > l
 	} else {
-		yyb1586 = r.CheckBreak()
+		yyb1590 = r.CheckBreak()
 	}
-	if yyb1586 {
+	if yyb1590 {
 		r.ReadEnd()
 		return
 	}
@@ -19595,34 +19625,34 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Phase = PodPhase(r.DecodeString())
 	}
-	yyj1586++
-	if yyhl1586 {
-		yyb1586 = yyj1586 > l
+	yyj1590++
+	if yyhl1590 {
+		yyb1590 = yyj1590 > l
 	} else {
-		yyb1586 = r.CheckBreak()
+		yyb1590 = r.CheckBreak()
 	}
-	if yyb1586 {
+	if yyb1590 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv1588 := &x.Conditions
-		yym1589 := z.DecBinary()
-		_ = yym1589
+		yyv1592 := &x.Conditions
+		yym1593 := z.DecBinary()
+		_ = yym1593
 		if false {
 		} else {
-			h.decSlicePodCondition((*[]PodCondition)(yyv1588), d)
+			h.decSlicePodCondition((*[]PodCondition)(yyv1592), d)
 		}
 	}
-	yyj1586++
-	if yyhl1586 {
-		yyb1586 = yyj1586 > l
+	yyj1590++
+	if yyhl1590 {
+		yyb1590 = yyj1590 > l
 	} else {
-		yyb1586 = r.CheckBreak()
+		yyb1590 = r.CheckBreak()
 	}
-	if yyb1586 {
+	if yyb1590 {
 		r.ReadEnd()
 		return
 	}
@@ -19631,13 +19661,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj1586++
-	if yyhl1586 {
-		yyb1586 = yyj1586 > l
+	yyj1590++
+	if yyhl1590 {
+		yyb1590 = yyj1590 > l
 	} else {
-		yyb1586 = r.CheckBreak()
+		yyb1590 = r.CheckBreak()
 	}
-	if yyb1586 {
+	if yyb1590 {
 		r.ReadEnd()
 		return
 	}
@@ -19646,13 +19676,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj1586++
-	if yyhl1586 {
-		yyb1586 = yyj1586 > l
+	yyj1590++
+	if yyhl1590 {
+		yyb1590 = yyj1590 > l
 	} else {
-		yyb1586 = r.CheckBreak()
+		yyb1590 = r.CheckBreak()
 	}
-	if yyb1586 {
+	if yyb1590 {
 		r.ReadEnd()
 		return
 	}
@@ -19661,13 +19691,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.HostIP = string(r.DecodeString())
 	}
-	yyj1586++
-	if yyhl1586 {
-		yyb1586 = yyj1586 > l
+	yyj1590++
+	if yyhl1590 {
+		yyb1590 = yyj1590 > l
 	} else {
-		yyb1586 = r.CheckBreak()
+		yyb1590 = r.CheckBreak()
 	}
-	if yyb1586 {
+	if yyb1590 {
 		r.ReadEnd()
 		return
 	}
@@ -19676,13 +19706,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.PodIP = string(r.DecodeString())
 	}
-	yyj1586++
-	if yyhl1586 {
-		yyb1586 = yyj1586 > l
+	yyj1590++
+	if yyhl1590 {
+		yyb1590 = yyj1590 > l
 	} else {
-		yyb1586 = r.CheckBreak()
+		yyb1590 = r.CheckBreak()
 	}
-	if yyb1586 {
+	if yyb1590 {
 		r.ReadEnd()
 		return
 	}
@@ -19694,50 +19724,50 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg2_unversioned.Time)
 		}
-		yym1595 := z.DecBinary()
-		_ = yym1595
+		yym1599 := z.DecBinary()
+		_ = yym1599
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym1595 {
+		} else if yym1599 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym1595 && z.IsJSONHandle() {
+		} else if !yym1599 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj1586++
-	if yyhl1586 {
-		yyb1586 = yyj1586 > l
+	yyj1590++
+	if yyhl1590 {
+		yyb1590 = yyj1590 > l
 	} else {
-		yyb1586 = r.CheckBreak()
+		yyb1590 = r.CheckBreak()
 	}
-	if yyb1586 {
+	if yyb1590 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ContainerStatuses = nil
 	} else {
-		yyv1596 := &x.ContainerStatuses
-		yym1597 := z.DecBinary()
-		_ = yym1597
+		yyv1600 := &x.ContainerStatuses
+		yym1601 := z.DecBinary()
+		_ = yym1601
 		if false {
 		} else {
-			h.decSliceContainerStatus((*[]ContainerStatus)(yyv1596), d)
+			h.decSliceContainerStatus((*[]ContainerStatus)(yyv1600), d)
 		}
 	}
 	for {
-		yyj1586++
-		if yyhl1586 {
-			yyb1586 = yyj1586 > l
+		yyj1590++
+		if yyhl1590 {
+			yyb1590 = yyj1590 > l
 		} else {
-			yyb1586 = r.CheckBreak()
+			yyb1590 = r.CheckBreak()
 		}
-		if yyb1586 {
+		if yyb1590 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1586-1, "")
+		z.DecStructFieldNotFound(yyj1590-1, "")
 	}
 	r.ReadEnd()
 }
@@ -19749,104 +19779,104 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1598 := z.EncBinary()
-		_ = yym1598
+		yym1602 := z.EncBinary()
+		_ = yym1602
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1599 := !z.EncBinary()
-			yy2arr1599 := z.EncBasicHandle().StructToArray
-			var yyq1599 [4]bool
-			_, _, _ = yysep1599, yyq1599, yy2arr1599
-			const yyr1599 bool = false
-			yyq1599[0] = x.Kind != ""
-			yyq1599[1] = x.APIVersion != ""
-			yyq1599[2] = true
-			yyq1599[3] = true
-			if yyr1599 || yy2arr1599 {
+			yysep1603 := !z.EncBinary()
+			yy2arr1603 := z.EncBasicHandle().StructToArray
+			var yyq1603 [4]bool
+			_, _, _ = yysep1603, yyq1603, yy2arr1603
+			const yyr1603 bool = false
+			yyq1603[0] = x.Kind != ""
+			yyq1603[1] = x.APIVersion != ""
+			yyq1603[2] = true
+			yyq1603[3] = true
+			if yyr1603 || yy2arr1603 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1599 int = 0
-				for _, b := range yyq1599 {
+				var yynn1603 int = 0
+				for _, b := range yyq1603 {
 					if b {
-						yynn1599++
+						yynn1603++
 					}
 				}
-				r.EncodeMapStart(yynn1599)
+				r.EncodeMapStart(yynn1603)
 			}
-			if yyr1599 || yy2arr1599 {
-				if yyq1599[0] {
-					yym1601 := z.EncBinary()
-					_ = yym1601
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1599[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1602 := z.EncBinary()
-					_ = yym1602
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1599 || yy2arr1599 {
-				if yyq1599[1] {
-					yym1604 := z.EncBinary()
-					_ = yym1604
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1599[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr1603 || yy2arr1603 {
+				if yyq1603[0] {
 					yym1605 := z.EncBinary()
 					_ = yym1605
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1603[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym1606 := z.EncBinary()
+					_ = yym1606
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1603 || yy2arr1603 {
+				if yyq1603[1] {
+					yym1608 := z.EncBinary()
+					_ = yym1608
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1603[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1609 := z.EncBinary()
+					_ = yym1609
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1599 || yy2arr1599 {
-				if yyq1599[2] {
-					yy1607 := &x.ObjectMeta
-					yy1607.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1599[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1608 := &x.ObjectMeta
-					yy1608.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1599 || yy2arr1599 {
-				if yyq1599[3] {
-					yy1610 := &x.Status
-					yy1610.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1599[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy1611 := &x.Status
+			if yyr1603 || yy2arr1603 {
+				if yyq1603[2] {
+					yy1611 := &x.ObjectMeta
 					yy1611.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1603[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1612 := &x.ObjectMeta
+					yy1612.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1599 {
+			if yyr1603 || yy2arr1603 {
+				if yyq1603[3] {
+					yy1614 := &x.Status
+					yy1614.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1603[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy1615 := &x.Status
+					yy1615.CodecEncodeSelf(e)
+				}
+			}
+			if yysep1603 {
 				r.EncodeEnd()
 			}
 		}
@@ -19857,24 +19887,24 @@ func (x *PodStatusResult) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1612 := z.DecBinary()
-	_ = yym1612
+	yym1616 := z.DecBinary()
+	_ = yym1616
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1613 := r.ReadMapStart()
-			if yyl1613 == 0 {
+			yyl1617 := r.ReadMapStart()
+			if yyl1617 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1613, d)
+				x.codecDecodeSelfFromMap(yyl1617, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1613 := r.ReadArrayStart()
-			if yyl1613 == 0 {
+			yyl1617 := r.ReadArrayStart()
+			if yyl1617 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1613, d)
+				x.codecDecodeSelfFromArray(yyl1617, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -19886,12 +19916,12 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1614Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1614Slc
-	var yyhl1614 bool = l >= 0
-	for yyj1614 := 0; ; yyj1614++ {
-		if yyhl1614 {
-			if yyj1614 >= l {
+	var yys1618Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1618Slc
+	var yyhl1618 bool = l >= 0
+	for yyj1618 := 0; ; yyj1618++ {
+		if yyhl1618 {
+			if yyj1618 >= l {
 				break
 			}
 		} else {
@@ -19899,9 +19929,9 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1614Slc = r.DecodeBytes(yys1614Slc, true, true)
-		yys1614 := string(yys1614Slc)
-		switch yys1614 {
+		yys1618Slc = r.DecodeBytes(yys1618Slc, true, true)
+		yys1618 := string(yys1618Slc)
+		switch yys1618 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -19918,21 +19948,21 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1617 := &x.ObjectMeta
-				yyv1617.CodecDecodeSelf(d)
+				yyv1621 := &x.ObjectMeta
+				yyv1621.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = PodStatus{}
 			} else {
-				yyv1618 := &x.Status
-				yyv1618.CodecDecodeSelf(d)
+				yyv1622 := &x.Status
+				yyv1622.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1614)
-		} // end switch yys1614
-	} // end for yyj1614
-	if !yyhl1614 {
+			z.DecStructFieldNotFound(-1, yys1618)
+		} // end switch yys1618
+	} // end for yyj1618
+	if !yyhl1618 {
 		r.ReadEnd()
 	}
 }
@@ -19941,16 +19971,16 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1619 int
-	var yyb1619 bool
-	var yyhl1619 bool = l >= 0
-	yyj1619++
-	if yyhl1619 {
-		yyb1619 = yyj1619 > l
+	var yyj1623 int
+	var yyb1623 bool
+	var yyhl1623 bool = l >= 0
+	yyj1623++
+	if yyhl1623 {
+		yyb1623 = yyj1623 > l
 	} else {
-		yyb1619 = r.CheckBreak()
+		yyb1623 = r.CheckBreak()
 	}
-	if yyb1619 {
+	if yyb1623 {
 		r.ReadEnd()
 		return
 	}
@@ -19959,13 +19989,13 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1619++
-	if yyhl1619 {
-		yyb1619 = yyj1619 > l
+	yyj1623++
+	if yyhl1623 {
+		yyb1623 = yyj1623 > l
 	} else {
-		yyb1619 = r.CheckBreak()
+		yyb1623 = r.CheckBreak()
 	}
-	if yyb1619 {
+	if yyb1623 {
 		r.ReadEnd()
 		return
 	}
@@ -19974,49 +20004,49 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1619++
-	if yyhl1619 {
-		yyb1619 = yyj1619 > l
+	yyj1623++
+	if yyhl1623 {
+		yyb1623 = yyj1623 > l
 	} else {
-		yyb1619 = r.CheckBreak()
+		yyb1623 = r.CheckBreak()
 	}
-	if yyb1619 {
+	if yyb1623 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1622 := &x.ObjectMeta
-		yyv1622.CodecDecodeSelf(d)
+		yyv1626 := &x.ObjectMeta
+		yyv1626.CodecDecodeSelf(d)
 	}
-	yyj1619++
-	if yyhl1619 {
-		yyb1619 = yyj1619 > l
+	yyj1623++
+	if yyhl1623 {
+		yyb1623 = yyj1623 > l
 	} else {
-		yyb1619 = r.CheckBreak()
+		yyb1623 = r.CheckBreak()
 	}
-	if yyb1619 {
+	if yyb1623 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = PodStatus{}
 	} else {
-		yyv1623 := &x.Status
-		yyv1623.CodecDecodeSelf(d)
+		yyv1627 := &x.Status
+		yyv1627.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1619++
-		if yyhl1619 {
-			yyb1619 = yyj1619 > l
+		yyj1623++
+		if yyhl1623 {
+			yyb1623 = yyj1623 > l
 		} else {
-			yyb1619 = r.CheckBreak()
+			yyb1623 = r.CheckBreak()
 		}
-		if yyb1619 {
+		if yyb1623 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1619-1, "")
+		z.DecStructFieldNotFound(yyj1623-1, "")
 	}
 	r.ReadEnd()
 }
@@ -20028,119 +20058,119 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1624 := z.EncBinary()
-		_ = yym1624
+		yym1628 := z.EncBinary()
+		_ = yym1628
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1625 := !z.EncBinary()
-			yy2arr1625 := z.EncBasicHandle().StructToArray
-			var yyq1625 [5]bool
-			_, _, _ = yysep1625, yyq1625, yy2arr1625
-			const yyr1625 bool = false
-			yyq1625[0] = x.Kind != ""
-			yyq1625[1] = x.APIVersion != ""
-			yyq1625[2] = true
-			yyq1625[3] = true
-			yyq1625[4] = true
-			if yyr1625 || yy2arr1625 {
+			yysep1629 := !z.EncBinary()
+			yy2arr1629 := z.EncBasicHandle().StructToArray
+			var yyq1629 [5]bool
+			_, _, _ = yysep1629, yyq1629, yy2arr1629
+			const yyr1629 bool = false
+			yyq1629[0] = x.Kind != ""
+			yyq1629[1] = x.APIVersion != ""
+			yyq1629[2] = true
+			yyq1629[3] = true
+			yyq1629[4] = true
+			if yyr1629 || yy2arr1629 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1625 int = 0
-				for _, b := range yyq1625 {
+				var yynn1629 int = 0
+				for _, b := range yyq1629 {
 					if b {
-						yynn1625++
+						yynn1629++
 					}
 				}
-				r.EncodeMapStart(yynn1625)
+				r.EncodeMapStart(yynn1629)
 			}
-			if yyr1625 || yy2arr1625 {
-				if yyq1625[0] {
-					yym1627 := z.EncBinary()
-					_ = yym1627
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1625[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1628 := z.EncBinary()
-					_ = yym1628
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1625 || yy2arr1625 {
-				if yyq1625[1] {
-					yym1630 := z.EncBinary()
-					_ = yym1630
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1625[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr1629 || yy2arr1629 {
+				if yyq1629[0] {
 					yym1631 := z.EncBinary()
 					_ = yym1631
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1629[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym1632 := z.EncBinary()
+					_ = yym1632
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1629 || yy2arr1629 {
+				if yyq1629[1] {
+					yym1634 := z.EncBinary()
+					_ = yym1634
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1629[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1635 := z.EncBinary()
+					_ = yym1635
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1625 || yy2arr1625 {
-				if yyq1625[2] {
-					yy1633 := &x.ObjectMeta
-					yy1633.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1625[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1634 := &x.ObjectMeta
-					yy1634.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1625 || yy2arr1625 {
-				if yyq1625[3] {
-					yy1636 := &x.Spec
-					yy1636.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1625[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1637 := &x.Spec
+			if yyr1629 || yy2arr1629 {
+				if yyq1629[2] {
+					yy1637 := &x.ObjectMeta
 					yy1637.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1625 || yy2arr1625 {
-				if yyq1625[4] {
-					yy1639 := &x.Status
-					yy1639.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1625[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy1640 := &x.Status
-					yy1640.CodecEncodeSelf(e)
+				if yyq1629[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1638 := &x.ObjectMeta
+					yy1638.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1625 {
+			if yyr1629 || yy2arr1629 {
+				if yyq1629[3] {
+					yy1640 := &x.Spec
+					yy1640.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1629[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy1641 := &x.Spec
+					yy1641.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1629 || yy2arr1629 {
+				if yyq1629[4] {
+					yy1643 := &x.Status
+					yy1643.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1629[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy1644 := &x.Status
+					yy1644.CodecEncodeSelf(e)
+				}
+			}
+			if yysep1629 {
 				r.EncodeEnd()
 			}
 		}
@@ -20151,24 +20181,24 @@ func (x *Pod) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1641 := z.DecBinary()
-	_ = yym1641
+	yym1645 := z.DecBinary()
+	_ = yym1645
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1642 := r.ReadMapStart()
-			if yyl1642 == 0 {
+			yyl1646 := r.ReadMapStart()
+			if yyl1646 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1642, d)
+				x.codecDecodeSelfFromMap(yyl1646, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1642 := r.ReadArrayStart()
-			if yyl1642 == 0 {
+			yyl1646 := r.ReadArrayStart()
+			if yyl1646 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1642, d)
+				x.codecDecodeSelfFromArray(yyl1646, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -20180,12 +20210,12 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1643Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1643Slc
-	var yyhl1643 bool = l >= 0
-	for yyj1643 := 0; ; yyj1643++ {
-		if yyhl1643 {
-			if yyj1643 >= l {
+	var yys1647Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1647Slc
+	var yyhl1647 bool = l >= 0
+	for yyj1647 := 0; ; yyj1647++ {
+		if yyhl1647 {
+			if yyj1647 >= l {
 				break
 			}
 		} else {
@@ -20193,9 +20223,9 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1643Slc = r.DecodeBytes(yys1643Slc, true, true)
-		yys1643 := string(yys1643Slc)
-		switch yys1643 {
+		yys1647Slc = r.DecodeBytes(yys1647Slc, true, true)
+		yys1647 := string(yys1647Slc)
+		switch yys1647 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -20212,28 +20242,28 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1646 := &x.ObjectMeta
-				yyv1646.CodecDecodeSelf(d)
+				yyv1650 := &x.ObjectMeta
+				yyv1650.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = PodSpec{}
 			} else {
-				yyv1647 := &x.Spec
-				yyv1647.CodecDecodeSelf(d)
+				yyv1651 := &x.Spec
+				yyv1651.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = PodStatus{}
 			} else {
-				yyv1648 := &x.Status
-				yyv1648.CodecDecodeSelf(d)
+				yyv1652 := &x.Status
+				yyv1652.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1643)
-		} // end switch yys1643
-	} // end for yyj1643
-	if !yyhl1643 {
+			z.DecStructFieldNotFound(-1, yys1647)
+		} // end switch yys1647
+	} // end for yyj1647
+	if !yyhl1647 {
 		r.ReadEnd()
 	}
 }
@@ -20242,16 +20272,16 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1649 int
-	var yyb1649 bool
-	var yyhl1649 bool = l >= 0
-	yyj1649++
-	if yyhl1649 {
-		yyb1649 = yyj1649 > l
+	var yyj1653 int
+	var yyb1653 bool
+	var yyhl1653 bool = l >= 0
+	yyj1653++
+	if yyhl1653 {
+		yyb1653 = yyj1653 > l
 	} else {
-		yyb1649 = r.CheckBreak()
+		yyb1653 = r.CheckBreak()
 	}
-	if yyb1649 {
+	if yyb1653 {
 		r.ReadEnd()
 		return
 	}
@@ -20260,13 +20290,13 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1649++
-	if yyhl1649 {
-		yyb1649 = yyj1649 > l
+	yyj1653++
+	if yyhl1653 {
+		yyb1653 = yyj1653 > l
 	} else {
-		yyb1649 = r.CheckBreak()
+		yyb1653 = r.CheckBreak()
 	}
-	if yyb1649 {
+	if yyb1653 {
 		r.ReadEnd()
 		return
 	}
@@ -20275,65 +20305,65 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1649++
-	if yyhl1649 {
-		yyb1649 = yyj1649 > l
+	yyj1653++
+	if yyhl1653 {
+		yyb1653 = yyj1653 > l
 	} else {
-		yyb1649 = r.CheckBreak()
+		yyb1653 = r.CheckBreak()
 	}
-	if yyb1649 {
+	if yyb1653 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1652 := &x.ObjectMeta
-		yyv1652.CodecDecodeSelf(d)
+		yyv1656 := &x.ObjectMeta
+		yyv1656.CodecDecodeSelf(d)
 	}
-	yyj1649++
-	if yyhl1649 {
-		yyb1649 = yyj1649 > l
+	yyj1653++
+	if yyhl1653 {
+		yyb1653 = yyj1653 > l
 	} else {
-		yyb1649 = r.CheckBreak()
+		yyb1653 = r.CheckBreak()
 	}
-	if yyb1649 {
+	if yyb1653 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSpec{}
 	} else {
-		yyv1653 := &x.Spec
-		yyv1653.CodecDecodeSelf(d)
+		yyv1657 := &x.Spec
+		yyv1657.CodecDecodeSelf(d)
 	}
-	yyj1649++
-	if yyhl1649 {
-		yyb1649 = yyj1649 > l
+	yyj1653++
+	if yyhl1653 {
+		yyb1653 = yyj1653 > l
 	} else {
-		yyb1649 = r.CheckBreak()
+		yyb1653 = r.CheckBreak()
 	}
-	if yyb1649 {
+	if yyb1653 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = PodStatus{}
 	} else {
-		yyv1654 := &x.Status
-		yyv1654.CodecDecodeSelf(d)
+		yyv1658 := &x.Status
+		yyv1658.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1649++
-		if yyhl1649 {
-			yyb1649 = yyj1649 > l
+		yyj1653++
+		if yyhl1653 {
+			yyb1653 = yyj1653 > l
 		} else {
-			yyb1649 = r.CheckBreak()
+			yyb1653 = r.CheckBreak()
 		}
-		if yyb1649 {
+		if yyb1653 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1649-1, "")
+		z.DecStructFieldNotFound(yyj1653-1, "")
 	}
 	r.ReadEnd()
 }
@@ -20345,58 +20375,58 @@ func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1655 := z.EncBinary()
-		_ = yym1655
+		yym1659 := z.EncBinary()
+		_ = yym1659
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1656 := !z.EncBinary()
-			yy2arr1656 := z.EncBasicHandle().StructToArray
-			var yyq1656 [2]bool
-			_, _, _ = yysep1656, yyq1656, yy2arr1656
-			const yyr1656 bool = false
-			yyq1656[0] = true
-			yyq1656[1] = true
-			if yyr1656 || yy2arr1656 {
+			yysep1660 := !z.EncBinary()
+			yy2arr1660 := z.EncBasicHandle().StructToArray
+			var yyq1660 [2]bool
+			_, _, _ = yysep1660, yyq1660, yy2arr1660
+			const yyr1660 bool = false
+			yyq1660[0] = true
+			yyq1660[1] = true
+			if yyr1660 || yy2arr1660 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1656 int = 0
-				for _, b := range yyq1656 {
+				var yynn1660 int = 0
+				for _, b := range yyq1660 {
 					if b {
-						yynn1656++
+						yynn1660++
 					}
 				}
-				r.EncodeMapStart(yynn1656)
+				r.EncodeMapStart(yynn1660)
 			}
-			if yyr1656 || yy2arr1656 {
-				if yyq1656[0] {
-					yy1658 := &x.ObjectMeta
-					yy1658.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1656[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1659 := &x.ObjectMeta
-					yy1659.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1656 || yy2arr1656 {
-				if yyq1656[1] {
-					yy1661 := &x.Spec
-					yy1661.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1656[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1662 := &x.Spec
+			if yyr1660 || yy2arr1660 {
+				if yyq1660[0] {
+					yy1662 := &x.ObjectMeta
 					yy1662.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1660[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1663 := &x.ObjectMeta
+					yy1663.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1656 {
+			if yyr1660 || yy2arr1660 {
+				if yyq1660[1] {
+					yy1665 := &x.Spec
+					yy1665.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1660[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy1666 := &x.Spec
+					yy1666.CodecEncodeSelf(e)
+				}
+			}
+			if yysep1660 {
 				r.EncodeEnd()
 			}
 		}
@@ -20407,24 +20437,24 @@ func (x *PodTemplateSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1663 := z.DecBinary()
-	_ = yym1663
+	yym1667 := z.DecBinary()
+	_ = yym1667
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1664 := r.ReadMapStart()
-			if yyl1664 == 0 {
+			yyl1668 := r.ReadMapStart()
+			if yyl1668 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1664, d)
+				x.codecDecodeSelfFromMap(yyl1668, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1664 := r.ReadArrayStart()
-			if yyl1664 == 0 {
+			yyl1668 := r.ReadArrayStart()
+			if yyl1668 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1664, d)
+				x.codecDecodeSelfFromArray(yyl1668, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -20436,12 +20466,12 @@ func (x *PodTemplateSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1665Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1665Slc
-	var yyhl1665 bool = l >= 0
-	for yyj1665 := 0; ; yyj1665++ {
-		if yyhl1665 {
-			if yyj1665 >= l {
+	var yys1669Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1669Slc
+	var yyhl1669 bool = l >= 0
+	for yyj1669 := 0; ; yyj1669++ {
+		if yyhl1669 {
+			if yyj1669 >= l {
 				break
 			}
 		} else {
@@ -20449,28 +20479,28 @@ func (x *PodTemplateSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1665Slc = r.DecodeBytes(yys1665Slc, true, true)
-		yys1665 := string(yys1665Slc)
-		switch yys1665 {
+		yys1669Slc = r.DecodeBytes(yys1669Slc, true, true)
+		yys1669 := string(yys1669Slc)
+		switch yys1669 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1666 := &x.ObjectMeta
-				yyv1666.CodecDecodeSelf(d)
+				yyv1670 := &x.ObjectMeta
+				yyv1670.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = PodSpec{}
 			} else {
-				yyv1667 := &x.Spec
-				yyv1667.CodecDecodeSelf(d)
+				yyv1671 := &x.Spec
+				yyv1671.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1665)
-		} // end switch yys1665
-	} // end for yyj1665
-	if !yyhl1665 {
+			z.DecStructFieldNotFound(-1, yys1669)
+		} // end switch yys1669
+	} // end for yyj1669
+	if !yyhl1669 {
 		r.ReadEnd()
 	}
 }
@@ -20479,52 +20509,52 @@ func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1668 int
-	var yyb1668 bool
-	var yyhl1668 bool = l >= 0
-	yyj1668++
-	if yyhl1668 {
-		yyb1668 = yyj1668 > l
+	var yyj1672 int
+	var yyb1672 bool
+	var yyhl1672 bool = l >= 0
+	yyj1672++
+	if yyhl1672 {
+		yyb1672 = yyj1672 > l
 	} else {
-		yyb1668 = r.CheckBreak()
+		yyb1672 = r.CheckBreak()
 	}
-	if yyb1668 {
+	if yyb1672 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1669 := &x.ObjectMeta
-		yyv1669.CodecDecodeSelf(d)
+		yyv1673 := &x.ObjectMeta
+		yyv1673.CodecDecodeSelf(d)
 	}
-	yyj1668++
-	if yyhl1668 {
-		yyb1668 = yyj1668 > l
+	yyj1672++
+	if yyhl1672 {
+		yyb1672 = yyj1672 > l
 	} else {
-		yyb1668 = r.CheckBreak()
+		yyb1672 = r.CheckBreak()
 	}
-	if yyb1668 {
+	if yyb1672 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSpec{}
 	} else {
-		yyv1670 := &x.Spec
-		yyv1670.CodecDecodeSelf(d)
+		yyv1674 := &x.Spec
+		yyv1674.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1668++
-		if yyhl1668 {
-			yyb1668 = yyj1668 > l
+		yyj1672++
+		if yyhl1672 {
+			yyb1672 = yyj1672 > l
 		} else {
-			yyb1668 = r.CheckBreak()
+			yyb1672 = r.CheckBreak()
 		}
-		if yyb1668 {
+		if yyb1672 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1668-1, "")
+		z.DecStructFieldNotFound(yyj1672-1, "")
 	}
 	r.ReadEnd()
 }
@@ -20536,104 +20566,104 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1671 := z.EncBinary()
-		_ = yym1671
+		yym1675 := z.EncBinary()
+		_ = yym1675
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1672 := !z.EncBinary()
-			yy2arr1672 := z.EncBasicHandle().StructToArray
-			var yyq1672 [4]bool
-			_, _, _ = yysep1672, yyq1672, yy2arr1672
-			const yyr1672 bool = false
-			yyq1672[0] = x.Kind != ""
-			yyq1672[1] = x.APIVersion != ""
-			yyq1672[2] = true
-			yyq1672[3] = true
-			if yyr1672 || yy2arr1672 {
+			yysep1676 := !z.EncBinary()
+			yy2arr1676 := z.EncBasicHandle().StructToArray
+			var yyq1676 [4]bool
+			_, _, _ = yysep1676, yyq1676, yy2arr1676
+			const yyr1676 bool = false
+			yyq1676[0] = x.Kind != ""
+			yyq1676[1] = x.APIVersion != ""
+			yyq1676[2] = true
+			yyq1676[3] = true
+			if yyr1676 || yy2arr1676 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1672 int = 0
-				for _, b := range yyq1672 {
+				var yynn1676 int = 0
+				for _, b := range yyq1676 {
 					if b {
-						yynn1672++
+						yynn1676++
 					}
 				}
-				r.EncodeMapStart(yynn1672)
+				r.EncodeMapStart(yynn1676)
 			}
-			if yyr1672 || yy2arr1672 {
-				if yyq1672[0] {
-					yym1674 := z.EncBinary()
-					_ = yym1674
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1672[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1675 := z.EncBinary()
-					_ = yym1675
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1672 || yy2arr1672 {
-				if yyq1672[1] {
-					yym1677 := z.EncBinary()
-					_ = yym1677
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1672[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr1676 || yy2arr1676 {
+				if yyq1676[0] {
 					yym1678 := z.EncBinary()
 					_ = yym1678
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1676[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym1679 := z.EncBinary()
+					_ = yym1679
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1676 || yy2arr1676 {
+				if yyq1676[1] {
+					yym1681 := z.EncBinary()
+					_ = yym1681
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1676[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1682 := z.EncBinary()
+					_ = yym1682
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1672 || yy2arr1672 {
-				if yyq1672[2] {
-					yy1680 := &x.ObjectMeta
-					yy1680.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1672[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1681 := &x.ObjectMeta
-					yy1681.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1672 || yy2arr1672 {
-				if yyq1672[3] {
-					yy1683 := &x.Template
-					yy1683.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1672[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("template"))
-					yy1684 := &x.Template
+			if yyr1676 || yy2arr1676 {
+				if yyq1676[2] {
+					yy1684 := &x.ObjectMeta
 					yy1684.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1676[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1685 := &x.ObjectMeta
+					yy1685.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1672 {
+			if yyr1676 || yy2arr1676 {
+				if yyq1676[3] {
+					yy1687 := &x.Template
+					yy1687.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1676[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("template"))
+					yy1688 := &x.Template
+					yy1688.CodecEncodeSelf(e)
+				}
+			}
+			if yysep1676 {
 				r.EncodeEnd()
 			}
 		}
@@ -20644,24 +20674,24 @@ func (x *PodTemplate) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1685 := z.DecBinary()
-	_ = yym1685
+	yym1689 := z.DecBinary()
+	_ = yym1689
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1686 := r.ReadMapStart()
-			if yyl1686 == 0 {
+			yyl1690 := r.ReadMapStart()
+			if yyl1690 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1686, d)
+				x.codecDecodeSelfFromMap(yyl1690, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1686 := r.ReadArrayStart()
-			if yyl1686 == 0 {
+			yyl1690 := r.ReadArrayStart()
+			if yyl1690 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1686, d)
+				x.codecDecodeSelfFromArray(yyl1690, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -20673,12 +20703,12 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1687Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1687Slc
-	var yyhl1687 bool = l >= 0
-	for yyj1687 := 0; ; yyj1687++ {
-		if yyhl1687 {
-			if yyj1687 >= l {
+	var yys1691Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1691Slc
+	var yyhl1691 bool = l >= 0
+	for yyj1691 := 0; ; yyj1691++ {
+		if yyhl1691 {
+			if yyj1691 >= l {
 				break
 			}
 		} else {
@@ -20686,9 +20716,9 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1687Slc = r.DecodeBytes(yys1687Slc, true, true)
-		yys1687 := string(yys1687Slc)
-		switch yys1687 {
+		yys1691Slc = r.DecodeBytes(yys1691Slc, true, true)
+		yys1691 := string(yys1691Slc)
+		switch yys1691 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -20705,21 +20735,21 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1690 := &x.ObjectMeta
-				yyv1690.CodecDecodeSelf(d)
+				yyv1694 := &x.ObjectMeta
+				yyv1694.CodecDecodeSelf(d)
 			}
 		case "template":
 			if r.TryDecodeAsNil() {
 				x.Template = PodTemplateSpec{}
 			} else {
-				yyv1691 := &x.Template
-				yyv1691.CodecDecodeSelf(d)
+				yyv1695 := &x.Template
+				yyv1695.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1687)
-		} // end switch yys1687
-	} // end for yyj1687
-	if !yyhl1687 {
+			z.DecStructFieldNotFound(-1, yys1691)
+		} // end switch yys1691
+	} // end for yyj1691
+	if !yyhl1691 {
 		r.ReadEnd()
 	}
 }
@@ -20728,16 +20758,16 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1692 int
-	var yyb1692 bool
-	var yyhl1692 bool = l >= 0
-	yyj1692++
-	if yyhl1692 {
-		yyb1692 = yyj1692 > l
+	var yyj1696 int
+	var yyb1696 bool
+	var yyhl1696 bool = l >= 0
+	yyj1696++
+	if yyhl1696 {
+		yyb1696 = yyj1696 > l
 	} else {
-		yyb1692 = r.CheckBreak()
+		yyb1696 = r.CheckBreak()
 	}
-	if yyb1692 {
+	if yyb1696 {
 		r.ReadEnd()
 		return
 	}
@@ -20746,13 +20776,13 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1692++
-	if yyhl1692 {
-		yyb1692 = yyj1692 > l
+	yyj1696++
+	if yyhl1696 {
+		yyb1696 = yyj1696 > l
 	} else {
-		yyb1692 = r.CheckBreak()
+		yyb1696 = r.CheckBreak()
 	}
-	if yyb1692 {
+	if yyb1696 {
 		r.ReadEnd()
 		return
 	}
@@ -20761,49 +20791,49 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1692++
-	if yyhl1692 {
-		yyb1692 = yyj1692 > l
+	yyj1696++
+	if yyhl1696 {
+		yyb1696 = yyj1696 > l
 	} else {
-		yyb1692 = r.CheckBreak()
+		yyb1696 = r.CheckBreak()
 	}
-	if yyb1692 {
+	if yyb1696 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1695 := &x.ObjectMeta
-		yyv1695.CodecDecodeSelf(d)
+		yyv1699 := &x.ObjectMeta
+		yyv1699.CodecDecodeSelf(d)
 	}
-	yyj1692++
-	if yyhl1692 {
-		yyb1692 = yyj1692 > l
+	yyj1696++
+	if yyhl1696 {
+		yyb1696 = yyj1696 > l
 	} else {
-		yyb1692 = r.CheckBreak()
+		yyb1696 = r.CheckBreak()
 	}
-	if yyb1692 {
+	if yyb1696 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = PodTemplateSpec{}
 	} else {
-		yyv1696 := &x.Template
-		yyv1696.CodecDecodeSelf(d)
+		yyv1700 := &x.Template
+		yyv1700.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1692++
-		if yyhl1692 {
-			yyb1692 = yyj1692 > l
+		yyj1696++
+		if yyhl1696 {
+			yyb1696 = yyj1696 > l
 		} else {
-			yyb1692 = r.CheckBreak()
+			yyb1696 = r.CheckBreak()
 		}
-		if yyb1692 {
+		if yyb1696 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1692-1, "")
+		z.DecStructFieldNotFound(yyj1696-1, "")
 	}
 	r.ReadEnd()
 }
@@ -20815,106 +20845,106 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1697 := z.EncBinary()
-		_ = yym1697
+		yym1701 := z.EncBinary()
+		_ = yym1701
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1698 := !z.EncBinary()
-			yy2arr1698 := z.EncBasicHandle().StructToArray
-			var yyq1698 [4]bool
-			_, _, _ = yysep1698, yyq1698, yy2arr1698
-			const yyr1698 bool = false
-			yyq1698[0] = x.Kind != ""
-			yyq1698[1] = x.APIVersion != ""
-			yyq1698[2] = true
-			if yyr1698 || yy2arr1698 {
+			yysep1702 := !z.EncBinary()
+			yy2arr1702 := z.EncBasicHandle().StructToArray
+			var yyq1702 [4]bool
+			_, _, _ = yysep1702, yyq1702, yy2arr1702
+			const yyr1702 bool = false
+			yyq1702[0] = x.Kind != ""
+			yyq1702[1] = x.APIVersion != ""
+			yyq1702[2] = true
+			if yyr1702 || yy2arr1702 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1698 int = 1
-				for _, b := range yyq1698 {
+				var yynn1702 int = 1
+				for _, b := range yyq1702 {
 					if b {
-						yynn1698++
+						yynn1702++
 					}
 				}
-				r.EncodeMapStart(yynn1698)
+				r.EncodeMapStart(yynn1702)
 			}
-			if yyr1698 || yy2arr1698 {
-				if yyq1698[0] {
-					yym1700 := z.EncBinary()
-					_ = yym1700
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1698[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1701 := z.EncBinary()
-					_ = yym1701
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1698 || yy2arr1698 {
-				if yyq1698[1] {
-					yym1703 := z.EncBinary()
-					_ = yym1703
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1698[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr1702 || yy2arr1702 {
+				if yyq1702[0] {
 					yym1704 := z.EncBinary()
 					_ = yym1704
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1702[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym1705 := z.EncBinary()
+					_ = yym1705
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1702 || yy2arr1702 {
+				if yyq1702[1] {
+					yym1707 := z.EncBinary()
+					_ = yym1707
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1702[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1708 := z.EncBinary()
+					_ = yym1708
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1698 || yy2arr1698 {
-				if yyq1698[2] {
-					yy1706 := &x.ListMeta
-					yym1707 := z.EncBinary()
-					_ = yym1707
+			if yyr1702 || yy2arr1702 {
+				if yyq1702[2] {
+					yy1710 := &x.ListMeta
+					yym1711 := z.EncBinary()
+					_ = yym1711
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1706) {
+					} else if z.HasExtensions() && z.EncExt(yy1710) {
 					} else {
-						z.EncFallback(yy1706)
+						z.EncFallback(yy1710)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1698[2] {
+				if yyq1702[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1708 := &x.ListMeta
-					yym1709 := z.EncBinary()
-					_ = yym1709
+					yy1712 := &x.ListMeta
+					yym1713 := z.EncBinary()
+					_ = yym1713
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1708) {
+					} else if z.HasExtensions() && z.EncExt(yy1712) {
 					} else {
-						z.EncFallback(yy1708)
+						z.EncFallback(yy1712)
 					}
 				}
 			}
-			if yyr1698 || yy2arr1698 {
+			if yyr1702 || yy2arr1702 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1711 := z.EncBinary()
-					_ = yym1711
+					yym1715 := z.EncBinary()
+					_ = yym1715
 					if false {
 					} else {
 						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
@@ -20925,15 +20955,15 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1712 := z.EncBinary()
-					_ = yym1712
+					yym1716 := z.EncBinary()
+					_ = yym1716
 					if false {
 					} else {
 						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
 					}
 				}
 			}
-			if yysep1698 {
+			if yysep1702 {
 				r.EncodeEnd()
 			}
 		}
@@ -20944,24 +20974,24 @@ func (x *PodTemplateList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1713 := z.DecBinary()
-	_ = yym1713
+	yym1717 := z.DecBinary()
+	_ = yym1717
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1714 := r.ReadMapStart()
-			if yyl1714 == 0 {
+			yyl1718 := r.ReadMapStart()
+			if yyl1718 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1714, d)
+				x.codecDecodeSelfFromMap(yyl1718, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1714 := r.ReadArrayStart()
-			if yyl1714 == 0 {
+			yyl1718 := r.ReadArrayStart()
+			if yyl1718 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1714, d)
+				x.codecDecodeSelfFromArray(yyl1718, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -20973,12 +21003,12 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1715Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1715Slc
-	var yyhl1715 bool = l >= 0
-	for yyj1715 := 0; ; yyj1715++ {
-		if yyhl1715 {
-			if yyj1715 >= l {
+	var yys1719Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1719Slc
+	var yyhl1719 bool = l >= 0
+	for yyj1719 := 0; ; yyj1719++ {
+		if yyhl1719 {
+			if yyj1719 >= l {
 				break
 			}
 		} else {
@@ -20986,9 +21016,9 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1715Slc = r.DecodeBytes(yys1715Slc, true, true)
-		yys1715 := string(yys1715Slc)
-		switch yys1715 {
+		yys1719Slc = r.DecodeBytes(yys1719Slc, true, true)
+		yys1719 := string(yys1719Slc)
+		switch yys1719 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -21005,32 +21035,32 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv1718 := &x.ListMeta
-				yym1719 := z.DecBinary()
-				_ = yym1719
+				yyv1722 := &x.ListMeta
+				yym1723 := z.DecBinary()
+				_ = yym1723
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1718) {
+				} else if z.HasExtensions() && z.DecExt(yyv1722) {
 				} else {
-					z.DecFallback(yyv1718, false)
+					z.DecFallback(yyv1722, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1720 := &x.Items
-				yym1721 := z.DecBinary()
-				_ = yym1721
+				yyv1724 := &x.Items
+				yym1725 := z.DecBinary()
+				_ = yym1725
 				if false {
 				} else {
-					h.decSlicePodTemplate((*[]PodTemplate)(yyv1720), d)
+					h.decSlicePodTemplate((*[]PodTemplate)(yyv1724), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1715)
-		} // end switch yys1715
-	} // end for yyj1715
-	if !yyhl1715 {
+			z.DecStructFieldNotFound(-1, yys1719)
+		} // end switch yys1719
+	} // end for yyj1719
+	if !yyhl1719 {
 		r.ReadEnd()
 	}
 }
@@ -21039,16 +21069,16 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1722 int
-	var yyb1722 bool
-	var yyhl1722 bool = l >= 0
-	yyj1722++
-	if yyhl1722 {
-		yyb1722 = yyj1722 > l
+	var yyj1726 int
+	var yyb1726 bool
+	var yyhl1726 bool = l >= 0
+	yyj1726++
+	if yyhl1726 {
+		yyb1726 = yyj1726 > l
 	} else {
-		yyb1722 = r.CheckBreak()
+		yyb1726 = r.CheckBreak()
 	}
-	if yyb1722 {
+	if yyb1726 {
 		r.ReadEnd()
 		return
 	}
@@ -21057,13 +21087,13 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1722++
-	if yyhl1722 {
-		yyb1722 = yyj1722 > l
+	yyj1726++
+	if yyhl1726 {
+		yyb1726 = yyj1726 > l
 	} else {
-		yyb1722 = r.CheckBreak()
+		yyb1726 = r.CheckBreak()
 	}
-	if yyb1722 {
+	if yyb1726 {
 		r.ReadEnd()
 		return
 	}
@@ -21072,60 +21102,60 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1722++
-	if yyhl1722 {
-		yyb1722 = yyj1722 > l
+	yyj1726++
+	if yyhl1726 {
+		yyb1726 = yyj1726 > l
 	} else {
-		yyb1722 = r.CheckBreak()
+		yyb1726 = r.CheckBreak()
 	}
-	if yyb1722 {
+	if yyb1726 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv1725 := &x.ListMeta
-		yym1726 := z.DecBinary()
-		_ = yym1726
+		yyv1729 := &x.ListMeta
+		yym1730 := z.DecBinary()
+		_ = yym1730
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1725) {
+		} else if z.HasExtensions() && z.DecExt(yyv1729) {
 		} else {
-			z.DecFallback(yyv1725, false)
+			z.DecFallback(yyv1729, false)
 		}
 	}
-	yyj1722++
-	if yyhl1722 {
-		yyb1722 = yyj1722 > l
+	yyj1726++
+	if yyhl1726 {
+		yyb1726 = yyj1726 > l
 	} else {
-		yyb1722 = r.CheckBreak()
+		yyb1726 = r.CheckBreak()
 	}
-	if yyb1722 {
+	if yyb1726 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1727 := &x.Items
-		yym1728 := z.DecBinary()
-		_ = yym1728
+		yyv1731 := &x.Items
+		yym1732 := z.DecBinary()
+		_ = yym1732
 		if false {
 		} else {
-			h.decSlicePodTemplate((*[]PodTemplate)(yyv1727), d)
+			h.decSlicePodTemplate((*[]PodTemplate)(yyv1731), d)
 		}
 	}
 	for {
-		yyj1722++
-		if yyhl1722 {
-			yyb1722 = yyj1722 > l
+		yyj1726++
+		if yyhl1726 {
+			yyb1726 = yyj1726 > l
 		} else {
-			yyb1722 = r.CheckBreak()
+			yyb1726 = r.CheckBreak()
 		}
-		if yyb1722 {
+		if yyb1726 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1722-1, "")
+		z.DecStructFieldNotFound(yyj1726-1, "")
 	}
 	r.ReadEnd()
 }
@@ -21137,50 +21167,50 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1729 := z.EncBinary()
-		_ = yym1729
+		yym1733 := z.EncBinary()
+		_ = yym1733
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1730 := !z.EncBinary()
-			yy2arr1730 := z.EncBasicHandle().StructToArray
-			var yyq1730 [3]bool
-			_, _, _ = yysep1730, yyq1730, yy2arr1730
-			const yyr1730 bool = false
-			yyq1730[2] = x.Template != nil
-			if yyr1730 || yy2arr1730 {
+			yysep1734 := !z.EncBinary()
+			yy2arr1734 := z.EncBasicHandle().StructToArray
+			var yyq1734 [3]bool
+			_, _, _ = yysep1734, yyq1734, yy2arr1734
+			const yyr1734 bool = false
+			yyq1734[2] = x.Template != nil
+			if yyr1734 || yy2arr1734 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1730 int = 2
-				for _, b := range yyq1730 {
+				var yynn1734 int = 2
+				for _, b := range yyq1734 {
 					if b {
-						yynn1730++
+						yynn1734++
 					}
 				}
-				r.EncodeMapStart(yynn1730)
+				r.EncodeMapStart(yynn1734)
 			}
-			if yyr1730 || yy2arr1730 {
-				yym1732 := z.EncBinary()
-				_ = yym1732
+			if yyr1734 || yy2arr1734 {
+				yym1736 := z.EncBinary()
+				_ = yym1736
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-				yym1733 := z.EncBinary()
-				_ = yym1733
+				yym1737 := z.EncBinary()
+				_ = yym1737
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			}
-			if yyr1730 || yy2arr1730 {
+			if yyr1734 || yy2arr1734 {
 				if x.Selector == nil {
 					r.EncodeNil()
 				} else {
-					yym1735 := z.EncBinary()
-					_ = yym1735
+					yym1739 := z.EncBinary()
+					_ = yym1739
 					if false {
 					} else {
 						z.F.EncMapStringStringV(x.Selector, false, e)
@@ -21191,16 +21221,16 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Selector == nil {
 					r.EncodeNil()
 				} else {
-					yym1736 := z.EncBinary()
-					_ = yym1736
+					yym1740 := z.EncBinary()
+					_ = yym1740
 					if false {
 					} else {
 						z.F.EncMapStringStringV(x.Selector, false, e)
 					}
 				}
 			}
-			if yyr1730 || yy2arr1730 {
-				if yyq1730[2] {
+			if yyr1734 || yy2arr1734 {
+				if yyq1734[2] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -21210,7 +21240,7 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1730[2] {
+				if yyq1734[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					if x.Template == nil {
 						r.EncodeNil()
@@ -21219,7 +21249,7 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1730 {
+			if yysep1734 {
 				r.EncodeEnd()
 			}
 		}
@@ -21230,24 +21260,24 @@ func (x *ReplicationControllerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1738 := z.DecBinary()
-	_ = yym1738
+	yym1742 := z.DecBinary()
+	_ = yym1742
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1739 := r.ReadMapStart()
-			if yyl1739 == 0 {
+			yyl1743 := r.ReadMapStart()
+			if yyl1743 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1739, d)
+				x.codecDecodeSelfFromMap(yyl1743, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1739 := r.ReadArrayStart()
-			if yyl1739 == 0 {
+			yyl1743 := r.ReadArrayStart()
+			if yyl1743 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1739, d)
+				x.codecDecodeSelfFromArray(yyl1743, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -21259,12 +21289,12 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1740Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1740Slc
-	var yyhl1740 bool = l >= 0
-	for yyj1740 := 0; ; yyj1740++ {
-		if yyhl1740 {
-			if yyj1740 >= l {
+	var yys1744Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1744Slc
+	var yyhl1744 bool = l >= 0
+	for yyj1744 := 0; ; yyj1744++ {
+		if yyhl1744 {
+			if yyj1744 >= l {
 				break
 			}
 		} else {
@@ -21272,9 +21302,9 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
-		yys1740Slc = r.DecodeBytes(yys1740Slc, true, true)
-		yys1740 := string(yys1740Slc)
-		switch yys1740 {
+		yys1744Slc = r.DecodeBytes(yys1744Slc, true, true)
+		yys1744 := string(yys1744Slc)
+		switch yys1744 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -21285,12 +21315,12 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv1742 := &x.Selector
-				yym1743 := z.DecBinary()
-				_ = yym1743
+				yyv1746 := &x.Selector
+				yym1747 := z.DecBinary()
+				_ = yym1747
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1742, false, d)
+					z.F.DecMapStringStringX(yyv1746, false, d)
 				}
 			}
 		case "template":
@@ -21305,10 +21335,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				x.Template.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1740)
-		} // end switch yys1740
-	} // end for yyj1740
-	if !yyhl1740 {
+			z.DecStructFieldNotFound(-1, yys1744)
+		} // end switch yys1744
+	} // end for yyj1744
+	if !yyhl1744 {
 		r.ReadEnd()
 	}
 }
@@ -21317,16 +21347,16 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1745 int
-	var yyb1745 bool
-	var yyhl1745 bool = l >= 0
-	yyj1745++
-	if yyhl1745 {
-		yyb1745 = yyj1745 > l
+	var yyj1749 int
+	var yyb1749 bool
+	var yyhl1749 bool = l >= 0
+	yyj1749++
+	if yyhl1749 {
+		yyb1749 = yyj1749 > l
 	} else {
-		yyb1745 = r.CheckBreak()
+		yyb1749 = r.CheckBreak()
 	}
-	if yyb1745 {
+	if yyb1749 {
 		r.ReadEnd()
 		return
 	}
@@ -21335,34 +21365,34 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1745++
-	if yyhl1745 {
-		yyb1745 = yyj1745 > l
+	yyj1749++
+	if yyhl1749 {
+		yyb1749 = yyj1749 > l
 	} else {
-		yyb1745 = r.CheckBreak()
+		yyb1749 = r.CheckBreak()
 	}
-	if yyb1745 {
+	if yyb1749 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv1747 := &x.Selector
-		yym1748 := z.DecBinary()
-		_ = yym1748
+		yyv1751 := &x.Selector
+		yym1752 := z.DecBinary()
+		_ = yym1752
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1747, false, d)
+			z.F.DecMapStringStringX(yyv1751, false, d)
 		}
 	}
-	yyj1745++
-	if yyhl1745 {
-		yyb1745 = yyj1745 > l
+	yyj1749++
+	if yyhl1749 {
+		yyb1749 = yyj1749 > l
 	} else {
-		yyb1745 = r.CheckBreak()
+		yyb1749 = r.CheckBreak()
 	}
-	if yyb1745 {
+	if yyb1749 {
 		r.ReadEnd()
 		return
 	}
@@ -21377,16 +21407,16 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		x.Template.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1745++
-		if yyhl1745 {
-			yyb1745 = yyj1745 > l
+		yyj1749++
+		if yyhl1749 {
+			yyb1749 = yyj1749 > l
 		} else {
-			yyb1745 = r.CheckBreak()
+			yyb1749 = r.CheckBreak()
 		}
-		if yyb1745 {
+		if yyb1749 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1745-1, "")
+		z.DecStructFieldNotFound(yyj1749-1, "")
 	}
 	r.ReadEnd()
 }
@@ -21398,48 +21428,48 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1750 := z.EncBinary()
-		_ = yym1750
+		yym1754 := z.EncBinary()
+		_ = yym1754
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1751 := !z.EncBinary()
-			yy2arr1751 := z.EncBasicHandle().StructToArray
-			var yyq1751 [2]bool
-			_, _, _ = yysep1751, yyq1751, yy2arr1751
-			const yyr1751 bool = false
-			yyq1751[1] = x.ObservedGeneration != 0
-			if yyr1751 || yy2arr1751 {
+			yysep1755 := !z.EncBinary()
+			yy2arr1755 := z.EncBasicHandle().StructToArray
+			var yyq1755 [2]bool
+			_, _, _ = yysep1755, yyq1755, yy2arr1755
+			const yyr1755 bool = false
+			yyq1755[1] = x.ObservedGeneration != 0
+			if yyr1755 || yy2arr1755 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1751 int = 1
-				for _, b := range yyq1751 {
+				var yynn1755 int = 1
+				for _, b := range yyq1755 {
 					if b {
-						yynn1751++
+						yynn1755++
 					}
 				}
-				r.EncodeMapStart(yynn1751)
+				r.EncodeMapStart(yynn1755)
 			}
-			if yyr1751 || yy2arr1751 {
-				yym1753 := z.EncBinary()
-				_ = yym1753
+			if yyr1755 || yy2arr1755 {
+				yym1757 := z.EncBinary()
+				_ = yym1757
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-				yym1754 := z.EncBinary()
-				_ = yym1754
+				yym1758 := z.EncBinary()
+				_ = yym1758
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			}
-			if yyr1751 || yy2arr1751 {
-				if yyq1751[1] {
-					yym1756 := z.EncBinary()
-					_ = yym1756
+			if yyr1755 || yy2arr1755 {
+				if yyq1755[1] {
+					yym1760 := z.EncBinary()
+					_ = yym1760
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
@@ -21448,17 +21478,17 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1751[1] {
+				if yyq1755[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
-					yym1757 := z.EncBinary()
-					_ = yym1757
+					yym1761 := z.EncBinary()
+					_ = yym1761
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
 					}
 				}
 			}
-			if yysep1751 {
+			if yysep1755 {
 				r.EncodeEnd()
 			}
 		}
@@ -21469,24 +21499,24 @@ func (x *ReplicationControllerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1758 := z.DecBinary()
-	_ = yym1758
+	yym1762 := z.DecBinary()
+	_ = yym1762
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1759 := r.ReadMapStart()
-			if yyl1759 == 0 {
+			yyl1763 := r.ReadMapStart()
+			if yyl1763 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1759, d)
+				x.codecDecodeSelfFromMap(yyl1763, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1759 := r.ReadArrayStart()
-			if yyl1759 == 0 {
+			yyl1763 := r.ReadArrayStart()
+			if yyl1763 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1759, d)
+				x.codecDecodeSelfFromArray(yyl1763, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -21498,12 +21528,12 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1760Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1760Slc
-	var yyhl1760 bool = l >= 0
-	for yyj1760 := 0; ; yyj1760++ {
-		if yyhl1760 {
-			if yyj1760 >= l {
+	var yys1764Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1764Slc
+	var yyhl1764 bool = l >= 0
+	for yyj1764 := 0; ; yyj1764++ {
+		if yyhl1764 {
+			if yyj1764 >= l {
 				break
 			}
 		} else {
@@ -21511,9 +21541,9 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys1760Slc = r.DecodeBytes(yys1760Slc, true, true)
-		yys1760 := string(yys1760Slc)
-		switch yys1760 {
+		yys1764Slc = r.DecodeBytes(yys1764Slc, true, true)
+		yys1764 := string(yys1764Slc)
+		switch yys1764 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -21527,10 +21557,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 				x.ObservedGeneration = int64(r.DecodeInt(64))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1760)
-		} // end switch yys1760
-	} // end for yyj1760
-	if !yyhl1760 {
+			z.DecStructFieldNotFound(-1, yys1764)
+		} // end switch yys1764
+	} // end for yyj1764
+	if !yyhl1764 {
 		r.ReadEnd()
 	}
 }
@@ -21539,16 +21569,16 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1763 int
-	var yyb1763 bool
-	var yyhl1763 bool = l >= 0
-	yyj1763++
-	if yyhl1763 {
-		yyb1763 = yyj1763 > l
+	var yyj1767 int
+	var yyb1767 bool
+	var yyhl1767 bool = l >= 0
+	yyj1767++
+	if yyhl1767 {
+		yyb1767 = yyj1767 > l
 	} else {
-		yyb1763 = r.CheckBreak()
+		yyb1767 = r.CheckBreak()
 	}
-	if yyb1763 {
+	if yyb1767 {
 		r.ReadEnd()
 		return
 	}
@@ -21557,13 +21587,13 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1763++
-	if yyhl1763 {
-		yyb1763 = yyj1763 > l
+	yyj1767++
+	if yyhl1767 {
+		yyb1767 = yyj1767 > l
 	} else {
-		yyb1763 = r.CheckBreak()
+		yyb1767 = r.CheckBreak()
 	}
-	if yyb1763 {
+	if yyb1767 {
 		r.ReadEnd()
 		return
 	}
@@ -21573,16 +21603,16 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 		x.ObservedGeneration = int64(r.DecodeInt(64))
 	}
 	for {
-		yyj1763++
-		if yyhl1763 {
-			yyb1763 = yyj1763 > l
+		yyj1767++
+		if yyhl1767 {
+			yyb1767 = yyj1767 > l
 		} else {
-			yyb1763 = r.CheckBreak()
+			yyb1767 = r.CheckBreak()
 		}
-		if yyb1763 {
+		if yyb1767 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1763-1, "")
+		z.DecStructFieldNotFound(yyj1767-1, "")
 	}
 	r.ReadEnd()
 }
@@ -21594,119 +21624,119 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1766 := z.EncBinary()
-		_ = yym1766
+		yym1770 := z.EncBinary()
+		_ = yym1770
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1767 := !z.EncBinary()
-			yy2arr1767 := z.EncBasicHandle().StructToArray
-			var yyq1767 [5]bool
-			_, _, _ = yysep1767, yyq1767, yy2arr1767
-			const yyr1767 bool = false
-			yyq1767[0] = x.Kind != ""
-			yyq1767[1] = x.APIVersion != ""
-			yyq1767[2] = true
-			yyq1767[3] = true
-			yyq1767[4] = true
-			if yyr1767 || yy2arr1767 {
+			yysep1771 := !z.EncBinary()
+			yy2arr1771 := z.EncBasicHandle().StructToArray
+			var yyq1771 [5]bool
+			_, _, _ = yysep1771, yyq1771, yy2arr1771
+			const yyr1771 bool = false
+			yyq1771[0] = x.Kind != ""
+			yyq1771[1] = x.APIVersion != ""
+			yyq1771[2] = true
+			yyq1771[3] = true
+			yyq1771[4] = true
+			if yyr1771 || yy2arr1771 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1767 int = 0
-				for _, b := range yyq1767 {
+				var yynn1771 int = 0
+				for _, b := range yyq1771 {
 					if b {
-						yynn1767++
+						yynn1771++
 					}
 				}
-				r.EncodeMapStart(yynn1767)
+				r.EncodeMapStart(yynn1771)
 			}
-			if yyr1767 || yy2arr1767 {
-				if yyq1767[0] {
-					yym1769 := z.EncBinary()
-					_ = yym1769
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1767[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1770 := z.EncBinary()
-					_ = yym1770
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1767 || yy2arr1767 {
-				if yyq1767[1] {
-					yym1772 := z.EncBinary()
-					_ = yym1772
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1767[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr1771 || yy2arr1771 {
+				if yyq1771[0] {
 					yym1773 := z.EncBinary()
 					_ = yym1773
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1771[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym1774 := z.EncBinary()
+					_ = yym1774
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1771 || yy2arr1771 {
+				if yyq1771[1] {
+					yym1776 := z.EncBinary()
+					_ = yym1776
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1771[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1777 := z.EncBinary()
+					_ = yym1777
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1767 || yy2arr1767 {
-				if yyq1767[2] {
-					yy1775 := &x.ObjectMeta
-					yy1775.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1767[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1776 := &x.ObjectMeta
-					yy1776.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1767 || yy2arr1767 {
-				if yyq1767[3] {
-					yy1778 := &x.Spec
-					yy1778.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1767[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1779 := &x.Spec
+			if yyr1771 || yy2arr1771 {
+				if yyq1771[2] {
+					yy1779 := &x.ObjectMeta
 					yy1779.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1767 || yy2arr1767 {
-				if yyq1767[4] {
-					yy1781 := &x.Status
-					yy1781.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1767[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy1782 := &x.Status
-					yy1782.CodecEncodeSelf(e)
+				if yyq1771[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1780 := &x.ObjectMeta
+					yy1780.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1767 {
+			if yyr1771 || yy2arr1771 {
+				if yyq1771[3] {
+					yy1782 := &x.Spec
+					yy1782.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1771[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy1783 := &x.Spec
+					yy1783.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1771 || yy2arr1771 {
+				if yyq1771[4] {
+					yy1785 := &x.Status
+					yy1785.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1771[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy1786 := &x.Status
+					yy1786.CodecEncodeSelf(e)
+				}
+			}
+			if yysep1771 {
 				r.EncodeEnd()
 			}
 		}
@@ -21717,24 +21747,24 @@ func (x *ReplicationController) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1783 := z.DecBinary()
-	_ = yym1783
+	yym1787 := z.DecBinary()
+	_ = yym1787
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1784 := r.ReadMapStart()
-			if yyl1784 == 0 {
+			yyl1788 := r.ReadMapStart()
+			if yyl1788 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1784, d)
+				x.codecDecodeSelfFromMap(yyl1788, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1784 := r.ReadArrayStart()
-			if yyl1784 == 0 {
+			yyl1788 := r.ReadArrayStart()
+			if yyl1788 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1784, d)
+				x.codecDecodeSelfFromArray(yyl1788, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -21746,12 +21776,12 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1785Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1785Slc
-	var yyhl1785 bool = l >= 0
-	for yyj1785 := 0; ; yyj1785++ {
-		if yyhl1785 {
-			if yyj1785 >= l {
+	var yys1789Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1789Slc
+	var yyhl1789 bool = l >= 0
+	for yyj1789 := 0; ; yyj1789++ {
+		if yyhl1789 {
+			if yyj1789 >= l {
 				break
 			}
 		} else {
@@ -21759,9 +21789,9 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1785Slc = r.DecodeBytes(yys1785Slc, true, true)
-		yys1785 := string(yys1785Slc)
-		switch yys1785 {
+		yys1789Slc = r.DecodeBytes(yys1789Slc, true, true)
+		yys1789 := string(yys1789Slc)
+		switch yys1789 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -21778,28 +21808,28 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1788 := &x.ObjectMeta
-				yyv1788.CodecDecodeSelf(d)
+				yyv1792 := &x.ObjectMeta
+				yyv1792.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ReplicationControllerSpec{}
 			} else {
-				yyv1789 := &x.Spec
-				yyv1789.CodecDecodeSelf(d)
+				yyv1793 := &x.Spec
+				yyv1793.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ReplicationControllerStatus{}
 			} else {
-				yyv1790 := &x.Status
-				yyv1790.CodecDecodeSelf(d)
+				yyv1794 := &x.Status
+				yyv1794.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1785)
-		} // end switch yys1785
-	} // end for yyj1785
-	if !yyhl1785 {
+			z.DecStructFieldNotFound(-1, yys1789)
+		} // end switch yys1789
+	} // end for yyj1789
+	if !yyhl1789 {
 		r.ReadEnd()
 	}
 }
@@ -21808,16 +21838,16 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1791 int
-	var yyb1791 bool
-	var yyhl1791 bool = l >= 0
-	yyj1791++
-	if yyhl1791 {
-		yyb1791 = yyj1791 > l
+	var yyj1795 int
+	var yyb1795 bool
+	var yyhl1795 bool = l >= 0
+	yyj1795++
+	if yyhl1795 {
+		yyb1795 = yyj1795 > l
 	} else {
-		yyb1791 = r.CheckBreak()
+		yyb1795 = r.CheckBreak()
 	}
-	if yyb1791 {
+	if yyb1795 {
 		r.ReadEnd()
 		return
 	}
@@ -21826,13 +21856,13 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1791++
-	if yyhl1791 {
-		yyb1791 = yyj1791 > l
+	yyj1795++
+	if yyhl1795 {
+		yyb1795 = yyj1795 > l
 	} else {
-		yyb1791 = r.CheckBreak()
+		yyb1795 = r.CheckBreak()
 	}
-	if yyb1791 {
+	if yyb1795 {
 		r.ReadEnd()
 		return
 	}
@@ -21841,65 +21871,65 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1791++
-	if yyhl1791 {
-		yyb1791 = yyj1791 > l
+	yyj1795++
+	if yyhl1795 {
+		yyb1795 = yyj1795 > l
 	} else {
-		yyb1791 = r.CheckBreak()
+		yyb1795 = r.CheckBreak()
 	}
-	if yyb1791 {
+	if yyb1795 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1794 := &x.ObjectMeta
-		yyv1794.CodecDecodeSelf(d)
+		yyv1798 := &x.ObjectMeta
+		yyv1798.CodecDecodeSelf(d)
 	}
-	yyj1791++
-	if yyhl1791 {
-		yyb1791 = yyj1791 > l
+	yyj1795++
+	if yyhl1795 {
+		yyb1795 = yyj1795 > l
 	} else {
-		yyb1791 = r.CheckBreak()
+		yyb1795 = r.CheckBreak()
 	}
-	if yyb1791 {
+	if yyb1795 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ReplicationControllerSpec{}
 	} else {
-		yyv1795 := &x.Spec
-		yyv1795.CodecDecodeSelf(d)
+		yyv1799 := &x.Spec
+		yyv1799.CodecDecodeSelf(d)
 	}
-	yyj1791++
-	if yyhl1791 {
-		yyb1791 = yyj1791 > l
+	yyj1795++
+	if yyhl1795 {
+		yyb1795 = yyj1795 > l
 	} else {
-		yyb1791 = r.CheckBreak()
+		yyb1795 = r.CheckBreak()
 	}
-	if yyb1791 {
+	if yyb1795 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ReplicationControllerStatus{}
 	} else {
-		yyv1796 := &x.Status
-		yyv1796.CodecDecodeSelf(d)
+		yyv1800 := &x.Status
+		yyv1800.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1791++
-		if yyhl1791 {
-			yyb1791 = yyj1791 > l
+		yyj1795++
+		if yyhl1795 {
+			yyb1795 = yyj1795 > l
 		} else {
-			yyb1791 = r.CheckBreak()
+			yyb1795 = r.CheckBreak()
 		}
-		if yyb1791 {
+		if yyb1795 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1791-1, "")
+		z.DecStructFieldNotFound(yyj1795-1, "")
 	}
 	r.ReadEnd()
 }
@@ -21911,106 +21941,106 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1797 := z.EncBinary()
-		_ = yym1797
+		yym1801 := z.EncBinary()
+		_ = yym1801
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1798 := !z.EncBinary()
-			yy2arr1798 := z.EncBasicHandle().StructToArray
-			var yyq1798 [4]bool
-			_, _, _ = yysep1798, yyq1798, yy2arr1798
-			const yyr1798 bool = false
-			yyq1798[0] = x.Kind != ""
-			yyq1798[1] = x.APIVersion != ""
-			yyq1798[2] = true
-			if yyr1798 || yy2arr1798 {
+			yysep1802 := !z.EncBinary()
+			yy2arr1802 := z.EncBasicHandle().StructToArray
+			var yyq1802 [4]bool
+			_, _, _ = yysep1802, yyq1802, yy2arr1802
+			const yyr1802 bool = false
+			yyq1802[0] = x.Kind != ""
+			yyq1802[1] = x.APIVersion != ""
+			yyq1802[2] = true
+			if yyr1802 || yy2arr1802 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1798 int = 1
-				for _, b := range yyq1798 {
+				var yynn1802 int = 1
+				for _, b := range yyq1802 {
 					if b {
-						yynn1798++
+						yynn1802++
 					}
 				}
-				r.EncodeMapStart(yynn1798)
+				r.EncodeMapStart(yynn1802)
 			}
-			if yyr1798 || yy2arr1798 {
-				if yyq1798[0] {
-					yym1800 := z.EncBinary()
-					_ = yym1800
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1798[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1801 := z.EncBinary()
-					_ = yym1801
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1798 || yy2arr1798 {
-				if yyq1798[1] {
-					yym1803 := z.EncBinary()
-					_ = yym1803
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1798[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr1802 || yy2arr1802 {
+				if yyq1802[0] {
 					yym1804 := z.EncBinary()
 					_ = yym1804
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1802[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym1805 := z.EncBinary()
+					_ = yym1805
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1802 || yy2arr1802 {
+				if yyq1802[1] {
+					yym1807 := z.EncBinary()
+					_ = yym1807
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1802[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1808 := z.EncBinary()
+					_ = yym1808
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1798 || yy2arr1798 {
-				if yyq1798[2] {
-					yy1806 := &x.ListMeta
-					yym1807 := z.EncBinary()
-					_ = yym1807
+			if yyr1802 || yy2arr1802 {
+				if yyq1802[2] {
+					yy1810 := &x.ListMeta
+					yym1811 := z.EncBinary()
+					_ = yym1811
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1806) {
+					} else if z.HasExtensions() && z.EncExt(yy1810) {
 					} else {
-						z.EncFallback(yy1806)
+						z.EncFallback(yy1810)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1798[2] {
+				if yyq1802[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1808 := &x.ListMeta
-					yym1809 := z.EncBinary()
-					_ = yym1809
+					yy1812 := &x.ListMeta
+					yym1813 := z.EncBinary()
+					_ = yym1813
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1808) {
+					} else if z.HasExtensions() && z.EncExt(yy1812) {
 					} else {
-						z.EncFallback(yy1808)
+						z.EncFallback(yy1812)
 					}
 				}
 			}
-			if yyr1798 || yy2arr1798 {
+			if yyr1802 || yy2arr1802 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1811 := z.EncBinary()
-					_ = yym1811
+					yym1815 := z.EncBinary()
+					_ = yym1815
 					if false {
 					} else {
 						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
@@ -22021,15 +22051,15 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1812 := z.EncBinary()
-					_ = yym1812
+					yym1816 := z.EncBinary()
+					_ = yym1816
 					if false {
 					} else {
 						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
 					}
 				}
 			}
-			if yysep1798 {
+			if yysep1802 {
 				r.EncodeEnd()
 			}
 		}
@@ -22040,24 +22070,24 @@ func (x *ReplicationControllerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1813 := z.DecBinary()
-	_ = yym1813
+	yym1817 := z.DecBinary()
+	_ = yym1817
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1814 := r.ReadMapStart()
-			if yyl1814 == 0 {
+			yyl1818 := r.ReadMapStart()
+			if yyl1818 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1814, d)
+				x.codecDecodeSelfFromMap(yyl1818, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1814 := r.ReadArrayStart()
-			if yyl1814 == 0 {
+			yyl1818 := r.ReadArrayStart()
+			if yyl1818 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1814, d)
+				x.codecDecodeSelfFromArray(yyl1818, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -22069,12 +22099,12 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1815Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1815Slc
-	var yyhl1815 bool = l >= 0
-	for yyj1815 := 0; ; yyj1815++ {
-		if yyhl1815 {
-			if yyj1815 >= l {
+	var yys1819Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1819Slc
+	var yyhl1819 bool = l >= 0
+	for yyj1819 := 0; ; yyj1819++ {
+		if yyhl1819 {
+			if yyj1819 >= l {
 				break
 			}
 		} else {
@@ -22082,9 +22112,9 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
-		yys1815Slc = r.DecodeBytes(yys1815Slc, true, true)
-		yys1815 := string(yys1815Slc)
-		switch yys1815 {
+		yys1819Slc = r.DecodeBytes(yys1819Slc, true, true)
+		yys1819 := string(yys1819Slc)
+		switch yys1819 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -22101,32 +22131,32 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv1818 := &x.ListMeta
-				yym1819 := z.DecBinary()
-				_ = yym1819
+				yyv1822 := &x.ListMeta
+				yym1823 := z.DecBinary()
+				_ = yym1823
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1818) {
+				} else if z.HasExtensions() && z.DecExt(yyv1822) {
 				} else {
-					z.DecFallback(yyv1818, false)
+					z.DecFallback(yyv1822, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1820 := &x.Items
-				yym1821 := z.DecBinary()
-				_ = yym1821
+				yyv1824 := &x.Items
+				yym1825 := z.DecBinary()
+				_ = yym1825
 				if false {
 				} else {
-					h.decSliceReplicationController((*[]ReplicationController)(yyv1820), d)
+					h.decSliceReplicationController((*[]ReplicationController)(yyv1824), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1815)
-		} // end switch yys1815
-	} // end for yyj1815
-	if !yyhl1815 {
+			z.DecStructFieldNotFound(-1, yys1819)
+		} // end switch yys1819
+	} // end for yyj1819
+	if !yyhl1819 {
 		r.ReadEnd()
 	}
 }
@@ -22135,16 +22165,16 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1822 int
-	var yyb1822 bool
-	var yyhl1822 bool = l >= 0
-	yyj1822++
-	if yyhl1822 {
-		yyb1822 = yyj1822 > l
+	var yyj1826 int
+	var yyb1826 bool
+	var yyhl1826 bool = l >= 0
+	yyj1826++
+	if yyhl1826 {
+		yyb1826 = yyj1826 > l
 	} else {
-		yyb1822 = r.CheckBreak()
+		yyb1826 = r.CheckBreak()
 	}
-	if yyb1822 {
+	if yyb1826 {
 		r.ReadEnd()
 		return
 	}
@@ -22153,13 +22183,13 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1822++
-	if yyhl1822 {
-		yyb1822 = yyj1822 > l
+	yyj1826++
+	if yyhl1826 {
+		yyb1826 = yyj1826 > l
 	} else {
-		yyb1822 = r.CheckBreak()
+		yyb1826 = r.CheckBreak()
 	}
-	if yyb1822 {
+	if yyb1826 {
 		r.ReadEnd()
 		return
 	}
@@ -22168,60 +22198,60 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1822++
-	if yyhl1822 {
-		yyb1822 = yyj1822 > l
+	yyj1826++
+	if yyhl1826 {
+		yyb1826 = yyj1826 > l
 	} else {
-		yyb1822 = r.CheckBreak()
+		yyb1826 = r.CheckBreak()
 	}
-	if yyb1822 {
+	if yyb1826 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv1825 := &x.ListMeta
-		yym1826 := z.DecBinary()
-		_ = yym1826
+		yyv1829 := &x.ListMeta
+		yym1830 := z.DecBinary()
+		_ = yym1830
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1825) {
+		} else if z.HasExtensions() && z.DecExt(yyv1829) {
 		} else {
-			z.DecFallback(yyv1825, false)
+			z.DecFallback(yyv1829, false)
 		}
 	}
-	yyj1822++
-	if yyhl1822 {
-		yyb1822 = yyj1822 > l
+	yyj1826++
+	if yyhl1826 {
+		yyb1826 = yyj1826 > l
 	} else {
-		yyb1822 = r.CheckBreak()
+		yyb1826 = r.CheckBreak()
 	}
-	if yyb1822 {
+	if yyb1826 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1827 := &x.Items
-		yym1828 := z.DecBinary()
-		_ = yym1828
+		yyv1831 := &x.Items
+		yym1832 := z.DecBinary()
+		_ = yym1832
 		if false {
 		} else {
-			h.decSliceReplicationController((*[]ReplicationController)(yyv1827), d)
+			h.decSliceReplicationController((*[]ReplicationController)(yyv1831), d)
 		}
 	}
 	for {
-		yyj1822++
-		if yyhl1822 {
-			yyb1822 = yyj1822 > l
+		yyj1826++
+		if yyhl1826 {
+			yyb1826 = yyj1826 > l
 		} else {
-			yyb1822 = r.CheckBreak()
+			yyb1826 = r.CheckBreak()
 		}
-		if yyb1822 {
+		if yyb1826 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1822-1, "")
+		z.DecStructFieldNotFound(yyj1826-1, "")
 	}
 	r.ReadEnd()
 }
@@ -22233,106 +22263,106 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1829 := z.EncBinary()
-		_ = yym1829
+		yym1833 := z.EncBinary()
+		_ = yym1833
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1830 := !z.EncBinary()
-			yy2arr1830 := z.EncBasicHandle().StructToArray
-			var yyq1830 [4]bool
-			_, _, _ = yysep1830, yyq1830, yy2arr1830
-			const yyr1830 bool = false
-			yyq1830[0] = x.Kind != ""
-			yyq1830[1] = x.APIVersion != ""
-			yyq1830[2] = true
-			if yyr1830 || yy2arr1830 {
+			yysep1834 := !z.EncBinary()
+			yy2arr1834 := z.EncBasicHandle().StructToArray
+			var yyq1834 [4]bool
+			_, _, _ = yysep1834, yyq1834, yy2arr1834
+			const yyr1834 bool = false
+			yyq1834[0] = x.Kind != ""
+			yyq1834[1] = x.APIVersion != ""
+			yyq1834[2] = true
+			if yyr1834 || yy2arr1834 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1830 int = 1
-				for _, b := range yyq1830 {
+				var yynn1834 int = 1
+				for _, b := range yyq1834 {
 					if b {
-						yynn1830++
+						yynn1834++
 					}
 				}
-				r.EncodeMapStart(yynn1830)
+				r.EncodeMapStart(yynn1834)
 			}
-			if yyr1830 || yy2arr1830 {
-				if yyq1830[0] {
-					yym1832 := z.EncBinary()
-					_ = yym1832
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1830[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1833 := z.EncBinary()
-					_ = yym1833
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1830 || yy2arr1830 {
-				if yyq1830[1] {
-					yym1835 := z.EncBinary()
-					_ = yym1835
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1830[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr1834 || yy2arr1834 {
+				if yyq1834[0] {
 					yym1836 := z.EncBinary()
 					_ = yym1836
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1834[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym1837 := z.EncBinary()
+					_ = yym1837
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1834 || yy2arr1834 {
+				if yyq1834[1] {
+					yym1839 := z.EncBinary()
+					_ = yym1839
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1834[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1840 := z.EncBinary()
+					_ = yym1840
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1830 || yy2arr1830 {
-				if yyq1830[2] {
-					yy1838 := &x.ListMeta
-					yym1839 := z.EncBinary()
-					_ = yym1839
+			if yyr1834 || yy2arr1834 {
+				if yyq1834[2] {
+					yy1842 := &x.ListMeta
+					yym1843 := z.EncBinary()
+					_ = yym1843
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1838) {
+					} else if z.HasExtensions() && z.EncExt(yy1842) {
 					} else {
-						z.EncFallback(yy1838)
+						z.EncFallback(yy1842)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1830[2] {
+				if yyq1834[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1840 := &x.ListMeta
-					yym1841 := z.EncBinary()
-					_ = yym1841
+					yy1844 := &x.ListMeta
+					yym1845 := z.EncBinary()
+					_ = yym1845
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1840) {
+					} else if z.HasExtensions() && z.EncExt(yy1844) {
 					} else {
-						z.EncFallback(yy1840)
+						z.EncFallback(yy1844)
 					}
 				}
 			}
-			if yyr1830 || yy2arr1830 {
+			if yyr1834 || yy2arr1834 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1843 := z.EncBinary()
-					_ = yym1843
+					yym1847 := z.EncBinary()
+					_ = yym1847
 					if false {
 					} else {
 						h.encSliceService(([]Service)(x.Items), e)
@@ -22343,15 +22373,15 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1844 := z.EncBinary()
-					_ = yym1844
+					yym1848 := z.EncBinary()
+					_ = yym1848
 					if false {
 					} else {
 						h.encSliceService(([]Service)(x.Items), e)
 					}
 				}
 			}
-			if yysep1830 {
+			if yysep1834 {
 				r.EncodeEnd()
 			}
 		}
@@ -22362,24 +22392,24 @@ func (x *ServiceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1845 := z.DecBinary()
-	_ = yym1845
+	yym1849 := z.DecBinary()
+	_ = yym1849
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1846 := r.ReadMapStart()
-			if yyl1846 == 0 {
+			yyl1850 := r.ReadMapStart()
+			if yyl1850 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1846, d)
+				x.codecDecodeSelfFromMap(yyl1850, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1846 := r.ReadArrayStart()
-			if yyl1846 == 0 {
+			yyl1850 := r.ReadArrayStart()
+			if yyl1850 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1846, d)
+				x.codecDecodeSelfFromArray(yyl1850, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -22391,12 +22421,12 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1847Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1847Slc
-	var yyhl1847 bool = l >= 0
-	for yyj1847 := 0; ; yyj1847++ {
-		if yyhl1847 {
-			if yyj1847 >= l {
+	var yys1851Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1851Slc
+	var yyhl1851 bool = l >= 0
+	for yyj1851 := 0; ; yyj1851++ {
+		if yyhl1851 {
+			if yyj1851 >= l {
 				break
 			}
 		} else {
@@ -22404,9 +22434,9 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1847Slc = r.DecodeBytes(yys1847Slc, true, true)
-		yys1847 := string(yys1847Slc)
-		switch yys1847 {
+		yys1851Slc = r.DecodeBytes(yys1851Slc, true, true)
+		yys1851 := string(yys1851Slc)
+		switch yys1851 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -22423,32 +22453,32 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv1850 := &x.ListMeta
-				yym1851 := z.DecBinary()
-				_ = yym1851
+				yyv1854 := &x.ListMeta
+				yym1855 := z.DecBinary()
+				_ = yym1855
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1850) {
+				} else if z.HasExtensions() && z.DecExt(yyv1854) {
 				} else {
-					z.DecFallback(yyv1850, false)
+					z.DecFallback(yyv1854, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1852 := &x.Items
-				yym1853 := z.DecBinary()
-				_ = yym1853
+				yyv1856 := &x.Items
+				yym1857 := z.DecBinary()
+				_ = yym1857
 				if false {
 				} else {
-					h.decSliceService((*[]Service)(yyv1852), d)
+					h.decSliceService((*[]Service)(yyv1856), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1847)
-		} // end switch yys1847
-	} // end for yyj1847
-	if !yyhl1847 {
+			z.DecStructFieldNotFound(-1, yys1851)
+		} // end switch yys1851
+	} // end for yyj1851
+	if !yyhl1851 {
 		r.ReadEnd()
 	}
 }
@@ -22457,16 +22487,16 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1854 int
-	var yyb1854 bool
-	var yyhl1854 bool = l >= 0
-	yyj1854++
-	if yyhl1854 {
-		yyb1854 = yyj1854 > l
+	var yyj1858 int
+	var yyb1858 bool
+	var yyhl1858 bool = l >= 0
+	yyj1858++
+	if yyhl1858 {
+		yyb1858 = yyj1858 > l
 	} else {
-		yyb1854 = r.CheckBreak()
+		yyb1858 = r.CheckBreak()
 	}
-	if yyb1854 {
+	if yyb1858 {
 		r.ReadEnd()
 		return
 	}
@@ -22475,13 +22505,13 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1854++
-	if yyhl1854 {
-		yyb1854 = yyj1854 > l
+	yyj1858++
+	if yyhl1858 {
+		yyb1858 = yyj1858 > l
 	} else {
-		yyb1854 = r.CheckBreak()
+		yyb1858 = r.CheckBreak()
 	}
-	if yyb1854 {
+	if yyb1858 {
 		r.ReadEnd()
 		return
 	}
@@ -22490,60 +22520,60 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1854++
-	if yyhl1854 {
-		yyb1854 = yyj1854 > l
+	yyj1858++
+	if yyhl1858 {
+		yyb1858 = yyj1858 > l
 	} else {
-		yyb1854 = r.CheckBreak()
+		yyb1858 = r.CheckBreak()
 	}
-	if yyb1854 {
+	if yyb1858 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv1857 := &x.ListMeta
-		yym1858 := z.DecBinary()
-		_ = yym1858
+		yyv1861 := &x.ListMeta
+		yym1862 := z.DecBinary()
+		_ = yym1862
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1857) {
+		} else if z.HasExtensions() && z.DecExt(yyv1861) {
 		} else {
-			z.DecFallback(yyv1857, false)
+			z.DecFallback(yyv1861, false)
 		}
 	}
-	yyj1854++
-	if yyhl1854 {
-		yyb1854 = yyj1854 > l
+	yyj1858++
+	if yyhl1858 {
+		yyb1858 = yyj1858 > l
 	} else {
-		yyb1854 = r.CheckBreak()
+		yyb1858 = r.CheckBreak()
 	}
-	if yyb1854 {
+	if yyb1858 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1859 := &x.Items
-		yym1860 := z.DecBinary()
-		_ = yym1860
+		yyv1863 := &x.Items
+		yym1864 := z.DecBinary()
+		_ = yym1864
 		if false {
 		} else {
-			h.decSliceService((*[]Service)(yyv1859), d)
+			h.decSliceService((*[]Service)(yyv1863), d)
 		}
 	}
 	for {
-		yyj1854++
-		if yyhl1854 {
-			yyb1854 = yyj1854 > l
+		yyj1858++
+		if yyhl1858 {
+			yyb1858 = yyj1858 > l
 		} else {
-			yyb1854 = r.CheckBreak()
+			yyb1858 = r.CheckBreak()
 		}
-		if yyb1854 {
+		if yyb1858 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1854-1, "")
+		z.DecStructFieldNotFound(yyj1858-1, "")
 	}
 	r.ReadEnd()
 }
@@ -22552,8 +22582,8 @@ func (x ServiceAffinity) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1861 := z.EncBinary()
-	_ = yym1861
+	yym1865 := z.EncBinary()
+	_ = yym1865
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -22565,8 +22595,8 @@ func (x *ServiceAffinity) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1862 := z.DecBinary()
-	_ = yym1862
+	yym1866 := z.DecBinary()
+	_ = yym1866
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -22578,8 +22608,8 @@ func (x ServiceType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1863 := z.EncBinary()
-	_ = yym1863
+	yym1867 := z.EncBinary()
+	_ = yym1867
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -22591,8 +22621,8 @@ func (x *ServiceType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1864 := z.DecBinary()
-	_ = yym1864
+	yym1868 := z.DecBinary()
+	_ = yym1868
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -22607,43 +22637,43 @@ func (x *ServiceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1865 := z.EncBinary()
-		_ = yym1865
+		yym1869 := z.EncBinary()
+		_ = yym1869
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1866 := !z.EncBinary()
-			yy2arr1866 := z.EncBasicHandle().StructToArray
-			var yyq1866 [1]bool
-			_, _, _ = yysep1866, yyq1866, yy2arr1866
-			const yyr1866 bool = false
-			yyq1866[0] = true
-			if yyr1866 || yy2arr1866 {
+			yysep1870 := !z.EncBinary()
+			yy2arr1870 := z.EncBasicHandle().StructToArray
+			var yyq1870 [1]bool
+			_, _, _ = yysep1870, yyq1870, yy2arr1870
+			const yyr1870 bool = false
+			yyq1870[0] = true
+			if yyr1870 || yy2arr1870 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1866 int = 0
-				for _, b := range yyq1866 {
+				var yynn1870 int = 0
+				for _, b := range yyq1870 {
 					if b {
-						yynn1866++
+						yynn1870++
 					}
 				}
-				r.EncodeMapStart(yynn1866)
+				r.EncodeMapStart(yynn1870)
 			}
-			if yyr1866 || yy2arr1866 {
-				if yyq1866[0] {
-					yy1868 := &x.LoadBalancer
-					yy1868.CodecEncodeSelf(e)
+			if yyr1870 || yy2arr1870 {
+				if yyq1870[0] {
+					yy1872 := &x.LoadBalancer
+					yy1872.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1866[0] {
+				if yyq1870[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
-					yy1869 := &x.LoadBalancer
-					yy1869.CodecEncodeSelf(e)
+					yy1873 := &x.LoadBalancer
+					yy1873.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1866 {
+			if yysep1870 {
 				r.EncodeEnd()
 			}
 		}
@@ -22654,24 +22684,24 @@ func (x *ServiceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1870 := z.DecBinary()
-	_ = yym1870
+	yym1874 := z.DecBinary()
+	_ = yym1874
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1871 := r.ReadMapStart()
-			if yyl1871 == 0 {
+			yyl1875 := r.ReadMapStart()
+			if yyl1875 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1871, d)
+				x.codecDecodeSelfFromMap(yyl1875, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1871 := r.ReadArrayStart()
-			if yyl1871 == 0 {
+			yyl1875 := r.ReadArrayStart()
+			if yyl1875 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1871, d)
+				x.codecDecodeSelfFromArray(yyl1875, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -22683,12 +22713,12 @@ func (x *ServiceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1872Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1872Slc
-	var yyhl1872 bool = l >= 0
-	for yyj1872 := 0; ; yyj1872++ {
-		if yyhl1872 {
-			if yyj1872 >= l {
+	var yys1876Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1876Slc
+	var yyhl1876 bool = l >= 0
+	for yyj1876 := 0; ; yyj1876++ {
+		if yyhl1876 {
+			if yyj1876 >= l {
 				break
 			}
 		} else {
@@ -22696,21 +22726,21 @@ func (x *ServiceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1872Slc = r.DecodeBytes(yys1872Slc, true, true)
-		yys1872 := string(yys1872Slc)
-		switch yys1872 {
+		yys1876Slc = r.DecodeBytes(yys1876Slc, true, true)
+		yys1876 := string(yys1876Slc)
+		switch yys1876 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = LoadBalancerStatus{}
 			} else {
-				yyv1873 := &x.LoadBalancer
-				yyv1873.CodecDecodeSelf(d)
+				yyv1877 := &x.LoadBalancer
+				yyv1877.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1872)
-		} // end switch yys1872
-	} // end for yyj1872
-	if !yyhl1872 {
+			z.DecStructFieldNotFound(-1, yys1876)
+		} // end switch yys1876
+	} // end for yyj1876
+	if !yyhl1876 {
 		r.ReadEnd()
 	}
 }
@@ -22719,36 +22749,36 @@ func (x *ServiceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1874 int
-	var yyb1874 bool
-	var yyhl1874 bool = l >= 0
-	yyj1874++
-	if yyhl1874 {
-		yyb1874 = yyj1874 > l
+	var yyj1878 int
+	var yyb1878 bool
+	var yyhl1878 bool = l >= 0
+	yyj1878++
+	if yyhl1878 {
+		yyb1878 = yyj1878 > l
 	} else {
-		yyb1874 = r.CheckBreak()
+		yyb1878 = r.CheckBreak()
 	}
-	if yyb1874 {
+	if yyb1878 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = LoadBalancerStatus{}
 	} else {
-		yyv1875 := &x.LoadBalancer
-		yyv1875.CodecDecodeSelf(d)
+		yyv1879 := &x.LoadBalancer
+		yyv1879.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1874++
-		if yyhl1874 {
-			yyb1874 = yyj1874 > l
+		yyj1878++
+		if yyhl1878 {
+			yyb1878 = yyj1878 > l
 		} else {
-			yyb1874 = r.CheckBreak()
+			yyb1878 = r.CheckBreak()
 		}
-		if yyb1874 {
+		if yyb1878 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1874-1, "")
+		z.DecStructFieldNotFound(yyj1878-1, "")
 	}
 	r.ReadEnd()
 }
@@ -22760,35 +22790,35 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1876 := z.EncBinary()
-		_ = yym1876
+		yym1880 := z.EncBinary()
+		_ = yym1880
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1877 := !z.EncBinary()
-			yy2arr1877 := z.EncBasicHandle().StructToArray
-			var yyq1877 [1]bool
-			_, _, _ = yysep1877, yyq1877, yy2arr1877
-			const yyr1877 bool = false
-			yyq1877[0] = len(x.Ingress) != 0
-			if yyr1877 || yy2arr1877 {
+			yysep1881 := !z.EncBinary()
+			yy2arr1881 := z.EncBasicHandle().StructToArray
+			var yyq1881 [1]bool
+			_, _, _ = yysep1881, yyq1881, yy2arr1881
+			const yyr1881 bool = false
+			yyq1881[0] = len(x.Ingress) != 0
+			if yyr1881 || yy2arr1881 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1877 int = 0
-				for _, b := range yyq1877 {
+				var yynn1881 int = 0
+				for _, b := range yyq1881 {
 					if b {
-						yynn1877++
+						yynn1881++
 					}
 				}
-				r.EncodeMapStart(yynn1877)
+				r.EncodeMapStart(yynn1881)
 			}
-			if yyr1877 || yy2arr1877 {
-				if yyq1877[0] {
+			if yyr1881 || yy2arr1881 {
+				if yyq1881[0] {
 					if x.Ingress == nil {
 						r.EncodeNil()
 					} else {
-						yym1879 := z.EncBinary()
-						_ = yym1879
+						yym1883 := z.EncBinary()
+						_ = yym1883
 						if false {
 						} else {
 							h.encSliceLoadBalancerIngress(([]LoadBalancerIngress)(x.Ingress), e)
@@ -22798,13 +22828,13 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1877[0] {
+				if yyq1881[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("ingress"))
 					if x.Ingress == nil {
 						r.EncodeNil()
 					} else {
-						yym1880 := z.EncBinary()
-						_ = yym1880
+						yym1884 := z.EncBinary()
+						_ = yym1884
 						if false {
 						} else {
 							h.encSliceLoadBalancerIngress(([]LoadBalancerIngress)(x.Ingress), e)
@@ -22812,7 +22842,7 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1877 {
+			if yysep1881 {
 				r.EncodeEnd()
 			}
 		}
@@ -22823,24 +22853,24 @@ func (x *LoadBalancerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1881 := z.DecBinary()
-	_ = yym1881
+	yym1885 := z.DecBinary()
+	_ = yym1885
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1882 := r.ReadMapStart()
-			if yyl1882 == 0 {
+			yyl1886 := r.ReadMapStart()
+			if yyl1886 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1882, d)
+				x.codecDecodeSelfFromMap(yyl1886, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1882 := r.ReadArrayStart()
-			if yyl1882 == 0 {
+			yyl1886 := r.ReadArrayStart()
+			if yyl1886 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1882, d)
+				x.codecDecodeSelfFromArray(yyl1886, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -22852,12 +22882,12 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1883Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1883Slc
-	var yyhl1883 bool = l >= 0
-	for yyj1883 := 0; ; yyj1883++ {
-		if yyhl1883 {
-			if yyj1883 >= l {
+	var yys1887Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1887Slc
+	var yyhl1887 bool = l >= 0
+	for yyj1887 := 0; ; yyj1887++ {
+		if yyhl1887 {
+			if yyj1887 >= l {
 				break
 			}
 		} else {
@@ -22865,26 +22895,26 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys1883Slc = r.DecodeBytes(yys1883Slc, true, true)
-		yys1883 := string(yys1883Slc)
-		switch yys1883 {
+		yys1887Slc = r.DecodeBytes(yys1887Slc, true, true)
+		yys1887 := string(yys1887Slc)
+		switch yys1887 {
 		case "ingress":
 			if r.TryDecodeAsNil() {
 				x.Ingress = nil
 			} else {
-				yyv1884 := &x.Ingress
-				yym1885 := z.DecBinary()
-				_ = yym1885
+				yyv1888 := &x.Ingress
+				yym1889 := z.DecBinary()
+				_ = yym1889
 				if false {
 				} else {
-					h.decSliceLoadBalancerIngress((*[]LoadBalancerIngress)(yyv1884), d)
+					h.decSliceLoadBalancerIngress((*[]LoadBalancerIngress)(yyv1888), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1883)
-		} // end switch yys1883
-	} // end for yyj1883
-	if !yyhl1883 {
+			z.DecStructFieldNotFound(-1, yys1887)
+		} // end switch yys1887
+	} // end for yyj1887
+	if !yyhl1887 {
 		r.ReadEnd()
 	}
 }
@@ -22893,41 +22923,41 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1886 int
-	var yyb1886 bool
-	var yyhl1886 bool = l >= 0
-	yyj1886++
-	if yyhl1886 {
-		yyb1886 = yyj1886 > l
+	var yyj1890 int
+	var yyb1890 bool
+	var yyhl1890 bool = l >= 0
+	yyj1890++
+	if yyhl1890 {
+		yyb1890 = yyj1890 > l
 	} else {
-		yyb1886 = r.CheckBreak()
+		yyb1890 = r.CheckBreak()
 	}
-	if yyb1886 {
+	if yyb1890 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Ingress = nil
 	} else {
-		yyv1887 := &x.Ingress
-		yym1888 := z.DecBinary()
-		_ = yym1888
+		yyv1891 := &x.Ingress
+		yym1892 := z.DecBinary()
+		_ = yym1892
 		if false {
 		} else {
-			h.decSliceLoadBalancerIngress((*[]LoadBalancerIngress)(yyv1887), d)
+			h.decSliceLoadBalancerIngress((*[]LoadBalancerIngress)(yyv1891), d)
 		}
 	}
 	for {
-		yyj1886++
-		if yyhl1886 {
-			yyb1886 = yyj1886 > l
+		yyj1890++
+		if yyhl1890 {
+			yyb1890 = yyj1890 > l
 		} else {
-			yyb1886 = r.CheckBreak()
+			yyb1890 = r.CheckBreak()
 		}
-		if yyb1886 {
+		if yyb1890 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1886-1, "")
+		z.DecStructFieldNotFound(yyj1890-1, "")
 	}
 	r.ReadEnd()
 }
@@ -22939,74 +22969,74 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1889 := z.EncBinary()
-		_ = yym1889
+		yym1893 := z.EncBinary()
+		_ = yym1893
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1890 := !z.EncBinary()
-			yy2arr1890 := z.EncBasicHandle().StructToArray
-			var yyq1890 [2]bool
-			_, _, _ = yysep1890, yyq1890, yy2arr1890
-			const yyr1890 bool = false
-			yyq1890[0] = x.IP != ""
-			yyq1890[1] = x.Hostname != ""
-			if yyr1890 || yy2arr1890 {
+			yysep1894 := !z.EncBinary()
+			yy2arr1894 := z.EncBasicHandle().StructToArray
+			var yyq1894 [2]bool
+			_, _, _ = yysep1894, yyq1894, yy2arr1894
+			const yyr1894 bool = false
+			yyq1894[0] = x.IP != ""
+			yyq1894[1] = x.Hostname != ""
+			if yyr1894 || yy2arr1894 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1890 int = 0
-				for _, b := range yyq1890 {
+				var yynn1894 int = 0
+				for _, b := range yyq1894 {
 					if b {
-						yynn1890++
+						yynn1894++
 					}
 				}
-				r.EncodeMapStart(yynn1890)
+				r.EncodeMapStart(yynn1894)
 			}
-			if yyr1890 || yy2arr1890 {
-				if yyq1890[0] {
-					yym1892 := z.EncBinary()
-					_ = yym1892
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.IP))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1890[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("ip"))
-					yym1893 := z.EncBinary()
-					_ = yym1893
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.IP))
-					}
-				}
-			}
-			if yyr1890 || yy2arr1890 {
-				if yyq1890[1] {
-					yym1895 := z.EncBinary()
-					_ = yym1895
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Hostname))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1890[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("hostname"))
+			if yyr1894 || yy2arr1894 {
+				if yyq1894[0] {
 					yym1896 := z.EncBinary()
 					_ = yym1896
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.IP))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1894[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("ip"))
+					yym1897 := z.EncBinary()
+					_ = yym1897
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.IP))
+					}
+				}
+			}
+			if yyr1894 || yy2arr1894 {
+				if yyq1894[1] {
+					yym1899 := z.EncBinary()
+					_ = yym1899
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Hostname))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1894[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("hostname"))
+					yym1900 := z.EncBinary()
+					_ = yym1900
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Hostname))
 					}
 				}
 			}
-			if yysep1890 {
+			if yysep1894 {
 				r.EncodeEnd()
 			}
 		}
@@ -23017,24 +23047,24 @@ func (x *LoadBalancerIngress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1897 := z.DecBinary()
-	_ = yym1897
+	yym1901 := z.DecBinary()
+	_ = yym1901
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1898 := r.ReadMapStart()
-			if yyl1898 == 0 {
+			yyl1902 := r.ReadMapStart()
+			if yyl1902 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1898, d)
+				x.codecDecodeSelfFromMap(yyl1902, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1898 := r.ReadArrayStart()
-			if yyl1898 == 0 {
+			yyl1902 := r.ReadArrayStart()
+			if yyl1902 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1898, d)
+				x.codecDecodeSelfFromArray(yyl1902, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -23046,12 +23076,12 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1899Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1899Slc
-	var yyhl1899 bool = l >= 0
-	for yyj1899 := 0; ; yyj1899++ {
-		if yyhl1899 {
-			if yyj1899 >= l {
+	var yys1903Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1903Slc
+	var yyhl1903 bool = l >= 0
+	for yyj1903 := 0; ; yyj1903++ {
+		if yyhl1903 {
+			if yyj1903 >= l {
 				break
 			}
 		} else {
@@ -23059,9 +23089,9 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys1899Slc = r.DecodeBytes(yys1899Slc, true, true)
-		yys1899 := string(yys1899Slc)
-		switch yys1899 {
+		yys1903Slc = r.DecodeBytes(yys1903Slc, true, true)
+		yys1903 := string(yys1903Slc)
+		switch yys1903 {
 		case "ip":
 			if r.TryDecodeAsNil() {
 				x.IP = ""
@@ -23075,10 +23105,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.Hostname = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1899)
-		} // end switch yys1899
-	} // end for yyj1899
-	if !yyhl1899 {
+			z.DecStructFieldNotFound(-1, yys1903)
+		} // end switch yys1903
+	} // end for yyj1903
+	if !yyhl1903 {
 		r.ReadEnd()
 	}
 }
@@ -23087,16 +23117,16 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1902 int
-	var yyb1902 bool
-	var yyhl1902 bool = l >= 0
-	yyj1902++
-	if yyhl1902 {
-		yyb1902 = yyj1902 > l
+	var yyj1906 int
+	var yyb1906 bool
+	var yyhl1906 bool = l >= 0
+	yyj1906++
+	if yyhl1906 {
+		yyb1906 = yyj1906 > l
 	} else {
-		yyb1902 = r.CheckBreak()
+		yyb1906 = r.CheckBreak()
 	}
-	if yyb1902 {
+	if yyb1906 {
 		r.ReadEnd()
 		return
 	}
@@ -23105,13 +23135,13 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.IP = string(r.DecodeString())
 	}
-	yyj1902++
-	if yyhl1902 {
-		yyb1902 = yyj1902 > l
+	yyj1906++
+	if yyhl1906 {
+		yyb1906 = yyj1906 > l
 	} else {
-		yyb1902 = r.CheckBreak()
+		yyb1906 = r.CheckBreak()
 	}
-	if yyb1902 {
+	if yyb1906 {
 		r.ReadEnd()
 		return
 	}
@@ -23121,16 +23151,16 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.Hostname = string(r.DecodeString())
 	}
 	for {
-		yyj1902++
-		if yyhl1902 {
-			yyb1902 = yyj1902 > l
+		yyj1906++
+		if yyhl1906 {
+			yyb1906 = yyj1906 > l
 		} else {
-			yyb1902 = r.CheckBreak()
+			yyb1906 = r.CheckBreak()
 		}
-		if yyb1902 {
+		if yyb1906 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1902-1, "")
+		z.DecStructFieldNotFound(yyj1906-1, "")
 	}
 	r.ReadEnd()
 }
@@ -23142,50 +23172,50 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1905 := z.EncBinary()
-		_ = yym1905
+		yym1909 := z.EncBinary()
+		_ = yym1909
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1906 := !z.EncBinary()
-			yy2arr1906 := z.EncBasicHandle().StructToArray
-			var yyq1906 [7]bool
-			_, _, _ = yysep1906, yyq1906, yy2arr1906
-			const yyr1906 bool = false
-			yyq1906[0] = x.Type != ""
-			yyq1906[3] = x.ClusterIP != ""
-			yyq1906[4] = len(x.ExternalIPs) != 0
-			yyq1906[5] = x.LoadBalancerIP != ""
-			yyq1906[6] = x.SessionAffinity != ""
-			if yyr1906 || yy2arr1906 {
+			yysep1910 := !z.EncBinary()
+			yy2arr1910 := z.EncBasicHandle().StructToArray
+			var yyq1910 [7]bool
+			_, _, _ = yysep1910, yyq1910, yy2arr1910
+			const yyr1910 bool = false
+			yyq1910[0] = x.Type != ""
+			yyq1910[3] = x.ClusterIP != ""
+			yyq1910[4] = len(x.ExternalIPs) != 0
+			yyq1910[5] = x.LoadBalancerIP != ""
+			yyq1910[6] = x.SessionAffinity != ""
+			if yyr1910 || yy2arr1910 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn1906 int = 2
-				for _, b := range yyq1906 {
+				var yynn1910 int = 2
+				for _, b := range yyq1910 {
 					if b {
-						yynn1906++
+						yynn1910++
 					}
 				}
-				r.EncodeMapStart(yynn1906)
+				r.EncodeMapStart(yynn1910)
 			}
-			if yyr1906 || yy2arr1906 {
-				if yyq1906[0] {
+			if yyr1910 || yy2arr1910 {
+				if yyq1910[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1906[0] {
+				if yyq1910[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1906 || yy2arr1906 {
+			if yyr1910 || yy2arr1910 {
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
-					yym1909 := z.EncBinary()
-					_ = yym1909
+					yym1913 := z.EncBinary()
+					_ = yym1913
 					if false {
 					} else {
 						h.encSliceServicePort(([]ServicePort)(x.Ports), e)
@@ -23196,20 +23226,20 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
-					yym1910 := z.EncBinary()
-					_ = yym1910
+					yym1914 := z.EncBinary()
+					_ = yym1914
 					if false {
 					} else {
 						h.encSliceServicePort(([]ServicePort)(x.Ports), e)
 					}
 				}
 			}
-			if yyr1906 || yy2arr1906 {
+			if yyr1910 || yy2arr1910 {
 				if x.Selector == nil {
 					r.EncodeNil()
 				} else {
-					yym1912 := z.EncBinary()
-					_ = yym1912
+					yym1916 := z.EncBinary()
+					_ = yym1916
 					if false {
 					} else {
 						z.F.EncMapStringStringV(x.Selector, false, e)
@@ -23220,18 +23250,18 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Selector == nil {
 					r.EncodeNil()
 				} else {
-					yym1913 := z.EncBinary()
-					_ = yym1913
+					yym1917 := z.EncBinary()
+					_ = yym1917
 					if false {
 					} else {
 						z.F.EncMapStringStringV(x.Selector, false, e)
 					}
 				}
 			}
-			if yyr1906 || yy2arr1906 {
-				if yyq1906[3] {
-					yym1915 := z.EncBinary()
-					_ = yym1915
+			if yyr1910 || yy2arr1910 {
+				if yyq1910[3] {
+					yym1919 := z.EncBinary()
+					_ = yym1919
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ClusterIP))
@@ -23240,23 +23270,23 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1906[3] {
+				if yyq1910[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("clusterIP"))
-					yym1916 := z.EncBinary()
-					_ = yym1916
+					yym1920 := z.EncBinary()
+					_ = yym1920
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ClusterIP))
 					}
 				}
 			}
-			if yyr1906 || yy2arr1906 {
-				if yyq1906[4] {
+			if yyr1910 || yy2arr1910 {
+				if yyq1910[4] {
 					if x.ExternalIPs == nil {
 						r.EncodeNil()
 					} else {
-						yym1918 := z.EncBinary()
-						_ = yym1918
+						yym1922 := z.EncBinary()
+						_ = yym1922
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.ExternalIPs, false, e)
@@ -23266,13 +23296,13 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1906[4] {
+				if yyq1910[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("externalIPs"))
 					if x.ExternalIPs == nil {
 						r.EncodeNil()
 					} else {
-						yym1919 := z.EncBinary()
-						_ = yym1919
+						yym1923 := z.EncBinary()
+						_ = yym1923
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.ExternalIPs, false, e)
@@ -23280,10 +23310,10 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1906 || yy2arr1906 {
-				if yyq1906[5] {
-					yym1921 := z.EncBinary()
-					_ = yym1921
+			if yyr1910 || yy2arr1910 {
+				if yyq1910[5] {
+					yym1925 := z.EncBinary()
+					_ = yym1925
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.LoadBalancerIP))
@@ -23292,29 +23322,29 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1906[5] {
+				if yyq1910[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancerIP"))
-					yym1922 := z.EncBinary()
-					_ = yym1922
+					yym1926 := z.EncBinary()
+					_ = yym1926
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.LoadBalancerIP))
 					}
 				}
 			}
-			if yyr1906 || yy2arr1906 {
-				if yyq1906[6] {
+			if yyr1910 || yy2arr1910 {
+				if yyq1910[6] {
 					x.SessionAffinity.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1906[6] {
+				if yyq1910[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("sessionAffinity"))
 					x.SessionAffinity.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1906 {
+			if yysep1910 {
 				r.EncodeEnd()
 			}
 		}
@@ -23325,24 +23355,24 @@ func (x *ServiceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1924 := z.DecBinary()
-	_ = yym1924
+	yym1928 := z.DecBinary()
+	_ = yym1928
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1925 := r.ReadMapStart()
-			if yyl1925 == 0 {
+			yyl1929 := r.ReadMapStart()
+			if yyl1929 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1925, d)
+				x.codecDecodeSelfFromMap(yyl1929, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1925 := r.ReadArrayStart()
-			if yyl1925 == 0 {
+			yyl1929 := r.ReadArrayStart()
+			if yyl1929 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1925, d)
+				x.codecDecodeSelfFromArray(yyl1929, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -23354,12 +23384,12 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1926Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1926Slc
-	var yyhl1926 bool = l >= 0
-	for yyj1926 := 0; ; yyj1926++ {
-		if yyhl1926 {
-			if yyj1926 >= l {
+	var yys1930Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1930Slc
+	var yyhl1930 bool = l >= 0
+	for yyj1930 := 0; ; yyj1930++ {
+		if yyhl1930 {
+			if yyj1930 >= l {
 				break
 			}
 		} else {
@@ -23367,9 +23397,9 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1926Slc = r.DecodeBytes(yys1926Slc, true, true)
-		yys1926 := string(yys1926Slc)
-		switch yys1926 {
+		yys1930Slc = r.DecodeBytes(yys1930Slc, true, true)
+		yys1930 := string(yys1930Slc)
+		switch yys1930 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -23380,24 +23410,24 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Ports = nil
 			} else {
-				yyv1928 := &x.Ports
-				yym1929 := z.DecBinary()
-				_ = yym1929
+				yyv1932 := &x.Ports
+				yym1933 := z.DecBinary()
+				_ = yym1933
 				if false {
 				} else {
-					h.decSliceServicePort((*[]ServicePort)(yyv1928), d)
+					h.decSliceServicePort((*[]ServicePort)(yyv1932), d)
 				}
 			}
 		case "selector":
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv1930 := &x.Selector
-				yym1931 := z.DecBinary()
-				_ = yym1931
+				yyv1934 := &x.Selector
+				yym1935 := z.DecBinary()
+				_ = yym1935
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1930, false, d)
+					z.F.DecMapStringStringX(yyv1934, false, d)
 				}
 			}
 		case "clusterIP":
@@ -23410,12 +23440,12 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ExternalIPs = nil
 			} else {
-				yyv1933 := &x.ExternalIPs
-				yym1934 := z.DecBinary()
-				_ = yym1934
+				yyv1937 := &x.ExternalIPs
+				yym1938 := z.DecBinary()
+				_ = yym1938
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1933, false, d)
+					z.F.DecSliceStringX(yyv1937, false, d)
 				}
 			}
 		case "loadBalancerIP":
@@ -23431,10 +23461,10 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.SessionAffinity = ServiceAffinity(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1926)
-		} // end switch yys1926
-	} // end for yyj1926
-	if !yyhl1926 {
+			z.DecStructFieldNotFound(-1, yys1930)
+		} // end switch yys1930
+	} // end for yyj1930
+	if !yyhl1930 {
 		r.ReadEnd()
 	}
 }
@@ -23443,16 +23473,16 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1937 int
-	var yyb1937 bool
-	var yyhl1937 bool = l >= 0
-	yyj1937++
-	if yyhl1937 {
-		yyb1937 = yyj1937 > l
+	var yyj1941 int
+	var yyb1941 bool
+	var yyhl1941 bool = l >= 0
+	yyj1941++
+	if yyhl1941 {
+		yyb1941 = yyj1941 > l
 	} else {
-		yyb1937 = r.CheckBreak()
+		yyb1941 = r.CheckBreak()
 	}
-	if yyb1937 {
+	if yyb1941 {
 		r.ReadEnd()
 		return
 	}
@@ -23461,55 +23491,55 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = ServiceType(r.DecodeString())
 	}
-	yyj1937++
-	if yyhl1937 {
-		yyb1937 = yyj1937 > l
+	yyj1941++
+	if yyhl1941 {
+		yyb1941 = yyj1941 > l
 	} else {
-		yyb1937 = r.CheckBreak()
+		yyb1941 = r.CheckBreak()
 	}
-	if yyb1937 {
+	if yyb1941 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
-		yyv1939 := &x.Ports
-		yym1940 := z.DecBinary()
-		_ = yym1940
+		yyv1943 := &x.Ports
+		yym1944 := z.DecBinary()
+		_ = yym1944
 		if false {
 		} else {
-			h.decSliceServicePort((*[]ServicePort)(yyv1939), d)
+			h.decSliceServicePort((*[]ServicePort)(yyv1943), d)
 		}
 	}
-	yyj1937++
-	if yyhl1937 {
-		yyb1937 = yyj1937 > l
+	yyj1941++
+	if yyhl1941 {
+		yyb1941 = yyj1941 > l
 	} else {
-		yyb1937 = r.CheckBreak()
+		yyb1941 = r.CheckBreak()
 	}
-	if yyb1937 {
+	if yyb1941 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv1941 := &x.Selector
-		yym1942 := z.DecBinary()
-		_ = yym1942
+		yyv1945 := &x.Selector
+		yym1946 := z.DecBinary()
+		_ = yym1946
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1941, false, d)
+			z.F.DecMapStringStringX(yyv1945, false, d)
 		}
 	}
-	yyj1937++
-	if yyhl1937 {
-		yyb1937 = yyj1937 > l
+	yyj1941++
+	if yyhl1941 {
+		yyb1941 = yyj1941 > l
 	} else {
-		yyb1937 = r.CheckBreak()
+		yyb1941 = r.CheckBreak()
 	}
-	if yyb1937 {
+	if yyb1941 {
 		r.ReadEnd()
 		return
 	}
@@ -23518,34 +23548,34 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ClusterIP = string(r.DecodeString())
 	}
-	yyj1937++
-	if yyhl1937 {
-		yyb1937 = yyj1937 > l
+	yyj1941++
+	if yyhl1941 {
+		yyb1941 = yyj1941 > l
 	} else {
-		yyb1937 = r.CheckBreak()
+		yyb1941 = r.CheckBreak()
 	}
-	if yyb1937 {
+	if yyb1941 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ExternalIPs = nil
 	} else {
-		yyv1944 := &x.ExternalIPs
-		yym1945 := z.DecBinary()
-		_ = yym1945
+		yyv1948 := &x.ExternalIPs
+		yym1949 := z.DecBinary()
+		_ = yym1949
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1944, false, d)
+			z.F.DecSliceStringX(yyv1948, false, d)
 		}
 	}
-	yyj1937++
-	if yyhl1937 {
-		yyb1937 = yyj1937 > l
+	yyj1941++
+	if yyhl1941 {
+		yyb1941 = yyj1941 > l
 	} else {
-		yyb1937 = r.CheckBreak()
+		yyb1941 = r.CheckBreak()
 	}
-	if yyb1937 {
+	if yyb1941 {
 		r.ReadEnd()
 		return
 	}
@@ -23554,13 +23584,13 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.LoadBalancerIP = string(r.DecodeString())
 	}
-	yyj1937++
-	if yyhl1937 {
-		yyb1937 = yyj1937 > l
+	yyj1941++
+	if yyhl1941 {
+		yyb1941 = yyj1941 > l
 	} else {
-		yyb1937 = r.CheckBreak()
+		yyb1941 = r.CheckBreak()
 	}
-	if yyb1937 {
+	if yyb1941 {
 		r.ReadEnd()
 		return
 	}
@@ -23570,16 +23600,16 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.SessionAffinity = ServiceAffinity(r.DecodeString())
 	}
 	for {
-		yyj1937++
-		if yyhl1937 {
-			yyb1937 = yyj1937 > l
+		yyj1941++
+		if yyhl1941 {
+			yyb1941 = yyj1941 > l
 		} else {
-			yyb1937 = r.CheckBreak()
+			yyb1941 = r.CheckBreak()
 		}
-		if yyb1937 {
+		if yyb1941 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1937-1, "")
+		z.DecStructFieldNotFound(yyj1941-1, "")
 	}
 	r.ReadEnd()
 }
@@ -23591,106 +23621,106 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1948 := z.EncBinary()
-		_ = yym1948
+		yym1952 := z.EncBinary()
+		_ = yym1952
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1949 := !z.EncBinary()
-			yy2arr1949 := z.EncBasicHandle().StructToArray
-			var yyq1949 [5]bool
-			_, _, _ = yysep1949, yyq1949, yy2arr1949
-			const yyr1949 bool = false
-			if yyr1949 || yy2arr1949 {
+			yysep1953 := !z.EncBinary()
+			yy2arr1953 := z.EncBasicHandle().StructToArray
+			var yyq1953 [5]bool
+			_, _, _ = yysep1953, yyq1953, yy2arr1953
+			const yyr1953 bool = false
+			if yyr1953 || yy2arr1953 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1949 int = 5
-				for _, b := range yyq1949 {
+				var yynn1953 int = 5
+				for _, b := range yyq1953 {
 					if b {
-						yynn1949++
+						yynn1953++
 					}
 				}
-				r.EncodeMapStart(yynn1949)
+				r.EncodeMapStart(yynn1953)
 			}
-			if yyr1949 || yy2arr1949 {
-				yym1951 := z.EncBinary()
-				_ = yym1951
+			if yyr1953 || yy2arr1953 {
+				yym1955 := z.EncBinary()
+				_ = yym1955
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
-				yym1952 := z.EncBinary()
-				_ = yym1952
+				yym1956 := z.EncBinary()
+				_ = yym1956
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yyr1949 || yy2arr1949 {
+			if yyr1953 || yy2arr1953 {
 				x.Protocol.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("protocol"))
 				x.Protocol.CodecEncodeSelf(e)
 			}
-			if yyr1949 || yy2arr1949 {
-				yym1955 := z.EncBinary()
-				_ = yym1955
+			if yyr1953 || yy2arr1953 {
+				yym1959 := z.EncBinary()
+				_ = yym1959
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
-				yym1956 := z.EncBinary()
-				_ = yym1956
+				yym1960 := z.EncBinary()
+				_ = yym1960
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yyr1949 || yy2arr1949 {
-				yy1958 := &x.TargetPort
-				yym1959 := z.EncBinary()
-				_ = yym1959
+			if yyr1953 || yy2arr1953 {
+				yy1962 := &x.TargetPort
+				yym1963 := z.EncBinary()
+				_ = yym1963
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1958) {
-				} else if !yym1959 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1958)
+				} else if z.HasExtensions() && z.EncExt(yy1962) {
+				} else if !yym1963 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1962)
 				} else {
-					z.EncFallback(yy1958)
+					z.EncFallback(yy1962)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("targetPort"))
-				yy1960 := &x.TargetPort
-				yym1961 := z.EncBinary()
-				_ = yym1961
+				yy1964 := &x.TargetPort
+				yym1965 := z.EncBinary()
+				_ = yym1965
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1960) {
-				} else if !yym1961 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1960)
+				} else if z.HasExtensions() && z.EncExt(yy1964) {
+				} else if !yym1965 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1964)
 				} else {
-					z.EncFallback(yy1960)
+					z.EncFallback(yy1964)
 				}
 			}
-			if yyr1949 || yy2arr1949 {
-				yym1963 := z.EncBinary()
-				_ = yym1963
+			if yyr1953 || yy2arr1953 {
+				yym1967 := z.EncBinary()
+				_ = yym1967
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NodePort))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("nodePort"))
-				yym1964 := z.EncBinary()
-				_ = yym1964
+				yym1968 := z.EncBinary()
+				_ = yym1968
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NodePort))
 				}
 			}
-			if yysep1949 {
+			if yysep1953 {
 				r.EncodeEnd()
 			}
 		}
@@ -23701,24 +23731,24 @@ func (x *ServicePort) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1965 := z.DecBinary()
-	_ = yym1965
+	yym1969 := z.DecBinary()
+	_ = yym1969
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1966 := r.ReadMapStart()
-			if yyl1966 == 0 {
+			yyl1970 := r.ReadMapStart()
+			if yyl1970 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1966, d)
+				x.codecDecodeSelfFromMap(yyl1970, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1966 := r.ReadArrayStart()
-			if yyl1966 == 0 {
+			yyl1970 := r.ReadArrayStart()
+			if yyl1970 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1966, d)
+				x.codecDecodeSelfFromArray(yyl1970, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -23730,12 +23760,12 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1967Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1967Slc
-	var yyhl1967 bool = l >= 0
-	for yyj1967 := 0; ; yyj1967++ {
-		if yyhl1967 {
-			if yyj1967 >= l {
+	var yys1971Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1971Slc
+	var yyhl1971 bool = l >= 0
+	for yyj1971 := 0; ; yyj1971++ {
+		if yyhl1971 {
+			if yyj1971 >= l {
 				break
 			}
 		} else {
@@ -23743,9 +23773,9 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1967Slc = r.DecodeBytes(yys1967Slc, true, true)
-		yys1967 := string(yys1967Slc)
-		switch yys1967 {
+		yys1971Slc = r.DecodeBytes(yys1971Slc, true, true)
+		yys1971 := string(yys1971Slc)
+		switch yys1971 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -23768,15 +23798,15 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.TargetPort = pkg5_intstr.IntOrString{}
 			} else {
-				yyv1971 := &x.TargetPort
-				yym1972 := z.DecBinary()
-				_ = yym1972
+				yyv1975 := &x.TargetPort
+				yym1976 := z.DecBinary()
+				_ = yym1976
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1971) {
-				} else if !yym1972 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1971)
+				} else if z.HasExtensions() && z.DecExt(yyv1975) {
+				} else if !yym1976 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1975)
 				} else {
-					z.DecFallback(yyv1971, false)
+					z.DecFallback(yyv1975, false)
 				}
 			}
 		case "nodePort":
@@ -23786,10 +23816,10 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.NodePort = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1967)
-		} // end switch yys1967
-	} // end for yyj1967
-	if !yyhl1967 {
+			z.DecStructFieldNotFound(-1, yys1971)
+		} // end switch yys1971
+	} // end for yyj1971
+	if !yyhl1971 {
 		r.ReadEnd()
 	}
 }
@@ -23798,16 +23828,16 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1974 int
-	var yyb1974 bool
-	var yyhl1974 bool = l >= 0
-	yyj1974++
-	if yyhl1974 {
-		yyb1974 = yyj1974 > l
+	var yyj1978 int
+	var yyb1978 bool
+	var yyhl1978 bool = l >= 0
+	yyj1978++
+	if yyhl1978 {
+		yyb1978 = yyj1978 > l
 	} else {
-		yyb1974 = r.CheckBreak()
+		yyb1978 = r.CheckBreak()
 	}
-	if yyb1974 {
+	if yyb1978 {
 		r.ReadEnd()
 		return
 	}
@@ -23816,13 +23846,13 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj1974++
-	if yyhl1974 {
-		yyb1974 = yyj1974 > l
+	yyj1978++
+	if yyhl1978 {
+		yyb1978 = yyj1978 > l
 	} else {
-		yyb1974 = r.CheckBreak()
+		yyb1978 = r.CheckBreak()
 	}
-	if yyb1974 {
+	if yyb1978 {
 		r.ReadEnd()
 		return
 	}
@@ -23831,13 +23861,13 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Protocol = Protocol(r.DecodeString())
 	}
-	yyj1974++
-	if yyhl1974 {
-		yyb1974 = yyj1974 > l
+	yyj1978++
+	if yyhl1978 {
+		yyb1978 = yyj1978 > l
 	} else {
-		yyb1974 = r.CheckBreak()
+		yyb1978 = r.CheckBreak()
 	}
-	if yyb1974 {
+	if yyb1978 {
 		r.ReadEnd()
 		return
 	}
@@ -23846,37 +23876,37 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Port = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1974++
-	if yyhl1974 {
-		yyb1974 = yyj1974 > l
+	yyj1978++
+	if yyhl1978 {
+		yyb1978 = yyj1978 > l
 	} else {
-		yyb1974 = r.CheckBreak()
+		yyb1978 = r.CheckBreak()
 	}
-	if yyb1974 {
+	if yyb1978 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.TargetPort = pkg5_intstr.IntOrString{}
 	} else {
-		yyv1978 := &x.TargetPort
-		yym1979 := z.DecBinary()
-		_ = yym1979
+		yyv1982 := &x.TargetPort
+		yym1983 := z.DecBinary()
+		_ = yym1983
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1978) {
-		} else if !yym1979 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1978)
+		} else if z.HasExtensions() && z.DecExt(yyv1982) {
+		} else if !yym1983 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1982)
 		} else {
-			z.DecFallback(yyv1978, false)
+			z.DecFallback(yyv1982, false)
 		}
 	}
-	yyj1974++
-	if yyhl1974 {
-		yyb1974 = yyj1974 > l
+	yyj1978++
+	if yyhl1978 {
+		yyb1978 = yyj1978 > l
 	} else {
-		yyb1974 = r.CheckBreak()
+		yyb1978 = r.CheckBreak()
 	}
-	if yyb1974 {
+	if yyb1978 {
 		r.ReadEnd()
 		return
 	}
@@ -23886,16 +23916,16 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.NodePort = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj1974++
-		if yyhl1974 {
-			yyb1974 = yyj1974 > l
+		yyj1978++
+		if yyhl1978 {
+			yyb1978 = yyj1978 > l
 		} else {
-			yyb1974 = r.CheckBreak()
+			yyb1978 = r.CheckBreak()
 		}
-		if yyb1974 {
+		if yyb1978 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1974-1, "")
+		z.DecStructFieldNotFound(yyj1978-1, "")
 	}
 	r.ReadEnd()
 }
@@ -23907,119 +23937,119 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1981 := z.EncBinary()
-		_ = yym1981
+		yym1985 := z.EncBinary()
+		_ = yym1985
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1982 := !z.EncBinary()
-			yy2arr1982 := z.EncBasicHandle().StructToArray
-			var yyq1982 [5]bool
-			_, _, _ = yysep1982, yyq1982, yy2arr1982
-			const yyr1982 bool = false
-			yyq1982[0] = x.Kind != ""
-			yyq1982[1] = x.APIVersion != ""
-			yyq1982[2] = true
-			yyq1982[3] = true
-			yyq1982[4] = true
-			if yyr1982 || yy2arr1982 {
+			yysep1986 := !z.EncBinary()
+			yy2arr1986 := z.EncBasicHandle().StructToArray
+			var yyq1986 [5]bool
+			_, _, _ = yysep1986, yyq1986, yy2arr1986
+			const yyr1986 bool = false
+			yyq1986[0] = x.Kind != ""
+			yyq1986[1] = x.APIVersion != ""
+			yyq1986[2] = true
+			yyq1986[3] = true
+			yyq1986[4] = true
+			if yyr1986 || yy2arr1986 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1982 int = 0
-				for _, b := range yyq1982 {
+				var yynn1986 int = 0
+				for _, b := range yyq1986 {
 					if b {
-						yynn1982++
+						yynn1986++
 					}
 				}
-				r.EncodeMapStart(yynn1982)
+				r.EncodeMapStart(yynn1986)
 			}
-			if yyr1982 || yy2arr1982 {
-				if yyq1982[0] {
-					yym1984 := z.EncBinary()
-					_ = yym1984
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1982[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1985 := z.EncBinary()
-					_ = yym1985
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1982 || yy2arr1982 {
-				if yyq1982[1] {
-					yym1987 := z.EncBinary()
-					_ = yym1987
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1982[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr1986 || yy2arr1986 {
+				if yyq1986[0] {
 					yym1988 := z.EncBinary()
 					_ = yym1988
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1986[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym1989 := z.EncBinary()
+					_ = yym1989
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1986 || yy2arr1986 {
+				if yyq1986[1] {
+					yym1991 := z.EncBinary()
+					_ = yym1991
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1986[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1992 := z.EncBinary()
+					_ = yym1992
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1982 || yy2arr1982 {
-				if yyq1982[2] {
-					yy1990 := &x.ObjectMeta
-					yy1990.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1982[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1991 := &x.ObjectMeta
-					yy1991.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1982 || yy2arr1982 {
-				if yyq1982[3] {
-					yy1993 := &x.Spec
-					yy1993.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1982[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1994 := &x.Spec
+			if yyr1986 || yy2arr1986 {
+				if yyq1986[2] {
+					yy1994 := &x.ObjectMeta
 					yy1994.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1982 || yy2arr1982 {
-				if yyq1982[4] {
-					yy1996 := &x.Status
-					yy1996.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1982[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy1997 := &x.Status
-					yy1997.CodecEncodeSelf(e)
+				if yyq1986[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1995 := &x.ObjectMeta
+					yy1995.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1982 {
+			if yyr1986 || yy2arr1986 {
+				if yyq1986[3] {
+					yy1997 := &x.Spec
+					yy1997.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1986[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy1998 := &x.Spec
+					yy1998.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1986 || yy2arr1986 {
+				if yyq1986[4] {
+					yy2000 := &x.Status
+					yy2000.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1986[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy2001 := &x.Status
+					yy2001.CodecEncodeSelf(e)
+				}
+			}
+			if yysep1986 {
 				r.EncodeEnd()
 			}
 		}
@@ -24030,24 +24060,24 @@ func (x *Service) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1998 := z.DecBinary()
-	_ = yym1998
+	yym2002 := z.DecBinary()
+	_ = yym2002
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1999 := r.ReadMapStart()
-			if yyl1999 == 0 {
+			yyl2003 := r.ReadMapStart()
+			if yyl2003 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1999, d)
+				x.codecDecodeSelfFromMap(yyl2003, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1999 := r.ReadArrayStart()
-			if yyl1999 == 0 {
+			yyl2003 := r.ReadArrayStart()
+			if yyl2003 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1999, d)
+				x.codecDecodeSelfFromArray(yyl2003, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -24059,12 +24089,12 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2000Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2000Slc
-	var yyhl2000 bool = l >= 0
-	for yyj2000 := 0; ; yyj2000++ {
-		if yyhl2000 {
-			if yyj2000 >= l {
+	var yys2004Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2004Slc
+	var yyhl2004 bool = l >= 0
+	for yyj2004 := 0; ; yyj2004++ {
+		if yyhl2004 {
+			if yyj2004 >= l {
 				break
 			}
 		} else {
@@ -24072,9 +24102,9 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2000Slc = r.DecodeBytes(yys2000Slc, true, true)
-		yys2000 := string(yys2000Slc)
-		switch yys2000 {
+		yys2004Slc = r.DecodeBytes(yys2004Slc, true, true)
+		yys2004 := string(yys2004Slc)
+		switch yys2004 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24091,28 +24121,28 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2003 := &x.ObjectMeta
-				yyv2003.CodecDecodeSelf(d)
+				yyv2007 := &x.ObjectMeta
+				yyv2007.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ServiceSpec{}
 			} else {
-				yyv2004 := &x.Spec
-				yyv2004.CodecDecodeSelf(d)
+				yyv2008 := &x.Spec
+				yyv2008.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ServiceStatus{}
 			} else {
-				yyv2005 := &x.Status
-				yyv2005.CodecDecodeSelf(d)
+				yyv2009 := &x.Status
+				yyv2009.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2000)
-		} // end switch yys2000
-	} // end for yyj2000
-	if !yyhl2000 {
+			z.DecStructFieldNotFound(-1, yys2004)
+		} // end switch yys2004
+	} // end for yyj2004
+	if !yyhl2004 {
 		r.ReadEnd()
 	}
 }
@@ -24121,16 +24151,16 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2006 int
-	var yyb2006 bool
-	var yyhl2006 bool = l >= 0
-	yyj2006++
-	if yyhl2006 {
-		yyb2006 = yyj2006 > l
+	var yyj2010 int
+	var yyb2010 bool
+	var yyhl2010 bool = l >= 0
+	yyj2010++
+	if yyhl2010 {
+		yyb2010 = yyj2010 > l
 	} else {
-		yyb2006 = r.CheckBreak()
+		yyb2010 = r.CheckBreak()
 	}
-	if yyb2006 {
+	if yyb2010 {
 		r.ReadEnd()
 		return
 	}
@@ -24139,13 +24169,13 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2006++
-	if yyhl2006 {
-		yyb2006 = yyj2006 > l
+	yyj2010++
+	if yyhl2010 {
+		yyb2010 = yyj2010 > l
 	} else {
-		yyb2006 = r.CheckBreak()
+		yyb2010 = r.CheckBreak()
 	}
-	if yyb2006 {
+	if yyb2010 {
 		r.ReadEnd()
 		return
 	}
@@ -24154,65 +24184,65 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2006++
-	if yyhl2006 {
-		yyb2006 = yyj2006 > l
+	yyj2010++
+	if yyhl2010 {
+		yyb2010 = yyj2010 > l
 	} else {
-		yyb2006 = r.CheckBreak()
+		yyb2010 = r.CheckBreak()
 	}
-	if yyb2006 {
+	if yyb2010 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2009 := &x.ObjectMeta
-		yyv2009.CodecDecodeSelf(d)
+		yyv2013 := &x.ObjectMeta
+		yyv2013.CodecDecodeSelf(d)
 	}
-	yyj2006++
-	if yyhl2006 {
-		yyb2006 = yyj2006 > l
+	yyj2010++
+	if yyhl2010 {
+		yyb2010 = yyj2010 > l
 	} else {
-		yyb2006 = r.CheckBreak()
+		yyb2010 = r.CheckBreak()
 	}
-	if yyb2006 {
+	if yyb2010 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ServiceSpec{}
 	} else {
-		yyv2010 := &x.Spec
-		yyv2010.CodecDecodeSelf(d)
+		yyv2014 := &x.Spec
+		yyv2014.CodecDecodeSelf(d)
 	}
-	yyj2006++
-	if yyhl2006 {
-		yyb2006 = yyj2006 > l
+	yyj2010++
+	if yyhl2010 {
+		yyb2010 = yyj2010 > l
 	} else {
-		yyb2006 = r.CheckBreak()
+		yyb2010 = r.CheckBreak()
 	}
-	if yyb2006 {
+	if yyb2010 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ServiceStatus{}
 	} else {
-		yyv2011 := &x.Status
-		yyv2011.CodecDecodeSelf(d)
+		yyv2015 := &x.Status
+		yyv2015.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2006++
-		if yyhl2006 {
-			yyb2006 = yyj2006 > l
+		yyj2010++
+		if yyhl2010 {
+			yyb2010 = yyj2010 > l
 		} else {
-			yyb2006 = r.CheckBreak()
+			yyb2010 = r.CheckBreak()
 		}
-		if yyb2006 {
+		if yyb2010 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2006-1, "")
+		z.DecStructFieldNotFound(yyj2010-1, "")
 	}
 	r.ReadEnd()
 }
@@ -24224,95 +24254,95 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2012 := z.EncBinary()
-		_ = yym2012
+		yym2016 := z.EncBinary()
+		_ = yym2016
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2013 := !z.EncBinary()
-			yy2arr2013 := z.EncBasicHandle().StructToArray
-			var yyq2013 [5]bool
-			_, _, _ = yysep2013, yyq2013, yy2arr2013
-			const yyr2013 bool = false
-			yyq2013[0] = x.Kind != ""
-			yyq2013[1] = x.APIVersion != ""
-			yyq2013[2] = true
-			yyq2013[4] = len(x.ImagePullSecrets) != 0
-			if yyr2013 || yy2arr2013 {
+			yysep2017 := !z.EncBinary()
+			yy2arr2017 := z.EncBasicHandle().StructToArray
+			var yyq2017 [5]bool
+			_, _, _ = yysep2017, yyq2017, yy2arr2017
+			const yyr2017 bool = false
+			yyq2017[0] = x.Kind != ""
+			yyq2017[1] = x.APIVersion != ""
+			yyq2017[2] = true
+			yyq2017[4] = len(x.ImagePullSecrets) != 0
+			if yyr2017 || yy2arr2017 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2013 int = 1
-				for _, b := range yyq2013 {
+				var yynn2017 int = 1
+				for _, b := range yyq2017 {
 					if b {
-						yynn2013++
+						yynn2017++
 					}
 				}
-				r.EncodeMapStart(yynn2013)
+				r.EncodeMapStart(yynn2017)
 			}
-			if yyr2013 || yy2arr2013 {
-				if yyq2013[0] {
-					yym2015 := z.EncBinary()
-					_ = yym2015
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2013[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2016 := z.EncBinary()
-					_ = yym2016
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2013 || yy2arr2013 {
-				if yyq2013[1] {
-					yym2018 := z.EncBinary()
-					_ = yym2018
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2013[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2017 || yy2arr2017 {
+				if yyq2017[0] {
 					yym2019 := z.EncBinary()
 					_ = yym2019
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2017[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2020 := z.EncBinary()
+					_ = yym2020
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2017 || yy2arr2017 {
+				if yyq2017[1] {
+					yym2022 := z.EncBinary()
+					_ = yym2022
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2017[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2023 := z.EncBinary()
+					_ = yym2023
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2013 || yy2arr2013 {
-				if yyq2013[2] {
-					yy2021 := &x.ObjectMeta
-					yy2021.CodecEncodeSelf(e)
+			if yyr2017 || yy2arr2017 {
+				if yyq2017[2] {
+					yy2025 := &x.ObjectMeta
+					yy2025.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2013[2] {
+				if yyq2017[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2022 := &x.ObjectMeta
-					yy2022.CodecEncodeSelf(e)
+					yy2026 := &x.ObjectMeta
+					yy2026.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2013 || yy2arr2013 {
+			if yyr2017 || yy2arr2017 {
 				if x.Secrets == nil {
 					r.EncodeNil()
 				} else {
-					yym2024 := z.EncBinary()
-					_ = yym2024
+					yym2028 := z.EncBinary()
+					_ = yym2028
 					if false {
 					} else {
 						h.encSliceObjectReference(([]ObjectReference)(x.Secrets), e)
@@ -24323,21 +24353,21 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Secrets == nil {
 					r.EncodeNil()
 				} else {
-					yym2025 := z.EncBinary()
-					_ = yym2025
+					yym2029 := z.EncBinary()
+					_ = yym2029
 					if false {
 					} else {
 						h.encSliceObjectReference(([]ObjectReference)(x.Secrets), e)
 					}
 				}
 			}
-			if yyr2013 || yy2arr2013 {
-				if yyq2013[4] {
+			if yyr2017 || yy2arr2017 {
+				if yyq2017[4] {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2027 := z.EncBinary()
-						_ = yym2027
+						yym2031 := z.EncBinary()
+						_ = yym2031
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -24347,13 +24377,13 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2013[4] {
+				if yyq2017[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("imagePullSecrets"))
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2028 := z.EncBinary()
-						_ = yym2028
+						yym2032 := z.EncBinary()
+						_ = yym2032
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -24361,7 +24391,7 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2013 {
+			if yysep2017 {
 				r.EncodeEnd()
 			}
 		}
@@ -24372,24 +24402,24 @@ func (x *ServiceAccount) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2029 := z.DecBinary()
-	_ = yym2029
+	yym2033 := z.DecBinary()
+	_ = yym2033
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2030 := r.ReadMapStart()
-			if yyl2030 == 0 {
+			yyl2034 := r.ReadMapStart()
+			if yyl2034 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2030, d)
+				x.codecDecodeSelfFromMap(yyl2034, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2030 := r.ReadArrayStart()
-			if yyl2030 == 0 {
+			yyl2034 := r.ReadArrayStart()
+			if yyl2034 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2030, d)
+				x.codecDecodeSelfFromArray(yyl2034, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -24401,12 +24431,12 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2031Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2031Slc
-	var yyhl2031 bool = l >= 0
-	for yyj2031 := 0; ; yyj2031++ {
-		if yyhl2031 {
-			if yyj2031 >= l {
+	var yys2035Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2035Slc
+	var yyhl2035 bool = l >= 0
+	for yyj2035 := 0; ; yyj2035++ {
+		if yyhl2035 {
+			if yyj2035 >= l {
 				break
 			}
 		} else {
@@ -24414,9 +24444,9 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2031Slc = r.DecodeBytes(yys2031Slc, true, true)
-		yys2031 := string(yys2031Slc)
-		switch yys2031 {
+		yys2035Slc = r.DecodeBytes(yys2035Slc, true, true)
+		yys2035 := string(yys2035Slc)
+		switch yys2035 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24433,38 +24463,38 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2034 := &x.ObjectMeta
-				yyv2034.CodecDecodeSelf(d)
+				yyv2038 := &x.ObjectMeta
+				yyv2038.CodecDecodeSelf(d)
 			}
 		case "secrets":
 			if r.TryDecodeAsNil() {
 				x.Secrets = nil
 			} else {
-				yyv2035 := &x.Secrets
-				yym2036 := z.DecBinary()
-				_ = yym2036
+				yyv2039 := &x.Secrets
+				yym2040 := z.DecBinary()
+				_ = yym2040
 				if false {
 				} else {
-					h.decSliceObjectReference((*[]ObjectReference)(yyv2035), d)
+					h.decSliceObjectReference((*[]ObjectReference)(yyv2039), d)
 				}
 			}
 		case "imagePullSecrets":
 			if r.TryDecodeAsNil() {
 				x.ImagePullSecrets = nil
 			} else {
-				yyv2037 := &x.ImagePullSecrets
-				yym2038 := z.DecBinary()
-				_ = yym2038
+				yyv2041 := &x.ImagePullSecrets
+				yym2042 := z.DecBinary()
+				_ = yym2042
 				if false {
 				} else {
-					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2037), d)
+					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2041), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2031)
-		} // end switch yys2031
-	} // end for yyj2031
-	if !yyhl2031 {
+			z.DecStructFieldNotFound(-1, yys2035)
+		} // end switch yys2035
+	} // end for yyj2035
+	if !yyhl2035 {
 		r.ReadEnd()
 	}
 }
@@ -24473,16 +24503,16 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2039 int
-	var yyb2039 bool
-	var yyhl2039 bool = l >= 0
-	yyj2039++
-	if yyhl2039 {
-		yyb2039 = yyj2039 > l
+	var yyj2043 int
+	var yyb2043 bool
+	var yyhl2043 bool = l >= 0
+	yyj2043++
+	if yyhl2043 {
+		yyb2043 = yyj2043 > l
 	} else {
-		yyb2039 = r.CheckBreak()
+		yyb2043 = r.CheckBreak()
 	}
-	if yyb2039 {
+	if yyb2043 {
 		r.ReadEnd()
 		return
 	}
@@ -24491,13 +24521,13 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2039++
-	if yyhl2039 {
-		yyb2039 = yyj2039 > l
+	yyj2043++
+	if yyhl2043 {
+		yyb2043 = yyj2043 > l
 	} else {
-		yyb2039 = r.CheckBreak()
+		yyb2043 = r.CheckBreak()
 	}
-	if yyb2039 {
+	if yyb2043 {
 		r.ReadEnd()
 		return
 	}
@@ -24506,75 +24536,75 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2039++
-	if yyhl2039 {
-		yyb2039 = yyj2039 > l
+	yyj2043++
+	if yyhl2043 {
+		yyb2043 = yyj2043 > l
 	} else {
-		yyb2039 = r.CheckBreak()
+		yyb2043 = r.CheckBreak()
 	}
-	if yyb2039 {
+	if yyb2043 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2042 := &x.ObjectMeta
-		yyv2042.CodecDecodeSelf(d)
+		yyv2046 := &x.ObjectMeta
+		yyv2046.CodecDecodeSelf(d)
 	}
-	yyj2039++
-	if yyhl2039 {
-		yyb2039 = yyj2039 > l
+	yyj2043++
+	if yyhl2043 {
+		yyb2043 = yyj2043 > l
 	} else {
-		yyb2039 = r.CheckBreak()
+		yyb2043 = r.CheckBreak()
 	}
-	if yyb2039 {
+	if yyb2043 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Secrets = nil
 	} else {
-		yyv2043 := &x.Secrets
-		yym2044 := z.DecBinary()
-		_ = yym2044
+		yyv2047 := &x.Secrets
+		yym2048 := z.DecBinary()
+		_ = yym2048
 		if false {
 		} else {
-			h.decSliceObjectReference((*[]ObjectReference)(yyv2043), d)
+			h.decSliceObjectReference((*[]ObjectReference)(yyv2047), d)
 		}
 	}
-	yyj2039++
-	if yyhl2039 {
-		yyb2039 = yyj2039 > l
+	yyj2043++
+	if yyhl2043 {
+		yyb2043 = yyj2043 > l
 	} else {
-		yyb2039 = r.CheckBreak()
+		yyb2043 = r.CheckBreak()
 	}
-	if yyb2039 {
+	if yyb2043 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ImagePullSecrets = nil
 	} else {
-		yyv2045 := &x.ImagePullSecrets
-		yym2046 := z.DecBinary()
-		_ = yym2046
+		yyv2049 := &x.ImagePullSecrets
+		yym2050 := z.DecBinary()
+		_ = yym2050
 		if false {
 		} else {
-			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2045), d)
+			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2049), d)
 		}
 	}
 	for {
-		yyj2039++
-		if yyhl2039 {
-			yyb2039 = yyj2039 > l
+		yyj2043++
+		if yyhl2043 {
+			yyb2043 = yyj2043 > l
 		} else {
-			yyb2039 = r.CheckBreak()
+			yyb2043 = r.CheckBreak()
 		}
-		if yyb2039 {
+		if yyb2043 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2039-1, "")
+		z.DecStructFieldNotFound(yyj2043-1, "")
 	}
 	r.ReadEnd()
 }
@@ -24586,106 +24616,106 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2047 := z.EncBinary()
-		_ = yym2047
+		yym2051 := z.EncBinary()
+		_ = yym2051
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2048 := !z.EncBinary()
-			yy2arr2048 := z.EncBasicHandle().StructToArray
-			var yyq2048 [4]bool
-			_, _, _ = yysep2048, yyq2048, yy2arr2048
-			const yyr2048 bool = false
-			yyq2048[0] = x.Kind != ""
-			yyq2048[1] = x.APIVersion != ""
-			yyq2048[2] = true
-			if yyr2048 || yy2arr2048 {
+			yysep2052 := !z.EncBinary()
+			yy2arr2052 := z.EncBasicHandle().StructToArray
+			var yyq2052 [4]bool
+			_, _, _ = yysep2052, yyq2052, yy2arr2052
+			const yyr2052 bool = false
+			yyq2052[0] = x.Kind != ""
+			yyq2052[1] = x.APIVersion != ""
+			yyq2052[2] = true
+			if yyr2052 || yy2arr2052 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2048 int = 1
-				for _, b := range yyq2048 {
+				var yynn2052 int = 1
+				for _, b := range yyq2052 {
 					if b {
-						yynn2048++
+						yynn2052++
 					}
 				}
-				r.EncodeMapStart(yynn2048)
+				r.EncodeMapStart(yynn2052)
 			}
-			if yyr2048 || yy2arr2048 {
-				if yyq2048[0] {
-					yym2050 := z.EncBinary()
-					_ = yym2050
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2048[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2051 := z.EncBinary()
-					_ = yym2051
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2048 || yy2arr2048 {
-				if yyq2048[1] {
-					yym2053 := z.EncBinary()
-					_ = yym2053
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2048[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2052 || yy2arr2052 {
+				if yyq2052[0] {
 					yym2054 := z.EncBinary()
 					_ = yym2054
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2052[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2055 := z.EncBinary()
+					_ = yym2055
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2052 || yy2arr2052 {
+				if yyq2052[1] {
+					yym2057 := z.EncBinary()
+					_ = yym2057
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2052[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2058 := z.EncBinary()
+					_ = yym2058
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2048 || yy2arr2048 {
-				if yyq2048[2] {
-					yy2056 := &x.ListMeta
-					yym2057 := z.EncBinary()
-					_ = yym2057
+			if yyr2052 || yy2arr2052 {
+				if yyq2052[2] {
+					yy2060 := &x.ListMeta
+					yym2061 := z.EncBinary()
+					_ = yym2061
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2056) {
+					} else if z.HasExtensions() && z.EncExt(yy2060) {
 					} else {
-						z.EncFallback(yy2056)
+						z.EncFallback(yy2060)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2048[2] {
+				if yyq2052[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2058 := &x.ListMeta
-					yym2059 := z.EncBinary()
-					_ = yym2059
+					yy2062 := &x.ListMeta
+					yym2063 := z.EncBinary()
+					_ = yym2063
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2058) {
+					} else if z.HasExtensions() && z.EncExt(yy2062) {
 					} else {
-						z.EncFallback(yy2058)
+						z.EncFallback(yy2062)
 					}
 				}
 			}
-			if yyr2048 || yy2arr2048 {
+			if yyr2052 || yy2arr2052 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2061 := z.EncBinary()
-					_ = yym2061
+					yym2065 := z.EncBinary()
+					_ = yym2065
 					if false {
 					} else {
 						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
@@ -24696,15 +24726,15 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2062 := z.EncBinary()
-					_ = yym2062
+					yym2066 := z.EncBinary()
+					_ = yym2066
 					if false {
 					} else {
 						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
 					}
 				}
 			}
-			if yysep2048 {
+			if yysep2052 {
 				r.EncodeEnd()
 			}
 		}
@@ -24715,24 +24745,24 @@ func (x *ServiceAccountList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2063 := z.DecBinary()
-	_ = yym2063
+	yym2067 := z.DecBinary()
+	_ = yym2067
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2064 := r.ReadMapStart()
-			if yyl2064 == 0 {
+			yyl2068 := r.ReadMapStart()
+			if yyl2068 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2064, d)
+				x.codecDecodeSelfFromMap(yyl2068, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2064 := r.ReadArrayStart()
-			if yyl2064 == 0 {
+			yyl2068 := r.ReadArrayStart()
+			if yyl2068 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2064, d)
+				x.codecDecodeSelfFromArray(yyl2068, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -24744,12 +24774,12 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2065Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2065Slc
-	var yyhl2065 bool = l >= 0
-	for yyj2065 := 0; ; yyj2065++ {
-		if yyhl2065 {
-			if yyj2065 >= l {
+	var yys2069Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2069Slc
+	var yyhl2069 bool = l >= 0
+	for yyj2069 := 0; ; yyj2069++ {
+		if yyhl2069 {
+			if yyj2069 >= l {
 				break
 			}
 		} else {
@@ -24757,9 +24787,9 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys2065Slc = r.DecodeBytes(yys2065Slc, true, true)
-		yys2065 := string(yys2065Slc)
-		switch yys2065 {
+		yys2069Slc = r.DecodeBytes(yys2069Slc, true, true)
+		yys2069 := string(yys2069Slc)
+		switch yys2069 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24776,32 +24806,32 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2068 := &x.ListMeta
-				yym2069 := z.DecBinary()
-				_ = yym2069
+				yyv2072 := &x.ListMeta
+				yym2073 := z.DecBinary()
+				_ = yym2073
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2068) {
+				} else if z.HasExtensions() && z.DecExt(yyv2072) {
 				} else {
-					z.DecFallback(yyv2068, false)
+					z.DecFallback(yyv2072, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2070 := &x.Items
-				yym2071 := z.DecBinary()
-				_ = yym2071
+				yyv2074 := &x.Items
+				yym2075 := z.DecBinary()
+				_ = yym2075
 				if false {
 				} else {
-					h.decSliceServiceAccount((*[]ServiceAccount)(yyv2070), d)
+					h.decSliceServiceAccount((*[]ServiceAccount)(yyv2074), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2065)
-		} // end switch yys2065
-	} // end for yyj2065
-	if !yyhl2065 {
+			z.DecStructFieldNotFound(-1, yys2069)
+		} // end switch yys2069
+	} // end for yyj2069
+	if !yyhl2069 {
 		r.ReadEnd()
 	}
 }
@@ -24810,16 +24840,16 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2072 int
-	var yyb2072 bool
-	var yyhl2072 bool = l >= 0
-	yyj2072++
-	if yyhl2072 {
-		yyb2072 = yyj2072 > l
+	var yyj2076 int
+	var yyb2076 bool
+	var yyhl2076 bool = l >= 0
+	yyj2076++
+	if yyhl2076 {
+		yyb2076 = yyj2076 > l
 	} else {
-		yyb2072 = r.CheckBreak()
+		yyb2076 = r.CheckBreak()
 	}
-	if yyb2072 {
+	if yyb2076 {
 		r.ReadEnd()
 		return
 	}
@@ -24828,13 +24858,13 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2072++
-	if yyhl2072 {
-		yyb2072 = yyj2072 > l
+	yyj2076++
+	if yyhl2076 {
+		yyb2076 = yyj2076 > l
 	} else {
-		yyb2072 = r.CheckBreak()
+		yyb2076 = r.CheckBreak()
 	}
-	if yyb2072 {
+	if yyb2076 {
 		r.ReadEnd()
 		return
 	}
@@ -24843,60 +24873,60 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2072++
-	if yyhl2072 {
-		yyb2072 = yyj2072 > l
+	yyj2076++
+	if yyhl2076 {
+		yyb2076 = yyj2076 > l
 	} else {
-		yyb2072 = r.CheckBreak()
+		yyb2076 = r.CheckBreak()
 	}
-	if yyb2072 {
+	if yyb2076 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2075 := &x.ListMeta
-		yym2076 := z.DecBinary()
-		_ = yym2076
+		yyv2079 := &x.ListMeta
+		yym2080 := z.DecBinary()
+		_ = yym2080
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2075) {
+		} else if z.HasExtensions() && z.DecExt(yyv2079) {
 		} else {
-			z.DecFallback(yyv2075, false)
+			z.DecFallback(yyv2079, false)
 		}
 	}
-	yyj2072++
-	if yyhl2072 {
-		yyb2072 = yyj2072 > l
+	yyj2076++
+	if yyhl2076 {
+		yyb2076 = yyj2076 > l
 	} else {
-		yyb2072 = r.CheckBreak()
+		yyb2076 = r.CheckBreak()
 	}
-	if yyb2072 {
+	if yyb2076 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2077 := &x.Items
-		yym2078 := z.DecBinary()
-		_ = yym2078
+		yyv2081 := &x.Items
+		yym2082 := z.DecBinary()
+		_ = yym2082
 		if false {
 		} else {
-			h.decSliceServiceAccount((*[]ServiceAccount)(yyv2077), d)
+			h.decSliceServiceAccount((*[]ServiceAccount)(yyv2081), d)
 		}
 	}
 	for {
-		yyj2072++
-		if yyhl2072 {
-			yyb2072 = yyj2072 > l
+		yyj2076++
+		if yyhl2076 {
+			yyb2076 = yyj2076 > l
 		} else {
-			yyb2072 = r.CheckBreak()
+			yyb2076 = r.CheckBreak()
 		}
-		if yyb2072 {
+		if yyb2076 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2072-1, "")
+		z.DecStructFieldNotFound(yyj2076-1, "")
 	}
 	r.ReadEnd()
 }
@@ -24908,94 +24938,94 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2079 := z.EncBinary()
-		_ = yym2079
+		yym2083 := z.EncBinary()
+		_ = yym2083
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2080 := !z.EncBinary()
-			yy2arr2080 := z.EncBasicHandle().StructToArray
-			var yyq2080 [4]bool
-			_, _, _ = yysep2080, yyq2080, yy2arr2080
-			const yyr2080 bool = false
-			yyq2080[0] = x.Kind != ""
-			yyq2080[1] = x.APIVersion != ""
-			yyq2080[2] = true
-			if yyr2080 || yy2arr2080 {
+			yysep2084 := !z.EncBinary()
+			yy2arr2084 := z.EncBasicHandle().StructToArray
+			var yyq2084 [4]bool
+			_, _, _ = yysep2084, yyq2084, yy2arr2084
+			const yyr2084 bool = false
+			yyq2084[0] = x.Kind != ""
+			yyq2084[1] = x.APIVersion != ""
+			yyq2084[2] = true
+			if yyr2084 || yy2arr2084 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2080 int = 1
-				for _, b := range yyq2080 {
+				var yynn2084 int = 1
+				for _, b := range yyq2084 {
 					if b {
-						yynn2080++
+						yynn2084++
 					}
 				}
-				r.EncodeMapStart(yynn2080)
+				r.EncodeMapStart(yynn2084)
 			}
-			if yyr2080 || yy2arr2080 {
-				if yyq2080[0] {
-					yym2082 := z.EncBinary()
-					_ = yym2082
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2080[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2083 := z.EncBinary()
-					_ = yym2083
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2080 || yy2arr2080 {
-				if yyq2080[1] {
-					yym2085 := z.EncBinary()
-					_ = yym2085
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2080[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2084 || yy2arr2084 {
+				if yyq2084[0] {
 					yym2086 := z.EncBinary()
 					_ = yym2086
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2084[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2087 := z.EncBinary()
+					_ = yym2087
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2084 || yy2arr2084 {
+				if yyq2084[1] {
+					yym2089 := z.EncBinary()
+					_ = yym2089
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2084[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2090 := z.EncBinary()
+					_ = yym2090
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2080 || yy2arr2080 {
-				if yyq2080[2] {
-					yy2088 := &x.ObjectMeta
-					yy2088.CodecEncodeSelf(e)
+			if yyr2084 || yy2arr2084 {
+				if yyq2084[2] {
+					yy2092 := &x.ObjectMeta
+					yy2092.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2080[2] {
+				if yyq2084[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2089 := &x.ObjectMeta
-					yy2089.CodecEncodeSelf(e)
+					yy2093 := &x.ObjectMeta
+					yy2093.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2080 || yy2arr2080 {
+			if yyr2084 || yy2arr2084 {
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
-					yym2091 := z.EncBinary()
-					_ = yym2091
+					yym2095 := z.EncBinary()
+					_ = yym2095
 					if false {
 					} else {
 						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
@@ -25006,15 +25036,15 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
-					yym2092 := z.EncBinary()
-					_ = yym2092
+					yym2096 := z.EncBinary()
+					_ = yym2096
 					if false {
 					} else {
 						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
 					}
 				}
 			}
-			if yysep2080 {
+			if yysep2084 {
 				r.EncodeEnd()
 			}
 		}
@@ -25025,24 +25055,24 @@ func (x *Endpoints) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2093 := z.DecBinary()
-	_ = yym2093
+	yym2097 := z.DecBinary()
+	_ = yym2097
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2094 := r.ReadMapStart()
-			if yyl2094 == 0 {
+			yyl2098 := r.ReadMapStart()
+			if yyl2098 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2094, d)
+				x.codecDecodeSelfFromMap(yyl2098, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2094 := r.ReadArrayStart()
-			if yyl2094 == 0 {
+			yyl2098 := r.ReadArrayStart()
+			if yyl2098 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2094, d)
+				x.codecDecodeSelfFromArray(yyl2098, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -25054,12 +25084,12 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2095Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2095Slc
-	var yyhl2095 bool = l >= 0
-	for yyj2095 := 0; ; yyj2095++ {
-		if yyhl2095 {
-			if yyj2095 >= l {
+	var yys2099Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2099Slc
+	var yyhl2099 bool = l >= 0
+	for yyj2099 := 0; ; yyj2099++ {
+		if yyhl2099 {
+			if yyj2099 >= l {
 				break
 			}
 		} else {
@@ -25067,9 +25097,9 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2095Slc = r.DecodeBytes(yys2095Slc, true, true)
-		yys2095 := string(yys2095Slc)
-		switch yys2095 {
+		yys2099Slc = r.DecodeBytes(yys2099Slc, true, true)
+		yys2099 := string(yys2099Slc)
+		switch yys2099 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -25086,26 +25116,26 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2098 := &x.ObjectMeta
-				yyv2098.CodecDecodeSelf(d)
+				yyv2102 := &x.ObjectMeta
+				yyv2102.CodecDecodeSelf(d)
 			}
 		case "Subsets":
 			if r.TryDecodeAsNil() {
 				x.Subsets = nil
 			} else {
-				yyv2099 := &x.Subsets
-				yym2100 := z.DecBinary()
-				_ = yym2100
+				yyv2103 := &x.Subsets
+				yym2104 := z.DecBinary()
+				_ = yym2104
 				if false {
 				} else {
-					h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2099), d)
+					h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2103), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2095)
-		} // end switch yys2095
-	} // end for yyj2095
-	if !yyhl2095 {
+			z.DecStructFieldNotFound(-1, yys2099)
+		} // end switch yys2099
+	} // end for yyj2099
+	if !yyhl2099 {
 		r.ReadEnd()
 	}
 }
@@ -25114,16 +25144,16 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2101 int
-	var yyb2101 bool
-	var yyhl2101 bool = l >= 0
-	yyj2101++
-	if yyhl2101 {
-		yyb2101 = yyj2101 > l
+	var yyj2105 int
+	var yyb2105 bool
+	var yyhl2105 bool = l >= 0
+	yyj2105++
+	if yyhl2105 {
+		yyb2105 = yyj2105 > l
 	} else {
-		yyb2101 = r.CheckBreak()
+		yyb2105 = r.CheckBreak()
 	}
-	if yyb2101 {
+	if yyb2105 {
 		r.ReadEnd()
 		return
 	}
@@ -25132,13 +25162,13 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2101++
-	if yyhl2101 {
-		yyb2101 = yyj2101 > l
+	yyj2105++
+	if yyhl2105 {
+		yyb2105 = yyj2105 > l
 	} else {
-		yyb2101 = r.CheckBreak()
+		yyb2105 = r.CheckBreak()
 	}
-	if yyb2101 {
+	if yyb2105 {
 		r.ReadEnd()
 		return
 	}
@@ -25147,54 +25177,54 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2101++
-	if yyhl2101 {
-		yyb2101 = yyj2101 > l
+	yyj2105++
+	if yyhl2105 {
+		yyb2105 = yyj2105 > l
 	} else {
-		yyb2101 = r.CheckBreak()
+		yyb2105 = r.CheckBreak()
 	}
-	if yyb2101 {
+	if yyb2105 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2104 := &x.ObjectMeta
-		yyv2104.CodecDecodeSelf(d)
+		yyv2108 := &x.ObjectMeta
+		yyv2108.CodecDecodeSelf(d)
 	}
-	yyj2101++
-	if yyhl2101 {
-		yyb2101 = yyj2101 > l
+	yyj2105++
+	if yyhl2105 {
+		yyb2105 = yyj2105 > l
 	} else {
-		yyb2101 = r.CheckBreak()
+		yyb2105 = r.CheckBreak()
 	}
-	if yyb2101 {
+	if yyb2105 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Subsets = nil
 	} else {
-		yyv2105 := &x.Subsets
-		yym2106 := z.DecBinary()
-		_ = yym2106
+		yyv2109 := &x.Subsets
+		yym2110 := z.DecBinary()
+		_ = yym2110
 		if false {
 		} else {
-			h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2105), d)
+			h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2109), d)
 		}
 	}
 	for {
-		yyj2101++
-		if yyhl2101 {
-			yyb2101 = yyj2101 > l
+		yyj2105++
+		if yyhl2105 {
+			yyb2105 = yyj2105 > l
 		} else {
-			yyb2101 = r.CheckBreak()
+			yyb2105 = r.CheckBreak()
 		}
-		if yyb2101 {
+		if yyb2105 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2101-1, "")
+		z.DecStructFieldNotFound(yyj2105-1, "")
 	}
 	r.ReadEnd()
 }
@@ -25206,33 +25236,33 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2107 := z.EncBinary()
-		_ = yym2107
+		yym2111 := z.EncBinary()
+		_ = yym2111
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2108 := !z.EncBinary()
-			yy2arr2108 := z.EncBasicHandle().StructToArray
-			var yyq2108 [3]bool
-			_, _, _ = yysep2108, yyq2108, yy2arr2108
-			const yyr2108 bool = false
-			if yyr2108 || yy2arr2108 {
+			yysep2112 := !z.EncBinary()
+			yy2arr2112 := z.EncBasicHandle().StructToArray
+			var yyq2112 [3]bool
+			_, _, _ = yysep2112, yyq2112, yy2arr2112
+			const yyr2112 bool = false
+			if yyr2112 || yy2arr2112 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2108 int = 3
-				for _, b := range yyq2108 {
+				var yynn2112 int = 3
+				for _, b := range yyq2112 {
 					if b {
-						yynn2108++
+						yynn2112++
 					}
 				}
-				r.EncodeMapStart(yynn2108)
+				r.EncodeMapStart(yynn2112)
 			}
-			if yyr2108 || yy2arr2108 {
+			if yyr2112 || yy2arr2112 {
 				if x.Addresses == nil {
 					r.EncodeNil()
 				} else {
-					yym2110 := z.EncBinary()
-					_ = yym2110
+					yym2114 := z.EncBinary()
+					_ = yym2114
 					if false {
 					} else {
 						h.encSliceEndpointAddress(([]EndpointAddress)(x.Addresses), e)
@@ -25243,20 +25273,20 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Addresses == nil {
 					r.EncodeNil()
 				} else {
-					yym2111 := z.EncBinary()
-					_ = yym2111
+					yym2115 := z.EncBinary()
+					_ = yym2115
 					if false {
 					} else {
 						h.encSliceEndpointAddress(([]EndpointAddress)(x.Addresses), e)
 					}
 				}
 			}
-			if yyr2108 || yy2arr2108 {
+			if yyr2112 || yy2arr2112 {
 				if x.NotReadyAddresses == nil {
 					r.EncodeNil()
 				} else {
-					yym2113 := z.EncBinary()
-					_ = yym2113
+					yym2117 := z.EncBinary()
+					_ = yym2117
 					if false {
 					} else {
 						h.encSliceEndpointAddress(([]EndpointAddress)(x.NotReadyAddresses), e)
@@ -25267,20 +25297,20 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.NotReadyAddresses == nil {
 					r.EncodeNil()
 				} else {
-					yym2114 := z.EncBinary()
-					_ = yym2114
+					yym2118 := z.EncBinary()
+					_ = yym2118
 					if false {
 					} else {
 						h.encSliceEndpointAddress(([]EndpointAddress)(x.NotReadyAddresses), e)
 					}
 				}
 			}
-			if yyr2108 || yy2arr2108 {
+			if yyr2112 || yy2arr2112 {
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
-					yym2116 := z.EncBinary()
-					_ = yym2116
+					yym2120 := z.EncBinary()
+					_ = yym2120
 					if false {
 					} else {
 						h.encSliceEndpointPort(([]EndpointPort)(x.Ports), e)
@@ -25291,15 +25321,15 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
-					yym2117 := z.EncBinary()
-					_ = yym2117
+					yym2121 := z.EncBinary()
+					_ = yym2121
 					if false {
 					} else {
 						h.encSliceEndpointPort(([]EndpointPort)(x.Ports), e)
 					}
 				}
 			}
-			if yysep2108 {
+			if yysep2112 {
 				r.EncodeEnd()
 			}
 		}
@@ -25310,24 +25340,24 @@ func (x *EndpointSubset) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2118 := z.DecBinary()
-	_ = yym2118
+	yym2122 := z.DecBinary()
+	_ = yym2122
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2119 := r.ReadMapStart()
-			if yyl2119 == 0 {
+			yyl2123 := r.ReadMapStart()
+			if yyl2123 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2119, d)
+				x.codecDecodeSelfFromMap(yyl2123, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2119 := r.ReadArrayStart()
-			if yyl2119 == 0 {
+			yyl2123 := r.ReadArrayStart()
+			if yyl2123 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2119, d)
+				x.codecDecodeSelfFromArray(yyl2123, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -25339,12 +25369,12 @@ func (x *EndpointSubset) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2120Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2120Slc
-	var yyhl2120 bool = l >= 0
-	for yyj2120 := 0; ; yyj2120++ {
-		if yyhl2120 {
-			if yyj2120 >= l {
+	var yys2124Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2124Slc
+	var yyhl2124 bool = l >= 0
+	for yyj2124 := 0; ; yyj2124++ {
+		if yyhl2124 {
+			if yyj2124 >= l {
 				break
 			}
 		} else {
@@ -25352,50 +25382,50 @@ func (x *EndpointSubset) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2120Slc = r.DecodeBytes(yys2120Slc, true, true)
-		yys2120 := string(yys2120Slc)
-		switch yys2120 {
+		yys2124Slc = r.DecodeBytes(yys2124Slc, true, true)
+		yys2124 := string(yys2124Slc)
+		switch yys2124 {
 		case "Addresses":
 			if r.TryDecodeAsNil() {
 				x.Addresses = nil
 			} else {
-				yyv2121 := &x.Addresses
-				yym2122 := z.DecBinary()
-				_ = yym2122
+				yyv2125 := &x.Addresses
+				yym2126 := z.DecBinary()
+				_ = yym2126
 				if false {
 				} else {
-					h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2121), d)
+					h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2125), d)
 				}
 			}
 		case "NotReadyAddresses":
 			if r.TryDecodeAsNil() {
 				x.NotReadyAddresses = nil
 			} else {
-				yyv2123 := &x.NotReadyAddresses
-				yym2124 := z.DecBinary()
-				_ = yym2124
+				yyv2127 := &x.NotReadyAddresses
+				yym2128 := z.DecBinary()
+				_ = yym2128
 				if false {
 				} else {
-					h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2123), d)
+					h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2127), d)
 				}
 			}
 		case "Ports":
 			if r.TryDecodeAsNil() {
 				x.Ports = nil
 			} else {
-				yyv2125 := &x.Ports
-				yym2126 := z.DecBinary()
-				_ = yym2126
+				yyv2129 := &x.Ports
+				yym2130 := z.DecBinary()
+				_ = yym2130
 				if false {
 				} else {
-					h.decSliceEndpointPort((*[]EndpointPort)(yyv2125), d)
+					h.decSliceEndpointPort((*[]EndpointPort)(yyv2129), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2120)
-		} // end switch yys2120
-	} // end for yyj2120
-	if !yyhl2120 {
+			z.DecStructFieldNotFound(-1, yys2124)
+		} // end switch yys2124
+	} // end for yyj2124
+	if !yyhl2124 {
 		r.ReadEnd()
 	}
 }
@@ -25404,83 +25434,83 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2127 int
-	var yyb2127 bool
-	var yyhl2127 bool = l >= 0
-	yyj2127++
-	if yyhl2127 {
-		yyb2127 = yyj2127 > l
+	var yyj2131 int
+	var yyb2131 bool
+	var yyhl2131 bool = l >= 0
+	yyj2131++
+	if yyhl2131 {
+		yyb2131 = yyj2131 > l
 	} else {
-		yyb2127 = r.CheckBreak()
+		yyb2131 = r.CheckBreak()
 	}
-	if yyb2127 {
+	if yyb2131 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Addresses = nil
 	} else {
-		yyv2128 := &x.Addresses
-		yym2129 := z.DecBinary()
-		_ = yym2129
+		yyv2132 := &x.Addresses
+		yym2133 := z.DecBinary()
+		_ = yym2133
 		if false {
 		} else {
-			h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2128), d)
+			h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2132), d)
 		}
 	}
-	yyj2127++
-	if yyhl2127 {
-		yyb2127 = yyj2127 > l
+	yyj2131++
+	if yyhl2131 {
+		yyb2131 = yyj2131 > l
 	} else {
-		yyb2127 = r.CheckBreak()
+		yyb2131 = r.CheckBreak()
 	}
-	if yyb2127 {
+	if yyb2131 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.NotReadyAddresses = nil
 	} else {
-		yyv2130 := &x.NotReadyAddresses
-		yym2131 := z.DecBinary()
-		_ = yym2131
+		yyv2134 := &x.NotReadyAddresses
+		yym2135 := z.DecBinary()
+		_ = yym2135
 		if false {
 		} else {
-			h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2130), d)
+			h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2134), d)
 		}
 	}
-	yyj2127++
-	if yyhl2127 {
-		yyb2127 = yyj2127 > l
+	yyj2131++
+	if yyhl2131 {
+		yyb2131 = yyj2131 > l
 	} else {
-		yyb2127 = r.CheckBreak()
+		yyb2131 = r.CheckBreak()
 	}
-	if yyb2127 {
+	if yyb2131 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
-		yyv2132 := &x.Ports
-		yym2133 := z.DecBinary()
-		_ = yym2133
+		yyv2136 := &x.Ports
+		yym2137 := z.DecBinary()
+		_ = yym2137
 		if false {
 		} else {
-			h.decSliceEndpointPort((*[]EndpointPort)(yyv2132), d)
+			h.decSliceEndpointPort((*[]EndpointPort)(yyv2136), d)
 		}
 	}
 	for {
-		yyj2127++
-		if yyhl2127 {
-			yyb2127 = yyj2127 > l
+		yyj2131++
+		if yyhl2131 {
+			yyb2131 = yyj2131 > l
 		} else {
-			yyb2127 = r.CheckBreak()
+			yyb2131 = r.CheckBreak()
 		}
-		if yyb2127 {
+		if yyb2131 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2127-1, "")
+		z.DecStructFieldNotFound(yyj2131-1, "")
 	}
 	r.ReadEnd()
 }
@@ -25492,44 +25522,44 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2134 := z.EncBinary()
-		_ = yym2134
+		yym2138 := z.EncBinary()
+		_ = yym2138
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2135 := !z.EncBinary()
-			yy2arr2135 := z.EncBasicHandle().StructToArray
-			var yyq2135 [2]bool
-			_, _, _ = yysep2135, yyq2135, yy2arr2135
-			const yyr2135 bool = false
-			if yyr2135 || yy2arr2135 {
+			yysep2139 := !z.EncBinary()
+			yy2arr2139 := z.EncBasicHandle().StructToArray
+			var yyq2139 [2]bool
+			_, _, _ = yysep2139, yyq2139, yy2arr2139
+			const yyr2139 bool = false
+			if yyr2139 || yy2arr2139 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2135 int = 2
-				for _, b := range yyq2135 {
+				var yynn2139 int = 2
+				for _, b := range yyq2139 {
 					if b {
-						yynn2135++
+						yynn2139++
 					}
 				}
-				r.EncodeMapStart(yynn2135)
+				r.EncodeMapStart(yynn2139)
 			}
-			if yyr2135 || yy2arr2135 {
-				yym2137 := z.EncBinary()
-				_ = yym2137
+			if yyr2139 || yy2arr2139 {
+				yym2141 := z.EncBinary()
+				_ = yym2141
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.IP))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("IP"))
-				yym2138 := z.EncBinary()
-				_ = yym2138
+				yym2142 := z.EncBinary()
+				_ = yym2142
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.IP))
 				}
 			}
-			if yyr2135 || yy2arr2135 {
+			if yyr2139 || yy2arr2139 {
 				if x.TargetRef == nil {
 					r.EncodeNil()
 				} else {
@@ -25543,7 +25573,7 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					x.TargetRef.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2135 {
+			if yysep2139 {
 				r.EncodeEnd()
 			}
 		}
@@ -25554,24 +25584,24 @@ func (x *EndpointAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2140 := z.DecBinary()
-	_ = yym2140
+	yym2144 := z.DecBinary()
+	_ = yym2144
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2141 := r.ReadMapStart()
-			if yyl2141 == 0 {
+			yyl2145 := r.ReadMapStart()
+			if yyl2145 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2141, d)
+				x.codecDecodeSelfFromMap(yyl2145, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2141 := r.ReadArrayStart()
-			if yyl2141 == 0 {
+			yyl2145 := r.ReadArrayStart()
+			if yyl2145 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2141, d)
+				x.codecDecodeSelfFromArray(yyl2145, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -25583,12 +25613,12 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2142Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2142Slc
-	var yyhl2142 bool = l >= 0
-	for yyj2142 := 0; ; yyj2142++ {
-		if yyhl2142 {
-			if yyj2142 >= l {
+	var yys2146Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2146Slc
+	var yyhl2146 bool = l >= 0
+	for yyj2146 := 0; ; yyj2146++ {
+		if yyhl2146 {
+			if yyj2146 >= l {
 				break
 			}
 		} else {
@@ -25596,9 +25626,9 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2142Slc = r.DecodeBytes(yys2142Slc, true, true)
-		yys2142 := string(yys2142Slc)
-		switch yys2142 {
+		yys2146Slc = r.DecodeBytes(yys2146Slc, true, true)
+		yys2146 := string(yys2146Slc)
+		switch yys2146 {
 		case "IP":
 			if r.TryDecodeAsNil() {
 				x.IP = ""
@@ -25617,10 +25647,10 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.TargetRef.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2142)
-		} // end switch yys2142
-	} // end for yyj2142
-	if !yyhl2142 {
+			z.DecStructFieldNotFound(-1, yys2146)
+		} // end switch yys2146
+	} // end for yyj2146
+	if !yyhl2146 {
 		r.ReadEnd()
 	}
 }
@@ -25629,16 +25659,16 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2145 int
-	var yyb2145 bool
-	var yyhl2145 bool = l >= 0
-	yyj2145++
-	if yyhl2145 {
-		yyb2145 = yyj2145 > l
+	var yyj2149 int
+	var yyb2149 bool
+	var yyhl2149 bool = l >= 0
+	yyj2149++
+	if yyhl2149 {
+		yyb2149 = yyj2149 > l
 	} else {
-		yyb2145 = r.CheckBreak()
+		yyb2149 = r.CheckBreak()
 	}
-	if yyb2145 {
+	if yyb2149 {
 		r.ReadEnd()
 		return
 	}
@@ -25647,13 +25677,13 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.IP = string(r.DecodeString())
 	}
-	yyj2145++
-	if yyhl2145 {
-		yyb2145 = yyj2145 > l
+	yyj2149++
+	if yyhl2149 {
+		yyb2149 = yyj2149 > l
 	} else {
-		yyb2145 = r.CheckBreak()
+		yyb2149 = r.CheckBreak()
 	}
-	if yyb2145 {
+	if yyb2149 {
 		r.ReadEnd()
 		return
 	}
@@ -25668,16 +25698,16 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.TargetRef.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2145++
-		if yyhl2145 {
-			yyb2145 = yyj2145 > l
+		yyj2149++
+		if yyhl2149 {
+			yyb2149 = yyj2149 > l
 		} else {
-			yyb2145 = r.CheckBreak()
+			yyb2149 = r.CheckBreak()
 		}
-		if yyb2145 {
+		if yyb2149 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2145-1, "")
+		z.DecStructFieldNotFound(yyj2149-1, "")
 	}
 	r.ReadEnd()
 }
@@ -25689,66 +25719,66 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2148 := z.EncBinary()
-		_ = yym2148
+		yym2152 := z.EncBinary()
+		_ = yym2152
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2149 := !z.EncBinary()
-			yy2arr2149 := z.EncBasicHandle().StructToArray
-			var yyq2149 [3]bool
-			_, _, _ = yysep2149, yyq2149, yy2arr2149
-			const yyr2149 bool = false
-			if yyr2149 || yy2arr2149 {
+			yysep2153 := !z.EncBinary()
+			yy2arr2153 := z.EncBasicHandle().StructToArray
+			var yyq2153 [3]bool
+			_, _, _ = yysep2153, yyq2153, yy2arr2153
+			const yyr2153 bool = false
+			if yyr2153 || yy2arr2153 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2149 int = 3
-				for _, b := range yyq2149 {
+				var yynn2153 int = 3
+				for _, b := range yyq2153 {
 					if b {
-						yynn2149++
+						yynn2153++
 					}
 				}
-				r.EncodeMapStart(yynn2149)
+				r.EncodeMapStart(yynn2153)
 			}
-			if yyr2149 || yy2arr2149 {
-				yym2151 := z.EncBinary()
-				_ = yym2151
+			if yyr2153 || yy2arr2153 {
+				yym2155 := z.EncBinary()
+				_ = yym2155
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Name"))
-				yym2152 := z.EncBinary()
-				_ = yym2152
+				yym2156 := z.EncBinary()
+				_ = yym2156
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yyr2149 || yy2arr2149 {
-				yym2154 := z.EncBinary()
-				_ = yym2154
+			if yyr2153 || yy2arr2153 {
+				yym2158 := z.EncBinary()
+				_ = yym2158
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Port"))
-				yym2155 := z.EncBinary()
-				_ = yym2155
+				yym2159 := z.EncBinary()
+				_ = yym2159
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yyr2149 || yy2arr2149 {
+			if yyr2153 || yy2arr2153 {
 				x.Protocol.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Protocol"))
 				x.Protocol.CodecEncodeSelf(e)
 			}
-			if yysep2149 {
+			if yysep2153 {
 				r.EncodeEnd()
 			}
 		}
@@ -25759,24 +25789,24 @@ func (x *EndpointPort) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2157 := z.DecBinary()
-	_ = yym2157
+	yym2161 := z.DecBinary()
+	_ = yym2161
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2158 := r.ReadMapStart()
-			if yyl2158 == 0 {
+			yyl2162 := r.ReadMapStart()
+			if yyl2162 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2158, d)
+				x.codecDecodeSelfFromMap(yyl2162, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2158 := r.ReadArrayStart()
-			if yyl2158 == 0 {
+			yyl2162 := r.ReadArrayStart()
+			if yyl2162 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2158, d)
+				x.codecDecodeSelfFromArray(yyl2162, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -25788,12 +25818,12 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2159Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2159Slc
-	var yyhl2159 bool = l >= 0
-	for yyj2159 := 0; ; yyj2159++ {
-		if yyhl2159 {
-			if yyj2159 >= l {
+	var yys2163Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2163Slc
+	var yyhl2163 bool = l >= 0
+	for yyj2163 := 0; ; yyj2163++ {
+		if yyhl2163 {
+			if yyj2163 >= l {
 				break
 			}
 		} else {
@@ -25801,9 +25831,9 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2159Slc = r.DecodeBytes(yys2159Slc, true, true)
-		yys2159 := string(yys2159Slc)
-		switch yys2159 {
+		yys2163Slc = r.DecodeBytes(yys2163Slc, true, true)
+		yys2163 := string(yys2163Slc)
+		switch yys2163 {
 		case "Name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -25823,10 +25853,10 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Protocol = Protocol(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2159)
-		} // end switch yys2159
-	} // end for yyj2159
-	if !yyhl2159 {
+			z.DecStructFieldNotFound(-1, yys2163)
+		} // end switch yys2163
+	} // end for yyj2163
+	if !yyhl2163 {
 		r.ReadEnd()
 	}
 }
@@ -25835,16 +25865,16 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2163 int
-	var yyb2163 bool
-	var yyhl2163 bool = l >= 0
-	yyj2163++
-	if yyhl2163 {
-		yyb2163 = yyj2163 > l
+	var yyj2167 int
+	var yyb2167 bool
+	var yyhl2167 bool = l >= 0
+	yyj2167++
+	if yyhl2167 {
+		yyb2167 = yyj2167 > l
 	} else {
-		yyb2163 = r.CheckBreak()
+		yyb2167 = r.CheckBreak()
 	}
-	if yyb2163 {
+	if yyb2167 {
 		r.ReadEnd()
 		return
 	}
@@ -25853,13 +25883,13 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj2163++
-	if yyhl2163 {
-		yyb2163 = yyj2163 > l
+	yyj2167++
+	if yyhl2167 {
+		yyb2167 = yyj2167 > l
 	} else {
-		yyb2163 = r.CheckBreak()
+		yyb2167 = r.CheckBreak()
 	}
-	if yyb2163 {
+	if yyb2167 {
 		r.ReadEnd()
 		return
 	}
@@ -25868,13 +25898,13 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Port = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj2163++
-	if yyhl2163 {
-		yyb2163 = yyj2163 > l
+	yyj2167++
+	if yyhl2167 {
+		yyb2167 = yyj2167 > l
 	} else {
-		yyb2163 = r.CheckBreak()
+		yyb2167 = r.CheckBreak()
 	}
-	if yyb2163 {
+	if yyb2167 {
 		r.ReadEnd()
 		return
 	}
@@ -25884,16 +25914,16 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Protocol = Protocol(r.DecodeString())
 	}
 	for {
-		yyj2163++
-		if yyhl2163 {
-			yyb2163 = yyj2163 > l
+		yyj2167++
+		if yyhl2167 {
+			yyb2167 = yyj2167 > l
 		} else {
-			yyb2163 = r.CheckBreak()
+			yyb2167 = r.CheckBreak()
 		}
-		if yyb2163 {
+		if yyb2167 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2163-1, "")
+		z.DecStructFieldNotFound(yyj2167-1, "")
 	}
 	r.ReadEnd()
 }
@@ -25905,106 +25935,106 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2167 := z.EncBinary()
-		_ = yym2167
+		yym2171 := z.EncBinary()
+		_ = yym2171
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2168 := !z.EncBinary()
-			yy2arr2168 := z.EncBasicHandle().StructToArray
-			var yyq2168 [4]bool
-			_, _, _ = yysep2168, yyq2168, yy2arr2168
-			const yyr2168 bool = false
-			yyq2168[0] = x.Kind != ""
-			yyq2168[1] = x.APIVersion != ""
-			yyq2168[2] = true
-			if yyr2168 || yy2arr2168 {
+			yysep2172 := !z.EncBinary()
+			yy2arr2172 := z.EncBasicHandle().StructToArray
+			var yyq2172 [4]bool
+			_, _, _ = yysep2172, yyq2172, yy2arr2172
+			const yyr2172 bool = false
+			yyq2172[0] = x.Kind != ""
+			yyq2172[1] = x.APIVersion != ""
+			yyq2172[2] = true
+			if yyr2172 || yy2arr2172 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2168 int = 1
-				for _, b := range yyq2168 {
+				var yynn2172 int = 1
+				for _, b := range yyq2172 {
 					if b {
-						yynn2168++
+						yynn2172++
 					}
 				}
-				r.EncodeMapStart(yynn2168)
+				r.EncodeMapStart(yynn2172)
 			}
-			if yyr2168 || yy2arr2168 {
-				if yyq2168[0] {
-					yym2170 := z.EncBinary()
-					_ = yym2170
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2168[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2171 := z.EncBinary()
-					_ = yym2171
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2168 || yy2arr2168 {
-				if yyq2168[1] {
-					yym2173 := z.EncBinary()
-					_ = yym2173
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2168[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2172 || yy2arr2172 {
+				if yyq2172[0] {
 					yym2174 := z.EncBinary()
 					_ = yym2174
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2172[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2175 := z.EncBinary()
+					_ = yym2175
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2172 || yy2arr2172 {
+				if yyq2172[1] {
+					yym2177 := z.EncBinary()
+					_ = yym2177
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2172[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2178 := z.EncBinary()
+					_ = yym2178
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2168 || yy2arr2168 {
-				if yyq2168[2] {
-					yy2176 := &x.ListMeta
-					yym2177 := z.EncBinary()
-					_ = yym2177
+			if yyr2172 || yy2arr2172 {
+				if yyq2172[2] {
+					yy2180 := &x.ListMeta
+					yym2181 := z.EncBinary()
+					_ = yym2181
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2176) {
+					} else if z.HasExtensions() && z.EncExt(yy2180) {
 					} else {
-						z.EncFallback(yy2176)
+						z.EncFallback(yy2180)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2168[2] {
+				if yyq2172[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2178 := &x.ListMeta
-					yym2179 := z.EncBinary()
-					_ = yym2179
+					yy2182 := &x.ListMeta
+					yym2183 := z.EncBinary()
+					_ = yym2183
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2178) {
+					} else if z.HasExtensions() && z.EncExt(yy2182) {
 					} else {
-						z.EncFallback(yy2178)
+						z.EncFallback(yy2182)
 					}
 				}
 			}
-			if yyr2168 || yy2arr2168 {
+			if yyr2172 || yy2arr2172 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2181 := z.EncBinary()
-					_ = yym2181
+					yym2185 := z.EncBinary()
+					_ = yym2185
 					if false {
 					} else {
 						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
@@ -26015,15 +26045,15 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2182 := z.EncBinary()
-					_ = yym2182
+					yym2186 := z.EncBinary()
+					_ = yym2186
 					if false {
 					} else {
 						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
 					}
 				}
 			}
-			if yysep2168 {
+			if yysep2172 {
 				r.EncodeEnd()
 			}
 		}
@@ -26034,24 +26064,24 @@ func (x *EndpointsList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2183 := z.DecBinary()
-	_ = yym2183
+	yym2187 := z.DecBinary()
+	_ = yym2187
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2184 := r.ReadMapStart()
-			if yyl2184 == 0 {
+			yyl2188 := r.ReadMapStart()
+			if yyl2188 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2184, d)
+				x.codecDecodeSelfFromMap(yyl2188, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2184 := r.ReadArrayStart()
-			if yyl2184 == 0 {
+			yyl2188 := r.ReadArrayStart()
+			if yyl2188 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2184, d)
+				x.codecDecodeSelfFromArray(yyl2188, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -26063,12 +26093,12 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2185Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2185Slc
-	var yyhl2185 bool = l >= 0
-	for yyj2185 := 0; ; yyj2185++ {
-		if yyhl2185 {
-			if yyj2185 >= l {
+	var yys2189Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2189Slc
+	var yyhl2189 bool = l >= 0
+	for yyj2189 := 0; ; yyj2189++ {
+		if yyhl2189 {
+			if yyj2189 >= l {
 				break
 			}
 		} else {
@@ -26076,9 +26106,9 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2185Slc = r.DecodeBytes(yys2185Slc, true, true)
-		yys2185 := string(yys2185Slc)
-		switch yys2185 {
+		yys2189Slc = r.DecodeBytes(yys2189Slc, true, true)
+		yys2189 := string(yys2189Slc)
+		switch yys2189 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -26095,32 +26125,32 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2188 := &x.ListMeta
-				yym2189 := z.DecBinary()
-				_ = yym2189
+				yyv2192 := &x.ListMeta
+				yym2193 := z.DecBinary()
+				_ = yym2193
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2188) {
+				} else if z.HasExtensions() && z.DecExt(yyv2192) {
 				} else {
-					z.DecFallback(yyv2188, false)
+					z.DecFallback(yyv2192, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2190 := &x.Items
-				yym2191 := z.DecBinary()
-				_ = yym2191
+				yyv2194 := &x.Items
+				yym2195 := z.DecBinary()
+				_ = yym2195
 				if false {
 				} else {
-					h.decSliceEndpoints((*[]Endpoints)(yyv2190), d)
+					h.decSliceEndpoints((*[]Endpoints)(yyv2194), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2185)
-		} // end switch yys2185
-	} // end for yyj2185
-	if !yyhl2185 {
+			z.DecStructFieldNotFound(-1, yys2189)
+		} // end switch yys2189
+	} // end for yyj2189
+	if !yyhl2189 {
 		r.ReadEnd()
 	}
 }
@@ -26129,16 +26159,16 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2192 int
-	var yyb2192 bool
-	var yyhl2192 bool = l >= 0
-	yyj2192++
-	if yyhl2192 {
-		yyb2192 = yyj2192 > l
+	var yyj2196 int
+	var yyb2196 bool
+	var yyhl2196 bool = l >= 0
+	yyj2196++
+	if yyhl2196 {
+		yyb2196 = yyj2196 > l
 	} else {
-		yyb2192 = r.CheckBreak()
+		yyb2196 = r.CheckBreak()
 	}
-	if yyb2192 {
+	if yyb2196 {
 		r.ReadEnd()
 		return
 	}
@@ -26147,13 +26177,13 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2192++
-	if yyhl2192 {
-		yyb2192 = yyj2192 > l
+	yyj2196++
+	if yyhl2196 {
+		yyb2196 = yyj2196 > l
 	} else {
-		yyb2192 = r.CheckBreak()
+		yyb2196 = r.CheckBreak()
 	}
-	if yyb2192 {
+	if yyb2196 {
 		r.ReadEnd()
 		return
 	}
@@ -26162,60 +26192,60 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2192++
-	if yyhl2192 {
-		yyb2192 = yyj2192 > l
+	yyj2196++
+	if yyhl2196 {
+		yyb2196 = yyj2196 > l
 	} else {
-		yyb2192 = r.CheckBreak()
+		yyb2196 = r.CheckBreak()
 	}
-	if yyb2192 {
+	if yyb2196 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2195 := &x.ListMeta
-		yym2196 := z.DecBinary()
-		_ = yym2196
+		yyv2199 := &x.ListMeta
+		yym2200 := z.DecBinary()
+		_ = yym2200
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2195) {
+		} else if z.HasExtensions() && z.DecExt(yyv2199) {
 		} else {
-			z.DecFallback(yyv2195, false)
+			z.DecFallback(yyv2199, false)
 		}
 	}
-	yyj2192++
-	if yyhl2192 {
-		yyb2192 = yyj2192 > l
+	yyj2196++
+	if yyhl2196 {
+		yyb2196 = yyj2196 > l
 	} else {
-		yyb2192 = r.CheckBreak()
+		yyb2196 = r.CheckBreak()
 	}
-	if yyb2192 {
+	if yyb2196 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2197 := &x.Items
-		yym2198 := z.DecBinary()
-		_ = yym2198
+		yyv2201 := &x.Items
+		yym2202 := z.DecBinary()
+		_ = yym2202
 		if false {
 		} else {
-			h.decSliceEndpoints((*[]Endpoints)(yyv2197), d)
+			h.decSliceEndpoints((*[]Endpoints)(yyv2201), d)
 		}
 	}
 	for {
-		yyj2192++
-		if yyhl2192 {
-			yyb2192 = yyj2192 > l
+		yyj2196++
+		if yyhl2196 {
+			yyb2196 = yyj2196 > l
 		} else {
-			yyb2192 = r.CheckBreak()
+			yyb2196 = r.CheckBreak()
 		}
-		if yyb2192 {
+		if yyb2196 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2192-1, "")
+		z.DecStructFieldNotFound(yyj2196-1, "")
 	}
 	r.ReadEnd()
 }
@@ -26227,79 +26257,79 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2199 := z.EncBinary()
-		_ = yym2199
+		yym2203 := z.EncBinary()
+		_ = yym2203
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2200 := !z.EncBinary()
-			yy2arr2200 := z.EncBasicHandle().StructToArray
-			var yyq2200 [4]bool
-			_, _, _ = yysep2200, yyq2200, yy2arr2200
-			const yyr2200 bool = false
-			yyq2200[0] = x.PodCIDR != ""
-			yyq2200[1] = x.ExternalID != ""
-			yyq2200[2] = x.ProviderID != ""
-			yyq2200[3] = x.Unschedulable != false
-			if yyr2200 || yy2arr2200 {
+			yysep2204 := !z.EncBinary()
+			yy2arr2204 := z.EncBasicHandle().StructToArray
+			var yyq2204 [4]bool
+			_, _, _ = yysep2204, yyq2204, yy2arr2204
+			const yyr2204 bool = false
+			yyq2204[0] = x.PodCIDR != ""
+			yyq2204[1] = x.ExternalID != ""
+			yyq2204[2] = x.ProviderID != ""
+			yyq2204[3] = x.Unschedulable != false
+			if yyr2204 || yy2arr2204 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2200 int = 0
-				for _, b := range yyq2200 {
+				var yynn2204 int = 0
+				for _, b := range yyq2204 {
 					if b {
-						yynn2200++
+						yynn2204++
 					}
 				}
-				r.EncodeMapStart(yynn2200)
+				r.EncodeMapStart(yynn2204)
 			}
-			if yyr2200 || yy2arr2200 {
-				if yyq2200[0] {
-					yym2202 := z.EncBinary()
-					_ = yym2202
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2200[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("podCIDR"))
-					yym2203 := z.EncBinary()
-					_ = yym2203
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
-					}
-				}
-			}
-			if yyr2200 || yy2arr2200 {
-				if yyq2200[1] {
-					yym2205 := z.EncBinary()
-					_ = yym2205
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ExternalID))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2200[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("externalID"))
+			if yyr2204 || yy2arr2204 {
+				if yyq2204[0] {
 					yym2206 := z.EncBinary()
 					_ = yym2206
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2204[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("podCIDR"))
+					yym2207 := z.EncBinary()
+					_ = yym2207
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
+					}
+				}
+			}
+			if yyr2204 || yy2arr2204 {
+				if yyq2204[1] {
+					yym2209 := z.EncBinary()
+					_ = yym2209
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ExternalID))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2204[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("externalID"))
+					yym2210 := z.EncBinary()
+					_ = yym2210
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ExternalID))
 					}
 				}
 			}
-			if yyr2200 || yy2arr2200 {
-				if yyq2200[2] {
-					yym2208 := z.EncBinary()
-					_ = yym2208
+			if yyr2204 || yy2arr2204 {
+				if yyq2204[2] {
+					yym2212 := z.EncBinary()
+					_ = yym2212
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ProviderID))
@@ -26308,20 +26338,20 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2200[2] {
+				if yyq2204[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("providerID"))
-					yym2209 := z.EncBinary()
-					_ = yym2209
+					yym2213 := z.EncBinary()
+					_ = yym2213
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ProviderID))
 					}
 				}
 			}
-			if yyr2200 || yy2arr2200 {
-				if yyq2200[3] {
-					yym2211 := z.EncBinary()
-					_ = yym2211
+			if yyr2204 || yy2arr2204 {
+				if yyq2204[3] {
+					yym2215 := z.EncBinary()
+					_ = yym2215
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Unschedulable))
@@ -26330,17 +26360,17 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2200[3] {
+				if yyq2204[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("unschedulable"))
-					yym2212 := z.EncBinary()
-					_ = yym2212
+					yym2216 := z.EncBinary()
+					_ = yym2216
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Unschedulable))
 					}
 				}
 			}
-			if yysep2200 {
+			if yysep2204 {
 				r.EncodeEnd()
 			}
 		}
@@ -26351,24 +26381,24 @@ func (x *NodeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2213 := z.DecBinary()
-	_ = yym2213
+	yym2217 := z.DecBinary()
+	_ = yym2217
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2214 := r.ReadMapStart()
-			if yyl2214 == 0 {
+			yyl2218 := r.ReadMapStart()
+			if yyl2218 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2214, d)
+				x.codecDecodeSelfFromMap(yyl2218, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2214 := r.ReadArrayStart()
-			if yyl2214 == 0 {
+			yyl2218 := r.ReadArrayStart()
+			if yyl2218 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2214, d)
+				x.codecDecodeSelfFromArray(yyl2218, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -26380,12 +26410,12 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2215Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2215Slc
-	var yyhl2215 bool = l >= 0
-	for yyj2215 := 0; ; yyj2215++ {
-		if yyhl2215 {
-			if yyj2215 >= l {
+	var yys2219Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2219Slc
+	var yyhl2219 bool = l >= 0
+	for yyj2219 := 0; ; yyj2219++ {
+		if yyhl2219 {
+			if yyj2219 >= l {
 				break
 			}
 		} else {
@@ -26393,9 +26423,9 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2215Slc = r.DecodeBytes(yys2215Slc, true, true)
-		yys2215 := string(yys2215Slc)
-		switch yys2215 {
+		yys2219Slc = r.DecodeBytes(yys2219Slc, true, true)
+		yys2219 := string(yys2219Slc)
+		switch yys2219 {
 		case "podCIDR":
 			if r.TryDecodeAsNil() {
 				x.PodCIDR = ""
@@ -26421,10 +26451,10 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Unschedulable = bool(r.DecodeBool())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2215)
-		} // end switch yys2215
-	} // end for yyj2215
-	if !yyhl2215 {
+			z.DecStructFieldNotFound(-1, yys2219)
+		} // end switch yys2219
+	} // end for yyj2219
+	if !yyhl2219 {
 		r.ReadEnd()
 	}
 }
@@ -26433,16 +26463,16 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2220 int
-	var yyb2220 bool
-	var yyhl2220 bool = l >= 0
-	yyj2220++
-	if yyhl2220 {
-		yyb2220 = yyj2220 > l
+	var yyj2224 int
+	var yyb2224 bool
+	var yyhl2224 bool = l >= 0
+	yyj2224++
+	if yyhl2224 {
+		yyb2224 = yyj2224 > l
 	} else {
-		yyb2220 = r.CheckBreak()
+		yyb2224 = r.CheckBreak()
 	}
-	if yyb2220 {
+	if yyb2224 {
 		r.ReadEnd()
 		return
 	}
@@ -26451,13 +26481,13 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.PodCIDR = string(r.DecodeString())
 	}
-	yyj2220++
-	if yyhl2220 {
-		yyb2220 = yyj2220 > l
+	yyj2224++
+	if yyhl2224 {
+		yyb2224 = yyj2224 > l
 	} else {
-		yyb2220 = r.CheckBreak()
+		yyb2224 = r.CheckBreak()
 	}
-	if yyb2220 {
+	if yyb2224 {
 		r.ReadEnd()
 		return
 	}
@@ -26466,13 +26496,13 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ExternalID = string(r.DecodeString())
 	}
-	yyj2220++
-	if yyhl2220 {
-		yyb2220 = yyj2220 > l
+	yyj2224++
+	if yyhl2224 {
+		yyb2224 = yyj2224 > l
 	} else {
-		yyb2220 = r.CheckBreak()
+		yyb2224 = r.CheckBreak()
 	}
-	if yyb2220 {
+	if yyb2224 {
 		r.ReadEnd()
 		return
 	}
@@ -26481,13 +26511,13 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ProviderID = string(r.DecodeString())
 	}
-	yyj2220++
-	if yyhl2220 {
-		yyb2220 = yyj2220 > l
+	yyj2224++
+	if yyhl2224 {
+		yyb2224 = yyj2224 > l
 	} else {
-		yyb2220 = r.CheckBreak()
+		yyb2224 = r.CheckBreak()
 	}
-	if yyb2220 {
+	if yyb2224 {
 		r.ReadEnd()
 		return
 	}
@@ -26497,16 +26527,16 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Unschedulable = bool(r.DecodeBool())
 	}
 	for {
-		yyj2220++
-		if yyhl2220 {
-			yyb2220 = yyj2220 > l
+		yyj2224++
+		if yyhl2224 {
+			yyb2224 = yyj2224 > l
 		} else {
-			yyb2220 = r.CheckBreak()
+			yyb2224 = r.CheckBreak()
 		}
-		if yyb2220 {
+		if yyb2224 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2220-1, "")
+		z.DecStructFieldNotFound(yyj2224-1, "")
 	}
 	r.ReadEnd()
 }
@@ -26518,44 +26548,44 @@ func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2225 := z.EncBinary()
-		_ = yym2225
+		yym2229 := z.EncBinary()
+		_ = yym2229
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2226 := !z.EncBinary()
-			yy2arr2226 := z.EncBasicHandle().StructToArray
-			var yyq2226 [1]bool
-			_, _, _ = yysep2226, yyq2226, yy2arr2226
-			const yyr2226 bool = false
-			if yyr2226 || yy2arr2226 {
+			yysep2230 := !z.EncBinary()
+			yy2arr2230 := z.EncBasicHandle().StructToArray
+			var yyq2230 [1]bool
+			_, _, _ = yysep2230, yyq2230, yy2arr2230
+			const yyr2230 bool = false
+			if yyr2230 || yy2arr2230 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2226 int = 1
-				for _, b := range yyq2226 {
+				var yynn2230 int = 1
+				for _, b := range yyq2230 {
 					if b {
-						yynn2226++
+						yynn2230++
 					}
 				}
-				r.EncodeMapStart(yynn2226)
+				r.EncodeMapStart(yynn2230)
 			}
-			if yyr2226 || yy2arr2226 {
-				yym2228 := z.EncBinary()
-				_ = yym2228
+			if yyr2230 || yy2arr2230 {
+				yym2232 := z.EncBinary()
+				_ = yym2232
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Port"))
-				yym2229 := z.EncBinary()
-				_ = yym2229
+				yym2233 := z.EncBinary()
+				_ = yym2233
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yysep2226 {
+			if yysep2230 {
 				r.EncodeEnd()
 			}
 		}
@@ -26566,24 +26596,24 @@ func (x *DaemonEndpoint) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2230 := z.DecBinary()
-	_ = yym2230
+	yym2234 := z.DecBinary()
+	_ = yym2234
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2231 := r.ReadMapStart()
-			if yyl2231 == 0 {
+			yyl2235 := r.ReadMapStart()
+			if yyl2235 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2231, d)
+				x.codecDecodeSelfFromMap(yyl2235, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2231 := r.ReadArrayStart()
-			if yyl2231 == 0 {
+			yyl2235 := r.ReadArrayStart()
+			if yyl2235 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2231, d)
+				x.codecDecodeSelfFromArray(yyl2235, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -26595,12 +26625,12 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2232Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2232Slc
-	var yyhl2232 bool = l >= 0
-	for yyj2232 := 0; ; yyj2232++ {
-		if yyhl2232 {
-			if yyj2232 >= l {
+	var yys2236Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2236Slc
+	var yyhl2236 bool = l >= 0
+	for yyj2236 := 0; ; yyj2236++ {
+		if yyhl2236 {
+			if yyj2236 >= l {
 				break
 			}
 		} else {
@@ -26608,9 +26638,9 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2232Slc = r.DecodeBytes(yys2232Slc, true, true)
-		yys2232 := string(yys2232Slc)
-		switch yys2232 {
+		yys2236Slc = r.DecodeBytes(yys2236Slc, true, true)
+		yys2236 := string(yys2236Slc)
+		switch yys2236 {
 		case "Port":
 			if r.TryDecodeAsNil() {
 				x.Port = 0
@@ -26618,10 +26648,10 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Port = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2232)
-		} // end switch yys2232
-	} // end for yyj2232
-	if !yyhl2232 {
+			z.DecStructFieldNotFound(-1, yys2236)
+		} // end switch yys2236
+	} // end for yyj2236
+	if !yyhl2236 {
 		r.ReadEnd()
 	}
 }
@@ -26630,16 +26660,16 @@ func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2234 int
-	var yyb2234 bool
-	var yyhl2234 bool = l >= 0
-	yyj2234++
-	if yyhl2234 {
-		yyb2234 = yyj2234 > l
+	var yyj2238 int
+	var yyb2238 bool
+	var yyhl2238 bool = l >= 0
+	yyj2238++
+	if yyhl2238 {
+		yyb2238 = yyj2238 > l
 	} else {
-		yyb2234 = r.CheckBreak()
+		yyb2238 = r.CheckBreak()
 	}
-	if yyb2234 {
+	if yyb2238 {
 		r.ReadEnd()
 		return
 	}
@@ -26649,16 +26679,16 @@ func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Port = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj2234++
-		if yyhl2234 {
-			yyb2234 = yyj2234 > l
+		yyj2238++
+		if yyhl2238 {
+			yyb2238 = yyj2238 > l
 		} else {
-			yyb2234 = r.CheckBreak()
+			yyb2238 = r.CheckBreak()
 		}
-		if yyb2234 {
+		if yyb2238 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2234-1, "")
+		z.DecStructFieldNotFound(yyj2238-1, "")
 	}
 	r.ReadEnd()
 }
@@ -26670,43 +26700,43 @@ func (x *NodeDaemonEndpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2236 := z.EncBinary()
-		_ = yym2236
+		yym2240 := z.EncBinary()
+		_ = yym2240
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2237 := !z.EncBinary()
-			yy2arr2237 := z.EncBasicHandle().StructToArray
-			var yyq2237 [1]bool
-			_, _, _ = yysep2237, yyq2237, yy2arr2237
-			const yyr2237 bool = false
-			yyq2237[0] = true
-			if yyr2237 || yy2arr2237 {
+			yysep2241 := !z.EncBinary()
+			yy2arr2241 := z.EncBasicHandle().StructToArray
+			var yyq2241 [1]bool
+			_, _, _ = yysep2241, yyq2241, yy2arr2241
+			const yyr2241 bool = false
+			yyq2241[0] = true
+			if yyr2241 || yy2arr2241 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2237 int = 0
-				for _, b := range yyq2237 {
+				var yynn2241 int = 0
+				for _, b := range yyq2241 {
 					if b {
-						yynn2237++
+						yynn2241++
 					}
 				}
-				r.EncodeMapStart(yynn2237)
+				r.EncodeMapStart(yynn2241)
 			}
-			if yyr2237 || yy2arr2237 {
-				if yyq2237[0] {
-					yy2239 := &x.KubeletEndpoint
-					yy2239.CodecEncodeSelf(e)
+			if yyr2241 || yy2arr2241 {
+				if yyq2241[0] {
+					yy2243 := &x.KubeletEndpoint
+					yy2243.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2237[0] {
+				if yyq2241[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kubeletEndpoint"))
-					yy2240 := &x.KubeletEndpoint
-					yy2240.CodecEncodeSelf(e)
+					yy2244 := &x.KubeletEndpoint
+					yy2244.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2237 {
+			if yysep2241 {
 				r.EncodeEnd()
 			}
 		}
@@ -26717,24 +26747,24 @@ func (x *NodeDaemonEndpoints) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2241 := z.DecBinary()
-	_ = yym2241
+	yym2245 := z.DecBinary()
+	_ = yym2245
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2242 := r.ReadMapStart()
-			if yyl2242 == 0 {
+			yyl2246 := r.ReadMapStart()
+			if yyl2246 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2242, d)
+				x.codecDecodeSelfFromMap(yyl2246, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2242 := r.ReadArrayStart()
-			if yyl2242 == 0 {
+			yyl2246 := r.ReadArrayStart()
+			if yyl2246 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2242, d)
+				x.codecDecodeSelfFromArray(yyl2246, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -26746,12 +26776,12 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2243Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2243Slc
-	var yyhl2243 bool = l >= 0
-	for yyj2243 := 0; ; yyj2243++ {
-		if yyhl2243 {
-			if yyj2243 >= l {
+	var yys2247Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2247Slc
+	var yyhl2247 bool = l >= 0
+	for yyj2247 := 0; ; yyj2247++ {
+		if yyhl2247 {
+			if yyj2247 >= l {
 				break
 			}
 		} else {
@@ -26759,21 +26789,21 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys2243Slc = r.DecodeBytes(yys2243Slc, true, true)
-		yys2243 := string(yys2243Slc)
-		switch yys2243 {
+		yys2247Slc = r.DecodeBytes(yys2247Slc, true, true)
+		yys2247 := string(yys2247Slc)
+		switch yys2247 {
 		case "kubeletEndpoint":
 			if r.TryDecodeAsNil() {
 				x.KubeletEndpoint = DaemonEndpoint{}
 			} else {
-				yyv2244 := &x.KubeletEndpoint
-				yyv2244.CodecDecodeSelf(d)
+				yyv2248 := &x.KubeletEndpoint
+				yyv2248.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2243)
-		} // end switch yys2243
-	} // end for yyj2243
-	if !yyhl2243 {
+			z.DecStructFieldNotFound(-1, yys2247)
+		} // end switch yys2247
+	} // end for yyj2247
+	if !yyhl2247 {
 		r.ReadEnd()
 	}
 }
@@ -26782,36 +26812,36 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2245 int
-	var yyb2245 bool
-	var yyhl2245 bool = l >= 0
-	yyj2245++
-	if yyhl2245 {
-		yyb2245 = yyj2245 > l
+	var yyj2249 int
+	var yyb2249 bool
+	var yyhl2249 bool = l >= 0
+	yyj2249++
+	if yyhl2249 {
+		yyb2249 = yyj2249 > l
 	} else {
-		yyb2245 = r.CheckBreak()
+		yyb2249 = r.CheckBreak()
 	}
-	if yyb2245 {
+	if yyb2249 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.KubeletEndpoint = DaemonEndpoint{}
 	} else {
-		yyv2246 := &x.KubeletEndpoint
-		yyv2246.CodecDecodeSelf(d)
+		yyv2250 := &x.KubeletEndpoint
+		yyv2250.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2245++
-		if yyhl2245 {
-			yyb2245 = yyj2245 > l
+		yyj2249++
+		if yyhl2249 {
+			yyb2249 = yyj2249 > l
 		} else {
-			yyb2245 = r.CheckBreak()
+			yyb2249 = r.CheckBreak()
 		}
-		if yyb2245 {
+		if yyb2249 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2245-1, "")
+		z.DecStructFieldNotFound(yyj2249-1, "")
 	}
 	r.ReadEnd()
 }
@@ -26823,156 +26853,156 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2247 := z.EncBinary()
-		_ = yym2247
+		yym2251 := z.EncBinary()
+		_ = yym2251
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2248 := !z.EncBinary()
-			yy2arr2248 := z.EncBasicHandle().StructToArray
-			var yyq2248 [8]bool
-			_, _, _ = yysep2248, yyq2248, yy2arr2248
-			const yyr2248 bool = false
-			if yyr2248 || yy2arr2248 {
+			yysep2252 := !z.EncBinary()
+			yy2arr2252 := z.EncBasicHandle().StructToArray
+			var yyq2252 [8]bool
+			_, _, _ = yysep2252, yyq2252, yy2arr2252
+			const yyr2252 bool = false
+			if yyr2252 || yy2arr2252 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2248 int = 8
-				for _, b := range yyq2248 {
+				var yynn2252 int = 8
+				for _, b := range yyq2252 {
 					if b {
-						yynn2248++
+						yynn2252++
 					}
 				}
-				r.EncodeMapStart(yynn2248)
+				r.EncodeMapStart(yynn2252)
 			}
-			if yyr2248 || yy2arr2248 {
-				yym2250 := z.EncBinary()
-				_ = yym2250
+			if yyr2252 || yy2arr2252 {
+				yym2254 := z.EncBinary()
+				_ = yym2254
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MachineID))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("machineID"))
-				yym2251 := z.EncBinary()
-				_ = yym2251
+				yym2255 := z.EncBinary()
+				_ = yym2255
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MachineID))
 				}
 			}
-			if yyr2248 || yy2arr2248 {
-				yym2253 := z.EncBinary()
-				_ = yym2253
+			if yyr2252 || yy2arr2252 {
+				yym2257 := z.EncBinary()
+				_ = yym2257
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SystemUUID))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("systemUUID"))
-				yym2254 := z.EncBinary()
-				_ = yym2254
+				yym2258 := z.EncBinary()
+				_ = yym2258
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SystemUUID))
 				}
 			}
-			if yyr2248 || yy2arr2248 {
-				yym2256 := z.EncBinary()
-				_ = yym2256
+			if yyr2252 || yy2arr2252 {
+				yym2260 := z.EncBinary()
+				_ = yym2260
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BootID))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("bootID"))
-				yym2257 := z.EncBinary()
-				_ = yym2257
+				yym2261 := z.EncBinary()
+				_ = yym2261
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BootID))
 				}
 			}
-			if yyr2248 || yy2arr2248 {
-				yym2259 := z.EncBinary()
-				_ = yym2259
+			if yyr2252 || yy2arr2252 {
+				yym2263 := z.EncBinary()
+				_ = yym2263
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KernelVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("kernelVersion"))
-				yym2260 := z.EncBinary()
-				_ = yym2260
+				yym2264 := z.EncBinary()
+				_ = yym2264
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KernelVersion))
 				}
 			}
-			if yyr2248 || yy2arr2248 {
-				yym2262 := z.EncBinary()
-				_ = yym2262
+			if yyr2252 || yy2arr2252 {
+				yym2266 := z.EncBinary()
+				_ = yym2266
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.OsImage))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("osImage"))
-				yym2263 := z.EncBinary()
-				_ = yym2263
+				yym2267 := z.EncBinary()
+				_ = yym2267
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.OsImage))
 				}
 			}
-			if yyr2248 || yy2arr2248 {
-				yym2265 := z.EncBinary()
-				_ = yym2265
+			if yyr2252 || yy2arr2252 {
+				yym2269 := z.EncBinary()
+				_ = yym2269
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntimeVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("containerRuntimeVersion"))
-				yym2266 := z.EncBinary()
-				_ = yym2266
+				yym2270 := z.EncBinary()
+				_ = yym2270
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntimeVersion))
 				}
 			}
-			if yyr2248 || yy2arr2248 {
-				yym2268 := z.EncBinary()
-				_ = yym2268
+			if yyr2252 || yy2arr2252 {
+				yym2272 := z.EncBinary()
+				_ = yym2272
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeletVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("kubeletVersion"))
-				yym2269 := z.EncBinary()
-				_ = yym2269
+				yym2273 := z.EncBinary()
+				_ = yym2273
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeletVersion))
 				}
 			}
-			if yyr2248 || yy2arr2248 {
-				yym2271 := z.EncBinary()
-				_ = yym2271
+			if yyr2252 || yy2arr2252 {
+				yym2275 := z.EncBinary()
+				_ = yym2275
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeProxyVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("kubeProxyVersion"))
-				yym2272 := z.EncBinary()
-				_ = yym2272
+				yym2276 := z.EncBinary()
+				_ = yym2276
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeProxyVersion))
 				}
 			}
-			if yysep2248 {
+			if yysep2252 {
 				r.EncodeEnd()
 			}
 		}
@@ -26983,24 +27013,24 @@ func (x *NodeSystemInfo) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2273 := z.DecBinary()
-	_ = yym2273
+	yym2277 := z.DecBinary()
+	_ = yym2277
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2274 := r.ReadMapStart()
-			if yyl2274 == 0 {
+			yyl2278 := r.ReadMapStart()
+			if yyl2278 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2274, d)
+				x.codecDecodeSelfFromMap(yyl2278, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2274 := r.ReadArrayStart()
-			if yyl2274 == 0 {
+			yyl2278 := r.ReadArrayStart()
+			if yyl2278 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2274, d)
+				x.codecDecodeSelfFromArray(yyl2278, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -27012,12 +27042,12 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2275Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2275Slc
-	var yyhl2275 bool = l >= 0
-	for yyj2275 := 0; ; yyj2275++ {
-		if yyhl2275 {
-			if yyj2275 >= l {
+	var yys2279Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2279Slc
+	var yyhl2279 bool = l >= 0
+	for yyj2279 := 0; ; yyj2279++ {
+		if yyhl2279 {
+			if yyj2279 >= l {
 				break
 			}
 		} else {
@@ -27025,9 +27055,9 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2275Slc = r.DecodeBytes(yys2275Slc, true, true)
-		yys2275 := string(yys2275Slc)
-		switch yys2275 {
+		yys2279Slc = r.DecodeBytes(yys2279Slc, true, true)
+		yys2279 := string(yys2279Slc)
+		switch yys2279 {
 		case "machineID":
 			if r.TryDecodeAsNil() {
 				x.MachineID = ""
@@ -27077,10 +27107,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.KubeProxyVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2275)
-		} // end switch yys2275
-	} // end for yyj2275
-	if !yyhl2275 {
+			z.DecStructFieldNotFound(-1, yys2279)
+		} // end switch yys2279
+	} // end for yyj2279
+	if !yyhl2279 {
 		r.ReadEnd()
 	}
 }
@@ -27089,16 +27119,16 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2284 int
-	var yyb2284 bool
-	var yyhl2284 bool = l >= 0
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
+	var yyj2288 int
+	var yyb2288 bool
+	var yyhl2288 bool = l >= 0
+	yyj2288++
+	if yyhl2288 {
+		yyb2288 = yyj2288 > l
 	} else {
-		yyb2284 = r.CheckBreak()
+		yyb2288 = r.CheckBreak()
 	}
-	if yyb2284 {
+	if yyb2288 {
 		r.ReadEnd()
 		return
 	}
@@ -27107,13 +27137,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.MachineID = string(r.DecodeString())
 	}
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
+	yyj2288++
+	if yyhl2288 {
+		yyb2288 = yyj2288 > l
 	} else {
-		yyb2284 = r.CheckBreak()
+		yyb2288 = r.CheckBreak()
 	}
-	if yyb2284 {
+	if yyb2288 {
 		r.ReadEnd()
 		return
 	}
@@ -27122,13 +27152,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.SystemUUID = string(r.DecodeString())
 	}
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
+	yyj2288++
+	if yyhl2288 {
+		yyb2288 = yyj2288 > l
 	} else {
-		yyb2284 = r.CheckBreak()
+		yyb2288 = r.CheckBreak()
 	}
-	if yyb2284 {
+	if yyb2288 {
 		r.ReadEnd()
 		return
 	}
@@ -27137,13 +27167,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.BootID = string(r.DecodeString())
 	}
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
+	yyj2288++
+	if yyhl2288 {
+		yyb2288 = yyj2288 > l
 	} else {
-		yyb2284 = r.CheckBreak()
+		yyb2288 = r.CheckBreak()
 	}
-	if yyb2284 {
+	if yyb2288 {
 		r.ReadEnd()
 		return
 	}
@@ -27152,13 +27182,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.KernelVersion = string(r.DecodeString())
 	}
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
+	yyj2288++
+	if yyhl2288 {
+		yyb2288 = yyj2288 > l
 	} else {
-		yyb2284 = r.CheckBreak()
+		yyb2288 = r.CheckBreak()
 	}
-	if yyb2284 {
+	if yyb2288 {
 		r.ReadEnd()
 		return
 	}
@@ -27167,13 +27197,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.OsImage = string(r.DecodeString())
 	}
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
+	yyj2288++
+	if yyhl2288 {
+		yyb2288 = yyj2288 > l
 	} else {
-		yyb2284 = r.CheckBreak()
+		yyb2288 = r.CheckBreak()
 	}
-	if yyb2284 {
+	if yyb2288 {
 		r.ReadEnd()
 		return
 	}
@@ -27182,13 +27212,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ContainerRuntimeVersion = string(r.DecodeString())
 	}
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
+	yyj2288++
+	if yyhl2288 {
+		yyb2288 = yyj2288 > l
 	} else {
-		yyb2284 = r.CheckBreak()
+		yyb2288 = r.CheckBreak()
 	}
-	if yyb2284 {
+	if yyb2288 {
 		r.ReadEnd()
 		return
 	}
@@ -27197,13 +27227,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.KubeletVersion = string(r.DecodeString())
 	}
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
+	yyj2288++
+	if yyhl2288 {
+		yyb2288 = yyj2288 > l
 	} else {
-		yyb2284 = r.CheckBreak()
+		yyb2288 = r.CheckBreak()
 	}
-	if yyb2284 {
+	if yyb2288 {
 		r.ReadEnd()
 		return
 	}
@@ -27213,16 +27243,16 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.KubeProxyVersion = string(r.DecodeString())
 	}
 	for {
-		yyj2284++
-		if yyhl2284 {
-			yyb2284 = yyj2284 > l
+		yyj2288++
+		if yyhl2288 {
+			yyb2288 = yyj2288 > l
 		} else {
-			yyb2284 = r.CheckBreak()
+			yyb2288 = r.CheckBreak()
 		}
-		if yyb2284 {
+		if yyb2288 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2284-1, "")
+		z.DecStructFieldNotFound(yyj2288-1, "")
 	}
 	r.ReadEnd()
 }
@@ -27234,35 +27264,35 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2293 := z.EncBinary()
-		_ = yym2293
+		yym2297 := z.EncBinary()
+		_ = yym2297
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2294 := !z.EncBinary()
-			yy2arr2294 := z.EncBasicHandle().StructToArray
-			var yyq2294 [6]bool
-			_, _, _ = yysep2294, yyq2294, yy2arr2294
-			const yyr2294 bool = false
-			yyq2294[0] = len(x.Capacity) != 0
-			yyq2294[1] = x.Phase != ""
-			yyq2294[2] = len(x.Conditions) != 0
-			yyq2294[3] = len(x.Addresses) != 0
-			yyq2294[4] = true
-			yyq2294[5] = true
-			if yyr2294 || yy2arr2294 {
+			yysep2298 := !z.EncBinary()
+			yy2arr2298 := z.EncBasicHandle().StructToArray
+			var yyq2298 [6]bool
+			_, _, _ = yysep2298, yyq2298, yy2arr2298
+			const yyr2298 bool = false
+			yyq2298[0] = len(x.Capacity) != 0
+			yyq2298[1] = x.Phase != ""
+			yyq2298[2] = len(x.Conditions) != 0
+			yyq2298[3] = len(x.Addresses) != 0
+			yyq2298[4] = true
+			yyq2298[5] = true
+			if yyr2298 || yy2arr2298 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn2294 int = 0
-				for _, b := range yyq2294 {
+				var yynn2298 int = 0
+				for _, b := range yyq2298 {
 					if b {
-						yynn2294++
+						yynn2298++
 					}
 				}
-				r.EncodeMapStart(yynn2294)
+				r.EncodeMapStart(yynn2298)
 			}
-			if yyr2294 || yy2arr2294 {
-				if yyq2294[0] {
+			if yyr2298 || yy2arr2298 {
+				if yyq2298[0] {
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -27272,7 +27302,7 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2294[0] {
+				if yyq2298[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -27281,107 +27311,107 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2294 || yy2arr2294 {
-				if yyq2294[1] {
+			if yyr2298 || yy2arr2298 {
+				if yyq2298[1] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2294[1] {
+				if yyq2298[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2294 || yy2arr2294 {
-				if yyq2294[2] {
+			if yyr2298 || yy2arr2298 {
+				if yyq2298[2] {
 					if x.Conditions == nil {
-						r.EncodeNil()
-					} else {
-						yym2298 := z.EncBinary()
-						_ = yym2298
-						if false {
-						} else {
-							h.encSliceNodeCondition(([]NodeCondition)(x.Conditions), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2294[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
-					if x.Conditions == nil {
-						r.EncodeNil()
-					} else {
-						yym2299 := z.EncBinary()
-						_ = yym2299
-						if false {
-						} else {
-							h.encSliceNodeCondition(([]NodeCondition)(x.Conditions), e)
-						}
-					}
-				}
-			}
-			if yyr2294 || yy2arr2294 {
-				if yyq2294[3] {
-					if x.Addresses == nil {
-						r.EncodeNil()
-					} else {
-						yym2301 := z.EncBinary()
-						_ = yym2301
-						if false {
-						} else {
-							h.encSliceNodeAddress(([]NodeAddress)(x.Addresses), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2294[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("addresses"))
-					if x.Addresses == nil {
 						r.EncodeNil()
 					} else {
 						yym2302 := z.EncBinary()
 						_ = yym2302
 						if false {
 						} else {
+							h.encSliceNodeCondition(([]NodeCondition)(x.Conditions), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2298[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
+					if x.Conditions == nil {
+						r.EncodeNil()
+					} else {
+						yym2303 := z.EncBinary()
+						_ = yym2303
+						if false {
+						} else {
+							h.encSliceNodeCondition(([]NodeCondition)(x.Conditions), e)
+						}
+					}
+				}
+			}
+			if yyr2298 || yy2arr2298 {
+				if yyq2298[3] {
+					if x.Addresses == nil {
+						r.EncodeNil()
+					} else {
+						yym2305 := z.EncBinary()
+						_ = yym2305
+						if false {
+						} else {
+							h.encSliceNodeAddress(([]NodeAddress)(x.Addresses), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2298[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("addresses"))
+					if x.Addresses == nil {
+						r.EncodeNil()
+					} else {
+						yym2306 := z.EncBinary()
+						_ = yym2306
+						if false {
+						} else {
 							h.encSliceNodeAddress(([]NodeAddress)(x.Addresses), e)
 						}
 					}
 				}
 			}
-			if yyr2294 || yy2arr2294 {
-				if yyq2294[4] {
-					yy2304 := &x.DaemonEndpoints
-					yy2304.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2294[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("daemonEndpoints"))
-					yy2305 := &x.DaemonEndpoints
-					yy2305.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2294 || yy2arr2294 {
-				if yyq2294[5] {
-					yy2307 := &x.NodeInfo
-					yy2307.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2294[5] {
-					r.EncodeString(codecSelferC_UTF81234, string("nodeInfo"))
-					yy2308 := &x.NodeInfo
+			if yyr2298 || yy2arr2298 {
+				if yyq2298[4] {
+					yy2308 := &x.DaemonEndpoints
 					yy2308.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2298[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("daemonEndpoints"))
+					yy2309 := &x.DaemonEndpoints
+					yy2309.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2294 {
+			if yyr2298 || yy2arr2298 {
+				if yyq2298[5] {
+					yy2311 := &x.NodeInfo
+					yy2311.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2298[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("nodeInfo"))
+					yy2312 := &x.NodeInfo
+					yy2312.CodecEncodeSelf(e)
+				}
+			}
+			if yysep2298 {
 				r.EncodeEnd()
 			}
 		}
@@ -27392,24 +27422,24 @@ func (x *NodeStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2309 := z.DecBinary()
-	_ = yym2309
+	yym2313 := z.DecBinary()
+	_ = yym2313
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2310 := r.ReadMapStart()
-			if yyl2310 == 0 {
+			yyl2314 := r.ReadMapStart()
+			if yyl2314 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2310, d)
+				x.codecDecodeSelfFromMap(yyl2314, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2310 := r.ReadArrayStart()
-			if yyl2310 == 0 {
+			yyl2314 := r.ReadArrayStart()
+			if yyl2314 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2310, d)
+				x.codecDecodeSelfFromArray(yyl2314, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -27421,12 +27451,12 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2311Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2311Slc
-	var yyhl2311 bool = l >= 0
-	for yyj2311 := 0; ; yyj2311++ {
-		if yyhl2311 {
-			if yyj2311 >= l {
+	var yys2315Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2315Slc
+	var yyhl2315 bool = l >= 0
+	for yyj2315 := 0; ; yyj2315++ {
+		if yyhl2315 {
+			if yyj2315 >= l {
 				break
 			}
 		} else {
@@ -27434,15 +27464,15 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2311Slc = r.DecodeBytes(yys2311Slc, true, true)
-		yys2311 := string(yys2311Slc)
-		switch yys2311 {
+		yys2315Slc = r.DecodeBytes(yys2315Slc, true, true)
+		yys2315 := string(yys2315Slc)
+		switch yys2315 {
 		case "capacity":
 			if r.TryDecodeAsNil() {
 				x.Capacity = nil
 			} else {
-				yyv2312 := &x.Capacity
-				yyv2312.CodecDecodeSelf(d)
+				yyv2316 := &x.Capacity
+				yyv2316.CodecDecodeSelf(d)
 			}
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -27454,45 +27484,45 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv2314 := &x.Conditions
-				yym2315 := z.DecBinary()
-				_ = yym2315
+				yyv2318 := &x.Conditions
+				yym2319 := z.DecBinary()
+				_ = yym2319
 				if false {
 				} else {
-					h.decSliceNodeCondition((*[]NodeCondition)(yyv2314), d)
+					h.decSliceNodeCondition((*[]NodeCondition)(yyv2318), d)
 				}
 			}
 		case "addresses":
 			if r.TryDecodeAsNil() {
 				x.Addresses = nil
 			} else {
-				yyv2316 := &x.Addresses
-				yym2317 := z.DecBinary()
-				_ = yym2317
+				yyv2320 := &x.Addresses
+				yym2321 := z.DecBinary()
+				_ = yym2321
 				if false {
 				} else {
-					h.decSliceNodeAddress((*[]NodeAddress)(yyv2316), d)
+					h.decSliceNodeAddress((*[]NodeAddress)(yyv2320), d)
 				}
 			}
 		case "daemonEndpoints":
 			if r.TryDecodeAsNil() {
 				x.DaemonEndpoints = NodeDaemonEndpoints{}
 			} else {
-				yyv2318 := &x.DaemonEndpoints
-				yyv2318.CodecDecodeSelf(d)
+				yyv2322 := &x.DaemonEndpoints
+				yyv2322.CodecDecodeSelf(d)
 			}
 		case "nodeInfo":
 			if r.TryDecodeAsNil() {
 				x.NodeInfo = NodeSystemInfo{}
 			} else {
-				yyv2319 := &x.NodeInfo
-				yyv2319.CodecDecodeSelf(d)
+				yyv2323 := &x.NodeInfo
+				yyv2323.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2311)
-		} // end switch yys2311
-	} // end for yyj2311
-	if !yyhl2311 {
+			z.DecStructFieldNotFound(-1, yys2315)
+		} // end switch yys2315
+	} // end for yyj2315
+	if !yyhl2315 {
 		r.ReadEnd()
 	}
 }
@@ -27501,32 +27531,32 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2320 int
-	var yyb2320 bool
-	var yyhl2320 bool = l >= 0
-	yyj2320++
-	if yyhl2320 {
-		yyb2320 = yyj2320 > l
+	var yyj2324 int
+	var yyb2324 bool
+	var yyhl2324 bool = l >= 0
+	yyj2324++
+	if yyhl2324 {
+		yyb2324 = yyj2324 > l
 	} else {
-		yyb2320 = r.CheckBreak()
+		yyb2324 = r.CheckBreak()
 	}
-	if yyb2320 {
+	if yyb2324 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
-		yyv2321 := &x.Capacity
-		yyv2321.CodecDecodeSelf(d)
+		yyv2325 := &x.Capacity
+		yyv2325.CodecDecodeSelf(d)
 	}
-	yyj2320++
-	if yyhl2320 {
-		yyb2320 = yyj2320 > l
+	yyj2324++
+	if yyhl2324 {
+		yyb2324 = yyj2324 > l
 	} else {
-		yyb2320 = r.CheckBreak()
+		yyb2324 = r.CheckBreak()
 	}
-	if yyb2320 {
+	if yyb2324 {
 		r.ReadEnd()
 		return
 	}
@@ -27535,91 +27565,91 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Phase = NodePhase(r.DecodeString())
 	}
-	yyj2320++
-	if yyhl2320 {
-		yyb2320 = yyj2320 > l
+	yyj2324++
+	if yyhl2324 {
+		yyb2324 = yyj2324 > l
 	} else {
-		yyb2320 = r.CheckBreak()
+		yyb2324 = r.CheckBreak()
 	}
-	if yyb2320 {
+	if yyb2324 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv2323 := &x.Conditions
-		yym2324 := z.DecBinary()
-		_ = yym2324
+		yyv2327 := &x.Conditions
+		yym2328 := z.DecBinary()
+		_ = yym2328
 		if false {
 		} else {
-			h.decSliceNodeCondition((*[]NodeCondition)(yyv2323), d)
+			h.decSliceNodeCondition((*[]NodeCondition)(yyv2327), d)
 		}
 	}
-	yyj2320++
-	if yyhl2320 {
-		yyb2320 = yyj2320 > l
+	yyj2324++
+	if yyhl2324 {
+		yyb2324 = yyj2324 > l
 	} else {
-		yyb2320 = r.CheckBreak()
+		yyb2324 = r.CheckBreak()
 	}
-	if yyb2320 {
+	if yyb2324 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Addresses = nil
 	} else {
-		yyv2325 := &x.Addresses
-		yym2326 := z.DecBinary()
-		_ = yym2326
+		yyv2329 := &x.Addresses
+		yym2330 := z.DecBinary()
+		_ = yym2330
 		if false {
 		} else {
-			h.decSliceNodeAddress((*[]NodeAddress)(yyv2325), d)
+			h.decSliceNodeAddress((*[]NodeAddress)(yyv2329), d)
 		}
 	}
-	yyj2320++
-	if yyhl2320 {
-		yyb2320 = yyj2320 > l
+	yyj2324++
+	if yyhl2324 {
+		yyb2324 = yyj2324 > l
 	} else {
-		yyb2320 = r.CheckBreak()
+		yyb2324 = r.CheckBreak()
 	}
-	if yyb2320 {
+	if yyb2324 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.DaemonEndpoints = NodeDaemonEndpoints{}
 	} else {
-		yyv2327 := &x.DaemonEndpoints
-		yyv2327.CodecDecodeSelf(d)
+		yyv2331 := &x.DaemonEndpoints
+		yyv2331.CodecDecodeSelf(d)
 	}
-	yyj2320++
-	if yyhl2320 {
-		yyb2320 = yyj2320 > l
+	yyj2324++
+	if yyhl2324 {
+		yyb2324 = yyj2324 > l
 	} else {
-		yyb2320 = r.CheckBreak()
+		yyb2324 = r.CheckBreak()
 	}
-	if yyb2320 {
+	if yyb2324 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.NodeInfo = NodeSystemInfo{}
 	} else {
-		yyv2328 := &x.NodeInfo
-		yyv2328.CodecDecodeSelf(d)
+		yyv2332 := &x.NodeInfo
+		yyv2332.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2320++
-		if yyhl2320 {
-			yyb2320 = yyj2320 > l
+		yyj2324++
+		if yyhl2324 {
+			yyb2324 = yyj2324 > l
 		} else {
-			yyb2320 = r.CheckBreak()
+			yyb2324 = r.CheckBreak()
 		}
-		if yyb2320 {
+		if yyb2324 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2320-1, "")
+		z.DecStructFieldNotFound(yyj2324-1, "")
 	}
 	r.ReadEnd()
 }
@@ -27628,8 +27658,8 @@ func (x NodePhase) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2329 := z.EncBinary()
-	_ = yym2329
+	yym2333 := z.EncBinary()
+	_ = yym2333
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -27641,8 +27671,8 @@ func (x *NodePhase) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2330 := z.DecBinary()
-	_ = yym2330
+	yym2334 := z.DecBinary()
+	_ = yym2334
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -27654,8 +27684,8 @@ func (x NodeConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2331 := z.EncBinary()
-	_ = yym2331
+	yym2335 := z.EncBinary()
+	_ = yym2335
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -27667,8 +27697,8 @@ func (x *NodeConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2332 := z.DecBinary()
-	_ = yym2332
+	yym2336 := z.DecBinary()
+	_ = yym2336
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -27683,156 +27713,156 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2333 := z.EncBinary()
-		_ = yym2333
+		yym2337 := z.EncBinary()
+		_ = yym2337
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2334 := !z.EncBinary()
-			yy2arr2334 := z.EncBasicHandle().StructToArray
-			var yyq2334 [6]bool
-			_, _, _ = yysep2334, yyq2334, yy2arr2334
-			const yyr2334 bool = false
-			yyq2334[2] = true
-			yyq2334[3] = true
-			yyq2334[4] = x.Reason != ""
-			yyq2334[5] = x.Message != ""
-			if yyr2334 || yy2arr2334 {
+			yysep2338 := !z.EncBinary()
+			yy2arr2338 := z.EncBasicHandle().StructToArray
+			var yyq2338 [6]bool
+			_, _, _ = yysep2338, yyq2338, yy2arr2338
+			const yyr2338 bool = false
+			yyq2338[2] = true
+			yyq2338[3] = true
+			yyq2338[4] = x.Reason != ""
+			yyq2338[5] = x.Message != ""
+			if yyr2338 || yy2arr2338 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn2334 int = 2
-				for _, b := range yyq2334 {
+				var yynn2338 int = 2
+				for _, b := range yyq2338 {
 					if b {
-						yynn2334++
+						yynn2338++
 					}
 				}
-				r.EncodeMapStart(yynn2334)
+				r.EncodeMapStart(yynn2338)
 			}
-			if yyr2334 || yy2arr2334 {
+			if yyr2338 || yy2arr2338 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr2334 || yy2arr2334 {
+			if yyr2338 || yy2arr2338 {
 				x.Status.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
 				x.Status.CodecEncodeSelf(e)
 			}
-			if yyr2334 || yy2arr2334 {
-				if yyq2334[2] {
-					yy2338 := &x.LastHeartbeatTime
-					yym2339 := z.EncBinary()
-					_ = yym2339
+			if yyr2338 || yy2arr2338 {
+				if yyq2338[2] {
+					yy2342 := &x.LastHeartbeatTime
+					yym2343 := z.EncBinary()
+					_ = yym2343
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2338) {
-					} else if yym2339 {
-						z.EncBinaryMarshal(yy2338)
-					} else if !yym2339 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2338)
+					} else if z.HasExtensions() && z.EncExt(yy2342) {
+					} else if yym2343 {
+						z.EncBinaryMarshal(yy2342)
+					} else if !yym2343 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2342)
 					} else {
-						z.EncFallback(yy2338)
+						z.EncFallback(yy2342)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2334[2] {
+				if yyq2338[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastHeartbeatTime"))
-					yy2340 := &x.LastHeartbeatTime
-					yym2341 := z.EncBinary()
-					_ = yym2341
+					yy2344 := &x.LastHeartbeatTime
+					yym2345 := z.EncBinary()
+					_ = yym2345
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2340) {
-					} else if yym2341 {
-						z.EncBinaryMarshal(yy2340)
-					} else if !yym2341 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2340)
+					} else if z.HasExtensions() && z.EncExt(yy2344) {
+					} else if yym2345 {
+						z.EncBinaryMarshal(yy2344)
+					} else if !yym2345 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2344)
 					} else {
-						z.EncFallback(yy2340)
+						z.EncFallback(yy2344)
 					}
 				}
 			}
-			if yyr2334 || yy2arr2334 {
-				if yyq2334[3] {
-					yy2343 := &x.LastTransitionTime
-					yym2344 := z.EncBinary()
-					_ = yym2344
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2343) {
-					} else if yym2344 {
-						z.EncBinaryMarshal(yy2343)
-					} else if !yym2344 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2343)
-					} else {
-						z.EncFallback(yy2343)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2334[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
-					yy2345 := &x.LastTransitionTime
-					yym2346 := z.EncBinary()
-					_ = yym2346
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2345) {
-					} else if yym2346 {
-						z.EncBinaryMarshal(yy2345)
-					} else if !yym2346 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2345)
-					} else {
-						z.EncFallback(yy2345)
-					}
-				}
-			}
-			if yyr2334 || yy2arr2334 {
-				if yyq2334[4] {
+			if yyr2338 || yy2arr2338 {
+				if yyq2338[3] {
+					yy2347 := &x.LastTransitionTime
 					yym2348 := z.EncBinary()
 					_ = yym2348
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2347) {
+					} else if yym2348 {
+						z.EncBinaryMarshal(yy2347)
+					} else if !yym2348 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2347)
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+						z.EncFallback(yy2347)
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
-				if yyq2334[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym2349 := z.EncBinary()
-					_ = yym2349
+				if yyq2338[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					yy2349 := &x.LastTransitionTime
+					yym2350 := z.EncBinary()
+					_ = yym2350
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2349) {
+					} else if yym2350 {
+						z.EncBinaryMarshal(yy2349)
+					} else if !yym2350 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2349)
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+						z.EncFallback(yy2349)
 					}
 				}
 			}
-			if yyr2334 || yy2arr2334 {
-				if yyq2334[5] {
-					yym2351 := z.EncBinary()
-					_ = yym2351
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2334[5] {
-					r.EncodeString(codecSelferC_UTF81234, string("message"))
+			if yyr2338 || yy2arr2338 {
+				if yyq2338[4] {
 					yym2352 := z.EncBinary()
 					_ = yym2352
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2338[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					yym2353 := z.EncBinary()
+					_ = yym2353
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				}
+			}
+			if yyr2338 || yy2arr2338 {
+				if yyq2338[5] {
+					yym2355 := z.EncBinary()
+					_ = yym2355
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2338[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					yym2356 := z.EncBinary()
+					_ = yym2356
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yysep2334 {
+			if yysep2338 {
 				r.EncodeEnd()
 			}
 		}
@@ -27843,24 +27873,24 @@ func (x *NodeCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2353 := z.DecBinary()
-	_ = yym2353
+	yym2357 := z.DecBinary()
+	_ = yym2357
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2354 := r.ReadMapStart()
-			if yyl2354 == 0 {
+			yyl2358 := r.ReadMapStart()
+			if yyl2358 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2354, d)
+				x.codecDecodeSelfFromMap(yyl2358, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2354 := r.ReadArrayStart()
-			if yyl2354 == 0 {
+			yyl2358 := r.ReadArrayStart()
+			if yyl2358 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2354, d)
+				x.codecDecodeSelfFromArray(yyl2358, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -27872,12 +27902,12 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2355Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2355Slc
-	var yyhl2355 bool = l >= 0
-	for yyj2355 := 0; ; yyj2355++ {
-		if yyhl2355 {
-			if yyj2355 >= l {
+	var yys2359Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2359Slc
+	var yyhl2359 bool = l >= 0
+	for yyj2359 := 0; ; yyj2359++ {
+		if yyhl2359 {
+			if yyj2359 >= l {
 				break
 			}
 		} else {
@@ -27885,9 +27915,9 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2355Slc = r.DecodeBytes(yys2355Slc, true, true)
-		yys2355 := string(yys2355Slc)
-		switch yys2355 {
+		yys2359Slc = r.DecodeBytes(yys2359Slc, true, true)
+		yys2359 := string(yys2359Slc)
+		switch yys2359 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -27904,34 +27934,34 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastHeartbeatTime = pkg2_unversioned.Time{}
 			} else {
-				yyv2358 := &x.LastHeartbeatTime
-				yym2359 := z.DecBinary()
-				_ = yym2359
+				yyv2362 := &x.LastHeartbeatTime
+				yym2363 := z.DecBinary()
+				_ = yym2363
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2358) {
-				} else if yym2359 {
-					z.DecBinaryUnmarshal(yyv2358)
-				} else if !yym2359 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2358)
+				} else if z.HasExtensions() && z.DecExt(yyv2362) {
+				} else if yym2363 {
+					z.DecBinaryUnmarshal(yyv2362)
+				} else if !yym2363 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2362)
 				} else {
-					z.DecFallback(yyv2358, false)
+					z.DecFallback(yyv2362, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg2_unversioned.Time{}
 			} else {
-				yyv2360 := &x.LastTransitionTime
-				yym2361 := z.DecBinary()
-				_ = yym2361
+				yyv2364 := &x.LastTransitionTime
+				yym2365 := z.DecBinary()
+				_ = yym2365
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2360) {
-				} else if yym2361 {
-					z.DecBinaryUnmarshal(yyv2360)
-				} else if !yym2361 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2360)
+				} else if z.HasExtensions() && z.DecExt(yyv2364) {
+				} else if yym2365 {
+					z.DecBinaryUnmarshal(yyv2364)
+				} else if !yym2365 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2364)
 				} else {
-					z.DecFallback(yyv2360, false)
+					z.DecFallback(yyv2364, false)
 				}
 			}
 		case "reason":
@@ -27947,10 +27977,10 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2355)
-		} // end switch yys2355
-	} // end for yyj2355
-	if !yyhl2355 {
+			z.DecStructFieldNotFound(-1, yys2359)
+		} // end switch yys2359
+	} // end for yyj2359
+	if !yyhl2359 {
 		r.ReadEnd()
 	}
 }
@@ -27959,16 +27989,16 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2364 int
-	var yyb2364 bool
-	var yyhl2364 bool = l >= 0
-	yyj2364++
-	if yyhl2364 {
-		yyb2364 = yyj2364 > l
+	var yyj2368 int
+	var yyb2368 bool
+	var yyhl2368 bool = l >= 0
+	yyj2368++
+	if yyhl2368 {
+		yyb2368 = yyj2368 > l
 	} else {
-		yyb2364 = r.CheckBreak()
+		yyb2368 = r.CheckBreak()
 	}
-	if yyb2364 {
+	if yyb2368 {
 		r.ReadEnd()
 		return
 	}
@@ -27977,13 +28007,13 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = NodeConditionType(r.DecodeString())
 	}
-	yyj2364++
-	if yyhl2364 {
-		yyb2364 = yyj2364 > l
+	yyj2368++
+	if yyhl2368 {
+		yyb2368 = yyj2368 > l
 	} else {
-		yyb2364 = r.CheckBreak()
+		yyb2368 = r.CheckBreak()
 	}
-	if yyb2364 {
+	if yyb2368 {
 		r.ReadEnd()
 		return
 	}
@@ -27992,65 +28022,65 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = ConditionStatus(r.DecodeString())
 	}
-	yyj2364++
-	if yyhl2364 {
-		yyb2364 = yyj2364 > l
+	yyj2368++
+	if yyhl2368 {
+		yyb2368 = yyj2368 > l
 	} else {
-		yyb2364 = r.CheckBreak()
+		yyb2368 = r.CheckBreak()
 	}
-	if yyb2364 {
+	if yyb2368 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastHeartbeatTime = pkg2_unversioned.Time{}
 	} else {
-		yyv2367 := &x.LastHeartbeatTime
-		yym2368 := z.DecBinary()
-		_ = yym2368
+		yyv2371 := &x.LastHeartbeatTime
+		yym2372 := z.DecBinary()
+		_ = yym2372
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2367) {
-		} else if yym2368 {
-			z.DecBinaryUnmarshal(yyv2367)
-		} else if !yym2368 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2367)
+		} else if z.HasExtensions() && z.DecExt(yyv2371) {
+		} else if yym2372 {
+			z.DecBinaryUnmarshal(yyv2371)
+		} else if !yym2372 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2371)
 		} else {
-			z.DecFallback(yyv2367, false)
+			z.DecFallback(yyv2371, false)
 		}
 	}
-	yyj2364++
-	if yyhl2364 {
-		yyb2364 = yyj2364 > l
+	yyj2368++
+	if yyhl2368 {
+		yyb2368 = yyj2368 > l
 	} else {
-		yyb2364 = r.CheckBreak()
+		yyb2368 = r.CheckBreak()
 	}
-	if yyb2364 {
+	if yyb2368 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg2_unversioned.Time{}
 	} else {
-		yyv2369 := &x.LastTransitionTime
-		yym2370 := z.DecBinary()
-		_ = yym2370
+		yyv2373 := &x.LastTransitionTime
+		yym2374 := z.DecBinary()
+		_ = yym2374
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2369) {
-		} else if yym2370 {
-			z.DecBinaryUnmarshal(yyv2369)
-		} else if !yym2370 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2369)
+		} else if z.HasExtensions() && z.DecExt(yyv2373) {
+		} else if yym2374 {
+			z.DecBinaryUnmarshal(yyv2373)
+		} else if !yym2374 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2373)
 		} else {
-			z.DecFallback(yyv2369, false)
+			z.DecFallback(yyv2373, false)
 		}
 	}
-	yyj2364++
-	if yyhl2364 {
-		yyb2364 = yyj2364 > l
+	yyj2368++
+	if yyhl2368 {
+		yyb2368 = yyj2368 > l
 	} else {
-		yyb2364 = r.CheckBreak()
+		yyb2368 = r.CheckBreak()
 	}
-	if yyb2364 {
+	if yyb2368 {
 		r.ReadEnd()
 		return
 	}
@@ -28059,13 +28089,13 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj2364++
-	if yyhl2364 {
-		yyb2364 = yyj2364 > l
+	yyj2368++
+	if yyhl2368 {
+		yyb2368 = yyj2368 > l
 	} else {
-		yyb2364 = r.CheckBreak()
+		yyb2368 = r.CheckBreak()
 	}
-	if yyb2364 {
+	if yyb2368 {
 		r.ReadEnd()
 		return
 	}
@@ -28075,16 +28105,16 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj2364++
-		if yyhl2364 {
-			yyb2364 = yyj2364 > l
+		yyj2368++
+		if yyhl2368 {
+			yyb2368 = yyj2368 > l
 		} else {
-			yyb2364 = r.CheckBreak()
+			yyb2368 = r.CheckBreak()
 		}
-		if yyb2364 {
+		if yyb2368 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2364-1, "")
+		z.DecStructFieldNotFound(yyj2368-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28093,8 +28123,8 @@ func (x NodeAddressType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2373 := z.EncBinary()
-	_ = yym2373
+	yym2377 := z.EncBinary()
+	_ = yym2377
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -28106,8 +28136,8 @@ func (x *NodeAddressType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2374 := z.DecBinary()
-	_ = yym2374
+	yym2378 := z.DecBinary()
+	_ = yym2378
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28122,50 +28152,50 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2375 := z.EncBinary()
-		_ = yym2375
+		yym2379 := z.EncBinary()
+		_ = yym2379
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2376 := !z.EncBinary()
-			yy2arr2376 := z.EncBasicHandle().StructToArray
-			var yyq2376 [2]bool
-			_, _, _ = yysep2376, yyq2376, yy2arr2376
-			const yyr2376 bool = false
-			if yyr2376 || yy2arr2376 {
+			yysep2380 := !z.EncBinary()
+			yy2arr2380 := z.EncBasicHandle().StructToArray
+			var yyq2380 [2]bool
+			_, _, _ = yysep2380, yyq2380, yy2arr2380
+			const yyr2380 bool = false
+			if yyr2380 || yy2arr2380 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2376 int = 2
-				for _, b := range yyq2376 {
+				var yynn2380 int = 2
+				for _, b := range yyq2380 {
 					if b {
-						yynn2376++
+						yynn2380++
 					}
 				}
-				r.EncodeMapStart(yynn2376)
+				r.EncodeMapStart(yynn2380)
 			}
-			if yyr2376 || yy2arr2376 {
+			if yyr2380 || yy2arr2380 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr2376 || yy2arr2376 {
-				yym2379 := z.EncBinary()
-				_ = yym2379
+			if yyr2380 || yy2arr2380 {
+				yym2383 := z.EncBinary()
+				_ = yym2383
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
-				yym2380 := z.EncBinary()
-				_ = yym2380
+				yym2384 := z.EncBinary()
+				_ = yym2384
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
-			if yysep2376 {
+			if yysep2380 {
 				r.EncodeEnd()
 			}
 		}
@@ -28176,24 +28206,24 @@ func (x *NodeAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2381 := z.DecBinary()
-	_ = yym2381
+	yym2385 := z.DecBinary()
+	_ = yym2385
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2382 := r.ReadMapStart()
-			if yyl2382 == 0 {
+			yyl2386 := r.ReadMapStart()
+			if yyl2386 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2382, d)
+				x.codecDecodeSelfFromMap(yyl2386, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2382 := r.ReadArrayStart()
-			if yyl2382 == 0 {
+			yyl2386 := r.ReadArrayStart()
+			if yyl2386 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2382, d)
+				x.codecDecodeSelfFromArray(yyl2386, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28205,12 +28235,12 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2383Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2383Slc
-	var yyhl2383 bool = l >= 0
-	for yyj2383 := 0; ; yyj2383++ {
-		if yyhl2383 {
-			if yyj2383 >= l {
+	var yys2387Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2387Slc
+	var yyhl2387 bool = l >= 0
+	for yyj2387 := 0; ; yyj2387++ {
+		if yyhl2387 {
+			if yyj2387 >= l {
 				break
 			}
 		} else {
@@ -28218,9 +28248,9 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2383Slc = r.DecodeBytes(yys2383Slc, true, true)
-		yys2383 := string(yys2383Slc)
-		switch yys2383 {
+		yys2387Slc = r.DecodeBytes(yys2387Slc, true, true)
+		yys2387 := string(yys2387Slc)
+		switch yys2387 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -28234,10 +28264,10 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Address = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2383)
-		} // end switch yys2383
-	} // end for yyj2383
-	if !yyhl2383 {
+			z.DecStructFieldNotFound(-1, yys2387)
+		} // end switch yys2387
+	} // end for yyj2387
+	if !yyhl2387 {
 		r.ReadEnd()
 	}
 }
@@ -28246,16 +28276,16 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2386 int
-	var yyb2386 bool
-	var yyhl2386 bool = l >= 0
-	yyj2386++
-	if yyhl2386 {
-		yyb2386 = yyj2386 > l
+	var yyj2390 int
+	var yyb2390 bool
+	var yyhl2390 bool = l >= 0
+	yyj2390++
+	if yyhl2390 {
+		yyb2390 = yyj2390 > l
 	} else {
-		yyb2386 = r.CheckBreak()
+		yyb2390 = r.CheckBreak()
 	}
-	if yyb2386 {
+	if yyb2390 {
 		r.ReadEnd()
 		return
 	}
@@ -28264,13 +28294,13 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = NodeAddressType(r.DecodeString())
 	}
-	yyj2386++
-	if yyhl2386 {
-		yyb2386 = yyj2386 > l
+	yyj2390++
+	if yyhl2390 {
+		yyb2390 = yyj2390 > l
 	} else {
-		yyb2386 = r.CheckBreak()
+		yyb2390 = r.CheckBreak()
 	}
-	if yyb2386 {
+	if yyb2390 {
 		r.ReadEnd()
 		return
 	}
@@ -28280,16 +28310,16 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Address = string(r.DecodeString())
 	}
 	for {
-		yyj2386++
-		if yyhl2386 {
-			yyb2386 = yyj2386 > l
+		yyj2390++
+		if yyhl2390 {
+			yyb2390 = yyj2390 > l
 		} else {
-			yyb2386 = r.CheckBreak()
+			yyb2390 = r.CheckBreak()
 		}
-		if yyb2386 {
+		if yyb2390 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2386-1, "")
+		z.DecStructFieldNotFound(yyj2390-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28301,30 +28331,30 @@ func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2389 := z.EncBinary()
-		_ = yym2389
+		yym2393 := z.EncBinary()
+		_ = yym2393
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2390 := !z.EncBinary()
-			yy2arr2390 := z.EncBasicHandle().StructToArray
-			var yyq2390 [1]bool
-			_, _, _ = yysep2390, yyq2390, yy2arr2390
-			const yyr2390 bool = false
-			yyq2390[0] = len(x.Capacity) != 0
-			if yyr2390 || yy2arr2390 {
+			yysep2394 := !z.EncBinary()
+			yy2arr2394 := z.EncBasicHandle().StructToArray
+			var yyq2394 [1]bool
+			_, _, _ = yysep2394, yyq2394, yy2arr2394
+			const yyr2394 bool = false
+			yyq2394[0] = len(x.Capacity) != 0
+			if yyr2394 || yy2arr2394 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2390 int = 0
-				for _, b := range yyq2390 {
+				var yynn2394 int = 0
+				for _, b := range yyq2394 {
 					if b {
-						yynn2390++
+						yynn2394++
 					}
 				}
-				r.EncodeMapStart(yynn2390)
+				r.EncodeMapStart(yynn2394)
 			}
-			if yyr2390 || yy2arr2390 {
-				if yyq2390[0] {
+			if yyr2394 || yy2arr2394 {
+				if yyq2394[0] {
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -28334,7 +28364,7 @@ func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2390[0] {
+				if yyq2394[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -28343,7 +28373,7 @@ func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2390 {
+			if yysep2394 {
 				r.EncodeEnd()
 			}
 		}
@@ -28354,24 +28384,24 @@ func (x *NodeResources) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2392 := z.DecBinary()
-	_ = yym2392
+	yym2396 := z.DecBinary()
+	_ = yym2396
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2393 := r.ReadMapStart()
-			if yyl2393 == 0 {
+			yyl2397 := r.ReadMapStart()
+			if yyl2397 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2393, d)
+				x.codecDecodeSelfFromMap(yyl2397, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2393 := r.ReadArrayStart()
-			if yyl2393 == 0 {
+			yyl2397 := r.ReadArrayStart()
+			if yyl2397 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2393, d)
+				x.codecDecodeSelfFromArray(yyl2397, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28383,12 +28413,12 @@ func (x *NodeResources) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2394Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2394Slc
-	var yyhl2394 bool = l >= 0
-	for yyj2394 := 0; ; yyj2394++ {
-		if yyhl2394 {
-			if yyj2394 >= l {
+	var yys2398Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2398Slc
+	var yyhl2398 bool = l >= 0
+	for yyj2398 := 0; ; yyj2398++ {
+		if yyhl2398 {
+			if yyj2398 >= l {
 				break
 			}
 		} else {
@@ -28396,21 +28426,21 @@ func (x *NodeResources) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2394Slc = r.DecodeBytes(yys2394Slc, true, true)
-		yys2394 := string(yys2394Slc)
-		switch yys2394 {
+		yys2398Slc = r.DecodeBytes(yys2398Slc, true, true)
+		yys2398 := string(yys2398Slc)
+		switch yys2398 {
 		case "capacity":
 			if r.TryDecodeAsNil() {
 				x.Capacity = nil
 			} else {
-				yyv2395 := &x.Capacity
-				yyv2395.CodecDecodeSelf(d)
+				yyv2399 := &x.Capacity
+				yyv2399.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2394)
-		} // end switch yys2394
-	} // end for yyj2394
-	if !yyhl2394 {
+			z.DecStructFieldNotFound(-1, yys2398)
+		} // end switch yys2398
+	} // end for yyj2398
+	if !yyhl2398 {
 		r.ReadEnd()
 	}
 }
@@ -28419,36 +28449,36 @@ func (x *NodeResources) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2396 int
-	var yyb2396 bool
-	var yyhl2396 bool = l >= 0
-	yyj2396++
-	if yyhl2396 {
-		yyb2396 = yyj2396 > l
+	var yyj2400 int
+	var yyb2400 bool
+	var yyhl2400 bool = l >= 0
+	yyj2400++
+	if yyhl2400 {
+		yyb2400 = yyj2400 > l
 	} else {
-		yyb2396 = r.CheckBreak()
+		yyb2400 = r.CheckBreak()
 	}
-	if yyb2396 {
+	if yyb2400 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
-		yyv2397 := &x.Capacity
-		yyv2397.CodecDecodeSelf(d)
+		yyv2401 := &x.Capacity
+		yyv2401.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2396++
-		if yyhl2396 {
-			yyb2396 = yyj2396 > l
+		yyj2400++
+		if yyhl2400 {
+			yyb2400 = yyj2400 > l
 		} else {
-			yyb2396 = r.CheckBreak()
+			yyb2400 = r.CheckBreak()
 		}
-		if yyb2396 {
+		if yyb2400 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2396-1, "")
+		z.DecStructFieldNotFound(yyj2400-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28457,8 +28487,8 @@ func (x ResourceName) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2398 := z.EncBinary()
-	_ = yym2398
+	yym2402 := z.EncBinary()
+	_ = yym2402
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -28470,8 +28500,8 @@ func (x *ResourceName) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2399 := z.DecBinary()
-	_ = yym2399
+	yym2403 := z.DecBinary()
+	_ = yym2403
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28486,8 +28516,8 @@ func (x ResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2400 := z.EncBinary()
-		_ = yym2400
+		yym2404 := z.EncBinary()
+		_ = yym2404
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
@@ -28500,8 +28530,8 @@ func (x *ResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2401 := z.DecBinary()
-	_ = yym2401
+	yym2405 := z.DecBinary()
+	_ = yym2405
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28516,119 +28546,119 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2402 := z.EncBinary()
-		_ = yym2402
+		yym2406 := z.EncBinary()
+		_ = yym2406
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2403 := !z.EncBinary()
-			yy2arr2403 := z.EncBasicHandle().StructToArray
-			var yyq2403 [5]bool
-			_, _, _ = yysep2403, yyq2403, yy2arr2403
-			const yyr2403 bool = false
-			yyq2403[0] = x.Kind != ""
-			yyq2403[1] = x.APIVersion != ""
-			yyq2403[2] = true
-			yyq2403[3] = true
-			yyq2403[4] = true
-			if yyr2403 || yy2arr2403 {
+			yysep2407 := !z.EncBinary()
+			yy2arr2407 := z.EncBasicHandle().StructToArray
+			var yyq2407 [5]bool
+			_, _, _ = yysep2407, yyq2407, yy2arr2407
+			const yyr2407 bool = false
+			yyq2407[0] = x.Kind != ""
+			yyq2407[1] = x.APIVersion != ""
+			yyq2407[2] = true
+			yyq2407[3] = true
+			yyq2407[4] = true
+			if yyr2407 || yy2arr2407 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2403 int = 0
-				for _, b := range yyq2403 {
+				var yynn2407 int = 0
+				for _, b := range yyq2407 {
 					if b {
-						yynn2403++
+						yynn2407++
 					}
 				}
-				r.EncodeMapStart(yynn2403)
+				r.EncodeMapStart(yynn2407)
 			}
-			if yyr2403 || yy2arr2403 {
-				if yyq2403[0] {
-					yym2405 := z.EncBinary()
-					_ = yym2405
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2403[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2406 := z.EncBinary()
-					_ = yym2406
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2403 || yy2arr2403 {
-				if yyq2403[1] {
-					yym2408 := z.EncBinary()
-					_ = yym2408
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2403[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2407 || yy2arr2407 {
+				if yyq2407[0] {
 					yym2409 := z.EncBinary()
 					_ = yym2409
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2407[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2410 := z.EncBinary()
+					_ = yym2410
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2407 || yy2arr2407 {
+				if yyq2407[1] {
+					yym2412 := z.EncBinary()
+					_ = yym2412
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2407[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2413 := z.EncBinary()
+					_ = yym2413
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2403 || yy2arr2403 {
-				if yyq2403[2] {
-					yy2411 := &x.ObjectMeta
-					yy2411.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2403[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2412 := &x.ObjectMeta
-					yy2412.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2403 || yy2arr2403 {
-				if yyq2403[3] {
-					yy2414 := &x.Spec
-					yy2414.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2403[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy2415 := &x.Spec
+			if yyr2407 || yy2arr2407 {
+				if yyq2407[2] {
+					yy2415 := &x.ObjectMeta
 					yy2415.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2403 || yy2arr2403 {
-				if yyq2403[4] {
-					yy2417 := &x.Status
-					yy2417.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2403[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy2418 := &x.Status
-					yy2418.CodecEncodeSelf(e)
+				if yyq2407[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2416 := &x.ObjectMeta
+					yy2416.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2403 {
+			if yyr2407 || yy2arr2407 {
+				if yyq2407[3] {
+					yy2418 := &x.Spec
+					yy2418.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2407[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy2419 := &x.Spec
+					yy2419.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2407 || yy2arr2407 {
+				if yyq2407[4] {
+					yy2421 := &x.Status
+					yy2421.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2407[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy2422 := &x.Status
+					yy2422.CodecEncodeSelf(e)
+				}
+			}
+			if yysep2407 {
 				r.EncodeEnd()
 			}
 		}
@@ -28639,24 +28669,24 @@ func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2419 := z.DecBinary()
-	_ = yym2419
+	yym2423 := z.DecBinary()
+	_ = yym2423
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2420 := r.ReadMapStart()
-			if yyl2420 == 0 {
+			yyl2424 := r.ReadMapStart()
+			if yyl2424 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2420, d)
+				x.codecDecodeSelfFromMap(yyl2424, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2420 := r.ReadArrayStart()
-			if yyl2420 == 0 {
+			yyl2424 := r.ReadArrayStart()
+			if yyl2424 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2420, d)
+				x.codecDecodeSelfFromArray(yyl2424, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28668,12 +28698,12 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2421Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2421Slc
-	var yyhl2421 bool = l >= 0
-	for yyj2421 := 0; ; yyj2421++ {
-		if yyhl2421 {
-			if yyj2421 >= l {
+	var yys2425Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2425Slc
+	var yyhl2425 bool = l >= 0
+	for yyj2425 := 0; ; yyj2425++ {
+		if yyhl2425 {
+			if yyj2425 >= l {
 				break
 			}
 		} else {
@@ -28681,9 +28711,9 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2421Slc = r.DecodeBytes(yys2421Slc, true, true)
-		yys2421 := string(yys2421Slc)
-		switch yys2421 {
+		yys2425Slc = r.DecodeBytes(yys2425Slc, true, true)
+		yys2425 := string(yys2425Slc)
+		switch yys2425 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28700,28 +28730,28 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2424 := &x.ObjectMeta
-				yyv2424.CodecDecodeSelf(d)
+				yyv2428 := &x.ObjectMeta
+				yyv2428.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = NodeSpec{}
 			} else {
-				yyv2425 := &x.Spec
-				yyv2425.CodecDecodeSelf(d)
+				yyv2429 := &x.Spec
+				yyv2429.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = NodeStatus{}
 			} else {
-				yyv2426 := &x.Status
-				yyv2426.CodecDecodeSelf(d)
+				yyv2430 := &x.Status
+				yyv2430.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2421)
-		} // end switch yys2421
-	} // end for yyj2421
-	if !yyhl2421 {
+			z.DecStructFieldNotFound(-1, yys2425)
+		} // end switch yys2425
+	} // end for yyj2425
+	if !yyhl2425 {
 		r.ReadEnd()
 	}
 }
@@ -28730,16 +28760,16 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2427 int
-	var yyb2427 bool
-	var yyhl2427 bool = l >= 0
-	yyj2427++
-	if yyhl2427 {
-		yyb2427 = yyj2427 > l
+	var yyj2431 int
+	var yyb2431 bool
+	var yyhl2431 bool = l >= 0
+	yyj2431++
+	if yyhl2431 {
+		yyb2431 = yyj2431 > l
 	} else {
-		yyb2427 = r.CheckBreak()
+		yyb2431 = r.CheckBreak()
 	}
-	if yyb2427 {
+	if yyb2431 {
 		r.ReadEnd()
 		return
 	}
@@ -28748,13 +28778,13 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2427++
-	if yyhl2427 {
-		yyb2427 = yyj2427 > l
+	yyj2431++
+	if yyhl2431 {
+		yyb2431 = yyj2431 > l
 	} else {
-		yyb2427 = r.CheckBreak()
+		yyb2431 = r.CheckBreak()
 	}
-	if yyb2427 {
+	if yyb2431 {
 		r.ReadEnd()
 		return
 	}
@@ -28763,65 +28793,65 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2427++
-	if yyhl2427 {
-		yyb2427 = yyj2427 > l
+	yyj2431++
+	if yyhl2431 {
+		yyb2431 = yyj2431 > l
 	} else {
-		yyb2427 = r.CheckBreak()
+		yyb2431 = r.CheckBreak()
 	}
-	if yyb2427 {
+	if yyb2431 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2430 := &x.ObjectMeta
-		yyv2430.CodecDecodeSelf(d)
+		yyv2434 := &x.ObjectMeta
+		yyv2434.CodecDecodeSelf(d)
 	}
-	yyj2427++
-	if yyhl2427 {
-		yyb2427 = yyj2427 > l
+	yyj2431++
+	if yyhl2431 {
+		yyb2431 = yyj2431 > l
 	} else {
-		yyb2427 = r.CheckBreak()
+		yyb2431 = r.CheckBreak()
 	}
-	if yyb2427 {
+	if yyb2431 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = NodeSpec{}
 	} else {
-		yyv2431 := &x.Spec
-		yyv2431.CodecDecodeSelf(d)
+		yyv2435 := &x.Spec
+		yyv2435.CodecDecodeSelf(d)
 	}
-	yyj2427++
-	if yyhl2427 {
-		yyb2427 = yyj2427 > l
+	yyj2431++
+	if yyhl2431 {
+		yyb2431 = yyj2431 > l
 	} else {
-		yyb2427 = r.CheckBreak()
+		yyb2431 = r.CheckBreak()
 	}
-	if yyb2427 {
+	if yyb2431 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = NodeStatus{}
 	} else {
-		yyv2432 := &x.Status
-		yyv2432.CodecDecodeSelf(d)
+		yyv2436 := &x.Status
+		yyv2436.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2427++
-		if yyhl2427 {
-			yyb2427 = yyj2427 > l
+		yyj2431++
+		if yyhl2431 {
+			yyb2431 = yyj2431 > l
 		} else {
-			yyb2427 = r.CheckBreak()
+			yyb2431 = r.CheckBreak()
 		}
-		if yyb2427 {
+		if yyb2431 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2427-1, "")
+		z.DecStructFieldNotFound(yyj2431-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28833,106 +28863,106 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2433 := z.EncBinary()
-		_ = yym2433
+		yym2437 := z.EncBinary()
+		_ = yym2437
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2434 := !z.EncBinary()
-			yy2arr2434 := z.EncBasicHandle().StructToArray
-			var yyq2434 [4]bool
-			_, _, _ = yysep2434, yyq2434, yy2arr2434
-			const yyr2434 bool = false
-			yyq2434[0] = x.Kind != ""
-			yyq2434[1] = x.APIVersion != ""
-			yyq2434[2] = true
-			if yyr2434 || yy2arr2434 {
+			yysep2438 := !z.EncBinary()
+			yy2arr2438 := z.EncBasicHandle().StructToArray
+			var yyq2438 [4]bool
+			_, _, _ = yysep2438, yyq2438, yy2arr2438
+			const yyr2438 bool = false
+			yyq2438[0] = x.Kind != ""
+			yyq2438[1] = x.APIVersion != ""
+			yyq2438[2] = true
+			if yyr2438 || yy2arr2438 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2434 int = 1
-				for _, b := range yyq2434 {
+				var yynn2438 int = 1
+				for _, b := range yyq2438 {
 					if b {
-						yynn2434++
+						yynn2438++
 					}
 				}
-				r.EncodeMapStart(yynn2434)
+				r.EncodeMapStart(yynn2438)
 			}
-			if yyr2434 || yy2arr2434 {
-				if yyq2434[0] {
-					yym2436 := z.EncBinary()
-					_ = yym2436
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2434[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2437 := z.EncBinary()
-					_ = yym2437
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2434 || yy2arr2434 {
-				if yyq2434[1] {
-					yym2439 := z.EncBinary()
-					_ = yym2439
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2434[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2438 || yy2arr2438 {
+				if yyq2438[0] {
 					yym2440 := z.EncBinary()
 					_ = yym2440
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2438[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2441 := z.EncBinary()
+					_ = yym2441
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2438 || yy2arr2438 {
+				if yyq2438[1] {
+					yym2443 := z.EncBinary()
+					_ = yym2443
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2438[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2444 := z.EncBinary()
+					_ = yym2444
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2434 || yy2arr2434 {
-				if yyq2434[2] {
-					yy2442 := &x.ListMeta
-					yym2443 := z.EncBinary()
-					_ = yym2443
+			if yyr2438 || yy2arr2438 {
+				if yyq2438[2] {
+					yy2446 := &x.ListMeta
+					yym2447 := z.EncBinary()
+					_ = yym2447
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2442) {
+					} else if z.HasExtensions() && z.EncExt(yy2446) {
 					} else {
-						z.EncFallback(yy2442)
+						z.EncFallback(yy2446)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2434[2] {
+				if yyq2438[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2444 := &x.ListMeta
-					yym2445 := z.EncBinary()
-					_ = yym2445
+					yy2448 := &x.ListMeta
+					yym2449 := z.EncBinary()
+					_ = yym2449
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2444) {
+					} else if z.HasExtensions() && z.EncExt(yy2448) {
 					} else {
-						z.EncFallback(yy2444)
+						z.EncFallback(yy2448)
 					}
 				}
 			}
-			if yyr2434 || yy2arr2434 {
+			if yyr2438 || yy2arr2438 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2447 := z.EncBinary()
-					_ = yym2447
+					yym2451 := z.EncBinary()
+					_ = yym2451
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
@@ -28943,15 +28973,15 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2448 := z.EncBinary()
-					_ = yym2448
+					yym2452 := z.EncBinary()
+					_ = yym2452
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
 					}
 				}
 			}
-			if yysep2434 {
+			if yysep2438 {
 				r.EncodeEnd()
 			}
 		}
@@ -28962,24 +28992,24 @@ func (x *NodeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2449 := z.DecBinary()
-	_ = yym2449
+	yym2453 := z.DecBinary()
+	_ = yym2453
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2450 := r.ReadMapStart()
-			if yyl2450 == 0 {
+			yyl2454 := r.ReadMapStart()
+			if yyl2454 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2450, d)
+				x.codecDecodeSelfFromMap(yyl2454, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2450 := r.ReadArrayStart()
-			if yyl2450 == 0 {
+			yyl2454 := r.ReadArrayStart()
+			if yyl2454 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2450, d)
+				x.codecDecodeSelfFromArray(yyl2454, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28991,12 +29021,12 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2451Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2451Slc
-	var yyhl2451 bool = l >= 0
-	for yyj2451 := 0; ; yyj2451++ {
-		if yyhl2451 {
-			if yyj2451 >= l {
+	var yys2455Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2455Slc
+	var yyhl2455 bool = l >= 0
+	for yyj2455 := 0; ; yyj2455++ {
+		if yyhl2455 {
+			if yyj2455 >= l {
 				break
 			}
 		} else {
@@ -29004,9 +29034,9 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2451Slc = r.DecodeBytes(yys2451Slc, true, true)
-		yys2451 := string(yys2451Slc)
-		switch yys2451 {
+		yys2455Slc = r.DecodeBytes(yys2455Slc, true, true)
+		yys2455 := string(yys2455Slc)
+		switch yys2455 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29023,32 +29053,32 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2454 := &x.ListMeta
-				yym2455 := z.DecBinary()
-				_ = yym2455
+				yyv2458 := &x.ListMeta
+				yym2459 := z.DecBinary()
+				_ = yym2459
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2454) {
+				} else if z.HasExtensions() && z.DecExt(yyv2458) {
 				} else {
-					z.DecFallback(yyv2454, false)
+					z.DecFallback(yyv2458, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2456 := &x.Items
-				yym2457 := z.DecBinary()
-				_ = yym2457
+				yyv2460 := &x.Items
+				yym2461 := z.DecBinary()
+				_ = yym2461
 				if false {
 				} else {
-					h.decSliceNode((*[]Node)(yyv2456), d)
+					h.decSliceNode((*[]Node)(yyv2460), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2451)
-		} // end switch yys2451
-	} // end for yyj2451
-	if !yyhl2451 {
+			z.DecStructFieldNotFound(-1, yys2455)
+		} // end switch yys2455
+	} // end for yyj2455
+	if !yyhl2455 {
 		r.ReadEnd()
 	}
 }
@@ -29057,16 +29087,16 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2458 int
-	var yyb2458 bool
-	var yyhl2458 bool = l >= 0
-	yyj2458++
-	if yyhl2458 {
-		yyb2458 = yyj2458 > l
+	var yyj2462 int
+	var yyb2462 bool
+	var yyhl2462 bool = l >= 0
+	yyj2462++
+	if yyhl2462 {
+		yyb2462 = yyj2462 > l
 	} else {
-		yyb2458 = r.CheckBreak()
+		yyb2462 = r.CheckBreak()
 	}
-	if yyb2458 {
+	if yyb2462 {
 		r.ReadEnd()
 		return
 	}
@@ -29075,13 +29105,13 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2458++
-	if yyhl2458 {
-		yyb2458 = yyj2458 > l
+	yyj2462++
+	if yyhl2462 {
+		yyb2462 = yyj2462 > l
 	} else {
-		yyb2458 = r.CheckBreak()
+		yyb2462 = r.CheckBreak()
 	}
-	if yyb2458 {
+	if yyb2462 {
 		r.ReadEnd()
 		return
 	}
@@ -29090,60 +29120,60 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2458++
-	if yyhl2458 {
-		yyb2458 = yyj2458 > l
+	yyj2462++
+	if yyhl2462 {
+		yyb2462 = yyj2462 > l
 	} else {
-		yyb2458 = r.CheckBreak()
+		yyb2462 = r.CheckBreak()
 	}
-	if yyb2458 {
+	if yyb2462 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2461 := &x.ListMeta
-		yym2462 := z.DecBinary()
-		_ = yym2462
+		yyv2465 := &x.ListMeta
+		yym2466 := z.DecBinary()
+		_ = yym2466
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2461) {
+		} else if z.HasExtensions() && z.DecExt(yyv2465) {
 		} else {
-			z.DecFallback(yyv2461, false)
+			z.DecFallback(yyv2465, false)
 		}
 	}
-	yyj2458++
-	if yyhl2458 {
-		yyb2458 = yyj2458 > l
+	yyj2462++
+	if yyhl2462 {
+		yyb2462 = yyj2462 > l
 	} else {
-		yyb2458 = r.CheckBreak()
+		yyb2462 = r.CheckBreak()
 	}
-	if yyb2458 {
+	if yyb2462 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2463 := &x.Items
-		yym2464 := z.DecBinary()
-		_ = yym2464
+		yyv2467 := &x.Items
+		yym2468 := z.DecBinary()
+		_ = yym2468
 		if false {
 		} else {
-			h.decSliceNode((*[]Node)(yyv2463), d)
+			h.decSliceNode((*[]Node)(yyv2467), d)
 		}
 	}
 	for {
-		yyj2458++
-		if yyhl2458 {
-			yyb2458 = yyj2458 > l
+		yyj2462++
+		if yyhl2462 {
+			yyb2462 = yyj2462 > l
 		} else {
-			yyb2458 = r.CheckBreak()
+			yyb2462 = r.CheckBreak()
 		}
-		if yyb2458 {
+		if yyb2462 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2458-1, "")
+		z.DecStructFieldNotFound(yyj2462-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29155,33 +29185,33 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2465 := z.EncBinary()
-		_ = yym2465
+		yym2469 := z.EncBinary()
+		_ = yym2469
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2466 := !z.EncBinary()
-			yy2arr2466 := z.EncBasicHandle().StructToArray
-			var yyq2466 [1]bool
-			_, _, _ = yysep2466, yyq2466, yy2arr2466
-			const yyr2466 bool = false
-			if yyr2466 || yy2arr2466 {
+			yysep2470 := !z.EncBinary()
+			yy2arr2470 := z.EncBasicHandle().StructToArray
+			var yyq2470 [1]bool
+			_, _, _ = yysep2470, yyq2470, yy2arr2470
+			const yyr2470 bool = false
+			if yyr2470 || yy2arr2470 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2466 int = 1
-				for _, b := range yyq2466 {
+				var yynn2470 int = 1
+				for _, b := range yyq2470 {
 					if b {
-						yynn2466++
+						yynn2470++
 					}
 				}
-				r.EncodeMapStart(yynn2466)
+				r.EncodeMapStart(yynn2470)
 			}
-			if yyr2466 || yy2arr2466 {
+			if yyr2470 || yy2arr2470 {
 				if x.Finalizers == nil {
 					r.EncodeNil()
 				} else {
-					yym2468 := z.EncBinary()
-					_ = yym2468
+					yym2472 := z.EncBinary()
+					_ = yym2472
 					if false {
 					} else {
 						h.encSliceFinalizerName(([]FinalizerName)(x.Finalizers), e)
@@ -29192,15 +29222,15 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Finalizers == nil {
 					r.EncodeNil()
 				} else {
-					yym2469 := z.EncBinary()
-					_ = yym2469
+					yym2473 := z.EncBinary()
+					_ = yym2473
 					if false {
 					} else {
 						h.encSliceFinalizerName(([]FinalizerName)(x.Finalizers), e)
 					}
 				}
 			}
-			if yysep2466 {
+			if yysep2470 {
 				r.EncodeEnd()
 			}
 		}
@@ -29211,24 +29241,24 @@ func (x *NamespaceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2470 := z.DecBinary()
-	_ = yym2470
+	yym2474 := z.DecBinary()
+	_ = yym2474
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2471 := r.ReadMapStart()
-			if yyl2471 == 0 {
+			yyl2475 := r.ReadMapStart()
+			if yyl2475 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2471, d)
+				x.codecDecodeSelfFromMap(yyl2475, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2471 := r.ReadArrayStart()
-			if yyl2471 == 0 {
+			yyl2475 := r.ReadArrayStart()
+			if yyl2475 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2471, d)
+				x.codecDecodeSelfFromArray(yyl2475, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29240,12 +29270,12 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2472Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2472Slc
-	var yyhl2472 bool = l >= 0
-	for yyj2472 := 0; ; yyj2472++ {
-		if yyhl2472 {
-			if yyj2472 >= l {
+	var yys2476Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2476Slc
+	var yyhl2476 bool = l >= 0
+	for yyj2476 := 0; ; yyj2476++ {
+		if yyhl2476 {
+			if yyj2476 >= l {
 				break
 			}
 		} else {
@@ -29253,26 +29283,26 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2472Slc = r.DecodeBytes(yys2472Slc, true, true)
-		yys2472 := string(yys2472Slc)
-		switch yys2472 {
+		yys2476Slc = r.DecodeBytes(yys2476Slc, true, true)
+		yys2476 := string(yys2476Slc)
+		switch yys2476 {
 		case "Finalizers":
 			if r.TryDecodeAsNil() {
 				x.Finalizers = nil
 			} else {
-				yyv2473 := &x.Finalizers
-				yym2474 := z.DecBinary()
-				_ = yym2474
+				yyv2477 := &x.Finalizers
+				yym2478 := z.DecBinary()
+				_ = yym2478
 				if false {
 				} else {
-					h.decSliceFinalizerName((*[]FinalizerName)(yyv2473), d)
+					h.decSliceFinalizerName((*[]FinalizerName)(yyv2477), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2472)
-		} // end switch yys2472
-	} // end for yyj2472
-	if !yyhl2472 {
+			z.DecStructFieldNotFound(-1, yys2476)
+		} // end switch yys2476
+	} // end for yyj2476
+	if !yyhl2476 {
 		r.ReadEnd()
 	}
 }
@@ -29281,41 +29311,41 @@ func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2475 int
-	var yyb2475 bool
-	var yyhl2475 bool = l >= 0
-	yyj2475++
-	if yyhl2475 {
-		yyb2475 = yyj2475 > l
+	var yyj2479 int
+	var yyb2479 bool
+	var yyhl2479 bool = l >= 0
+	yyj2479++
+	if yyhl2479 {
+		yyb2479 = yyj2479 > l
 	} else {
-		yyb2475 = r.CheckBreak()
+		yyb2479 = r.CheckBreak()
 	}
-	if yyb2475 {
+	if yyb2479 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Finalizers = nil
 	} else {
-		yyv2476 := &x.Finalizers
-		yym2477 := z.DecBinary()
-		_ = yym2477
+		yyv2480 := &x.Finalizers
+		yym2481 := z.DecBinary()
+		_ = yym2481
 		if false {
 		} else {
-			h.decSliceFinalizerName((*[]FinalizerName)(yyv2476), d)
+			h.decSliceFinalizerName((*[]FinalizerName)(yyv2480), d)
 		}
 	}
 	for {
-		yyj2475++
-		if yyhl2475 {
-			yyb2475 = yyj2475 > l
+		yyj2479++
+		if yyhl2479 {
+			yyb2479 = yyj2479 > l
 		} else {
-			yyb2475 = r.CheckBreak()
+			yyb2479 = r.CheckBreak()
 		}
-		if yyb2475 {
+		if yyb2479 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2475-1, "")
+		z.DecStructFieldNotFound(yyj2479-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29324,8 +29354,8 @@ func (x FinalizerName) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2478 := z.EncBinary()
-	_ = yym2478
+	yym2482 := z.EncBinary()
+	_ = yym2482
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -29337,8 +29367,8 @@ func (x *FinalizerName) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2479 := z.DecBinary()
-	_ = yym2479
+	yym2483 := z.DecBinary()
+	_ = yym2483
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -29353,41 +29383,41 @@ func (x *NamespaceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2480 := z.EncBinary()
-		_ = yym2480
+		yym2484 := z.EncBinary()
+		_ = yym2484
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2481 := !z.EncBinary()
-			yy2arr2481 := z.EncBasicHandle().StructToArray
-			var yyq2481 [1]bool
-			_, _, _ = yysep2481, yyq2481, yy2arr2481
-			const yyr2481 bool = false
-			yyq2481[0] = x.Phase != ""
-			if yyr2481 || yy2arr2481 {
+			yysep2485 := !z.EncBinary()
+			yy2arr2485 := z.EncBasicHandle().StructToArray
+			var yyq2485 [1]bool
+			_, _, _ = yysep2485, yyq2485, yy2arr2485
+			const yyr2485 bool = false
+			yyq2485[0] = x.Phase != ""
+			if yyr2485 || yy2arr2485 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2481 int = 0
-				for _, b := range yyq2481 {
+				var yynn2485 int = 0
+				for _, b := range yyq2485 {
 					if b {
-						yynn2481++
+						yynn2485++
 					}
 				}
-				r.EncodeMapStart(yynn2481)
+				r.EncodeMapStart(yynn2485)
 			}
-			if yyr2481 || yy2arr2481 {
-				if yyq2481[0] {
+			if yyr2485 || yy2arr2485 {
+				if yyq2485[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2481[0] {
+				if yyq2485[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2481 {
+			if yysep2485 {
 				r.EncodeEnd()
 			}
 		}
@@ -29398,24 +29428,24 @@ func (x *NamespaceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2483 := z.DecBinary()
-	_ = yym2483
+	yym2487 := z.DecBinary()
+	_ = yym2487
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2484 := r.ReadMapStart()
-			if yyl2484 == 0 {
+			yyl2488 := r.ReadMapStart()
+			if yyl2488 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2484, d)
+				x.codecDecodeSelfFromMap(yyl2488, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2484 := r.ReadArrayStart()
-			if yyl2484 == 0 {
+			yyl2488 := r.ReadArrayStart()
+			if yyl2488 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2484, d)
+				x.codecDecodeSelfFromArray(yyl2488, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29427,12 +29457,12 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2485Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2485Slc
-	var yyhl2485 bool = l >= 0
-	for yyj2485 := 0; ; yyj2485++ {
-		if yyhl2485 {
-			if yyj2485 >= l {
+	var yys2489Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2489Slc
+	var yyhl2489 bool = l >= 0
+	for yyj2489 := 0; ; yyj2489++ {
+		if yyhl2489 {
+			if yyj2489 >= l {
 				break
 			}
 		} else {
@@ -29440,9 +29470,9 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2485Slc = r.DecodeBytes(yys2485Slc, true, true)
-		yys2485 := string(yys2485Slc)
-		switch yys2485 {
+		yys2489Slc = r.DecodeBytes(yys2489Slc, true, true)
+		yys2489 := string(yys2489Slc)
+		switch yys2489 {
 		case "phase":
 			if r.TryDecodeAsNil() {
 				x.Phase = ""
@@ -29450,10 +29480,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Phase = NamespacePhase(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2485)
-		} // end switch yys2485
-	} // end for yyj2485
-	if !yyhl2485 {
+			z.DecStructFieldNotFound(-1, yys2489)
+		} // end switch yys2489
+	} // end for yyj2489
+	if !yyhl2489 {
 		r.ReadEnd()
 	}
 }
@@ -29462,16 +29492,16 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2487 int
-	var yyb2487 bool
-	var yyhl2487 bool = l >= 0
-	yyj2487++
-	if yyhl2487 {
-		yyb2487 = yyj2487 > l
+	var yyj2491 int
+	var yyb2491 bool
+	var yyhl2491 bool = l >= 0
+	yyj2491++
+	if yyhl2491 {
+		yyb2491 = yyj2491 > l
 	} else {
-		yyb2487 = r.CheckBreak()
+		yyb2491 = r.CheckBreak()
 	}
-	if yyb2487 {
+	if yyb2491 {
 		r.ReadEnd()
 		return
 	}
@@ -29481,16 +29511,16 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Phase = NamespacePhase(r.DecodeString())
 	}
 	for {
-		yyj2487++
-		if yyhl2487 {
-			yyb2487 = yyj2487 > l
+		yyj2491++
+		if yyhl2491 {
+			yyb2491 = yyj2491 > l
 		} else {
-			yyb2487 = r.CheckBreak()
+			yyb2491 = r.CheckBreak()
 		}
-		if yyb2487 {
+		if yyb2491 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2487-1, "")
+		z.DecStructFieldNotFound(yyj2491-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29499,8 +29529,8 @@ func (x NamespacePhase) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2489 := z.EncBinary()
-	_ = yym2489
+	yym2493 := z.EncBinary()
+	_ = yym2493
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -29512,8 +29542,8 @@ func (x *NamespacePhase) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2490 := z.DecBinary()
-	_ = yym2490
+	yym2494 := z.DecBinary()
+	_ = yym2494
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -29528,119 +29558,119 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2491 := z.EncBinary()
-		_ = yym2491
+		yym2495 := z.EncBinary()
+		_ = yym2495
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2492 := !z.EncBinary()
-			yy2arr2492 := z.EncBasicHandle().StructToArray
-			var yyq2492 [5]bool
-			_, _, _ = yysep2492, yyq2492, yy2arr2492
-			const yyr2492 bool = false
-			yyq2492[0] = x.Kind != ""
-			yyq2492[1] = x.APIVersion != ""
-			yyq2492[2] = true
-			yyq2492[3] = true
-			yyq2492[4] = true
-			if yyr2492 || yy2arr2492 {
+			yysep2496 := !z.EncBinary()
+			yy2arr2496 := z.EncBasicHandle().StructToArray
+			var yyq2496 [5]bool
+			_, _, _ = yysep2496, yyq2496, yy2arr2496
+			const yyr2496 bool = false
+			yyq2496[0] = x.Kind != ""
+			yyq2496[1] = x.APIVersion != ""
+			yyq2496[2] = true
+			yyq2496[3] = true
+			yyq2496[4] = true
+			if yyr2496 || yy2arr2496 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2492 int = 0
-				for _, b := range yyq2492 {
+				var yynn2496 int = 0
+				for _, b := range yyq2496 {
 					if b {
-						yynn2492++
+						yynn2496++
 					}
 				}
-				r.EncodeMapStart(yynn2492)
+				r.EncodeMapStart(yynn2496)
 			}
-			if yyr2492 || yy2arr2492 {
-				if yyq2492[0] {
-					yym2494 := z.EncBinary()
-					_ = yym2494
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2492[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2495 := z.EncBinary()
-					_ = yym2495
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2492 || yy2arr2492 {
-				if yyq2492[1] {
-					yym2497 := z.EncBinary()
-					_ = yym2497
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2492[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2496 || yy2arr2496 {
+				if yyq2496[0] {
 					yym2498 := z.EncBinary()
 					_ = yym2498
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2496[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2499 := z.EncBinary()
+					_ = yym2499
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2496 || yy2arr2496 {
+				if yyq2496[1] {
+					yym2501 := z.EncBinary()
+					_ = yym2501
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2496[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2502 := z.EncBinary()
+					_ = yym2502
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2492 || yy2arr2492 {
-				if yyq2492[2] {
-					yy2500 := &x.ObjectMeta
-					yy2500.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2492[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2501 := &x.ObjectMeta
-					yy2501.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2492 || yy2arr2492 {
-				if yyq2492[3] {
-					yy2503 := &x.Spec
-					yy2503.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2492[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy2504 := &x.Spec
+			if yyr2496 || yy2arr2496 {
+				if yyq2496[2] {
+					yy2504 := &x.ObjectMeta
 					yy2504.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2492 || yy2arr2492 {
-				if yyq2492[4] {
-					yy2506 := &x.Status
-					yy2506.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2492[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy2507 := &x.Status
-					yy2507.CodecEncodeSelf(e)
+				if yyq2496[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2505 := &x.ObjectMeta
+					yy2505.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2492 {
+			if yyr2496 || yy2arr2496 {
+				if yyq2496[3] {
+					yy2507 := &x.Spec
+					yy2507.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2496[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy2508 := &x.Spec
+					yy2508.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2496 || yy2arr2496 {
+				if yyq2496[4] {
+					yy2510 := &x.Status
+					yy2510.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2496[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy2511 := &x.Status
+					yy2511.CodecEncodeSelf(e)
+				}
+			}
+			if yysep2496 {
 				r.EncodeEnd()
 			}
 		}
@@ -29651,24 +29681,24 @@ func (x *Namespace) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2508 := z.DecBinary()
-	_ = yym2508
+	yym2512 := z.DecBinary()
+	_ = yym2512
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2509 := r.ReadMapStart()
-			if yyl2509 == 0 {
+			yyl2513 := r.ReadMapStart()
+			if yyl2513 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2509, d)
+				x.codecDecodeSelfFromMap(yyl2513, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2509 := r.ReadArrayStart()
-			if yyl2509 == 0 {
+			yyl2513 := r.ReadArrayStart()
+			if yyl2513 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2509, d)
+				x.codecDecodeSelfFromArray(yyl2513, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29680,12 +29710,12 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2510Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2510Slc
-	var yyhl2510 bool = l >= 0
-	for yyj2510 := 0; ; yyj2510++ {
-		if yyhl2510 {
-			if yyj2510 >= l {
+	var yys2514Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2514Slc
+	var yyhl2514 bool = l >= 0
+	for yyj2514 := 0; ; yyj2514++ {
+		if yyhl2514 {
+			if yyj2514 >= l {
 				break
 			}
 		} else {
@@ -29693,9 +29723,9 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2510Slc = r.DecodeBytes(yys2510Slc, true, true)
-		yys2510 := string(yys2510Slc)
-		switch yys2510 {
+		yys2514Slc = r.DecodeBytes(yys2514Slc, true, true)
+		yys2514 := string(yys2514Slc)
+		switch yys2514 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29712,28 +29742,28 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2513 := &x.ObjectMeta
-				yyv2513.CodecDecodeSelf(d)
+				yyv2517 := &x.ObjectMeta
+				yyv2517.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = NamespaceSpec{}
 			} else {
-				yyv2514 := &x.Spec
-				yyv2514.CodecDecodeSelf(d)
+				yyv2518 := &x.Spec
+				yyv2518.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = NamespaceStatus{}
 			} else {
-				yyv2515 := &x.Status
-				yyv2515.CodecDecodeSelf(d)
+				yyv2519 := &x.Status
+				yyv2519.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2510)
-		} // end switch yys2510
-	} // end for yyj2510
-	if !yyhl2510 {
+			z.DecStructFieldNotFound(-1, yys2514)
+		} // end switch yys2514
+	} // end for yyj2514
+	if !yyhl2514 {
 		r.ReadEnd()
 	}
 }
@@ -29742,16 +29772,16 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2516 int
-	var yyb2516 bool
-	var yyhl2516 bool = l >= 0
-	yyj2516++
-	if yyhl2516 {
-		yyb2516 = yyj2516 > l
+	var yyj2520 int
+	var yyb2520 bool
+	var yyhl2520 bool = l >= 0
+	yyj2520++
+	if yyhl2520 {
+		yyb2520 = yyj2520 > l
 	} else {
-		yyb2516 = r.CheckBreak()
+		yyb2520 = r.CheckBreak()
 	}
-	if yyb2516 {
+	if yyb2520 {
 		r.ReadEnd()
 		return
 	}
@@ -29760,13 +29790,13 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2516++
-	if yyhl2516 {
-		yyb2516 = yyj2516 > l
+	yyj2520++
+	if yyhl2520 {
+		yyb2520 = yyj2520 > l
 	} else {
-		yyb2516 = r.CheckBreak()
+		yyb2520 = r.CheckBreak()
 	}
-	if yyb2516 {
+	if yyb2520 {
 		r.ReadEnd()
 		return
 	}
@@ -29775,65 +29805,65 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2516++
-	if yyhl2516 {
-		yyb2516 = yyj2516 > l
+	yyj2520++
+	if yyhl2520 {
+		yyb2520 = yyj2520 > l
 	} else {
-		yyb2516 = r.CheckBreak()
+		yyb2520 = r.CheckBreak()
 	}
-	if yyb2516 {
+	if yyb2520 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2519 := &x.ObjectMeta
-		yyv2519.CodecDecodeSelf(d)
+		yyv2523 := &x.ObjectMeta
+		yyv2523.CodecDecodeSelf(d)
 	}
-	yyj2516++
-	if yyhl2516 {
-		yyb2516 = yyj2516 > l
+	yyj2520++
+	if yyhl2520 {
+		yyb2520 = yyj2520 > l
 	} else {
-		yyb2516 = r.CheckBreak()
+		yyb2520 = r.CheckBreak()
 	}
-	if yyb2516 {
+	if yyb2520 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = NamespaceSpec{}
 	} else {
-		yyv2520 := &x.Spec
-		yyv2520.CodecDecodeSelf(d)
+		yyv2524 := &x.Spec
+		yyv2524.CodecDecodeSelf(d)
 	}
-	yyj2516++
-	if yyhl2516 {
-		yyb2516 = yyj2516 > l
+	yyj2520++
+	if yyhl2520 {
+		yyb2520 = yyj2520 > l
 	} else {
-		yyb2516 = r.CheckBreak()
+		yyb2520 = r.CheckBreak()
 	}
-	if yyb2516 {
+	if yyb2520 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = NamespaceStatus{}
 	} else {
-		yyv2521 := &x.Status
-		yyv2521.CodecDecodeSelf(d)
+		yyv2525 := &x.Status
+		yyv2525.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2516++
-		if yyhl2516 {
-			yyb2516 = yyj2516 > l
+		yyj2520++
+		if yyhl2520 {
+			yyb2520 = yyj2520 > l
 		} else {
-			yyb2516 = r.CheckBreak()
+			yyb2520 = r.CheckBreak()
 		}
-		if yyb2516 {
+		if yyb2520 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2516-1, "")
+		z.DecStructFieldNotFound(yyj2520-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29845,106 +29875,106 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2522 := z.EncBinary()
-		_ = yym2522
+		yym2526 := z.EncBinary()
+		_ = yym2526
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2523 := !z.EncBinary()
-			yy2arr2523 := z.EncBasicHandle().StructToArray
-			var yyq2523 [4]bool
-			_, _, _ = yysep2523, yyq2523, yy2arr2523
-			const yyr2523 bool = false
-			yyq2523[0] = x.Kind != ""
-			yyq2523[1] = x.APIVersion != ""
-			yyq2523[2] = true
-			if yyr2523 || yy2arr2523 {
+			yysep2527 := !z.EncBinary()
+			yy2arr2527 := z.EncBasicHandle().StructToArray
+			var yyq2527 [4]bool
+			_, _, _ = yysep2527, yyq2527, yy2arr2527
+			const yyr2527 bool = false
+			yyq2527[0] = x.Kind != ""
+			yyq2527[1] = x.APIVersion != ""
+			yyq2527[2] = true
+			if yyr2527 || yy2arr2527 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2523 int = 1
-				for _, b := range yyq2523 {
+				var yynn2527 int = 1
+				for _, b := range yyq2527 {
 					if b {
-						yynn2523++
+						yynn2527++
 					}
 				}
-				r.EncodeMapStart(yynn2523)
+				r.EncodeMapStart(yynn2527)
 			}
-			if yyr2523 || yy2arr2523 {
-				if yyq2523[0] {
-					yym2525 := z.EncBinary()
-					_ = yym2525
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2523[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2526 := z.EncBinary()
-					_ = yym2526
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2523 || yy2arr2523 {
-				if yyq2523[1] {
-					yym2528 := z.EncBinary()
-					_ = yym2528
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2523[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2527 || yy2arr2527 {
+				if yyq2527[0] {
 					yym2529 := z.EncBinary()
 					_ = yym2529
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2527[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2530 := z.EncBinary()
+					_ = yym2530
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2527 || yy2arr2527 {
+				if yyq2527[1] {
+					yym2532 := z.EncBinary()
+					_ = yym2532
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2527[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2533 := z.EncBinary()
+					_ = yym2533
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2523 || yy2arr2523 {
-				if yyq2523[2] {
-					yy2531 := &x.ListMeta
-					yym2532 := z.EncBinary()
-					_ = yym2532
+			if yyr2527 || yy2arr2527 {
+				if yyq2527[2] {
+					yy2535 := &x.ListMeta
+					yym2536 := z.EncBinary()
+					_ = yym2536
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2531) {
+					} else if z.HasExtensions() && z.EncExt(yy2535) {
 					} else {
-						z.EncFallback(yy2531)
+						z.EncFallback(yy2535)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2523[2] {
+				if yyq2527[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2533 := &x.ListMeta
-					yym2534 := z.EncBinary()
-					_ = yym2534
+					yy2537 := &x.ListMeta
+					yym2538 := z.EncBinary()
+					_ = yym2538
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2533) {
+					} else if z.HasExtensions() && z.EncExt(yy2537) {
 					} else {
-						z.EncFallback(yy2533)
+						z.EncFallback(yy2537)
 					}
 				}
 			}
-			if yyr2523 || yy2arr2523 {
+			if yyr2527 || yy2arr2527 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2536 := z.EncBinary()
-					_ = yym2536
+					yym2540 := z.EncBinary()
+					_ = yym2540
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
@@ -29955,15 +29985,15 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2537 := z.EncBinary()
-					_ = yym2537
+					yym2541 := z.EncBinary()
+					_ = yym2541
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
 					}
 				}
 			}
-			if yysep2523 {
+			if yysep2527 {
 				r.EncodeEnd()
 			}
 		}
@@ -29974,24 +30004,24 @@ func (x *NamespaceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2538 := z.DecBinary()
-	_ = yym2538
+	yym2542 := z.DecBinary()
+	_ = yym2542
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2539 := r.ReadMapStart()
-			if yyl2539 == 0 {
+			yyl2543 := r.ReadMapStart()
+			if yyl2543 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2539, d)
+				x.codecDecodeSelfFromMap(yyl2543, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2539 := r.ReadArrayStart()
-			if yyl2539 == 0 {
+			yyl2543 := r.ReadArrayStart()
+			if yyl2543 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2539, d)
+				x.codecDecodeSelfFromArray(yyl2543, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30003,12 +30033,12 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2540Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2540Slc
-	var yyhl2540 bool = l >= 0
-	for yyj2540 := 0; ; yyj2540++ {
-		if yyhl2540 {
-			if yyj2540 >= l {
+	var yys2544Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2544Slc
+	var yyhl2544 bool = l >= 0
+	for yyj2544 := 0; ; yyj2544++ {
+		if yyhl2544 {
+			if yyj2544 >= l {
 				break
 			}
 		} else {
@@ -30016,9 +30046,9 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2540Slc = r.DecodeBytes(yys2540Slc, true, true)
-		yys2540 := string(yys2540Slc)
-		switch yys2540 {
+		yys2544Slc = r.DecodeBytes(yys2544Slc, true, true)
+		yys2544 := string(yys2544Slc)
+		switch yys2544 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30035,32 +30065,32 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2543 := &x.ListMeta
-				yym2544 := z.DecBinary()
-				_ = yym2544
+				yyv2547 := &x.ListMeta
+				yym2548 := z.DecBinary()
+				_ = yym2548
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2543) {
+				} else if z.HasExtensions() && z.DecExt(yyv2547) {
 				} else {
-					z.DecFallback(yyv2543, false)
+					z.DecFallback(yyv2547, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2545 := &x.Items
-				yym2546 := z.DecBinary()
-				_ = yym2546
+				yyv2549 := &x.Items
+				yym2550 := z.DecBinary()
+				_ = yym2550
 				if false {
 				} else {
-					h.decSliceNamespace((*[]Namespace)(yyv2545), d)
+					h.decSliceNamespace((*[]Namespace)(yyv2549), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2540)
-		} // end switch yys2540
-	} // end for yyj2540
-	if !yyhl2540 {
+			z.DecStructFieldNotFound(-1, yys2544)
+		} // end switch yys2544
+	} // end for yyj2544
+	if !yyhl2544 {
 		r.ReadEnd()
 	}
 }
@@ -30069,16 +30099,16 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2547 int
-	var yyb2547 bool
-	var yyhl2547 bool = l >= 0
-	yyj2547++
-	if yyhl2547 {
-		yyb2547 = yyj2547 > l
+	var yyj2551 int
+	var yyb2551 bool
+	var yyhl2551 bool = l >= 0
+	yyj2551++
+	if yyhl2551 {
+		yyb2551 = yyj2551 > l
 	} else {
-		yyb2547 = r.CheckBreak()
+		yyb2551 = r.CheckBreak()
 	}
-	if yyb2547 {
+	if yyb2551 {
 		r.ReadEnd()
 		return
 	}
@@ -30087,13 +30117,13 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2547++
-	if yyhl2547 {
-		yyb2547 = yyj2547 > l
+	yyj2551++
+	if yyhl2551 {
+		yyb2551 = yyj2551 > l
 	} else {
-		yyb2547 = r.CheckBreak()
+		yyb2551 = r.CheckBreak()
 	}
-	if yyb2547 {
+	if yyb2551 {
 		r.ReadEnd()
 		return
 	}
@@ -30102,60 +30132,60 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2547++
-	if yyhl2547 {
-		yyb2547 = yyj2547 > l
+	yyj2551++
+	if yyhl2551 {
+		yyb2551 = yyj2551 > l
 	} else {
-		yyb2547 = r.CheckBreak()
+		yyb2551 = r.CheckBreak()
 	}
-	if yyb2547 {
+	if yyb2551 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2550 := &x.ListMeta
-		yym2551 := z.DecBinary()
-		_ = yym2551
+		yyv2554 := &x.ListMeta
+		yym2555 := z.DecBinary()
+		_ = yym2555
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2550) {
+		} else if z.HasExtensions() && z.DecExt(yyv2554) {
 		} else {
-			z.DecFallback(yyv2550, false)
+			z.DecFallback(yyv2554, false)
 		}
 	}
-	yyj2547++
-	if yyhl2547 {
-		yyb2547 = yyj2547 > l
+	yyj2551++
+	if yyhl2551 {
+		yyb2551 = yyj2551 > l
 	} else {
-		yyb2547 = r.CheckBreak()
+		yyb2551 = r.CheckBreak()
 	}
-	if yyb2547 {
+	if yyb2551 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2552 := &x.Items
-		yym2553 := z.DecBinary()
-		_ = yym2553
+		yyv2556 := &x.Items
+		yym2557 := z.DecBinary()
+		_ = yym2557
 		if false {
 		} else {
-			h.decSliceNamespace((*[]Namespace)(yyv2552), d)
+			h.decSliceNamespace((*[]Namespace)(yyv2556), d)
 		}
 	}
 	for {
-		yyj2547++
-		if yyhl2547 {
-			yyb2547 = yyj2547 > l
+		yyj2551++
+		if yyhl2551 {
+			yyb2551 = yyj2551 > l
 		} else {
-			yyb2547 = r.CheckBreak()
+			yyb2551 = r.CheckBreak()
 		}
-		if yyb2547 {
+		if yyb2551 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2547-1, "")
+		z.DecStructFieldNotFound(yyj2551-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30167,97 +30197,97 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2554 := z.EncBinary()
-		_ = yym2554
+		yym2558 := z.EncBinary()
+		_ = yym2558
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2555 := !z.EncBinary()
-			yy2arr2555 := z.EncBasicHandle().StructToArray
-			var yyq2555 [4]bool
-			_, _, _ = yysep2555, yyq2555, yy2arr2555
-			const yyr2555 bool = false
-			yyq2555[0] = x.Kind != ""
-			yyq2555[1] = x.APIVersion != ""
-			yyq2555[2] = true
-			if yyr2555 || yy2arr2555 {
+			yysep2559 := !z.EncBinary()
+			yy2arr2559 := z.EncBasicHandle().StructToArray
+			var yyq2559 [4]bool
+			_, _, _ = yysep2559, yyq2559, yy2arr2559
+			const yyr2559 bool = false
+			yyq2559[0] = x.Kind != ""
+			yyq2559[1] = x.APIVersion != ""
+			yyq2559[2] = true
+			if yyr2559 || yy2arr2559 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2555 int = 1
-				for _, b := range yyq2555 {
+				var yynn2559 int = 1
+				for _, b := range yyq2559 {
 					if b {
-						yynn2555++
+						yynn2559++
 					}
 				}
-				r.EncodeMapStart(yynn2555)
+				r.EncodeMapStart(yynn2559)
 			}
-			if yyr2555 || yy2arr2555 {
-				if yyq2555[0] {
-					yym2557 := z.EncBinary()
-					_ = yym2557
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2555[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2558 := z.EncBinary()
-					_ = yym2558
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2555 || yy2arr2555 {
-				if yyq2555[1] {
-					yym2560 := z.EncBinary()
-					_ = yym2560
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2555[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2559 || yy2arr2559 {
+				if yyq2559[0] {
 					yym2561 := z.EncBinary()
 					_ = yym2561
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2559[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2562 := z.EncBinary()
+					_ = yym2562
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2559 || yy2arr2559 {
+				if yyq2559[1] {
+					yym2564 := z.EncBinary()
+					_ = yym2564
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2559[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2565 := z.EncBinary()
+					_ = yym2565
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2555 || yy2arr2555 {
-				if yyq2555[2] {
-					yy2563 := &x.ObjectMeta
-					yy2563.CodecEncodeSelf(e)
+			if yyr2559 || yy2arr2559 {
+				if yyq2559[2] {
+					yy2567 := &x.ObjectMeta
+					yy2567.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2555[2] {
+				if yyq2559[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2564 := &x.ObjectMeta
-					yy2564.CodecEncodeSelf(e)
+					yy2568 := &x.ObjectMeta
+					yy2568.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2555 || yy2arr2555 {
-				yy2566 := &x.Target
-				yy2566.CodecEncodeSelf(e)
+			if yyr2559 || yy2arr2559 {
+				yy2570 := &x.Target
+				yy2570.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
-				yy2567 := &x.Target
-				yy2567.CodecEncodeSelf(e)
+				yy2571 := &x.Target
+				yy2571.CodecEncodeSelf(e)
 			}
-			if yysep2555 {
+			if yysep2559 {
 				r.EncodeEnd()
 			}
 		}
@@ -30268,24 +30298,24 @@ func (x *Binding) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2568 := z.DecBinary()
-	_ = yym2568
+	yym2572 := z.DecBinary()
+	_ = yym2572
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2569 := r.ReadMapStart()
-			if yyl2569 == 0 {
+			yyl2573 := r.ReadMapStart()
+			if yyl2573 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2569, d)
+				x.codecDecodeSelfFromMap(yyl2573, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2569 := r.ReadArrayStart()
-			if yyl2569 == 0 {
+			yyl2573 := r.ReadArrayStart()
+			if yyl2573 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2569, d)
+				x.codecDecodeSelfFromArray(yyl2573, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30297,12 +30327,12 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2570Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2570Slc
-	var yyhl2570 bool = l >= 0
-	for yyj2570 := 0; ; yyj2570++ {
-		if yyhl2570 {
-			if yyj2570 >= l {
+	var yys2574Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2574Slc
+	var yyhl2574 bool = l >= 0
+	for yyj2574 := 0; ; yyj2574++ {
+		if yyhl2574 {
+			if yyj2574 >= l {
 				break
 			}
 		} else {
@@ -30310,9 +30340,9 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2570Slc = r.DecodeBytes(yys2570Slc, true, true)
-		yys2570 := string(yys2570Slc)
-		switch yys2570 {
+		yys2574Slc = r.DecodeBytes(yys2574Slc, true, true)
+		yys2574 := string(yys2574Slc)
+		switch yys2574 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30329,21 +30359,21 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2573 := &x.ObjectMeta
-				yyv2573.CodecDecodeSelf(d)
+				yyv2577 := &x.ObjectMeta
+				yyv2577.CodecDecodeSelf(d)
 			}
 		case "target":
 			if r.TryDecodeAsNil() {
 				x.Target = ObjectReference{}
 			} else {
-				yyv2574 := &x.Target
-				yyv2574.CodecDecodeSelf(d)
+				yyv2578 := &x.Target
+				yyv2578.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2570)
-		} // end switch yys2570
-	} // end for yyj2570
-	if !yyhl2570 {
+			z.DecStructFieldNotFound(-1, yys2574)
+		} // end switch yys2574
+	} // end for yyj2574
+	if !yyhl2574 {
 		r.ReadEnd()
 	}
 }
@@ -30352,16 +30382,16 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2575 int
-	var yyb2575 bool
-	var yyhl2575 bool = l >= 0
-	yyj2575++
-	if yyhl2575 {
-		yyb2575 = yyj2575 > l
+	var yyj2579 int
+	var yyb2579 bool
+	var yyhl2579 bool = l >= 0
+	yyj2579++
+	if yyhl2579 {
+		yyb2579 = yyj2579 > l
 	} else {
-		yyb2575 = r.CheckBreak()
+		yyb2579 = r.CheckBreak()
 	}
-	if yyb2575 {
+	if yyb2579 {
 		r.ReadEnd()
 		return
 	}
@@ -30370,13 +30400,13 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2575++
-	if yyhl2575 {
-		yyb2575 = yyj2575 > l
+	yyj2579++
+	if yyhl2579 {
+		yyb2579 = yyj2579 > l
 	} else {
-		yyb2575 = r.CheckBreak()
+		yyb2579 = r.CheckBreak()
 	}
-	if yyb2575 {
+	if yyb2579 {
 		r.ReadEnd()
 		return
 	}
@@ -30385,49 +30415,49 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2575++
-	if yyhl2575 {
-		yyb2575 = yyj2575 > l
+	yyj2579++
+	if yyhl2579 {
+		yyb2579 = yyj2579 > l
 	} else {
-		yyb2575 = r.CheckBreak()
+		yyb2579 = r.CheckBreak()
 	}
-	if yyb2575 {
+	if yyb2579 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2578 := &x.ObjectMeta
-		yyv2578.CodecDecodeSelf(d)
+		yyv2582 := &x.ObjectMeta
+		yyv2582.CodecDecodeSelf(d)
 	}
-	yyj2575++
-	if yyhl2575 {
-		yyb2575 = yyj2575 > l
+	yyj2579++
+	if yyhl2579 {
+		yyb2579 = yyj2579 > l
 	} else {
-		yyb2575 = r.CheckBreak()
+		yyb2579 = r.CheckBreak()
 	}
-	if yyb2575 {
+	if yyb2579 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Target = ObjectReference{}
 	} else {
-		yyv2579 := &x.Target
-		yyv2579.CodecDecodeSelf(d)
+		yyv2583 := &x.Target
+		yyv2583.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2575++
-		if yyhl2575 {
-			yyb2575 = yyj2575 > l
+		yyj2579++
+		if yyhl2579 {
+			yyb2579 = yyj2579 > l
 		} else {
-			yyb2575 = r.CheckBreak()
+			yyb2579 = r.CheckBreak()
 		}
-		if yyb2575 {
+		if yyb2579 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2575-1, "")
+		z.DecStructFieldNotFound(yyj2579-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30439,83 +30469,83 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2580 := z.EncBinary()
-		_ = yym2580
+		yym2584 := z.EncBinary()
+		_ = yym2584
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2581 := !z.EncBinary()
-			yy2arr2581 := z.EncBasicHandle().StructToArray
-			var yyq2581 [3]bool
-			_, _, _ = yysep2581, yyq2581, yy2arr2581
-			const yyr2581 bool = false
-			yyq2581[0] = x.Kind != ""
-			yyq2581[1] = x.APIVersion != ""
-			if yyr2581 || yy2arr2581 {
+			yysep2585 := !z.EncBinary()
+			yy2arr2585 := z.EncBasicHandle().StructToArray
+			var yyq2585 [3]bool
+			_, _, _ = yysep2585, yyq2585, yy2arr2585
+			const yyr2585 bool = false
+			yyq2585[0] = x.Kind != ""
+			yyq2585[1] = x.APIVersion != ""
+			if yyr2585 || yy2arr2585 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2581 int = 1
-				for _, b := range yyq2581 {
+				var yynn2585 int = 1
+				for _, b := range yyq2585 {
 					if b {
-						yynn2581++
+						yynn2585++
 					}
 				}
-				r.EncodeMapStart(yynn2581)
+				r.EncodeMapStart(yynn2585)
 			}
-			if yyr2581 || yy2arr2581 {
-				if yyq2581[0] {
-					yym2583 := z.EncBinary()
-					_ = yym2583
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2581[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2584 := z.EncBinary()
-					_ = yym2584
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2581 || yy2arr2581 {
-				if yyq2581[1] {
-					yym2586 := z.EncBinary()
-					_ = yym2586
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2581[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2585 || yy2arr2585 {
+				if yyq2585[0] {
 					yym2587 := z.EncBinary()
 					_ = yym2587
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2585[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2588 := z.EncBinary()
+					_ = yym2588
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2581 || yy2arr2581 {
-				if x.GracePeriodSeconds == nil {
-					r.EncodeNil()
-				} else {
-					yy2589 := *x.GracePeriodSeconds
+			if yyr2585 || yy2arr2585 {
+				if yyq2585[1] {
 					yym2590 := z.EncBinary()
 					_ = yym2590
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2589))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2585[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2591 := z.EncBinary()
+					_ = yym2591
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2585 || yy2arr2585 {
+				if x.GracePeriodSeconds == nil {
+					r.EncodeNil()
+				} else {
+					yy2593 := *x.GracePeriodSeconds
+					yym2594 := z.EncBinary()
+					_ = yym2594
+					if false {
+					} else {
+						r.EncodeInt(int64(yy2593))
 					}
 				}
 			} else {
@@ -30523,16 +30553,16 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2591 := *x.GracePeriodSeconds
-					yym2592 := z.EncBinary()
-					_ = yym2592
+					yy2595 := *x.GracePeriodSeconds
+					yym2596 := z.EncBinary()
+					_ = yym2596
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2591))
+						r.EncodeInt(int64(yy2595))
 					}
 				}
 			}
-			if yysep2581 {
+			if yysep2585 {
 				r.EncodeEnd()
 			}
 		}
@@ -30543,24 +30573,24 @@ func (x *DeleteOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2593 := z.DecBinary()
-	_ = yym2593
+	yym2597 := z.DecBinary()
+	_ = yym2597
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2594 := r.ReadMapStart()
-			if yyl2594 == 0 {
+			yyl2598 := r.ReadMapStart()
+			if yyl2598 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2594, d)
+				x.codecDecodeSelfFromMap(yyl2598, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2594 := r.ReadArrayStart()
-			if yyl2594 == 0 {
+			yyl2598 := r.ReadArrayStart()
+			if yyl2598 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2594, d)
+				x.codecDecodeSelfFromArray(yyl2598, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30572,12 +30602,12 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2595Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2595Slc
-	var yyhl2595 bool = l >= 0
-	for yyj2595 := 0; ; yyj2595++ {
-		if yyhl2595 {
-			if yyj2595 >= l {
+	var yys2599Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2599Slc
+	var yyhl2599 bool = l >= 0
+	for yyj2599 := 0; ; yyj2599++ {
+		if yyhl2599 {
+			if yyj2599 >= l {
 				break
 			}
 		} else {
@@ -30585,9 +30615,9 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2595Slc = r.DecodeBytes(yys2595Slc, true, true)
-		yys2595 := string(yys2595Slc)
-		switch yys2595 {
+		yys2599Slc = r.DecodeBytes(yys2599Slc, true, true)
+		yys2599 := string(yys2599Slc)
+		switch yys2599 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30609,18 +30639,18 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.GracePeriodSeconds == nil {
 					x.GracePeriodSeconds = new(int64)
 				}
-				yym2599 := z.DecBinary()
-				_ = yym2599
+				yym2603 := z.DecBinary()
+				_ = yym2603
 				if false {
 				} else {
 					*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2595)
-		} // end switch yys2595
-	} // end for yyj2595
-	if !yyhl2595 {
+			z.DecStructFieldNotFound(-1, yys2599)
+		} // end switch yys2599
+	} // end for yyj2599
+	if !yyhl2599 {
 		r.ReadEnd()
 	}
 }
@@ -30629,16 +30659,16 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2600 int
-	var yyb2600 bool
-	var yyhl2600 bool = l >= 0
-	yyj2600++
-	if yyhl2600 {
-		yyb2600 = yyj2600 > l
+	var yyj2604 int
+	var yyb2604 bool
+	var yyhl2604 bool = l >= 0
+	yyj2604++
+	if yyhl2604 {
+		yyb2604 = yyj2604 > l
 	} else {
-		yyb2600 = r.CheckBreak()
+		yyb2604 = r.CheckBreak()
 	}
-	if yyb2600 {
+	if yyb2604 {
 		r.ReadEnd()
 		return
 	}
@@ -30647,13 +30677,13 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2600++
-	if yyhl2600 {
-		yyb2600 = yyj2600 > l
+	yyj2604++
+	if yyhl2604 {
+		yyb2604 = yyj2604 > l
 	} else {
-		yyb2600 = r.CheckBreak()
+		yyb2604 = r.CheckBreak()
 	}
-	if yyb2600 {
+	if yyb2604 {
 		r.ReadEnd()
 		return
 	}
@@ -30662,13 +30692,13 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2600++
-	if yyhl2600 {
-		yyb2600 = yyj2600 > l
+	yyj2604++
+	if yyhl2604 {
+		yyb2604 = yyj2604 > l
 	} else {
-		yyb2600 = r.CheckBreak()
+		yyb2604 = r.CheckBreak()
 	}
-	if yyb2600 {
+	if yyb2604 {
 		r.ReadEnd()
 		return
 	}
@@ -30680,24 +30710,24 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.GracePeriodSeconds == nil {
 			x.GracePeriodSeconds = new(int64)
 		}
-		yym2604 := z.DecBinary()
-		_ = yym2604
+		yym2608 := z.DecBinary()
+		_ = yym2608
 		if false {
 		} else {
 			*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2600++
-		if yyhl2600 {
-			yyb2600 = yyj2600 > l
+		yyj2604++
+		if yyhl2604 {
+			yyb2604 = yyj2604 > l
 		} else {
-			yyb2600 = r.CheckBreak()
+			yyb2604 = r.CheckBreak()
 		}
-		if yyb2600 {
+		if yyb2604 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2600-1, "")
+		z.DecStructFieldNotFound(yyj2604-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30709,79 +30739,79 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2605 := z.EncBinary()
-		_ = yym2605
+		yym2609 := z.EncBinary()
+		_ = yym2609
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2606 := !z.EncBinary()
-			yy2arr2606 := z.EncBasicHandle().StructToArray
-			var yyq2606 [7]bool
-			_, _, _ = yysep2606, yyq2606, yy2arr2606
-			const yyr2606 bool = false
-			yyq2606[0] = x.Kind != ""
-			yyq2606[1] = x.APIVersion != ""
-			if yyr2606 || yy2arr2606 {
+			yysep2610 := !z.EncBinary()
+			yy2arr2610 := z.EncBasicHandle().StructToArray
+			var yyq2610 [7]bool
+			_, _, _ = yysep2610, yyq2610, yy2arr2610
+			const yyr2610 bool = false
+			yyq2610[0] = x.Kind != ""
+			yyq2610[1] = x.APIVersion != ""
+			if yyr2610 || yy2arr2610 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2606 int = 5
-				for _, b := range yyq2606 {
+				var yynn2610 int = 5
+				for _, b := range yyq2610 {
 					if b {
-						yynn2606++
+						yynn2610++
 					}
 				}
-				r.EncodeMapStart(yynn2606)
+				r.EncodeMapStart(yynn2610)
 			}
-			if yyr2606 || yy2arr2606 {
-				if yyq2606[0] {
-					yym2608 := z.EncBinary()
-					_ = yym2608
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2606[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2609 := z.EncBinary()
-					_ = yym2609
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2606 || yy2arr2606 {
-				if yyq2606[1] {
-					yym2611 := z.EncBinary()
-					_ = yym2611
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2606[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2610 || yy2arr2610 {
+				if yyq2610[0] {
 					yym2612 := z.EncBinary()
 					_ = yym2612
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2610[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2613 := z.EncBinary()
+					_ = yym2613
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2610 || yy2arr2610 {
+				if yyq2610[1] {
+					yym2615 := z.EncBinary()
+					_ = yym2615
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2610[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2616 := z.EncBinary()
+					_ = yym2616
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2606 || yy2arr2606 {
+			if yyr2610 || yy2arr2610 {
 				if x.LabelSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2614 := z.EncBinary()
-					_ = yym2614
+					yym2618 := z.EncBinary()
+					_ = yym2618
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.LabelSelector) {
 					} else {
@@ -30793,8 +30823,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.LabelSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2615 := z.EncBinary()
-					_ = yym2615
+					yym2619 := z.EncBinary()
+					_ = yym2619
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.LabelSelector) {
 					} else {
@@ -30802,12 +30832,12 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2606 || yy2arr2606 {
+			if yyr2610 || yy2arr2610 {
 				if x.FieldSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2617 := z.EncBinary()
-					_ = yym2617
+					yym2621 := z.EncBinary()
+					_ = yym2621
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.FieldSelector) {
 					} else {
@@ -30819,8 +30849,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.FieldSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2618 := z.EncBinary()
-					_ = yym2618
+					yym2622 := z.EncBinary()
+					_ = yym2622
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.FieldSelector) {
 					} else {
@@ -30828,48 +30858,48 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2606 || yy2arr2606 {
-				yym2620 := z.EncBinary()
-				_ = yym2620
+			if yyr2610 || yy2arr2610 {
+				yym2624 := z.EncBinary()
+				_ = yym2624
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Watch))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Watch"))
-				yym2621 := z.EncBinary()
-				_ = yym2621
+				yym2625 := z.EncBinary()
+				_ = yym2625
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Watch))
 				}
 			}
-			if yyr2606 || yy2arr2606 {
-				yym2623 := z.EncBinary()
-				_ = yym2623
+			if yyr2610 || yy2arr2610 {
+				yym2627 := z.EncBinary()
+				_ = yym2627
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("ResourceVersion"))
-				yym2624 := z.EncBinary()
-				_ = yym2624
+				yym2628 := z.EncBinary()
+				_ = yym2628
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 				}
 			}
-			if yyr2606 || yy2arr2606 {
+			if yyr2610 || yy2arr2610 {
 				if x.TimeoutSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2626 := *x.TimeoutSeconds
-					yym2627 := z.EncBinary()
-					_ = yym2627
+					yy2630 := *x.TimeoutSeconds
+					yym2631 := z.EncBinary()
+					_ = yym2631
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2626))
+						r.EncodeInt(int64(yy2630))
 					}
 				}
 			} else {
@@ -30877,16 +30907,16 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TimeoutSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2628 := *x.TimeoutSeconds
-					yym2629 := z.EncBinary()
-					_ = yym2629
+					yy2632 := *x.TimeoutSeconds
+					yym2633 := z.EncBinary()
+					_ = yym2633
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2628))
+						r.EncodeInt(int64(yy2632))
 					}
 				}
 			}
-			if yysep2606 {
+			if yysep2610 {
 				r.EncodeEnd()
 			}
 		}
@@ -30897,24 +30927,24 @@ func (x *ListOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2630 := z.DecBinary()
-	_ = yym2630
+	yym2634 := z.DecBinary()
+	_ = yym2634
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2631 := r.ReadMapStart()
-			if yyl2631 == 0 {
+			yyl2635 := r.ReadMapStart()
+			if yyl2635 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2631, d)
+				x.codecDecodeSelfFromMap(yyl2635, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2631 := r.ReadArrayStart()
-			if yyl2631 == 0 {
+			yyl2635 := r.ReadArrayStart()
+			if yyl2635 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2631, d)
+				x.codecDecodeSelfFromArray(yyl2635, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30926,12 +30956,12 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2632Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2632Slc
-	var yyhl2632 bool = l >= 0
-	for yyj2632 := 0; ; yyj2632++ {
-		if yyhl2632 {
-			if yyj2632 >= l {
+	var yys2636Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2636Slc
+	var yyhl2636 bool = l >= 0
+	for yyj2636 := 0; ; yyj2636++ {
+		if yyhl2636 {
+			if yyj2636 >= l {
 				break
 			}
 		} else {
@@ -30939,9 +30969,9 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2632Slc = r.DecodeBytes(yys2632Slc, true, true)
-		yys2632 := string(yys2632Slc)
-		switch yys2632 {
+		yys2636Slc = r.DecodeBytes(yys2636Slc, true, true)
+		yys2636 := string(yys2636Slc)
+		switch yys2636 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30958,26 +30988,26 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LabelSelector = nil
 			} else {
-				yyv2635 := &x.LabelSelector
-				yym2636 := z.DecBinary()
-				_ = yym2636
+				yyv2639 := &x.LabelSelector
+				yym2640 := z.DecBinary()
+				_ = yym2640
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2635) {
+				} else if z.HasExtensions() && z.DecExt(yyv2639) {
 				} else {
-					z.DecFallback(yyv2635, true)
+					z.DecFallback(yyv2639, true)
 				}
 			}
 		case "FieldSelector":
 			if r.TryDecodeAsNil() {
 				x.FieldSelector = nil
 			} else {
-				yyv2637 := &x.FieldSelector
-				yym2638 := z.DecBinary()
-				_ = yym2638
+				yyv2641 := &x.FieldSelector
+				yym2642 := z.DecBinary()
+				_ = yym2642
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2637) {
+				} else if z.HasExtensions() && z.DecExt(yyv2641) {
 				} else {
-					z.DecFallback(yyv2637, true)
+					z.DecFallback(yyv2641, true)
 				}
 			}
 		case "Watch":
@@ -31001,18 +31031,18 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TimeoutSeconds == nil {
 					x.TimeoutSeconds = new(int64)
 				}
-				yym2642 := z.DecBinary()
-				_ = yym2642
+				yym2646 := z.DecBinary()
+				_ = yym2646
 				if false {
 				} else {
 					*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2632)
-		} // end switch yys2632
-	} // end for yyj2632
-	if !yyhl2632 {
+			z.DecStructFieldNotFound(-1, yys2636)
+		} // end switch yys2636
+	} // end for yyj2636
+	if !yyhl2636 {
 		r.ReadEnd()
 	}
 }
@@ -31021,16 +31051,16 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2643 int
-	var yyb2643 bool
-	var yyhl2643 bool = l >= 0
-	yyj2643++
-	if yyhl2643 {
-		yyb2643 = yyj2643 > l
+	var yyj2647 int
+	var yyb2647 bool
+	var yyhl2647 bool = l >= 0
+	yyj2647++
+	if yyhl2647 {
+		yyb2647 = yyj2647 > l
 	} else {
-		yyb2643 = r.CheckBreak()
+		yyb2647 = r.CheckBreak()
 	}
-	if yyb2643 {
+	if yyb2647 {
 		r.ReadEnd()
 		return
 	}
@@ -31039,13 +31069,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2643++
-	if yyhl2643 {
-		yyb2643 = yyj2643 > l
+	yyj2647++
+	if yyhl2647 {
+		yyb2647 = yyj2647 > l
 	} else {
-		yyb2643 = r.CheckBreak()
+		yyb2647 = r.CheckBreak()
 	}
-	if yyb2643 {
+	if yyb2647 {
 		r.ReadEnd()
 		return
 	}
@@ -31054,57 +31084,57 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2643++
-	if yyhl2643 {
-		yyb2643 = yyj2643 > l
+	yyj2647++
+	if yyhl2647 {
+		yyb2647 = yyj2647 > l
 	} else {
-		yyb2643 = r.CheckBreak()
+		yyb2647 = r.CheckBreak()
 	}
-	if yyb2643 {
+	if yyb2647 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LabelSelector = nil
 	} else {
-		yyv2646 := &x.LabelSelector
-		yym2647 := z.DecBinary()
-		_ = yym2647
+		yyv2650 := &x.LabelSelector
+		yym2651 := z.DecBinary()
+		_ = yym2651
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2646) {
+		} else if z.HasExtensions() && z.DecExt(yyv2650) {
 		} else {
-			z.DecFallback(yyv2646, true)
+			z.DecFallback(yyv2650, true)
 		}
 	}
-	yyj2643++
-	if yyhl2643 {
-		yyb2643 = yyj2643 > l
+	yyj2647++
+	if yyhl2647 {
+		yyb2647 = yyj2647 > l
 	} else {
-		yyb2643 = r.CheckBreak()
+		yyb2647 = r.CheckBreak()
 	}
-	if yyb2643 {
+	if yyb2647 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.FieldSelector = nil
 	} else {
-		yyv2648 := &x.FieldSelector
-		yym2649 := z.DecBinary()
-		_ = yym2649
+		yyv2652 := &x.FieldSelector
+		yym2653 := z.DecBinary()
+		_ = yym2653
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2648) {
+		} else if z.HasExtensions() && z.DecExt(yyv2652) {
 		} else {
-			z.DecFallback(yyv2648, true)
+			z.DecFallback(yyv2652, true)
 		}
 	}
-	yyj2643++
-	if yyhl2643 {
-		yyb2643 = yyj2643 > l
+	yyj2647++
+	if yyhl2647 {
+		yyb2647 = yyj2647 > l
 	} else {
-		yyb2643 = r.CheckBreak()
+		yyb2647 = r.CheckBreak()
 	}
-	if yyb2643 {
+	if yyb2647 {
 		r.ReadEnd()
 		return
 	}
@@ -31113,13 +31143,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Watch = bool(r.DecodeBool())
 	}
-	yyj2643++
-	if yyhl2643 {
-		yyb2643 = yyj2643 > l
+	yyj2647++
+	if yyhl2647 {
+		yyb2647 = yyj2647 > l
 	} else {
-		yyb2643 = r.CheckBreak()
+		yyb2647 = r.CheckBreak()
 	}
-	if yyb2643 {
+	if yyb2647 {
 		r.ReadEnd()
 		return
 	}
@@ -31128,13 +31158,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj2643++
-	if yyhl2643 {
-		yyb2643 = yyj2643 > l
+	yyj2647++
+	if yyhl2647 {
+		yyb2647 = yyj2647 > l
 	} else {
-		yyb2643 = r.CheckBreak()
+		yyb2647 = r.CheckBreak()
 	}
-	if yyb2643 {
+	if yyb2647 {
 		r.ReadEnd()
 		return
 	}
@@ -31146,24 +31176,24 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TimeoutSeconds == nil {
 			x.TimeoutSeconds = new(int64)
 		}
-		yym2653 := z.DecBinary()
-		_ = yym2653
+		yym2657 := z.DecBinary()
+		_ = yym2657
 		if false {
 		} else {
 			*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2643++
-		if yyhl2643 {
-			yyb2643 = yyj2643 > l
+		yyj2647++
+		if yyhl2647 {
+			yyb2647 = yyj2647 > l
 		} else {
-			yyb2643 = r.CheckBreak()
+			yyb2647 = r.CheckBreak()
 		}
-		if yyb2643 {
+		if yyb2647 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2643-1, "")
+		z.DecStructFieldNotFound(yyj2647-1, "")
 	}
 	r.ReadEnd()
 }
@@ -31175,131 +31205,131 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2654 := z.EncBinary()
-		_ = yym2654
+		yym2658 := z.EncBinary()
+		_ = yym2658
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2655 := !z.EncBinary()
-			yy2arr2655 := z.EncBasicHandle().StructToArray
-			var yyq2655 [10]bool
-			_, _, _ = yysep2655, yyq2655, yy2arr2655
-			const yyr2655 bool = false
-			yyq2655[0] = x.Kind != ""
-			yyq2655[1] = x.APIVersion != ""
-			if yyr2655 || yy2arr2655 {
+			yysep2659 := !z.EncBinary()
+			yy2arr2659 := z.EncBasicHandle().StructToArray
+			var yyq2659 [10]bool
+			_, _, _ = yysep2659, yyq2659, yy2arr2659
+			const yyr2659 bool = false
+			yyq2659[0] = x.Kind != ""
+			yyq2659[1] = x.APIVersion != ""
+			if yyr2659 || yy2arr2659 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2655 int = 8
-				for _, b := range yyq2655 {
+				var yynn2659 int = 8
+				for _, b := range yyq2659 {
 					if b {
-						yynn2655++
+						yynn2659++
 					}
 				}
-				r.EncodeMapStart(yynn2655)
+				r.EncodeMapStart(yynn2659)
 			}
-			if yyr2655 || yy2arr2655 {
-				if yyq2655[0] {
-					yym2657 := z.EncBinary()
-					_ = yym2657
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2655[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2658 := z.EncBinary()
-					_ = yym2658
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2655 || yy2arr2655 {
-				if yyq2655[1] {
-					yym2660 := z.EncBinary()
-					_ = yym2660
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2655[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2659 || yy2arr2659 {
+				if yyq2659[0] {
 					yym2661 := z.EncBinary()
 					_ = yym2661
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2659[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2662 := z.EncBinary()
+					_ = yym2662
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2659 || yy2arr2659 {
+				if yyq2659[1] {
+					yym2664 := z.EncBinary()
+					_ = yym2664
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2659[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2665 := z.EncBinary()
+					_ = yym2665
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2655 || yy2arr2655 {
-				yym2663 := z.EncBinary()
-				_ = yym2663
+			if yyr2659 || yy2arr2659 {
+				yym2667 := z.EncBinary()
+				_ = yym2667
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Container"))
-				yym2664 := z.EncBinary()
-				_ = yym2664
+				yym2668 := z.EncBinary()
+				_ = yym2668
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			}
-			if yyr2655 || yy2arr2655 {
-				yym2666 := z.EncBinary()
-				_ = yym2666
+			if yyr2659 || yy2arr2659 {
+				yym2670 := z.EncBinary()
+				_ = yym2670
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Follow))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Follow"))
-				yym2667 := z.EncBinary()
-				_ = yym2667
+				yym2671 := z.EncBinary()
+				_ = yym2671
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Follow))
 				}
 			}
-			if yyr2655 || yy2arr2655 {
-				yym2669 := z.EncBinary()
-				_ = yym2669
+			if yyr2659 || yy2arr2659 {
+				yym2673 := z.EncBinary()
+				_ = yym2673
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Previous))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Previous"))
-				yym2670 := z.EncBinary()
-				_ = yym2670
+				yym2674 := z.EncBinary()
+				_ = yym2674
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Previous))
 				}
 			}
-			if yyr2655 || yy2arr2655 {
+			if yyr2659 || yy2arr2659 {
 				if x.SinceSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2672 := *x.SinceSeconds
-					yym2673 := z.EncBinary()
-					_ = yym2673
+					yy2676 := *x.SinceSeconds
+					yym2677 := z.EncBinary()
+					_ = yym2677
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2672))
+						r.EncodeInt(int64(yy2676))
 					}
 				}
 			} else {
@@ -31307,26 +31337,26 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SinceSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2674 := *x.SinceSeconds
-					yym2675 := z.EncBinary()
-					_ = yym2675
+					yy2678 := *x.SinceSeconds
+					yym2679 := z.EncBinary()
+					_ = yym2679
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2674))
+						r.EncodeInt(int64(yy2678))
 					}
 				}
 			}
-			if yyr2655 || yy2arr2655 {
+			if yyr2659 || yy2arr2659 {
 				if x.SinceTime == nil {
 					r.EncodeNil()
 				} else {
-					yym2677 := z.EncBinary()
-					_ = yym2677
+					yym2681 := z.EncBinary()
+					_ = yym2681
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-					} else if yym2677 {
+					} else if yym2681 {
 						z.EncBinaryMarshal(x.SinceTime)
-					} else if !yym2677 && z.IsJSONHandle() {
+					} else if !yym2681 && z.IsJSONHandle() {
 						z.EncJSONMarshal(x.SinceTime)
 					} else {
 						z.EncFallback(x.SinceTime)
@@ -31337,45 +31367,45 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SinceTime == nil {
 					r.EncodeNil()
 				} else {
-					yym2678 := z.EncBinary()
-					_ = yym2678
+					yym2682 := z.EncBinary()
+					_ = yym2682
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-					} else if yym2678 {
+					} else if yym2682 {
 						z.EncBinaryMarshal(x.SinceTime)
-					} else if !yym2678 && z.IsJSONHandle() {
+					} else if !yym2682 && z.IsJSONHandle() {
 						z.EncJSONMarshal(x.SinceTime)
 					} else {
 						z.EncFallback(x.SinceTime)
 					}
 				}
 			}
-			if yyr2655 || yy2arr2655 {
-				yym2680 := z.EncBinary()
-				_ = yym2680
+			if yyr2659 || yy2arr2659 {
+				yym2684 := z.EncBinary()
+				_ = yym2684
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Timestamps))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Timestamps"))
-				yym2681 := z.EncBinary()
-				_ = yym2681
+				yym2685 := z.EncBinary()
+				_ = yym2685
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Timestamps))
 				}
 			}
-			if yyr2655 || yy2arr2655 {
+			if yyr2659 || yy2arr2659 {
 				if x.TailLines == nil {
 					r.EncodeNil()
 				} else {
-					yy2683 := *x.TailLines
-					yym2684 := z.EncBinary()
-					_ = yym2684
+					yy2687 := *x.TailLines
+					yym2688 := z.EncBinary()
+					_ = yym2688
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2683))
+						r.EncodeInt(int64(yy2687))
 					}
 				}
 			} else {
@@ -31383,25 +31413,25 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TailLines == nil {
 					r.EncodeNil()
 				} else {
-					yy2685 := *x.TailLines
-					yym2686 := z.EncBinary()
-					_ = yym2686
+					yy2689 := *x.TailLines
+					yym2690 := z.EncBinary()
+					_ = yym2690
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2685))
+						r.EncodeInt(int64(yy2689))
 					}
 				}
 			}
-			if yyr2655 || yy2arr2655 {
+			if yyr2659 || yy2arr2659 {
 				if x.LimitBytes == nil {
 					r.EncodeNil()
 				} else {
-					yy2688 := *x.LimitBytes
-					yym2689 := z.EncBinary()
-					_ = yym2689
+					yy2692 := *x.LimitBytes
+					yym2693 := z.EncBinary()
+					_ = yym2693
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2688))
+						r.EncodeInt(int64(yy2692))
 					}
 				}
 			} else {
@@ -31409,16 +31439,16 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.LimitBytes == nil {
 					r.EncodeNil()
 				} else {
-					yy2690 := *x.LimitBytes
-					yym2691 := z.EncBinary()
-					_ = yym2691
+					yy2694 := *x.LimitBytes
+					yym2695 := z.EncBinary()
+					_ = yym2695
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2690))
+						r.EncodeInt(int64(yy2694))
 					}
 				}
 			}
-			if yysep2655 {
+			if yysep2659 {
 				r.EncodeEnd()
 			}
 		}
@@ -31429,24 +31459,24 @@ func (x *PodLogOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2692 := z.DecBinary()
-	_ = yym2692
+	yym2696 := z.DecBinary()
+	_ = yym2696
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2693 := r.ReadMapStart()
-			if yyl2693 == 0 {
+			yyl2697 := r.ReadMapStart()
+			if yyl2697 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2693, d)
+				x.codecDecodeSelfFromMap(yyl2697, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2693 := r.ReadArrayStart()
-			if yyl2693 == 0 {
+			yyl2697 := r.ReadArrayStart()
+			if yyl2697 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2693, d)
+				x.codecDecodeSelfFromArray(yyl2697, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -31458,12 +31488,12 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2694Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2694Slc
-	var yyhl2694 bool = l >= 0
-	for yyj2694 := 0; ; yyj2694++ {
-		if yyhl2694 {
-			if yyj2694 >= l {
+	var yys2698Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2698Slc
+	var yyhl2698 bool = l >= 0
+	for yyj2698 := 0; ; yyj2698++ {
+		if yyhl2698 {
+			if yyj2698 >= l {
 				break
 			}
 		} else {
@@ -31471,9 +31501,9 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2694Slc = r.DecodeBytes(yys2694Slc, true, true)
-		yys2694 := string(yys2694Slc)
-		switch yys2694 {
+		yys2698Slc = r.DecodeBytes(yys2698Slc, true, true)
+		yys2698 := string(yys2698Slc)
+		switch yys2698 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -31513,8 +31543,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceSeconds == nil {
 					x.SinceSeconds = new(int64)
 				}
-				yym2701 := z.DecBinary()
-				_ = yym2701
+				yym2705 := z.DecBinary()
+				_ = yym2705
 				if false {
 				} else {
 					*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
@@ -31529,13 +31559,13 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg2_unversioned.Time)
 				}
-				yym2703 := z.DecBinary()
-				_ = yym2703
+				yym2707 := z.DecBinary()
+				_ = yym2707
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym2703 {
+				} else if yym2707 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym2703 && z.IsJSONHandle() {
+				} else if !yym2707 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -31556,8 +31586,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TailLines == nil {
 					x.TailLines = new(int64)
 				}
-				yym2706 := z.DecBinary()
-				_ = yym2706
+				yym2710 := z.DecBinary()
+				_ = yym2710
 				if false {
 				} else {
 					*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
@@ -31572,18 +31602,18 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(int64)
 				}
-				yym2708 := z.DecBinary()
-				_ = yym2708
+				yym2712 := z.DecBinary()
+				_ = yym2712
 				if false {
 				} else {
 					*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2694)
-		} // end switch yys2694
-	} // end for yyj2694
-	if !yyhl2694 {
+			z.DecStructFieldNotFound(-1, yys2698)
+		} // end switch yys2698
+	} // end for yyj2698
+	if !yyhl2698 {
 		r.ReadEnd()
 	}
 }
@@ -31592,16 +31622,16 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2709 int
-	var yyb2709 bool
-	var yyhl2709 bool = l >= 0
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	var yyj2713 int
+	var yyb2713 bool
+	var yyhl2713 bool = l >= 0
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31610,13 +31640,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31625,13 +31655,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31640,13 +31670,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Container = string(r.DecodeString())
 	}
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31655,13 +31685,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Follow = bool(r.DecodeBool())
 	}
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31670,13 +31700,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Previous = bool(r.DecodeBool())
 	}
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31688,20 +31718,20 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceSeconds == nil {
 			x.SinceSeconds = new(int64)
 		}
-		yym2716 := z.DecBinary()
-		_ = yym2716
+		yym2720 := z.DecBinary()
+		_ = yym2720
 		if false {
 		} else {
 			*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31713,25 +31743,25 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg2_unversioned.Time)
 		}
-		yym2718 := z.DecBinary()
-		_ = yym2718
+		yym2722 := z.DecBinary()
+		_ = yym2722
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym2718 {
+		} else if yym2722 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym2718 && z.IsJSONHandle() {
+		} else if !yym2722 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31740,13 +31770,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Timestamps = bool(r.DecodeBool())
 	}
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31758,20 +31788,20 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TailLines == nil {
 			x.TailLines = new(int64)
 		}
-		yym2721 := z.DecBinary()
-		_ = yym2721
+		yym2725 := z.DecBinary()
+		_ = yym2725
 		if false {
 		} else {
 			*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj2709++
-	if yyhl2709 {
-		yyb2709 = yyj2709 > l
+	yyj2713++
+	if yyhl2713 {
+		yyb2713 = yyj2713 > l
 	} else {
-		yyb2709 = r.CheckBreak()
+		yyb2713 = r.CheckBreak()
 	}
-	if yyb2709 {
+	if yyb2713 {
 		r.ReadEnd()
 		return
 	}
@@ -31783,24 +31813,24 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(int64)
 		}
-		yym2723 := z.DecBinary()
-		_ = yym2723
+		yym2727 := z.DecBinary()
+		_ = yym2727
 		if false {
 		} else {
 			*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2709++
-		if yyhl2709 {
-			yyb2709 = yyj2709 > l
+		yyj2713++
+		if yyhl2713 {
+			yyb2713 = yyj2713 > l
 		} else {
-			yyb2709 = r.CheckBreak()
+			yyb2713 = r.CheckBreak()
 		}
-		if yyb2709 {
+		if yyb2713 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2709-1, "")
+		z.DecStructFieldNotFound(yyj2713-1, "")
 	}
 	r.ReadEnd()
 }
@@ -31812,148 +31842,148 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2724 := z.EncBinary()
-		_ = yym2724
+		yym2728 := z.EncBinary()
+		_ = yym2728
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2725 := !z.EncBinary()
-			yy2arr2725 := z.EncBasicHandle().StructToArray
-			var yyq2725 [7]bool
-			_, _, _ = yysep2725, yyq2725, yy2arr2725
-			const yyr2725 bool = false
-			yyq2725[0] = x.Kind != ""
-			yyq2725[1] = x.APIVersion != ""
-			yyq2725[2] = x.Stdin != false
-			yyq2725[3] = x.Stdout != false
-			yyq2725[4] = x.Stderr != false
-			yyq2725[5] = x.TTY != false
-			yyq2725[6] = x.Container != ""
-			if yyr2725 || yy2arr2725 {
+			yysep2729 := !z.EncBinary()
+			yy2arr2729 := z.EncBasicHandle().StructToArray
+			var yyq2729 [7]bool
+			_, _, _ = yysep2729, yyq2729, yy2arr2729
+			const yyr2729 bool = false
+			yyq2729[0] = x.Kind != ""
+			yyq2729[1] = x.APIVersion != ""
+			yyq2729[2] = x.Stdin != false
+			yyq2729[3] = x.Stdout != false
+			yyq2729[4] = x.Stderr != false
+			yyq2729[5] = x.TTY != false
+			yyq2729[6] = x.Container != ""
+			if yyr2729 || yy2arr2729 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2725 int = 0
-				for _, b := range yyq2725 {
+				var yynn2729 int = 0
+				for _, b := range yyq2729 {
 					if b {
-						yynn2725++
+						yynn2729++
 					}
 				}
-				r.EncodeMapStart(yynn2725)
+				r.EncodeMapStart(yynn2729)
 			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[0] {
-					yym2727 := z.EncBinary()
-					_ = yym2727
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2725[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2728 := z.EncBinary()
-					_ = yym2728
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[1] {
-					yym2730 := z.EncBinary()
-					_ = yym2730
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2725[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2729 || yy2arr2729 {
+				if yyq2729[0] {
 					yym2731 := z.EncBinary()
 					_ = yym2731
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2729[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2732 := z.EncBinary()
+					_ = yym2732
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[2] {
-					yym2733 := z.EncBinary()
-					_ = yym2733
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdin))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2725[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+			if yyr2729 || yy2arr2729 {
+				if yyq2729[1] {
 					yym2734 := z.EncBinary()
 					_ = yym2734
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2729[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2735 := z.EncBinary()
+					_ = yym2735
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[3] {
-					yym2736 := z.EncBinary()
-					_ = yym2736
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdout))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2725[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+			if yyr2729 || yy2arr2729 {
+				if yyq2729[2] {
 					yym2737 := z.EncBinary()
 					_ = yym2737
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
-					}
-				}
-			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[4] {
-					yym2739 := z.EncBinary()
-					_ = yym2739
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeBool(bool(x.Stdin))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2725[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+				if yyq2729[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+					yym2738 := z.EncBinary()
+					_ = yym2738
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdin))
+					}
+				}
+			}
+			if yyr2729 || yy2arr2729 {
+				if yyq2729[3] {
 					yym2740 := z.EncBinary()
 					_ = yym2740
 					if false {
 					} else {
+						r.EncodeBool(bool(x.Stdout))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2729[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+					yym2741 := z.EncBinary()
+					_ = yym2741
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdout))
+					}
+				}
+			}
+			if yyr2729 || yy2arr2729 {
+				if yyq2729[4] {
+					yym2743 := z.EncBinary()
+					_ = yym2743
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2729[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					yym2744 := z.EncBinary()
+					_ = yym2744
+					if false {
+					} else {
 						r.EncodeBool(bool(x.Stderr))
 					}
 				}
 			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[5] {
-					yym2742 := z.EncBinary()
-					_ = yym2742
+			if yyr2729 || yy2arr2729 {
+				if yyq2729[5] {
+					yym2746 := z.EncBinary()
+					_ = yym2746
 					if false {
 					} else {
 						r.EncodeBool(bool(x.TTY))
@@ -31962,20 +31992,20 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2725[5] {
+				if yyq2729[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
-					yym2743 := z.EncBinary()
-					_ = yym2743
+					yym2747 := z.EncBinary()
+					_ = yym2747
 					if false {
 					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				}
 			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[6] {
-					yym2745 := z.EncBinary()
-					_ = yym2745
+			if yyr2729 || yy2arr2729 {
+				if yyq2729[6] {
+					yym2749 := z.EncBinary()
+					_ = yym2749
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -31984,17 +32014,17 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2725[6] {
+				if yyq2729[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
-					yym2746 := z.EncBinary()
-					_ = yym2746
+					yym2750 := z.EncBinary()
+					_ = yym2750
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
-			if yysep2725 {
+			if yysep2729 {
 				r.EncodeEnd()
 			}
 		}
@@ -32005,24 +32035,24 @@ func (x *PodAttachOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2747 := z.DecBinary()
-	_ = yym2747
+	yym2751 := z.DecBinary()
+	_ = yym2751
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2748 := r.ReadMapStart()
-			if yyl2748 == 0 {
+			yyl2752 := r.ReadMapStart()
+			if yyl2752 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2748, d)
+				x.codecDecodeSelfFromMap(yyl2752, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2748 := r.ReadArrayStart()
-			if yyl2748 == 0 {
+			yyl2752 := r.ReadArrayStart()
+			if yyl2752 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2748, d)
+				x.codecDecodeSelfFromArray(yyl2752, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32034,12 +32064,12 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2749Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2749Slc
-	var yyhl2749 bool = l >= 0
-	for yyj2749 := 0; ; yyj2749++ {
-		if yyhl2749 {
-			if yyj2749 >= l {
+	var yys2753Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2753Slc
+	var yyhl2753 bool = l >= 0
+	for yyj2753 := 0; ; yyj2753++ {
+		if yyhl2753 {
+			if yyj2753 >= l {
 				break
 			}
 		} else {
@@ -32047,9 +32077,9 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2749Slc = r.DecodeBytes(yys2749Slc, true, true)
-		yys2749 := string(yys2749Slc)
-		switch yys2749 {
+		yys2753Slc = r.DecodeBytes(yys2753Slc, true, true)
+		yys2753 := string(yys2753Slc)
+		switch yys2753 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32093,10 +32123,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Container = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2749)
-		} // end switch yys2749
-	} // end for yyj2749
-	if !yyhl2749 {
+			z.DecStructFieldNotFound(-1, yys2753)
+		} // end switch yys2753
+	} // end for yyj2753
+	if !yyhl2753 {
 		r.ReadEnd()
 	}
 }
@@ -32105,16 +32135,16 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2757 int
-	var yyb2757 bool
-	var yyhl2757 bool = l >= 0
-	yyj2757++
-	if yyhl2757 {
-		yyb2757 = yyj2757 > l
+	var yyj2761 int
+	var yyb2761 bool
+	var yyhl2761 bool = l >= 0
+	yyj2761++
+	if yyhl2761 {
+		yyb2761 = yyj2761 > l
 	} else {
-		yyb2757 = r.CheckBreak()
+		yyb2761 = r.CheckBreak()
 	}
-	if yyb2757 {
+	if yyb2761 {
 		r.ReadEnd()
 		return
 	}
@@ -32123,13 +32153,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2757++
-	if yyhl2757 {
-		yyb2757 = yyj2757 > l
+	yyj2761++
+	if yyhl2761 {
+		yyb2761 = yyj2761 > l
 	} else {
-		yyb2757 = r.CheckBreak()
+		yyb2761 = r.CheckBreak()
 	}
-	if yyb2757 {
+	if yyb2761 {
 		r.ReadEnd()
 		return
 	}
@@ -32138,13 +32168,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2757++
-	if yyhl2757 {
-		yyb2757 = yyj2757 > l
+	yyj2761++
+	if yyhl2761 {
+		yyb2761 = yyj2761 > l
 	} else {
-		yyb2757 = r.CheckBreak()
+		yyb2761 = r.CheckBreak()
 	}
-	if yyb2757 {
+	if yyb2761 {
 		r.ReadEnd()
 		return
 	}
@@ -32153,13 +32183,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stdin = bool(r.DecodeBool())
 	}
-	yyj2757++
-	if yyhl2757 {
-		yyb2757 = yyj2757 > l
+	yyj2761++
+	if yyhl2761 {
+		yyb2761 = yyj2761 > l
 	} else {
-		yyb2757 = r.CheckBreak()
+		yyb2761 = r.CheckBreak()
 	}
-	if yyb2757 {
+	if yyb2761 {
 		r.ReadEnd()
 		return
 	}
@@ -32168,13 +32198,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stdout = bool(r.DecodeBool())
 	}
-	yyj2757++
-	if yyhl2757 {
-		yyb2757 = yyj2757 > l
+	yyj2761++
+	if yyhl2761 {
+		yyb2761 = yyj2761 > l
 	} else {
-		yyb2757 = r.CheckBreak()
+		yyb2761 = r.CheckBreak()
 	}
-	if yyb2757 {
+	if yyb2761 {
 		r.ReadEnd()
 		return
 	}
@@ -32183,13 +32213,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stderr = bool(r.DecodeBool())
 	}
-	yyj2757++
-	if yyhl2757 {
-		yyb2757 = yyj2757 > l
+	yyj2761++
+	if yyhl2761 {
+		yyb2761 = yyj2761 > l
 	} else {
-		yyb2757 = r.CheckBreak()
+		yyb2761 = r.CheckBreak()
 	}
-	if yyb2757 {
+	if yyb2761 {
 		r.ReadEnd()
 		return
 	}
@@ -32198,13 +32228,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.TTY = bool(r.DecodeBool())
 	}
-	yyj2757++
-	if yyhl2757 {
-		yyb2757 = yyj2757 > l
+	yyj2761++
+	if yyhl2761 {
+		yyb2761 = yyj2761 > l
 	} else {
-		yyb2757 = r.CheckBreak()
+		yyb2761 = r.CheckBreak()
 	}
-	if yyb2757 {
+	if yyb2761 {
 		r.ReadEnd()
 		return
 	}
@@ -32214,16 +32244,16 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.Container = string(r.DecodeString())
 	}
 	for {
-		yyj2757++
-		if yyhl2757 {
-			yyb2757 = yyj2757 > l
+		yyj2761++
+		if yyhl2761 {
+			yyb2761 = yyj2761 > l
 		} else {
-			yyb2757 = r.CheckBreak()
+			yyb2761 = r.CheckBreak()
 		}
-		if yyb2757 {
+		if yyb2761 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2757-1, "")
+		z.DecStructFieldNotFound(yyj2761-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32235,159 +32265,159 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2765 := z.EncBinary()
-		_ = yym2765
+		yym2769 := z.EncBinary()
+		_ = yym2769
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2766 := !z.EncBinary()
-			yy2arr2766 := z.EncBasicHandle().StructToArray
-			var yyq2766 [8]bool
-			_, _, _ = yysep2766, yyq2766, yy2arr2766
-			const yyr2766 bool = false
-			yyq2766[0] = x.Kind != ""
-			yyq2766[1] = x.APIVersion != ""
-			if yyr2766 || yy2arr2766 {
+			yysep2770 := !z.EncBinary()
+			yy2arr2770 := z.EncBasicHandle().StructToArray
+			var yyq2770 [8]bool
+			_, _, _ = yysep2770, yyq2770, yy2arr2770
+			const yyr2770 bool = false
+			yyq2770[0] = x.Kind != ""
+			yyq2770[1] = x.APIVersion != ""
+			if yyr2770 || yy2arr2770 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2766 int = 6
-				for _, b := range yyq2766 {
+				var yynn2770 int = 6
+				for _, b := range yyq2770 {
 					if b {
-						yynn2766++
+						yynn2770++
 					}
 				}
-				r.EncodeMapStart(yynn2766)
+				r.EncodeMapStart(yynn2770)
 			}
-			if yyr2766 || yy2arr2766 {
-				if yyq2766[0] {
-					yym2768 := z.EncBinary()
-					_ = yym2768
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2766[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2769 := z.EncBinary()
-					_ = yym2769
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2766 || yy2arr2766 {
-				if yyq2766[1] {
-					yym2771 := z.EncBinary()
-					_ = yym2771
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2766[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2770 || yy2arr2770 {
+				if yyq2770[0] {
 					yym2772 := z.EncBinary()
 					_ = yym2772
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2770[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2773 := z.EncBinary()
+					_ = yym2773
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2770 || yy2arr2770 {
+				if yyq2770[1] {
+					yym2775 := z.EncBinary()
+					_ = yym2775
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2770[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2776 := z.EncBinary()
+					_ = yym2776
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2766 || yy2arr2766 {
-				yym2774 := z.EncBinary()
-				_ = yym2774
+			if yyr2770 || yy2arr2770 {
+				yym2778 := z.EncBinary()
+				_ = yym2778
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdin))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Stdin"))
-				yym2775 := z.EncBinary()
-				_ = yym2775
+				yym2779 := z.EncBinary()
+				_ = yym2779
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdin))
 				}
 			}
-			if yyr2766 || yy2arr2766 {
-				yym2777 := z.EncBinary()
-				_ = yym2777
+			if yyr2770 || yy2arr2770 {
+				yym2781 := z.EncBinary()
+				_ = yym2781
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdout))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Stdout"))
-				yym2778 := z.EncBinary()
-				_ = yym2778
+				yym2782 := z.EncBinary()
+				_ = yym2782
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdout))
 				}
 			}
-			if yyr2766 || yy2arr2766 {
-				yym2780 := z.EncBinary()
-				_ = yym2780
+			if yyr2770 || yy2arr2770 {
+				yym2784 := z.EncBinary()
+				_ = yym2784
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stderr))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Stderr"))
-				yym2781 := z.EncBinary()
-				_ = yym2781
+				yym2785 := z.EncBinary()
+				_ = yym2785
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stderr))
 				}
 			}
-			if yyr2766 || yy2arr2766 {
-				yym2783 := z.EncBinary()
-				_ = yym2783
+			if yyr2770 || yy2arr2770 {
+				yym2787 := z.EncBinary()
+				_ = yym2787
 				if false {
 				} else {
 					r.EncodeBool(bool(x.TTY))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("TTY"))
-				yym2784 := z.EncBinary()
-				_ = yym2784
+				yym2788 := z.EncBinary()
+				_ = yym2788
 				if false {
 				} else {
 					r.EncodeBool(bool(x.TTY))
 				}
 			}
-			if yyr2766 || yy2arr2766 {
-				yym2786 := z.EncBinary()
-				_ = yym2786
+			if yyr2770 || yy2arr2770 {
+				yym2790 := z.EncBinary()
+				_ = yym2790
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Container"))
-				yym2787 := z.EncBinary()
-				_ = yym2787
+				yym2791 := z.EncBinary()
+				_ = yym2791
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			}
-			if yyr2766 || yy2arr2766 {
+			if yyr2770 || yy2arr2770 {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym2789 := z.EncBinary()
-					_ = yym2789
+					yym2793 := z.EncBinary()
+					_ = yym2793
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
@@ -32398,15 +32428,15 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym2790 := z.EncBinary()
-					_ = yym2790
+					yym2794 := z.EncBinary()
+					_ = yym2794
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
 					}
 				}
 			}
-			if yysep2766 {
+			if yysep2770 {
 				r.EncodeEnd()
 			}
 		}
@@ -32417,24 +32447,24 @@ func (x *PodExecOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2791 := z.DecBinary()
-	_ = yym2791
+	yym2795 := z.DecBinary()
+	_ = yym2795
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2792 := r.ReadMapStart()
-			if yyl2792 == 0 {
+			yyl2796 := r.ReadMapStart()
+			if yyl2796 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2792, d)
+				x.codecDecodeSelfFromMap(yyl2796, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2792 := r.ReadArrayStart()
-			if yyl2792 == 0 {
+			yyl2796 := r.ReadArrayStart()
+			if yyl2796 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2792, d)
+				x.codecDecodeSelfFromArray(yyl2796, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32446,12 +32476,12 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2793Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2793Slc
-	var yyhl2793 bool = l >= 0
-	for yyj2793 := 0; ; yyj2793++ {
-		if yyhl2793 {
-			if yyj2793 >= l {
+	var yys2797Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2797Slc
+	var yyhl2797 bool = l >= 0
+	for yyj2797 := 0; ; yyj2797++ {
+		if yyhl2797 {
+			if yyj2797 >= l {
 				break
 			}
 		} else {
@@ -32459,9 +32489,9 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2793Slc = r.DecodeBytes(yys2793Slc, true, true)
-		yys2793 := string(yys2793Slc)
-		switch yys2793 {
+		yys2797Slc = r.DecodeBytes(yys2797Slc, true, true)
+		yys2797 := string(yys2797Slc)
+		switch yys2797 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32508,19 +32538,19 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Command = nil
 			} else {
-				yyv2801 := &x.Command
-				yym2802 := z.DecBinary()
-				_ = yym2802
+				yyv2805 := &x.Command
+				yym2806 := z.DecBinary()
+				_ = yym2806
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv2801, false, d)
+					z.F.DecSliceStringX(yyv2805, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2793)
-		} // end switch yys2793
-	} // end for yyj2793
-	if !yyhl2793 {
+			z.DecStructFieldNotFound(-1, yys2797)
+		} // end switch yys2797
+	} // end for yyj2797
+	if !yyhl2797 {
 		r.ReadEnd()
 	}
 }
@@ -32529,16 +32559,16 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2803 int
-	var yyb2803 bool
-	var yyhl2803 bool = l >= 0
-	yyj2803++
-	if yyhl2803 {
-		yyb2803 = yyj2803 > l
+	var yyj2807 int
+	var yyb2807 bool
+	var yyhl2807 bool = l >= 0
+	yyj2807++
+	if yyhl2807 {
+		yyb2807 = yyj2807 > l
 	} else {
-		yyb2803 = r.CheckBreak()
+		yyb2807 = r.CheckBreak()
 	}
-	if yyb2803 {
+	if yyb2807 {
 		r.ReadEnd()
 		return
 	}
@@ -32547,13 +32577,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2803++
-	if yyhl2803 {
-		yyb2803 = yyj2803 > l
+	yyj2807++
+	if yyhl2807 {
+		yyb2807 = yyj2807 > l
 	} else {
-		yyb2803 = r.CheckBreak()
+		yyb2807 = r.CheckBreak()
 	}
-	if yyb2803 {
+	if yyb2807 {
 		r.ReadEnd()
 		return
 	}
@@ -32562,13 +32592,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2803++
-	if yyhl2803 {
-		yyb2803 = yyj2803 > l
+	yyj2807++
+	if yyhl2807 {
+		yyb2807 = yyj2807 > l
 	} else {
-		yyb2803 = r.CheckBreak()
+		yyb2807 = r.CheckBreak()
 	}
-	if yyb2803 {
+	if yyb2807 {
 		r.ReadEnd()
 		return
 	}
@@ -32577,13 +32607,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stdin = bool(r.DecodeBool())
 	}
-	yyj2803++
-	if yyhl2803 {
-		yyb2803 = yyj2803 > l
+	yyj2807++
+	if yyhl2807 {
+		yyb2807 = yyj2807 > l
 	} else {
-		yyb2803 = r.CheckBreak()
+		yyb2807 = r.CheckBreak()
 	}
-	if yyb2803 {
+	if yyb2807 {
 		r.ReadEnd()
 		return
 	}
@@ -32592,13 +32622,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stdout = bool(r.DecodeBool())
 	}
-	yyj2803++
-	if yyhl2803 {
-		yyb2803 = yyj2803 > l
+	yyj2807++
+	if yyhl2807 {
+		yyb2807 = yyj2807 > l
 	} else {
-		yyb2803 = r.CheckBreak()
+		yyb2807 = r.CheckBreak()
 	}
-	if yyb2803 {
+	if yyb2807 {
 		r.ReadEnd()
 		return
 	}
@@ -32607,13 +32637,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stderr = bool(r.DecodeBool())
 	}
-	yyj2803++
-	if yyhl2803 {
-		yyb2803 = yyj2803 > l
+	yyj2807++
+	if yyhl2807 {
+		yyb2807 = yyj2807 > l
 	} else {
-		yyb2803 = r.CheckBreak()
+		yyb2807 = r.CheckBreak()
 	}
-	if yyb2803 {
+	if yyb2807 {
 		r.ReadEnd()
 		return
 	}
@@ -32622,13 +32652,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.TTY = bool(r.DecodeBool())
 	}
-	yyj2803++
-	if yyhl2803 {
-		yyb2803 = yyj2803 > l
+	yyj2807++
+	if yyhl2807 {
+		yyb2807 = yyj2807 > l
 	} else {
-		yyb2803 = r.CheckBreak()
+		yyb2807 = r.CheckBreak()
 	}
-	if yyb2803 {
+	if yyb2807 {
 		r.ReadEnd()
 		return
 	}
@@ -32637,38 +32667,38 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Container = string(r.DecodeString())
 	}
-	yyj2803++
-	if yyhl2803 {
-		yyb2803 = yyj2803 > l
+	yyj2807++
+	if yyhl2807 {
+		yyb2807 = yyj2807 > l
 	} else {
-		yyb2803 = r.CheckBreak()
+		yyb2807 = r.CheckBreak()
 	}
-	if yyb2803 {
+	if yyb2807 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
-		yyv2811 := &x.Command
-		yym2812 := z.DecBinary()
-		_ = yym2812
+		yyv2815 := &x.Command
+		yym2816 := z.DecBinary()
+		_ = yym2816
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv2811, false, d)
+			z.F.DecSliceStringX(yyv2815, false, d)
 		}
 	}
 	for {
-		yyj2803++
-		if yyhl2803 {
-			yyb2803 = yyj2803 > l
+		yyj2807++
+		if yyhl2807 {
+			yyb2807 = yyj2807 > l
 		} else {
-			yyb2803 = r.CheckBreak()
+			yyb2807 = r.CheckBreak()
 		}
-		if yyb2803 {
+		if yyb2807 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2803-1, "")
+		z.DecStructFieldNotFound(yyj2807-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32680,90 +32710,90 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2813 := z.EncBinary()
-		_ = yym2813
+		yym2817 := z.EncBinary()
+		_ = yym2817
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2814 := !z.EncBinary()
-			yy2arr2814 := z.EncBasicHandle().StructToArray
-			var yyq2814 [3]bool
-			_, _, _ = yysep2814, yyq2814, yy2arr2814
-			const yyr2814 bool = false
-			yyq2814[0] = x.Kind != ""
-			yyq2814[1] = x.APIVersion != ""
-			if yyr2814 || yy2arr2814 {
+			yysep2818 := !z.EncBinary()
+			yy2arr2818 := z.EncBasicHandle().StructToArray
+			var yyq2818 [3]bool
+			_, _, _ = yysep2818, yyq2818, yy2arr2818
+			const yyr2818 bool = false
+			yyq2818[0] = x.Kind != ""
+			yyq2818[1] = x.APIVersion != ""
+			if yyr2818 || yy2arr2818 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2814 int = 1
-				for _, b := range yyq2814 {
+				var yynn2818 int = 1
+				for _, b := range yyq2818 {
 					if b {
-						yynn2814++
+						yynn2818++
 					}
 				}
-				r.EncodeMapStart(yynn2814)
+				r.EncodeMapStart(yynn2818)
 			}
-			if yyr2814 || yy2arr2814 {
-				if yyq2814[0] {
-					yym2816 := z.EncBinary()
-					_ = yym2816
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2814[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2817 := z.EncBinary()
-					_ = yym2817
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2814 || yy2arr2814 {
-				if yyq2814[1] {
-					yym2819 := z.EncBinary()
-					_ = yym2819
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2814[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2818 || yy2arr2818 {
+				if yyq2818[0] {
 					yym2820 := z.EncBinary()
 					_ = yym2820
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2818[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2821 := z.EncBinary()
+					_ = yym2821
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2818 || yy2arr2818 {
+				if yyq2818[1] {
+					yym2823 := z.EncBinary()
+					_ = yym2823
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2818[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2824 := z.EncBinary()
+					_ = yym2824
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2814 || yy2arr2814 {
-				yym2822 := z.EncBinary()
-				_ = yym2822
+			if yyr2818 || yy2arr2818 {
+				yym2826 := z.EncBinary()
+				_ = yym2826
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Path"))
-				yym2823 := z.EncBinary()
-				_ = yym2823
+				yym2827 := z.EncBinary()
+				_ = yym2827
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yysep2814 {
+			if yysep2818 {
 				r.EncodeEnd()
 			}
 		}
@@ -32774,24 +32804,24 @@ func (x *PodProxyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2824 := z.DecBinary()
-	_ = yym2824
+	yym2828 := z.DecBinary()
+	_ = yym2828
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2825 := r.ReadMapStart()
-			if yyl2825 == 0 {
+			yyl2829 := r.ReadMapStart()
+			if yyl2829 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2825, d)
+				x.codecDecodeSelfFromMap(yyl2829, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2825 := r.ReadArrayStart()
-			if yyl2825 == 0 {
+			yyl2829 := r.ReadArrayStart()
+			if yyl2829 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2825, d)
+				x.codecDecodeSelfFromArray(yyl2829, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32803,12 +32833,12 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2826Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2826Slc
-	var yyhl2826 bool = l >= 0
-	for yyj2826 := 0; ; yyj2826++ {
-		if yyhl2826 {
-			if yyj2826 >= l {
+	var yys2830Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2830Slc
+	var yyhl2830 bool = l >= 0
+	for yyj2830 := 0; ; yyj2830++ {
+		if yyhl2830 {
+			if yyj2830 >= l {
 				break
 			}
 		} else {
@@ -32816,9 +32846,9 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2826Slc = r.DecodeBytes(yys2826Slc, true, true)
-		yys2826 := string(yys2826Slc)
-		switch yys2826 {
+		yys2830Slc = r.DecodeBytes(yys2830Slc, true, true)
+		yys2830 := string(yys2830Slc)
+		switch yys2830 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32838,10 +32868,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Path = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2826)
-		} // end switch yys2826
-	} // end for yyj2826
-	if !yyhl2826 {
+			z.DecStructFieldNotFound(-1, yys2830)
+		} // end switch yys2830
+	} // end for yyj2830
+	if !yyhl2830 {
 		r.ReadEnd()
 	}
 }
@@ -32850,16 +32880,16 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2830 int
-	var yyb2830 bool
-	var yyhl2830 bool = l >= 0
-	yyj2830++
-	if yyhl2830 {
-		yyb2830 = yyj2830 > l
+	var yyj2834 int
+	var yyb2834 bool
+	var yyhl2834 bool = l >= 0
+	yyj2834++
+	if yyhl2834 {
+		yyb2834 = yyj2834 > l
 	} else {
-		yyb2830 = r.CheckBreak()
+		yyb2834 = r.CheckBreak()
 	}
-	if yyb2830 {
+	if yyb2834 {
 		r.ReadEnd()
 		return
 	}
@@ -32868,13 +32898,13 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2830++
-	if yyhl2830 {
-		yyb2830 = yyj2830 > l
+	yyj2834++
+	if yyhl2834 {
+		yyb2834 = yyj2834 > l
 	} else {
-		yyb2830 = r.CheckBreak()
+		yyb2834 = r.CheckBreak()
 	}
-	if yyb2830 {
+	if yyb2834 {
 		r.ReadEnd()
 		return
 	}
@@ -32883,13 +32913,13 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2830++
-	if yyhl2830 {
-		yyb2830 = yyj2830 > l
+	yyj2834++
+	if yyhl2834 {
+		yyb2834 = yyj2834 > l
 	} else {
-		yyb2830 = r.CheckBreak()
+		yyb2834 = r.CheckBreak()
 	}
-	if yyb2830 {
+	if yyb2834 {
 		r.ReadEnd()
 		return
 	}
@@ -32899,16 +32929,16 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Path = string(r.DecodeString())
 	}
 	for {
-		yyj2830++
-		if yyhl2830 {
-			yyb2830 = yyj2830 > l
+		yyj2834++
+		if yyhl2834 {
+			yyb2834 = yyj2834 > l
 		} else {
-			yyb2830 = r.CheckBreak()
+			yyb2834 = r.CheckBreak()
 		}
-		if yyb2830 {
+		if yyb2834 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2830-1, "")
+		z.DecStructFieldNotFound(yyj2834-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32920,172 +32950,172 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2834 := z.EncBinary()
-		_ = yym2834
+		yym2838 := z.EncBinary()
+		_ = yym2838
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2835 := !z.EncBinary()
-			yy2arr2835 := z.EncBasicHandle().StructToArray
-			var yyq2835 [7]bool
-			_, _, _ = yysep2835, yyq2835, yy2arr2835
-			const yyr2835 bool = false
-			yyq2835[0] = x.Kind != ""
-			yyq2835[1] = x.Namespace != ""
-			yyq2835[2] = x.Name != ""
-			yyq2835[3] = x.UID != ""
-			yyq2835[4] = x.APIVersion != ""
-			yyq2835[5] = x.ResourceVersion != ""
-			yyq2835[6] = x.FieldPath != ""
-			if yyr2835 || yy2arr2835 {
+			yysep2839 := !z.EncBinary()
+			yy2arr2839 := z.EncBasicHandle().StructToArray
+			var yyq2839 [7]bool
+			_, _, _ = yysep2839, yyq2839, yy2arr2839
+			const yyr2839 bool = false
+			yyq2839[0] = x.Kind != ""
+			yyq2839[1] = x.Namespace != ""
+			yyq2839[2] = x.Name != ""
+			yyq2839[3] = x.UID != ""
+			yyq2839[4] = x.APIVersion != ""
+			yyq2839[5] = x.ResourceVersion != ""
+			yyq2839[6] = x.FieldPath != ""
+			if yyr2839 || yy2arr2839 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2835 int = 0
-				for _, b := range yyq2835 {
+				var yynn2839 int = 0
+				for _, b := range yyq2839 {
 					if b {
-						yynn2835++
+						yynn2839++
 					}
 				}
-				r.EncodeMapStart(yynn2835)
+				r.EncodeMapStart(yynn2839)
 			}
-			if yyr2835 || yy2arr2835 {
-				if yyq2835[0] {
-					yym2837 := z.EncBinary()
-					_ = yym2837
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2835[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2838 := z.EncBinary()
-					_ = yym2838
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2835 || yy2arr2835 {
-				if yyq2835[1] {
-					yym2840 := z.EncBinary()
-					_ = yym2840
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2835[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+			if yyr2839 || yy2arr2839 {
+				if yyq2839[0] {
 					yym2841 := z.EncBinary()
 					_ = yym2841
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				}
-			}
-			if yyr2835 || yy2arr2835 {
-				if yyq2835[2] {
-					yym2843 := z.EncBinary()
-					_ = yym2843
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2835[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
+				if yyq2839[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2842 := z.EncBinary()
+					_ = yym2842
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2839 || yy2arr2839 {
+				if yyq2839[1] {
 					yym2844 := z.EncBinary()
 					_ = yym2844
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2839[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+					yym2845 := z.EncBinary()
+					_ = yym2845
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+					}
+				}
+			}
+			if yyr2839 || yy2arr2839 {
+				if yyq2839[2] {
+					yym2847 := z.EncBinary()
+					_ = yym2847
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2839[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					yym2848 := z.EncBinary()
+					_ = yym2848
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yyr2835 || yy2arr2835 {
-				if yyq2835[3] {
-					yym2846 := z.EncBinary()
-					_ = yym2846
-					if false {
-					} else if z.HasExtensions() && z.EncExt(x.UID) {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2835[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("uid"))
-					yym2847 := z.EncBinary()
-					_ = yym2847
-					if false {
-					} else if z.HasExtensions() && z.EncExt(x.UID) {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
-					}
-				}
-			}
-			if yyr2835 || yy2arr2835 {
-				if yyq2835[4] {
-					yym2849 := z.EncBinary()
-					_ = yym2849
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2835[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2839 || yy2arr2839 {
+				if yyq2839[3] {
 					yym2850 := z.EncBinary()
 					_ = yym2850
 					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2835 || yy2arr2835 {
-				if yyq2835[5] {
-					yym2852 := z.EncBinary()
-					_ = yym2852
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2835[5] {
-					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+				if yyq2839[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("uid"))
+					yym2851 := z.EncBinary()
+					_ = yym2851
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+					}
+				}
+			}
+			if yyr2839 || yy2arr2839 {
+				if yyq2839[4] {
 					yym2853 := z.EncBinary()
 					_ = yym2853
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2839[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2854 := z.EncBinary()
+					_ = yym2854
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2839 || yy2arr2839 {
+				if yyq2839[5] {
+					yym2856 := z.EncBinary()
+					_ = yym2856
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2839[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					yym2857 := z.EncBinary()
+					_ = yym2857
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 					}
 				}
 			}
-			if yyr2835 || yy2arr2835 {
-				if yyq2835[6] {
-					yym2855 := z.EncBinary()
-					_ = yym2855
+			if yyr2839 || yy2arr2839 {
+				if yyq2839[6] {
+					yym2859 := z.EncBinary()
+					_ = yym2859
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
@@ -33094,17 +33124,17 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2835[6] {
+				if yyq2839[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("fieldPath"))
-					yym2856 := z.EncBinary()
-					_ = yym2856
+					yym2860 := z.EncBinary()
+					_ = yym2860
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 					}
 				}
 			}
-			if yysep2835 {
+			if yysep2839 {
 				r.EncodeEnd()
 			}
 		}
@@ -33115,24 +33145,24 @@ func (x *ObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2857 := z.DecBinary()
-	_ = yym2857
+	yym2861 := z.DecBinary()
+	_ = yym2861
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2858 := r.ReadMapStart()
-			if yyl2858 == 0 {
+			yyl2862 := r.ReadMapStart()
+			if yyl2862 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2858, d)
+				x.codecDecodeSelfFromMap(yyl2862, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2858 := r.ReadArrayStart()
-			if yyl2858 == 0 {
+			yyl2862 := r.ReadArrayStart()
+			if yyl2862 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2858, d)
+				x.codecDecodeSelfFromArray(yyl2862, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33144,12 +33174,12 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2859Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2859Slc
-	var yyhl2859 bool = l >= 0
-	for yyj2859 := 0; ; yyj2859++ {
-		if yyhl2859 {
-			if yyj2859 >= l {
+	var yys2863Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2863Slc
+	var yyhl2863 bool = l >= 0
+	for yyj2863 := 0; ; yyj2863++ {
+		if yyhl2863 {
+			if yyj2863 >= l {
 				break
 			}
 		} else {
@@ -33157,9 +33187,9 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2859Slc = r.DecodeBytes(yys2859Slc, true, true)
-		yys2859 := string(yys2859Slc)
-		switch yys2859 {
+		yys2863Slc = r.DecodeBytes(yys2863Slc, true, true)
+		yys2863 := string(yys2863Slc)
+		switch yys2863 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -33203,10 +33233,10 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.FieldPath = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2859)
-		} // end switch yys2859
-	} // end for yyj2859
-	if !yyhl2859 {
+			z.DecStructFieldNotFound(-1, yys2863)
+		} // end switch yys2863
+	} // end for yyj2863
+	if !yyhl2863 {
 		r.ReadEnd()
 	}
 }
@@ -33215,16 +33245,16 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2867 int
-	var yyb2867 bool
-	var yyhl2867 bool = l >= 0
-	yyj2867++
-	if yyhl2867 {
-		yyb2867 = yyj2867 > l
+	var yyj2871 int
+	var yyb2871 bool
+	var yyhl2871 bool = l >= 0
+	yyj2871++
+	if yyhl2871 {
+		yyb2871 = yyj2871 > l
 	} else {
-		yyb2867 = r.CheckBreak()
+		yyb2871 = r.CheckBreak()
 	}
-	if yyb2867 {
+	if yyb2871 {
 		r.ReadEnd()
 		return
 	}
@@ -33233,13 +33263,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2867++
-	if yyhl2867 {
-		yyb2867 = yyj2867 > l
+	yyj2871++
+	if yyhl2871 {
+		yyb2871 = yyj2871 > l
 	} else {
-		yyb2867 = r.CheckBreak()
+		yyb2871 = r.CheckBreak()
 	}
-	if yyb2867 {
+	if yyb2871 {
 		r.ReadEnd()
 		return
 	}
@@ -33248,13 +33278,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Namespace = string(r.DecodeString())
 	}
-	yyj2867++
-	if yyhl2867 {
-		yyb2867 = yyj2867 > l
+	yyj2871++
+	if yyhl2871 {
+		yyb2871 = yyj2871 > l
 	} else {
-		yyb2867 = r.CheckBreak()
+		yyb2871 = r.CheckBreak()
 	}
-	if yyb2867 {
+	if yyb2871 {
 		r.ReadEnd()
 		return
 	}
@@ -33263,13 +33293,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj2867++
-	if yyhl2867 {
-		yyb2867 = yyj2867 > l
+	yyj2871++
+	if yyhl2871 {
+		yyb2871 = yyj2871 > l
 	} else {
-		yyb2867 = r.CheckBreak()
+		yyb2871 = r.CheckBreak()
 	}
-	if yyb2867 {
+	if yyb2871 {
 		r.ReadEnd()
 		return
 	}
@@ -33278,13 +33308,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.UID = pkg1_types.UID(r.DecodeString())
 	}
-	yyj2867++
-	if yyhl2867 {
-		yyb2867 = yyj2867 > l
+	yyj2871++
+	if yyhl2871 {
+		yyb2871 = yyj2871 > l
 	} else {
-		yyb2867 = r.CheckBreak()
+		yyb2871 = r.CheckBreak()
 	}
-	if yyb2867 {
+	if yyb2871 {
 		r.ReadEnd()
 		return
 	}
@@ -33293,13 +33323,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2867++
-	if yyhl2867 {
-		yyb2867 = yyj2867 > l
+	yyj2871++
+	if yyhl2871 {
+		yyb2871 = yyj2871 > l
 	} else {
-		yyb2867 = r.CheckBreak()
+		yyb2871 = r.CheckBreak()
 	}
-	if yyb2867 {
+	if yyb2871 {
 		r.ReadEnd()
 		return
 	}
@@ -33308,13 +33338,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj2867++
-	if yyhl2867 {
-		yyb2867 = yyj2867 > l
+	yyj2871++
+	if yyhl2871 {
+		yyb2871 = yyj2871 > l
 	} else {
-		yyb2867 = r.CheckBreak()
+		yyb2871 = r.CheckBreak()
 	}
-	if yyb2867 {
+	if yyb2871 {
 		r.ReadEnd()
 		return
 	}
@@ -33324,16 +33354,16 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.FieldPath = string(r.DecodeString())
 	}
 	for {
-		yyj2867++
-		if yyhl2867 {
-			yyb2867 = yyj2867 > l
+		yyj2871++
+		if yyhl2871 {
+			yyb2871 = yyj2871 > l
 		} else {
-			yyb2867 = r.CheckBreak()
+			yyb2871 = r.CheckBreak()
 		}
-		if yyb2867 {
+		if yyb2871 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2867-1, "")
+		z.DecStructFieldNotFound(yyj2871-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33345,44 +33375,44 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2875 := z.EncBinary()
-		_ = yym2875
+		yym2879 := z.EncBinary()
+		_ = yym2879
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2876 := !z.EncBinary()
-			yy2arr2876 := z.EncBasicHandle().StructToArray
-			var yyq2876 [1]bool
-			_, _, _ = yysep2876, yyq2876, yy2arr2876
-			const yyr2876 bool = false
-			if yyr2876 || yy2arr2876 {
+			yysep2880 := !z.EncBinary()
+			yy2arr2880 := z.EncBasicHandle().StructToArray
+			var yyq2880 [1]bool
+			_, _, _ = yysep2880, yyq2880, yy2arr2880
+			const yyr2880 bool = false
+			if yyr2880 || yy2arr2880 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2876 int = 1
-				for _, b := range yyq2876 {
+				var yynn2880 int = 1
+				for _, b := range yyq2880 {
 					if b {
-						yynn2876++
+						yynn2880++
 					}
 				}
-				r.EncodeMapStart(yynn2876)
+				r.EncodeMapStart(yynn2880)
 			}
-			if yyr2876 || yy2arr2876 {
-				yym2878 := z.EncBinary()
-				_ = yym2878
+			if yyr2880 || yy2arr2880 {
+				yym2882 := z.EncBinary()
+				_ = yym2882
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Name"))
-				yym2879 := z.EncBinary()
-				_ = yym2879
+				yym2883 := z.EncBinary()
+				_ = yym2883
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yysep2876 {
+			if yysep2880 {
 				r.EncodeEnd()
 			}
 		}
@@ -33393,24 +33423,24 @@ func (x *LocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2880 := z.DecBinary()
-	_ = yym2880
+	yym2884 := z.DecBinary()
+	_ = yym2884
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2881 := r.ReadMapStart()
-			if yyl2881 == 0 {
+			yyl2885 := r.ReadMapStart()
+			if yyl2885 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2881, d)
+				x.codecDecodeSelfFromMap(yyl2885, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2881 := r.ReadArrayStart()
-			if yyl2881 == 0 {
+			yyl2885 := r.ReadArrayStart()
+			if yyl2885 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2881, d)
+				x.codecDecodeSelfFromArray(yyl2885, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33422,12 +33452,12 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2882Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2882Slc
-	var yyhl2882 bool = l >= 0
-	for yyj2882 := 0; ; yyj2882++ {
-		if yyhl2882 {
-			if yyj2882 >= l {
+	var yys2886Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2886Slc
+	var yyhl2886 bool = l >= 0
+	for yyj2886 := 0; ; yyj2886++ {
+		if yyhl2886 {
+			if yyj2886 >= l {
 				break
 			}
 		} else {
@@ -33435,9 +33465,9 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys2882Slc = r.DecodeBytes(yys2882Slc, true, true)
-		yys2882 := string(yys2882Slc)
-		switch yys2882 {
+		yys2886Slc = r.DecodeBytes(yys2886Slc, true, true)
+		yys2886 := string(yys2886Slc)
+		switch yys2886 {
 		case "Name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -33445,10 +33475,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.Name = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2882)
-		} // end switch yys2882
-	} // end for yyj2882
-	if !yyhl2882 {
+			z.DecStructFieldNotFound(-1, yys2886)
+		} // end switch yys2886
+	} // end for yyj2886
+	if !yyhl2886 {
 		r.ReadEnd()
 	}
 }
@@ -33457,16 +33487,16 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2884 int
-	var yyb2884 bool
-	var yyhl2884 bool = l >= 0
-	yyj2884++
-	if yyhl2884 {
-		yyb2884 = yyj2884 > l
+	var yyj2888 int
+	var yyb2888 bool
+	var yyhl2888 bool = l >= 0
+	yyj2888++
+	if yyhl2888 {
+		yyb2888 = yyj2888 > l
 	} else {
-		yyb2884 = r.CheckBreak()
+		yyb2888 = r.CheckBreak()
 	}
-	if yyb2884 {
+	if yyb2888 {
 		r.ReadEnd()
 		return
 	}
@@ -33476,16 +33506,16 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.Name = string(r.DecodeString())
 	}
 	for {
-		yyj2884++
-		if yyhl2884 {
-			yyb2884 = yyj2884 > l
+		yyj2888++
+		if yyhl2888 {
+			yyb2888 = yyj2888 > l
 		} else {
-			yyb2884 = r.CheckBreak()
+			yyb2888 = r.CheckBreak()
 		}
-		if yyb2884 {
+		if yyb2888 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2884-1, "")
+		z.DecStructFieldNotFound(yyj2888-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33497,89 +33527,89 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2886 := z.EncBinary()
-		_ = yym2886
+		yym2890 := z.EncBinary()
+		_ = yym2890
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2887 := !z.EncBinary()
-			yy2arr2887 := z.EncBasicHandle().StructToArray
-			var yyq2887 [3]bool
-			_, _, _ = yysep2887, yyq2887, yy2arr2887
-			const yyr2887 bool = false
-			yyq2887[0] = x.Kind != ""
-			yyq2887[1] = x.APIVersion != ""
-			yyq2887[2] = true
-			if yyr2887 || yy2arr2887 {
+			yysep2891 := !z.EncBinary()
+			yy2arr2891 := z.EncBasicHandle().StructToArray
+			var yyq2891 [3]bool
+			_, _, _ = yysep2891, yyq2891, yy2arr2891
+			const yyr2891 bool = false
+			yyq2891[0] = x.Kind != ""
+			yyq2891[1] = x.APIVersion != ""
+			yyq2891[2] = true
+			if yyr2891 || yy2arr2891 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2887 int = 0
-				for _, b := range yyq2887 {
+				var yynn2891 int = 0
+				for _, b := range yyq2891 {
 					if b {
-						yynn2887++
+						yynn2891++
 					}
 				}
-				r.EncodeMapStart(yynn2887)
+				r.EncodeMapStart(yynn2891)
 			}
-			if yyr2887 || yy2arr2887 {
-				if yyq2887[0] {
-					yym2889 := z.EncBinary()
-					_ = yym2889
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2887[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2890 := z.EncBinary()
-					_ = yym2890
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2887 || yy2arr2887 {
-				if yyq2887[1] {
-					yym2892 := z.EncBinary()
-					_ = yym2892
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2887[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2891 || yy2arr2891 {
+				if yyq2891[0] {
 					yym2893 := z.EncBinary()
 					_ = yym2893
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2891[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2894 := z.EncBinary()
+					_ = yym2894
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2891 || yy2arr2891 {
+				if yyq2891[1] {
+					yym2896 := z.EncBinary()
+					_ = yym2896
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2891[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2897 := z.EncBinary()
+					_ = yym2897
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2887 || yy2arr2887 {
-				if yyq2887[2] {
-					yy2895 := &x.Reference
-					yy2895.CodecEncodeSelf(e)
+			if yyr2891 || yy2arr2891 {
+				if yyq2891[2] {
+					yy2899 := &x.Reference
+					yy2899.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2887[2] {
+				if yyq2891[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("reference"))
-					yy2896 := &x.Reference
-					yy2896.CodecEncodeSelf(e)
+					yy2900 := &x.Reference
+					yy2900.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2887 {
+			if yysep2891 {
 				r.EncodeEnd()
 			}
 		}
@@ -33590,24 +33620,24 @@ func (x *SerializedReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2897 := z.DecBinary()
-	_ = yym2897
+	yym2901 := z.DecBinary()
+	_ = yym2901
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2898 := r.ReadMapStart()
-			if yyl2898 == 0 {
+			yyl2902 := r.ReadMapStart()
+			if yyl2902 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2898, d)
+				x.codecDecodeSelfFromMap(yyl2902, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2898 := r.ReadArrayStart()
-			if yyl2898 == 0 {
+			yyl2902 := r.ReadArrayStart()
+			if yyl2902 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2898, d)
+				x.codecDecodeSelfFromArray(yyl2902, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33619,12 +33649,12 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2899Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2899Slc
-	var yyhl2899 bool = l >= 0
-	for yyj2899 := 0; ; yyj2899++ {
-		if yyhl2899 {
-			if yyj2899 >= l {
+	var yys2903Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2903Slc
+	var yyhl2903 bool = l >= 0
+	for yyj2903 := 0; ; yyj2903++ {
+		if yyhl2903 {
+			if yyj2903 >= l {
 				break
 			}
 		} else {
@@ -33632,9 +33662,9 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys2899Slc = r.DecodeBytes(yys2899Slc, true, true)
-		yys2899 := string(yys2899Slc)
-		switch yys2899 {
+		yys2903Slc = r.DecodeBytes(yys2903Slc, true, true)
+		yys2903 := string(yys2903Slc)
+		switch yys2903 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -33651,14 +33681,14 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.Reference = ObjectReference{}
 			} else {
-				yyv2902 := &x.Reference
-				yyv2902.CodecDecodeSelf(d)
+				yyv2906 := &x.Reference
+				yyv2906.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2899)
-		} // end switch yys2899
-	} // end for yyj2899
-	if !yyhl2899 {
+			z.DecStructFieldNotFound(-1, yys2903)
+		} // end switch yys2903
+	} // end for yyj2903
+	if !yyhl2903 {
 		r.ReadEnd()
 	}
 }
@@ -33667,16 +33697,16 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2903 int
-	var yyb2903 bool
-	var yyhl2903 bool = l >= 0
-	yyj2903++
-	if yyhl2903 {
-		yyb2903 = yyj2903 > l
+	var yyj2907 int
+	var yyb2907 bool
+	var yyhl2907 bool = l >= 0
+	yyj2907++
+	if yyhl2907 {
+		yyb2907 = yyj2907 > l
 	} else {
-		yyb2903 = r.CheckBreak()
+		yyb2907 = r.CheckBreak()
 	}
-	if yyb2903 {
+	if yyb2907 {
 		r.ReadEnd()
 		return
 	}
@@ -33685,13 +33715,13 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2903++
-	if yyhl2903 {
-		yyb2903 = yyj2903 > l
+	yyj2907++
+	if yyhl2907 {
+		yyb2907 = yyj2907 > l
 	} else {
-		yyb2903 = r.CheckBreak()
+		yyb2907 = r.CheckBreak()
 	}
-	if yyb2903 {
+	if yyb2907 {
 		r.ReadEnd()
 		return
 	}
@@ -33700,33 +33730,33 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2903++
-	if yyhl2903 {
-		yyb2903 = yyj2903 > l
+	yyj2907++
+	if yyhl2907 {
+		yyb2907 = yyj2907 > l
 	} else {
-		yyb2903 = r.CheckBreak()
+		yyb2907 = r.CheckBreak()
 	}
-	if yyb2903 {
+	if yyb2907 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Reference = ObjectReference{}
 	} else {
-		yyv2906 := &x.Reference
-		yyv2906.CodecDecodeSelf(d)
+		yyv2910 := &x.Reference
+		yyv2910.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2903++
-		if yyhl2903 {
-			yyb2903 = yyj2903 > l
+		yyj2907++
+		if yyhl2907 {
+			yyb2907 = yyj2907 > l
 		} else {
-			yyb2903 = r.CheckBreak()
+			yyb2907 = r.CheckBreak()
 		}
-		if yyb2903 {
+		if yyb2907 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2903-1, "")
+		z.DecStructFieldNotFound(yyj2907-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33738,74 +33768,74 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2907 := z.EncBinary()
-		_ = yym2907
+		yym2911 := z.EncBinary()
+		_ = yym2911
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2908 := !z.EncBinary()
-			yy2arr2908 := z.EncBasicHandle().StructToArray
-			var yyq2908 [2]bool
-			_, _, _ = yysep2908, yyq2908, yy2arr2908
-			const yyr2908 bool = false
-			yyq2908[0] = x.Component != ""
-			yyq2908[1] = x.Host != ""
-			if yyr2908 || yy2arr2908 {
+			yysep2912 := !z.EncBinary()
+			yy2arr2912 := z.EncBasicHandle().StructToArray
+			var yyq2912 [2]bool
+			_, _, _ = yysep2912, yyq2912, yy2arr2912
+			const yyr2912 bool = false
+			yyq2912[0] = x.Component != ""
+			yyq2912[1] = x.Host != ""
+			if yyr2912 || yy2arr2912 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2908 int = 0
-				for _, b := range yyq2908 {
+				var yynn2912 int = 0
+				for _, b := range yyq2912 {
 					if b {
-						yynn2908++
+						yynn2912++
 					}
 				}
-				r.EncodeMapStart(yynn2908)
+				r.EncodeMapStart(yynn2912)
 			}
-			if yyr2908 || yy2arr2908 {
-				if yyq2908[0] {
-					yym2910 := z.EncBinary()
-					_ = yym2910
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2908[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("component"))
-					yym2911 := z.EncBinary()
-					_ = yym2911
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
-					}
-				}
-			}
-			if yyr2908 || yy2arr2908 {
-				if yyq2908[1] {
-					yym2913 := z.EncBinary()
-					_ = yym2913
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2908[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("host"))
+			if yyr2912 || yy2arr2912 {
+				if yyq2912[0] {
 					yym2914 := z.EncBinary()
 					_ = yym2914
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2912[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("component"))
+					yym2915 := z.EncBinary()
+					_ = yym2915
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
+					}
+				}
+			}
+			if yyr2912 || yy2arr2912 {
+				if yyq2912[1] {
+					yym2917 := z.EncBinary()
+					_ = yym2917
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2912[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("host"))
+					yym2918 := z.EncBinary()
+					_ = yym2918
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			if yysep2908 {
+			if yysep2912 {
 				r.EncodeEnd()
 			}
 		}
@@ -33816,24 +33846,24 @@ func (x *EventSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2915 := z.DecBinary()
-	_ = yym2915
+	yym2919 := z.DecBinary()
+	_ = yym2919
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2916 := r.ReadMapStart()
-			if yyl2916 == 0 {
+			yyl2920 := r.ReadMapStart()
+			if yyl2920 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2916, d)
+				x.codecDecodeSelfFromMap(yyl2920, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2916 := r.ReadArrayStart()
-			if yyl2916 == 0 {
+			yyl2920 := r.ReadArrayStart()
+			if yyl2920 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2916, d)
+				x.codecDecodeSelfFromArray(yyl2920, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33845,12 +33875,12 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2917Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2917Slc
-	var yyhl2917 bool = l >= 0
-	for yyj2917 := 0; ; yyj2917++ {
-		if yyhl2917 {
-			if yyj2917 >= l {
+	var yys2921Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2921Slc
+	var yyhl2921 bool = l >= 0
+	for yyj2921 := 0; ; yyj2921++ {
+		if yyhl2921 {
+			if yyj2921 >= l {
 				break
 			}
 		} else {
@@ -33858,9 +33888,9 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2917Slc = r.DecodeBytes(yys2917Slc, true, true)
-		yys2917 := string(yys2917Slc)
-		switch yys2917 {
+		yys2921Slc = r.DecodeBytes(yys2921Slc, true, true)
+		yys2921 := string(yys2921Slc)
+		switch yys2921 {
 		case "component":
 			if r.TryDecodeAsNil() {
 				x.Component = ""
@@ -33874,10 +33904,10 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Host = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2917)
-		} // end switch yys2917
-	} // end for yyj2917
-	if !yyhl2917 {
+			z.DecStructFieldNotFound(-1, yys2921)
+		} // end switch yys2921
+	} // end for yyj2921
+	if !yyhl2921 {
 		r.ReadEnd()
 	}
 }
@@ -33886,16 +33916,16 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2920 int
-	var yyb2920 bool
-	var yyhl2920 bool = l >= 0
-	yyj2920++
-	if yyhl2920 {
-		yyb2920 = yyj2920 > l
+	var yyj2924 int
+	var yyb2924 bool
+	var yyhl2924 bool = l >= 0
+	yyj2924++
+	if yyhl2924 {
+		yyb2924 = yyj2924 > l
 	} else {
-		yyb2920 = r.CheckBreak()
+		yyb2924 = r.CheckBreak()
 	}
-	if yyb2920 {
+	if yyb2924 {
 		r.ReadEnd()
 		return
 	}
@@ -33904,13 +33934,13 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Component = string(r.DecodeString())
 	}
-	yyj2920++
-	if yyhl2920 {
-		yyb2920 = yyj2920 > l
+	yyj2924++
+	if yyhl2924 {
+		yyb2924 = yyj2924 > l
 	} else {
-		yyb2920 = r.CheckBreak()
+		yyb2924 = r.CheckBreak()
 	}
-	if yyb2920 {
+	if yyb2924 {
 		r.ReadEnd()
 		return
 	}
@@ -33920,16 +33950,16 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Host = string(r.DecodeString())
 	}
 	for {
-		yyj2920++
-		if yyhl2920 {
-			yyb2920 = yyj2920 > l
+		yyj2924++
+		if yyhl2924 {
+			yyb2924 = yyj2924 > l
 		} else {
-			yyb2920 = r.CheckBreak()
+			yyb2924 = r.CheckBreak()
 		}
-		if yyb2920 {
+		if yyb2924 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2920-1, "")
+		z.DecStructFieldNotFound(yyj2924-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33941,239 +33971,239 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2923 := z.EncBinary()
-		_ = yym2923
+		yym2927 := z.EncBinary()
+		_ = yym2927
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2924 := !z.EncBinary()
-			yy2arr2924 := z.EncBasicHandle().StructToArray
-			var yyq2924 [10]bool
-			_, _, _ = yysep2924, yyq2924, yy2arr2924
-			const yyr2924 bool = false
-			yyq2924[0] = x.Kind != ""
-			yyq2924[1] = x.APIVersion != ""
-			yyq2924[2] = true
-			yyq2924[3] = true
-			yyq2924[4] = x.Reason != ""
-			yyq2924[5] = x.Message != ""
-			yyq2924[6] = true
-			yyq2924[7] = true
-			yyq2924[8] = true
-			yyq2924[9] = x.Count != 0
-			if yyr2924 || yy2arr2924 {
+			yysep2928 := !z.EncBinary()
+			yy2arr2928 := z.EncBasicHandle().StructToArray
+			var yyq2928 [10]bool
+			_, _, _ = yysep2928, yyq2928, yy2arr2928
+			const yyr2928 bool = false
+			yyq2928[0] = x.Kind != ""
+			yyq2928[1] = x.APIVersion != ""
+			yyq2928[2] = true
+			yyq2928[3] = true
+			yyq2928[4] = x.Reason != ""
+			yyq2928[5] = x.Message != ""
+			yyq2928[6] = true
+			yyq2928[7] = true
+			yyq2928[8] = true
+			yyq2928[9] = x.Count != 0
+			if yyr2928 || yy2arr2928 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2924 int = 0
-				for _, b := range yyq2924 {
+				var yynn2928 int = 0
+				for _, b := range yyq2928 {
 					if b {
-						yynn2924++
+						yynn2928++
 					}
 				}
-				r.EncodeMapStart(yynn2924)
+				r.EncodeMapStart(yynn2928)
 			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[0] {
-					yym2926 := z.EncBinary()
-					_ = yym2926
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2924[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2927 := z.EncBinary()
-					_ = yym2927
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[1] {
-					yym2929 := z.EncBinary()
-					_ = yym2929
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2924[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[0] {
 					yym2930 := z.EncBinary()
 					_ = yym2930
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2928[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2931 := z.EncBinary()
+					_ = yym2931
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[1] {
+					yym2933 := z.EncBinary()
+					_ = yym2933
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2928[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2934 := z.EncBinary()
+					_ = yym2934
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[2] {
-					yy2932 := &x.ObjectMeta
-					yy2932.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2924[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2933 := &x.ObjectMeta
-					yy2933.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[3] {
-					yy2935 := &x.InvolvedObject
-					yy2935.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2924[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
-					yy2936 := &x.InvolvedObject
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[2] {
+					yy2936 := &x.ObjectMeta
 					yy2936.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[4] {
-					yym2938 := z.EncBinary()
-					_ = yym2938
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
-				if yyq2924[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym2939 := z.EncBinary()
-					_ = yym2939
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
+				if yyq2928[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2937 := &x.ObjectMeta
+					yy2937.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[5] {
-					yym2941 := z.EncBinary()
-					_ = yym2941
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[3] {
+					yy2939 := &x.InvolvedObject
+					yy2939.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
-				if yyq2924[5] {
-					r.EncodeString(codecSelferC_UTF81234, string("message"))
+				if yyq2928[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
+					yy2940 := &x.InvolvedObject
+					yy2940.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[4] {
 					yym2942 := z.EncBinary()
 					_ = yym2942
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2928[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					yym2943 := z.EncBinary()
+					_ = yym2943
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				}
+			}
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[5] {
+					yym2945 := z.EncBinary()
+					_ = yym2945
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2928[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					yym2946 := z.EncBinary()
+					_ = yym2946
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[6] {
-					yy2944 := &x.Source
-					yy2944.CodecEncodeSelf(e)
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[6] {
+					yy2948 := &x.Source
+					yy2948.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2924[6] {
+				if yyq2928[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("source"))
-					yy2945 := &x.Source
-					yy2945.CodecEncodeSelf(e)
+					yy2949 := &x.Source
+					yy2949.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[7] {
-					yy2947 := &x.FirstTimestamp
-					yym2948 := z.EncBinary()
-					_ = yym2948
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[7] {
+					yy2951 := &x.FirstTimestamp
+					yym2952 := z.EncBinary()
+					_ = yym2952
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2947) {
-					} else if yym2948 {
-						z.EncBinaryMarshal(yy2947)
-					} else if !yym2948 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2947)
+					} else if z.HasExtensions() && z.EncExt(yy2951) {
+					} else if yym2952 {
+						z.EncBinaryMarshal(yy2951)
+					} else if !yym2952 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2951)
 					} else {
-						z.EncFallback(yy2947)
+						z.EncFallback(yy2951)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2924[7] {
+				if yyq2928[7] {
 					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
-					yy2949 := &x.FirstTimestamp
-					yym2950 := z.EncBinary()
-					_ = yym2950
+					yy2953 := &x.FirstTimestamp
+					yym2954 := z.EncBinary()
+					_ = yym2954
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2949) {
-					} else if yym2950 {
-						z.EncBinaryMarshal(yy2949)
-					} else if !yym2950 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2949)
+					} else if z.HasExtensions() && z.EncExt(yy2953) {
+					} else if yym2954 {
+						z.EncBinaryMarshal(yy2953)
+					} else if !yym2954 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2953)
 					} else {
-						z.EncFallback(yy2949)
+						z.EncFallback(yy2953)
 					}
 				}
 			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[8] {
-					yy2952 := &x.LastTimestamp
-					yym2953 := z.EncBinary()
-					_ = yym2953
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2952) {
-					} else if yym2953 {
-						z.EncBinaryMarshal(yy2952)
-					} else if !yym2953 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2952)
-					} else {
-						z.EncFallback(yy2952)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2924[8] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
-					yy2954 := &x.LastTimestamp
-					yym2955 := z.EncBinary()
-					_ = yym2955
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2954) {
-					} else if yym2955 {
-						z.EncBinaryMarshal(yy2954)
-					} else if !yym2955 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2954)
-					} else {
-						z.EncFallback(yy2954)
-					}
-				}
-			}
-			if yyr2924 || yy2arr2924 {
-				if yyq2924[9] {
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[8] {
+					yy2956 := &x.LastTimestamp
 					yym2957 := z.EncBinary()
 					_ = yym2957
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2956) {
+					} else if yym2957 {
+						z.EncBinaryMarshal(yy2956)
+					} else if !yym2957 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2956)
+					} else {
+						z.EncFallback(yy2956)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2928[8] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					yy2958 := &x.LastTimestamp
+					yym2959 := z.EncBinary()
+					_ = yym2959
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2958) {
+					} else if yym2959 {
+						z.EncBinaryMarshal(yy2958)
+					} else if !yym2959 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2958)
+					} else {
+						z.EncFallback(yy2958)
+					}
+				}
+			}
+			if yyr2928 || yy2arr2928 {
+				if yyq2928[9] {
+					yym2961 := z.EncBinary()
+					_ = yym2961
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Count))
@@ -34182,17 +34212,17 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq2924[9] {
+				if yyq2928[9] {
 					r.EncodeString(codecSelferC_UTF81234, string("count"))
-					yym2958 := z.EncBinary()
-					_ = yym2958
+					yym2962 := z.EncBinary()
+					_ = yym2962
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Count))
 					}
 				}
 			}
-			if yysep2924 {
+			if yysep2928 {
 				r.EncodeEnd()
 			}
 		}
@@ -34203,24 +34233,24 @@ func (x *Event) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2959 := z.DecBinary()
-	_ = yym2959
+	yym2963 := z.DecBinary()
+	_ = yym2963
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2960 := r.ReadMapStart()
-			if yyl2960 == 0 {
+			yyl2964 := r.ReadMapStart()
+			if yyl2964 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2960, d)
+				x.codecDecodeSelfFromMap(yyl2964, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2960 := r.ReadArrayStart()
-			if yyl2960 == 0 {
+			yyl2964 := r.ReadArrayStart()
+			if yyl2964 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2960, d)
+				x.codecDecodeSelfFromArray(yyl2964, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34232,12 +34262,12 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2961Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2961Slc
-	var yyhl2961 bool = l >= 0
-	for yyj2961 := 0; ; yyj2961++ {
-		if yyhl2961 {
-			if yyj2961 >= l {
+	var yys2965Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2965Slc
+	var yyhl2965 bool = l >= 0
+	for yyj2965 := 0; ; yyj2965++ {
+		if yyhl2965 {
+			if yyj2965 >= l {
 				break
 			}
 		} else {
@@ -34245,9 +34275,9 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2961Slc = r.DecodeBytes(yys2961Slc, true, true)
-		yys2961 := string(yys2961Slc)
-		switch yys2961 {
+		yys2965Slc = r.DecodeBytes(yys2965Slc, true, true)
+		yys2965 := string(yys2965Slc)
+		switch yys2965 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34264,15 +34294,15 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2964 := &x.ObjectMeta
-				yyv2964.CodecDecodeSelf(d)
+				yyv2968 := &x.ObjectMeta
+				yyv2968.CodecDecodeSelf(d)
 			}
 		case "involvedObject":
 			if r.TryDecodeAsNil() {
 				x.InvolvedObject = ObjectReference{}
 			} else {
-				yyv2965 := &x.InvolvedObject
-				yyv2965.CodecDecodeSelf(d)
+				yyv2969 := &x.InvolvedObject
+				yyv2969.CodecDecodeSelf(d)
 			}
 		case "reason":
 			if r.TryDecodeAsNil() {
@@ -34290,41 +34320,41 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Source = EventSource{}
 			} else {
-				yyv2968 := &x.Source
-				yyv2968.CodecDecodeSelf(d)
+				yyv2972 := &x.Source
+				yyv2972.CodecDecodeSelf(d)
 			}
 		case "firstTimestamp":
 			if r.TryDecodeAsNil() {
 				x.FirstTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv2969 := &x.FirstTimestamp
-				yym2970 := z.DecBinary()
-				_ = yym2970
+				yyv2973 := &x.FirstTimestamp
+				yym2974 := z.DecBinary()
+				_ = yym2974
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2969) {
-				} else if yym2970 {
-					z.DecBinaryUnmarshal(yyv2969)
-				} else if !yym2970 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2969)
+				} else if z.HasExtensions() && z.DecExt(yyv2973) {
+				} else if yym2974 {
+					z.DecBinaryUnmarshal(yyv2973)
+				} else if !yym2974 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2973)
 				} else {
-					z.DecFallback(yyv2969, false)
+					z.DecFallback(yyv2973, false)
 				}
 			}
 		case "lastTimestamp":
 			if r.TryDecodeAsNil() {
 				x.LastTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv2971 := &x.LastTimestamp
-				yym2972 := z.DecBinary()
-				_ = yym2972
+				yyv2975 := &x.LastTimestamp
+				yym2976 := z.DecBinary()
+				_ = yym2976
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2971) {
-				} else if yym2972 {
-					z.DecBinaryUnmarshal(yyv2971)
-				} else if !yym2972 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2971)
+				} else if z.HasExtensions() && z.DecExt(yyv2975) {
+				} else if yym2976 {
+					z.DecBinaryUnmarshal(yyv2975)
+				} else if !yym2976 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2975)
 				} else {
-					z.DecFallback(yyv2971, false)
+					z.DecFallback(yyv2975, false)
 				}
 			}
 		case "count":
@@ -34334,10 +34364,10 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Count = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2961)
-		} // end switch yys2961
-	} // end for yyj2961
-	if !yyhl2961 {
+			z.DecStructFieldNotFound(-1, yys2965)
+		} // end switch yys2965
+	} // end for yyj2965
+	if !yyhl2965 {
 		r.ReadEnd()
 	}
 }
@@ -34346,16 +34376,16 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2974 int
-	var yyb2974 bool
-	var yyhl2974 bool = l >= 0
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	var yyj2978 int
+	var yyb2978 bool
+	var yyhl2978 bool = l >= 0
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
@@ -34364,13 +34394,13 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
@@ -34379,45 +34409,45 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2977 := &x.ObjectMeta
-		yyv2977.CodecDecodeSelf(d)
+		yyv2981 := &x.ObjectMeta
+		yyv2981.CodecDecodeSelf(d)
 	}
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.InvolvedObject = ObjectReference{}
 	} else {
-		yyv2978 := &x.InvolvedObject
-		yyv2978.CodecDecodeSelf(d)
+		yyv2982 := &x.InvolvedObject
+		yyv2982.CodecDecodeSelf(d)
 	}
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
@@ -34426,13 +34456,13 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
@@ -34441,81 +34471,81 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Source = EventSource{}
 	} else {
-		yyv2981 := &x.Source
-		yyv2981.CodecDecodeSelf(d)
+		yyv2985 := &x.Source
+		yyv2985.CodecDecodeSelf(d)
 	}
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.FirstTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv2982 := &x.FirstTimestamp
-		yym2983 := z.DecBinary()
-		_ = yym2983
+		yyv2986 := &x.FirstTimestamp
+		yym2987 := z.DecBinary()
+		_ = yym2987
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2982) {
-		} else if yym2983 {
-			z.DecBinaryUnmarshal(yyv2982)
-		} else if !yym2983 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2982)
+		} else if z.HasExtensions() && z.DecExt(yyv2986) {
+		} else if yym2987 {
+			z.DecBinaryUnmarshal(yyv2986)
+		} else if !yym2987 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2986)
 		} else {
-			z.DecFallback(yyv2982, false)
+			z.DecFallback(yyv2986, false)
 		}
 	}
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv2984 := &x.LastTimestamp
-		yym2985 := z.DecBinary()
-		_ = yym2985
+		yyv2988 := &x.LastTimestamp
+		yym2989 := z.DecBinary()
+		_ = yym2989
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2984) {
-		} else if yym2985 {
-			z.DecBinaryUnmarshal(yyv2984)
-		} else if !yym2985 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2984)
+		} else if z.HasExtensions() && z.DecExt(yyv2988) {
+		} else if yym2989 {
+			z.DecBinaryUnmarshal(yyv2988)
+		} else if !yym2989 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2988)
 		} else {
-			z.DecFallback(yyv2984, false)
+			z.DecFallback(yyv2988, false)
 		}
 	}
-	yyj2974++
-	if yyhl2974 {
-		yyb2974 = yyj2974 > l
+	yyj2978++
+	if yyhl2978 {
+		yyb2978 = yyj2978 > l
 	} else {
-		yyb2974 = r.CheckBreak()
+		yyb2978 = r.CheckBreak()
 	}
-	if yyb2974 {
+	if yyb2978 {
 		r.ReadEnd()
 		return
 	}
@@ -34525,16 +34555,16 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Count = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj2974++
-		if yyhl2974 {
-			yyb2974 = yyj2974 > l
+		yyj2978++
+		if yyhl2978 {
+			yyb2978 = yyj2978 > l
 		} else {
-			yyb2974 = r.CheckBreak()
+			yyb2978 = r.CheckBreak()
 		}
-		if yyb2974 {
+		if yyb2978 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2974-1, "")
+		z.DecStructFieldNotFound(yyj2978-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34546,106 +34576,106 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2987 := z.EncBinary()
-		_ = yym2987
+		yym2991 := z.EncBinary()
+		_ = yym2991
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2988 := !z.EncBinary()
-			yy2arr2988 := z.EncBasicHandle().StructToArray
-			var yyq2988 [4]bool
-			_, _, _ = yysep2988, yyq2988, yy2arr2988
-			const yyr2988 bool = false
-			yyq2988[0] = x.Kind != ""
-			yyq2988[1] = x.APIVersion != ""
-			yyq2988[2] = true
-			if yyr2988 || yy2arr2988 {
+			yysep2992 := !z.EncBinary()
+			yy2arr2992 := z.EncBasicHandle().StructToArray
+			var yyq2992 [4]bool
+			_, _, _ = yysep2992, yyq2992, yy2arr2992
+			const yyr2992 bool = false
+			yyq2992[0] = x.Kind != ""
+			yyq2992[1] = x.APIVersion != ""
+			yyq2992[2] = true
+			if yyr2992 || yy2arr2992 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2988 int = 1
-				for _, b := range yyq2988 {
+				var yynn2992 int = 1
+				for _, b := range yyq2992 {
 					if b {
-						yynn2988++
+						yynn2992++
 					}
 				}
-				r.EncodeMapStart(yynn2988)
+				r.EncodeMapStart(yynn2992)
 			}
-			if yyr2988 || yy2arr2988 {
-				if yyq2988[0] {
-					yym2990 := z.EncBinary()
-					_ = yym2990
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2988[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2991 := z.EncBinary()
-					_ = yym2991
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2988 || yy2arr2988 {
-				if yyq2988[1] {
-					yym2993 := z.EncBinary()
-					_ = yym2993
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2988[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr2992 || yy2arr2992 {
+				if yyq2992[0] {
 					yym2994 := z.EncBinary()
 					_ = yym2994
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2992[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym2995 := z.EncBinary()
+					_ = yym2995
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2992 || yy2arr2992 {
+				if yyq2992[1] {
+					yym2997 := z.EncBinary()
+					_ = yym2997
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2992[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2998 := z.EncBinary()
+					_ = yym2998
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2988 || yy2arr2988 {
-				if yyq2988[2] {
-					yy2996 := &x.ListMeta
-					yym2997 := z.EncBinary()
-					_ = yym2997
+			if yyr2992 || yy2arr2992 {
+				if yyq2992[2] {
+					yy3000 := &x.ListMeta
+					yym3001 := z.EncBinary()
+					_ = yym3001
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2996) {
+					} else if z.HasExtensions() && z.EncExt(yy3000) {
 					} else {
-						z.EncFallback(yy2996)
+						z.EncFallback(yy3000)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2988[2] {
+				if yyq2992[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2998 := &x.ListMeta
-					yym2999 := z.EncBinary()
-					_ = yym2999
+					yy3002 := &x.ListMeta
+					yym3003 := z.EncBinary()
+					_ = yym3003
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2998) {
+					} else if z.HasExtensions() && z.EncExt(yy3002) {
 					} else {
-						z.EncFallback(yy2998)
+						z.EncFallback(yy3002)
 					}
 				}
 			}
-			if yyr2988 || yy2arr2988 {
+			if yyr2992 || yy2arr2992 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3001 := z.EncBinary()
-					_ = yym3001
+					yym3005 := z.EncBinary()
+					_ = yym3005
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
@@ -34656,15 +34686,15 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3002 := z.EncBinary()
-					_ = yym3002
+					yym3006 := z.EncBinary()
+					_ = yym3006
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
 					}
 				}
 			}
-			if yysep2988 {
+			if yysep2992 {
 				r.EncodeEnd()
 			}
 		}
@@ -34675,24 +34705,24 @@ func (x *EventList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3003 := z.DecBinary()
-	_ = yym3003
+	yym3007 := z.DecBinary()
+	_ = yym3007
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3004 := r.ReadMapStart()
-			if yyl3004 == 0 {
+			yyl3008 := r.ReadMapStart()
+			if yyl3008 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3004, d)
+				x.codecDecodeSelfFromMap(yyl3008, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3004 := r.ReadArrayStart()
-			if yyl3004 == 0 {
+			yyl3008 := r.ReadArrayStart()
+			if yyl3008 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3004, d)
+				x.codecDecodeSelfFromArray(yyl3008, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34704,12 +34734,12 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3005Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3005Slc
-	var yyhl3005 bool = l >= 0
-	for yyj3005 := 0; ; yyj3005++ {
-		if yyhl3005 {
-			if yyj3005 >= l {
+	var yys3009Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3009Slc
+	var yyhl3009 bool = l >= 0
+	for yyj3009 := 0; ; yyj3009++ {
+		if yyhl3009 {
+			if yyj3009 >= l {
 				break
 			}
 		} else {
@@ -34717,9 +34747,9 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3005Slc = r.DecodeBytes(yys3005Slc, true, true)
-		yys3005 := string(yys3005Slc)
-		switch yys3005 {
+		yys3009Slc = r.DecodeBytes(yys3009Slc, true, true)
+		yys3009 := string(yys3009Slc)
+		switch yys3009 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34736,32 +34766,32 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3008 := &x.ListMeta
-				yym3009 := z.DecBinary()
-				_ = yym3009
+				yyv3012 := &x.ListMeta
+				yym3013 := z.DecBinary()
+				_ = yym3013
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3008) {
+				} else if z.HasExtensions() && z.DecExt(yyv3012) {
 				} else {
-					z.DecFallback(yyv3008, false)
+					z.DecFallback(yyv3012, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3010 := &x.Items
-				yym3011 := z.DecBinary()
-				_ = yym3011
+				yyv3014 := &x.Items
+				yym3015 := z.DecBinary()
+				_ = yym3015
 				if false {
 				} else {
-					h.decSliceEvent((*[]Event)(yyv3010), d)
+					h.decSliceEvent((*[]Event)(yyv3014), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3005)
-		} // end switch yys3005
-	} // end for yyj3005
-	if !yyhl3005 {
+			z.DecStructFieldNotFound(-1, yys3009)
+		} // end switch yys3009
+	} // end for yyj3009
+	if !yyhl3009 {
 		r.ReadEnd()
 	}
 }
@@ -34770,16 +34800,16 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3012 int
-	var yyb3012 bool
-	var yyhl3012 bool = l >= 0
-	yyj3012++
-	if yyhl3012 {
-		yyb3012 = yyj3012 > l
+	var yyj3016 int
+	var yyb3016 bool
+	var yyhl3016 bool = l >= 0
+	yyj3016++
+	if yyhl3016 {
+		yyb3016 = yyj3016 > l
 	} else {
-		yyb3012 = r.CheckBreak()
+		yyb3016 = r.CheckBreak()
 	}
-	if yyb3012 {
+	if yyb3016 {
 		r.ReadEnd()
 		return
 	}
@@ -34788,13 +34818,13 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3012++
-	if yyhl3012 {
-		yyb3012 = yyj3012 > l
+	yyj3016++
+	if yyhl3016 {
+		yyb3016 = yyj3016 > l
 	} else {
-		yyb3012 = r.CheckBreak()
+		yyb3016 = r.CheckBreak()
 	}
-	if yyb3012 {
+	if yyb3016 {
 		r.ReadEnd()
 		return
 	}
@@ -34803,60 +34833,60 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3012++
-	if yyhl3012 {
-		yyb3012 = yyj3012 > l
+	yyj3016++
+	if yyhl3016 {
+		yyb3016 = yyj3016 > l
 	} else {
-		yyb3012 = r.CheckBreak()
+		yyb3016 = r.CheckBreak()
 	}
-	if yyb3012 {
+	if yyb3016 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3015 := &x.ListMeta
-		yym3016 := z.DecBinary()
-		_ = yym3016
+		yyv3019 := &x.ListMeta
+		yym3020 := z.DecBinary()
+		_ = yym3020
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3015) {
+		} else if z.HasExtensions() && z.DecExt(yyv3019) {
 		} else {
-			z.DecFallback(yyv3015, false)
+			z.DecFallback(yyv3019, false)
 		}
 	}
-	yyj3012++
-	if yyhl3012 {
-		yyb3012 = yyj3012 > l
+	yyj3016++
+	if yyhl3016 {
+		yyb3016 = yyj3016 > l
 	} else {
-		yyb3012 = r.CheckBreak()
+		yyb3016 = r.CheckBreak()
 	}
-	if yyb3012 {
+	if yyb3016 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3017 := &x.Items
-		yym3018 := z.DecBinary()
-		_ = yym3018
+		yyv3021 := &x.Items
+		yym3022 := z.DecBinary()
+		_ = yym3022
 		if false {
 		} else {
-			h.decSliceEvent((*[]Event)(yyv3017), d)
+			h.decSliceEvent((*[]Event)(yyv3021), d)
 		}
 	}
 	for {
-		yyj3012++
-		if yyhl3012 {
-			yyb3012 = yyj3012 > l
+		yyj3016++
+		if yyhl3016 {
+			yyb3016 = yyj3016 > l
 		} else {
-			yyb3012 = r.CheckBreak()
+			yyb3016 = r.CheckBreak()
 		}
-		if yyb3012 {
+		if yyb3016 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3012-1, "")
+		z.DecStructFieldNotFound(yyj3016-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34868,106 +34898,106 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3019 := z.EncBinary()
-		_ = yym3019
+		yym3023 := z.EncBinary()
+		_ = yym3023
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3020 := !z.EncBinary()
-			yy2arr3020 := z.EncBasicHandle().StructToArray
-			var yyq3020 [4]bool
-			_, _, _ = yysep3020, yyq3020, yy2arr3020
-			const yyr3020 bool = false
-			yyq3020[0] = x.Kind != ""
-			yyq3020[1] = x.APIVersion != ""
-			yyq3020[2] = true
-			if yyr3020 || yy2arr3020 {
+			yysep3024 := !z.EncBinary()
+			yy2arr3024 := z.EncBasicHandle().StructToArray
+			var yyq3024 [4]bool
+			_, _, _ = yysep3024, yyq3024, yy2arr3024
+			const yyr3024 bool = false
+			yyq3024[0] = x.Kind != ""
+			yyq3024[1] = x.APIVersion != ""
+			yyq3024[2] = true
+			if yyr3024 || yy2arr3024 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3020 int = 1
-				for _, b := range yyq3020 {
+				var yynn3024 int = 1
+				for _, b := range yyq3024 {
 					if b {
-						yynn3020++
+						yynn3024++
 					}
 				}
-				r.EncodeMapStart(yynn3020)
+				r.EncodeMapStart(yynn3024)
 			}
-			if yyr3020 || yy2arr3020 {
-				if yyq3020[0] {
-					yym3022 := z.EncBinary()
-					_ = yym3022
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3020[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3023 := z.EncBinary()
-					_ = yym3023
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3020 || yy2arr3020 {
-				if yyq3020[1] {
-					yym3025 := z.EncBinary()
-					_ = yym3025
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3020[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3024 || yy2arr3024 {
+				if yyq3024[0] {
 					yym3026 := z.EncBinary()
 					_ = yym3026
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3024[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3027 := z.EncBinary()
+					_ = yym3027
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3024 || yy2arr3024 {
+				if yyq3024[1] {
+					yym3029 := z.EncBinary()
+					_ = yym3029
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3024[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3030 := z.EncBinary()
+					_ = yym3030
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3020 || yy2arr3020 {
-				if yyq3020[2] {
-					yy3028 := &x.ListMeta
-					yym3029 := z.EncBinary()
-					_ = yym3029
+			if yyr3024 || yy2arr3024 {
+				if yyq3024[2] {
+					yy3032 := &x.ListMeta
+					yym3033 := z.EncBinary()
+					_ = yym3033
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3028) {
+					} else if z.HasExtensions() && z.EncExt(yy3032) {
 					} else {
-						z.EncFallback(yy3028)
+						z.EncFallback(yy3032)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3020[2] {
+				if yyq3024[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3030 := &x.ListMeta
-					yym3031 := z.EncBinary()
-					_ = yym3031
+					yy3034 := &x.ListMeta
+					yym3035 := z.EncBinary()
+					_ = yym3035
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3030) {
+					} else if z.HasExtensions() && z.EncExt(yy3034) {
 					} else {
-						z.EncFallback(yy3030)
+						z.EncFallback(yy3034)
 					}
 				}
 			}
-			if yyr3020 || yy2arr3020 {
+			if yyr3024 || yy2arr3024 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3033 := z.EncBinary()
-					_ = yym3033
+					yym3037 := z.EncBinary()
+					_ = yym3037
 					if false {
 					} else {
 						h.encSliceruntime_Object(([]pkg8_runtime.Object)(x.Items), e)
@@ -34978,15 +35008,15 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3034 := z.EncBinary()
-					_ = yym3034
+					yym3038 := z.EncBinary()
+					_ = yym3038
 					if false {
 					} else {
 						h.encSliceruntime_Object(([]pkg8_runtime.Object)(x.Items), e)
 					}
 				}
 			}
-			if yysep3020 {
+			if yysep3024 {
 				r.EncodeEnd()
 			}
 		}
@@ -34997,24 +35027,24 @@ func (x *List) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3035 := z.DecBinary()
-	_ = yym3035
+	yym3039 := z.DecBinary()
+	_ = yym3039
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3036 := r.ReadMapStart()
-			if yyl3036 == 0 {
+			yyl3040 := r.ReadMapStart()
+			if yyl3040 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3036, d)
+				x.codecDecodeSelfFromMap(yyl3040, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3036 := r.ReadArrayStart()
-			if yyl3036 == 0 {
+			yyl3040 := r.ReadArrayStart()
+			if yyl3040 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3036, d)
+				x.codecDecodeSelfFromArray(yyl3040, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35026,12 +35056,12 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3037Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3037Slc
-	var yyhl3037 bool = l >= 0
-	for yyj3037 := 0; ; yyj3037++ {
-		if yyhl3037 {
-			if yyj3037 >= l {
+	var yys3041Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3041Slc
+	var yyhl3041 bool = l >= 0
+	for yyj3041 := 0; ; yyj3041++ {
+		if yyhl3041 {
+			if yyj3041 >= l {
 				break
 			}
 		} else {
@@ -35039,9 +35069,9 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3037Slc = r.DecodeBytes(yys3037Slc, true, true)
-		yys3037 := string(yys3037Slc)
-		switch yys3037 {
+		yys3041Slc = r.DecodeBytes(yys3041Slc, true, true)
+		yys3041 := string(yys3041Slc)
+		switch yys3041 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35058,32 +35088,32 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3040 := &x.ListMeta
-				yym3041 := z.DecBinary()
-				_ = yym3041
+				yyv3044 := &x.ListMeta
+				yym3045 := z.DecBinary()
+				_ = yym3045
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3040) {
+				} else if z.HasExtensions() && z.DecExt(yyv3044) {
 				} else {
-					z.DecFallback(yyv3040, false)
+					z.DecFallback(yyv3044, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3042 := &x.Items
-				yym3043 := z.DecBinary()
-				_ = yym3043
+				yyv3046 := &x.Items
+				yym3047 := z.DecBinary()
+				_ = yym3047
 				if false {
 				} else {
-					h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3042), d)
+					h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3046), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3037)
-		} // end switch yys3037
-	} // end for yyj3037
-	if !yyhl3037 {
+			z.DecStructFieldNotFound(-1, yys3041)
+		} // end switch yys3041
+	} // end for yyj3041
+	if !yyhl3041 {
 		r.ReadEnd()
 	}
 }
@@ -35092,16 +35122,16 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3044 int
-	var yyb3044 bool
-	var yyhl3044 bool = l >= 0
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	var yyj3048 int
+	var yyb3048 bool
+	var yyhl3048 bool = l >= 0
+	yyj3048++
+	if yyhl3048 {
+		yyb3048 = yyj3048 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3048 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3048 {
 		r.ReadEnd()
 		return
 	}
@@ -35110,13 +35140,13 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	yyj3048++
+	if yyhl3048 {
+		yyb3048 = yyj3048 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3048 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3048 {
 		r.ReadEnd()
 		return
 	}
@@ -35125,60 +35155,60 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	yyj3048++
+	if yyhl3048 {
+		yyb3048 = yyj3048 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3048 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3048 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3047 := &x.ListMeta
-		yym3048 := z.DecBinary()
-		_ = yym3048
+		yyv3051 := &x.ListMeta
+		yym3052 := z.DecBinary()
+		_ = yym3052
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3047) {
+		} else if z.HasExtensions() && z.DecExt(yyv3051) {
 		} else {
-			z.DecFallback(yyv3047, false)
+			z.DecFallback(yyv3051, false)
 		}
 	}
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	yyj3048++
+	if yyhl3048 {
+		yyb3048 = yyj3048 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3048 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3048 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3049 := &x.Items
-		yym3050 := z.DecBinary()
-		_ = yym3050
+		yyv3053 := &x.Items
+		yym3054 := z.DecBinary()
+		_ = yym3054
 		if false {
 		} else {
-			h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3049), d)
+			h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3053), d)
 		}
 	}
 	for {
-		yyj3044++
-		if yyhl3044 {
-			yyb3044 = yyj3044 > l
+		yyj3048++
+		if yyhl3048 {
+			yyb3048 = yyj3048 > l
 		} else {
-			yyb3044 = r.CheckBreak()
+			yyb3048 = r.CheckBreak()
 		}
-		if yyb3044 {
+		if yyb3048 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3044-1, "")
+		z.DecStructFieldNotFound(yyj3048-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35187,8 +35217,8 @@ func (x LimitType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3051 := z.EncBinary()
-	_ = yym3051
+	yym3055 := z.EncBinary()
+	_ = yym3055
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -35200,8 +35230,8 @@ func (x *LimitType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3052 := z.DecBinary()
-	_ = yym3052
+	yym3056 := z.DecBinary()
+	_ = yym3056
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -35216,47 +35246,47 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3053 := z.EncBinary()
-		_ = yym3053
+		yym3057 := z.EncBinary()
+		_ = yym3057
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3054 := !z.EncBinary()
-			yy2arr3054 := z.EncBasicHandle().StructToArray
-			var yyq3054 [6]bool
-			_, _, _ = yysep3054, yyq3054, yy2arr3054
-			const yyr3054 bool = false
-			yyq3054[0] = x.Type != ""
-			yyq3054[1] = len(x.Max) != 0
-			yyq3054[2] = len(x.Min) != 0
-			yyq3054[3] = len(x.Default) != 0
-			yyq3054[4] = len(x.DefaultRequest) != 0
-			yyq3054[5] = len(x.MaxLimitRequestRatio) != 0
-			if yyr3054 || yy2arr3054 {
+			yysep3058 := !z.EncBinary()
+			yy2arr3058 := z.EncBasicHandle().StructToArray
+			var yyq3058 [6]bool
+			_, _, _ = yysep3058, yyq3058, yy2arr3058
+			const yyr3058 bool = false
+			yyq3058[0] = x.Type != ""
+			yyq3058[1] = len(x.Max) != 0
+			yyq3058[2] = len(x.Min) != 0
+			yyq3058[3] = len(x.Default) != 0
+			yyq3058[4] = len(x.DefaultRequest) != 0
+			yyq3058[5] = len(x.MaxLimitRequestRatio) != 0
+			if yyr3058 || yy2arr3058 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn3054 int = 0
-				for _, b := range yyq3054 {
+				var yynn3058 int = 0
+				for _, b := range yyq3058 {
 					if b {
-						yynn3054++
+						yynn3058++
 					}
 				}
-				r.EncodeMapStart(yynn3054)
+				r.EncodeMapStart(yynn3058)
 			}
-			if yyr3054 || yy2arr3054 {
-				if yyq3054[0] {
+			if yyr3058 || yy2arr3058 {
+				if yyq3058[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3054[0] {
+				if yyq3058[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3054 || yy2arr3054 {
-				if yyq3054[1] {
+			if yyr3058 || yy2arr3058 {
+				if yyq3058[1] {
 					if x.Max == nil {
 						r.EncodeNil()
 					} else {
@@ -35266,7 +35296,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3054[1] {
+				if yyq3058[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("max"))
 					if x.Max == nil {
 						r.EncodeNil()
@@ -35275,8 +35305,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3054 || yy2arr3054 {
-				if yyq3054[2] {
+			if yyr3058 || yy2arr3058 {
+				if yyq3058[2] {
 					if x.Min == nil {
 						r.EncodeNil()
 					} else {
@@ -35286,7 +35316,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3054[2] {
+				if yyq3058[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("min"))
 					if x.Min == nil {
 						r.EncodeNil()
@@ -35295,8 +35325,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3054 || yy2arr3054 {
-				if yyq3054[3] {
+			if yyr3058 || yy2arr3058 {
+				if yyq3058[3] {
 					if x.Default == nil {
 						r.EncodeNil()
 					} else {
@@ -35306,7 +35336,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3054[3] {
+				if yyq3058[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("default"))
 					if x.Default == nil {
 						r.EncodeNil()
@@ -35315,8 +35345,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3054 || yy2arr3054 {
-				if yyq3054[4] {
+			if yyr3058 || yy2arr3058 {
+				if yyq3058[4] {
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
 					} else {
@@ -35326,7 +35356,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3054[4] {
+				if yyq3058[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("defaultRequest"))
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
@@ -35335,8 +35365,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3054 || yy2arr3054 {
-				if yyq3054[5] {
+			if yyr3058 || yy2arr3058 {
+				if yyq3058[5] {
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
 					} else {
@@ -35346,7 +35376,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3054[5] {
+				if yyq3058[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxLimitRequestRatio"))
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
@@ -35355,7 +35385,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3054 {
+			if yysep3058 {
 				r.EncodeEnd()
 			}
 		}
@@ -35366,24 +35396,24 @@ func (x *LimitRangeItem) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3061 := z.DecBinary()
-	_ = yym3061
+	yym3065 := z.DecBinary()
+	_ = yym3065
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3062 := r.ReadMapStart()
-			if yyl3062 == 0 {
+			yyl3066 := r.ReadMapStart()
+			if yyl3066 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3062, d)
+				x.codecDecodeSelfFromMap(yyl3066, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3062 := r.ReadArrayStart()
-			if yyl3062 == 0 {
+			yyl3066 := r.ReadArrayStart()
+			if yyl3066 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3062, d)
+				x.codecDecodeSelfFromArray(yyl3066, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35395,12 +35425,12 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3063Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3063Slc
-	var yyhl3063 bool = l >= 0
-	for yyj3063 := 0; ; yyj3063++ {
-		if yyhl3063 {
-			if yyj3063 >= l {
+	var yys3067Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3067Slc
+	var yyhl3067 bool = l >= 0
+	for yyj3067 := 0; ; yyj3067++ {
+		if yyhl3067 {
+			if yyj3067 >= l {
 				break
 			}
 		} else {
@@ -35408,9 +35438,9 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3063Slc = r.DecodeBytes(yys3063Slc, true, true)
-		yys3063 := string(yys3063Slc)
-		switch yys3063 {
+		yys3067Slc = r.DecodeBytes(yys3067Slc, true, true)
+		yys3067 := string(yys3067Slc)
+		switch yys3067 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -35421,42 +35451,42 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Max = nil
 			} else {
-				yyv3065 := &x.Max
-				yyv3065.CodecDecodeSelf(d)
+				yyv3069 := &x.Max
+				yyv3069.CodecDecodeSelf(d)
 			}
 		case "min":
 			if r.TryDecodeAsNil() {
 				x.Min = nil
 			} else {
-				yyv3066 := &x.Min
-				yyv3066.CodecDecodeSelf(d)
+				yyv3070 := &x.Min
+				yyv3070.CodecDecodeSelf(d)
 			}
 		case "default":
 			if r.TryDecodeAsNil() {
 				x.Default = nil
 			} else {
-				yyv3067 := &x.Default
-				yyv3067.CodecDecodeSelf(d)
+				yyv3071 := &x.Default
+				yyv3071.CodecDecodeSelf(d)
 			}
 		case "defaultRequest":
 			if r.TryDecodeAsNil() {
 				x.DefaultRequest = nil
 			} else {
-				yyv3068 := &x.DefaultRequest
-				yyv3068.CodecDecodeSelf(d)
+				yyv3072 := &x.DefaultRequest
+				yyv3072.CodecDecodeSelf(d)
 			}
 		case "maxLimitRequestRatio":
 			if r.TryDecodeAsNil() {
 				x.MaxLimitRequestRatio = nil
 			} else {
-				yyv3069 := &x.MaxLimitRequestRatio
-				yyv3069.CodecDecodeSelf(d)
+				yyv3073 := &x.MaxLimitRequestRatio
+				yyv3073.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3063)
-		} // end switch yys3063
-	} // end for yyj3063
-	if !yyhl3063 {
+			z.DecStructFieldNotFound(-1, yys3067)
+		} // end switch yys3067
+	} // end for yyj3067
+	if !yyhl3067 {
 		r.ReadEnd()
 	}
 }
@@ -35465,16 +35495,16 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3070 int
-	var yyb3070 bool
-	var yyhl3070 bool = l >= 0
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	var yyj3074 int
+	var yyb3074 bool
+	var yyhl3074 bool = l >= 0
+	yyj3074++
+	if yyhl3074 {
+		yyb3074 = yyj3074 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3074 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3074 {
 		r.ReadEnd()
 		return
 	}
@@ -35483,97 +35513,97 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = LimitType(r.DecodeString())
 	}
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	yyj3074++
+	if yyhl3074 {
+		yyb3074 = yyj3074 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3074 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3074 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Max = nil
 	} else {
-		yyv3072 := &x.Max
-		yyv3072.CodecDecodeSelf(d)
+		yyv3076 := &x.Max
+		yyv3076.CodecDecodeSelf(d)
 	}
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	yyj3074++
+	if yyhl3074 {
+		yyb3074 = yyj3074 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3074 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3074 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Min = nil
 	} else {
-		yyv3073 := &x.Min
-		yyv3073.CodecDecodeSelf(d)
+		yyv3077 := &x.Min
+		yyv3077.CodecDecodeSelf(d)
 	}
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	yyj3074++
+	if yyhl3074 {
+		yyb3074 = yyj3074 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3074 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3074 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Default = nil
 	} else {
-		yyv3074 := &x.Default
-		yyv3074.CodecDecodeSelf(d)
+		yyv3078 := &x.Default
+		yyv3078.CodecDecodeSelf(d)
 	}
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	yyj3074++
+	if yyhl3074 {
+		yyb3074 = yyj3074 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3074 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3074 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.DefaultRequest = nil
 	} else {
-		yyv3075 := &x.DefaultRequest
-		yyv3075.CodecDecodeSelf(d)
+		yyv3079 := &x.DefaultRequest
+		yyv3079.CodecDecodeSelf(d)
 	}
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	yyj3074++
+	if yyhl3074 {
+		yyb3074 = yyj3074 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3074 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3074 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxLimitRequestRatio = nil
 	} else {
-		yyv3076 := &x.MaxLimitRequestRatio
-		yyv3076.CodecDecodeSelf(d)
+		yyv3080 := &x.MaxLimitRequestRatio
+		yyv3080.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3070++
-		if yyhl3070 {
-			yyb3070 = yyj3070 > l
+		yyj3074++
+		if yyhl3074 {
+			yyb3074 = yyj3074 > l
 		} else {
-			yyb3070 = r.CheckBreak()
+			yyb3074 = r.CheckBreak()
 		}
-		if yyb3070 {
+		if yyb3074 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3070-1, "")
+		z.DecStructFieldNotFound(yyj3074-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35585,33 +35615,33 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3077 := z.EncBinary()
-		_ = yym3077
+		yym3081 := z.EncBinary()
+		_ = yym3081
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3078 := !z.EncBinary()
-			yy2arr3078 := z.EncBasicHandle().StructToArray
-			var yyq3078 [1]bool
-			_, _, _ = yysep3078, yyq3078, yy2arr3078
-			const yyr3078 bool = false
-			if yyr3078 || yy2arr3078 {
+			yysep3082 := !z.EncBinary()
+			yy2arr3082 := z.EncBasicHandle().StructToArray
+			var yyq3082 [1]bool
+			_, _, _ = yysep3082, yyq3082, yy2arr3082
+			const yyr3082 bool = false
+			if yyr3082 || yy2arr3082 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3078 int = 1
-				for _, b := range yyq3078 {
+				var yynn3082 int = 1
+				for _, b := range yyq3082 {
 					if b {
-						yynn3078++
+						yynn3082++
 					}
 				}
-				r.EncodeMapStart(yynn3078)
+				r.EncodeMapStart(yynn3082)
 			}
-			if yyr3078 || yy2arr3078 {
+			if yyr3082 || yy2arr3082 {
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
-					yym3080 := z.EncBinary()
-					_ = yym3080
+					yym3084 := z.EncBinary()
+					_ = yym3084
 					if false {
 					} else {
 						h.encSliceLimitRangeItem(([]LimitRangeItem)(x.Limits), e)
@@ -35622,15 +35652,15 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
-					yym3081 := z.EncBinary()
-					_ = yym3081
+					yym3085 := z.EncBinary()
+					_ = yym3085
 					if false {
 					} else {
 						h.encSliceLimitRangeItem(([]LimitRangeItem)(x.Limits), e)
 					}
 				}
 			}
-			if yysep3078 {
+			if yysep3082 {
 				r.EncodeEnd()
 			}
 		}
@@ -35641,24 +35671,24 @@ func (x *LimitRangeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3082 := z.DecBinary()
-	_ = yym3082
+	yym3086 := z.DecBinary()
+	_ = yym3086
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3083 := r.ReadMapStart()
-			if yyl3083 == 0 {
+			yyl3087 := r.ReadMapStart()
+			if yyl3087 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3083, d)
+				x.codecDecodeSelfFromMap(yyl3087, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3083 := r.ReadArrayStart()
-			if yyl3083 == 0 {
+			yyl3087 := r.ReadArrayStart()
+			if yyl3087 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3083, d)
+				x.codecDecodeSelfFromArray(yyl3087, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35670,12 +35700,12 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3084Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3084Slc
-	var yyhl3084 bool = l >= 0
-	for yyj3084 := 0; ; yyj3084++ {
-		if yyhl3084 {
-			if yyj3084 >= l {
+	var yys3088Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3088Slc
+	var yyhl3088 bool = l >= 0
+	for yyj3088 := 0; ; yyj3088++ {
+		if yyhl3088 {
+			if yyj3088 >= l {
 				break
 			}
 		} else {
@@ -35683,26 +35713,26 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3084Slc = r.DecodeBytes(yys3084Slc, true, true)
-		yys3084 := string(yys3084Slc)
-		switch yys3084 {
+		yys3088Slc = r.DecodeBytes(yys3088Slc, true, true)
+		yys3088 := string(yys3088Slc)
+		switch yys3088 {
 		case "limits":
 			if r.TryDecodeAsNil() {
 				x.Limits = nil
 			} else {
-				yyv3085 := &x.Limits
-				yym3086 := z.DecBinary()
-				_ = yym3086
+				yyv3089 := &x.Limits
+				yym3090 := z.DecBinary()
+				_ = yym3090
 				if false {
 				} else {
-					h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3085), d)
+					h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3089), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3084)
-		} // end switch yys3084
-	} // end for yyj3084
-	if !yyhl3084 {
+			z.DecStructFieldNotFound(-1, yys3088)
+		} // end switch yys3088
+	} // end for yyj3088
+	if !yyhl3088 {
 		r.ReadEnd()
 	}
 }
@@ -35711,41 +35741,41 @@ func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3087 int
-	var yyb3087 bool
-	var yyhl3087 bool = l >= 0
-	yyj3087++
-	if yyhl3087 {
-		yyb3087 = yyj3087 > l
+	var yyj3091 int
+	var yyb3091 bool
+	var yyhl3091 bool = l >= 0
+	yyj3091++
+	if yyhl3091 {
+		yyb3091 = yyj3091 > l
 	} else {
-		yyb3087 = r.CheckBreak()
+		yyb3091 = r.CheckBreak()
 	}
-	if yyb3087 {
+	if yyb3091 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Limits = nil
 	} else {
-		yyv3088 := &x.Limits
-		yym3089 := z.DecBinary()
-		_ = yym3089
+		yyv3092 := &x.Limits
+		yym3093 := z.DecBinary()
+		_ = yym3093
 		if false {
 		} else {
-			h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3088), d)
+			h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3092), d)
 		}
 	}
 	for {
-		yyj3087++
-		if yyhl3087 {
-			yyb3087 = yyj3087 > l
+		yyj3091++
+		if yyhl3091 {
+			yyb3091 = yyj3091 > l
 		} else {
-			yyb3087 = r.CheckBreak()
+			yyb3091 = r.CheckBreak()
 		}
-		if yyb3087 {
+		if yyb3091 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3087-1, "")
+		z.DecStructFieldNotFound(yyj3091-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35757,104 +35787,104 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3090 := z.EncBinary()
-		_ = yym3090
+		yym3094 := z.EncBinary()
+		_ = yym3094
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3091 := !z.EncBinary()
-			yy2arr3091 := z.EncBasicHandle().StructToArray
-			var yyq3091 [4]bool
-			_, _, _ = yysep3091, yyq3091, yy2arr3091
-			const yyr3091 bool = false
-			yyq3091[0] = x.Kind != ""
-			yyq3091[1] = x.APIVersion != ""
-			yyq3091[2] = true
-			yyq3091[3] = true
-			if yyr3091 || yy2arr3091 {
+			yysep3095 := !z.EncBinary()
+			yy2arr3095 := z.EncBasicHandle().StructToArray
+			var yyq3095 [4]bool
+			_, _, _ = yysep3095, yyq3095, yy2arr3095
+			const yyr3095 bool = false
+			yyq3095[0] = x.Kind != ""
+			yyq3095[1] = x.APIVersion != ""
+			yyq3095[2] = true
+			yyq3095[3] = true
+			if yyr3095 || yy2arr3095 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3091 int = 0
-				for _, b := range yyq3091 {
+				var yynn3095 int = 0
+				for _, b := range yyq3095 {
 					if b {
-						yynn3091++
+						yynn3095++
 					}
 				}
-				r.EncodeMapStart(yynn3091)
+				r.EncodeMapStart(yynn3095)
 			}
-			if yyr3091 || yy2arr3091 {
-				if yyq3091[0] {
-					yym3093 := z.EncBinary()
-					_ = yym3093
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3091[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3094 := z.EncBinary()
-					_ = yym3094
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3091 || yy2arr3091 {
-				if yyq3091[1] {
-					yym3096 := z.EncBinary()
-					_ = yym3096
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3091[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3095 || yy2arr3095 {
+				if yyq3095[0] {
 					yym3097 := z.EncBinary()
 					_ = yym3097
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3095[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3098 := z.EncBinary()
+					_ = yym3098
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3095 || yy2arr3095 {
+				if yyq3095[1] {
+					yym3100 := z.EncBinary()
+					_ = yym3100
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3095[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3101 := z.EncBinary()
+					_ = yym3101
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3091 || yy2arr3091 {
-				if yyq3091[2] {
-					yy3099 := &x.ObjectMeta
-					yy3099.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3091[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3100 := &x.ObjectMeta
-					yy3100.CodecEncodeSelf(e)
-				}
-			}
-			if yyr3091 || yy2arr3091 {
-				if yyq3091[3] {
-					yy3102 := &x.Spec
-					yy3102.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3091[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy3103 := &x.Spec
+			if yyr3095 || yy2arr3095 {
+				if yyq3095[2] {
+					yy3103 := &x.ObjectMeta
 					yy3103.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3095[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3104 := &x.ObjectMeta
+					yy3104.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3091 {
+			if yyr3095 || yy2arr3095 {
+				if yyq3095[3] {
+					yy3106 := &x.Spec
+					yy3106.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3095[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy3107 := &x.Spec
+					yy3107.CodecEncodeSelf(e)
+				}
+			}
+			if yysep3095 {
 				r.EncodeEnd()
 			}
 		}
@@ -35865,24 +35895,24 @@ func (x *LimitRange) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3104 := z.DecBinary()
-	_ = yym3104
+	yym3108 := z.DecBinary()
+	_ = yym3108
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3105 := r.ReadMapStart()
-			if yyl3105 == 0 {
+			yyl3109 := r.ReadMapStart()
+			if yyl3109 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3105, d)
+				x.codecDecodeSelfFromMap(yyl3109, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3105 := r.ReadArrayStart()
-			if yyl3105 == 0 {
+			yyl3109 := r.ReadArrayStart()
+			if yyl3109 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3105, d)
+				x.codecDecodeSelfFromArray(yyl3109, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35894,12 +35924,12 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3106Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3106Slc
-	var yyhl3106 bool = l >= 0
-	for yyj3106 := 0; ; yyj3106++ {
-		if yyhl3106 {
-			if yyj3106 >= l {
+	var yys3110Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3110Slc
+	var yyhl3110 bool = l >= 0
+	for yyj3110 := 0; ; yyj3110++ {
+		if yyhl3110 {
+			if yyj3110 >= l {
 				break
 			}
 		} else {
@@ -35907,9 +35937,9 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3106Slc = r.DecodeBytes(yys3106Slc, true, true)
-		yys3106 := string(yys3106Slc)
-		switch yys3106 {
+		yys3110Slc = r.DecodeBytes(yys3110Slc, true, true)
+		yys3110 := string(yys3110Slc)
+		switch yys3110 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35926,21 +35956,21 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3109 := &x.ObjectMeta
-				yyv3109.CodecDecodeSelf(d)
+				yyv3113 := &x.ObjectMeta
+				yyv3113.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = LimitRangeSpec{}
 			} else {
-				yyv3110 := &x.Spec
-				yyv3110.CodecDecodeSelf(d)
+				yyv3114 := &x.Spec
+				yyv3114.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3106)
-		} // end switch yys3106
-	} // end for yyj3106
-	if !yyhl3106 {
+			z.DecStructFieldNotFound(-1, yys3110)
+		} // end switch yys3110
+	} // end for yyj3110
+	if !yyhl3110 {
 		r.ReadEnd()
 	}
 }
@@ -35949,16 +35979,16 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3111 int
-	var yyb3111 bool
-	var yyhl3111 bool = l >= 0
-	yyj3111++
-	if yyhl3111 {
-		yyb3111 = yyj3111 > l
+	var yyj3115 int
+	var yyb3115 bool
+	var yyhl3115 bool = l >= 0
+	yyj3115++
+	if yyhl3115 {
+		yyb3115 = yyj3115 > l
 	} else {
-		yyb3111 = r.CheckBreak()
+		yyb3115 = r.CheckBreak()
 	}
-	if yyb3111 {
+	if yyb3115 {
 		r.ReadEnd()
 		return
 	}
@@ -35967,13 +35997,13 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3111++
-	if yyhl3111 {
-		yyb3111 = yyj3111 > l
+	yyj3115++
+	if yyhl3115 {
+		yyb3115 = yyj3115 > l
 	} else {
-		yyb3111 = r.CheckBreak()
+		yyb3115 = r.CheckBreak()
 	}
-	if yyb3111 {
+	if yyb3115 {
 		r.ReadEnd()
 		return
 	}
@@ -35982,49 +36012,49 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3111++
-	if yyhl3111 {
-		yyb3111 = yyj3111 > l
+	yyj3115++
+	if yyhl3115 {
+		yyb3115 = yyj3115 > l
 	} else {
-		yyb3111 = r.CheckBreak()
+		yyb3115 = r.CheckBreak()
 	}
-	if yyb3111 {
+	if yyb3115 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3114 := &x.ObjectMeta
-		yyv3114.CodecDecodeSelf(d)
+		yyv3118 := &x.ObjectMeta
+		yyv3118.CodecDecodeSelf(d)
 	}
-	yyj3111++
-	if yyhl3111 {
-		yyb3111 = yyj3111 > l
+	yyj3115++
+	if yyhl3115 {
+		yyb3115 = yyj3115 > l
 	} else {
-		yyb3111 = r.CheckBreak()
+		yyb3115 = r.CheckBreak()
 	}
-	if yyb3111 {
+	if yyb3115 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = LimitRangeSpec{}
 	} else {
-		yyv3115 := &x.Spec
-		yyv3115.CodecDecodeSelf(d)
+		yyv3119 := &x.Spec
+		yyv3119.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3111++
-		if yyhl3111 {
-			yyb3111 = yyj3111 > l
+		yyj3115++
+		if yyhl3115 {
+			yyb3115 = yyj3115 > l
 		} else {
-			yyb3111 = r.CheckBreak()
+			yyb3115 = r.CheckBreak()
 		}
-		if yyb3111 {
+		if yyb3115 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3111-1, "")
+		z.DecStructFieldNotFound(yyj3115-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36036,106 +36066,106 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3116 := z.EncBinary()
-		_ = yym3116
+		yym3120 := z.EncBinary()
+		_ = yym3120
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3117 := !z.EncBinary()
-			yy2arr3117 := z.EncBasicHandle().StructToArray
-			var yyq3117 [4]bool
-			_, _, _ = yysep3117, yyq3117, yy2arr3117
-			const yyr3117 bool = false
-			yyq3117[0] = x.Kind != ""
-			yyq3117[1] = x.APIVersion != ""
-			yyq3117[2] = true
-			if yyr3117 || yy2arr3117 {
+			yysep3121 := !z.EncBinary()
+			yy2arr3121 := z.EncBasicHandle().StructToArray
+			var yyq3121 [4]bool
+			_, _, _ = yysep3121, yyq3121, yy2arr3121
+			const yyr3121 bool = false
+			yyq3121[0] = x.Kind != ""
+			yyq3121[1] = x.APIVersion != ""
+			yyq3121[2] = true
+			if yyr3121 || yy2arr3121 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3117 int = 1
-				for _, b := range yyq3117 {
+				var yynn3121 int = 1
+				for _, b := range yyq3121 {
 					if b {
-						yynn3117++
+						yynn3121++
 					}
 				}
-				r.EncodeMapStart(yynn3117)
+				r.EncodeMapStart(yynn3121)
 			}
-			if yyr3117 || yy2arr3117 {
-				if yyq3117[0] {
-					yym3119 := z.EncBinary()
-					_ = yym3119
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3117[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3120 := z.EncBinary()
-					_ = yym3120
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3117 || yy2arr3117 {
-				if yyq3117[1] {
-					yym3122 := z.EncBinary()
-					_ = yym3122
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3117[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3121 || yy2arr3121 {
+				if yyq3121[0] {
 					yym3123 := z.EncBinary()
 					_ = yym3123
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3121[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3124 := z.EncBinary()
+					_ = yym3124
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3121 || yy2arr3121 {
+				if yyq3121[1] {
+					yym3126 := z.EncBinary()
+					_ = yym3126
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3121[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3127 := z.EncBinary()
+					_ = yym3127
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3117 || yy2arr3117 {
-				if yyq3117[2] {
-					yy3125 := &x.ListMeta
-					yym3126 := z.EncBinary()
-					_ = yym3126
+			if yyr3121 || yy2arr3121 {
+				if yyq3121[2] {
+					yy3129 := &x.ListMeta
+					yym3130 := z.EncBinary()
+					_ = yym3130
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3125) {
+					} else if z.HasExtensions() && z.EncExt(yy3129) {
 					} else {
-						z.EncFallback(yy3125)
+						z.EncFallback(yy3129)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3117[2] {
+				if yyq3121[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3127 := &x.ListMeta
-					yym3128 := z.EncBinary()
-					_ = yym3128
+					yy3131 := &x.ListMeta
+					yym3132 := z.EncBinary()
+					_ = yym3132
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3127) {
+					} else if z.HasExtensions() && z.EncExt(yy3131) {
 					} else {
-						z.EncFallback(yy3127)
+						z.EncFallback(yy3131)
 					}
 				}
 			}
-			if yyr3117 || yy2arr3117 {
+			if yyr3121 || yy2arr3121 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3130 := z.EncBinary()
-					_ = yym3130
+					yym3134 := z.EncBinary()
+					_ = yym3134
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
@@ -36146,15 +36176,15 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3131 := z.EncBinary()
-					_ = yym3131
+					yym3135 := z.EncBinary()
+					_ = yym3135
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
 					}
 				}
 			}
-			if yysep3117 {
+			if yysep3121 {
 				r.EncodeEnd()
 			}
 		}
@@ -36165,24 +36195,24 @@ func (x *LimitRangeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3132 := z.DecBinary()
-	_ = yym3132
+	yym3136 := z.DecBinary()
+	_ = yym3136
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3133 := r.ReadMapStart()
-			if yyl3133 == 0 {
+			yyl3137 := r.ReadMapStart()
+			if yyl3137 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3133, d)
+				x.codecDecodeSelfFromMap(yyl3137, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3133 := r.ReadArrayStart()
-			if yyl3133 == 0 {
+			yyl3137 := r.ReadArrayStart()
+			if yyl3137 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3133, d)
+				x.codecDecodeSelfFromArray(yyl3137, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36194,12 +36224,12 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3134Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3134Slc
-	var yyhl3134 bool = l >= 0
-	for yyj3134 := 0; ; yyj3134++ {
-		if yyhl3134 {
-			if yyj3134 >= l {
+	var yys3138Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3138Slc
+	var yyhl3138 bool = l >= 0
+	for yyj3138 := 0; ; yyj3138++ {
+		if yyhl3138 {
+			if yyj3138 >= l {
 				break
 			}
 		} else {
@@ -36207,9 +36237,9 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3134Slc = r.DecodeBytes(yys3134Slc, true, true)
-		yys3134 := string(yys3134Slc)
-		switch yys3134 {
+		yys3138Slc = r.DecodeBytes(yys3138Slc, true, true)
+		yys3138 := string(yys3138Slc)
+		switch yys3138 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -36226,32 +36256,32 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3137 := &x.ListMeta
-				yym3138 := z.DecBinary()
-				_ = yym3138
+				yyv3141 := &x.ListMeta
+				yym3142 := z.DecBinary()
+				_ = yym3142
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3137) {
+				} else if z.HasExtensions() && z.DecExt(yyv3141) {
 				} else {
-					z.DecFallback(yyv3137, false)
+					z.DecFallback(yyv3141, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3139 := &x.Items
-				yym3140 := z.DecBinary()
-				_ = yym3140
+				yyv3143 := &x.Items
+				yym3144 := z.DecBinary()
+				_ = yym3144
 				if false {
 				} else {
-					h.decSliceLimitRange((*[]LimitRange)(yyv3139), d)
+					h.decSliceLimitRange((*[]LimitRange)(yyv3143), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3134)
-		} // end switch yys3134
-	} // end for yyj3134
-	if !yyhl3134 {
+			z.DecStructFieldNotFound(-1, yys3138)
+		} // end switch yys3138
+	} // end for yyj3138
+	if !yyhl3138 {
 		r.ReadEnd()
 	}
 }
@@ -36260,16 +36290,16 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3141 int
-	var yyb3141 bool
-	var yyhl3141 bool = l >= 0
-	yyj3141++
-	if yyhl3141 {
-		yyb3141 = yyj3141 > l
+	var yyj3145 int
+	var yyb3145 bool
+	var yyhl3145 bool = l >= 0
+	yyj3145++
+	if yyhl3145 {
+		yyb3145 = yyj3145 > l
 	} else {
-		yyb3141 = r.CheckBreak()
+		yyb3145 = r.CheckBreak()
 	}
-	if yyb3141 {
+	if yyb3145 {
 		r.ReadEnd()
 		return
 	}
@@ -36278,13 +36308,13 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3141++
-	if yyhl3141 {
-		yyb3141 = yyj3141 > l
+	yyj3145++
+	if yyhl3145 {
+		yyb3145 = yyj3145 > l
 	} else {
-		yyb3141 = r.CheckBreak()
+		yyb3145 = r.CheckBreak()
 	}
-	if yyb3141 {
+	if yyb3145 {
 		r.ReadEnd()
 		return
 	}
@@ -36293,60 +36323,60 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3141++
-	if yyhl3141 {
-		yyb3141 = yyj3141 > l
+	yyj3145++
+	if yyhl3145 {
+		yyb3145 = yyj3145 > l
 	} else {
-		yyb3141 = r.CheckBreak()
+		yyb3145 = r.CheckBreak()
 	}
-	if yyb3141 {
+	if yyb3145 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3144 := &x.ListMeta
-		yym3145 := z.DecBinary()
-		_ = yym3145
+		yyv3148 := &x.ListMeta
+		yym3149 := z.DecBinary()
+		_ = yym3149
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3144) {
+		} else if z.HasExtensions() && z.DecExt(yyv3148) {
 		} else {
-			z.DecFallback(yyv3144, false)
+			z.DecFallback(yyv3148, false)
 		}
 	}
-	yyj3141++
-	if yyhl3141 {
-		yyb3141 = yyj3141 > l
+	yyj3145++
+	if yyhl3145 {
+		yyb3145 = yyj3145 > l
 	} else {
-		yyb3141 = r.CheckBreak()
+		yyb3145 = r.CheckBreak()
 	}
-	if yyb3141 {
+	if yyb3145 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3146 := &x.Items
-		yym3147 := z.DecBinary()
-		_ = yym3147
+		yyv3150 := &x.Items
+		yym3151 := z.DecBinary()
+		_ = yym3151
 		if false {
 		} else {
-			h.decSliceLimitRange((*[]LimitRange)(yyv3146), d)
+			h.decSliceLimitRange((*[]LimitRange)(yyv3150), d)
 		}
 	}
 	for {
-		yyj3141++
-		if yyhl3141 {
-			yyb3141 = yyj3141 > l
+		yyj3145++
+		if yyhl3145 {
+			yyb3145 = yyj3145 > l
 		} else {
-			yyb3141 = r.CheckBreak()
+			yyb3145 = r.CheckBreak()
 		}
-		if yyb3141 {
+		if yyb3145 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3141-1, "")
+		z.DecStructFieldNotFound(yyj3145-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36358,30 +36388,30 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3148 := z.EncBinary()
-		_ = yym3148
+		yym3152 := z.EncBinary()
+		_ = yym3152
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3149 := !z.EncBinary()
-			yy2arr3149 := z.EncBasicHandle().StructToArray
-			var yyq3149 [1]bool
-			_, _, _ = yysep3149, yyq3149, yy2arr3149
-			const yyr3149 bool = false
-			yyq3149[0] = len(x.Hard) != 0
-			if yyr3149 || yy2arr3149 {
+			yysep3153 := !z.EncBinary()
+			yy2arr3153 := z.EncBasicHandle().StructToArray
+			var yyq3153 [1]bool
+			_, _, _ = yysep3153, yyq3153, yy2arr3153
+			const yyr3153 bool = false
+			yyq3153[0] = len(x.Hard) != 0
+			if yyr3153 || yy2arr3153 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3149 int = 0
-				for _, b := range yyq3149 {
+				var yynn3153 int = 0
+				for _, b := range yyq3153 {
 					if b {
-						yynn3149++
+						yynn3153++
 					}
 				}
-				r.EncodeMapStart(yynn3149)
+				r.EncodeMapStart(yynn3153)
 			}
-			if yyr3149 || yy2arr3149 {
-				if yyq3149[0] {
+			if yyr3153 || yy2arr3153 {
+				if yyq3153[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36391,7 +36421,7 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3149[0] {
+				if yyq3153[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36400,7 +36430,7 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3149 {
+			if yysep3153 {
 				r.EncodeEnd()
 			}
 		}
@@ -36411,24 +36441,24 @@ func (x *ResourceQuotaSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3151 := z.DecBinary()
-	_ = yym3151
+	yym3155 := z.DecBinary()
+	_ = yym3155
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3152 := r.ReadMapStart()
-			if yyl3152 == 0 {
+			yyl3156 := r.ReadMapStart()
+			if yyl3156 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3152, d)
+				x.codecDecodeSelfFromMap(yyl3156, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3152 := r.ReadArrayStart()
-			if yyl3152 == 0 {
+			yyl3156 := r.ReadArrayStart()
+			if yyl3156 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3152, d)
+				x.codecDecodeSelfFromArray(yyl3156, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36440,12 +36470,12 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3153Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3153Slc
-	var yyhl3153 bool = l >= 0
-	for yyj3153 := 0; ; yyj3153++ {
-		if yyhl3153 {
-			if yyj3153 >= l {
+	var yys3157Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3157Slc
+	var yyhl3157 bool = l >= 0
+	for yyj3157 := 0; ; yyj3157++ {
+		if yyhl3157 {
+			if yyj3157 >= l {
 				break
 			}
 		} else {
@@ -36453,21 +36483,21 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys3153Slc = r.DecodeBytes(yys3153Slc, true, true)
-		yys3153 := string(yys3153Slc)
-		switch yys3153 {
+		yys3157Slc = r.DecodeBytes(yys3157Slc, true, true)
+		yys3157 := string(yys3157Slc)
+		switch yys3157 {
 		case "hard":
 			if r.TryDecodeAsNil() {
 				x.Hard = nil
 			} else {
-				yyv3154 := &x.Hard
-				yyv3154.CodecDecodeSelf(d)
+				yyv3158 := &x.Hard
+				yyv3158.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3153)
-		} // end switch yys3153
-	} // end for yyj3153
-	if !yyhl3153 {
+			z.DecStructFieldNotFound(-1, yys3157)
+		} // end switch yys3157
+	} // end for yyj3157
+	if !yyhl3157 {
 		r.ReadEnd()
 	}
 }
@@ -36476,36 +36506,36 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3155 int
-	var yyb3155 bool
-	var yyhl3155 bool = l >= 0
-	yyj3155++
-	if yyhl3155 {
-		yyb3155 = yyj3155 > l
+	var yyj3159 int
+	var yyb3159 bool
+	var yyhl3159 bool = l >= 0
+	yyj3159++
+	if yyhl3159 {
+		yyb3159 = yyj3159 > l
 	} else {
-		yyb3155 = r.CheckBreak()
+		yyb3159 = r.CheckBreak()
 	}
-	if yyb3155 {
+	if yyb3159 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
-		yyv3156 := &x.Hard
-		yyv3156.CodecDecodeSelf(d)
+		yyv3160 := &x.Hard
+		yyv3160.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3155++
-		if yyhl3155 {
-			yyb3155 = yyj3155 > l
+		yyj3159++
+		if yyhl3159 {
+			yyb3159 = yyj3159 > l
 		} else {
-			yyb3155 = r.CheckBreak()
+			yyb3159 = r.CheckBreak()
 		}
-		if yyb3155 {
+		if yyb3159 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3155-1, "")
+		z.DecStructFieldNotFound(yyj3159-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36517,31 +36547,31 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3157 := z.EncBinary()
-		_ = yym3157
+		yym3161 := z.EncBinary()
+		_ = yym3161
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3158 := !z.EncBinary()
-			yy2arr3158 := z.EncBasicHandle().StructToArray
-			var yyq3158 [2]bool
-			_, _, _ = yysep3158, yyq3158, yy2arr3158
-			const yyr3158 bool = false
-			yyq3158[0] = len(x.Hard) != 0
-			yyq3158[1] = len(x.Used) != 0
-			if yyr3158 || yy2arr3158 {
+			yysep3162 := !z.EncBinary()
+			yy2arr3162 := z.EncBasicHandle().StructToArray
+			var yyq3162 [2]bool
+			_, _, _ = yysep3162, yyq3162, yy2arr3162
+			const yyr3162 bool = false
+			yyq3162[0] = len(x.Hard) != 0
+			yyq3162[1] = len(x.Used) != 0
+			if yyr3162 || yy2arr3162 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn3158 int = 0
-				for _, b := range yyq3158 {
+				var yynn3162 int = 0
+				for _, b := range yyq3162 {
 					if b {
-						yynn3158++
+						yynn3162++
 					}
 				}
-				r.EncodeMapStart(yynn3158)
+				r.EncodeMapStart(yynn3162)
 			}
-			if yyr3158 || yy2arr3158 {
-				if yyq3158[0] {
+			if yyr3162 || yy2arr3162 {
+				if yyq3162[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36551,7 +36581,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3158[0] {
+				if yyq3162[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36560,8 +36590,8 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3158 || yy2arr3158 {
-				if yyq3158[1] {
+			if yyr3162 || yy2arr3162 {
+				if yyq3162[1] {
 					if x.Used == nil {
 						r.EncodeNil()
 					} else {
@@ -36571,7 +36601,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3158[1] {
+				if yyq3162[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("used"))
 					if x.Used == nil {
 						r.EncodeNil()
@@ -36580,7 +36610,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3158 {
+			if yysep3162 {
 				r.EncodeEnd()
 			}
 		}
@@ -36591,24 +36621,24 @@ func (x *ResourceQuotaStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3161 := z.DecBinary()
-	_ = yym3161
+	yym3165 := z.DecBinary()
+	_ = yym3165
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3162 := r.ReadMapStart()
-			if yyl3162 == 0 {
+			yyl3166 := r.ReadMapStart()
+			if yyl3166 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3162, d)
+				x.codecDecodeSelfFromMap(yyl3166, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3162 := r.ReadArrayStart()
-			if yyl3162 == 0 {
+			yyl3166 := r.ReadArrayStart()
+			if yyl3166 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3162, d)
+				x.codecDecodeSelfFromArray(yyl3166, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36620,12 +36650,12 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3163Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3163Slc
-	var yyhl3163 bool = l >= 0
-	for yyj3163 := 0; ; yyj3163++ {
-		if yyhl3163 {
-			if yyj3163 >= l {
+	var yys3167Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3167Slc
+	var yyhl3167 bool = l >= 0
+	for yyj3167 := 0; ; yyj3167++ {
+		if yyhl3167 {
+			if yyj3167 >= l {
 				break
 			}
 		} else {
@@ -36633,28 +36663,28 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys3163Slc = r.DecodeBytes(yys3163Slc, true, true)
-		yys3163 := string(yys3163Slc)
-		switch yys3163 {
+		yys3167Slc = r.DecodeBytes(yys3167Slc, true, true)
+		yys3167 := string(yys3167Slc)
+		switch yys3167 {
 		case "hard":
 			if r.TryDecodeAsNil() {
 				x.Hard = nil
 			} else {
-				yyv3164 := &x.Hard
-				yyv3164.CodecDecodeSelf(d)
+				yyv3168 := &x.Hard
+				yyv3168.CodecDecodeSelf(d)
 			}
 		case "used":
 			if r.TryDecodeAsNil() {
 				x.Used = nil
 			} else {
-				yyv3165 := &x.Used
-				yyv3165.CodecDecodeSelf(d)
+				yyv3169 := &x.Used
+				yyv3169.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3163)
-		} // end switch yys3163
-	} // end for yyj3163
-	if !yyhl3163 {
+			z.DecStructFieldNotFound(-1, yys3167)
+		} // end switch yys3167
+	} // end for yyj3167
+	if !yyhl3167 {
 		r.ReadEnd()
 	}
 }
@@ -36663,52 +36693,52 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3166 int
-	var yyb3166 bool
-	var yyhl3166 bool = l >= 0
-	yyj3166++
-	if yyhl3166 {
-		yyb3166 = yyj3166 > l
+	var yyj3170 int
+	var yyb3170 bool
+	var yyhl3170 bool = l >= 0
+	yyj3170++
+	if yyhl3170 {
+		yyb3170 = yyj3170 > l
 	} else {
-		yyb3166 = r.CheckBreak()
+		yyb3170 = r.CheckBreak()
 	}
-	if yyb3166 {
+	if yyb3170 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
-		yyv3167 := &x.Hard
-		yyv3167.CodecDecodeSelf(d)
+		yyv3171 := &x.Hard
+		yyv3171.CodecDecodeSelf(d)
 	}
-	yyj3166++
-	if yyhl3166 {
-		yyb3166 = yyj3166 > l
+	yyj3170++
+	if yyhl3170 {
+		yyb3170 = yyj3170 > l
 	} else {
-		yyb3166 = r.CheckBreak()
+		yyb3170 = r.CheckBreak()
 	}
-	if yyb3166 {
+	if yyb3170 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Used = nil
 	} else {
-		yyv3168 := &x.Used
-		yyv3168.CodecDecodeSelf(d)
+		yyv3172 := &x.Used
+		yyv3172.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3166++
-		if yyhl3166 {
-			yyb3166 = yyj3166 > l
+		yyj3170++
+		if yyhl3170 {
+			yyb3170 = yyj3170 > l
 		} else {
-			yyb3166 = r.CheckBreak()
+			yyb3170 = r.CheckBreak()
 		}
-		if yyb3166 {
+		if yyb3170 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3166-1, "")
+		z.DecStructFieldNotFound(yyj3170-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36720,119 +36750,119 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3169 := z.EncBinary()
-		_ = yym3169
+		yym3173 := z.EncBinary()
+		_ = yym3173
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3170 := !z.EncBinary()
-			yy2arr3170 := z.EncBasicHandle().StructToArray
-			var yyq3170 [5]bool
-			_, _, _ = yysep3170, yyq3170, yy2arr3170
-			const yyr3170 bool = false
-			yyq3170[0] = x.Kind != ""
-			yyq3170[1] = x.APIVersion != ""
-			yyq3170[2] = true
-			yyq3170[3] = true
-			yyq3170[4] = true
-			if yyr3170 || yy2arr3170 {
+			yysep3174 := !z.EncBinary()
+			yy2arr3174 := z.EncBasicHandle().StructToArray
+			var yyq3174 [5]bool
+			_, _, _ = yysep3174, yyq3174, yy2arr3174
+			const yyr3174 bool = false
+			yyq3174[0] = x.Kind != ""
+			yyq3174[1] = x.APIVersion != ""
+			yyq3174[2] = true
+			yyq3174[3] = true
+			yyq3174[4] = true
+			if yyr3174 || yy2arr3174 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3170 int = 0
-				for _, b := range yyq3170 {
+				var yynn3174 int = 0
+				for _, b := range yyq3174 {
 					if b {
-						yynn3170++
+						yynn3174++
 					}
 				}
-				r.EncodeMapStart(yynn3170)
+				r.EncodeMapStart(yynn3174)
 			}
-			if yyr3170 || yy2arr3170 {
-				if yyq3170[0] {
-					yym3172 := z.EncBinary()
-					_ = yym3172
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3170[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3173 := z.EncBinary()
-					_ = yym3173
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3170 || yy2arr3170 {
-				if yyq3170[1] {
-					yym3175 := z.EncBinary()
-					_ = yym3175
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3170[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3174 || yy2arr3174 {
+				if yyq3174[0] {
 					yym3176 := z.EncBinary()
 					_ = yym3176
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3174[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3177 := z.EncBinary()
+					_ = yym3177
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3174 || yy2arr3174 {
+				if yyq3174[1] {
+					yym3179 := z.EncBinary()
+					_ = yym3179
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3174[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3180 := z.EncBinary()
+					_ = yym3180
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3170 || yy2arr3170 {
-				if yyq3170[2] {
-					yy3178 := &x.ObjectMeta
-					yy3178.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3170[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3179 := &x.ObjectMeta
-					yy3179.CodecEncodeSelf(e)
-				}
-			}
-			if yyr3170 || yy2arr3170 {
-				if yyq3170[3] {
-					yy3181 := &x.Spec
-					yy3181.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3170[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy3182 := &x.Spec
+			if yyr3174 || yy2arr3174 {
+				if yyq3174[2] {
+					yy3182 := &x.ObjectMeta
 					yy3182.CodecEncodeSelf(e)
-				}
-			}
-			if yyr3170 || yy2arr3170 {
-				if yyq3170[4] {
-					yy3184 := &x.Status
-					yy3184.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3170[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy3185 := &x.Status
-					yy3185.CodecEncodeSelf(e)
+				if yyq3174[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3183 := &x.ObjectMeta
+					yy3183.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3170 {
+			if yyr3174 || yy2arr3174 {
+				if yyq3174[3] {
+					yy3185 := &x.Spec
+					yy3185.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3174[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy3186 := &x.Spec
+					yy3186.CodecEncodeSelf(e)
+				}
+			}
+			if yyr3174 || yy2arr3174 {
+				if yyq3174[4] {
+					yy3188 := &x.Status
+					yy3188.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3174[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy3189 := &x.Status
+					yy3189.CodecEncodeSelf(e)
+				}
+			}
+			if yysep3174 {
 				r.EncodeEnd()
 			}
 		}
@@ -36843,24 +36873,24 @@ func (x *ResourceQuota) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3186 := z.DecBinary()
-	_ = yym3186
+	yym3190 := z.DecBinary()
+	_ = yym3190
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3187 := r.ReadMapStart()
-			if yyl3187 == 0 {
+			yyl3191 := r.ReadMapStart()
+			if yyl3191 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3187, d)
+				x.codecDecodeSelfFromMap(yyl3191, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3187 := r.ReadArrayStart()
-			if yyl3187 == 0 {
+			yyl3191 := r.ReadArrayStart()
+			if yyl3191 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3187, d)
+				x.codecDecodeSelfFromArray(yyl3191, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36872,12 +36902,12 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3188Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3188Slc
-	var yyhl3188 bool = l >= 0
-	for yyj3188 := 0; ; yyj3188++ {
-		if yyhl3188 {
-			if yyj3188 >= l {
+	var yys3192Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3192Slc
+	var yyhl3192 bool = l >= 0
+	for yyj3192 := 0; ; yyj3192++ {
+		if yyhl3192 {
+			if yyj3192 >= l {
 				break
 			}
 		} else {
@@ -36885,9 +36915,9 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3188Slc = r.DecodeBytes(yys3188Slc, true, true)
-		yys3188 := string(yys3188Slc)
-		switch yys3188 {
+		yys3192Slc = r.DecodeBytes(yys3192Slc, true, true)
+		yys3192 := string(yys3192Slc)
+		switch yys3192 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -36904,28 +36934,28 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3191 := &x.ObjectMeta
-				yyv3191.CodecDecodeSelf(d)
+				yyv3195 := &x.ObjectMeta
+				yyv3195.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ResourceQuotaSpec{}
 			} else {
-				yyv3192 := &x.Spec
-				yyv3192.CodecDecodeSelf(d)
+				yyv3196 := &x.Spec
+				yyv3196.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ResourceQuotaStatus{}
 			} else {
-				yyv3193 := &x.Status
-				yyv3193.CodecDecodeSelf(d)
+				yyv3197 := &x.Status
+				yyv3197.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3188)
-		} // end switch yys3188
-	} // end for yyj3188
-	if !yyhl3188 {
+			z.DecStructFieldNotFound(-1, yys3192)
+		} // end switch yys3192
+	} // end for yyj3192
+	if !yyhl3192 {
 		r.ReadEnd()
 	}
 }
@@ -36934,16 +36964,16 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3194 int
-	var yyb3194 bool
-	var yyhl3194 bool = l >= 0
-	yyj3194++
-	if yyhl3194 {
-		yyb3194 = yyj3194 > l
+	var yyj3198 int
+	var yyb3198 bool
+	var yyhl3198 bool = l >= 0
+	yyj3198++
+	if yyhl3198 {
+		yyb3198 = yyj3198 > l
 	} else {
-		yyb3194 = r.CheckBreak()
+		yyb3198 = r.CheckBreak()
 	}
-	if yyb3194 {
+	if yyb3198 {
 		r.ReadEnd()
 		return
 	}
@@ -36952,13 +36982,13 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3194++
-	if yyhl3194 {
-		yyb3194 = yyj3194 > l
+	yyj3198++
+	if yyhl3198 {
+		yyb3198 = yyj3198 > l
 	} else {
-		yyb3194 = r.CheckBreak()
+		yyb3198 = r.CheckBreak()
 	}
-	if yyb3194 {
+	if yyb3198 {
 		r.ReadEnd()
 		return
 	}
@@ -36967,65 +36997,65 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3194++
-	if yyhl3194 {
-		yyb3194 = yyj3194 > l
+	yyj3198++
+	if yyhl3198 {
+		yyb3198 = yyj3198 > l
 	} else {
-		yyb3194 = r.CheckBreak()
+		yyb3198 = r.CheckBreak()
 	}
-	if yyb3194 {
+	if yyb3198 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3197 := &x.ObjectMeta
-		yyv3197.CodecDecodeSelf(d)
+		yyv3201 := &x.ObjectMeta
+		yyv3201.CodecDecodeSelf(d)
 	}
-	yyj3194++
-	if yyhl3194 {
-		yyb3194 = yyj3194 > l
+	yyj3198++
+	if yyhl3198 {
+		yyb3198 = yyj3198 > l
 	} else {
-		yyb3194 = r.CheckBreak()
+		yyb3198 = r.CheckBreak()
 	}
-	if yyb3194 {
+	if yyb3198 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ResourceQuotaSpec{}
 	} else {
-		yyv3198 := &x.Spec
-		yyv3198.CodecDecodeSelf(d)
+		yyv3202 := &x.Spec
+		yyv3202.CodecDecodeSelf(d)
 	}
-	yyj3194++
-	if yyhl3194 {
-		yyb3194 = yyj3194 > l
+	yyj3198++
+	if yyhl3198 {
+		yyb3198 = yyj3198 > l
 	} else {
-		yyb3194 = r.CheckBreak()
+		yyb3198 = r.CheckBreak()
 	}
-	if yyb3194 {
+	if yyb3198 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ResourceQuotaStatus{}
 	} else {
-		yyv3199 := &x.Status
-		yyv3199.CodecDecodeSelf(d)
+		yyv3203 := &x.Status
+		yyv3203.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3194++
-		if yyhl3194 {
-			yyb3194 = yyj3194 > l
+		yyj3198++
+		if yyhl3198 {
+			yyb3198 = yyj3198 > l
 		} else {
-			yyb3194 = r.CheckBreak()
+			yyb3198 = r.CheckBreak()
 		}
-		if yyb3194 {
+		if yyb3198 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3194-1, "")
+		z.DecStructFieldNotFound(yyj3198-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37037,106 +37067,106 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3200 := z.EncBinary()
-		_ = yym3200
+		yym3204 := z.EncBinary()
+		_ = yym3204
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3201 := !z.EncBinary()
-			yy2arr3201 := z.EncBasicHandle().StructToArray
-			var yyq3201 [4]bool
-			_, _, _ = yysep3201, yyq3201, yy2arr3201
-			const yyr3201 bool = false
-			yyq3201[0] = x.Kind != ""
-			yyq3201[1] = x.APIVersion != ""
-			yyq3201[2] = true
-			if yyr3201 || yy2arr3201 {
+			yysep3205 := !z.EncBinary()
+			yy2arr3205 := z.EncBasicHandle().StructToArray
+			var yyq3205 [4]bool
+			_, _, _ = yysep3205, yyq3205, yy2arr3205
+			const yyr3205 bool = false
+			yyq3205[0] = x.Kind != ""
+			yyq3205[1] = x.APIVersion != ""
+			yyq3205[2] = true
+			if yyr3205 || yy2arr3205 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3201 int = 1
-				for _, b := range yyq3201 {
+				var yynn3205 int = 1
+				for _, b := range yyq3205 {
 					if b {
-						yynn3201++
+						yynn3205++
 					}
 				}
-				r.EncodeMapStart(yynn3201)
+				r.EncodeMapStart(yynn3205)
 			}
-			if yyr3201 || yy2arr3201 {
-				if yyq3201[0] {
-					yym3203 := z.EncBinary()
-					_ = yym3203
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3201[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3204 := z.EncBinary()
-					_ = yym3204
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3201 || yy2arr3201 {
-				if yyq3201[1] {
-					yym3206 := z.EncBinary()
-					_ = yym3206
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3201[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3205 || yy2arr3205 {
+				if yyq3205[0] {
 					yym3207 := z.EncBinary()
 					_ = yym3207
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3205[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3208 := z.EncBinary()
+					_ = yym3208
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3205 || yy2arr3205 {
+				if yyq3205[1] {
+					yym3210 := z.EncBinary()
+					_ = yym3210
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3205[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3211 := z.EncBinary()
+					_ = yym3211
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3201 || yy2arr3201 {
-				if yyq3201[2] {
-					yy3209 := &x.ListMeta
-					yym3210 := z.EncBinary()
-					_ = yym3210
+			if yyr3205 || yy2arr3205 {
+				if yyq3205[2] {
+					yy3213 := &x.ListMeta
+					yym3214 := z.EncBinary()
+					_ = yym3214
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3209) {
+					} else if z.HasExtensions() && z.EncExt(yy3213) {
 					} else {
-						z.EncFallback(yy3209)
+						z.EncFallback(yy3213)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3201[2] {
+				if yyq3205[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3211 := &x.ListMeta
-					yym3212 := z.EncBinary()
-					_ = yym3212
+					yy3215 := &x.ListMeta
+					yym3216 := z.EncBinary()
+					_ = yym3216
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3211) {
+					} else if z.HasExtensions() && z.EncExt(yy3215) {
 					} else {
-						z.EncFallback(yy3211)
+						z.EncFallback(yy3215)
 					}
 				}
 			}
-			if yyr3201 || yy2arr3201 {
+			if yyr3205 || yy2arr3205 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3214 := z.EncBinary()
-					_ = yym3214
+					yym3218 := z.EncBinary()
+					_ = yym3218
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
@@ -37147,15 +37177,15 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3215 := z.EncBinary()
-					_ = yym3215
+					yym3219 := z.EncBinary()
+					_ = yym3219
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
 					}
 				}
 			}
-			if yysep3201 {
+			if yysep3205 {
 				r.EncodeEnd()
 			}
 		}
@@ -37166,24 +37196,24 @@ func (x *ResourceQuotaList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3216 := z.DecBinary()
-	_ = yym3216
+	yym3220 := z.DecBinary()
+	_ = yym3220
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3217 := r.ReadMapStart()
-			if yyl3217 == 0 {
+			yyl3221 := r.ReadMapStart()
+			if yyl3221 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3217, d)
+				x.codecDecodeSelfFromMap(yyl3221, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3217 := r.ReadArrayStart()
-			if yyl3217 == 0 {
+			yyl3221 := r.ReadArrayStart()
+			if yyl3221 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3217, d)
+				x.codecDecodeSelfFromArray(yyl3221, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37195,12 +37225,12 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3218Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3218Slc
-	var yyhl3218 bool = l >= 0
-	for yyj3218 := 0; ; yyj3218++ {
-		if yyhl3218 {
-			if yyj3218 >= l {
+	var yys3222Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3222Slc
+	var yyhl3222 bool = l >= 0
+	for yyj3222 := 0; ; yyj3222++ {
+		if yyhl3222 {
+			if yyj3222 >= l {
 				break
 			}
 		} else {
@@ -37208,9 +37238,9 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys3218Slc = r.DecodeBytes(yys3218Slc, true, true)
-		yys3218 := string(yys3218Slc)
-		switch yys3218 {
+		yys3222Slc = r.DecodeBytes(yys3222Slc, true, true)
+		yys3222 := string(yys3222Slc)
+		switch yys3222 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37227,32 +37257,32 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3221 := &x.ListMeta
-				yym3222 := z.DecBinary()
-				_ = yym3222
+				yyv3225 := &x.ListMeta
+				yym3226 := z.DecBinary()
+				_ = yym3226
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3221) {
+				} else if z.HasExtensions() && z.DecExt(yyv3225) {
 				} else {
-					z.DecFallback(yyv3221, false)
+					z.DecFallback(yyv3225, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3223 := &x.Items
-				yym3224 := z.DecBinary()
-				_ = yym3224
+				yyv3227 := &x.Items
+				yym3228 := z.DecBinary()
+				_ = yym3228
 				if false {
 				} else {
-					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3223), d)
+					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3227), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3218)
-		} // end switch yys3218
-	} // end for yyj3218
-	if !yyhl3218 {
+			z.DecStructFieldNotFound(-1, yys3222)
+		} // end switch yys3222
+	} // end for yyj3222
+	if !yyhl3222 {
 		r.ReadEnd()
 	}
 }
@@ -37261,16 +37291,16 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3225 int
-	var yyb3225 bool
-	var yyhl3225 bool = l >= 0
-	yyj3225++
-	if yyhl3225 {
-		yyb3225 = yyj3225 > l
+	var yyj3229 int
+	var yyb3229 bool
+	var yyhl3229 bool = l >= 0
+	yyj3229++
+	if yyhl3229 {
+		yyb3229 = yyj3229 > l
 	} else {
-		yyb3225 = r.CheckBreak()
+		yyb3229 = r.CheckBreak()
 	}
-	if yyb3225 {
+	if yyb3229 {
 		r.ReadEnd()
 		return
 	}
@@ -37279,13 +37309,13 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3225++
-	if yyhl3225 {
-		yyb3225 = yyj3225 > l
+	yyj3229++
+	if yyhl3229 {
+		yyb3229 = yyj3229 > l
 	} else {
-		yyb3225 = r.CheckBreak()
+		yyb3229 = r.CheckBreak()
 	}
-	if yyb3225 {
+	if yyb3229 {
 		r.ReadEnd()
 		return
 	}
@@ -37294,60 +37324,60 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3225++
-	if yyhl3225 {
-		yyb3225 = yyj3225 > l
+	yyj3229++
+	if yyhl3229 {
+		yyb3229 = yyj3229 > l
 	} else {
-		yyb3225 = r.CheckBreak()
+		yyb3229 = r.CheckBreak()
 	}
-	if yyb3225 {
+	if yyb3229 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3228 := &x.ListMeta
-		yym3229 := z.DecBinary()
-		_ = yym3229
+		yyv3232 := &x.ListMeta
+		yym3233 := z.DecBinary()
+		_ = yym3233
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3228) {
+		} else if z.HasExtensions() && z.DecExt(yyv3232) {
 		} else {
-			z.DecFallback(yyv3228, false)
+			z.DecFallback(yyv3232, false)
 		}
 	}
-	yyj3225++
-	if yyhl3225 {
-		yyb3225 = yyj3225 > l
+	yyj3229++
+	if yyhl3229 {
+		yyb3229 = yyj3229 > l
 	} else {
-		yyb3225 = r.CheckBreak()
+		yyb3229 = r.CheckBreak()
 	}
-	if yyb3225 {
+	if yyb3229 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3230 := &x.Items
-		yym3231 := z.DecBinary()
-		_ = yym3231
+		yyv3234 := &x.Items
+		yym3235 := z.DecBinary()
+		_ = yym3235
 		if false {
 		} else {
-			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3230), d)
+			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3234), d)
 		}
 	}
 	for {
-		yyj3225++
-		if yyhl3225 {
-			yyb3225 = yyj3225 > l
+		yyj3229++
+		if yyhl3229 {
+			yyb3229 = yyj3229 > l
 		} else {
-			yyb3225 = r.CheckBreak()
+			yyb3229 = r.CheckBreak()
 		}
-		if yyb3225 {
+		if yyb3229 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3225-1, "")
+		z.DecStructFieldNotFound(yyj3229-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37359,97 +37389,97 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3232 := z.EncBinary()
-		_ = yym3232
+		yym3236 := z.EncBinary()
+		_ = yym3236
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3233 := !z.EncBinary()
-			yy2arr3233 := z.EncBasicHandle().StructToArray
-			var yyq3233 [5]bool
-			_, _, _ = yysep3233, yyq3233, yy2arr3233
-			const yyr3233 bool = false
-			yyq3233[0] = x.Kind != ""
-			yyq3233[1] = x.APIVersion != ""
-			yyq3233[2] = true
-			yyq3233[3] = len(x.Data) != 0
-			yyq3233[4] = x.Type != ""
-			if yyr3233 || yy2arr3233 {
+			yysep3237 := !z.EncBinary()
+			yy2arr3237 := z.EncBasicHandle().StructToArray
+			var yyq3237 [5]bool
+			_, _, _ = yysep3237, yyq3237, yy2arr3237
+			const yyr3237 bool = false
+			yyq3237[0] = x.Kind != ""
+			yyq3237[1] = x.APIVersion != ""
+			yyq3237[2] = true
+			yyq3237[3] = len(x.Data) != 0
+			yyq3237[4] = x.Type != ""
+			if yyr3237 || yy2arr3237 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3233 int = 0
-				for _, b := range yyq3233 {
+				var yynn3237 int = 0
+				for _, b := range yyq3237 {
 					if b {
-						yynn3233++
+						yynn3237++
 					}
 				}
-				r.EncodeMapStart(yynn3233)
+				r.EncodeMapStart(yynn3237)
 			}
-			if yyr3233 || yy2arr3233 {
-				if yyq3233[0] {
-					yym3235 := z.EncBinary()
-					_ = yym3235
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3233[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3236 := z.EncBinary()
-					_ = yym3236
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3233 || yy2arr3233 {
-				if yyq3233[1] {
-					yym3238 := z.EncBinary()
-					_ = yym3238
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3233[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3237 || yy2arr3237 {
+				if yyq3237[0] {
 					yym3239 := z.EncBinary()
 					_ = yym3239
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3237[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3240 := z.EncBinary()
+					_ = yym3240
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3237 || yy2arr3237 {
+				if yyq3237[1] {
+					yym3242 := z.EncBinary()
+					_ = yym3242
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3237[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3243 := z.EncBinary()
+					_ = yym3243
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3233 || yy2arr3233 {
-				if yyq3233[2] {
-					yy3241 := &x.ObjectMeta
-					yy3241.CodecEncodeSelf(e)
+			if yyr3237 || yy2arr3237 {
+				if yyq3237[2] {
+					yy3245 := &x.ObjectMeta
+					yy3245.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3233[2] {
+				if yyq3237[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3242 := &x.ObjectMeta
-					yy3242.CodecEncodeSelf(e)
+					yy3246 := &x.ObjectMeta
+					yy3246.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3233 || yy2arr3233 {
-				if yyq3233[3] {
+			if yyr3237 || yy2arr3237 {
+				if yyq3237[3] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3244 := z.EncBinary()
-						_ = yym3244
+						yym3248 := z.EncBinary()
+						_ = yym3248
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -37459,13 +37489,13 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3233[3] {
+				if yyq3237[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3245 := z.EncBinary()
-						_ = yym3245
+						yym3249 := z.EncBinary()
+						_ = yym3249
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -37473,19 +37503,19 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3233 || yy2arr3233 {
-				if yyq3233[4] {
+			if yyr3237 || yy2arr3237 {
+				if yyq3237[4] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3233[4] {
+				if yyq3237[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3233 {
+			if yysep3237 {
 				r.EncodeEnd()
 			}
 		}
@@ -37496,24 +37526,24 @@ func (x *Secret) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3247 := z.DecBinary()
-	_ = yym3247
+	yym3251 := z.DecBinary()
+	_ = yym3251
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3248 := r.ReadMapStart()
-			if yyl3248 == 0 {
+			yyl3252 := r.ReadMapStart()
+			if yyl3252 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3248, d)
+				x.codecDecodeSelfFromMap(yyl3252, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3248 := r.ReadArrayStart()
-			if yyl3248 == 0 {
+			yyl3252 := r.ReadArrayStart()
+			if yyl3252 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3248, d)
+				x.codecDecodeSelfFromArray(yyl3252, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37525,12 +37555,12 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3249Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3249Slc
-	var yyhl3249 bool = l >= 0
-	for yyj3249 := 0; ; yyj3249++ {
-		if yyhl3249 {
-			if yyj3249 >= l {
+	var yys3253Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3253Slc
+	var yyhl3253 bool = l >= 0
+	for yyj3253 := 0; ; yyj3253++ {
+		if yyhl3253 {
+			if yyj3253 >= l {
 				break
 			}
 		} else {
@@ -37538,9 +37568,9 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3249Slc = r.DecodeBytes(yys3249Slc, true, true)
-		yys3249 := string(yys3249Slc)
-		switch yys3249 {
+		yys3253Slc = r.DecodeBytes(yys3253Slc, true, true)
+		yys3253 := string(yys3253Slc)
+		switch yys3253 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37557,19 +37587,19 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3252 := &x.ObjectMeta
-				yyv3252.CodecDecodeSelf(d)
+				yyv3256 := &x.ObjectMeta
+				yyv3256.CodecDecodeSelf(d)
 			}
 		case "data":
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3253 := &x.Data
-				yym3254 := z.DecBinary()
-				_ = yym3254
+				yyv3257 := &x.Data
+				yym3258 := z.DecBinary()
+				_ = yym3258
 				if false {
 				} else {
-					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3253), d)
+					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3257), d)
 				}
 			}
 		case "type":
@@ -37579,10 +37609,10 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Type = SecretType(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3249)
-		} // end switch yys3249
-	} // end for yyj3249
-	if !yyhl3249 {
+			z.DecStructFieldNotFound(-1, yys3253)
+		} // end switch yys3253
+	} // end for yyj3253
+	if !yyhl3253 {
 		r.ReadEnd()
 	}
 }
@@ -37591,16 +37621,16 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3256 int
-	var yyb3256 bool
-	var yyhl3256 bool = l >= 0
-	yyj3256++
-	if yyhl3256 {
-		yyb3256 = yyj3256 > l
+	var yyj3260 int
+	var yyb3260 bool
+	var yyhl3260 bool = l >= 0
+	yyj3260++
+	if yyhl3260 {
+		yyb3260 = yyj3260 > l
 	} else {
-		yyb3256 = r.CheckBreak()
+		yyb3260 = r.CheckBreak()
 	}
-	if yyb3256 {
+	if yyb3260 {
 		r.ReadEnd()
 		return
 	}
@@ -37609,13 +37639,13 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3256++
-	if yyhl3256 {
-		yyb3256 = yyj3256 > l
+	yyj3260++
+	if yyhl3260 {
+		yyb3260 = yyj3260 > l
 	} else {
-		yyb3256 = r.CheckBreak()
+		yyb3260 = r.CheckBreak()
 	}
-	if yyb3256 {
+	if yyb3260 {
 		r.ReadEnd()
 		return
 	}
@@ -37624,50 +37654,50 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3256++
-	if yyhl3256 {
-		yyb3256 = yyj3256 > l
+	yyj3260++
+	if yyhl3260 {
+		yyb3260 = yyj3260 > l
 	} else {
-		yyb3256 = r.CheckBreak()
+		yyb3260 = r.CheckBreak()
 	}
-	if yyb3256 {
+	if yyb3260 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3259 := &x.ObjectMeta
-		yyv3259.CodecDecodeSelf(d)
+		yyv3263 := &x.ObjectMeta
+		yyv3263.CodecDecodeSelf(d)
 	}
-	yyj3256++
-	if yyhl3256 {
-		yyb3256 = yyj3256 > l
+	yyj3260++
+	if yyhl3260 {
+		yyb3260 = yyj3260 > l
 	} else {
-		yyb3256 = r.CheckBreak()
+		yyb3260 = r.CheckBreak()
 	}
-	if yyb3256 {
+	if yyb3260 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3260 := &x.Data
-		yym3261 := z.DecBinary()
-		_ = yym3261
+		yyv3264 := &x.Data
+		yym3265 := z.DecBinary()
+		_ = yym3265
 		if false {
 		} else {
-			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3260), d)
+			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3264), d)
 		}
 	}
-	yyj3256++
-	if yyhl3256 {
-		yyb3256 = yyj3256 > l
+	yyj3260++
+	if yyhl3260 {
+		yyb3260 = yyj3260 > l
 	} else {
-		yyb3256 = r.CheckBreak()
+		yyb3260 = r.CheckBreak()
 	}
-	if yyb3256 {
+	if yyb3260 {
 		r.ReadEnd()
 		return
 	}
@@ -37677,16 +37707,16 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Type = SecretType(r.DecodeString())
 	}
 	for {
-		yyj3256++
-		if yyhl3256 {
-			yyb3256 = yyj3256 > l
+		yyj3260++
+		if yyhl3260 {
+			yyb3260 = yyj3260 > l
 		} else {
-			yyb3256 = r.CheckBreak()
+			yyb3260 = r.CheckBreak()
 		}
-		if yyb3256 {
+		if yyb3260 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3256-1, "")
+		z.DecStructFieldNotFound(yyj3260-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37695,8 +37725,8 @@ func (x SecretType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3263 := z.EncBinary()
-	_ = yym3263
+	yym3267 := z.EncBinary()
+	_ = yym3267
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -37708,8 +37738,8 @@ func (x *SecretType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3264 := z.DecBinary()
-	_ = yym3264
+	yym3268 := z.DecBinary()
+	_ = yym3268
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -37724,106 +37754,106 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3265 := z.EncBinary()
-		_ = yym3265
+		yym3269 := z.EncBinary()
+		_ = yym3269
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3266 := !z.EncBinary()
-			yy2arr3266 := z.EncBasicHandle().StructToArray
-			var yyq3266 [4]bool
-			_, _, _ = yysep3266, yyq3266, yy2arr3266
-			const yyr3266 bool = false
-			yyq3266[0] = x.Kind != ""
-			yyq3266[1] = x.APIVersion != ""
-			yyq3266[2] = true
-			if yyr3266 || yy2arr3266 {
+			yysep3270 := !z.EncBinary()
+			yy2arr3270 := z.EncBasicHandle().StructToArray
+			var yyq3270 [4]bool
+			_, _, _ = yysep3270, yyq3270, yy2arr3270
+			const yyr3270 bool = false
+			yyq3270[0] = x.Kind != ""
+			yyq3270[1] = x.APIVersion != ""
+			yyq3270[2] = true
+			if yyr3270 || yy2arr3270 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3266 int = 1
-				for _, b := range yyq3266 {
+				var yynn3270 int = 1
+				for _, b := range yyq3270 {
 					if b {
-						yynn3266++
+						yynn3270++
 					}
 				}
-				r.EncodeMapStart(yynn3266)
+				r.EncodeMapStart(yynn3270)
 			}
-			if yyr3266 || yy2arr3266 {
-				if yyq3266[0] {
-					yym3268 := z.EncBinary()
-					_ = yym3268
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3266[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3269 := z.EncBinary()
-					_ = yym3269
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3266 || yy2arr3266 {
-				if yyq3266[1] {
-					yym3271 := z.EncBinary()
-					_ = yym3271
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3266[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3270 || yy2arr3270 {
+				if yyq3270[0] {
 					yym3272 := z.EncBinary()
 					_ = yym3272
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3270[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3273 := z.EncBinary()
+					_ = yym3273
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3270 || yy2arr3270 {
+				if yyq3270[1] {
+					yym3275 := z.EncBinary()
+					_ = yym3275
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3270[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3276 := z.EncBinary()
+					_ = yym3276
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3266 || yy2arr3266 {
-				if yyq3266[2] {
-					yy3274 := &x.ListMeta
-					yym3275 := z.EncBinary()
-					_ = yym3275
+			if yyr3270 || yy2arr3270 {
+				if yyq3270[2] {
+					yy3278 := &x.ListMeta
+					yym3279 := z.EncBinary()
+					_ = yym3279
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3274) {
+					} else if z.HasExtensions() && z.EncExt(yy3278) {
 					} else {
-						z.EncFallback(yy3274)
+						z.EncFallback(yy3278)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3266[2] {
+				if yyq3270[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3276 := &x.ListMeta
-					yym3277 := z.EncBinary()
-					_ = yym3277
+					yy3280 := &x.ListMeta
+					yym3281 := z.EncBinary()
+					_ = yym3281
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3276) {
+					} else if z.HasExtensions() && z.EncExt(yy3280) {
 					} else {
-						z.EncFallback(yy3276)
+						z.EncFallback(yy3280)
 					}
 				}
 			}
-			if yyr3266 || yy2arr3266 {
+			if yyr3270 || yy2arr3270 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3279 := z.EncBinary()
-					_ = yym3279
+					yym3283 := z.EncBinary()
+					_ = yym3283
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
@@ -37834,15 +37864,15 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3280 := z.EncBinary()
-					_ = yym3280
+					yym3284 := z.EncBinary()
+					_ = yym3284
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
 					}
 				}
 			}
-			if yysep3266 {
+			if yysep3270 {
 				r.EncodeEnd()
 			}
 		}
@@ -37853,24 +37883,24 @@ func (x *SecretList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3281 := z.DecBinary()
-	_ = yym3281
+	yym3285 := z.DecBinary()
+	_ = yym3285
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3282 := r.ReadMapStart()
-			if yyl3282 == 0 {
+			yyl3286 := r.ReadMapStart()
+			if yyl3286 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3282, d)
+				x.codecDecodeSelfFromMap(yyl3286, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3282 := r.ReadArrayStart()
-			if yyl3282 == 0 {
+			yyl3286 := r.ReadArrayStart()
+			if yyl3286 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3282, d)
+				x.codecDecodeSelfFromArray(yyl3286, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37882,12 +37912,12 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3283Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3283Slc
-	var yyhl3283 bool = l >= 0
-	for yyj3283 := 0; ; yyj3283++ {
-		if yyhl3283 {
-			if yyj3283 >= l {
+	var yys3287Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3287Slc
+	var yyhl3287 bool = l >= 0
+	for yyj3287 := 0; ; yyj3287++ {
+		if yyhl3287 {
+			if yyj3287 >= l {
 				break
 			}
 		} else {
@@ -37895,9 +37925,9 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3283Slc = r.DecodeBytes(yys3283Slc, true, true)
-		yys3283 := string(yys3283Slc)
-		switch yys3283 {
+		yys3287Slc = r.DecodeBytes(yys3287Slc, true, true)
+		yys3287 := string(yys3287Slc)
+		switch yys3287 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37914,32 +37944,32 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3286 := &x.ListMeta
-				yym3287 := z.DecBinary()
-				_ = yym3287
+				yyv3290 := &x.ListMeta
+				yym3291 := z.DecBinary()
+				_ = yym3291
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3286) {
+				} else if z.HasExtensions() && z.DecExt(yyv3290) {
 				} else {
-					z.DecFallback(yyv3286, false)
+					z.DecFallback(yyv3290, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3288 := &x.Items
-				yym3289 := z.DecBinary()
-				_ = yym3289
+				yyv3292 := &x.Items
+				yym3293 := z.DecBinary()
+				_ = yym3293
 				if false {
 				} else {
-					h.decSliceSecret((*[]Secret)(yyv3288), d)
+					h.decSliceSecret((*[]Secret)(yyv3292), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3283)
-		} // end switch yys3283
-	} // end for yyj3283
-	if !yyhl3283 {
+			z.DecStructFieldNotFound(-1, yys3287)
+		} // end switch yys3287
+	} // end for yyj3287
+	if !yyhl3287 {
 		r.ReadEnd()
 	}
 }
@@ -37948,16 +37978,16 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3290 int
-	var yyb3290 bool
-	var yyhl3290 bool = l >= 0
-	yyj3290++
-	if yyhl3290 {
-		yyb3290 = yyj3290 > l
+	var yyj3294 int
+	var yyb3294 bool
+	var yyhl3294 bool = l >= 0
+	yyj3294++
+	if yyhl3294 {
+		yyb3294 = yyj3294 > l
 	} else {
-		yyb3290 = r.CheckBreak()
+		yyb3294 = r.CheckBreak()
 	}
-	if yyb3290 {
+	if yyb3294 {
 		r.ReadEnd()
 		return
 	}
@@ -37966,13 +37996,13 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3290++
-	if yyhl3290 {
-		yyb3290 = yyj3290 > l
+	yyj3294++
+	if yyhl3294 {
+		yyb3294 = yyj3294 > l
 	} else {
-		yyb3290 = r.CheckBreak()
+		yyb3294 = r.CheckBreak()
 	}
-	if yyb3290 {
+	if yyb3294 {
 		r.ReadEnd()
 		return
 	}
@@ -37981,60 +38011,60 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3290++
-	if yyhl3290 {
-		yyb3290 = yyj3290 > l
+	yyj3294++
+	if yyhl3294 {
+		yyb3294 = yyj3294 > l
 	} else {
-		yyb3290 = r.CheckBreak()
+		yyb3294 = r.CheckBreak()
 	}
-	if yyb3290 {
+	if yyb3294 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3293 := &x.ListMeta
-		yym3294 := z.DecBinary()
-		_ = yym3294
+		yyv3297 := &x.ListMeta
+		yym3298 := z.DecBinary()
+		_ = yym3298
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3293) {
+		} else if z.HasExtensions() && z.DecExt(yyv3297) {
 		} else {
-			z.DecFallback(yyv3293, false)
+			z.DecFallback(yyv3297, false)
 		}
 	}
-	yyj3290++
-	if yyhl3290 {
-		yyb3290 = yyj3290 > l
+	yyj3294++
+	if yyhl3294 {
+		yyb3294 = yyj3294 > l
 	} else {
-		yyb3290 = r.CheckBreak()
+		yyb3294 = r.CheckBreak()
 	}
-	if yyb3290 {
+	if yyb3294 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3295 := &x.Items
-		yym3296 := z.DecBinary()
-		_ = yym3296
+		yyv3299 := &x.Items
+		yym3300 := z.DecBinary()
+		_ = yym3300
 		if false {
 		} else {
-			h.decSliceSecret((*[]Secret)(yyv3295), d)
+			h.decSliceSecret((*[]Secret)(yyv3299), d)
 		}
 	}
 	for {
-		yyj3290++
-		if yyhl3290 {
-			yyb3290 = yyj3290 > l
+		yyj3294++
+		if yyhl3294 {
+			yyb3294 = yyj3294 > l
 		} else {
-			yyb3290 = r.CheckBreak()
+			yyb3294 = r.CheckBreak()
 		}
-		if yyb3290 {
+		if yyb3294 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3290-1, "")
+		z.DecStructFieldNotFound(yyj3294-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38043,8 +38073,8 @@ func (x PatchType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3297 := z.EncBinary()
-	_ = yym3297
+	yym3301 := z.EncBinary()
+	_ = yym3301
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -38056,8 +38086,8 @@ func (x *PatchType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3298 := z.DecBinary()
-	_ = yym3298
+	yym3302 := z.DecBinary()
+	_ = yym3302
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -38069,8 +38099,8 @@ func (x ComponentConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3299 := z.EncBinary()
-	_ = yym3299
+	yym3303 := z.EncBinary()
+	_ = yym3303
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -38082,8 +38112,8 @@ func (x *ComponentConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3300 := z.DecBinary()
-	_ = yym3300
+	yym3304 := z.DecBinary()
+	_ = yym3304
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -38098,86 +38128,86 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3301 := z.EncBinary()
-		_ = yym3301
+		yym3305 := z.EncBinary()
+		_ = yym3305
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3302 := !z.EncBinary()
-			yy2arr3302 := z.EncBasicHandle().StructToArray
-			var yyq3302 [4]bool
-			_, _, _ = yysep3302, yyq3302, yy2arr3302
-			const yyr3302 bool = false
-			yyq3302[2] = x.Message != ""
-			yyq3302[3] = x.Error != ""
-			if yyr3302 || yy2arr3302 {
+			yysep3306 := !z.EncBinary()
+			yy2arr3306 := z.EncBasicHandle().StructToArray
+			var yyq3306 [4]bool
+			_, _, _ = yysep3306, yyq3306, yy2arr3306
+			const yyr3306 bool = false
+			yyq3306[2] = x.Message != ""
+			yyq3306[3] = x.Error != ""
+			if yyr3306 || yy2arr3306 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3302 int = 2
-				for _, b := range yyq3302 {
+				var yynn3306 int = 2
+				for _, b := range yyq3306 {
 					if b {
-						yynn3302++
+						yynn3306++
 					}
 				}
-				r.EncodeMapStart(yynn3302)
+				r.EncodeMapStart(yynn3306)
 			}
-			if yyr3302 || yy2arr3302 {
+			if yyr3306 || yy2arr3306 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr3302 || yy2arr3302 {
+			if yyr3306 || yy2arr3306 {
 				x.Status.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
 				x.Status.CodecEncodeSelf(e)
 			}
-			if yyr3302 || yy2arr3302 {
-				if yyq3302[2] {
-					yym3306 := z.EncBinary()
-					_ = yym3306
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3302[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym3307 := z.EncBinary()
-					_ = yym3307
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
-				}
-			}
-			if yyr3302 || yy2arr3302 {
-				if yyq3302[3] {
-					yym3309 := z.EncBinary()
-					_ = yym3309
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Error))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3302[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("error"))
+			if yyr3306 || yy2arr3306 {
+				if yyq3306[2] {
 					yym3310 := z.EncBinary()
 					_ = yym3310
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3306[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					yym3311 := z.EncBinary()
+					_ = yym3311
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
+					}
+				}
+			}
+			if yyr3306 || yy2arr3306 {
+				if yyq3306[3] {
+					yym3313 := z.EncBinary()
+					_ = yym3313
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Error))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3306[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("error"))
+					yym3314 := z.EncBinary()
+					_ = yym3314
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Error))
 					}
 				}
 			}
-			if yysep3302 {
+			if yysep3306 {
 				r.EncodeEnd()
 			}
 		}
@@ -38188,24 +38218,24 @@ func (x *ComponentCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3311 := z.DecBinary()
-	_ = yym3311
+	yym3315 := z.DecBinary()
+	_ = yym3315
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3312 := r.ReadMapStart()
-			if yyl3312 == 0 {
+			yyl3316 := r.ReadMapStart()
+			if yyl3316 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3312, d)
+				x.codecDecodeSelfFromMap(yyl3316, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3312 := r.ReadArrayStart()
-			if yyl3312 == 0 {
+			yyl3316 := r.ReadArrayStart()
+			if yyl3316 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3312, d)
+				x.codecDecodeSelfFromArray(yyl3316, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38217,12 +38247,12 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3313Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3313Slc
-	var yyhl3313 bool = l >= 0
-	for yyj3313 := 0; ; yyj3313++ {
-		if yyhl3313 {
-			if yyj3313 >= l {
+	var yys3317Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3317Slc
+	var yyhl3317 bool = l >= 0
+	for yyj3317 := 0; ; yyj3317++ {
+		if yyhl3317 {
+			if yyj3317 >= l {
 				break
 			}
 		} else {
@@ -38230,9 +38260,9 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys3313Slc = r.DecodeBytes(yys3313Slc, true, true)
-		yys3313 := string(yys3313Slc)
-		switch yys3313 {
+		yys3317Slc = r.DecodeBytes(yys3317Slc, true, true)
+		yys3317 := string(yys3317Slc)
+		switch yys3317 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -38258,10 +38288,10 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.Error = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3313)
-		} // end switch yys3313
-	} // end for yyj3313
-	if !yyhl3313 {
+			z.DecStructFieldNotFound(-1, yys3317)
+		} // end switch yys3317
+	} // end for yyj3317
+	if !yyhl3317 {
 		r.ReadEnd()
 	}
 }
@@ -38270,16 +38300,16 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3318 int
-	var yyb3318 bool
-	var yyhl3318 bool = l >= 0
-	yyj3318++
-	if yyhl3318 {
-		yyb3318 = yyj3318 > l
+	var yyj3322 int
+	var yyb3322 bool
+	var yyhl3322 bool = l >= 0
+	yyj3322++
+	if yyhl3322 {
+		yyb3322 = yyj3322 > l
 	} else {
-		yyb3318 = r.CheckBreak()
+		yyb3322 = r.CheckBreak()
 	}
-	if yyb3318 {
+	if yyb3322 {
 		r.ReadEnd()
 		return
 	}
@@ -38288,13 +38318,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = ComponentConditionType(r.DecodeString())
 	}
-	yyj3318++
-	if yyhl3318 {
-		yyb3318 = yyj3318 > l
+	yyj3322++
+	if yyhl3322 {
+		yyb3322 = yyj3322 > l
 	} else {
-		yyb3318 = r.CheckBreak()
+		yyb3322 = r.CheckBreak()
 	}
-	if yyb3318 {
+	if yyb3322 {
 		r.ReadEnd()
 		return
 	}
@@ -38303,13 +38333,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Status = ConditionStatus(r.DecodeString())
 	}
-	yyj3318++
-	if yyhl3318 {
-		yyb3318 = yyj3318 > l
+	yyj3322++
+	if yyhl3322 {
+		yyb3322 = yyj3322 > l
 	} else {
-		yyb3318 = r.CheckBreak()
+		yyb3322 = r.CheckBreak()
 	}
-	if yyb3318 {
+	if yyb3322 {
 		r.ReadEnd()
 		return
 	}
@@ -38318,13 +38348,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj3318++
-	if yyhl3318 {
-		yyb3318 = yyj3318 > l
+	yyj3322++
+	if yyhl3322 {
+		yyb3322 = yyj3322 > l
 	} else {
-		yyb3318 = r.CheckBreak()
+		yyb3322 = r.CheckBreak()
 	}
-	if yyb3318 {
+	if yyb3322 {
 		r.ReadEnd()
 		return
 	}
@@ -38334,16 +38364,16 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.Error = string(r.DecodeString())
 	}
 	for {
-		yyj3318++
-		if yyhl3318 {
-			yyb3318 = yyj3318 > l
+		yyj3322++
+		if yyhl3322 {
+			yyb3322 = yyj3322 > l
 		} else {
-			yyb3318 = r.CheckBreak()
+			yyb3322 = r.CheckBreak()
 		}
-		if yyb3318 {
+		if yyb3322 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3318-1, "")
+		z.DecStructFieldNotFound(yyj3322-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38355,96 +38385,96 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3323 := z.EncBinary()
-		_ = yym3323
+		yym3327 := z.EncBinary()
+		_ = yym3327
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3324 := !z.EncBinary()
-			yy2arr3324 := z.EncBasicHandle().StructToArray
-			var yyq3324 [4]bool
-			_, _, _ = yysep3324, yyq3324, yy2arr3324
-			const yyr3324 bool = false
-			yyq3324[0] = x.Kind != ""
-			yyq3324[1] = x.APIVersion != ""
-			yyq3324[2] = true
-			yyq3324[3] = len(x.Conditions) != 0
-			if yyr3324 || yy2arr3324 {
+			yysep3328 := !z.EncBinary()
+			yy2arr3328 := z.EncBasicHandle().StructToArray
+			var yyq3328 [4]bool
+			_, _, _ = yysep3328, yyq3328, yy2arr3328
+			const yyr3328 bool = false
+			yyq3328[0] = x.Kind != ""
+			yyq3328[1] = x.APIVersion != ""
+			yyq3328[2] = true
+			yyq3328[3] = len(x.Conditions) != 0
+			if yyr3328 || yy2arr3328 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3324 int = 0
-				for _, b := range yyq3324 {
+				var yynn3328 int = 0
+				for _, b := range yyq3328 {
 					if b {
-						yynn3324++
+						yynn3328++
 					}
 				}
-				r.EncodeMapStart(yynn3324)
+				r.EncodeMapStart(yynn3328)
 			}
-			if yyr3324 || yy2arr3324 {
-				if yyq3324[0] {
-					yym3326 := z.EncBinary()
-					_ = yym3326
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3324[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3327 := z.EncBinary()
-					_ = yym3327
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3324 || yy2arr3324 {
-				if yyq3324[1] {
-					yym3329 := z.EncBinary()
-					_ = yym3329
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3324[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3328 || yy2arr3328 {
+				if yyq3328[0] {
 					yym3330 := z.EncBinary()
 					_ = yym3330
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3328[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3331 := z.EncBinary()
+					_ = yym3331
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3328 || yy2arr3328 {
+				if yyq3328[1] {
+					yym3333 := z.EncBinary()
+					_ = yym3333
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3328[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3334 := z.EncBinary()
+					_ = yym3334
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3324 || yy2arr3324 {
-				if yyq3324[2] {
-					yy3332 := &x.ObjectMeta
-					yy3332.CodecEncodeSelf(e)
+			if yyr3328 || yy2arr3328 {
+				if yyq3328[2] {
+					yy3336 := &x.ObjectMeta
+					yy3336.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3324[2] {
+				if yyq3328[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3333 := &x.ObjectMeta
-					yy3333.CodecEncodeSelf(e)
+					yy3337 := &x.ObjectMeta
+					yy3337.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3324 || yy2arr3324 {
-				if yyq3324[3] {
+			if yyr3328 || yy2arr3328 {
+				if yyq3328[3] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3335 := z.EncBinary()
-						_ = yym3335
+						yym3339 := z.EncBinary()
+						_ = yym3339
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -38454,13 +38484,13 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3324[3] {
+				if yyq3328[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3336 := z.EncBinary()
-						_ = yym3336
+						yym3340 := z.EncBinary()
+						_ = yym3340
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -38468,7 +38498,7 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3324 {
+			if yysep3328 {
 				r.EncodeEnd()
 			}
 		}
@@ -38479,24 +38509,24 @@ func (x *ComponentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3337 := z.DecBinary()
-	_ = yym3337
+	yym3341 := z.DecBinary()
+	_ = yym3341
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3338 := r.ReadMapStart()
-			if yyl3338 == 0 {
+			yyl3342 := r.ReadMapStart()
+			if yyl3342 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3338, d)
+				x.codecDecodeSelfFromMap(yyl3342, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3338 := r.ReadArrayStart()
-			if yyl3338 == 0 {
+			yyl3342 := r.ReadArrayStart()
+			if yyl3342 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3338, d)
+				x.codecDecodeSelfFromArray(yyl3342, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38508,12 +38538,12 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3339Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3339Slc
-	var yyhl3339 bool = l >= 0
-	for yyj3339 := 0; ; yyj3339++ {
-		if yyhl3339 {
-			if yyj3339 >= l {
+	var yys3343Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3343Slc
+	var yyhl3343 bool = l >= 0
+	for yyj3343 := 0; ; yyj3343++ {
+		if yyhl3343 {
+			if yyj3343 >= l {
 				break
 			}
 		} else {
@@ -38521,9 +38551,9 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3339Slc = r.DecodeBytes(yys3339Slc, true, true)
-		yys3339 := string(yys3339Slc)
-		switch yys3339 {
+		yys3343Slc = r.DecodeBytes(yys3343Slc, true, true)
+		yys3343 := string(yys3343Slc)
+		switch yys3343 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38540,26 +38570,26 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3342 := &x.ObjectMeta
-				yyv3342.CodecDecodeSelf(d)
+				yyv3346 := &x.ObjectMeta
+				yyv3346.CodecDecodeSelf(d)
 			}
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv3343 := &x.Conditions
-				yym3344 := z.DecBinary()
-				_ = yym3344
+				yyv3347 := &x.Conditions
+				yym3348 := z.DecBinary()
+				_ = yym3348
 				if false {
 				} else {
-					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3343), d)
+					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3347), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3339)
-		} // end switch yys3339
-	} // end for yyj3339
-	if !yyhl3339 {
+			z.DecStructFieldNotFound(-1, yys3343)
+		} // end switch yys3343
+	} // end for yyj3343
+	if !yyhl3343 {
 		r.ReadEnd()
 	}
 }
@@ -38568,16 +38598,16 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3345 int
-	var yyb3345 bool
-	var yyhl3345 bool = l >= 0
-	yyj3345++
-	if yyhl3345 {
-		yyb3345 = yyj3345 > l
+	var yyj3349 int
+	var yyb3349 bool
+	var yyhl3349 bool = l >= 0
+	yyj3349++
+	if yyhl3349 {
+		yyb3349 = yyj3349 > l
 	} else {
-		yyb3345 = r.CheckBreak()
+		yyb3349 = r.CheckBreak()
 	}
-	if yyb3345 {
+	if yyb3349 {
 		r.ReadEnd()
 		return
 	}
@@ -38586,13 +38616,13 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3345++
-	if yyhl3345 {
-		yyb3345 = yyj3345 > l
+	yyj3349++
+	if yyhl3349 {
+		yyb3349 = yyj3349 > l
 	} else {
-		yyb3345 = r.CheckBreak()
+		yyb3349 = r.CheckBreak()
 	}
-	if yyb3345 {
+	if yyb3349 {
 		r.ReadEnd()
 		return
 	}
@@ -38601,54 +38631,54 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3345++
-	if yyhl3345 {
-		yyb3345 = yyj3345 > l
+	yyj3349++
+	if yyhl3349 {
+		yyb3349 = yyj3349 > l
 	} else {
-		yyb3345 = r.CheckBreak()
+		yyb3349 = r.CheckBreak()
 	}
-	if yyb3345 {
+	if yyb3349 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3348 := &x.ObjectMeta
-		yyv3348.CodecDecodeSelf(d)
+		yyv3352 := &x.ObjectMeta
+		yyv3352.CodecDecodeSelf(d)
 	}
-	yyj3345++
-	if yyhl3345 {
-		yyb3345 = yyj3345 > l
+	yyj3349++
+	if yyhl3349 {
+		yyb3349 = yyj3349 > l
 	} else {
-		yyb3345 = r.CheckBreak()
+		yyb3349 = r.CheckBreak()
 	}
-	if yyb3345 {
+	if yyb3349 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv3349 := &x.Conditions
-		yym3350 := z.DecBinary()
-		_ = yym3350
+		yyv3353 := &x.Conditions
+		yym3354 := z.DecBinary()
+		_ = yym3354
 		if false {
 		} else {
-			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3349), d)
+			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3353), d)
 		}
 	}
 	for {
-		yyj3345++
-		if yyhl3345 {
-			yyb3345 = yyj3345 > l
+		yyj3349++
+		if yyhl3349 {
+			yyb3349 = yyj3349 > l
 		} else {
-			yyb3345 = r.CheckBreak()
+			yyb3349 = r.CheckBreak()
 		}
-		if yyb3345 {
+		if yyb3349 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3345-1, "")
+		z.DecStructFieldNotFound(yyj3349-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38660,106 +38690,106 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3351 := z.EncBinary()
-		_ = yym3351
+		yym3355 := z.EncBinary()
+		_ = yym3355
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3352 := !z.EncBinary()
-			yy2arr3352 := z.EncBasicHandle().StructToArray
-			var yyq3352 [4]bool
-			_, _, _ = yysep3352, yyq3352, yy2arr3352
-			const yyr3352 bool = false
-			yyq3352[0] = x.Kind != ""
-			yyq3352[1] = x.APIVersion != ""
-			yyq3352[2] = true
-			if yyr3352 || yy2arr3352 {
+			yysep3356 := !z.EncBinary()
+			yy2arr3356 := z.EncBasicHandle().StructToArray
+			var yyq3356 [4]bool
+			_, _, _ = yysep3356, yyq3356, yy2arr3356
+			const yyr3356 bool = false
+			yyq3356[0] = x.Kind != ""
+			yyq3356[1] = x.APIVersion != ""
+			yyq3356[2] = true
+			if yyr3356 || yy2arr3356 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3352 int = 1
-				for _, b := range yyq3352 {
+				var yynn3356 int = 1
+				for _, b := range yyq3356 {
 					if b {
-						yynn3352++
+						yynn3356++
 					}
 				}
-				r.EncodeMapStart(yynn3352)
+				r.EncodeMapStart(yynn3356)
 			}
-			if yyr3352 || yy2arr3352 {
-				if yyq3352[0] {
-					yym3354 := z.EncBinary()
-					_ = yym3354
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3352[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3355 := z.EncBinary()
-					_ = yym3355
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3352 || yy2arr3352 {
-				if yyq3352[1] {
-					yym3357 := z.EncBinary()
-					_ = yym3357
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3352[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3356 || yy2arr3356 {
+				if yyq3356[0] {
 					yym3358 := z.EncBinary()
 					_ = yym3358
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3356[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3359 := z.EncBinary()
+					_ = yym3359
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3356 || yy2arr3356 {
+				if yyq3356[1] {
+					yym3361 := z.EncBinary()
+					_ = yym3361
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3356[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3362 := z.EncBinary()
+					_ = yym3362
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3352 || yy2arr3352 {
-				if yyq3352[2] {
-					yy3360 := &x.ListMeta
-					yym3361 := z.EncBinary()
-					_ = yym3361
+			if yyr3356 || yy2arr3356 {
+				if yyq3356[2] {
+					yy3364 := &x.ListMeta
+					yym3365 := z.EncBinary()
+					_ = yym3365
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3360) {
+					} else if z.HasExtensions() && z.EncExt(yy3364) {
 					} else {
-						z.EncFallback(yy3360)
+						z.EncFallback(yy3364)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3352[2] {
+				if yyq3356[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3362 := &x.ListMeta
-					yym3363 := z.EncBinary()
-					_ = yym3363
+					yy3366 := &x.ListMeta
+					yym3367 := z.EncBinary()
+					_ = yym3367
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3362) {
+					} else if z.HasExtensions() && z.EncExt(yy3366) {
 					} else {
-						z.EncFallback(yy3362)
+						z.EncFallback(yy3366)
 					}
 				}
 			}
-			if yyr3352 || yy2arr3352 {
+			if yyr3356 || yy2arr3356 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3365 := z.EncBinary()
-					_ = yym3365
+					yym3369 := z.EncBinary()
+					_ = yym3369
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
@@ -38770,15 +38800,15 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3366 := z.EncBinary()
-					_ = yym3366
+					yym3370 := z.EncBinary()
+					_ = yym3370
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
 					}
 				}
 			}
-			if yysep3352 {
+			if yysep3356 {
 				r.EncodeEnd()
 			}
 		}
@@ -38789,24 +38819,24 @@ func (x *ComponentStatusList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3367 := z.DecBinary()
-	_ = yym3367
+	yym3371 := z.DecBinary()
+	_ = yym3371
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3368 := r.ReadMapStart()
-			if yyl3368 == 0 {
+			yyl3372 := r.ReadMapStart()
+			if yyl3372 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3368, d)
+				x.codecDecodeSelfFromMap(yyl3372, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3368 := r.ReadArrayStart()
-			if yyl3368 == 0 {
+			yyl3372 := r.ReadArrayStart()
+			if yyl3372 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3368, d)
+				x.codecDecodeSelfFromArray(yyl3372, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38818,12 +38848,12 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3369Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3369Slc
-	var yyhl3369 bool = l >= 0
-	for yyj3369 := 0; ; yyj3369++ {
-		if yyhl3369 {
-			if yyj3369 >= l {
+	var yys3373Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3373Slc
+	var yyhl3373 bool = l >= 0
+	for yyj3373 := 0; ; yyj3373++ {
+		if yyhl3373 {
+			if yyj3373 >= l {
 				break
 			}
 		} else {
@@ -38831,9 +38861,9 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys3369Slc = r.DecodeBytes(yys3369Slc, true, true)
-		yys3369 := string(yys3369Slc)
-		switch yys3369 {
+		yys3373Slc = r.DecodeBytes(yys3373Slc, true, true)
+		yys3373 := string(yys3373Slc)
+		switch yys3373 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38850,32 +38880,32 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3372 := &x.ListMeta
-				yym3373 := z.DecBinary()
-				_ = yym3373
+				yyv3376 := &x.ListMeta
+				yym3377 := z.DecBinary()
+				_ = yym3377
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3372) {
+				} else if z.HasExtensions() && z.DecExt(yyv3376) {
 				} else {
-					z.DecFallback(yyv3372, false)
+					z.DecFallback(yyv3376, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3374 := &x.Items
-				yym3375 := z.DecBinary()
-				_ = yym3375
+				yyv3378 := &x.Items
+				yym3379 := z.DecBinary()
+				_ = yym3379
 				if false {
 				} else {
-					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3374), d)
+					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3378), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3369)
-		} // end switch yys3369
-	} // end for yyj3369
-	if !yyhl3369 {
+			z.DecStructFieldNotFound(-1, yys3373)
+		} // end switch yys3373
+	} // end for yyj3373
+	if !yyhl3373 {
 		r.ReadEnd()
 	}
 }
@@ -38884,16 +38914,16 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3376 int
-	var yyb3376 bool
-	var yyhl3376 bool = l >= 0
-	yyj3376++
-	if yyhl3376 {
-		yyb3376 = yyj3376 > l
+	var yyj3380 int
+	var yyb3380 bool
+	var yyhl3380 bool = l >= 0
+	yyj3380++
+	if yyhl3380 {
+		yyb3380 = yyj3380 > l
 	} else {
-		yyb3376 = r.CheckBreak()
+		yyb3380 = r.CheckBreak()
 	}
-	if yyb3376 {
+	if yyb3380 {
 		r.ReadEnd()
 		return
 	}
@@ -38902,13 +38932,13 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3376++
-	if yyhl3376 {
-		yyb3376 = yyj3376 > l
+	yyj3380++
+	if yyhl3380 {
+		yyb3380 = yyj3380 > l
 	} else {
-		yyb3376 = r.CheckBreak()
+		yyb3380 = r.CheckBreak()
 	}
-	if yyb3376 {
+	if yyb3380 {
 		r.ReadEnd()
 		return
 	}
@@ -38917,60 +38947,60 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3376++
-	if yyhl3376 {
-		yyb3376 = yyj3376 > l
+	yyj3380++
+	if yyhl3380 {
+		yyb3380 = yyj3380 > l
 	} else {
-		yyb3376 = r.CheckBreak()
+		yyb3380 = r.CheckBreak()
 	}
-	if yyb3376 {
+	if yyb3380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3379 := &x.ListMeta
-		yym3380 := z.DecBinary()
-		_ = yym3380
+		yyv3383 := &x.ListMeta
+		yym3384 := z.DecBinary()
+		_ = yym3384
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3379) {
+		} else if z.HasExtensions() && z.DecExt(yyv3383) {
 		} else {
-			z.DecFallback(yyv3379, false)
+			z.DecFallback(yyv3383, false)
 		}
 	}
-	yyj3376++
-	if yyhl3376 {
-		yyb3376 = yyj3376 > l
+	yyj3380++
+	if yyhl3380 {
+		yyb3380 = yyj3380 > l
 	} else {
-		yyb3376 = r.CheckBreak()
+		yyb3380 = r.CheckBreak()
 	}
-	if yyb3376 {
+	if yyb3380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3381 := &x.Items
-		yym3382 := z.DecBinary()
-		_ = yym3382
+		yyv3385 := &x.Items
+		yym3386 := z.DecBinary()
+		_ = yym3386
 		if false {
 		} else {
-			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3381), d)
+			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3385), d)
 		}
 	}
 	for {
-		yyj3376++
-		if yyhl3376 {
-			yyb3376 = yyj3376 > l
+		yyj3380++
+		if yyhl3380 {
+			yyb3380 = yyj3380 > l
 		} else {
-			yyb3376 = r.CheckBreak()
+			yyb3380 = r.CheckBreak()
 		}
-		if yyb3376 {
+		if yyb3380 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3376-1, "")
+		z.DecStructFieldNotFound(yyj3380-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38982,34 +39012,34 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3383 := z.EncBinary()
-		_ = yym3383
+		yym3387 := z.EncBinary()
+		_ = yym3387
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3384 := !z.EncBinary()
-			yy2arr3384 := z.EncBasicHandle().StructToArray
-			var yyq3384 [5]bool
-			_, _, _ = yysep3384, yyq3384, yy2arr3384
-			const yyr3384 bool = false
-			yyq3384[0] = x.Capabilities != nil
-			yyq3384[1] = x.Privileged != nil
-			yyq3384[2] = x.SELinuxOptions != nil
-			yyq3384[3] = x.RunAsUser != nil
-			yyq3384[4] = x.RunAsNonRoot != nil
-			if yyr3384 || yy2arr3384 {
+			yysep3388 := !z.EncBinary()
+			yy2arr3388 := z.EncBasicHandle().StructToArray
+			var yyq3388 [5]bool
+			_, _, _ = yysep3388, yyq3388, yy2arr3388
+			const yyr3388 bool = false
+			yyq3388[0] = x.Capabilities != nil
+			yyq3388[1] = x.Privileged != nil
+			yyq3388[2] = x.SELinuxOptions != nil
+			yyq3388[3] = x.RunAsUser != nil
+			yyq3388[4] = x.RunAsNonRoot != nil
+			if yyr3388 || yy2arr3388 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3384 int = 0
-				for _, b := range yyq3384 {
+				var yynn3388 int = 0
+				for _, b := range yyq3388 {
 					if b {
-						yynn3384++
+						yynn3388++
 					}
 				}
-				r.EncodeMapStart(yynn3384)
+				r.EncodeMapStart(yynn3388)
 			}
-			if yyr3384 || yy2arr3384 {
-				if yyq3384[0] {
+			if yyr3388 || yy2arr3388 {
+				if yyq3388[0] {
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
@@ -39019,7 +39049,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3384[0] {
+				if yyq3388[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("capabilities"))
 					if x.Capabilities == nil {
 						r.EncodeNil()
@@ -39028,40 +39058,40 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3384 || yy2arr3384 {
-				if yyq3384[1] {
+			if yyr3388 || yy2arr3388 {
+				if yyq3388[1] {
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
-						yy3387 := *x.Privileged
-						yym3388 := z.EncBinary()
-						_ = yym3388
+						yy3391 := *x.Privileged
+						yym3392 := z.EncBinary()
+						_ = yym3392
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3387))
+							r.EncodeBool(bool(yy3391))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3384[1] {
+				if yyq3388[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("privileged"))
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
-						yy3389 := *x.Privileged
-						yym3390 := z.EncBinary()
-						_ = yym3390
+						yy3393 := *x.Privileged
+						yym3394 := z.EncBinary()
+						_ = yym3394
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3389))
+							r.EncodeBool(bool(yy3393))
 						}
 					}
 				}
 			}
-			if yyr3384 || yy2arr3384 {
-				if yyq3384[2] {
+			if yyr3388 || yy2arr3388 {
+				if yyq3388[2] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -39071,7 +39101,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3384[2] {
+				if yyq3388[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -39080,71 +39110,71 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3384 || yy2arr3384 {
-				if yyq3384[3] {
+			if yyr3388 || yy2arr3388 {
+				if yyq3388[3] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy3393 := *x.RunAsUser
-						yym3394 := z.EncBinary()
-						_ = yym3394
+						yy3397 := *x.RunAsUser
+						yym3398 := z.EncBinary()
+						_ = yym3398
 						if false {
 						} else {
-							r.EncodeInt(int64(yy3393))
+							r.EncodeInt(int64(yy3397))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3384[3] {
+				if yyq3388[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy3395 := *x.RunAsUser
-						yym3396 := z.EncBinary()
-						_ = yym3396
+						yy3399 := *x.RunAsUser
+						yym3400 := z.EncBinary()
+						_ = yym3400
 						if false {
 						} else {
-							r.EncodeInt(int64(yy3395))
+							r.EncodeInt(int64(yy3399))
 						}
 					}
 				}
 			}
-			if yyr3384 || yy2arr3384 {
-				if yyq3384[4] {
+			if yyr3388 || yy2arr3388 {
+				if yyq3388[4] {
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
-						yy3398 := *x.RunAsNonRoot
-						yym3399 := z.EncBinary()
-						_ = yym3399
+						yy3402 := *x.RunAsNonRoot
+						yym3403 := z.EncBinary()
+						_ = yym3403
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3398))
+							r.EncodeBool(bool(yy3402))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3384[4] {
+				if yyq3388[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
-						yy3400 := *x.RunAsNonRoot
-						yym3401 := z.EncBinary()
-						_ = yym3401
+						yy3404 := *x.RunAsNonRoot
+						yym3405 := z.EncBinary()
+						_ = yym3405
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3400))
+							r.EncodeBool(bool(yy3404))
 						}
 					}
 				}
 			}
-			if yysep3384 {
+			if yysep3388 {
 				r.EncodeEnd()
 			}
 		}
@@ -39155,24 +39185,24 @@ func (x *SecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3402 := z.DecBinary()
-	_ = yym3402
+	yym3406 := z.DecBinary()
+	_ = yym3406
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3403 := r.ReadMapStart()
-			if yyl3403 == 0 {
+			yyl3407 := r.ReadMapStart()
+			if yyl3407 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3403, d)
+				x.codecDecodeSelfFromMap(yyl3407, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3403 := r.ReadArrayStart()
-			if yyl3403 == 0 {
+			yyl3407 := r.ReadArrayStart()
+			if yyl3407 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3403, d)
+				x.codecDecodeSelfFromArray(yyl3407, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39184,12 +39214,12 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3404Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3404Slc
-	var yyhl3404 bool = l >= 0
-	for yyj3404 := 0; ; yyj3404++ {
-		if yyhl3404 {
-			if yyj3404 >= l {
+	var yys3408Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3408Slc
+	var yyhl3408 bool = l >= 0
+	for yyj3408 := 0; ; yyj3408++ {
+		if yyhl3408 {
+			if yyj3408 >= l {
 				break
 			}
 		} else {
@@ -39197,9 +39227,9 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3404Slc = r.DecodeBytes(yys3404Slc, true, true)
-		yys3404 := string(yys3404Slc)
-		switch yys3404 {
+		yys3408Slc = r.DecodeBytes(yys3408Slc, true, true)
+		yys3408 := string(yys3408Slc)
+		switch yys3408 {
 		case "capabilities":
 			if r.TryDecodeAsNil() {
 				if x.Capabilities != nil {
@@ -39220,8 +39250,8 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Privileged == nil {
 					x.Privileged = new(bool)
 				}
-				yym3407 := z.DecBinary()
-				_ = yym3407
+				yym3411 := z.DecBinary()
+				_ = yym3411
 				if false {
 				} else {
 					*((*bool)(x.Privileged)) = r.DecodeBool()
@@ -39247,8 +39277,8 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RunAsUser == nil {
 					x.RunAsUser = new(int64)
 				}
-				yym3410 := z.DecBinary()
-				_ = yym3410
+				yym3414 := z.DecBinary()
+				_ = yym3414
 				if false {
 				} else {
 					*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
@@ -39263,18 +39293,18 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RunAsNonRoot == nil {
 					x.RunAsNonRoot = new(bool)
 				}
-				yym3412 := z.DecBinary()
-				_ = yym3412
+				yym3416 := z.DecBinary()
+				_ = yym3416
 				if false {
 				} else {
 					*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3404)
-		} // end switch yys3404
-	} // end for yyj3404
-	if !yyhl3404 {
+			z.DecStructFieldNotFound(-1, yys3408)
+		} // end switch yys3408
+	} // end for yyj3408
+	if !yyhl3408 {
 		r.ReadEnd()
 	}
 }
@@ -39283,16 +39313,16 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3413 int
-	var yyb3413 bool
-	var yyhl3413 bool = l >= 0
-	yyj3413++
-	if yyhl3413 {
-		yyb3413 = yyj3413 > l
+	var yyj3417 int
+	var yyb3417 bool
+	var yyhl3417 bool = l >= 0
+	yyj3417++
+	if yyhl3417 {
+		yyb3417 = yyj3417 > l
 	} else {
-		yyb3413 = r.CheckBreak()
+		yyb3417 = r.CheckBreak()
 	}
-	if yyb3413 {
+	if yyb3417 {
 		r.ReadEnd()
 		return
 	}
@@ -39306,13 +39336,13 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Capabilities.CodecDecodeSelf(d)
 	}
-	yyj3413++
-	if yyhl3413 {
-		yyb3413 = yyj3413 > l
+	yyj3417++
+	if yyhl3417 {
+		yyb3417 = yyj3417 > l
 	} else {
-		yyb3413 = r.CheckBreak()
+		yyb3417 = r.CheckBreak()
 	}
-	if yyb3413 {
+	if yyb3417 {
 		r.ReadEnd()
 		return
 	}
@@ -39324,20 +39354,20 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.Privileged == nil {
 			x.Privileged = new(bool)
 		}
-		yym3416 := z.DecBinary()
-		_ = yym3416
+		yym3420 := z.DecBinary()
+		_ = yym3420
 		if false {
 		} else {
 			*((*bool)(x.Privileged)) = r.DecodeBool()
 		}
 	}
-	yyj3413++
-	if yyhl3413 {
-		yyb3413 = yyj3413 > l
+	yyj3417++
+	if yyhl3417 {
+		yyb3417 = yyj3417 > l
 	} else {
-		yyb3413 = r.CheckBreak()
+		yyb3417 = r.CheckBreak()
 	}
-	if yyb3413 {
+	if yyb3417 {
 		r.ReadEnd()
 		return
 	}
@@ -39351,13 +39381,13 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.SELinuxOptions.CodecDecodeSelf(d)
 	}
-	yyj3413++
-	if yyhl3413 {
-		yyb3413 = yyj3413 > l
+	yyj3417++
+	if yyhl3417 {
+		yyb3417 = yyj3417 > l
 	} else {
-		yyb3413 = r.CheckBreak()
+		yyb3417 = r.CheckBreak()
 	}
-	if yyb3413 {
+	if yyb3417 {
 		r.ReadEnd()
 		return
 	}
@@ -39369,20 +39399,20 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.RunAsUser == nil {
 			x.RunAsUser = new(int64)
 		}
-		yym3419 := z.DecBinary()
-		_ = yym3419
+		yym3423 := z.DecBinary()
+		_ = yym3423
 		if false {
 		} else {
 			*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj3413++
-	if yyhl3413 {
-		yyb3413 = yyj3413 > l
+	yyj3417++
+	if yyhl3417 {
+		yyb3417 = yyj3417 > l
 	} else {
-		yyb3413 = r.CheckBreak()
+		yyb3417 = r.CheckBreak()
 	}
-	if yyb3413 {
+	if yyb3417 {
 		r.ReadEnd()
 		return
 	}
@@ -39394,24 +39424,24 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.RunAsNonRoot == nil {
 			x.RunAsNonRoot = new(bool)
 		}
-		yym3421 := z.DecBinary()
-		_ = yym3421
+		yym3425 := z.DecBinary()
+		_ = yym3425
 		if false {
 		} else {
 			*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 		}
 	}
 	for {
-		yyj3413++
-		if yyhl3413 {
-			yyb3413 = yyj3413 > l
+		yyj3417++
+		if yyhl3417 {
+			yyb3417 = yyj3417 > l
 		} else {
-			yyb3413 = r.CheckBreak()
+			yyb3417 = r.CheckBreak()
 		}
-		if yyb3413 {
+		if yyb3417 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3413-1, "")
+		z.DecStructFieldNotFound(yyj3417-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39423,101 +39453,101 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3422 := z.EncBinary()
-		_ = yym3422
+		yym3426 := z.EncBinary()
+		_ = yym3426
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3423 := !z.EncBinary()
-			yy2arr3423 := z.EncBasicHandle().StructToArray
-			var yyq3423 [4]bool
-			_, _, _ = yysep3423, yyq3423, yy2arr3423
-			const yyr3423 bool = false
-			yyq3423[0] = x.User != ""
-			yyq3423[1] = x.Role != ""
-			yyq3423[2] = x.Type != ""
-			yyq3423[3] = x.Level != ""
-			if yyr3423 || yy2arr3423 {
+			yysep3427 := !z.EncBinary()
+			yy2arr3427 := z.EncBasicHandle().StructToArray
+			var yyq3427 [4]bool
+			_, _, _ = yysep3427, yyq3427, yy2arr3427
+			const yyr3427 bool = false
+			yyq3427[0] = x.User != ""
+			yyq3427[1] = x.Role != ""
+			yyq3427[2] = x.Type != ""
+			yyq3427[3] = x.Level != ""
+			if yyr3427 || yy2arr3427 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3423 int = 0
-				for _, b := range yyq3423 {
+				var yynn3427 int = 0
+				for _, b := range yyq3427 {
 					if b {
-						yynn3423++
+						yynn3427++
 					}
 				}
-				r.EncodeMapStart(yynn3423)
+				r.EncodeMapStart(yynn3427)
 			}
-			if yyr3423 || yy2arr3423 {
-				if yyq3423[0] {
-					yym3425 := z.EncBinary()
-					_ = yym3425
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.User))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3423[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("user"))
-					yym3426 := z.EncBinary()
-					_ = yym3426
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.User))
-					}
-				}
-			}
-			if yyr3423 || yy2arr3423 {
-				if yyq3423[1] {
-					yym3428 := z.EncBinary()
-					_ = yym3428
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3423[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("role"))
+			if yyr3427 || yy2arr3427 {
+				if yyq3427[0] {
 					yym3429 := z.EncBinary()
 					_ = yym3429
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
-					}
-				}
-			}
-			if yyr3423 || yy2arr3423 {
-				if yyq3423[2] {
-					yym3431 := z.EncBinary()
-					_ = yym3431
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+						r.EncodeString(codecSelferC_UTF81234, string(x.User))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3423[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
+				if yyq3427[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("user"))
+					yym3430 := z.EncBinary()
+					_ = yym3430
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.User))
+					}
+				}
+			}
+			if yyr3427 || yy2arr3427 {
+				if yyq3427[1] {
 					yym3432 := z.EncBinary()
 					_ = yym3432
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3427[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("role"))
+					yym3433 := z.EncBinary()
+					_ = yym3433
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
+					}
+				}
+			}
+			if yyr3427 || yy2arr3427 {
+				if yyq3427[2] {
+					yym3435 := z.EncBinary()
+					_ = yym3435
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3427[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					yym3436 := z.EncBinary()
+					_ = yym3436
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
 					}
 				}
 			}
-			if yyr3423 || yy2arr3423 {
-				if yyq3423[3] {
-					yym3434 := z.EncBinary()
-					_ = yym3434
+			if yyr3427 || yy2arr3427 {
+				if yyq3427[3] {
+					yym3438 := z.EncBinary()
+					_ = yym3438
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Level))
@@ -39526,17 +39556,17 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3423[3] {
+				if yyq3427[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("level"))
-					yym3435 := z.EncBinary()
-					_ = yym3435
+					yym3439 := z.EncBinary()
+					_ = yym3439
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Level))
 					}
 				}
 			}
-			if yysep3423 {
+			if yysep3427 {
 				r.EncodeEnd()
 			}
 		}
@@ -39547,24 +39577,24 @@ func (x *SELinuxOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3436 := z.DecBinary()
-	_ = yym3436
+	yym3440 := z.DecBinary()
+	_ = yym3440
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3437 := r.ReadMapStart()
-			if yyl3437 == 0 {
+			yyl3441 := r.ReadMapStart()
+			if yyl3441 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3437, d)
+				x.codecDecodeSelfFromMap(yyl3441, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3437 := r.ReadArrayStart()
-			if yyl3437 == 0 {
+			yyl3441 := r.ReadArrayStart()
+			if yyl3441 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3437, d)
+				x.codecDecodeSelfFromArray(yyl3441, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39576,12 +39606,12 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3438Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3438Slc
-	var yyhl3438 bool = l >= 0
-	for yyj3438 := 0; ; yyj3438++ {
-		if yyhl3438 {
-			if yyj3438 >= l {
+	var yys3442Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3442Slc
+	var yyhl3442 bool = l >= 0
+	for yyj3442 := 0; ; yyj3442++ {
+		if yyhl3442 {
+			if yyj3442 >= l {
 				break
 			}
 		} else {
@@ -39589,9 +39619,9 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3438Slc = r.DecodeBytes(yys3438Slc, true, true)
-		yys3438 := string(yys3438Slc)
-		switch yys3438 {
+		yys3442Slc = r.DecodeBytes(yys3442Slc, true, true)
+		yys3442 := string(yys3442Slc)
+		switch yys3442 {
 		case "user":
 			if r.TryDecodeAsNil() {
 				x.User = ""
@@ -39617,10 +39647,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Level = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3438)
-		} // end switch yys3438
-	} // end for yyj3438
-	if !yyhl3438 {
+			z.DecStructFieldNotFound(-1, yys3442)
+		} // end switch yys3442
+	} // end for yyj3442
+	if !yyhl3442 {
 		r.ReadEnd()
 	}
 }
@@ -39629,16 +39659,16 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3443 int
-	var yyb3443 bool
-	var yyhl3443 bool = l >= 0
-	yyj3443++
-	if yyhl3443 {
-		yyb3443 = yyj3443 > l
+	var yyj3447 int
+	var yyb3447 bool
+	var yyhl3447 bool = l >= 0
+	yyj3447++
+	if yyhl3447 {
+		yyb3447 = yyj3447 > l
 	} else {
-		yyb3443 = r.CheckBreak()
+		yyb3447 = r.CheckBreak()
 	}
-	if yyb3443 {
+	if yyb3447 {
 		r.ReadEnd()
 		return
 	}
@@ -39647,13 +39677,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.User = string(r.DecodeString())
 	}
-	yyj3443++
-	if yyhl3443 {
-		yyb3443 = yyj3443 > l
+	yyj3447++
+	if yyhl3447 {
+		yyb3447 = yyj3447 > l
 	} else {
-		yyb3443 = r.CheckBreak()
+		yyb3447 = r.CheckBreak()
 	}
-	if yyb3443 {
+	if yyb3447 {
 		r.ReadEnd()
 		return
 	}
@@ -39662,13 +39692,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Role = string(r.DecodeString())
 	}
-	yyj3443++
-	if yyhl3443 {
-		yyb3443 = yyj3443 > l
+	yyj3447++
+	if yyhl3447 {
+		yyb3447 = yyj3447 > l
 	} else {
-		yyb3443 = r.CheckBreak()
+		yyb3447 = r.CheckBreak()
 	}
-	if yyb3443 {
+	if yyb3447 {
 		r.ReadEnd()
 		return
 	}
@@ -39677,13 +39707,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = string(r.DecodeString())
 	}
-	yyj3443++
-	if yyhl3443 {
-		yyb3443 = yyj3443 > l
+	yyj3447++
+	if yyhl3447 {
+		yyb3447 = yyj3447 > l
 	} else {
-		yyb3443 = r.CheckBreak()
+		yyb3447 = r.CheckBreak()
 	}
-	if yyb3443 {
+	if yyb3447 {
 		r.ReadEnd()
 		return
 	}
@@ -39693,16 +39723,16 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Level = string(r.DecodeString())
 	}
 	for {
-		yyj3443++
-		if yyhl3443 {
-			yyb3443 = yyj3443 > l
+		yyj3447++
+		if yyhl3447 {
+			yyb3447 = yyj3447 > l
 		} else {
-			yyb3443 = r.CheckBreak()
+			yyb3447 = r.CheckBreak()
 		}
-		if yyb3443 {
+		if yyb3447 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3443-1, "")
+		z.DecStructFieldNotFound(yyj3447-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39714,110 +39744,110 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3448 := z.EncBinary()
-		_ = yym3448
+		yym3452 := z.EncBinary()
+		_ = yym3452
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3449 := !z.EncBinary()
-			yy2arr3449 := z.EncBasicHandle().StructToArray
-			var yyq3449 [5]bool
-			_, _, _ = yysep3449, yyq3449, yy2arr3449
-			const yyr3449 bool = false
-			yyq3449[0] = x.Kind != ""
-			yyq3449[1] = x.APIVersion != ""
-			yyq3449[2] = true
-			if yyr3449 || yy2arr3449 {
+			yysep3453 := !z.EncBinary()
+			yy2arr3453 := z.EncBasicHandle().StructToArray
+			var yyq3453 [5]bool
+			_, _, _ = yysep3453, yyq3453, yy2arr3453
+			const yyr3453 bool = false
+			yyq3453[0] = x.Kind != ""
+			yyq3453[1] = x.APIVersion != ""
+			yyq3453[2] = true
+			if yyr3453 || yy2arr3453 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3449 int = 2
-				for _, b := range yyq3449 {
+				var yynn3453 int = 2
+				for _, b := range yyq3453 {
 					if b {
-						yynn3449++
+						yynn3453++
 					}
 				}
-				r.EncodeMapStart(yynn3449)
+				r.EncodeMapStart(yynn3453)
 			}
-			if yyr3449 || yy2arr3449 {
-				if yyq3449[0] {
-					yym3451 := z.EncBinary()
-					_ = yym3451
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3449[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3452 := z.EncBinary()
-					_ = yym3452
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3449 || yy2arr3449 {
-				if yyq3449[1] {
-					yym3454 := z.EncBinary()
-					_ = yym3454
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3449[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr3453 || yy2arr3453 {
+				if yyq3453[0] {
 					yym3455 := z.EncBinary()
 					_ = yym3455
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3453[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym3456 := z.EncBinary()
+					_ = yym3456
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3453 || yy2arr3453 {
+				if yyq3453[1] {
+					yym3458 := z.EncBinary()
+					_ = yym3458
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3453[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3459 := z.EncBinary()
+					_ = yym3459
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3449 || yy2arr3449 {
-				if yyq3449[2] {
-					yy3457 := &x.ObjectMeta
-					yy3457.CodecEncodeSelf(e)
+			if yyr3453 || yy2arr3453 {
+				if yyq3453[2] {
+					yy3461 := &x.ObjectMeta
+					yy3461.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3449[2] {
+				if yyq3453[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3458 := &x.ObjectMeta
-					yy3458.CodecEncodeSelf(e)
+					yy3462 := &x.ObjectMeta
+					yy3462.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3449 || yy2arr3449 {
-				yym3460 := z.EncBinary()
-				_ = yym3460
+			if yyr3453 || yy2arr3453 {
+				yym3464 := z.EncBinary()
+				_ = yym3464
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("range"))
-				yym3461 := z.EncBinary()
-				_ = yym3461
+				yym3465 := z.EncBinary()
+				_ = yym3465
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			}
-			if yyr3449 || yy2arr3449 {
+			if yyr3453 || yy2arr3453 {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3463 := z.EncBinary()
-					_ = yym3463
+					yym3467 := z.EncBinary()
+					_ = yym3467
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -39828,15 +39858,15 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3464 := z.EncBinary()
-					_ = yym3464
+					yym3468 := z.EncBinary()
+					_ = yym3468
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
 					}
 				}
 			}
-			if yysep3449 {
+			if yysep3453 {
 				r.EncodeEnd()
 			}
 		}
@@ -39847,24 +39877,24 @@ func (x *RangeAllocation) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3465 := z.DecBinary()
-	_ = yym3465
+	yym3469 := z.DecBinary()
+	_ = yym3469
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3466 := r.ReadMapStart()
-			if yyl3466 == 0 {
+			yyl3470 := r.ReadMapStart()
+			if yyl3470 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3466, d)
+				x.codecDecodeSelfFromMap(yyl3470, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3466 := r.ReadArrayStart()
-			if yyl3466 == 0 {
+			yyl3470 := r.ReadArrayStart()
+			if yyl3470 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3466, d)
+				x.codecDecodeSelfFromArray(yyl3470, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39876,12 +39906,12 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3467Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3467Slc
-	var yyhl3467 bool = l >= 0
-	for yyj3467 := 0; ; yyj3467++ {
-		if yyhl3467 {
-			if yyj3467 >= l {
+	var yys3471Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3471Slc
+	var yyhl3471 bool = l >= 0
+	for yyj3471 := 0; ; yyj3471++ {
+		if yyhl3471 {
+			if yyj3471 >= l {
 				break
 			}
 		} else {
@@ -39889,9 +39919,9 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3467Slc = r.DecodeBytes(yys3467Slc, true, true)
-		yys3467 := string(yys3467Slc)
-		switch yys3467 {
+		yys3471Slc = r.DecodeBytes(yys3471Slc, true, true)
+		yys3471 := string(yys3471Slc)
+		switch yys3471 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -39908,8 +39938,8 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3470 := &x.ObjectMeta
-				yyv3470.CodecDecodeSelf(d)
+				yyv3474 := &x.ObjectMeta
+				yyv3474.CodecDecodeSelf(d)
 			}
 		case "range":
 			if r.TryDecodeAsNil() {
@@ -39921,19 +39951,19 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3472 := &x.Data
-				yym3473 := z.DecBinary()
-				_ = yym3473
+				yyv3476 := &x.Data
+				yym3477 := z.DecBinary()
+				_ = yym3477
 				if false {
 				} else {
-					*yyv3472 = r.DecodeBytes(*(*[]byte)(yyv3472), false, false)
+					*yyv3476 = r.DecodeBytes(*(*[]byte)(yyv3476), false, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3467)
-		} // end switch yys3467
-	} // end for yyj3467
-	if !yyhl3467 {
+			z.DecStructFieldNotFound(-1, yys3471)
+		} // end switch yys3471
+	} // end for yyj3471
+	if !yyhl3471 {
 		r.ReadEnd()
 	}
 }
@@ -39942,16 +39972,16 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3474 int
-	var yyb3474 bool
-	var yyhl3474 bool = l >= 0
-	yyj3474++
-	if yyhl3474 {
-		yyb3474 = yyj3474 > l
+	var yyj3478 int
+	var yyb3478 bool
+	var yyhl3478 bool = l >= 0
+	yyj3478++
+	if yyhl3478 {
+		yyb3478 = yyj3478 > l
 	} else {
-		yyb3474 = r.CheckBreak()
+		yyb3478 = r.CheckBreak()
 	}
-	if yyb3474 {
+	if yyb3478 {
 		r.ReadEnd()
 		return
 	}
@@ -39960,13 +39990,13 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3474++
-	if yyhl3474 {
-		yyb3474 = yyj3474 > l
+	yyj3478++
+	if yyhl3478 {
+		yyb3478 = yyj3478 > l
 	} else {
-		yyb3474 = r.CheckBreak()
+		yyb3478 = r.CheckBreak()
 	}
-	if yyb3474 {
+	if yyb3478 {
 		r.ReadEnd()
 		return
 	}
@@ -39975,29 +40005,29 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3474++
-	if yyhl3474 {
-		yyb3474 = yyj3474 > l
+	yyj3478++
+	if yyhl3478 {
+		yyb3478 = yyj3478 > l
 	} else {
-		yyb3474 = r.CheckBreak()
+		yyb3478 = r.CheckBreak()
 	}
-	if yyb3474 {
+	if yyb3478 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3477 := &x.ObjectMeta
-		yyv3477.CodecDecodeSelf(d)
+		yyv3481 := &x.ObjectMeta
+		yyv3481.CodecDecodeSelf(d)
 	}
-	yyj3474++
-	if yyhl3474 {
-		yyb3474 = yyj3474 > l
+	yyj3478++
+	if yyhl3478 {
+		yyb3478 = yyj3478 > l
 	} else {
-		yyb3474 = r.CheckBreak()
+		yyb3478 = r.CheckBreak()
 	}
-	if yyb3474 {
+	if yyb3478 {
 		r.ReadEnd()
 		return
 	}
@@ -40006,38 +40036,38 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Range = string(r.DecodeString())
 	}
-	yyj3474++
-	if yyhl3474 {
-		yyb3474 = yyj3474 > l
+	yyj3478++
+	if yyhl3478 {
+		yyb3478 = yyj3478 > l
 	} else {
-		yyb3474 = r.CheckBreak()
+		yyb3478 = r.CheckBreak()
 	}
-	if yyb3474 {
+	if yyb3478 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3479 := &x.Data
-		yym3480 := z.DecBinary()
-		_ = yym3480
+		yyv3483 := &x.Data
+		yym3484 := z.DecBinary()
+		_ = yym3484
 		if false {
 		} else {
-			*yyv3479 = r.DecodeBytes(*(*[]byte)(yyv3479), false, false)
+			*yyv3483 = r.DecodeBytes(*(*[]byte)(yyv3483), false, false)
 		}
 	}
 	for {
-		yyj3474++
-		if yyhl3474 {
-			yyb3474 = yyj3474 > l
+		yyj3478++
+		if yyhl3478 {
+			yyb3478 = yyj3478 > l
 		} else {
-			yyb3474 = r.CheckBreak()
+			yyb3478 = r.CheckBreak()
 		}
-		if yyb3474 {
+		if yyb3478 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3474-1, "")
+		z.DecStructFieldNotFound(yyj3478-1, "")
 	}
 	r.ReadEnd()
 }
@@ -40047,8 +40077,8 @@ func (x codecSelfer1234) encSlicePersistentVolumeAccessMode(v []PersistentVolume
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3481 := range v {
-		yyv3481.CodecEncodeSelf(e)
+	for _, yyv3485 := range v {
+		yyv3485.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40058,77 +40088,77 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3482 := *v
-	yyh3482, yyl3482 := z.DecSliceHelperStart()
+	yyv3486 := *v
+	yyh3486, yyl3486 := z.DecSliceHelperStart()
 
-	var yyrr3482, yyrl3482 int
-	var yyc3482, yyrt3482 bool
-	_, _, _ = yyc3482, yyrt3482, yyrl3482
-	yyrr3482 = yyl3482
+	var yyrr3486, yyrl3486 int
+	var yyc3486, yyrt3486 bool
+	_, _, _ = yyc3486, yyrt3486, yyrl3486
+	yyrr3486 = yyl3486
 
-	if yyv3482 == nil {
-		if yyrl3482, yyrt3482 = z.DecInferLen(yyl3482, z.DecBasicHandle().MaxInitLen, 16); yyrt3482 {
-			yyrr3482 = yyrl3482
+	if yyv3486 == nil {
+		if yyrl3486, yyrt3486 = z.DecInferLen(yyl3486, z.DecBasicHandle().MaxInitLen, 16); yyrt3486 {
+			yyrr3486 = yyrl3486
 		}
-		yyv3482 = make([]PersistentVolumeAccessMode, yyrl3482)
-		yyc3482 = true
+		yyv3486 = make([]PersistentVolumeAccessMode, yyrl3486)
+		yyc3486 = true
 	}
 
-	if yyl3482 == 0 {
-		if len(yyv3482) != 0 {
-			yyv3482 = yyv3482[:0]
-			yyc3482 = true
+	if yyl3486 == 0 {
+		if len(yyv3486) != 0 {
+			yyv3486 = yyv3486[:0]
+			yyc3486 = true
 		}
-	} else if yyl3482 > 0 {
+	} else if yyl3486 > 0 {
 
-		if yyl3482 > cap(yyv3482) {
-			yyrl3482, yyrt3482 = z.DecInferLen(yyl3482, z.DecBasicHandle().MaxInitLen, 16)
+		if yyl3486 > cap(yyv3486) {
+			yyrl3486, yyrt3486 = z.DecInferLen(yyl3486, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23482 := yyv3482
-			yyv3482 = make([]PersistentVolumeAccessMode, yyrl3482)
-			if len(yyv3482) > 0 {
-				copy(yyv3482, yyv23482[:cap(yyv23482)])
+			yyv23486 := yyv3486
+			yyv3486 = make([]PersistentVolumeAccessMode, yyrl3486)
+			if len(yyv3486) > 0 {
+				copy(yyv3486, yyv23486[:cap(yyv23486)])
 			}
-			yyc3482 = true
+			yyc3486 = true
 
-			yyrr3482 = len(yyv3482)
-		} else if yyl3482 != len(yyv3482) {
-			yyv3482 = yyv3482[:yyl3482]
-			yyc3482 = true
+			yyrr3486 = len(yyv3486)
+		} else if yyl3486 != len(yyv3486) {
+			yyv3486 = yyv3486[:yyl3486]
+			yyc3486 = true
 		}
-		yyj3482 := 0
-		for ; yyj3482 < yyrr3482; yyj3482++ {
+		yyj3486 := 0
+		for ; yyj3486 < yyrr3486; yyj3486++ {
 			if r.TryDecodeAsNil() {
-				yyv3482[yyj3482] = ""
+				yyv3486[yyj3486] = ""
 			} else {
-				yyv3482[yyj3482] = PersistentVolumeAccessMode(r.DecodeString())
+				yyv3486[yyj3486] = PersistentVolumeAccessMode(r.DecodeString())
 			}
 
 		}
-		if yyrt3482 {
-			for ; yyj3482 < yyl3482; yyj3482++ {
-				yyv3482 = append(yyv3482, "")
+		if yyrt3486 {
+			for ; yyj3486 < yyl3486; yyj3486++ {
+				yyv3486 = append(yyv3486, "")
 				if r.TryDecodeAsNil() {
-					yyv3482[yyj3482] = ""
+					yyv3486[yyj3486] = ""
 				} else {
-					yyv3482[yyj3482] = PersistentVolumeAccessMode(r.DecodeString())
+					yyv3486[yyj3486] = PersistentVolumeAccessMode(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3482 := 0; !r.CheckBreak(); yyj3482++ {
-			if yyj3482 >= len(yyv3482) {
-				yyv3482 = append(yyv3482, "") // var yyz3482 PersistentVolumeAccessMode
-				yyc3482 = true
+		for yyj3486 := 0; !r.CheckBreak(); yyj3486++ {
+			if yyj3486 >= len(yyv3486) {
+				yyv3486 = append(yyv3486, "") // var yyz3486 PersistentVolumeAccessMode
+				yyc3486 = true
 			}
 
-			if yyj3482 < len(yyv3482) {
+			if yyj3486 < len(yyv3486) {
 				if r.TryDecodeAsNil() {
-					yyv3482[yyj3482] = ""
+					yyv3486[yyj3486] = ""
 				} else {
-					yyv3482[yyj3482] = PersistentVolumeAccessMode(r.DecodeString())
+					yyv3486[yyj3486] = PersistentVolumeAccessMode(r.DecodeString())
 				}
 
 			} else {
@@ -40136,10 +40166,10 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 			}
 
 		}
-		yyh3482.End()
+		yyh3486.End()
 	}
-	if yyc3482 {
-		*v = yyv3482
+	if yyc3486 {
+		*v = yyv3486
 	}
 
 }
@@ -40149,9 +40179,9 @@ func (x codecSelfer1234) encSlicePersistentVolume(v []PersistentVolume, e *codec
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3486 := range v {
-		yy3487 := &yyv3486
-		yy3487.CodecEncodeSelf(e)
+	for _, yyv3490 := range v {
+		yy3491 := &yyv3490
+		yy3491.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40161,75 +40191,75 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3488 := *v
-	yyh3488, yyl3488 := z.DecSliceHelperStart()
+	yyv3492 := *v
+	yyh3492, yyl3492 := z.DecSliceHelperStart()
 
-	var yyrr3488, yyrl3488 int
-	var yyc3488, yyrt3488 bool
-	_, _, _ = yyc3488, yyrt3488, yyrl3488
-	yyrr3488 = yyl3488
+	var yyrr3492, yyrl3492 int
+	var yyc3492, yyrt3492 bool
+	_, _, _ = yyc3492, yyrt3492, yyrl3492
+	yyrr3492 = yyl3492
 
-	if yyv3488 == nil {
-		if yyrl3488, yyrt3488 = z.DecInferLen(yyl3488, z.DecBasicHandle().MaxInitLen, 384); yyrt3488 {
-			yyrr3488 = yyrl3488
+	if yyv3492 == nil {
+		if yyrl3492, yyrt3492 = z.DecInferLen(yyl3492, z.DecBasicHandle().MaxInitLen, 384); yyrt3492 {
+			yyrr3492 = yyrl3492
 		}
-		yyv3488 = make([]PersistentVolume, yyrl3488)
-		yyc3488 = true
+		yyv3492 = make([]PersistentVolume, yyrl3492)
+		yyc3492 = true
 	}
 
-	if yyl3488 == 0 {
-		if len(yyv3488) != 0 {
-			yyv3488 = yyv3488[:0]
-			yyc3488 = true
+	if yyl3492 == 0 {
+		if len(yyv3492) != 0 {
+			yyv3492 = yyv3492[:0]
+			yyc3492 = true
 		}
-	} else if yyl3488 > 0 {
+	} else if yyl3492 > 0 {
 
-		if yyl3488 > cap(yyv3488) {
-			yyrl3488, yyrt3488 = z.DecInferLen(yyl3488, z.DecBasicHandle().MaxInitLen, 384)
-			yyv3488 = make([]PersistentVolume, yyrl3488)
-			yyc3488 = true
+		if yyl3492 > cap(yyv3492) {
+			yyrl3492, yyrt3492 = z.DecInferLen(yyl3492, z.DecBasicHandle().MaxInitLen, 384)
+			yyv3492 = make([]PersistentVolume, yyrl3492)
+			yyc3492 = true
 
-			yyrr3488 = len(yyv3488)
-		} else if yyl3488 != len(yyv3488) {
-			yyv3488 = yyv3488[:yyl3488]
-			yyc3488 = true
+			yyrr3492 = len(yyv3492)
+		} else if yyl3492 != len(yyv3492) {
+			yyv3492 = yyv3492[:yyl3492]
+			yyc3492 = true
 		}
-		yyj3488 := 0
-		for ; yyj3488 < yyrr3488; yyj3488++ {
+		yyj3492 := 0
+		for ; yyj3492 < yyrr3492; yyj3492++ {
 			if r.TryDecodeAsNil() {
-				yyv3488[yyj3488] = PersistentVolume{}
+				yyv3492[yyj3492] = PersistentVolume{}
 			} else {
-				yyv3489 := &yyv3488[yyj3488]
-				yyv3489.CodecDecodeSelf(d)
+				yyv3493 := &yyv3492[yyj3492]
+				yyv3493.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3488 {
-			for ; yyj3488 < yyl3488; yyj3488++ {
-				yyv3488 = append(yyv3488, PersistentVolume{})
+		if yyrt3492 {
+			for ; yyj3492 < yyl3492; yyj3492++ {
+				yyv3492 = append(yyv3492, PersistentVolume{})
 				if r.TryDecodeAsNil() {
-					yyv3488[yyj3488] = PersistentVolume{}
+					yyv3492[yyj3492] = PersistentVolume{}
 				} else {
-					yyv3490 := &yyv3488[yyj3488]
-					yyv3490.CodecDecodeSelf(d)
+					yyv3494 := &yyv3492[yyj3492]
+					yyv3494.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3488 := 0; !r.CheckBreak(); yyj3488++ {
-			if yyj3488 >= len(yyv3488) {
-				yyv3488 = append(yyv3488, PersistentVolume{}) // var yyz3488 PersistentVolume
-				yyc3488 = true
+		for yyj3492 := 0; !r.CheckBreak(); yyj3492++ {
+			if yyj3492 >= len(yyv3492) {
+				yyv3492 = append(yyv3492, PersistentVolume{}) // var yyz3492 PersistentVolume
+				yyc3492 = true
 			}
 
-			if yyj3488 < len(yyv3488) {
+			if yyj3492 < len(yyv3492) {
 				if r.TryDecodeAsNil() {
-					yyv3488[yyj3488] = PersistentVolume{}
+					yyv3492[yyj3492] = PersistentVolume{}
 				} else {
-					yyv3491 := &yyv3488[yyj3488]
-					yyv3491.CodecDecodeSelf(d)
+					yyv3495 := &yyv3492[yyj3492]
+					yyv3495.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40237,10 +40267,10 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 			}
 
 		}
-		yyh3488.End()
+		yyh3492.End()
 	}
-	if yyc3488 {
-		*v = yyv3488
+	if yyc3492 {
+		*v = yyv3492
 	}
 
 }
@@ -40250,9 +40280,9 @@ func (x codecSelfer1234) encSlicePersistentVolumeClaim(v []PersistentVolumeClaim
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3492 := range v {
-		yy3493 := &yyv3492
-		yy3493.CodecEncodeSelf(e)
+	for _, yyv3496 := range v {
+		yy3497 := &yyv3496
+		yy3497.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40262,75 +40292,75 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3494 := *v
-	yyh3494, yyl3494 := z.DecSliceHelperStart()
+	yyv3498 := *v
+	yyh3498, yyl3498 := z.DecSliceHelperStart()
 
-	var yyrr3494, yyrl3494 int
-	var yyc3494, yyrt3494 bool
-	_, _, _ = yyc3494, yyrt3494, yyrl3494
-	yyrr3494 = yyl3494
+	var yyrr3498, yyrl3498 int
+	var yyc3498, yyrt3498 bool
+	_, _, _ = yyc3498, yyrt3498, yyrl3498
+	yyrr3498 = yyl3498
 
-	if yyv3494 == nil {
-		if yyrl3494, yyrt3494 = z.DecInferLen(yyl3494, z.DecBasicHandle().MaxInitLen, 296); yyrt3494 {
-			yyrr3494 = yyrl3494
+	if yyv3498 == nil {
+		if yyrl3498, yyrt3498 = z.DecInferLen(yyl3498, z.DecBasicHandle().MaxInitLen, 296); yyrt3498 {
+			yyrr3498 = yyrl3498
 		}
-		yyv3494 = make([]PersistentVolumeClaim, yyrl3494)
-		yyc3494 = true
+		yyv3498 = make([]PersistentVolumeClaim, yyrl3498)
+		yyc3498 = true
 	}
 
-	if yyl3494 == 0 {
-		if len(yyv3494) != 0 {
-			yyv3494 = yyv3494[:0]
-			yyc3494 = true
+	if yyl3498 == 0 {
+		if len(yyv3498) != 0 {
+			yyv3498 = yyv3498[:0]
+			yyc3498 = true
 		}
-	} else if yyl3494 > 0 {
+	} else if yyl3498 > 0 {
 
-		if yyl3494 > cap(yyv3494) {
-			yyrl3494, yyrt3494 = z.DecInferLen(yyl3494, z.DecBasicHandle().MaxInitLen, 296)
-			yyv3494 = make([]PersistentVolumeClaim, yyrl3494)
-			yyc3494 = true
+		if yyl3498 > cap(yyv3498) {
+			yyrl3498, yyrt3498 = z.DecInferLen(yyl3498, z.DecBasicHandle().MaxInitLen, 296)
+			yyv3498 = make([]PersistentVolumeClaim, yyrl3498)
+			yyc3498 = true
 
-			yyrr3494 = len(yyv3494)
-		} else if yyl3494 != len(yyv3494) {
-			yyv3494 = yyv3494[:yyl3494]
-			yyc3494 = true
+			yyrr3498 = len(yyv3498)
+		} else if yyl3498 != len(yyv3498) {
+			yyv3498 = yyv3498[:yyl3498]
+			yyc3498 = true
 		}
-		yyj3494 := 0
-		for ; yyj3494 < yyrr3494; yyj3494++ {
+		yyj3498 := 0
+		for ; yyj3498 < yyrr3498; yyj3498++ {
 			if r.TryDecodeAsNil() {
-				yyv3494[yyj3494] = PersistentVolumeClaim{}
+				yyv3498[yyj3498] = PersistentVolumeClaim{}
 			} else {
-				yyv3495 := &yyv3494[yyj3494]
-				yyv3495.CodecDecodeSelf(d)
+				yyv3499 := &yyv3498[yyj3498]
+				yyv3499.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3494 {
-			for ; yyj3494 < yyl3494; yyj3494++ {
-				yyv3494 = append(yyv3494, PersistentVolumeClaim{})
+		if yyrt3498 {
+			for ; yyj3498 < yyl3498; yyj3498++ {
+				yyv3498 = append(yyv3498, PersistentVolumeClaim{})
 				if r.TryDecodeAsNil() {
-					yyv3494[yyj3494] = PersistentVolumeClaim{}
+					yyv3498[yyj3498] = PersistentVolumeClaim{}
 				} else {
-					yyv3496 := &yyv3494[yyj3494]
-					yyv3496.CodecDecodeSelf(d)
+					yyv3500 := &yyv3498[yyj3498]
+					yyv3500.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3494 := 0; !r.CheckBreak(); yyj3494++ {
-			if yyj3494 >= len(yyv3494) {
-				yyv3494 = append(yyv3494, PersistentVolumeClaim{}) // var yyz3494 PersistentVolumeClaim
-				yyc3494 = true
+		for yyj3498 := 0; !r.CheckBreak(); yyj3498++ {
+			if yyj3498 >= len(yyv3498) {
+				yyv3498 = append(yyv3498, PersistentVolumeClaim{}) // var yyz3498 PersistentVolumeClaim
+				yyc3498 = true
 			}
 
-			if yyj3494 < len(yyv3494) {
+			if yyj3498 < len(yyv3498) {
 				if r.TryDecodeAsNil() {
-					yyv3494[yyj3494] = PersistentVolumeClaim{}
+					yyv3498[yyj3498] = PersistentVolumeClaim{}
 				} else {
-					yyv3497 := &yyv3494[yyj3494]
-					yyv3497.CodecDecodeSelf(d)
+					yyv3501 := &yyv3498[yyj3498]
+					yyv3501.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40338,10 +40368,10 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 			}
 
 		}
-		yyh3494.End()
+		yyh3498.End()
 	}
-	if yyc3494 {
-		*v = yyv3494
+	if yyc3498 {
+		*v = yyv3498
 	}
 
 }
@@ -40351,9 +40381,9 @@ func (x codecSelfer1234) encSliceDownwardAPIVolumeFile(v []DownwardAPIVolumeFile
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3498 := range v {
-		yy3499 := &yyv3498
-		yy3499.CodecEncodeSelf(e)
+	for _, yyv3502 := range v {
+		yy3503 := &yyv3502
+		yy3503.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40363,75 +40393,75 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3500 := *v
-	yyh3500, yyl3500 := z.DecSliceHelperStart()
+	yyv3504 := *v
+	yyh3504, yyl3504 := z.DecSliceHelperStart()
 
-	var yyrr3500, yyrl3500 int
-	var yyc3500, yyrt3500 bool
-	_, _, _ = yyc3500, yyrt3500, yyrl3500
-	yyrr3500 = yyl3500
+	var yyrr3504, yyrl3504 int
+	var yyc3504, yyrt3504 bool
+	_, _, _ = yyc3504, yyrt3504, yyrl3504
+	yyrr3504 = yyl3504
 
-	if yyv3500 == nil {
-		if yyrl3500, yyrt3500 = z.DecInferLen(yyl3500, z.DecBasicHandle().MaxInitLen, 48); yyrt3500 {
-			yyrr3500 = yyrl3500
+	if yyv3504 == nil {
+		if yyrl3504, yyrt3504 = z.DecInferLen(yyl3504, z.DecBasicHandle().MaxInitLen, 48); yyrt3504 {
+			yyrr3504 = yyrl3504
 		}
-		yyv3500 = make([]DownwardAPIVolumeFile, yyrl3500)
-		yyc3500 = true
+		yyv3504 = make([]DownwardAPIVolumeFile, yyrl3504)
+		yyc3504 = true
 	}
 
-	if yyl3500 == 0 {
-		if len(yyv3500) != 0 {
-			yyv3500 = yyv3500[:0]
-			yyc3500 = true
+	if yyl3504 == 0 {
+		if len(yyv3504) != 0 {
+			yyv3504 = yyv3504[:0]
+			yyc3504 = true
 		}
-	} else if yyl3500 > 0 {
+	} else if yyl3504 > 0 {
 
-		if yyl3500 > cap(yyv3500) {
-			yyrl3500, yyrt3500 = z.DecInferLen(yyl3500, z.DecBasicHandle().MaxInitLen, 48)
-			yyv3500 = make([]DownwardAPIVolumeFile, yyrl3500)
-			yyc3500 = true
+		if yyl3504 > cap(yyv3504) {
+			yyrl3504, yyrt3504 = z.DecInferLen(yyl3504, z.DecBasicHandle().MaxInitLen, 48)
+			yyv3504 = make([]DownwardAPIVolumeFile, yyrl3504)
+			yyc3504 = true
 
-			yyrr3500 = len(yyv3500)
-		} else if yyl3500 != len(yyv3500) {
-			yyv3500 = yyv3500[:yyl3500]
-			yyc3500 = true
+			yyrr3504 = len(yyv3504)
+		} else if yyl3504 != len(yyv3504) {
+			yyv3504 = yyv3504[:yyl3504]
+			yyc3504 = true
 		}
-		yyj3500 := 0
-		for ; yyj3500 < yyrr3500; yyj3500++ {
+		yyj3504 := 0
+		for ; yyj3504 < yyrr3504; yyj3504++ {
 			if r.TryDecodeAsNil() {
-				yyv3500[yyj3500] = DownwardAPIVolumeFile{}
+				yyv3504[yyj3504] = DownwardAPIVolumeFile{}
 			} else {
-				yyv3501 := &yyv3500[yyj3500]
-				yyv3501.CodecDecodeSelf(d)
+				yyv3505 := &yyv3504[yyj3504]
+				yyv3505.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3500 {
-			for ; yyj3500 < yyl3500; yyj3500++ {
-				yyv3500 = append(yyv3500, DownwardAPIVolumeFile{})
+		if yyrt3504 {
+			for ; yyj3504 < yyl3504; yyj3504++ {
+				yyv3504 = append(yyv3504, DownwardAPIVolumeFile{})
 				if r.TryDecodeAsNil() {
-					yyv3500[yyj3500] = DownwardAPIVolumeFile{}
+					yyv3504[yyj3504] = DownwardAPIVolumeFile{}
 				} else {
-					yyv3502 := &yyv3500[yyj3500]
-					yyv3502.CodecDecodeSelf(d)
+					yyv3506 := &yyv3504[yyj3504]
+					yyv3506.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3500 := 0; !r.CheckBreak(); yyj3500++ {
-			if yyj3500 >= len(yyv3500) {
-				yyv3500 = append(yyv3500, DownwardAPIVolumeFile{}) // var yyz3500 DownwardAPIVolumeFile
-				yyc3500 = true
+		for yyj3504 := 0; !r.CheckBreak(); yyj3504++ {
+			if yyj3504 >= len(yyv3504) {
+				yyv3504 = append(yyv3504, DownwardAPIVolumeFile{}) // var yyz3504 DownwardAPIVolumeFile
+				yyc3504 = true
 			}
 
-			if yyj3500 < len(yyv3500) {
+			if yyj3504 < len(yyv3504) {
 				if r.TryDecodeAsNil() {
-					yyv3500[yyj3500] = DownwardAPIVolumeFile{}
+					yyv3504[yyj3504] = DownwardAPIVolumeFile{}
 				} else {
-					yyv3503 := &yyv3500[yyj3500]
-					yyv3503.CodecDecodeSelf(d)
+					yyv3507 := &yyv3504[yyj3504]
+					yyv3507.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40439,10 +40469,10 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 			}
 
 		}
-		yyh3500.End()
+		yyh3504.End()
 	}
-	if yyc3500 {
-		*v = yyv3500
+	if yyc3504 {
+		*v = yyv3504
 	}
 
 }
@@ -40452,8 +40482,8 @@ func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3504 := range v {
-		yyv3504.CodecEncodeSelf(e)
+	for _, yyv3508 := range v {
+		yyv3508.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40463,77 +40493,77 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3505 := *v
-	yyh3505, yyl3505 := z.DecSliceHelperStart()
+	yyv3509 := *v
+	yyh3509, yyl3509 := z.DecSliceHelperStart()
 
-	var yyrr3505, yyrl3505 int
-	var yyc3505, yyrt3505 bool
-	_, _, _ = yyc3505, yyrt3505, yyrl3505
-	yyrr3505 = yyl3505
+	var yyrr3509, yyrl3509 int
+	var yyc3509, yyrt3509 bool
+	_, _, _ = yyc3509, yyrt3509, yyrl3509
+	yyrr3509 = yyl3509
 
-	if yyv3505 == nil {
-		if yyrl3505, yyrt3505 = z.DecInferLen(yyl3505, z.DecBasicHandle().MaxInitLen, 16); yyrt3505 {
-			yyrr3505 = yyrl3505
+	if yyv3509 == nil {
+		if yyrl3509, yyrt3509 = z.DecInferLen(yyl3509, z.DecBasicHandle().MaxInitLen, 16); yyrt3509 {
+			yyrr3509 = yyrl3509
 		}
-		yyv3505 = make([]Capability, yyrl3505)
-		yyc3505 = true
+		yyv3509 = make([]Capability, yyrl3509)
+		yyc3509 = true
 	}
 
-	if yyl3505 == 0 {
-		if len(yyv3505) != 0 {
-			yyv3505 = yyv3505[:0]
-			yyc3505 = true
+	if yyl3509 == 0 {
+		if len(yyv3509) != 0 {
+			yyv3509 = yyv3509[:0]
+			yyc3509 = true
 		}
-	} else if yyl3505 > 0 {
+	} else if yyl3509 > 0 {
 
-		if yyl3505 > cap(yyv3505) {
-			yyrl3505, yyrt3505 = z.DecInferLen(yyl3505, z.DecBasicHandle().MaxInitLen, 16)
+		if yyl3509 > cap(yyv3509) {
+			yyrl3509, yyrt3509 = z.DecInferLen(yyl3509, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23505 := yyv3505
-			yyv3505 = make([]Capability, yyrl3505)
-			if len(yyv3505) > 0 {
-				copy(yyv3505, yyv23505[:cap(yyv23505)])
+			yyv23509 := yyv3509
+			yyv3509 = make([]Capability, yyrl3509)
+			if len(yyv3509) > 0 {
+				copy(yyv3509, yyv23509[:cap(yyv23509)])
 			}
-			yyc3505 = true
+			yyc3509 = true
 
-			yyrr3505 = len(yyv3505)
-		} else if yyl3505 != len(yyv3505) {
-			yyv3505 = yyv3505[:yyl3505]
-			yyc3505 = true
+			yyrr3509 = len(yyv3509)
+		} else if yyl3509 != len(yyv3509) {
+			yyv3509 = yyv3509[:yyl3509]
+			yyc3509 = true
 		}
-		yyj3505 := 0
-		for ; yyj3505 < yyrr3505; yyj3505++ {
+		yyj3509 := 0
+		for ; yyj3509 < yyrr3509; yyj3509++ {
 			if r.TryDecodeAsNil() {
-				yyv3505[yyj3505] = ""
+				yyv3509[yyj3509] = ""
 			} else {
-				yyv3505[yyj3505] = Capability(r.DecodeString())
+				yyv3509[yyj3509] = Capability(r.DecodeString())
 			}
 
 		}
-		if yyrt3505 {
-			for ; yyj3505 < yyl3505; yyj3505++ {
-				yyv3505 = append(yyv3505, "")
+		if yyrt3509 {
+			for ; yyj3509 < yyl3509; yyj3509++ {
+				yyv3509 = append(yyv3509, "")
 				if r.TryDecodeAsNil() {
-					yyv3505[yyj3505] = ""
+					yyv3509[yyj3509] = ""
 				} else {
-					yyv3505[yyj3505] = Capability(r.DecodeString())
+					yyv3509[yyj3509] = Capability(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3505 := 0; !r.CheckBreak(); yyj3505++ {
-			if yyj3505 >= len(yyv3505) {
-				yyv3505 = append(yyv3505, "") // var yyz3505 Capability
-				yyc3505 = true
+		for yyj3509 := 0; !r.CheckBreak(); yyj3509++ {
+			if yyj3509 >= len(yyv3509) {
+				yyv3509 = append(yyv3509, "") // var yyz3509 Capability
+				yyc3509 = true
 			}
 
-			if yyj3505 < len(yyv3505) {
+			if yyj3509 < len(yyv3509) {
 				if r.TryDecodeAsNil() {
-					yyv3505[yyj3505] = ""
+					yyv3509[yyj3509] = ""
 				} else {
-					yyv3505[yyj3505] = Capability(r.DecodeString())
+					yyv3509[yyj3509] = Capability(r.DecodeString())
 				}
 
 			} else {
@@ -40541,10 +40571,10 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 			}
 
 		}
-		yyh3505.End()
+		yyh3509.End()
 	}
-	if yyc3505 {
-		*v = yyv3505
+	if yyc3509 {
+		*v = yyv3509
 	}
 
 }
@@ -40554,9 +40584,9 @@ func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3509 := range v {
-		yy3510 := &yyv3509
-		yy3510.CodecEncodeSelf(e)
+	for _, yyv3513 := range v {
+		yy3514 := &yyv3513
+		yy3514.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40566,75 +40596,75 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3511 := *v
-	yyh3511, yyl3511 := z.DecSliceHelperStart()
+	yyv3515 := *v
+	yyh3515, yyl3515 := z.DecSliceHelperStart()
 
-	var yyrr3511, yyrl3511 int
-	var yyc3511, yyrt3511 bool
-	_, _, _ = yyc3511, yyrt3511, yyrl3511
-	yyrr3511 = yyl3511
+	var yyrr3515, yyrl3515 int
+	var yyc3515, yyrt3515 bool
+	_, _, _ = yyc3515, yyrt3515, yyrl3515
+	yyrr3515 = yyl3515
 
-	if yyv3511 == nil {
-		if yyrl3511, yyrt3511 = z.DecInferLen(yyl3511, z.DecBasicHandle().MaxInitLen, 64); yyrt3511 {
-			yyrr3511 = yyrl3511
+	if yyv3515 == nil {
+		if yyrl3515, yyrt3515 = z.DecInferLen(yyl3515, z.DecBasicHandle().MaxInitLen, 64); yyrt3515 {
+			yyrr3515 = yyrl3515
 		}
-		yyv3511 = make([]ContainerPort, yyrl3511)
-		yyc3511 = true
+		yyv3515 = make([]ContainerPort, yyrl3515)
+		yyc3515 = true
 	}
 
-	if yyl3511 == 0 {
-		if len(yyv3511) != 0 {
-			yyv3511 = yyv3511[:0]
-			yyc3511 = true
+	if yyl3515 == 0 {
+		if len(yyv3515) != 0 {
+			yyv3515 = yyv3515[:0]
+			yyc3515 = true
 		}
-	} else if yyl3511 > 0 {
+	} else if yyl3515 > 0 {
 
-		if yyl3511 > cap(yyv3511) {
-			yyrl3511, yyrt3511 = z.DecInferLen(yyl3511, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3511 = make([]ContainerPort, yyrl3511)
-			yyc3511 = true
+		if yyl3515 > cap(yyv3515) {
+			yyrl3515, yyrt3515 = z.DecInferLen(yyl3515, z.DecBasicHandle().MaxInitLen, 64)
+			yyv3515 = make([]ContainerPort, yyrl3515)
+			yyc3515 = true
 
-			yyrr3511 = len(yyv3511)
-		} else if yyl3511 != len(yyv3511) {
-			yyv3511 = yyv3511[:yyl3511]
-			yyc3511 = true
+			yyrr3515 = len(yyv3515)
+		} else if yyl3515 != len(yyv3515) {
+			yyv3515 = yyv3515[:yyl3515]
+			yyc3515 = true
 		}
-		yyj3511 := 0
-		for ; yyj3511 < yyrr3511; yyj3511++ {
+		yyj3515 := 0
+		for ; yyj3515 < yyrr3515; yyj3515++ {
 			if r.TryDecodeAsNil() {
-				yyv3511[yyj3511] = ContainerPort{}
+				yyv3515[yyj3515] = ContainerPort{}
 			} else {
-				yyv3512 := &yyv3511[yyj3511]
-				yyv3512.CodecDecodeSelf(d)
+				yyv3516 := &yyv3515[yyj3515]
+				yyv3516.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3511 {
-			for ; yyj3511 < yyl3511; yyj3511++ {
-				yyv3511 = append(yyv3511, ContainerPort{})
+		if yyrt3515 {
+			for ; yyj3515 < yyl3515; yyj3515++ {
+				yyv3515 = append(yyv3515, ContainerPort{})
 				if r.TryDecodeAsNil() {
-					yyv3511[yyj3511] = ContainerPort{}
+					yyv3515[yyj3515] = ContainerPort{}
 				} else {
-					yyv3513 := &yyv3511[yyj3511]
-					yyv3513.CodecDecodeSelf(d)
+					yyv3517 := &yyv3515[yyj3515]
+					yyv3517.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3511 := 0; !r.CheckBreak(); yyj3511++ {
-			if yyj3511 >= len(yyv3511) {
-				yyv3511 = append(yyv3511, ContainerPort{}) // var yyz3511 ContainerPort
-				yyc3511 = true
+		for yyj3515 := 0; !r.CheckBreak(); yyj3515++ {
+			if yyj3515 >= len(yyv3515) {
+				yyv3515 = append(yyv3515, ContainerPort{}) // var yyz3515 ContainerPort
+				yyc3515 = true
 			}
 
-			if yyj3511 < len(yyv3511) {
+			if yyj3515 < len(yyv3515) {
 				if r.TryDecodeAsNil() {
-					yyv3511[yyj3511] = ContainerPort{}
+					yyv3515[yyj3515] = ContainerPort{}
 				} else {
-					yyv3514 := &yyv3511[yyj3511]
-					yyv3514.CodecDecodeSelf(d)
+					yyv3518 := &yyv3515[yyj3515]
+					yyv3518.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40642,10 +40672,10 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 			}
 
 		}
-		yyh3511.End()
+		yyh3515.End()
 	}
-	if yyc3511 {
-		*v = yyv3511
+	if yyc3515 {
+		*v = yyv3515
 	}
 
 }
@@ -40655,9 +40685,9 @@ func (x codecSelfer1234) encSliceEnvVar(v []EnvVar, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3515 := range v {
-		yy3516 := &yyv3515
-		yy3516.CodecEncodeSelf(e)
+	for _, yyv3519 := range v {
+		yy3520 := &yyv3519
+		yy3520.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40667,75 +40697,75 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3517 := *v
-	yyh3517, yyl3517 := z.DecSliceHelperStart()
+	yyv3521 := *v
+	yyh3521, yyl3521 := z.DecSliceHelperStart()
 
-	var yyrr3517, yyrl3517 int
-	var yyc3517, yyrt3517 bool
-	_, _, _ = yyc3517, yyrt3517, yyrl3517
-	yyrr3517 = yyl3517
+	var yyrr3521, yyrl3521 int
+	var yyc3521, yyrt3521 bool
+	_, _, _ = yyc3521, yyrt3521, yyrl3521
+	yyrr3521 = yyl3521
 
-	if yyv3517 == nil {
-		if yyrl3517, yyrt3517 = z.DecInferLen(yyl3517, z.DecBasicHandle().MaxInitLen, 40); yyrt3517 {
-			yyrr3517 = yyrl3517
+	if yyv3521 == nil {
+		if yyrl3521, yyrt3521 = z.DecInferLen(yyl3521, z.DecBasicHandle().MaxInitLen, 40); yyrt3521 {
+			yyrr3521 = yyrl3521
 		}
-		yyv3517 = make([]EnvVar, yyrl3517)
-		yyc3517 = true
+		yyv3521 = make([]EnvVar, yyrl3521)
+		yyc3521 = true
 	}
 
-	if yyl3517 == 0 {
-		if len(yyv3517) != 0 {
-			yyv3517 = yyv3517[:0]
-			yyc3517 = true
+	if yyl3521 == 0 {
+		if len(yyv3521) != 0 {
+			yyv3521 = yyv3521[:0]
+			yyc3521 = true
 		}
-	} else if yyl3517 > 0 {
+	} else if yyl3521 > 0 {
 
-		if yyl3517 > cap(yyv3517) {
-			yyrl3517, yyrt3517 = z.DecInferLen(yyl3517, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3517 = make([]EnvVar, yyrl3517)
-			yyc3517 = true
+		if yyl3521 > cap(yyv3521) {
+			yyrl3521, yyrt3521 = z.DecInferLen(yyl3521, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3521 = make([]EnvVar, yyrl3521)
+			yyc3521 = true
 
-			yyrr3517 = len(yyv3517)
-		} else if yyl3517 != len(yyv3517) {
-			yyv3517 = yyv3517[:yyl3517]
-			yyc3517 = true
+			yyrr3521 = len(yyv3521)
+		} else if yyl3521 != len(yyv3521) {
+			yyv3521 = yyv3521[:yyl3521]
+			yyc3521 = true
 		}
-		yyj3517 := 0
-		for ; yyj3517 < yyrr3517; yyj3517++ {
+		yyj3521 := 0
+		for ; yyj3521 < yyrr3521; yyj3521++ {
 			if r.TryDecodeAsNil() {
-				yyv3517[yyj3517] = EnvVar{}
+				yyv3521[yyj3521] = EnvVar{}
 			} else {
-				yyv3518 := &yyv3517[yyj3517]
-				yyv3518.CodecDecodeSelf(d)
+				yyv3522 := &yyv3521[yyj3521]
+				yyv3522.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3517 {
-			for ; yyj3517 < yyl3517; yyj3517++ {
-				yyv3517 = append(yyv3517, EnvVar{})
+		if yyrt3521 {
+			for ; yyj3521 < yyl3521; yyj3521++ {
+				yyv3521 = append(yyv3521, EnvVar{})
 				if r.TryDecodeAsNil() {
-					yyv3517[yyj3517] = EnvVar{}
+					yyv3521[yyj3521] = EnvVar{}
 				} else {
-					yyv3519 := &yyv3517[yyj3517]
-					yyv3519.CodecDecodeSelf(d)
+					yyv3523 := &yyv3521[yyj3521]
+					yyv3523.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3517 := 0; !r.CheckBreak(); yyj3517++ {
-			if yyj3517 >= len(yyv3517) {
-				yyv3517 = append(yyv3517, EnvVar{}) // var yyz3517 EnvVar
-				yyc3517 = true
+		for yyj3521 := 0; !r.CheckBreak(); yyj3521++ {
+			if yyj3521 >= len(yyv3521) {
+				yyv3521 = append(yyv3521, EnvVar{}) // var yyz3521 EnvVar
+				yyc3521 = true
 			}
 
-			if yyj3517 < len(yyv3517) {
+			if yyj3521 < len(yyv3521) {
 				if r.TryDecodeAsNil() {
-					yyv3517[yyj3517] = EnvVar{}
+					yyv3521[yyj3521] = EnvVar{}
 				} else {
-					yyv3520 := &yyv3517[yyj3517]
-					yyv3520.CodecDecodeSelf(d)
+					yyv3524 := &yyv3521[yyj3521]
+					yyv3524.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40743,10 +40773,10 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3517.End()
+		yyh3521.End()
 	}
-	if yyc3517 {
-		*v = yyv3517
+	if yyc3521 {
+		*v = yyv3521
 	}
 
 }
@@ -40756,9 +40786,9 @@ func (x codecSelfer1234) encSliceVolumeMount(v []VolumeMount, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3521 := range v {
-		yy3522 := &yyv3521
-		yy3522.CodecEncodeSelf(e)
+	for _, yyv3525 := range v {
+		yy3526 := &yyv3525
+		yy3526.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40768,75 +40798,75 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3523 := *v
-	yyh3523, yyl3523 := z.DecSliceHelperStart()
+	yyv3527 := *v
+	yyh3527, yyl3527 := z.DecSliceHelperStart()
 
-	var yyrr3523, yyrl3523 int
-	var yyc3523, yyrt3523 bool
-	_, _, _ = yyc3523, yyrt3523, yyrl3523
-	yyrr3523 = yyl3523
+	var yyrr3527, yyrl3527 int
+	var yyc3527, yyrt3527 bool
+	_, _, _ = yyc3527, yyrt3527, yyrl3527
+	yyrr3527 = yyl3527
 
-	if yyv3523 == nil {
-		if yyrl3523, yyrt3523 = z.DecInferLen(yyl3523, z.DecBasicHandle().MaxInitLen, 40); yyrt3523 {
-			yyrr3523 = yyrl3523
+	if yyv3527 == nil {
+		if yyrl3527, yyrt3527 = z.DecInferLen(yyl3527, z.DecBasicHandle().MaxInitLen, 40); yyrt3527 {
+			yyrr3527 = yyrl3527
 		}
-		yyv3523 = make([]VolumeMount, yyrl3523)
-		yyc3523 = true
+		yyv3527 = make([]VolumeMount, yyrl3527)
+		yyc3527 = true
 	}
 
-	if yyl3523 == 0 {
-		if len(yyv3523) != 0 {
-			yyv3523 = yyv3523[:0]
-			yyc3523 = true
+	if yyl3527 == 0 {
+		if len(yyv3527) != 0 {
+			yyv3527 = yyv3527[:0]
+			yyc3527 = true
 		}
-	} else if yyl3523 > 0 {
+	} else if yyl3527 > 0 {
 
-		if yyl3523 > cap(yyv3523) {
-			yyrl3523, yyrt3523 = z.DecInferLen(yyl3523, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3523 = make([]VolumeMount, yyrl3523)
-			yyc3523 = true
+		if yyl3527 > cap(yyv3527) {
+			yyrl3527, yyrt3527 = z.DecInferLen(yyl3527, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3527 = make([]VolumeMount, yyrl3527)
+			yyc3527 = true
 
-			yyrr3523 = len(yyv3523)
-		} else if yyl3523 != len(yyv3523) {
-			yyv3523 = yyv3523[:yyl3523]
-			yyc3523 = true
+			yyrr3527 = len(yyv3527)
+		} else if yyl3527 != len(yyv3527) {
+			yyv3527 = yyv3527[:yyl3527]
+			yyc3527 = true
 		}
-		yyj3523 := 0
-		for ; yyj3523 < yyrr3523; yyj3523++ {
+		yyj3527 := 0
+		for ; yyj3527 < yyrr3527; yyj3527++ {
 			if r.TryDecodeAsNil() {
-				yyv3523[yyj3523] = VolumeMount{}
+				yyv3527[yyj3527] = VolumeMount{}
 			} else {
-				yyv3524 := &yyv3523[yyj3523]
-				yyv3524.CodecDecodeSelf(d)
+				yyv3528 := &yyv3527[yyj3527]
+				yyv3528.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3523 {
-			for ; yyj3523 < yyl3523; yyj3523++ {
-				yyv3523 = append(yyv3523, VolumeMount{})
+		if yyrt3527 {
+			for ; yyj3527 < yyl3527; yyj3527++ {
+				yyv3527 = append(yyv3527, VolumeMount{})
 				if r.TryDecodeAsNil() {
-					yyv3523[yyj3523] = VolumeMount{}
+					yyv3527[yyj3527] = VolumeMount{}
 				} else {
-					yyv3525 := &yyv3523[yyj3523]
-					yyv3525.CodecDecodeSelf(d)
+					yyv3529 := &yyv3527[yyj3527]
+					yyv3529.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3523 := 0; !r.CheckBreak(); yyj3523++ {
-			if yyj3523 >= len(yyv3523) {
-				yyv3523 = append(yyv3523, VolumeMount{}) // var yyz3523 VolumeMount
-				yyc3523 = true
+		for yyj3527 := 0; !r.CheckBreak(); yyj3527++ {
+			if yyj3527 >= len(yyv3527) {
+				yyv3527 = append(yyv3527, VolumeMount{}) // var yyz3527 VolumeMount
+				yyc3527 = true
 			}
 
-			if yyj3523 < len(yyv3523) {
+			if yyj3527 < len(yyv3527) {
 				if r.TryDecodeAsNil() {
-					yyv3523[yyj3523] = VolumeMount{}
+					yyv3527[yyj3527] = VolumeMount{}
 				} else {
-					yyv3526 := &yyv3523[yyj3523]
-					yyv3526.CodecDecodeSelf(d)
+					yyv3530 := &yyv3527[yyj3527]
+					yyv3530.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40844,10 +40874,10 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 			}
 
 		}
-		yyh3523.End()
+		yyh3527.End()
 	}
-	if yyc3523 {
-		*v = yyv3523
+	if yyc3527 {
+		*v = yyv3527
 	}
 
 }
@@ -40857,9 +40887,9 @@ func (x codecSelfer1234) encSlicePod(v []Pod, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3527 := range v {
-		yy3528 := &yyv3527
-		yy3528.CodecEncodeSelf(e)
+	for _, yyv3531 := range v {
+		yy3532 := &yyv3531
+		yy3532.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40869,75 +40899,75 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3529 := *v
-	yyh3529, yyl3529 := z.DecSliceHelperStart()
+	yyv3533 := *v
+	yyh3533, yyl3533 := z.DecSliceHelperStart()
 
-	var yyrr3529, yyrl3529 int
-	var yyc3529, yyrt3529 bool
-	_, _, _ = yyc3529, yyrt3529, yyrl3529
-	yyrr3529 = yyl3529
+	var yyrr3533, yyrl3533 int
+	var yyc3533, yyrt3533 bool
+	_, _, _ = yyc3533, yyrt3533, yyrl3533
+	yyrr3533 = yyl3533
 
-	if yyv3529 == nil {
-		if yyrl3529, yyrt3529 = z.DecInferLen(yyl3529, z.DecBasicHandle().MaxInitLen, 496); yyrt3529 {
-			yyrr3529 = yyrl3529
+	if yyv3533 == nil {
+		if yyrl3533, yyrt3533 = z.DecInferLen(yyl3533, z.DecBasicHandle().MaxInitLen, 488); yyrt3533 {
+			yyrr3533 = yyrl3533
 		}
-		yyv3529 = make([]Pod, yyrl3529)
-		yyc3529 = true
+		yyv3533 = make([]Pod, yyrl3533)
+		yyc3533 = true
 	}
 
-	if yyl3529 == 0 {
-		if len(yyv3529) != 0 {
-			yyv3529 = yyv3529[:0]
-			yyc3529 = true
+	if yyl3533 == 0 {
+		if len(yyv3533) != 0 {
+			yyv3533 = yyv3533[:0]
+			yyc3533 = true
 		}
-	} else if yyl3529 > 0 {
+	} else if yyl3533 > 0 {
 
-		if yyl3529 > cap(yyv3529) {
-			yyrl3529, yyrt3529 = z.DecInferLen(yyl3529, z.DecBasicHandle().MaxInitLen, 496)
-			yyv3529 = make([]Pod, yyrl3529)
-			yyc3529 = true
+		if yyl3533 > cap(yyv3533) {
+			yyrl3533, yyrt3533 = z.DecInferLen(yyl3533, z.DecBasicHandle().MaxInitLen, 488)
+			yyv3533 = make([]Pod, yyrl3533)
+			yyc3533 = true
 
-			yyrr3529 = len(yyv3529)
-		} else if yyl3529 != len(yyv3529) {
-			yyv3529 = yyv3529[:yyl3529]
-			yyc3529 = true
+			yyrr3533 = len(yyv3533)
+		} else if yyl3533 != len(yyv3533) {
+			yyv3533 = yyv3533[:yyl3533]
+			yyc3533 = true
 		}
-		yyj3529 := 0
-		for ; yyj3529 < yyrr3529; yyj3529++ {
+		yyj3533 := 0
+		for ; yyj3533 < yyrr3533; yyj3533++ {
 			if r.TryDecodeAsNil() {
-				yyv3529[yyj3529] = Pod{}
+				yyv3533[yyj3533] = Pod{}
 			} else {
-				yyv3530 := &yyv3529[yyj3529]
-				yyv3530.CodecDecodeSelf(d)
+				yyv3534 := &yyv3533[yyj3533]
+				yyv3534.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3529 {
-			for ; yyj3529 < yyl3529; yyj3529++ {
-				yyv3529 = append(yyv3529, Pod{})
+		if yyrt3533 {
+			for ; yyj3533 < yyl3533; yyj3533++ {
+				yyv3533 = append(yyv3533, Pod{})
 				if r.TryDecodeAsNil() {
-					yyv3529[yyj3529] = Pod{}
+					yyv3533[yyj3533] = Pod{}
 				} else {
-					yyv3531 := &yyv3529[yyj3529]
-					yyv3531.CodecDecodeSelf(d)
+					yyv3535 := &yyv3533[yyj3533]
+					yyv3535.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3529 := 0; !r.CheckBreak(); yyj3529++ {
-			if yyj3529 >= len(yyv3529) {
-				yyv3529 = append(yyv3529, Pod{}) // var yyz3529 Pod
-				yyc3529 = true
+		for yyj3533 := 0; !r.CheckBreak(); yyj3533++ {
+			if yyj3533 >= len(yyv3533) {
+				yyv3533 = append(yyv3533, Pod{}) // var yyz3533 Pod
+				yyc3533 = true
 			}
 
-			if yyj3529 < len(yyv3529) {
+			if yyj3533 < len(yyv3533) {
 				if r.TryDecodeAsNil() {
-					yyv3529[yyj3529] = Pod{}
+					yyv3533[yyj3533] = Pod{}
 				} else {
-					yyv3532 := &yyv3529[yyj3529]
-					yyv3532.CodecDecodeSelf(d)
+					yyv3536 := &yyv3533[yyj3533]
+					yyv3536.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40945,10 +40975,10 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3529.End()
+		yyh3533.End()
 	}
-	if yyc3529 {
-		*v = yyv3529
+	if yyc3533 {
+		*v = yyv3533
 	}
 
 }
@@ -40958,9 +40988,9 @@ func (x codecSelfer1234) encSliceVolume(v []Volume, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3533 := range v {
-		yy3534 := &yyv3533
-		yy3534.CodecEncodeSelf(e)
+	for _, yyv3537 := range v {
+		yy3538 := &yyv3537
+		yy3538.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40970,75 +41000,75 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3535 := *v
-	yyh3535, yyl3535 := z.DecSliceHelperStart()
+	yyv3539 := *v
+	yyh3539, yyl3539 := z.DecSliceHelperStart()
 
-	var yyrr3535, yyrl3535 int
-	var yyc3535, yyrt3535 bool
-	_, _, _ = yyc3535, yyrt3535, yyrl3535
-	yyrr3535 = yyl3535
+	var yyrr3539, yyrl3539 int
+	var yyc3539, yyrt3539 bool
+	_, _, _ = yyc3539, yyrt3539, yyrl3539
+	yyrr3539 = yyl3539
 
-	if yyv3535 == nil {
-		if yyrl3535, yyrt3535 = z.DecInferLen(yyl3535, z.DecBasicHandle().MaxInitLen, 144); yyrt3535 {
-			yyrr3535 = yyrl3535
+	if yyv3539 == nil {
+		if yyrl3539, yyrt3539 = z.DecInferLen(yyl3539, z.DecBasicHandle().MaxInitLen, 144); yyrt3539 {
+			yyrr3539 = yyrl3539
 		}
-		yyv3535 = make([]Volume, yyrl3535)
-		yyc3535 = true
+		yyv3539 = make([]Volume, yyrl3539)
+		yyc3539 = true
 	}
 
-	if yyl3535 == 0 {
-		if len(yyv3535) != 0 {
-			yyv3535 = yyv3535[:0]
-			yyc3535 = true
+	if yyl3539 == 0 {
+		if len(yyv3539) != 0 {
+			yyv3539 = yyv3539[:0]
+			yyc3539 = true
 		}
-	} else if yyl3535 > 0 {
+	} else if yyl3539 > 0 {
 
-		if yyl3535 > cap(yyv3535) {
-			yyrl3535, yyrt3535 = z.DecInferLen(yyl3535, z.DecBasicHandle().MaxInitLen, 144)
-			yyv3535 = make([]Volume, yyrl3535)
-			yyc3535 = true
+		if yyl3539 > cap(yyv3539) {
+			yyrl3539, yyrt3539 = z.DecInferLen(yyl3539, z.DecBasicHandle().MaxInitLen, 144)
+			yyv3539 = make([]Volume, yyrl3539)
+			yyc3539 = true
 
-			yyrr3535 = len(yyv3535)
-		} else if yyl3535 != len(yyv3535) {
-			yyv3535 = yyv3535[:yyl3535]
-			yyc3535 = true
+			yyrr3539 = len(yyv3539)
+		} else if yyl3539 != len(yyv3539) {
+			yyv3539 = yyv3539[:yyl3539]
+			yyc3539 = true
 		}
-		yyj3535 := 0
-		for ; yyj3535 < yyrr3535; yyj3535++ {
+		yyj3539 := 0
+		for ; yyj3539 < yyrr3539; yyj3539++ {
 			if r.TryDecodeAsNil() {
-				yyv3535[yyj3535] = Volume{}
+				yyv3539[yyj3539] = Volume{}
 			} else {
-				yyv3536 := &yyv3535[yyj3535]
-				yyv3536.CodecDecodeSelf(d)
+				yyv3540 := &yyv3539[yyj3539]
+				yyv3540.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3535 {
-			for ; yyj3535 < yyl3535; yyj3535++ {
-				yyv3535 = append(yyv3535, Volume{})
+		if yyrt3539 {
+			for ; yyj3539 < yyl3539; yyj3539++ {
+				yyv3539 = append(yyv3539, Volume{})
 				if r.TryDecodeAsNil() {
-					yyv3535[yyj3535] = Volume{}
+					yyv3539[yyj3539] = Volume{}
 				} else {
-					yyv3537 := &yyv3535[yyj3535]
-					yyv3537.CodecDecodeSelf(d)
+					yyv3541 := &yyv3539[yyj3539]
+					yyv3541.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3535 := 0; !r.CheckBreak(); yyj3535++ {
-			if yyj3535 >= len(yyv3535) {
-				yyv3535 = append(yyv3535, Volume{}) // var yyz3535 Volume
-				yyc3535 = true
+		for yyj3539 := 0; !r.CheckBreak(); yyj3539++ {
+			if yyj3539 >= len(yyv3539) {
+				yyv3539 = append(yyv3539, Volume{}) // var yyz3539 Volume
+				yyc3539 = true
 			}
 
-			if yyj3535 < len(yyv3535) {
+			if yyj3539 < len(yyv3539) {
 				if r.TryDecodeAsNil() {
-					yyv3535[yyj3535] = Volume{}
+					yyv3539[yyj3539] = Volume{}
 				} else {
-					yyv3538 := &yyv3535[yyj3535]
-					yyv3538.CodecDecodeSelf(d)
+					yyv3542 := &yyv3539[yyj3539]
+					yyv3542.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41046,10 +41076,10 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3535.End()
+		yyh3539.End()
 	}
-	if yyc3535 {
-		*v = yyv3535
+	if yyc3539 {
+		*v = yyv3539
 	}
 
 }
@@ -41059,9 +41089,9 @@ func (x codecSelfer1234) encSliceContainer(v []Container, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3539 := range v {
-		yy3540 := &yyv3539
-		yy3540.CodecEncodeSelf(e)
+	for _, yyv3543 := range v {
+		yy3544 := &yyv3543
+		yy3544.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41071,75 +41101,75 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3541 := *v
-	yyh3541, yyl3541 := z.DecSliceHelperStart()
+	yyv3545 := *v
+	yyh3545, yyl3545 := z.DecSliceHelperStart()
 
-	var yyrr3541, yyrl3541 int
-	var yyc3541, yyrt3541 bool
-	_, _, _ = yyc3541, yyrt3541, yyrl3541
-	yyrr3541 = yyl3541
+	var yyrr3545, yyrl3545 int
+	var yyc3545, yyrt3545 bool
+	_, _, _ = yyc3545, yyrt3545, yyrl3545
+	yyrr3545 = yyl3545
 
-	if yyv3541 == nil {
-		if yyrl3541, yyrt3541 = z.DecInferLen(yyl3541, z.DecBasicHandle().MaxInitLen, 256); yyrt3541 {
-			yyrr3541 = yyrl3541
+	if yyv3545 == nil {
+		if yyrl3545, yyrt3545 = z.DecInferLen(yyl3545, z.DecBasicHandle().MaxInitLen, 256); yyrt3545 {
+			yyrr3545 = yyrl3545
 		}
-		yyv3541 = make([]Container, yyrl3541)
-		yyc3541 = true
+		yyv3545 = make([]Container, yyrl3545)
+		yyc3545 = true
 	}
 
-	if yyl3541 == 0 {
-		if len(yyv3541) != 0 {
-			yyv3541 = yyv3541[:0]
-			yyc3541 = true
+	if yyl3545 == 0 {
+		if len(yyv3545) != 0 {
+			yyv3545 = yyv3545[:0]
+			yyc3545 = true
 		}
-	} else if yyl3541 > 0 {
+	} else if yyl3545 > 0 {
 
-		if yyl3541 > cap(yyv3541) {
-			yyrl3541, yyrt3541 = z.DecInferLen(yyl3541, z.DecBasicHandle().MaxInitLen, 256)
-			yyv3541 = make([]Container, yyrl3541)
-			yyc3541 = true
+		if yyl3545 > cap(yyv3545) {
+			yyrl3545, yyrt3545 = z.DecInferLen(yyl3545, z.DecBasicHandle().MaxInitLen, 256)
+			yyv3545 = make([]Container, yyrl3545)
+			yyc3545 = true
 
-			yyrr3541 = len(yyv3541)
-		} else if yyl3541 != len(yyv3541) {
-			yyv3541 = yyv3541[:yyl3541]
-			yyc3541 = true
+			yyrr3545 = len(yyv3545)
+		} else if yyl3545 != len(yyv3545) {
+			yyv3545 = yyv3545[:yyl3545]
+			yyc3545 = true
 		}
-		yyj3541 := 0
-		for ; yyj3541 < yyrr3541; yyj3541++ {
+		yyj3545 := 0
+		for ; yyj3545 < yyrr3545; yyj3545++ {
 			if r.TryDecodeAsNil() {
-				yyv3541[yyj3541] = Container{}
+				yyv3545[yyj3545] = Container{}
 			} else {
-				yyv3542 := &yyv3541[yyj3541]
-				yyv3542.CodecDecodeSelf(d)
+				yyv3546 := &yyv3545[yyj3545]
+				yyv3546.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3541 {
-			for ; yyj3541 < yyl3541; yyj3541++ {
-				yyv3541 = append(yyv3541, Container{})
+		if yyrt3545 {
+			for ; yyj3545 < yyl3545; yyj3545++ {
+				yyv3545 = append(yyv3545, Container{})
 				if r.TryDecodeAsNil() {
-					yyv3541[yyj3541] = Container{}
+					yyv3545[yyj3545] = Container{}
 				} else {
-					yyv3543 := &yyv3541[yyj3541]
-					yyv3543.CodecDecodeSelf(d)
+					yyv3547 := &yyv3545[yyj3545]
+					yyv3547.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3541 := 0; !r.CheckBreak(); yyj3541++ {
-			if yyj3541 >= len(yyv3541) {
-				yyv3541 = append(yyv3541, Container{}) // var yyz3541 Container
-				yyc3541 = true
+		for yyj3545 := 0; !r.CheckBreak(); yyj3545++ {
+			if yyj3545 >= len(yyv3545) {
+				yyv3545 = append(yyv3545, Container{}) // var yyz3545 Container
+				yyc3545 = true
 			}
 
-			if yyj3541 < len(yyv3541) {
+			if yyj3545 < len(yyv3545) {
 				if r.TryDecodeAsNil() {
-					yyv3541[yyj3541] = Container{}
+					yyv3545[yyj3545] = Container{}
 				} else {
-					yyv3544 := &yyv3541[yyj3541]
-					yyv3544.CodecDecodeSelf(d)
+					yyv3548 := &yyv3545[yyj3545]
+					yyv3548.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41147,10 +41177,10 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3541.End()
+		yyh3545.End()
 	}
-	if yyc3541 {
-		*v = yyv3541
+	if yyc3545 {
+		*v = yyv3545
 	}
 
 }
@@ -41160,9 +41190,9 @@ func (x codecSelfer1234) encSliceLocalObjectReference(v []LocalObjectReference, 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3545 := range v {
-		yy3546 := &yyv3545
-		yy3546.CodecEncodeSelf(e)
+	for _, yyv3549 := range v {
+		yy3550 := &yyv3549
+		yy3550.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41172,75 +41202,75 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3547 := *v
-	yyh3547, yyl3547 := z.DecSliceHelperStart()
+	yyv3551 := *v
+	yyh3551, yyl3551 := z.DecSliceHelperStart()
 
-	var yyrr3547, yyrl3547 int
-	var yyc3547, yyrt3547 bool
-	_, _, _ = yyc3547, yyrt3547, yyrl3547
-	yyrr3547 = yyl3547
+	var yyrr3551, yyrl3551 int
+	var yyc3551, yyrt3551 bool
+	_, _, _ = yyc3551, yyrt3551, yyrl3551
+	yyrr3551 = yyl3551
 
-	if yyv3547 == nil {
-		if yyrl3547, yyrt3547 = z.DecInferLen(yyl3547, z.DecBasicHandle().MaxInitLen, 16); yyrt3547 {
-			yyrr3547 = yyrl3547
+	if yyv3551 == nil {
+		if yyrl3551, yyrt3551 = z.DecInferLen(yyl3551, z.DecBasicHandle().MaxInitLen, 16); yyrt3551 {
+			yyrr3551 = yyrl3551
 		}
-		yyv3547 = make([]LocalObjectReference, yyrl3547)
-		yyc3547 = true
+		yyv3551 = make([]LocalObjectReference, yyrl3551)
+		yyc3551 = true
 	}
 
-	if yyl3547 == 0 {
-		if len(yyv3547) != 0 {
-			yyv3547 = yyv3547[:0]
-			yyc3547 = true
+	if yyl3551 == 0 {
+		if len(yyv3551) != 0 {
+			yyv3551 = yyv3551[:0]
+			yyc3551 = true
 		}
-	} else if yyl3547 > 0 {
+	} else if yyl3551 > 0 {
 
-		if yyl3547 > cap(yyv3547) {
-			yyrl3547, yyrt3547 = z.DecInferLen(yyl3547, z.DecBasicHandle().MaxInitLen, 16)
-			yyv3547 = make([]LocalObjectReference, yyrl3547)
-			yyc3547 = true
+		if yyl3551 > cap(yyv3551) {
+			yyrl3551, yyrt3551 = z.DecInferLen(yyl3551, z.DecBasicHandle().MaxInitLen, 16)
+			yyv3551 = make([]LocalObjectReference, yyrl3551)
+			yyc3551 = true
 
-			yyrr3547 = len(yyv3547)
-		} else if yyl3547 != len(yyv3547) {
-			yyv3547 = yyv3547[:yyl3547]
-			yyc3547 = true
+			yyrr3551 = len(yyv3551)
+		} else if yyl3551 != len(yyv3551) {
+			yyv3551 = yyv3551[:yyl3551]
+			yyc3551 = true
 		}
-		yyj3547 := 0
-		for ; yyj3547 < yyrr3547; yyj3547++ {
+		yyj3551 := 0
+		for ; yyj3551 < yyrr3551; yyj3551++ {
 			if r.TryDecodeAsNil() {
-				yyv3547[yyj3547] = LocalObjectReference{}
+				yyv3551[yyj3551] = LocalObjectReference{}
 			} else {
-				yyv3548 := &yyv3547[yyj3547]
-				yyv3548.CodecDecodeSelf(d)
+				yyv3552 := &yyv3551[yyj3551]
+				yyv3552.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3547 {
-			for ; yyj3547 < yyl3547; yyj3547++ {
-				yyv3547 = append(yyv3547, LocalObjectReference{})
+		if yyrt3551 {
+			for ; yyj3551 < yyl3551; yyj3551++ {
+				yyv3551 = append(yyv3551, LocalObjectReference{})
 				if r.TryDecodeAsNil() {
-					yyv3547[yyj3547] = LocalObjectReference{}
+					yyv3551[yyj3551] = LocalObjectReference{}
 				} else {
-					yyv3549 := &yyv3547[yyj3547]
-					yyv3549.CodecDecodeSelf(d)
+					yyv3553 := &yyv3551[yyj3551]
+					yyv3553.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3547 := 0; !r.CheckBreak(); yyj3547++ {
-			if yyj3547 >= len(yyv3547) {
-				yyv3547 = append(yyv3547, LocalObjectReference{}) // var yyz3547 LocalObjectReference
-				yyc3547 = true
+		for yyj3551 := 0; !r.CheckBreak(); yyj3551++ {
+			if yyj3551 >= len(yyv3551) {
+				yyv3551 = append(yyv3551, LocalObjectReference{}) // var yyz3551 LocalObjectReference
+				yyc3551 = true
 			}
 
-			if yyj3547 < len(yyv3547) {
+			if yyj3551 < len(yyv3551) {
 				if r.TryDecodeAsNil() {
-					yyv3547[yyj3547] = LocalObjectReference{}
+					yyv3551[yyj3551] = LocalObjectReference{}
 				} else {
-					yyv3550 := &yyv3547[yyj3547]
-					yyv3550.CodecDecodeSelf(d)
+					yyv3554 := &yyv3551[yyj3551]
+					yyv3554.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41248,10 +41278,10 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 			}
 
 		}
-		yyh3547.End()
+		yyh3551.End()
 	}
-	if yyc3547 {
-		*v = yyv3547
+	if yyc3551 {
+		*v = yyv3551
 	}
 
 }
@@ -41261,9 +41291,9 @@ func (x codecSelfer1234) encSlicePodCondition(v []PodCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3551 := range v {
-		yy3552 := &yyv3551
-		yy3552.CodecEncodeSelf(e)
+	for _, yyv3555 := range v {
+		yy3556 := &yyv3555
+		yy3556.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41273,75 +41303,75 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3553 := *v
-	yyh3553, yyl3553 := z.DecSliceHelperStart()
+	yyv3557 := *v
+	yyh3557, yyl3557 := z.DecSliceHelperStart()
 
-	var yyrr3553, yyrl3553 int
-	var yyc3553, yyrt3553 bool
-	_, _, _ = yyc3553, yyrt3553, yyrl3553
-	yyrr3553 = yyl3553
+	var yyrr3557, yyrl3557 int
+	var yyc3557, yyrt3557 bool
+	_, _, _ = yyc3557, yyrt3557, yyrl3557
+	yyrr3557 = yyl3557
 
-	if yyv3553 == nil {
-		if yyrl3553, yyrt3553 = z.DecInferLen(yyl3553, z.DecBasicHandle().MaxInitLen, 112); yyrt3553 {
-			yyrr3553 = yyrl3553
+	if yyv3557 == nil {
+		if yyrl3557, yyrt3557 = z.DecInferLen(yyl3557, z.DecBasicHandle().MaxInitLen, 112); yyrt3557 {
+			yyrr3557 = yyrl3557
 		}
-		yyv3553 = make([]PodCondition, yyrl3553)
-		yyc3553 = true
+		yyv3557 = make([]PodCondition, yyrl3557)
+		yyc3557 = true
 	}
 
-	if yyl3553 == 0 {
-		if len(yyv3553) != 0 {
-			yyv3553 = yyv3553[:0]
-			yyc3553 = true
+	if yyl3557 == 0 {
+		if len(yyv3557) != 0 {
+			yyv3557 = yyv3557[:0]
+			yyc3557 = true
 		}
-	} else if yyl3553 > 0 {
+	} else if yyl3557 > 0 {
 
-		if yyl3553 > cap(yyv3553) {
-			yyrl3553, yyrt3553 = z.DecInferLen(yyl3553, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3553 = make([]PodCondition, yyrl3553)
-			yyc3553 = true
+		if yyl3557 > cap(yyv3557) {
+			yyrl3557, yyrt3557 = z.DecInferLen(yyl3557, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3557 = make([]PodCondition, yyrl3557)
+			yyc3557 = true
 
-			yyrr3553 = len(yyv3553)
-		} else if yyl3553 != len(yyv3553) {
-			yyv3553 = yyv3553[:yyl3553]
-			yyc3553 = true
+			yyrr3557 = len(yyv3557)
+		} else if yyl3557 != len(yyv3557) {
+			yyv3557 = yyv3557[:yyl3557]
+			yyc3557 = true
 		}
-		yyj3553 := 0
-		for ; yyj3553 < yyrr3553; yyj3553++ {
+		yyj3557 := 0
+		for ; yyj3557 < yyrr3557; yyj3557++ {
 			if r.TryDecodeAsNil() {
-				yyv3553[yyj3553] = PodCondition{}
+				yyv3557[yyj3557] = PodCondition{}
 			} else {
-				yyv3554 := &yyv3553[yyj3553]
-				yyv3554.CodecDecodeSelf(d)
+				yyv3558 := &yyv3557[yyj3557]
+				yyv3558.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3553 {
-			for ; yyj3553 < yyl3553; yyj3553++ {
-				yyv3553 = append(yyv3553, PodCondition{})
+		if yyrt3557 {
+			for ; yyj3557 < yyl3557; yyj3557++ {
+				yyv3557 = append(yyv3557, PodCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3553[yyj3553] = PodCondition{}
+					yyv3557[yyj3557] = PodCondition{}
 				} else {
-					yyv3555 := &yyv3553[yyj3553]
-					yyv3555.CodecDecodeSelf(d)
+					yyv3559 := &yyv3557[yyj3557]
+					yyv3559.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3553 := 0; !r.CheckBreak(); yyj3553++ {
-			if yyj3553 >= len(yyv3553) {
-				yyv3553 = append(yyv3553, PodCondition{}) // var yyz3553 PodCondition
-				yyc3553 = true
+		for yyj3557 := 0; !r.CheckBreak(); yyj3557++ {
+			if yyj3557 >= len(yyv3557) {
+				yyv3557 = append(yyv3557, PodCondition{}) // var yyz3557 PodCondition
+				yyc3557 = true
 			}
 
-			if yyj3553 < len(yyv3553) {
+			if yyj3557 < len(yyv3557) {
 				if r.TryDecodeAsNil() {
-					yyv3553[yyj3553] = PodCondition{}
+					yyv3557[yyj3557] = PodCondition{}
 				} else {
-					yyv3556 := &yyv3553[yyj3553]
-					yyv3556.CodecDecodeSelf(d)
+					yyv3560 := &yyv3557[yyj3557]
+					yyv3560.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41349,10 +41379,10 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 			}
 
 		}
-		yyh3553.End()
+		yyh3557.End()
 	}
-	if yyc3553 {
-		*v = yyv3553
+	if yyc3557 {
+		*v = yyv3557
 	}
 
 }
@@ -41362,9 +41392,9 @@ func (x codecSelfer1234) encSliceContainerStatus(v []ContainerStatus, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3557 := range v {
-		yy3558 := &yyv3557
-		yy3558.CodecEncodeSelf(e)
+	for _, yyv3561 := range v {
+		yy3562 := &yyv3561
+		yy3562.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41374,75 +41404,75 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3559 := *v
-	yyh3559, yyl3559 := z.DecSliceHelperStart()
+	yyv3563 := *v
+	yyh3563, yyl3563 := z.DecSliceHelperStart()
 
-	var yyrr3559, yyrl3559 int
-	var yyc3559, yyrt3559 bool
-	_, _, _ = yyc3559, yyrt3559, yyrl3559
-	yyrr3559 = yyl3559
+	var yyrr3563, yyrl3563 int
+	var yyc3563, yyrt3563 bool
+	_, _, _ = yyc3563, yyrt3563, yyrl3563
+	yyrr3563 = yyl3563
 
-	if yyv3559 == nil {
-		if yyrl3559, yyrt3559 = z.DecInferLen(yyl3559, z.DecBasicHandle().MaxInitLen, 128); yyrt3559 {
-			yyrr3559 = yyrl3559
+	if yyv3563 == nil {
+		if yyrl3563, yyrt3563 = z.DecInferLen(yyl3563, z.DecBasicHandle().MaxInitLen, 128); yyrt3563 {
+			yyrr3563 = yyrl3563
 		}
-		yyv3559 = make([]ContainerStatus, yyrl3559)
-		yyc3559 = true
+		yyv3563 = make([]ContainerStatus, yyrl3563)
+		yyc3563 = true
 	}
 
-	if yyl3559 == 0 {
-		if len(yyv3559) != 0 {
-			yyv3559 = yyv3559[:0]
-			yyc3559 = true
+	if yyl3563 == 0 {
+		if len(yyv3563) != 0 {
+			yyv3563 = yyv3563[:0]
+			yyc3563 = true
 		}
-	} else if yyl3559 > 0 {
+	} else if yyl3563 > 0 {
 
-		if yyl3559 > cap(yyv3559) {
-			yyrl3559, yyrt3559 = z.DecInferLen(yyl3559, z.DecBasicHandle().MaxInitLen, 128)
-			yyv3559 = make([]ContainerStatus, yyrl3559)
-			yyc3559 = true
+		if yyl3563 > cap(yyv3563) {
+			yyrl3563, yyrt3563 = z.DecInferLen(yyl3563, z.DecBasicHandle().MaxInitLen, 128)
+			yyv3563 = make([]ContainerStatus, yyrl3563)
+			yyc3563 = true
 
-			yyrr3559 = len(yyv3559)
-		} else if yyl3559 != len(yyv3559) {
-			yyv3559 = yyv3559[:yyl3559]
-			yyc3559 = true
+			yyrr3563 = len(yyv3563)
+		} else if yyl3563 != len(yyv3563) {
+			yyv3563 = yyv3563[:yyl3563]
+			yyc3563 = true
 		}
-		yyj3559 := 0
-		for ; yyj3559 < yyrr3559; yyj3559++ {
+		yyj3563 := 0
+		for ; yyj3563 < yyrr3563; yyj3563++ {
 			if r.TryDecodeAsNil() {
-				yyv3559[yyj3559] = ContainerStatus{}
+				yyv3563[yyj3563] = ContainerStatus{}
 			} else {
-				yyv3560 := &yyv3559[yyj3559]
-				yyv3560.CodecDecodeSelf(d)
+				yyv3564 := &yyv3563[yyj3563]
+				yyv3564.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3559 {
-			for ; yyj3559 < yyl3559; yyj3559++ {
-				yyv3559 = append(yyv3559, ContainerStatus{})
+		if yyrt3563 {
+			for ; yyj3563 < yyl3563; yyj3563++ {
+				yyv3563 = append(yyv3563, ContainerStatus{})
 				if r.TryDecodeAsNil() {
-					yyv3559[yyj3559] = ContainerStatus{}
+					yyv3563[yyj3563] = ContainerStatus{}
 				} else {
-					yyv3561 := &yyv3559[yyj3559]
-					yyv3561.CodecDecodeSelf(d)
+					yyv3565 := &yyv3563[yyj3563]
+					yyv3565.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3559 := 0; !r.CheckBreak(); yyj3559++ {
-			if yyj3559 >= len(yyv3559) {
-				yyv3559 = append(yyv3559, ContainerStatus{}) // var yyz3559 ContainerStatus
-				yyc3559 = true
+		for yyj3563 := 0; !r.CheckBreak(); yyj3563++ {
+			if yyj3563 >= len(yyv3563) {
+				yyv3563 = append(yyv3563, ContainerStatus{}) // var yyz3563 ContainerStatus
+				yyc3563 = true
 			}
 
-			if yyj3559 < len(yyv3559) {
+			if yyj3563 < len(yyv3563) {
 				if r.TryDecodeAsNil() {
-					yyv3559[yyj3559] = ContainerStatus{}
+					yyv3563[yyj3563] = ContainerStatus{}
 				} else {
-					yyv3562 := &yyv3559[yyj3559]
-					yyv3562.CodecDecodeSelf(d)
+					yyv3566 := &yyv3563[yyj3563]
+					yyv3566.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41450,10 +41480,10 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 			}
 
 		}
-		yyh3559.End()
+		yyh3563.End()
 	}
-	if yyc3559 {
-		*v = yyv3559
+	if yyc3563 {
+		*v = yyv3563
 	}
 
 }
@@ -41463,9 +41493,9 @@ func (x codecSelfer1234) encSlicePodTemplate(v []PodTemplate, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3563 := range v {
-		yy3564 := &yyv3563
-		yy3564.CodecEncodeSelf(e)
+	for _, yyv3567 := range v {
+		yy3568 := &yyv3567
+		yy3568.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41475,75 +41505,75 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3565 := *v
-	yyh3565, yyl3565 := z.DecSliceHelperStart()
+	yyv3569 := *v
+	yyh3569, yyl3569 := z.DecSliceHelperStart()
 
-	var yyrr3565, yyrl3565 int
-	var yyc3565, yyrt3565 bool
-	_, _, _ = yyc3565, yyrt3565, yyrl3565
-	yyrr3565 = yyl3565
+	var yyrr3569, yyrl3569 int
+	var yyc3569, yyrt3569 bool
+	_, _, _ = yyc3569, yyrt3569, yyrl3569
+	yyrr3569 = yyl3569
 
-	if yyv3565 == nil {
-		if yyrl3565, yyrt3565 = z.DecInferLen(yyl3565, z.DecBasicHandle().MaxInitLen, 520); yyrt3565 {
-			yyrr3565 = yyrl3565
+	if yyv3569 == nil {
+		if yyrl3569, yyrt3569 = z.DecInferLen(yyl3569, z.DecBasicHandle().MaxInitLen, 512); yyrt3569 {
+			yyrr3569 = yyrl3569
 		}
-		yyv3565 = make([]PodTemplate, yyrl3565)
-		yyc3565 = true
+		yyv3569 = make([]PodTemplate, yyrl3569)
+		yyc3569 = true
 	}
 
-	if yyl3565 == 0 {
-		if len(yyv3565) != 0 {
-			yyv3565 = yyv3565[:0]
-			yyc3565 = true
+	if yyl3569 == 0 {
+		if len(yyv3569) != 0 {
+			yyv3569 = yyv3569[:0]
+			yyc3569 = true
 		}
-	} else if yyl3565 > 0 {
+	} else if yyl3569 > 0 {
 
-		if yyl3565 > cap(yyv3565) {
-			yyrl3565, yyrt3565 = z.DecInferLen(yyl3565, z.DecBasicHandle().MaxInitLen, 520)
-			yyv3565 = make([]PodTemplate, yyrl3565)
-			yyc3565 = true
+		if yyl3569 > cap(yyv3569) {
+			yyrl3569, yyrt3569 = z.DecInferLen(yyl3569, z.DecBasicHandle().MaxInitLen, 512)
+			yyv3569 = make([]PodTemplate, yyrl3569)
+			yyc3569 = true
 
-			yyrr3565 = len(yyv3565)
-		} else if yyl3565 != len(yyv3565) {
-			yyv3565 = yyv3565[:yyl3565]
-			yyc3565 = true
+			yyrr3569 = len(yyv3569)
+		} else if yyl3569 != len(yyv3569) {
+			yyv3569 = yyv3569[:yyl3569]
+			yyc3569 = true
 		}
-		yyj3565 := 0
-		for ; yyj3565 < yyrr3565; yyj3565++ {
+		yyj3569 := 0
+		for ; yyj3569 < yyrr3569; yyj3569++ {
 			if r.TryDecodeAsNil() {
-				yyv3565[yyj3565] = PodTemplate{}
+				yyv3569[yyj3569] = PodTemplate{}
 			} else {
-				yyv3566 := &yyv3565[yyj3565]
-				yyv3566.CodecDecodeSelf(d)
+				yyv3570 := &yyv3569[yyj3569]
+				yyv3570.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3565 {
-			for ; yyj3565 < yyl3565; yyj3565++ {
-				yyv3565 = append(yyv3565, PodTemplate{})
+		if yyrt3569 {
+			for ; yyj3569 < yyl3569; yyj3569++ {
+				yyv3569 = append(yyv3569, PodTemplate{})
 				if r.TryDecodeAsNil() {
-					yyv3565[yyj3565] = PodTemplate{}
+					yyv3569[yyj3569] = PodTemplate{}
 				} else {
-					yyv3567 := &yyv3565[yyj3565]
-					yyv3567.CodecDecodeSelf(d)
+					yyv3571 := &yyv3569[yyj3569]
+					yyv3571.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3565 := 0; !r.CheckBreak(); yyj3565++ {
-			if yyj3565 >= len(yyv3565) {
-				yyv3565 = append(yyv3565, PodTemplate{}) // var yyz3565 PodTemplate
-				yyc3565 = true
+		for yyj3569 := 0; !r.CheckBreak(); yyj3569++ {
+			if yyj3569 >= len(yyv3569) {
+				yyv3569 = append(yyv3569, PodTemplate{}) // var yyz3569 PodTemplate
+				yyc3569 = true
 			}
 
-			if yyj3565 < len(yyv3565) {
+			if yyj3569 < len(yyv3569) {
 				if r.TryDecodeAsNil() {
-					yyv3565[yyj3565] = PodTemplate{}
+					yyv3569[yyj3569] = PodTemplate{}
 				} else {
-					yyv3568 := &yyv3565[yyj3565]
-					yyv3568.CodecDecodeSelf(d)
+					yyv3572 := &yyv3569[yyj3569]
+					yyv3572.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41551,10 +41581,10 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 			}
 
 		}
-		yyh3565.End()
+		yyh3569.End()
 	}
-	if yyc3565 {
-		*v = yyv3565
+	if yyc3569 {
+		*v = yyv3569
 	}
 
 }
@@ -41564,9 +41594,9 @@ func (x codecSelfer1234) encSliceReplicationController(v []ReplicationController
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3569 := range v {
-		yy3570 := &yyv3569
-		yy3570.CodecEncodeSelf(e)
+	for _, yyv3573 := range v {
+		yy3574 := &yyv3573
+		yy3574.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41576,75 +41606,75 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3571 := *v
-	yyh3571, yyl3571 := z.DecSliceHelperStart()
+	yyv3575 := *v
+	yyh3575, yyl3575 := z.DecSliceHelperStart()
 
-	var yyrr3571, yyrl3571 int
-	var yyc3571, yyrt3571 bool
-	_, _, _ = yyc3571, yyrt3571, yyrl3571
-	yyrr3571 = yyl3571
+	var yyrr3575, yyrl3575 int
+	var yyc3575, yyrt3575 bool
+	_, _, _ = yyc3575, yyrt3575, yyrl3575
+	yyrr3575 = yyl3575
 
-	if yyv3571 == nil {
-		if yyrl3571, yyrt3571 = z.DecInferLen(yyl3571, z.DecBasicHandle().MaxInitLen, 232); yyrt3571 {
-			yyrr3571 = yyrl3571
+	if yyv3575 == nil {
+		if yyrl3575, yyrt3575 = z.DecInferLen(yyl3575, z.DecBasicHandle().MaxInitLen, 232); yyrt3575 {
+			yyrr3575 = yyrl3575
 		}
-		yyv3571 = make([]ReplicationController, yyrl3571)
-		yyc3571 = true
+		yyv3575 = make([]ReplicationController, yyrl3575)
+		yyc3575 = true
 	}
 
-	if yyl3571 == 0 {
-		if len(yyv3571) != 0 {
-			yyv3571 = yyv3571[:0]
-			yyc3571 = true
+	if yyl3575 == 0 {
+		if len(yyv3575) != 0 {
+			yyv3575 = yyv3575[:0]
+			yyc3575 = true
 		}
-	} else if yyl3571 > 0 {
+	} else if yyl3575 > 0 {
 
-		if yyl3571 > cap(yyv3571) {
-			yyrl3571, yyrt3571 = z.DecInferLen(yyl3571, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3571 = make([]ReplicationController, yyrl3571)
-			yyc3571 = true
+		if yyl3575 > cap(yyv3575) {
+			yyrl3575, yyrt3575 = z.DecInferLen(yyl3575, z.DecBasicHandle().MaxInitLen, 232)
+			yyv3575 = make([]ReplicationController, yyrl3575)
+			yyc3575 = true
 
-			yyrr3571 = len(yyv3571)
-		} else if yyl3571 != len(yyv3571) {
-			yyv3571 = yyv3571[:yyl3571]
-			yyc3571 = true
+			yyrr3575 = len(yyv3575)
+		} else if yyl3575 != len(yyv3575) {
+			yyv3575 = yyv3575[:yyl3575]
+			yyc3575 = true
 		}
-		yyj3571 := 0
-		for ; yyj3571 < yyrr3571; yyj3571++ {
+		yyj3575 := 0
+		for ; yyj3575 < yyrr3575; yyj3575++ {
 			if r.TryDecodeAsNil() {
-				yyv3571[yyj3571] = ReplicationController{}
+				yyv3575[yyj3575] = ReplicationController{}
 			} else {
-				yyv3572 := &yyv3571[yyj3571]
-				yyv3572.CodecDecodeSelf(d)
+				yyv3576 := &yyv3575[yyj3575]
+				yyv3576.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3571 {
-			for ; yyj3571 < yyl3571; yyj3571++ {
-				yyv3571 = append(yyv3571, ReplicationController{})
+		if yyrt3575 {
+			for ; yyj3575 < yyl3575; yyj3575++ {
+				yyv3575 = append(yyv3575, ReplicationController{})
 				if r.TryDecodeAsNil() {
-					yyv3571[yyj3571] = ReplicationController{}
+					yyv3575[yyj3575] = ReplicationController{}
 				} else {
-					yyv3573 := &yyv3571[yyj3571]
-					yyv3573.CodecDecodeSelf(d)
+					yyv3577 := &yyv3575[yyj3575]
+					yyv3577.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3571 := 0; !r.CheckBreak(); yyj3571++ {
-			if yyj3571 >= len(yyv3571) {
-				yyv3571 = append(yyv3571, ReplicationController{}) // var yyz3571 ReplicationController
-				yyc3571 = true
+		for yyj3575 := 0; !r.CheckBreak(); yyj3575++ {
+			if yyj3575 >= len(yyv3575) {
+				yyv3575 = append(yyv3575, ReplicationController{}) // var yyz3575 ReplicationController
+				yyc3575 = true
 			}
 
-			if yyj3571 < len(yyv3571) {
+			if yyj3575 < len(yyv3575) {
 				if r.TryDecodeAsNil() {
-					yyv3571[yyj3571] = ReplicationController{}
+					yyv3575[yyj3575] = ReplicationController{}
 				} else {
-					yyv3574 := &yyv3571[yyj3571]
-					yyv3574.CodecDecodeSelf(d)
+					yyv3578 := &yyv3575[yyj3575]
+					yyv3578.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41652,10 +41682,10 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 			}
 
 		}
-		yyh3571.End()
+		yyh3575.End()
 	}
-	if yyc3571 {
-		*v = yyv3571
+	if yyc3575 {
+		*v = yyv3575
 	}
 
 }
@@ -41665,9 +41695,9 @@ func (x codecSelfer1234) encSliceService(v []Service, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3575 := range v {
-		yy3576 := &yyv3575
-		yy3576.CodecEncodeSelf(e)
+	for _, yyv3579 := range v {
+		yy3580 := &yyv3579
+		yy3580.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41677,75 +41707,75 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3577 := *v
-	yyh3577, yyl3577 := z.DecSliceHelperStart()
+	yyv3581 := *v
+	yyh3581, yyl3581 := z.DecSliceHelperStart()
 
-	var yyrr3577, yyrl3577 int
-	var yyc3577, yyrt3577 bool
-	_, _, _ = yyc3577, yyrt3577, yyrl3577
-	yyrr3577 = yyl3577
+	var yyrr3581, yyrl3581 int
+	var yyc3581, yyrt3581 bool
+	_, _, _ = yyc3581, yyrt3581, yyrl3581
+	yyrr3581 = yyl3581
 
-	if yyv3577 == nil {
-		if yyrl3577, yyrt3577 = z.DecInferLen(yyl3577, z.DecBasicHandle().MaxInitLen, 336); yyrt3577 {
-			yyrr3577 = yyrl3577
+	if yyv3581 == nil {
+		if yyrl3581, yyrt3581 = z.DecInferLen(yyl3581, z.DecBasicHandle().MaxInitLen, 336); yyrt3581 {
+			yyrr3581 = yyrl3581
 		}
-		yyv3577 = make([]Service, yyrl3577)
-		yyc3577 = true
+		yyv3581 = make([]Service, yyrl3581)
+		yyc3581 = true
 	}
 
-	if yyl3577 == 0 {
-		if len(yyv3577) != 0 {
-			yyv3577 = yyv3577[:0]
-			yyc3577 = true
+	if yyl3581 == 0 {
+		if len(yyv3581) != 0 {
+			yyv3581 = yyv3581[:0]
+			yyc3581 = true
 		}
-	} else if yyl3577 > 0 {
+	} else if yyl3581 > 0 {
 
-		if yyl3577 > cap(yyv3577) {
-			yyrl3577, yyrt3577 = z.DecInferLen(yyl3577, z.DecBasicHandle().MaxInitLen, 336)
-			yyv3577 = make([]Service, yyrl3577)
-			yyc3577 = true
+		if yyl3581 > cap(yyv3581) {
+			yyrl3581, yyrt3581 = z.DecInferLen(yyl3581, z.DecBasicHandle().MaxInitLen, 336)
+			yyv3581 = make([]Service, yyrl3581)
+			yyc3581 = true
 
-			yyrr3577 = len(yyv3577)
-		} else if yyl3577 != len(yyv3577) {
-			yyv3577 = yyv3577[:yyl3577]
-			yyc3577 = true
+			yyrr3581 = len(yyv3581)
+		} else if yyl3581 != len(yyv3581) {
+			yyv3581 = yyv3581[:yyl3581]
+			yyc3581 = true
 		}
-		yyj3577 := 0
-		for ; yyj3577 < yyrr3577; yyj3577++ {
+		yyj3581 := 0
+		for ; yyj3581 < yyrr3581; yyj3581++ {
 			if r.TryDecodeAsNil() {
-				yyv3577[yyj3577] = Service{}
+				yyv3581[yyj3581] = Service{}
 			} else {
-				yyv3578 := &yyv3577[yyj3577]
-				yyv3578.CodecDecodeSelf(d)
+				yyv3582 := &yyv3581[yyj3581]
+				yyv3582.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3577 {
-			for ; yyj3577 < yyl3577; yyj3577++ {
-				yyv3577 = append(yyv3577, Service{})
+		if yyrt3581 {
+			for ; yyj3581 < yyl3581; yyj3581++ {
+				yyv3581 = append(yyv3581, Service{})
 				if r.TryDecodeAsNil() {
-					yyv3577[yyj3577] = Service{}
+					yyv3581[yyj3581] = Service{}
 				} else {
-					yyv3579 := &yyv3577[yyj3577]
-					yyv3579.CodecDecodeSelf(d)
+					yyv3583 := &yyv3581[yyj3581]
+					yyv3583.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3577 := 0; !r.CheckBreak(); yyj3577++ {
-			if yyj3577 >= len(yyv3577) {
-				yyv3577 = append(yyv3577, Service{}) // var yyz3577 Service
-				yyc3577 = true
+		for yyj3581 := 0; !r.CheckBreak(); yyj3581++ {
+			if yyj3581 >= len(yyv3581) {
+				yyv3581 = append(yyv3581, Service{}) // var yyz3581 Service
+				yyc3581 = true
 			}
 
-			if yyj3577 < len(yyv3577) {
+			if yyj3581 < len(yyv3581) {
 				if r.TryDecodeAsNil() {
-					yyv3577[yyj3577] = Service{}
+					yyv3581[yyj3581] = Service{}
 				} else {
-					yyv3580 := &yyv3577[yyj3577]
-					yyv3580.CodecDecodeSelf(d)
+					yyv3584 := &yyv3581[yyj3581]
+					yyv3584.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41753,10 +41783,10 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3577.End()
+		yyh3581.End()
 	}
-	if yyc3577 {
-		*v = yyv3577
+	if yyc3581 {
+		*v = yyv3581
 	}
 
 }
@@ -41766,9 +41796,9 @@ func (x codecSelfer1234) encSliceLoadBalancerIngress(v []LoadBalancerIngress, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3581 := range v {
-		yy3582 := &yyv3581
-		yy3582.CodecEncodeSelf(e)
+	for _, yyv3585 := range v {
+		yy3586 := &yyv3585
+		yy3586.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41778,75 +41808,75 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3583 := *v
-	yyh3583, yyl3583 := z.DecSliceHelperStart()
+	yyv3587 := *v
+	yyh3587, yyl3587 := z.DecSliceHelperStart()
 
-	var yyrr3583, yyrl3583 int
-	var yyc3583, yyrt3583 bool
-	_, _, _ = yyc3583, yyrt3583, yyrl3583
-	yyrr3583 = yyl3583
+	var yyrr3587, yyrl3587 int
+	var yyc3587, yyrt3587 bool
+	_, _, _ = yyc3587, yyrt3587, yyrl3587
+	yyrr3587 = yyl3587
 
-	if yyv3583 == nil {
-		if yyrl3583, yyrt3583 = z.DecInferLen(yyl3583, z.DecBasicHandle().MaxInitLen, 32); yyrt3583 {
-			yyrr3583 = yyrl3583
+	if yyv3587 == nil {
+		if yyrl3587, yyrt3587 = z.DecInferLen(yyl3587, z.DecBasicHandle().MaxInitLen, 32); yyrt3587 {
+			yyrr3587 = yyrl3587
 		}
-		yyv3583 = make([]LoadBalancerIngress, yyrl3583)
-		yyc3583 = true
+		yyv3587 = make([]LoadBalancerIngress, yyrl3587)
+		yyc3587 = true
 	}
 
-	if yyl3583 == 0 {
-		if len(yyv3583) != 0 {
-			yyv3583 = yyv3583[:0]
-			yyc3583 = true
+	if yyl3587 == 0 {
+		if len(yyv3587) != 0 {
+			yyv3587 = yyv3587[:0]
+			yyc3587 = true
 		}
-	} else if yyl3583 > 0 {
+	} else if yyl3587 > 0 {
 
-		if yyl3583 > cap(yyv3583) {
-			yyrl3583, yyrt3583 = z.DecInferLen(yyl3583, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3583 = make([]LoadBalancerIngress, yyrl3583)
-			yyc3583 = true
+		if yyl3587 > cap(yyv3587) {
+			yyrl3587, yyrt3587 = z.DecInferLen(yyl3587, z.DecBasicHandle().MaxInitLen, 32)
+			yyv3587 = make([]LoadBalancerIngress, yyrl3587)
+			yyc3587 = true
 
-			yyrr3583 = len(yyv3583)
-		} else if yyl3583 != len(yyv3583) {
-			yyv3583 = yyv3583[:yyl3583]
-			yyc3583 = true
+			yyrr3587 = len(yyv3587)
+		} else if yyl3587 != len(yyv3587) {
+			yyv3587 = yyv3587[:yyl3587]
+			yyc3587 = true
 		}
-		yyj3583 := 0
-		for ; yyj3583 < yyrr3583; yyj3583++ {
+		yyj3587 := 0
+		for ; yyj3587 < yyrr3587; yyj3587++ {
 			if r.TryDecodeAsNil() {
-				yyv3583[yyj3583] = LoadBalancerIngress{}
+				yyv3587[yyj3587] = LoadBalancerIngress{}
 			} else {
-				yyv3584 := &yyv3583[yyj3583]
-				yyv3584.CodecDecodeSelf(d)
+				yyv3588 := &yyv3587[yyj3587]
+				yyv3588.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3583 {
-			for ; yyj3583 < yyl3583; yyj3583++ {
-				yyv3583 = append(yyv3583, LoadBalancerIngress{})
+		if yyrt3587 {
+			for ; yyj3587 < yyl3587; yyj3587++ {
+				yyv3587 = append(yyv3587, LoadBalancerIngress{})
 				if r.TryDecodeAsNil() {
-					yyv3583[yyj3583] = LoadBalancerIngress{}
+					yyv3587[yyj3587] = LoadBalancerIngress{}
 				} else {
-					yyv3585 := &yyv3583[yyj3583]
-					yyv3585.CodecDecodeSelf(d)
+					yyv3589 := &yyv3587[yyj3587]
+					yyv3589.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3583 := 0; !r.CheckBreak(); yyj3583++ {
-			if yyj3583 >= len(yyv3583) {
-				yyv3583 = append(yyv3583, LoadBalancerIngress{}) // var yyz3583 LoadBalancerIngress
-				yyc3583 = true
+		for yyj3587 := 0; !r.CheckBreak(); yyj3587++ {
+			if yyj3587 >= len(yyv3587) {
+				yyv3587 = append(yyv3587, LoadBalancerIngress{}) // var yyz3587 LoadBalancerIngress
+				yyc3587 = true
 			}
 
-			if yyj3583 < len(yyv3583) {
+			if yyj3587 < len(yyv3587) {
 				if r.TryDecodeAsNil() {
-					yyv3583[yyj3583] = LoadBalancerIngress{}
+					yyv3587[yyj3587] = LoadBalancerIngress{}
 				} else {
-					yyv3586 := &yyv3583[yyj3583]
-					yyv3586.CodecDecodeSelf(d)
+					yyv3590 := &yyv3587[yyj3587]
+					yyv3590.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41854,10 +41884,10 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 			}
 
 		}
-		yyh3583.End()
+		yyh3587.End()
 	}
-	if yyc3583 {
-		*v = yyv3583
+	if yyc3587 {
+		*v = yyv3587
 	}
 
 }
@@ -41867,9 +41897,9 @@ func (x codecSelfer1234) encSliceServicePort(v []ServicePort, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3587 := range v {
-		yy3588 := &yyv3587
-		yy3588.CodecEncodeSelf(e)
+	for _, yyv3591 := range v {
+		yy3592 := &yyv3591
+		yy3592.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41879,75 +41909,75 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3589 := *v
-	yyh3589, yyl3589 := z.DecSliceHelperStart()
+	yyv3593 := *v
+	yyh3593, yyl3593 := z.DecSliceHelperStart()
 
-	var yyrr3589, yyrl3589 int
-	var yyc3589, yyrt3589 bool
-	_, _, _ = yyc3589, yyrt3589, yyrl3589
-	yyrr3589 = yyl3589
+	var yyrr3593, yyrl3593 int
+	var yyc3593, yyrt3593 bool
+	_, _, _ = yyc3593, yyrt3593, yyrl3593
+	yyrr3593 = yyl3593
 
-	if yyv3589 == nil {
-		if yyrl3589, yyrt3589 = z.DecInferLen(yyl3589, z.DecBasicHandle().MaxInitLen, 80); yyrt3589 {
-			yyrr3589 = yyrl3589
+	if yyv3593 == nil {
+		if yyrl3593, yyrt3593 = z.DecInferLen(yyl3593, z.DecBasicHandle().MaxInitLen, 80); yyrt3593 {
+			yyrr3593 = yyrl3593
 		}
-		yyv3589 = make([]ServicePort, yyrl3589)
-		yyc3589 = true
+		yyv3593 = make([]ServicePort, yyrl3593)
+		yyc3593 = true
 	}
 
-	if yyl3589 == 0 {
-		if len(yyv3589) != 0 {
-			yyv3589 = yyv3589[:0]
-			yyc3589 = true
+	if yyl3593 == 0 {
+		if len(yyv3593) != 0 {
+			yyv3593 = yyv3593[:0]
+			yyc3593 = true
 		}
-	} else if yyl3589 > 0 {
+	} else if yyl3593 > 0 {
 
-		if yyl3589 > cap(yyv3589) {
-			yyrl3589, yyrt3589 = z.DecInferLen(yyl3589, z.DecBasicHandle().MaxInitLen, 80)
-			yyv3589 = make([]ServicePort, yyrl3589)
-			yyc3589 = true
+		if yyl3593 > cap(yyv3593) {
+			yyrl3593, yyrt3593 = z.DecInferLen(yyl3593, z.DecBasicHandle().MaxInitLen, 80)
+			yyv3593 = make([]ServicePort, yyrl3593)
+			yyc3593 = true
 
-			yyrr3589 = len(yyv3589)
-		} else if yyl3589 != len(yyv3589) {
-			yyv3589 = yyv3589[:yyl3589]
-			yyc3589 = true
+			yyrr3593 = len(yyv3593)
+		} else if yyl3593 != len(yyv3593) {
+			yyv3593 = yyv3593[:yyl3593]
+			yyc3593 = true
 		}
-		yyj3589 := 0
-		for ; yyj3589 < yyrr3589; yyj3589++ {
+		yyj3593 := 0
+		for ; yyj3593 < yyrr3593; yyj3593++ {
 			if r.TryDecodeAsNil() {
-				yyv3589[yyj3589] = ServicePort{}
+				yyv3593[yyj3593] = ServicePort{}
 			} else {
-				yyv3590 := &yyv3589[yyj3589]
-				yyv3590.CodecDecodeSelf(d)
+				yyv3594 := &yyv3593[yyj3593]
+				yyv3594.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3589 {
-			for ; yyj3589 < yyl3589; yyj3589++ {
-				yyv3589 = append(yyv3589, ServicePort{})
+		if yyrt3593 {
+			for ; yyj3593 < yyl3593; yyj3593++ {
+				yyv3593 = append(yyv3593, ServicePort{})
 				if r.TryDecodeAsNil() {
-					yyv3589[yyj3589] = ServicePort{}
+					yyv3593[yyj3593] = ServicePort{}
 				} else {
-					yyv3591 := &yyv3589[yyj3589]
-					yyv3591.CodecDecodeSelf(d)
+					yyv3595 := &yyv3593[yyj3593]
+					yyv3595.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3589 := 0; !r.CheckBreak(); yyj3589++ {
-			if yyj3589 >= len(yyv3589) {
-				yyv3589 = append(yyv3589, ServicePort{}) // var yyz3589 ServicePort
-				yyc3589 = true
+		for yyj3593 := 0; !r.CheckBreak(); yyj3593++ {
+			if yyj3593 >= len(yyv3593) {
+				yyv3593 = append(yyv3593, ServicePort{}) // var yyz3593 ServicePort
+				yyc3593 = true
 			}
 
-			if yyj3589 < len(yyv3589) {
+			if yyj3593 < len(yyv3593) {
 				if r.TryDecodeAsNil() {
-					yyv3589[yyj3589] = ServicePort{}
+					yyv3593[yyj3593] = ServicePort{}
 				} else {
-					yyv3592 := &yyv3589[yyj3589]
-					yyv3592.CodecDecodeSelf(d)
+					yyv3596 := &yyv3593[yyj3593]
+					yyv3596.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41955,10 +41985,10 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 			}
 
 		}
-		yyh3589.End()
+		yyh3593.End()
 	}
-	if yyc3589 {
-		*v = yyv3589
+	if yyc3593 {
+		*v = yyv3593
 	}
 
 }
@@ -41968,9 +41998,9 @@ func (x codecSelfer1234) encSliceObjectReference(v []ObjectReference, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3593 := range v {
-		yy3594 := &yyv3593
-		yy3594.CodecEncodeSelf(e)
+	for _, yyv3597 := range v {
+		yy3598 := &yyv3597
+		yy3598.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41980,75 +42010,75 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3595 := *v
-	yyh3595, yyl3595 := z.DecSliceHelperStart()
+	yyv3599 := *v
+	yyh3599, yyl3599 := z.DecSliceHelperStart()
 
-	var yyrr3595, yyrl3595 int
-	var yyc3595, yyrt3595 bool
-	_, _, _ = yyc3595, yyrt3595, yyrl3595
-	yyrr3595 = yyl3595
+	var yyrr3599, yyrl3599 int
+	var yyc3599, yyrt3599 bool
+	_, _, _ = yyc3599, yyrt3599, yyrl3599
+	yyrr3599 = yyl3599
 
-	if yyv3595 == nil {
-		if yyrl3595, yyrt3595 = z.DecInferLen(yyl3595, z.DecBasicHandle().MaxInitLen, 112); yyrt3595 {
-			yyrr3595 = yyrl3595
+	if yyv3599 == nil {
+		if yyrl3599, yyrt3599 = z.DecInferLen(yyl3599, z.DecBasicHandle().MaxInitLen, 112); yyrt3599 {
+			yyrr3599 = yyrl3599
 		}
-		yyv3595 = make([]ObjectReference, yyrl3595)
-		yyc3595 = true
+		yyv3599 = make([]ObjectReference, yyrl3599)
+		yyc3599 = true
 	}
 
-	if yyl3595 == 0 {
-		if len(yyv3595) != 0 {
-			yyv3595 = yyv3595[:0]
-			yyc3595 = true
+	if yyl3599 == 0 {
+		if len(yyv3599) != 0 {
+			yyv3599 = yyv3599[:0]
+			yyc3599 = true
 		}
-	} else if yyl3595 > 0 {
+	} else if yyl3599 > 0 {
 
-		if yyl3595 > cap(yyv3595) {
-			yyrl3595, yyrt3595 = z.DecInferLen(yyl3595, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3595 = make([]ObjectReference, yyrl3595)
-			yyc3595 = true
+		if yyl3599 > cap(yyv3599) {
+			yyrl3599, yyrt3599 = z.DecInferLen(yyl3599, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3599 = make([]ObjectReference, yyrl3599)
+			yyc3599 = true
 
-			yyrr3595 = len(yyv3595)
-		} else if yyl3595 != len(yyv3595) {
-			yyv3595 = yyv3595[:yyl3595]
-			yyc3595 = true
+			yyrr3599 = len(yyv3599)
+		} else if yyl3599 != len(yyv3599) {
+			yyv3599 = yyv3599[:yyl3599]
+			yyc3599 = true
 		}
-		yyj3595 := 0
-		for ; yyj3595 < yyrr3595; yyj3595++ {
+		yyj3599 := 0
+		for ; yyj3599 < yyrr3599; yyj3599++ {
 			if r.TryDecodeAsNil() {
-				yyv3595[yyj3595] = ObjectReference{}
+				yyv3599[yyj3599] = ObjectReference{}
 			} else {
-				yyv3596 := &yyv3595[yyj3595]
-				yyv3596.CodecDecodeSelf(d)
+				yyv3600 := &yyv3599[yyj3599]
+				yyv3600.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3595 {
-			for ; yyj3595 < yyl3595; yyj3595++ {
-				yyv3595 = append(yyv3595, ObjectReference{})
+		if yyrt3599 {
+			for ; yyj3599 < yyl3599; yyj3599++ {
+				yyv3599 = append(yyv3599, ObjectReference{})
 				if r.TryDecodeAsNil() {
-					yyv3595[yyj3595] = ObjectReference{}
+					yyv3599[yyj3599] = ObjectReference{}
 				} else {
-					yyv3597 := &yyv3595[yyj3595]
-					yyv3597.CodecDecodeSelf(d)
+					yyv3601 := &yyv3599[yyj3599]
+					yyv3601.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3595 := 0; !r.CheckBreak(); yyj3595++ {
-			if yyj3595 >= len(yyv3595) {
-				yyv3595 = append(yyv3595, ObjectReference{}) // var yyz3595 ObjectReference
-				yyc3595 = true
+		for yyj3599 := 0; !r.CheckBreak(); yyj3599++ {
+			if yyj3599 >= len(yyv3599) {
+				yyv3599 = append(yyv3599, ObjectReference{}) // var yyz3599 ObjectReference
+				yyc3599 = true
 			}
 
-			if yyj3595 < len(yyv3595) {
+			if yyj3599 < len(yyv3599) {
 				if r.TryDecodeAsNil() {
-					yyv3595[yyj3595] = ObjectReference{}
+					yyv3599[yyj3599] = ObjectReference{}
 				} else {
-					yyv3598 := &yyv3595[yyj3595]
-					yyv3598.CodecDecodeSelf(d)
+					yyv3602 := &yyv3599[yyj3599]
+					yyv3602.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42056,10 +42086,10 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 			}
 
 		}
-		yyh3595.End()
+		yyh3599.End()
 	}
-	if yyc3595 {
-		*v = yyv3595
+	if yyc3599 {
+		*v = yyv3599
 	}
 
 }
@@ -42069,9 +42099,9 @@ func (x codecSelfer1234) encSliceServiceAccount(v []ServiceAccount, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3599 := range v {
-		yy3600 := &yyv3599
-		yy3600.CodecEncodeSelf(e)
+	for _, yyv3603 := range v {
+		yy3604 := &yyv3603
+		yy3604.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42081,75 +42111,75 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3601 := *v
-	yyh3601, yyl3601 := z.DecSliceHelperStart()
+	yyv3605 := *v
+	yyh3605, yyl3605 := z.DecSliceHelperStart()
 
-	var yyrr3601, yyrl3601 int
-	var yyc3601, yyrt3601 bool
-	_, _, _ = yyc3601, yyrt3601, yyrl3601
-	yyrr3601 = yyl3601
+	var yyrr3605, yyrl3605 int
+	var yyc3605, yyrt3605 bool
+	_, _, _ = yyc3605, yyrt3605, yyrl3605
+	yyrr3605 = yyl3605
 
-	if yyv3601 == nil {
-		if yyrl3601, yyrt3601 = z.DecInferLen(yyl3601, z.DecBasicHandle().MaxInitLen, 240); yyrt3601 {
-			yyrr3601 = yyrl3601
+	if yyv3605 == nil {
+		if yyrl3605, yyrt3605 = z.DecInferLen(yyl3605, z.DecBasicHandle().MaxInitLen, 240); yyrt3605 {
+			yyrr3605 = yyrl3605
 		}
-		yyv3601 = make([]ServiceAccount, yyrl3601)
-		yyc3601 = true
+		yyv3605 = make([]ServiceAccount, yyrl3605)
+		yyc3605 = true
 	}
 
-	if yyl3601 == 0 {
-		if len(yyv3601) != 0 {
-			yyv3601 = yyv3601[:0]
-			yyc3601 = true
+	if yyl3605 == 0 {
+		if len(yyv3605) != 0 {
+			yyv3605 = yyv3605[:0]
+			yyc3605 = true
 		}
-	} else if yyl3601 > 0 {
+	} else if yyl3605 > 0 {
 
-		if yyl3601 > cap(yyv3601) {
-			yyrl3601, yyrt3601 = z.DecInferLen(yyl3601, z.DecBasicHandle().MaxInitLen, 240)
-			yyv3601 = make([]ServiceAccount, yyrl3601)
-			yyc3601 = true
+		if yyl3605 > cap(yyv3605) {
+			yyrl3605, yyrt3605 = z.DecInferLen(yyl3605, z.DecBasicHandle().MaxInitLen, 240)
+			yyv3605 = make([]ServiceAccount, yyrl3605)
+			yyc3605 = true
 
-			yyrr3601 = len(yyv3601)
-		} else if yyl3601 != len(yyv3601) {
-			yyv3601 = yyv3601[:yyl3601]
-			yyc3601 = true
+			yyrr3605 = len(yyv3605)
+		} else if yyl3605 != len(yyv3605) {
+			yyv3605 = yyv3605[:yyl3605]
+			yyc3605 = true
 		}
-		yyj3601 := 0
-		for ; yyj3601 < yyrr3601; yyj3601++ {
+		yyj3605 := 0
+		for ; yyj3605 < yyrr3605; yyj3605++ {
 			if r.TryDecodeAsNil() {
-				yyv3601[yyj3601] = ServiceAccount{}
+				yyv3605[yyj3605] = ServiceAccount{}
 			} else {
-				yyv3602 := &yyv3601[yyj3601]
-				yyv3602.CodecDecodeSelf(d)
+				yyv3606 := &yyv3605[yyj3605]
+				yyv3606.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3601 {
-			for ; yyj3601 < yyl3601; yyj3601++ {
-				yyv3601 = append(yyv3601, ServiceAccount{})
+		if yyrt3605 {
+			for ; yyj3605 < yyl3605; yyj3605++ {
+				yyv3605 = append(yyv3605, ServiceAccount{})
 				if r.TryDecodeAsNil() {
-					yyv3601[yyj3601] = ServiceAccount{}
+					yyv3605[yyj3605] = ServiceAccount{}
 				} else {
-					yyv3603 := &yyv3601[yyj3601]
-					yyv3603.CodecDecodeSelf(d)
+					yyv3607 := &yyv3605[yyj3605]
+					yyv3607.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3601 := 0; !r.CheckBreak(); yyj3601++ {
-			if yyj3601 >= len(yyv3601) {
-				yyv3601 = append(yyv3601, ServiceAccount{}) // var yyz3601 ServiceAccount
-				yyc3601 = true
+		for yyj3605 := 0; !r.CheckBreak(); yyj3605++ {
+			if yyj3605 >= len(yyv3605) {
+				yyv3605 = append(yyv3605, ServiceAccount{}) // var yyz3605 ServiceAccount
+				yyc3605 = true
 			}
 
-			if yyj3601 < len(yyv3601) {
+			if yyj3605 < len(yyv3605) {
 				if r.TryDecodeAsNil() {
-					yyv3601[yyj3601] = ServiceAccount{}
+					yyv3605[yyj3605] = ServiceAccount{}
 				} else {
-					yyv3604 := &yyv3601[yyj3601]
-					yyv3604.CodecDecodeSelf(d)
+					yyv3608 := &yyv3605[yyj3605]
+					yyv3608.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42157,10 +42187,10 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 			}
 
 		}
-		yyh3601.End()
+		yyh3605.End()
 	}
-	if yyc3601 {
-		*v = yyv3601
+	if yyc3605 {
+		*v = yyv3605
 	}
 
 }
@@ -42170,9 +42200,9 @@ func (x codecSelfer1234) encSliceEndpointSubset(v []EndpointSubset, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3605 := range v {
-		yy3606 := &yyv3605
-		yy3606.CodecEncodeSelf(e)
+	for _, yyv3609 := range v {
+		yy3610 := &yyv3609
+		yy3610.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42182,75 +42212,75 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3607 := *v
-	yyh3607, yyl3607 := z.DecSliceHelperStart()
+	yyv3611 := *v
+	yyh3611, yyl3611 := z.DecSliceHelperStart()
 
-	var yyrr3607, yyrl3607 int
-	var yyc3607, yyrt3607 bool
-	_, _, _ = yyc3607, yyrt3607, yyrl3607
-	yyrr3607 = yyl3607
+	var yyrr3611, yyrl3611 int
+	var yyc3611, yyrt3611 bool
+	_, _, _ = yyc3611, yyrt3611, yyrl3611
+	yyrr3611 = yyl3611
 
-	if yyv3607 == nil {
-		if yyrl3607, yyrt3607 = z.DecInferLen(yyl3607, z.DecBasicHandle().MaxInitLen, 72); yyrt3607 {
-			yyrr3607 = yyrl3607
+	if yyv3611 == nil {
+		if yyrl3611, yyrt3611 = z.DecInferLen(yyl3611, z.DecBasicHandle().MaxInitLen, 72); yyrt3611 {
+			yyrr3611 = yyrl3611
 		}
-		yyv3607 = make([]EndpointSubset, yyrl3607)
-		yyc3607 = true
+		yyv3611 = make([]EndpointSubset, yyrl3611)
+		yyc3611 = true
 	}
 
-	if yyl3607 == 0 {
-		if len(yyv3607) != 0 {
-			yyv3607 = yyv3607[:0]
-			yyc3607 = true
+	if yyl3611 == 0 {
+		if len(yyv3611) != 0 {
+			yyv3611 = yyv3611[:0]
+			yyc3611 = true
 		}
-	} else if yyl3607 > 0 {
+	} else if yyl3611 > 0 {
 
-		if yyl3607 > cap(yyv3607) {
-			yyrl3607, yyrt3607 = z.DecInferLen(yyl3607, z.DecBasicHandle().MaxInitLen, 72)
-			yyv3607 = make([]EndpointSubset, yyrl3607)
-			yyc3607 = true
+		if yyl3611 > cap(yyv3611) {
+			yyrl3611, yyrt3611 = z.DecInferLen(yyl3611, z.DecBasicHandle().MaxInitLen, 72)
+			yyv3611 = make([]EndpointSubset, yyrl3611)
+			yyc3611 = true
 
-			yyrr3607 = len(yyv3607)
-		} else if yyl3607 != len(yyv3607) {
-			yyv3607 = yyv3607[:yyl3607]
-			yyc3607 = true
+			yyrr3611 = len(yyv3611)
+		} else if yyl3611 != len(yyv3611) {
+			yyv3611 = yyv3611[:yyl3611]
+			yyc3611 = true
 		}
-		yyj3607 := 0
-		for ; yyj3607 < yyrr3607; yyj3607++ {
+		yyj3611 := 0
+		for ; yyj3611 < yyrr3611; yyj3611++ {
 			if r.TryDecodeAsNil() {
-				yyv3607[yyj3607] = EndpointSubset{}
+				yyv3611[yyj3611] = EndpointSubset{}
 			} else {
-				yyv3608 := &yyv3607[yyj3607]
-				yyv3608.CodecDecodeSelf(d)
+				yyv3612 := &yyv3611[yyj3611]
+				yyv3612.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3607 {
-			for ; yyj3607 < yyl3607; yyj3607++ {
-				yyv3607 = append(yyv3607, EndpointSubset{})
+		if yyrt3611 {
+			for ; yyj3611 < yyl3611; yyj3611++ {
+				yyv3611 = append(yyv3611, EndpointSubset{})
 				if r.TryDecodeAsNil() {
-					yyv3607[yyj3607] = EndpointSubset{}
+					yyv3611[yyj3611] = EndpointSubset{}
 				} else {
-					yyv3609 := &yyv3607[yyj3607]
-					yyv3609.CodecDecodeSelf(d)
+					yyv3613 := &yyv3611[yyj3611]
+					yyv3613.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3607 := 0; !r.CheckBreak(); yyj3607++ {
-			if yyj3607 >= len(yyv3607) {
-				yyv3607 = append(yyv3607, EndpointSubset{}) // var yyz3607 EndpointSubset
-				yyc3607 = true
+		for yyj3611 := 0; !r.CheckBreak(); yyj3611++ {
+			if yyj3611 >= len(yyv3611) {
+				yyv3611 = append(yyv3611, EndpointSubset{}) // var yyz3611 EndpointSubset
+				yyc3611 = true
 			}
 
-			if yyj3607 < len(yyv3607) {
+			if yyj3611 < len(yyv3611) {
 				if r.TryDecodeAsNil() {
-					yyv3607[yyj3607] = EndpointSubset{}
+					yyv3611[yyj3611] = EndpointSubset{}
 				} else {
-					yyv3610 := &yyv3607[yyj3607]
-					yyv3610.CodecDecodeSelf(d)
+					yyv3614 := &yyv3611[yyj3611]
+					yyv3614.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42258,10 +42288,10 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 			}
 
 		}
-		yyh3607.End()
+		yyh3611.End()
 	}
-	if yyc3607 {
-		*v = yyv3607
+	if yyc3611 {
+		*v = yyv3611
 	}
 
 }
@@ -42271,9 +42301,9 @@ func (x codecSelfer1234) encSliceEndpointAddress(v []EndpointAddress, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3611 := range v {
-		yy3612 := &yyv3611
-		yy3612.CodecEncodeSelf(e)
+	for _, yyv3615 := range v {
+		yy3616 := &yyv3615
+		yy3616.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42283,75 +42313,75 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3613 := *v
-	yyh3613, yyl3613 := z.DecSliceHelperStart()
+	yyv3617 := *v
+	yyh3617, yyl3617 := z.DecSliceHelperStart()
 
-	var yyrr3613, yyrl3613 int
-	var yyc3613, yyrt3613 bool
-	_, _, _ = yyc3613, yyrt3613, yyrl3613
-	yyrr3613 = yyl3613
+	var yyrr3617, yyrl3617 int
+	var yyc3617, yyrt3617 bool
+	_, _, _ = yyc3617, yyrt3617, yyrl3617
+	yyrr3617 = yyl3617
 
-	if yyv3613 == nil {
-		if yyrl3613, yyrt3613 = z.DecInferLen(yyl3613, z.DecBasicHandle().MaxInitLen, 24); yyrt3613 {
-			yyrr3613 = yyrl3613
+	if yyv3617 == nil {
+		if yyrl3617, yyrt3617 = z.DecInferLen(yyl3617, z.DecBasicHandle().MaxInitLen, 24); yyrt3617 {
+			yyrr3617 = yyrl3617
 		}
-		yyv3613 = make([]EndpointAddress, yyrl3613)
-		yyc3613 = true
+		yyv3617 = make([]EndpointAddress, yyrl3617)
+		yyc3617 = true
 	}
 
-	if yyl3613 == 0 {
-		if len(yyv3613) != 0 {
-			yyv3613 = yyv3613[:0]
-			yyc3613 = true
+	if yyl3617 == 0 {
+		if len(yyv3617) != 0 {
+			yyv3617 = yyv3617[:0]
+			yyc3617 = true
 		}
-	} else if yyl3613 > 0 {
+	} else if yyl3617 > 0 {
 
-		if yyl3613 > cap(yyv3613) {
-			yyrl3613, yyrt3613 = z.DecInferLen(yyl3613, z.DecBasicHandle().MaxInitLen, 24)
-			yyv3613 = make([]EndpointAddress, yyrl3613)
-			yyc3613 = true
+		if yyl3617 > cap(yyv3617) {
+			yyrl3617, yyrt3617 = z.DecInferLen(yyl3617, z.DecBasicHandle().MaxInitLen, 24)
+			yyv3617 = make([]EndpointAddress, yyrl3617)
+			yyc3617 = true
 
-			yyrr3613 = len(yyv3613)
-		} else if yyl3613 != len(yyv3613) {
-			yyv3613 = yyv3613[:yyl3613]
-			yyc3613 = true
+			yyrr3617 = len(yyv3617)
+		} else if yyl3617 != len(yyv3617) {
+			yyv3617 = yyv3617[:yyl3617]
+			yyc3617 = true
 		}
-		yyj3613 := 0
-		for ; yyj3613 < yyrr3613; yyj3613++ {
+		yyj3617 := 0
+		for ; yyj3617 < yyrr3617; yyj3617++ {
 			if r.TryDecodeAsNil() {
-				yyv3613[yyj3613] = EndpointAddress{}
+				yyv3617[yyj3617] = EndpointAddress{}
 			} else {
-				yyv3614 := &yyv3613[yyj3613]
-				yyv3614.CodecDecodeSelf(d)
+				yyv3618 := &yyv3617[yyj3617]
+				yyv3618.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3613 {
-			for ; yyj3613 < yyl3613; yyj3613++ {
-				yyv3613 = append(yyv3613, EndpointAddress{})
+		if yyrt3617 {
+			for ; yyj3617 < yyl3617; yyj3617++ {
+				yyv3617 = append(yyv3617, EndpointAddress{})
 				if r.TryDecodeAsNil() {
-					yyv3613[yyj3613] = EndpointAddress{}
+					yyv3617[yyj3617] = EndpointAddress{}
 				} else {
-					yyv3615 := &yyv3613[yyj3613]
-					yyv3615.CodecDecodeSelf(d)
+					yyv3619 := &yyv3617[yyj3617]
+					yyv3619.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3613 := 0; !r.CheckBreak(); yyj3613++ {
-			if yyj3613 >= len(yyv3613) {
-				yyv3613 = append(yyv3613, EndpointAddress{}) // var yyz3613 EndpointAddress
-				yyc3613 = true
+		for yyj3617 := 0; !r.CheckBreak(); yyj3617++ {
+			if yyj3617 >= len(yyv3617) {
+				yyv3617 = append(yyv3617, EndpointAddress{}) // var yyz3617 EndpointAddress
+				yyc3617 = true
 			}
 
-			if yyj3613 < len(yyv3613) {
+			if yyj3617 < len(yyv3617) {
 				if r.TryDecodeAsNil() {
-					yyv3613[yyj3613] = EndpointAddress{}
+					yyv3617[yyj3617] = EndpointAddress{}
 				} else {
-					yyv3616 := &yyv3613[yyj3613]
-					yyv3616.CodecDecodeSelf(d)
+					yyv3620 := &yyv3617[yyj3617]
+					yyv3620.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42359,10 +42389,10 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 			}
 
 		}
-		yyh3613.End()
+		yyh3617.End()
 	}
-	if yyc3613 {
-		*v = yyv3613
+	if yyc3617 {
+		*v = yyv3617
 	}
 
 }
@@ -42372,9 +42402,9 @@ func (x codecSelfer1234) encSliceEndpointPort(v []EndpointPort, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3617 := range v {
-		yy3618 := &yyv3617
-		yy3618.CodecEncodeSelf(e)
+	for _, yyv3621 := range v {
+		yy3622 := &yyv3621
+		yy3622.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42384,75 +42414,75 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3619 := *v
-	yyh3619, yyl3619 := z.DecSliceHelperStart()
+	yyv3623 := *v
+	yyh3623, yyl3623 := z.DecSliceHelperStart()
 
-	var yyrr3619, yyrl3619 int
-	var yyc3619, yyrt3619 bool
-	_, _, _ = yyc3619, yyrt3619, yyrl3619
-	yyrr3619 = yyl3619
+	var yyrr3623, yyrl3623 int
+	var yyc3623, yyrt3623 bool
+	_, _, _ = yyc3623, yyrt3623, yyrl3623
+	yyrr3623 = yyl3623
 
-	if yyv3619 == nil {
-		if yyrl3619, yyrt3619 = z.DecInferLen(yyl3619, z.DecBasicHandle().MaxInitLen, 40); yyrt3619 {
-			yyrr3619 = yyrl3619
+	if yyv3623 == nil {
+		if yyrl3623, yyrt3623 = z.DecInferLen(yyl3623, z.DecBasicHandle().MaxInitLen, 40); yyrt3623 {
+			yyrr3623 = yyrl3623
 		}
-		yyv3619 = make([]EndpointPort, yyrl3619)
-		yyc3619 = true
+		yyv3623 = make([]EndpointPort, yyrl3623)
+		yyc3623 = true
 	}
 
-	if yyl3619 == 0 {
-		if len(yyv3619) != 0 {
-			yyv3619 = yyv3619[:0]
-			yyc3619 = true
+	if yyl3623 == 0 {
+		if len(yyv3623) != 0 {
+			yyv3623 = yyv3623[:0]
+			yyc3623 = true
 		}
-	} else if yyl3619 > 0 {
+	} else if yyl3623 > 0 {
 
-		if yyl3619 > cap(yyv3619) {
-			yyrl3619, yyrt3619 = z.DecInferLen(yyl3619, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3619 = make([]EndpointPort, yyrl3619)
-			yyc3619 = true
+		if yyl3623 > cap(yyv3623) {
+			yyrl3623, yyrt3623 = z.DecInferLen(yyl3623, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3623 = make([]EndpointPort, yyrl3623)
+			yyc3623 = true
 
-			yyrr3619 = len(yyv3619)
-		} else if yyl3619 != len(yyv3619) {
-			yyv3619 = yyv3619[:yyl3619]
-			yyc3619 = true
+			yyrr3623 = len(yyv3623)
+		} else if yyl3623 != len(yyv3623) {
+			yyv3623 = yyv3623[:yyl3623]
+			yyc3623 = true
 		}
-		yyj3619 := 0
-		for ; yyj3619 < yyrr3619; yyj3619++ {
+		yyj3623 := 0
+		for ; yyj3623 < yyrr3623; yyj3623++ {
 			if r.TryDecodeAsNil() {
-				yyv3619[yyj3619] = EndpointPort{}
+				yyv3623[yyj3623] = EndpointPort{}
 			} else {
-				yyv3620 := &yyv3619[yyj3619]
-				yyv3620.CodecDecodeSelf(d)
+				yyv3624 := &yyv3623[yyj3623]
+				yyv3624.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3619 {
-			for ; yyj3619 < yyl3619; yyj3619++ {
-				yyv3619 = append(yyv3619, EndpointPort{})
+		if yyrt3623 {
+			for ; yyj3623 < yyl3623; yyj3623++ {
+				yyv3623 = append(yyv3623, EndpointPort{})
 				if r.TryDecodeAsNil() {
-					yyv3619[yyj3619] = EndpointPort{}
+					yyv3623[yyj3623] = EndpointPort{}
 				} else {
-					yyv3621 := &yyv3619[yyj3619]
-					yyv3621.CodecDecodeSelf(d)
+					yyv3625 := &yyv3623[yyj3623]
+					yyv3625.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3619 := 0; !r.CheckBreak(); yyj3619++ {
-			if yyj3619 >= len(yyv3619) {
-				yyv3619 = append(yyv3619, EndpointPort{}) // var yyz3619 EndpointPort
-				yyc3619 = true
+		for yyj3623 := 0; !r.CheckBreak(); yyj3623++ {
+			if yyj3623 >= len(yyv3623) {
+				yyv3623 = append(yyv3623, EndpointPort{}) // var yyz3623 EndpointPort
+				yyc3623 = true
 			}
 
-			if yyj3619 < len(yyv3619) {
+			if yyj3623 < len(yyv3623) {
 				if r.TryDecodeAsNil() {
-					yyv3619[yyj3619] = EndpointPort{}
+					yyv3623[yyj3623] = EndpointPort{}
 				} else {
-					yyv3622 := &yyv3619[yyj3619]
-					yyv3622.CodecDecodeSelf(d)
+					yyv3626 := &yyv3623[yyj3623]
+					yyv3626.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42460,10 +42490,10 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 			}
 
 		}
-		yyh3619.End()
+		yyh3623.End()
 	}
-	if yyc3619 {
-		*v = yyv3619
+	if yyc3623 {
+		*v = yyv3623
 	}
 
 }
@@ -42473,9 +42503,9 @@ func (x codecSelfer1234) encSliceEndpoints(v []Endpoints, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3623 := range v {
-		yy3624 := &yyv3623
-		yy3624.CodecEncodeSelf(e)
+	for _, yyv3627 := range v {
+		yy3628 := &yyv3627
+		yy3628.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42485,75 +42515,75 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3625 := *v
-	yyh3625, yyl3625 := z.DecSliceHelperStart()
+	yyv3629 := *v
+	yyh3629, yyl3629 := z.DecSliceHelperStart()
 
-	var yyrr3625, yyrl3625 int
-	var yyc3625, yyrt3625 bool
-	_, _, _ = yyc3625, yyrt3625, yyrl3625
-	yyrr3625 = yyl3625
+	var yyrr3629, yyrl3629 int
+	var yyc3629, yyrt3629 bool
+	_, _, _ = yyc3629, yyrt3629, yyrl3629
+	yyrr3629 = yyl3629
 
-	if yyv3625 == nil {
-		if yyrl3625, yyrt3625 = z.DecInferLen(yyl3625, z.DecBasicHandle().MaxInitLen, 216); yyrt3625 {
-			yyrr3625 = yyrl3625
+	if yyv3629 == nil {
+		if yyrl3629, yyrt3629 = z.DecInferLen(yyl3629, z.DecBasicHandle().MaxInitLen, 216); yyrt3629 {
+			yyrr3629 = yyrl3629
 		}
-		yyv3625 = make([]Endpoints, yyrl3625)
-		yyc3625 = true
+		yyv3629 = make([]Endpoints, yyrl3629)
+		yyc3629 = true
 	}
 
-	if yyl3625 == 0 {
-		if len(yyv3625) != 0 {
-			yyv3625 = yyv3625[:0]
-			yyc3625 = true
+	if yyl3629 == 0 {
+		if len(yyv3629) != 0 {
+			yyv3629 = yyv3629[:0]
+			yyc3629 = true
 		}
-	} else if yyl3625 > 0 {
+	} else if yyl3629 > 0 {
 
-		if yyl3625 > cap(yyv3625) {
-			yyrl3625, yyrt3625 = z.DecInferLen(yyl3625, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3625 = make([]Endpoints, yyrl3625)
-			yyc3625 = true
+		if yyl3629 > cap(yyv3629) {
+			yyrl3629, yyrt3629 = z.DecInferLen(yyl3629, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3629 = make([]Endpoints, yyrl3629)
+			yyc3629 = true
 
-			yyrr3625 = len(yyv3625)
-		} else if yyl3625 != len(yyv3625) {
-			yyv3625 = yyv3625[:yyl3625]
-			yyc3625 = true
+			yyrr3629 = len(yyv3629)
+		} else if yyl3629 != len(yyv3629) {
+			yyv3629 = yyv3629[:yyl3629]
+			yyc3629 = true
 		}
-		yyj3625 := 0
-		for ; yyj3625 < yyrr3625; yyj3625++ {
+		yyj3629 := 0
+		for ; yyj3629 < yyrr3629; yyj3629++ {
 			if r.TryDecodeAsNil() {
-				yyv3625[yyj3625] = Endpoints{}
+				yyv3629[yyj3629] = Endpoints{}
 			} else {
-				yyv3626 := &yyv3625[yyj3625]
-				yyv3626.CodecDecodeSelf(d)
+				yyv3630 := &yyv3629[yyj3629]
+				yyv3630.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3625 {
-			for ; yyj3625 < yyl3625; yyj3625++ {
-				yyv3625 = append(yyv3625, Endpoints{})
+		if yyrt3629 {
+			for ; yyj3629 < yyl3629; yyj3629++ {
+				yyv3629 = append(yyv3629, Endpoints{})
 				if r.TryDecodeAsNil() {
-					yyv3625[yyj3625] = Endpoints{}
+					yyv3629[yyj3629] = Endpoints{}
 				} else {
-					yyv3627 := &yyv3625[yyj3625]
-					yyv3627.CodecDecodeSelf(d)
+					yyv3631 := &yyv3629[yyj3629]
+					yyv3631.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3625 := 0; !r.CheckBreak(); yyj3625++ {
-			if yyj3625 >= len(yyv3625) {
-				yyv3625 = append(yyv3625, Endpoints{}) // var yyz3625 Endpoints
-				yyc3625 = true
+		for yyj3629 := 0; !r.CheckBreak(); yyj3629++ {
+			if yyj3629 >= len(yyv3629) {
+				yyv3629 = append(yyv3629, Endpoints{}) // var yyz3629 Endpoints
+				yyc3629 = true
 			}
 
-			if yyj3625 < len(yyv3625) {
+			if yyj3629 < len(yyv3629) {
 				if r.TryDecodeAsNil() {
-					yyv3625[yyj3625] = Endpoints{}
+					yyv3629[yyj3629] = Endpoints{}
 				} else {
-					yyv3628 := &yyv3625[yyj3625]
-					yyv3628.CodecDecodeSelf(d)
+					yyv3632 := &yyv3629[yyj3629]
+					yyv3632.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42561,10 +42591,10 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3625.End()
+		yyh3629.End()
 	}
-	if yyc3625 {
-		*v = yyv3625
+	if yyc3629 {
+		*v = yyv3629
 	}
 
 }
@@ -42574,9 +42604,9 @@ func (x codecSelfer1234) encSliceNodeCondition(v []NodeCondition, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3629 := range v {
-		yy3630 := &yyv3629
-		yy3630.CodecEncodeSelf(e)
+	for _, yyv3633 := range v {
+		yy3634 := &yyv3633
+		yy3634.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42586,75 +42616,75 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3631 := *v
-	yyh3631, yyl3631 := z.DecSliceHelperStart()
+	yyv3635 := *v
+	yyh3635, yyl3635 := z.DecSliceHelperStart()
 
-	var yyrr3631, yyrl3631 int
-	var yyc3631, yyrt3631 bool
-	_, _, _ = yyc3631, yyrt3631, yyrl3631
-	yyrr3631 = yyl3631
+	var yyrr3635, yyrl3635 int
+	var yyc3635, yyrt3635 bool
+	_, _, _ = yyc3635, yyrt3635, yyrl3635
+	yyrr3635 = yyl3635
 
-	if yyv3631 == nil {
-		if yyrl3631, yyrt3631 = z.DecInferLen(yyl3631, z.DecBasicHandle().MaxInitLen, 112); yyrt3631 {
-			yyrr3631 = yyrl3631
+	if yyv3635 == nil {
+		if yyrl3635, yyrt3635 = z.DecInferLen(yyl3635, z.DecBasicHandle().MaxInitLen, 112); yyrt3635 {
+			yyrr3635 = yyrl3635
 		}
-		yyv3631 = make([]NodeCondition, yyrl3631)
-		yyc3631 = true
+		yyv3635 = make([]NodeCondition, yyrl3635)
+		yyc3635 = true
 	}
 
-	if yyl3631 == 0 {
-		if len(yyv3631) != 0 {
-			yyv3631 = yyv3631[:0]
-			yyc3631 = true
+	if yyl3635 == 0 {
+		if len(yyv3635) != 0 {
+			yyv3635 = yyv3635[:0]
+			yyc3635 = true
 		}
-	} else if yyl3631 > 0 {
+	} else if yyl3635 > 0 {
 
-		if yyl3631 > cap(yyv3631) {
-			yyrl3631, yyrt3631 = z.DecInferLen(yyl3631, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3631 = make([]NodeCondition, yyrl3631)
-			yyc3631 = true
+		if yyl3635 > cap(yyv3635) {
+			yyrl3635, yyrt3635 = z.DecInferLen(yyl3635, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3635 = make([]NodeCondition, yyrl3635)
+			yyc3635 = true
 
-			yyrr3631 = len(yyv3631)
-		} else if yyl3631 != len(yyv3631) {
-			yyv3631 = yyv3631[:yyl3631]
-			yyc3631 = true
+			yyrr3635 = len(yyv3635)
+		} else if yyl3635 != len(yyv3635) {
+			yyv3635 = yyv3635[:yyl3635]
+			yyc3635 = true
 		}
-		yyj3631 := 0
-		for ; yyj3631 < yyrr3631; yyj3631++ {
+		yyj3635 := 0
+		for ; yyj3635 < yyrr3635; yyj3635++ {
 			if r.TryDecodeAsNil() {
-				yyv3631[yyj3631] = NodeCondition{}
+				yyv3635[yyj3635] = NodeCondition{}
 			} else {
-				yyv3632 := &yyv3631[yyj3631]
-				yyv3632.CodecDecodeSelf(d)
+				yyv3636 := &yyv3635[yyj3635]
+				yyv3636.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3631 {
-			for ; yyj3631 < yyl3631; yyj3631++ {
-				yyv3631 = append(yyv3631, NodeCondition{})
+		if yyrt3635 {
+			for ; yyj3635 < yyl3635; yyj3635++ {
+				yyv3635 = append(yyv3635, NodeCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3631[yyj3631] = NodeCondition{}
+					yyv3635[yyj3635] = NodeCondition{}
 				} else {
-					yyv3633 := &yyv3631[yyj3631]
-					yyv3633.CodecDecodeSelf(d)
+					yyv3637 := &yyv3635[yyj3635]
+					yyv3637.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3631 := 0; !r.CheckBreak(); yyj3631++ {
-			if yyj3631 >= len(yyv3631) {
-				yyv3631 = append(yyv3631, NodeCondition{}) // var yyz3631 NodeCondition
-				yyc3631 = true
+		for yyj3635 := 0; !r.CheckBreak(); yyj3635++ {
+			if yyj3635 >= len(yyv3635) {
+				yyv3635 = append(yyv3635, NodeCondition{}) // var yyz3635 NodeCondition
+				yyc3635 = true
 			}
 
-			if yyj3631 < len(yyv3631) {
+			if yyj3635 < len(yyv3635) {
 				if r.TryDecodeAsNil() {
-					yyv3631[yyj3631] = NodeCondition{}
+					yyv3635[yyj3635] = NodeCondition{}
 				} else {
-					yyv3634 := &yyv3631[yyj3631]
-					yyv3634.CodecDecodeSelf(d)
+					yyv3638 := &yyv3635[yyj3635]
+					yyv3638.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42662,10 +42692,10 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 			}
 
 		}
-		yyh3631.End()
+		yyh3635.End()
 	}
-	if yyc3631 {
-		*v = yyv3631
+	if yyc3635 {
+		*v = yyv3635
 	}
 
 }
@@ -42675,9 +42705,9 @@ func (x codecSelfer1234) encSliceNodeAddress(v []NodeAddress, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3635 := range v {
-		yy3636 := &yyv3635
-		yy3636.CodecEncodeSelf(e)
+	for _, yyv3639 := range v {
+		yy3640 := &yyv3639
+		yy3640.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42687,75 +42717,75 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3637 := *v
-	yyh3637, yyl3637 := z.DecSliceHelperStart()
+	yyv3641 := *v
+	yyh3641, yyl3641 := z.DecSliceHelperStart()
 
-	var yyrr3637, yyrl3637 int
-	var yyc3637, yyrt3637 bool
-	_, _, _ = yyc3637, yyrt3637, yyrl3637
-	yyrr3637 = yyl3637
+	var yyrr3641, yyrl3641 int
+	var yyc3641, yyrt3641 bool
+	_, _, _ = yyc3641, yyrt3641, yyrl3641
+	yyrr3641 = yyl3641
 
-	if yyv3637 == nil {
-		if yyrl3637, yyrt3637 = z.DecInferLen(yyl3637, z.DecBasicHandle().MaxInitLen, 32); yyrt3637 {
-			yyrr3637 = yyrl3637
+	if yyv3641 == nil {
+		if yyrl3641, yyrt3641 = z.DecInferLen(yyl3641, z.DecBasicHandle().MaxInitLen, 32); yyrt3641 {
+			yyrr3641 = yyrl3641
 		}
-		yyv3637 = make([]NodeAddress, yyrl3637)
-		yyc3637 = true
+		yyv3641 = make([]NodeAddress, yyrl3641)
+		yyc3641 = true
 	}
 
-	if yyl3637 == 0 {
-		if len(yyv3637) != 0 {
-			yyv3637 = yyv3637[:0]
-			yyc3637 = true
+	if yyl3641 == 0 {
+		if len(yyv3641) != 0 {
+			yyv3641 = yyv3641[:0]
+			yyc3641 = true
 		}
-	} else if yyl3637 > 0 {
+	} else if yyl3641 > 0 {
 
-		if yyl3637 > cap(yyv3637) {
-			yyrl3637, yyrt3637 = z.DecInferLen(yyl3637, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3637 = make([]NodeAddress, yyrl3637)
-			yyc3637 = true
+		if yyl3641 > cap(yyv3641) {
+			yyrl3641, yyrt3641 = z.DecInferLen(yyl3641, z.DecBasicHandle().MaxInitLen, 32)
+			yyv3641 = make([]NodeAddress, yyrl3641)
+			yyc3641 = true
 
-			yyrr3637 = len(yyv3637)
-		} else if yyl3637 != len(yyv3637) {
-			yyv3637 = yyv3637[:yyl3637]
-			yyc3637 = true
+			yyrr3641 = len(yyv3641)
+		} else if yyl3641 != len(yyv3641) {
+			yyv3641 = yyv3641[:yyl3641]
+			yyc3641 = true
 		}
-		yyj3637 := 0
-		for ; yyj3637 < yyrr3637; yyj3637++ {
+		yyj3641 := 0
+		for ; yyj3641 < yyrr3641; yyj3641++ {
 			if r.TryDecodeAsNil() {
-				yyv3637[yyj3637] = NodeAddress{}
+				yyv3641[yyj3641] = NodeAddress{}
 			} else {
-				yyv3638 := &yyv3637[yyj3637]
-				yyv3638.CodecDecodeSelf(d)
+				yyv3642 := &yyv3641[yyj3641]
+				yyv3642.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3637 {
-			for ; yyj3637 < yyl3637; yyj3637++ {
-				yyv3637 = append(yyv3637, NodeAddress{})
+		if yyrt3641 {
+			for ; yyj3641 < yyl3641; yyj3641++ {
+				yyv3641 = append(yyv3641, NodeAddress{})
 				if r.TryDecodeAsNil() {
-					yyv3637[yyj3637] = NodeAddress{}
+					yyv3641[yyj3641] = NodeAddress{}
 				} else {
-					yyv3639 := &yyv3637[yyj3637]
-					yyv3639.CodecDecodeSelf(d)
+					yyv3643 := &yyv3641[yyj3641]
+					yyv3643.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3637 := 0; !r.CheckBreak(); yyj3637++ {
-			if yyj3637 >= len(yyv3637) {
-				yyv3637 = append(yyv3637, NodeAddress{}) // var yyz3637 NodeAddress
-				yyc3637 = true
+		for yyj3641 := 0; !r.CheckBreak(); yyj3641++ {
+			if yyj3641 >= len(yyv3641) {
+				yyv3641 = append(yyv3641, NodeAddress{}) // var yyz3641 NodeAddress
+				yyc3641 = true
 			}
 
-			if yyj3637 < len(yyv3637) {
+			if yyj3641 < len(yyv3641) {
 				if r.TryDecodeAsNil() {
-					yyv3637[yyj3637] = NodeAddress{}
+					yyv3641[yyj3641] = NodeAddress{}
 				} else {
-					yyv3640 := &yyv3637[yyj3637]
-					yyv3640.CodecDecodeSelf(d)
+					yyv3644 := &yyv3641[yyj3641]
+					yyv3644.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42763,10 +42793,10 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 			}
 
 		}
-		yyh3637.End()
+		yyh3641.End()
 	}
-	if yyc3637 {
-		*v = yyv3637
+	if yyc3641 {
+		*v = yyv3641
 	}
 
 }
@@ -42776,17 +42806,17 @@ func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk3641, yyv3641 := range v {
-		yyk3641.CodecEncodeSelf(e)
-		yy3642 := &yyv3641
-		yym3643 := z.EncBinary()
-		_ = yym3643
+	for yyk3645, yyv3645 := range v {
+		yyk3645.CodecEncodeSelf(e)
+		yy3646 := &yyv3645
+		yym3647 := z.EncBinary()
+		_ = yym3647
 		if false {
-		} else if z.HasExtensions() && z.EncExt(yy3642) {
-		} else if !yym3643 && z.IsJSONHandle() {
-			z.EncJSONMarshal(yy3642)
+		} else if z.HasExtensions() && z.EncExt(yy3646) {
+		} else if !yym3647 && z.IsJSONHandle() {
+			z.EncJSONMarshal(yy3646)
 		} else {
-			z.EncFallback(yy3642)
+			z.EncFallback(yy3646)
 		}
 	}
 	r.EncodeEnd()
@@ -42797,82 +42827,82 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3644 := *v
-	yyl3644 := r.ReadMapStart()
-	yybh3644 := z.DecBasicHandle()
-	if yyv3644 == nil {
-		yyrl3644, _ := z.DecInferLen(yyl3644, yybh3644.MaxInitLen, 40)
-		yyv3644 = make(map[ResourceName]pkg3_resource.Quantity, yyrl3644)
-		*v = yyv3644
+	yyv3648 := *v
+	yyl3648 := r.ReadMapStart()
+	yybh3648 := z.DecBasicHandle()
+	if yyv3648 == nil {
+		yyrl3648, _ := z.DecInferLen(yyl3648, yybh3648.MaxInitLen, 40)
+		yyv3648 = make(map[ResourceName]pkg3_resource.Quantity, yyrl3648)
+		*v = yyv3648
 	}
-	var yymk3644 ResourceName
-	var yymv3644 pkg3_resource.Quantity
-	var yymg3644 bool
-	if yybh3644.MapValueReset {
-		yymg3644 = true
+	var yymk3648 ResourceName
+	var yymv3648 pkg3_resource.Quantity
+	var yymg3648 bool
+	if yybh3648.MapValueReset {
+		yymg3648 = true
 	}
-	if yyl3644 > 0 {
-		for yyj3644 := 0; yyj3644 < yyl3644; yyj3644++ {
+	if yyl3648 > 0 {
+		for yyj3648 := 0; yyj3648 < yyl3648; yyj3648++ {
 			if r.TryDecodeAsNil() {
-				yymk3644 = ""
+				yymk3648 = ""
 			} else {
-				yymk3644 = ResourceName(r.DecodeString())
+				yymk3648 = ResourceName(r.DecodeString())
 			}
 
-			if yymg3644 {
-				yymv3644 = yyv3644[yymk3644]
+			if yymg3648 {
+				yymv3648 = yyv3648[yymk3648]
 			} else {
-				yymv3644 = pkg3_resource.Quantity{}
+				yymv3648 = pkg3_resource.Quantity{}
 			}
 			if r.TryDecodeAsNil() {
-				yymv3644 = pkg3_resource.Quantity{}
+				yymv3648 = pkg3_resource.Quantity{}
 			} else {
-				yyv3646 := &yymv3644
-				yym3647 := z.DecBinary()
-				_ = yym3647
+				yyv3650 := &yymv3648
+				yym3651 := z.DecBinary()
+				_ = yym3651
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3646) {
-				} else if !yym3647 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3646)
+				} else if z.HasExtensions() && z.DecExt(yyv3650) {
+				} else if !yym3651 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3650)
 				} else {
-					z.DecFallback(yyv3646, false)
+					z.DecFallback(yyv3650, false)
 				}
 			}
 
-			if yyv3644 != nil {
-				yyv3644[yymk3644] = yymv3644
+			if yyv3648 != nil {
+				yyv3648[yymk3648] = yymv3648
 			}
 		}
-	} else if yyl3644 < 0 {
-		for yyj3644 := 0; !r.CheckBreak(); yyj3644++ {
+	} else if yyl3648 < 0 {
+		for yyj3648 := 0; !r.CheckBreak(); yyj3648++ {
 			if r.TryDecodeAsNil() {
-				yymk3644 = ""
+				yymk3648 = ""
 			} else {
-				yymk3644 = ResourceName(r.DecodeString())
+				yymk3648 = ResourceName(r.DecodeString())
 			}
 
-			if yymg3644 {
-				yymv3644 = yyv3644[yymk3644]
+			if yymg3648 {
+				yymv3648 = yyv3648[yymk3648]
 			} else {
-				yymv3644 = pkg3_resource.Quantity{}
+				yymv3648 = pkg3_resource.Quantity{}
 			}
 			if r.TryDecodeAsNil() {
-				yymv3644 = pkg3_resource.Quantity{}
+				yymv3648 = pkg3_resource.Quantity{}
 			} else {
-				yyv3649 := &yymv3644
-				yym3650 := z.DecBinary()
-				_ = yym3650
+				yyv3653 := &yymv3648
+				yym3654 := z.DecBinary()
+				_ = yym3654
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3649) {
-				} else if !yym3650 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3649)
+				} else if z.HasExtensions() && z.DecExt(yyv3653) {
+				} else if !yym3654 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3653)
 				} else {
-					z.DecFallback(yyv3649, false)
+					z.DecFallback(yyv3653, false)
 				}
 			}
 
-			if yyv3644 != nil {
-				yyv3644[yymk3644] = yymv3644
+			if yyv3648 != nil {
+				yyv3648[yymk3648] = yymv3648
 			}
 		}
 		r.ReadEnd()
@@ -42884,9 +42914,9 @@ func (x codecSelfer1234) encSliceNode(v []Node, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3651 := range v {
-		yy3652 := &yyv3651
-		yy3652.CodecEncodeSelf(e)
+	for _, yyv3655 := range v {
+		yy3656 := &yyv3655
+		yy3656.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42896,75 +42926,75 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3653 := *v
-	yyh3653, yyl3653 := z.DecSliceHelperStart()
+	yyv3657 := *v
+	yyh3657, yyl3657 := z.DecSliceHelperStart()
 
-	var yyrr3653, yyrl3653 int
-	var yyc3653, yyrt3653 bool
-	_, _, _ = yyc3653, yyrt3653, yyrl3653
-	yyrr3653 = yyl3653
+	var yyrr3657, yyrl3657 int
+	var yyc3657, yyrt3657 bool
+	_, _, _ = yyc3657, yyrt3657, yyrl3657
+	yyrr3657 = yyl3657
 
-	if yyv3653 == nil {
-		if yyrl3653, yyrt3653 = z.DecInferLen(yyl3653, z.DecBasicHandle().MaxInitLen, 456); yyrt3653 {
-			yyrr3653 = yyrl3653
+	if yyv3657 == nil {
+		if yyrl3657, yyrt3657 = z.DecInferLen(yyl3657, z.DecBasicHandle().MaxInitLen, 456); yyrt3657 {
+			yyrr3657 = yyrl3657
 		}
-		yyv3653 = make([]Node, yyrl3653)
-		yyc3653 = true
+		yyv3657 = make([]Node, yyrl3657)
+		yyc3657 = true
 	}
 
-	if yyl3653 == 0 {
-		if len(yyv3653) != 0 {
-			yyv3653 = yyv3653[:0]
-			yyc3653 = true
+	if yyl3657 == 0 {
+		if len(yyv3657) != 0 {
+			yyv3657 = yyv3657[:0]
+			yyc3657 = true
 		}
-	} else if yyl3653 > 0 {
+	} else if yyl3657 > 0 {
 
-		if yyl3653 > cap(yyv3653) {
-			yyrl3653, yyrt3653 = z.DecInferLen(yyl3653, z.DecBasicHandle().MaxInitLen, 456)
-			yyv3653 = make([]Node, yyrl3653)
-			yyc3653 = true
+		if yyl3657 > cap(yyv3657) {
+			yyrl3657, yyrt3657 = z.DecInferLen(yyl3657, z.DecBasicHandle().MaxInitLen, 456)
+			yyv3657 = make([]Node, yyrl3657)
+			yyc3657 = true
 
-			yyrr3653 = len(yyv3653)
-		} else if yyl3653 != len(yyv3653) {
-			yyv3653 = yyv3653[:yyl3653]
-			yyc3653 = true
+			yyrr3657 = len(yyv3657)
+		} else if yyl3657 != len(yyv3657) {
+			yyv3657 = yyv3657[:yyl3657]
+			yyc3657 = true
 		}
-		yyj3653 := 0
-		for ; yyj3653 < yyrr3653; yyj3653++ {
+		yyj3657 := 0
+		for ; yyj3657 < yyrr3657; yyj3657++ {
 			if r.TryDecodeAsNil() {
-				yyv3653[yyj3653] = Node{}
+				yyv3657[yyj3657] = Node{}
 			} else {
-				yyv3654 := &yyv3653[yyj3653]
-				yyv3654.CodecDecodeSelf(d)
+				yyv3658 := &yyv3657[yyj3657]
+				yyv3658.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3653 {
-			for ; yyj3653 < yyl3653; yyj3653++ {
-				yyv3653 = append(yyv3653, Node{})
+		if yyrt3657 {
+			for ; yyj3657 < yyl3657; yyj3657++ {
+				yyv3657 = append(yyv3657, Node{})
 				if r.TryDecodeAsNil() {
-					yyv3653[yyj3653] = Node{}
+					yyv3657[yyj3657] = Node{}
 				} else {
-					yyv3655 := &yyv3653[yyj3653]
-					yyv3655.CodecDecodeSelf(d)
+					yyv3659 := &yyv3657[yyj3657]
+					yyv3659.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3653 := 0; !r.CheckBreak(); yyj3653++ {
-			if yyj3653 >= len(yyv3653) {
-				yyv3653 = append(yyv3653, Node{}) // var yyz3653 Node
-				yyc3653 = true
+		for yyj3657 := 0; !r.CheckBreak(); yyj3657++ {
+			if yyj3657 >= len(yyv3657) {
+				yyv3657 = append(yyv3657, Node{}) // var yyz3657 Node
+				yyc3657 = true
 			}
 
-			if yyj3653 < len(yyv3653) {
+			if yyj3657 < len(yyv3657) {
 				if r.TryDecodeAsNil() {
-					yyv3653[yyj3653] = Node{}
+					yyv3657[yyj3657] = Node{}
 				} else {
-					yyv3656 := &yyv3653[yyj3653]
-					yyv3656.CodecDecodeSelf(d)
+					yyv3660 := &yyv3657[yyj3657]
+					yyv3660.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42972,10 +43002,10 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3653.End()
+		yyh3657.End()
 	}
-	if yyc3653 {
-		*v = yyv3653
+	if yyc3657 {
+		*v = yyv3657
 	}
 
 }
@@ -42985,8 +43015,8 @@ func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3657 := range v {
-		yyv3657.CodecEncodeSelf(e)
+	for _, yyv3661 := range v {
+		yyv3661.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42996,77 +43026,77 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3658 := *v
-	yyh3658, yyl3658 := z.DecSliceHelperStart()
+	yyv3662 := *v
+	yyh3662, yyl3662 := z.DecSliceHelperStart()
 
-	var yyrr3658, yyrl3658 int
-	var yyc3658, yyrt3658 bool
-	_, _, _ = yyc3658, yyrt3658, yyrl3658
-	yyrr3658 = yyl3658
+	var yyrr3662, yyrl3662 int
+	var yyc3662, yyrt3662 bool
+	_, _, _ = yyc3662, yyrt3662, yyrl3662
+	yyrr3662 = yyl3662
 
-	if yyv3658 == nil {
-		if yyrl3658, yyrt3658 = z.DecInferLen(yyl3658, z.DecBasicHandle().MaxInitLen, 16); yyrt3658 {
-			yyrr3658 = yyrl3658
+	if yyv3662 == nil {
+		if yyrl3662, yyrt3662 = z.DecInferLen(yyl3662, z.DecBasicHandle().MaxInitLen, 16); yyrt3662 {
+			yyrr3662 = yyrl3662
 		}
-		yyv3658 = make([]FinalizerName, yyrl3658)
-		yyc3658 = true
+		yyv3662 = make([]FinalizerName, yyrl3662)
+		yyc3662 = true
 	}
 
-	if yyl3658 == 0 {
-		if len(yyv3658) != 0 {
-			yyv3658 = yyv3658[:0]
-			yyc3658 = true
+	if yyl3662 == 0 {
+		if len(yyv3662) != 0 {
+			yyv3662 = yyv3662[:0]
+			yyc3662 = true
 		}
-	} else if yyl3658 > 0 {
+	} else if yyl3662 > 0 {
 
-		if yyl3658 > cap(yyv3658) {
-			yyrl3658, yyrt3658 = z.DecInferLen(yyl3658, z.DecBasicHandle().MaxInitLen, 16)
+		if yyl3662 > cap(yyv3662) {
+			yyrl3662, yyrt3662 = z.DecInferLen(yyl3662, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23658 := yyv3658
-			yyv3658 = make([]FinalizerName, yyrl3658)
-			if len(yyv3658) > 0 {
-				copy(yyv3658, yyv23658[:cap(yyv23658)])
+			yyv23662 := yyv3662
+			yyv3662 = make([]FinalizerName, yyrl3662)
+			if len(yyv3662) > 0 {
+				copy(yyv3662, yyv23662[:cap(yyv23662)])
 			}
-			yyc3658 = true
+			yyc3662 = true
 
-			yyrr3658 = len(yyv3658)
-		} else if yyl3658 != len(yyv3658) {
-			yyv3658 = yyv3658[:yyl3658]
-			yyc3658 = true
+			yyrr3662 = len(yyv3662)
+		} else if yyl3662 != len(yyv3662) {
+			yyv3662 = yyv3662[:yyl3662]
+			yyc3662 = true
 		}
-		yyj3658 := 0
-		for ; yyj3658 < yyrr3658; yyj3658++ {
+		yyj3662 := 0
+		for ; yyj3662 < yyrr3662; yyj3662++ {
 			if r.TryDecodeAsNil() {
-				yyv3658[yyj3658] = ""
+				yyv3662[yyj3662] = ""
 			} else {
-				yyv3658[yyj3658] = FinalizerName(r.DecodeString())
+				yyv3662[yyj3662] = FinalizerName(r.DecodeString())
 			}
 
 		}
-		if yyrt3658 {
-			for ; yyj3658 < yyl3658; yyj3658++ {
-				yyv3658 = append(yyv3658, "")
+		if yyrt3662 {
+			for ; yyj3662 < yyl3662; yyj3662++ {
+				yyv3662 = append(yyv3662, "")
 				if r.TryDecodeAsNil() {
-					yyv3658[yyj3658] = ""
+					yyv3662[yyj3662] = ""
 				} else {
-					yyv3658[yyj3658] = FinalizerName(r.DecodeString())
+					yyv3662[yyj3662] = FinalizerName(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3658 := 0; !r.CheckBreak(); yyj3658++ {
-			if yyj3658 >= len(yyv3658) {
-				yyv3658 = append(yyv3658, "") // var yyz3658 FinalizerName
-				yyc3658 = true
+		for yyj3662 := 0; !r.CheckBreak(); yyj3662++ {
+			if yyj3662 >= len(yyv3662) {
+				yyv3662 = append(yyv3662, "") // var yyz3662 FinalizerName
+				yyc3662 = true
 			}
 
-			if yyj3658 < len(yyv3658) {
+			if yyj3662 < len(yyv3662) {
 				if r.TryDecodeAsNil() {
-					yyv3658[yyj3658] = ""
+					yyv3662[yyj3662] = ""
 				} else {
-					yyv3658[yyj3658] = FinalizerName(r.DecodeString())
+					yyv3662[yyj3662] = FinalizerName(r.DecodeString())
 				}
 
 			} else {
@@ -43074,10 +43104,10 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 			}
 
 		}
-		yyh3658.End()
+		yyh3662.End()
 	}
-	if yyc3658 {
-		*v = yyv3658
+	if yyc3662 {
+		*v = yyv3662
 	}
 
 }
@@ -43087,9 +43117,9 @@ func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3662 := range v {
-		yy3663 := &yyv3662
-		yy3663.CodecEncodeSelf(e)
+	for _, yyv3666 := range v {
+		yy3667 := &yyv3666
+		yy3667.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43099,75 +43129,75 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3664 := *v
-	yyh3664, yyl3664 := z.DecSliceHelperStart()
+	yyv3668 := *v
+	yyh3668, yyl3668 := z.DecSliceHelperStart()
 
-	var yyrr3664, yyrl3664 int
-	var yyc3664, yyrt3664 bool
-	_, _, _ = yyc3664, yyrt3664, yyrl3664
-	yyrr3664 = yyl3664
+	var yyrr3668, yyrl3668 int
+	var yyc3668, yyrt3668 bool
+	_, _, _ = yyc3668, yyrt3668, yyrl3668
+	yyrr3668 = yyl3668
 
-	if yyv3664 == nil {
-		if yyrl3664, yyrt3664 = z.DecInferLen(yyl3664, z.DecBasicHandle().MaxInitLen, 232); yyrt3664 {
-			yyrr3664 = yyrl3664
+	if yyv3668 == nil {
+		if yyrl3668, yyrt3668 = z.DecInferLen(yyl3668, z.DecBasicHandle().MaxInitLen, 232); yyrt3668 {
+			yyrr3668 = yyrl3668
 		}
-		yyv3664 = make([]Namespace, yyrl3664)
-		yyc3664 = true
+		yyv3668 = make([]Namespace, yyrl3668)
+		yyc3668 = true
 	}
 
-	if yyl3664 == 0 {
-		if len(yyv3664) != 0 {
-			yyv3664 = yyv3664[:0]
-			yyc3664 = true
+	if yyl3668 == 0 {
+		if len(yyv3668) != 0 {
+			yyv3668 = yyv3668[:0]
+			yyc3668 = true
 		}
-	} else if yyl3664 > 0 {
+	} else if yyl3668 > 0 {
 
-		if yyl3664 > cap(yyv3664) {
-			yyrl3664, yyrt3664 = z.DecInferLen(yyl3664, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3664 = make([]Namespace, yyrl3664)
-			yyc3664 = true
+		if yyl3668 > cap(yyv3668) {
+			yyrl3668, yyrt3668 = z.DecInferLen(yyl3668, z.DecBasicHandle().MaxInitLen, 232)
+			yyv3668 = make([]Namespace, yyrl3668)
+			yyc3668 = true
 
-			yyrr3664 = len(yyv3664)
-		} else if yyl3664 != len(yyv3664) {
-			yyv3664 = yyv3664[:yyl3664]
-			yyc3664 = true
+			yyrr3668 = len(yyv3668)
+		} else if yyl3668 != len(yyv3668) {
+			yyv3668 = yyv3668[:yyl3668]
+			yyc3668 = true
 		}
-		yyj3664 := 0
-		for ; yyj3664 < yyrr3664; yyj3664++ {
+		yyj3668 := 0
+		for ; yyj3668 < yyrr3668; yyj3668++ {
 			if r.TryDecodeAsNil() {
-				yyv3664[yyj3664] = Namespace{}
+				yyv3668[yyj3668] = Namespace{}
 			} else {
-				yyv3665 := &yyv3664[yyj3664]
-				yyv3665.CodecDecodeSelf(d)
+				yyv3669 := &yyv3668[yyj3668]
+				yyv3669.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3664 {
-			for ; yyj3664 < yyl3664; yyj3664++ {
-				yyv3664 = append(yyv3664, Namespace{})
+		if yyrt3668 {
+			for ; yyj3668 < yyl3668; yyj3668++ {
+				yyv3668 = append(yyv3668, Namespace{})
 				if r.TryDecodeAsNil() {
-					yyv3664[yyj3664] = Namespace{}
+					yyv3668[yyj3668] = Namespace{}
 				} else {
-					yyv3666 := &yyv3664[yyj3664]
-					yyv3666.CodecDecodeSelf(d)
+					yyv3670 := &yyv3668[yyj3668]
+					yyv3670.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3664 := 0; !r.CheckBreak(); yyj3664++ {
-			if yyj3664 >= len(yyv3664) {
-				yyv3664 = append(yyv3664, Namespace{}) // var yyz3664 Namespace
-				yyc3664 = true
+		for yyj3668 := 0; !r.CheckBreak(); yyj3668++ {
+			if yyj3668 >= len(yyv3668) {
+				yyv3668 = append(yyv3668, Namespace{}) // var yyz3668 Namespace
+				yyc3668 = true
 			}
 
-			if yyj3664 < len(yyv3664) {
+			if yyj3668 < len(yyv3668) {
 				if r.TryDecodeAsNil() {
-					yyv3664[yyj3664] = Namespace{}
+					yyv3668[yyj3668] = Namespace{}
 				} else {
-					yyv3667 := &yyv3664[yyj3664]
-					yyv3667.CodecDecodeSelf(d)
+					yyv3671 := &yyv3668[yyj3668]
+					yyv3671.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43175,10 +43205,10 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3664.End()
+		yyh3668.End()
 	}
-	if yyc3664 {
-		*v = yyv3664
+	if yyc3668 {
+		*v = yyv3668
 	}
 
 }
@@ -43188,9 +43218,9 @@ func (x codecSelfer1234) encSliceEvent(v []Event, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3668 := range v {
-		yy3669 := &yyv3668
-		yy3669.CodecEncodeSelf(e)
+	for _, yyv3672 := range v {
+		yy3673 := &yyv3672
+		yy3673.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43200,75 +43230,75 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3670 := *v
-	yyh3670, yyl3670 := z.DecSliceHelperStart()
+	yyv3674 := *v
+	yyh3674, yyl3674 := z.DecSliceHelperStart()
 
-	var yyrr3670, yyrl3670 int
-	var yyc3670, yyrt3670 bool
-	_, _, _ = yyc3670, yyrt3670, yyrl3670
-	yyrr3670 = yyl3670
+	var yyrr3674, yyrl3674 int
+	var yyc3674, yyrt3674 bool
+	_, _, _ = yyc3674, yyrt3674, yyrl3674
+	yyrr3674 = yyl3674
 
-	if yyv3670 == nil {
-		if yyrl3670, yyrt3670 = z.DecInferLen(yyl3670, z.DecBasicHandle().MaxInitLen, 424); yyrt3670 {
-			yyrr3670 = yyrl3670
+	if yyv3674 == nil {
+		if yyrl3674, yyrt3674 = z.DecInferLen(yyl3674, z.DecBasicHandle().MaxInitLen, 424); yyrt3674 {
+			yyrr3674 = yyrl3674
 		}
-		yyv3670 = make([]Event, yyrl3670)
-		yyc3670 = true
+		yyv3674 = make([]Event, yyrl3674)
+		yyc3674 = true
 	}
 
-	if yyl3670 == 0 {
-		if len(yyv3670) != 0 {
-			yyv3670 = yyv3670[:0]
-			yyc3670 = true
+	if yyl3674 == 0 {
+		if len(yyv3674) != 0 {
+			yyv3674 = yyv3674[:0]
+			yyc3674 = true
 		}
-	} else if yyl3670 > 0 {
+	} else if yyl3674 > 0 {
 
-		if yyl3670 > cap(yyv3670) {
-			yyrl3670, yyrt3670 = z.DecInferLen(yyl3670, z.DecBasicHandle().MaxInitLen, 424)
-			yyv3670 = make([]Event, yyrl3670)
-			yyc3670 = true
+		if yyl3674 > cap(yyv3674) {
+			yyrl3674, yyrt3674 = z.DecInferLen(yyl3674, z.DecBasicHandle().MaxInitLen, 424)
+			yyv3674 = make([]Event, yyrl3674)
+			yyc3674 = true
 
-			yyrr3670 = len(yyv3670)
-		} else if yyl3670 != len(yyv3670) {
-			yyv3670 = yyv3670[:yyl3670]
-			yyc3670 = true
+			yyrr3674 = len(yyv3674)
+		} else if yyl3674 != len(yyv3674) {
+			yyv3674 = yyv3674[:yyl3674]
+			yyc3674 = true
 		}
-		yyj3670 := 0
-		for ; yyj3670 < yyrr3670; yyj3670++ {
+		yyj3674 := 0
+		for ; yyj3674 < yyrr3674; yyj3674++ {
 			if r.TryDecodeAsNil() {
-				yyv3670[yyj3670] = Event{}
+				yyv3674[yyj3674] = Event{}
 			} else {
-				yyv3671 := &yyv3670[yyj3670]
-				yyv3671.CodecDecodeSelf(d)
+				yyv3675 := &yyv3674[yyj3674]
+				yyv3675.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3670 {
-			for ; yyj3670 < yyl3670; yyj3670++ {
-				yyv3670 = append(yyv3670, Event{})
+		if yyrt3674 {
+			for ; yyj3674 < yyl3674; yyj3674++ {
+				yyv3674 = append(yyv3674, Event{})
 				if r.TryDecodeAsNil() {
-					yyv3670[yyj3670] = Event{}
+					yyv3674[yyj3674] = Event{}
 				} else {
-					yyv3672 := &yyv3670[yyj3670]
-					yyv3672.CodecDecodeSelf(d)
+					yyv3676 := &yyv3674[yyj3674]
+					yyv3676.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3670 := 0; !r.CheckBreak(); yyj3670++ {
-			if yyj3670 >= len(yyv3670) {
-				yyv3670 = append(yyv3670, Event{}) // var yyz3670 Event
-				yyc3670 = true
+		for yyj3674 := 0; !r.CheckBreak(); yyj3674++ {
+			if yyj3674 >= len(yyv3674) {
+				yyv3674 = append(yyv3674, Event{}) // var yyz3674 Event
+				yyc3674 = true
 			}
 
-			if yyj3670 < len(yyv3670) {
+			if yyj3674 < len(yyv3674) {
 				if r.TryDecodeAsNil() {
-					yyv3670[yyj3670] = Event{}
+					yyv3674[yyj3674] = Event{}
 				} else {
-					yyv3673 := &yyv3670[yyj3670]
-					yyv3673.CodecDecodeSelf(d)
+					yyv3677 := &yyv3674[yyj3674]
+					yyv3677.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43276,10 +43306,10 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3670.End()
+		yyh3674.End()
 	}
-	if yyc3670 {
-		*v = yyv3670
+	if yyc3674 {
+		*v = yyv3674
 	}
 
 }
@@ -43289,16 +43319,16 @@ func (x codecSelfer1234) encSliceruntime_Object(v []pkg8_runtime.Object, e *code
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3674 := range v {
-		if yyv3674 == nil {
+	for _, yyv3678 := range v {
+		if yyv3678 == nil {
 			r.EncodeNil()
 		} else {
-			yym3675 := z.EncBinary()
-			_ = yym3675
+			yym3679 := z.EncBinary()
+			_ = yym3679
 			if false {
-			} else if z.HasExtensions() && z.EncExt(yyv3674) {
+			} else if z.HasExtensions() && z.EncExt(yyv3678) {
 			} else {
-				z.EncFallback(yyv3674)
+				z.EncFallback(yyv3678)
 			}
 		}
 	}
@@ -43310,68 +43340,68 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3676 := *v
-	yyh3676, yyl3676 := z.DecSliceHelperStart()
+	yyv3680 := *v
+	yyh3680, yyl3680 := z.DecSliceHelperStart()
 
-	var yyrr3676, yyrl3676 int
-	var yyc3676, yyrt3676 bool
-	_, _, _ = yyc3676, yyrt3676, yyrl3676
-	yyrr3676 = yyl3676
+	var yyrr3680, yyrl3680 int
+	var yyc3680, yyrt3680 bool
+	_, _, _ = yyc3680, yyrt3680, yyrl3680
+	yyrr3680 = yyl3680
 
-	if yyv3676 == nil {
-		if yyrl3676, yyrt3676 = z.DecInferLen(yyl3676, z.DecBasicHandle().MaxInitLen, 16); yyrt3676 {
-			yyrr3676 = yyrl3676
+	if yyv3680 == nil {
+		if yyrl3680, yyrt3680 = z.DecInferLen(yyl3680, z.DecBasicHandle().MaxInitLen, 16); yyrt3680 {
+			yyrr3680 = yyrl3680
 		}
-		yyv3676 = make([]pkg8_runtime.Object, yyrl3676)
-		yyc3676 = true
+		yyv3680 = make([]pkg8_runtime.Object, yyrl3680)
+		yyc3680 = true
 	}
 
-	if yyl3676 == 0 {
-		if len(yyv3676) != 0 {
-			yyv3676 = yyv3676[:0]
-			yyc3676 = true
+	if yyl3680 == 0 {
+		if len(yyv3680) != 0 {
+			yyv3680 = yyv3680[:0]
+			yyc3680 = true
 		}
-	} else if yyl3676 > 0 {
+	} else if yyl3680 > 0 {
 
-		if yyl3676 > cap(yyv3676) {
-			yyrl3676, yyrt3676 = z.DecInferLen(yyl3676, z.DecBasicHandle().MaxInitLen, 16)
-			yyv3676 = make([]pkg8_runtime.Object, yyrl3676)
-			yyc3676 = true
+		if yyl3680 > cap(yyv3680) {
+			yyrl3680, yyrt3680 = z.DecInferLen(yyl3680, z.DecBasicHandle().MaxInitLen, 16)
+			yyv3680 = make([]pkg8_runtime.Object, yyrl3680)
+			yyc3680 = true
 
-			yyrr3676 = len(yyv3676)
-		} else if yyl3676 != len(yyv3676) {
-			yyv3676 = yyv3676[:yyl3676]
-			yyc3676 = true
+			yyrr3680 = len(yyv3680)
+		} else if yyl3680 != len(yyv3680) {
+			yyv3680 = yyv3680[:yyl3680]
+			yyc3680 = true
 		}
-		yyj3676 := 0
-		for ; yyj3676 < yyrr3676; yyj3676++ {
+		yyj3680 := 0
+		for ; yyj3680 < yyrr3680; yyj3680++ {
 			if r.TryDecodeAsNil() {
-				yyv3676[yyj3676] = nil
+				yyv3680[yyj3680] = nil
 			} else {
-				yyv3677 := &yyv3676[yyj3676]
-				yym3678 := z.DecBinary()
-				_ = yym3678
+				yyv3681 := &yyv3680[yyj3680]
+				yym3682 := z.DecBinary()
+				_ = yym3682
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3677) {
+				} else if z.HasExtensions() && z.DecExt(yyv3681) {
 				} else {
-					z.DecFallback(yyv3677, true)
+					z.DecFallback(yyv3681, true)
 				}
 			}
 
 		}
-		if yyrt3676 {
-			for ; yyj3676 < yyl3676; yyj3676++ {
-				yyv3676 = append(yyv3676, nil)
+		if yyrt3680 {
+			for ; yyj3680 < yyl3680; yyj3680++ {
+				yyv3680 = append(yyv3680, nil)
 				if r.TryDecodeAsNil() {
-					yyv3676[yyj3676] = nil
+					yyv3680[yyj3680] = nil
 				} else {
-					yyv3679 := &yyv3676[yyj3676]
-					yym3680 := z.DecBinary()
-					_ = yym3680
+					yyv3683 := &yyv3680[yyj3680]
+					yym3684 := z.DecBinary()
+					_ = yym3684
 					if false {
-					} else if z.HasExtensions() && z.DecExt(yyv3679) {
+					} else if z.HasExtensions() && z.DecExt(yyv3683) {
 					} else {
-						z.DecFallback(yyv3679, true)
+						z.DecFallback(yyv3683, true)
 					}
 				}
 
@@ -43379,23 +43409,23 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 		}
 
 	} else {
-		for yyj3676 := 0; !r.CheckBreak(); yyj3676++ {
-			if yyj3676 >= len(yyv3676) {
-				yyv3676 = append(yyv3676, nil) // var yyz3676 pkg8_runtime.Object
-				yyc3676 = true
+		for yyj3680 := 0; !r.CheckBreak(); yyj3680++ {
+			if yyj3680 >= len(yyv3680) {
+				yyv3680 = append(yyv3680, nil) // var yyz3680 pkg8_runtime.Object
+				yyc3680 = true
 			}
 
-			if yyj3676 < len(yyv3676) {
+			if yyj3680 < len(yyv3680) {
 				if r.TryDecodeAsNil() {
-					yyv3676[yyj3676] = nil
+					yyv3680[yyj3680] = nil
 				} else {
-					yyv3681 := &yyv3676[yyj3676]
-					yym3682 := z.DecBinary()
-					_ = yym3682
+					yyv3685 := &yyv3680[yyj3680]
+					yym3686 := z.DecBinary()
+					_ = yym3686
 					if false {
-					} else if z.HasExtensions() && z.DecExt(yyv3681) {
+					} else if z.HasExtensions() && z.DecExt(yyv3685) {
 					} else {
-						z.DecFallback(yyv3681, true)
+						z.DecFallback(yyv3685, true)
 					}
 				}
 
@@ -43404,10 +43434,10 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 			}
 
 		}
-		yyh3676.End()
+		yyh3680.End()
 	}
-	if yyc3676 {
-		*v = yyv3676
+	if yyc3680 {
+		*v = yyv3680
 	}
 
 }
@@ -43417,9 +43447,9 @@ func (x codecSelfer1234) encSliceLimitRangeItem(v []LimitRangeItem, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3683 := range v {
-		yy3684 := &yyv3683
-		yy3684.CodecEncodeSelf(e)
+	for _, yyv3687 := range v {
+		yy3688 := &yyv3687
+		yy3688.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43429,75 +43459,75 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3685 := *v
-	yyh3685, yyl3685 := z.DecSliceHelperStart()
+	yyv3689 := *v
+	yyh3689, yyl3689 := z.DecSliceHelperStart()
 
-	var yyrr3685, yyrl3685 int
-	var yyc3685, yyrt3685 bool
-	_, _, _ = yyc3685, yyrt3685, yyrl3685
-	yyrr3685 = yyl3685
+	var yyrr3689, yyrl3689 int
+	var yyc3689, yyrt3689 bool
+	_, _, _ = yyc3689, yyrt3689, yyrl3689
+	yyrr3689 = yyl3689
 
-	if yyv3685 == nil {
-		if yyrl3685, yyrt3685 = z.DecInferLen(yyl3685, z.DecBasicHandle().MaxInitLen, 56); yyrt3685 {
-			yyrr3685 = yyrl3685
+	if yyv3689 == nil {
+		if yyrl3689, yyrt3689 = z.DecInferLen(yyl3689, z.DecBasicHandle().MaxInitLen, 56); yyrt3689 {
+			yyrr3689 = yyrl3689
 		}
-		yyv3685 = make([]LimitRangeItem, yyrl3685)
-		yyc3685 = true
+		yyv3689 = make([]LimitRangeItem, yyrl3689)
+		yyc3689 = true
 	}
 
-	if yyl3685 == 0 {
-		if len(yyv3685) != 0 {
-			yyv3685 = yyv3685[:0]
-			yyc3685 = true
+	if yyl3689 == 0 {
+		if len(yyv3689) != 0 {
+			yyv3689 = yyv3689[:0]
+			yyc3689 = true
 		}
-	} else if yyl3685 > 0 {
+	} else if yyl3689 > 0 {
 
-		if yyl3685 > cap(yyv3685) {
-			yyrl3685, yyrt3685 = z.DecInferLen(yyl3685, z.DecBasicHandle().MaxInitLen, 56)
-			yyv3685 = make([]LimitRangeItem, yyrl3685)
-			yyc3685 = true
+		if yyl3689 > cap(yyv3689) {
+			yyrl3689, yyrt3689 = z.DecInferLen(yyl3689, z.DecBasicHandle().MaxInitLen, 56)
+			yyv3689 = make([]LimitRangeItem, yyrl3689)
+			yyc3689 = true
 
-			yyrr3685 = len(yyv3685)
-		} else if yyl3685 != len(yyv3685) {
-			yyv3685 = yyv3685[:yyl3685]
-			yyc3685 = true
+			yyrr3689 = len(yyv3689)
+		} else if yyl3689 != len(yyv3689) {
+			yyv3689 = yyv3689[:yyl3689]
+			yyc3689 = true
 		}
-		yyj3685 := 0
-		for ; yyj3685 < yyrr3685; yyj3685++ {
+		yyj3689 := 0
+		for ; yyj3689 < yyrr3689; yyj3689++ {
 			if r.TryDecodeAsNil() {
-				yyv3685[yyj3685] = LimitRangeItem{}
+				yyv3689[yyj3689] = LimitRangeItem{}
 			} else {
-				yyv3686 := &yyv3685[yyj3685]
-				yyv3686.CodecDecodeSelf(d)
+				yyv3690 := &yyv3689[yyj3689]
+				yyv3690.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3685 {
-			for ; yyj3685 < yyl3685; yyj3685++ {
-				yyv3685 = append(yyv3685, LimitRangeItem{})
+		if yyrt3689 {
+			for ; yyj3689 < yyl3689; yyj3689++ {
+				yyv3689 = append(yyv3689, LimitRangeItem{})
 				if r.TryDecodeAsNil() {
-					yyv3685[yyj3685] = LimitRangeItem{}
+					yyv3689[yyj3689] = LimitRangeItem{}
 				} else {
-					yyv3687 := &yyv3685[yyj3685]
-					yyv3687.CodecDecodeSelf(d)
+					yyv3691 := &yyv3689[yyj3689]
+					yyv3691.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3685 := 0; !r.CheckBreak(); yyj3685++ {
-			if yyj3685 >= len(yyv3685) {
-				yyv3685 = append(yyv3685, LimitRangeItem{}) // var yyz3685 LimitRangeItem
-				yyc3685 = true
+		for yyj3689 := 0; !r.CheckBreak(); yyj3689++ {
+			if yyj3689 >= len(yyv3689) {
+				yyv3689 = append(yyv3689, LimitRangeItem{}) // var yyz3689 LimitRangeItem
+				yyc3689 = true
 			}
 
-			if yyj3685 < len(yyv3685) {
+			if yyj3689 < len(yyv3689) {
 				if r.TryDecodeAsNil() {
-					yyv3685[yyj3685] = LimitRangeItem{}
+					yyv3689[yyj3689] = LimitRangeItem{}
 				} else {
-					yyv3688 := &yyv3685[yyj3685]
-					yyv3688.CodecDecodeSelf(d)
+					yyv3692 := &yyv3689[yyj3689]
+					yyv3692.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43505,10 +43535,10 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 			}
 
 		}
-		yyh3685.End()
+		yyh3689.End()
 	}
-	if yyc3685 {
-		*v = yyv3685
+	if yyc3689 {
+		*v = yyv3689
 	}
 
 }
@@ -43518,9 +43548,9 @@ func (x codecSelfer1234) encSliceLimitRange(v []LimitRange, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3689 := range v {
-		yy3690 := &yyv3689
-		yy3690.CodecEncodeSelf(e)
+	for _, yyv3693 := range v {
+		yy3694 := &yyv3693
+		yy3694.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43530,75 +43560,75 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3691 := *v
-	yyh3691, yyl3691 := z.DecSliceHelperStart()
+	yyv3695 := *v
+	yyh3695, yyl3695 := z.DecSliceHelperStart()
 
-	var yyrr3691, yyrl3691 int
-	var yyc3691, yyrt3691 bool
-	_, _, _ = yyc3691, yyrt3691, yyrl3691
-	yyrr3691 = yyl3691
+	var yyrr3695, yyrl3695 int
+	var yyc3695, yyrt3695 bool
+	_, _, _ = yyc3695, yyrt3695, yyrl3695
+	yyrr3695 = yyl3695
 
-	if yyv3691 == nil {
-		if yyrl3691, yyrt3691 = z.DecInferLen(yyl3691, z.DecBasicHandle().MaxInitLen, 216); yyrt3691 {
-			yyrr3691 = yyrl3691
+	if yyv3695 == nil {
+		if yyrl3695, yyrt3695 = z.DecInferLen(yyl3695, z.DecBasicHandle().MaxInitLen, 216); yyrt3695 {
+			yyrr3695 = yyrl3695
 		}
-		yyv3691 = make([]LimitRange, yyrl3691)
-		yyc3691 = true
+		yyv3695 = make([]LimitRange, yyrl3695)
+		yyc3695 = true
 	}
 
-	if yyl3691 == 0 {
-		if len(yyv3691) != 0 {
-			yyv3691 = yyv3691[:0]
-			yyc3691 = true
+	if yyl3695 == 0 {
+		if len(yyv3695) != 0 {
+			yyv3695 = yyv3695[:0]
+			yyc3695 = true
 		}
-	} else if yyl3691 > 0 {
+	} else if yyl3695 > 0 {
 
-		if yyl3691 > cap(yyv3691) {
-			yyrl3691, yyrt3691 = z.DecInferLen(yyl3691, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3691 = make([]LimitRange, yyrl3691)
-			yyc3691 = true
+		if yyl3695 > cap(yyv3695) {
+			yyrl3695, yyrt3695 = z.DecInferLen(yyl3695, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3695 = make([]LimitRange, yyrl3695)
+			yyc3695 = true
 
-			yyrr3691 = len(yyv3691)
-		} else if yyl3691 != len(yyv3691) {
-			yyv3691 = yyv3691[:yyl3691]
-			yyc3691 = true
+			yyrr3695 = len(yyv3695)
+		} else if yyl3695 != len(yyv3695) {
+			yyv3695 = yyv3695[:yyl3695]
+			yyc3695 = true
 		}
-		yyj3691 := 0
-		for ; yyj3691 < yyrr3691; yyj3691++ {
+		yyj3695 := 0
+		for ; yyj3695 < yyrr3695; yyj3695++ {
 			if r.TryDecodeAsNil() {
-				yyv3691[yyj3691] = LimitRange{}
+				yyv3695[yyj3695] = LimitRange{}
 			} else {
-				yyv3692 := &yyv3691[yyj3691]
-				yyv3692.CodecDecodeSelf(d)
+				yyv3696 := &yyv3695[yyj3695]
+				yyv3696.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3691 {
-			for ; yyj3691 < yyl3691; yyj3691++ {
-				yyv3691 = append(yyv3691, LimitRange{})
+		if yyrt3695 {
+			for ; yyj3695 < yyl3695; yyj3695++ {
+				yyv3695 = append(yyv3695, LimitRange{})
 				if r.TryDecodeAsNil() {
-					yyv3691[yyj3691] = LimitRange{}
+					yyv3695[yyj3695] = LimitRange{}
 				} else {
-					yyv3693 := &yyv3691[yyj3691]
-					yyv3693.CodecDecodeSelf(d)
+					yyv3697 := &yyv3695[yyj3695]
+					yyv3697.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3691 := 0; !r.CheckBreak(); yyj3691++ {
-			if yyj3691 >= len(yyv3691) {
-				yyv3691 = append(yyv3691, LimitRange{}) // var yyz3691 LimitRange
-				yyc3691 = true
+		for yyj3695 := 0; !r.CheckBreak(); yyj3695++ {
+			if yyj3695 >= len(yyv3695) {
+				yyv3695 = append(yyv3695, LimitRange{}) // var yyz3695 LimitRange
+				yyc3695 = true
 			}
 
-			if yyj3691 < len(yyv3691) {
+			if yyj3695 < len(yyv3695) {
 				if r.TryDecodeAsNil() {
-					yyv3691[yyj3691] = LimitRange{}
+					yyv3695[yyj3695] = LimitRange{}
 				} else {
-					yyv3694 := &yyv3691[yyj3691]
-					yyv3694.CodecDecodeSelf(d)
+					yyv3698 := &yyv3695[yyj3695]
+					yyv3698.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43606,10 +43636,10 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 			}
 
 		}
-		yyh3691.End()
+		yyh3695.End()
 	}
-	if yyc3691 {
-		*v = yyv3691
+	if yyc3695 {
+		*v = yyv3695
 	}
 
 }
@@ -43619,9 +43649,9 @@ func (x codecSelfer1234) encSliceResourceQuota(v []ResourceQuota, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3695 := range v {
-		yy3696 := &yyv3695
-		yy3696.CodecEncodeSelf(e)
+	for _, yyv3699 := range v {
+		yy3700 := &yyv3699
+		yy3700.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43631,75 +43661,75 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3697 := *v
-	yyh3697, yyl3697 := z.DecSliceHelperStart()
+	yyv3701 := *v
+	yyh3701, yyl3701 := z.DecSliceHelperStart()
 
-	var yyrr3697, yyrl3697 int
-	var yyc3697, yyrt3697 bool
-	_, _, _ = yyc3697, yyrt3697, yyrl3697
-	yyrr3697 = yyl3697
+	var yyrr3701, yyrl3701 int
+	var yyc3701, yyrt3701 bool
+	_, _, _ = yyc3701, yyrt3701, yyrl3701
+	yyrr3701 = yyl3701
 
-	if yyv3697 == nil {
-		if yyrl3697, yyrt3697 = z.DecInferLen(yyl3697, z.DecBasicHandle().MaxInitLen, 216); yyrt3697 {
-			yyrr3697 = yyrl3697
+	if yyv3701 == nil {
+		if yyrl3701, yyrt3701 = z.DecInferLen(yyl3701, z.DecBasicHandle().MaxInitLen, 216); yyrt3701 {
+			yyrr3701 = yyrl3701
 		}
-		yyv3697 = make([]ResourceQuota, yyrl3697)
-		yyc3697 = true
+		yyv3701 = make([]ResourceQuota, yyrl3701)
+		yyc3701 = true
 	}
 
-	if yyl3697 == 0 {
-		if len(yyv3697) != 0 {
-			yyv3697 = yyv3697[:0]
-			yyc3697 = true
+	if yyl3701 == 0 {
+		if len(yyv3701) != 0 {
+			yyv3701 = yyv3701[:0]
+			yyc3701 = true
 		}
-	} else if yyl3697 > 0 {
+	} else if yyl3701 > 0 {
 
-		if yyl3697 > cap(yyv3697) {
-			yyrl3697, yyrt3697 = z.DecInferLen(yyl3697, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3697 = make([]ResourceQuota, yyrl3697)
-			yyc3697 = true
+		if yyl3701 > cap(yyv3701) {
+			yyrl3701, yyrt3701 = z.DecInferLen(yyl3701, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3701 = make([]ResourceQuota, yyrl3701)
+			yyc3701 = true
 
-			yyrr3697 = len(yyv3697)
-		} else if yyl3697 != len(yyv3697) {
-			yyv3697 = yyv3697[:yyl3697]
-			yyc3697 = true
+			yyrr3701 = len(yyv3701)
+		} else if yyl3701 != len(yyv3701) {
+			yyv3701 = yyv3701[:yyl3701]
+			yyc3701 = true
 		}
-		yyj3697 := 0
-		for ; yyj3697 < yyrr3697; yyj3697++ {
+		yyj3701 := 0
+		for ; yyj3701 < yyrr3701; yyj3701++ {
 			if r.TryDecodeAsNil() {
-				yyv3697[yyj3697] = ResourceQuota{}
+				yyv3701[yyj3701] = ResourceQuota{}
 			} else {
-				yyv3698 := &yyv3697[yyj3697]
-				yyv3698.CodecDecodeSelf(d)
+				yyv3702 := &yyv3701[yyj3701]
+				yyv3702.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3697 {
-			for ; yyj3697 < yyl3697; yyj3697++ {
-				yyv3697 = append(yyv3697, ResourceQuota{})
+		if yyrt3701 {
+			for ; yyj3701 < yyl3701; yyj3701++ {
+				yyv3701 = append(yyv3701, ResourceQuota{})
 				if r.TryDecodeAsNil() {
-					yyv3697[yyj3697] = ResourceQuota{}
+					yyv3701[yyj3701] = ResourceQuota{}
 				} else {
-					yyv3699 := &yyv3697[yyj3697]
-					yyv3699.CodecDecodeSelf(d)
+					yyv3703 := &yyv3701[yyj3701]
+					yyv3703.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3697 := 0; !r.CheckBreak(); yyj3697++ {
-			if yyj3697 >= len(yyv3697) {
-				yyv3697 = append(yyv3697, ResourceQuota{}) // var yyz3697 ResourceQuota
-				yyc3697 = true
+		for yyj3701 := 0; !r.CheckBreak(); yyj3701++ {
+			if yyj3701 >= len(yyv3701) {
+				yyv3701 = append(yyv3701, ResourceQuota{}) // var yyz3701 ResourceQuota
+				yyc3701 = true
 			}
 
-			if yyj3697 < len(yyv3697) {
+			if yyj3701 < len(yyv3701) {
 				if r.TryDecodeAsNil() {
-					yyv3697[yyj3697] = ResourceQuota{}
+					yyv3701[yyj3701] = ResourceQuota{}
 				} else {
-					yyv3700 := &yyv3697[yyj3697]
-					yyv3700.CodecDecodeSelf(d)
+					yyv3704 := &yyv3701[yyj3701]
+					yyv3704.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43707,10 +43737,10 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 			}
 
 		}
-		yyh3697.End()
+		yyh3701.End()
 	}
-	if yyc3697 {
-		*v = yyv3697
+	if yyc3701 {
+		*v = yyv3701
 	}
 
 }
@@ -43720,21 +43750,21 @@ func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk3701, yyv3701 := range v {
-		yym3702 := z.EncBinary()
-		_ = yym3702
+	for yyk3705, yyv3705 := range v {
+		yym3706 := z.EncBinary()
+		_ = yym3706
 		if false {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyk3701))
+			r.EncodeString(codecSelferC_UTF81234, string(yyk3705))
 		}
-		if yyv3701 == nil {
+		if yyv3705 == nil {
 			r.EncodeNil()
 		} else {
-			yym3703 := z.EncBinary()
-			_ = yym3703
+			yym3707 := z.EncBinary()
+			_ = yym3707
 			if false {
 			} else {
-				r.EncodeStringBytes(codecSelferC_RAW1234, []byte(yyv3701))
+				r.EncodeStringBytes(codecSelferC_RAW1234, []byte(yyv3705))
 			}
 		}
 	}
@@ -43746,76 +43776,76 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3704 := *v
-	yyl3704 := r.ReadMapStart()
-	yybh3704 := z.DecBasicHandle()
-	if yyv3704 == nil {
-		yyrl3704, _ := z.DecInferLen(yyl3704, yybh3704.MaxInitLen, 40)
-		yyv3704 = make(map[string][]uint8, yyrl3704)
-		*v = yyv3704
+	yyv3708 := *v
+	yyl3708 := r.ReadMapStart()
+	yybh3708 := z.DecBasicHandle()
+	if yyv3708 == nil {
+		yyrl3708, _ := z.DecInferLen(yyl3708, yybh3708.MaxInitLen, 40)
+		yyv3708 = make(map[string][]uint8, yyrl3708)
+		*v = yyv3708
 	}
-	var yymk3704 string
-	var yymv3704 []uint8
-	var yymg3704 bool
-	if yybh3704.MapValueReset {
-		yymg3704 = true
+	var yymk3708 string
+	var yymv3708 []uint8
+	var yymg3708 bool
+	if yybh3708.MapValueReset {
+		yymg3708 = true
 	}
-	if yyl3704 > 0 {
-		for yyj3704 := 0; yyj3704 < yyl3704; yyj3704++ {
+	if yyl3708 > 0 {
+		for yyj3708 := 0; yyj3708 < yyl3708; yyj3708++ {
 			if r.TryDecodeAsNil() {
-				yymk3704 = ""
+				yymk3708 = ""
 			} else {
-				yymk3704 = string(r.DecodeString())
+				yymk3708 = string(r.DecodeString())
 			}
 
-			if yymg3704 {
-				yymv3704 = yyv3704[yymk3704]
+			if yymg3708 {
+				yymv3708 = yyv3708[yymk3708]
 			} else {
-				yymv3704 = nil
+				yymv3708 = nil
 			}
 			if r.TryDecodeAsNil() {
-				yymv3704 = nil
+				yymv3708 = nil
 			} else {
-				yyv3706 := &yymv3704
-				yym3707 := z.DecBinary()
-				_ = yym3707
+				yyv3710 := &yymv3708
+				yym3711 := z.DecBinary()
+				_ = yym3711
 				if false {
 				} else {
-					*yyv3706 = r.DecodeBytes(*(*[]byte)(yyv3706), false, false)
+					*yyv3710 = r.DecodeBytes(*(*[]byte)(yyv3710), false, false)
 				}
 			}
 
-			if yyv3704 != nil {
-				yyv3704[yymk3704] = yymv3704
+			if yyv3708 != nil {
+				yyv3708[yymk3708] = yymv3708
 			}
 		}
-	} else if yyl3704 < 0 {
-		for yyj3704 := 0; !r.CheckBreak(); yyj3704++ {
+	} else if yyl3708 < 0 {
+		for yyj3708 := 0; !r.CheckBreak(); yyj3708++ {
 			if r.TryDecodeAsNil() {
-				yymk3704 = ""
+				yymk3708 = ""
 			} else {
-				yymk3704 = string(r.DecodeString())
+				yymk3708 = string(r.DecodeString())
 			}
 
-			if yymg3704 {
-				yymv3704 = yyv3704[yymk3704]
+			if yymg3708 {
+				yymv3708 = yyv3708[yymk3708]
 			} else {
-				yymv3704 = nil
+				yymv3708 = nil
 			}
 			if r.TryDecodeAsNil() {
-				yymv3704 = nil
+				yymv3708 = nil
 			} else {
-				yyv3709 := &yymv3704
-				yym3710 := z.DecBinary()
-				_ = yym3710
+				yyv3713 := &yymv3708
+				yym3714 := z.DecBinary()
+				_ = yym3714
 				if false {
 				} else {
-					*yyv3709 = r.DecodeBytes(*(*[]byte)(yyv3709), false, false)
+					*yyv3713 = r.DecodeBytes(*(*[]byte)(yyv3713), false, false)
 				}
 			}
 
-			if yyv3704 != nil {
-				yyv3704[yymk3704] = yymv3704
+			if yyv3708 != nil {
+				yyv3708[yymk3708] = yymv3708
 			}
 		}
 		r.ReadEnd()
@@ -43827,9 +43857,9 @@ func (x codecSelfer1234) encSliceSecret(v []Secret, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3711 := range v {
-		yy3712 := &yyv3711
-		yy3712.CodecEncodeSelf(e)
+	for _, yyv3715 := range v {
+		yy3716 := &yyv3715
+		yy3716.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43839,75 +43869,75 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3713 := *v
-	yyh3713, yyl3713 := z.DecSliceHelperStart()
+	yyv3717 := *v
+	yyh3717, yyl3717 := z.DecSliceHelperStart()
 
-	var yyrr3713, yyrl3713 int
-	var yyc3713, yyrt3713 bool
-	_, _, _ = yyc3713, yyrt3713, yyrl3713
-	yyrr3713 = yyl3713
+	var yyrr3717, yyrl3717 int
+	var yyc3717, yyrt3717 bool
+	_, _, _ = yyc3717, yyrt3717, yyrl3717
+	yyrr3717 = yyl3717
 
-	if yyv3713 == nil {
-		if yyrl3713, yyrt3713 = z.DecInferLen(yyl3713, z.DecBasicHandle().MaxInitLen, 216); yyrt3713 {
-			yyrr3713 = yyrl3713
+	if yyv3717 == nil {
+		if yyrl3717, yyrt3717 = z.DecInferLen(yyl3717, z.DecBasicHandle().MaxInitLen, 216); yyrt3717 {
+			yyrr3717 = yyrl3717
 		}
-		yyv3713 = make([]Secret, yyrl3713)
-		yyc3713 = true
+		yyv3717 = make([]Secret, yyrl3717)
+		yyc3717 = true
 	}
 
-	if yyl3713 == 0 {
-		if len(yyv3713) != 0 {
-			yyv3713 = yyv3713[:0]
-			yyc3713 = true
+	if yyl3717 == 0 {
+		if len(yyv3717) != 0 {
+			yyv3717 = yyv3717[:0]
+			yyc3717 = true
 		}
-	} else if yyl3713 > 0 {
+	} else if yyl3717 > 0 {
 
-		if yyl3713 > cap(yyv3713) {
-			yyrl3713, yyrt3713 = z.DecInferLen(yyl3713, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3713 = make([]Secret, yyrl3713)
-			yyc3713 = true
+		if yyl3717 > cap(yyv3717) {
+			yyrl3717, yyrt3717 = z.DecInferLen(yyl3717, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3717 = make([]Secret, yyrl3717)
+			yyc3717 = true
 
-			yyrr3713 = len(yyv3713)
-		} else if yyl3713 != len(yyv3713) {
-			yyv3713 = yyv3713[:yyl3713]
-			yyc3713 = true
+			yyrr3717 = len(yyv3717)
+		} else if yyl3717 != len(yyv3717) {
+			yyv3717 = yyv3717[:yyl3717]
+			yyc3717 = true
 		}
-		yyj3713 := 0
-		for ; yyj3713 < yyrr3713; yyj3713++ {
+		yyj3717 := 0
+		for ; yyj3717 < yyrr3717; yyj3717++ {
 			if r.TryDecodeAsNil() {
-				yyv3713[yyj3713] = Secret{}
+				yyv3717[yyj3717] = Secret{}
 			} else {
-				yyv3714 := &yyv3713[yyj3713]
-				yyv3714.CodecDecodeSelf(d)
+				yyv3718 := &yyv3717[yyj3717]
+				yyv3718.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3713 {
-			for ; yyj3713 < yyl3713; yyj3713++ {
-				yyv3713 = append(yyv3713, Secret{})
+		if yyrt3717 {
+			for ; yyj3717 < yyl3717; yyj3717++ {
+				yyv3717 = append(yyv3717, Secret{})
 				if r.TryDecodeAsNil() {
-					yyv3713[yyj3713] = Secret{}
+					yyv3717[yyj3717] = Secret{}
 				} else {
-					yyv3715 := &yyv3713[yyj3713]
-					yyv3715.CodecDecodeSelf(d)
+					yyv3719 := &yyv3717[yyj3717]
+					yyv3719.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3713 := 0; !r.CheckBreak(); yyj3713++ {
-			if yyj3713 >= len(yyv3713) {
-				yyv3713 = append(yyv3713, Secret{}) // var yyz3713 Secret
-				yyc3713 = true
+		for yyj3717 := 0; !r.CheckBreak(); yyj3717++ {
+			if yyj3717 >= len(yyv3717) {
+				yyv3717 = append(yyv3717, Secret{}) // var yyz3717 Secret
+				yyc3717 = true
 			}
 
-			if yyj3713 < len(yyv3713) {
+			if yyj3717 < len(yyv3717) {
 				if r.TryDecodeAsNil() {
-					yyv3713[yyj3713] = Secret{}
+					yyv3717[yyj3717] = Secret{}
 				} else {
-					yyv3716 := &yyv3713[yyj3713]
-					yyv3716.CodecDecodeSelf(d)
+					yyv3720 := &yyv3717[yyj3717]
+					yyv3720.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43915,10 +43945,10 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3713.End()
+		yyh3717.End()
 	}
-	if yyc3713 {
-		*v = yyv3713
+	if yyc3717 {
+		*v = yyv3717
 	}
 
 }
@@ -43928,9 +43958,9 @@ func (x codecSelfer1234) encSliceComponentCondition(v []ComponentCondition, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3717 := range v {
-		yy3718 := &yyv3717
-		yy3718.CodecEncodeSelf(e)
+	for _, yyv3721 := range v {
+		yy3722 := &yyv3721
+		yy3722.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43940,75 +43970,75 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3719 := *v
-	yyh3719, yyl3719 := z.DecSliceHelperStart()
+	yyv3723 := *v
+	yyh3723, yyl3723 := z.DecSliceHelperStart()
 
-	var yyrr3719, yyrl3719 int
-	var yyc3719, yyrt3719 bool
-	_, _, _ = yyc3719, yyrt3719, yyrl3719
-	yyrr3719 = yyl3719
+	var yyrr3723, yyrl3723 int
+	var yyc3723, yyrt3723 bool
+	_, _, _ = yyc3723, yyrt3723, yyrl3723
+	yyrr3723 = yyl3723
 
-	if yyv3719 == nil {
-		if yyrl3719, yyrt3719 = z.DecInferLen(yyl3719, z.DecBasicHandle().MaxInitLen, 64); yyrt3719 {
-			yyrr3719 = yyrl3719
+	if yyv3723 == nil {
+		if yyrl3723, yyrt3723 = z.DecInferLen(yyl3723, z.DecBasicHandle().MaxInitLen, 64); yyrt3723 {
+			yyrr3723 = yyrl3723
 		}
-		yyv3719 = make([]ComponentCondition, yyrl3719)
-		yyc3719 = true
+		yyv3723 = make([]ComponentCondition, yyrl3723)
+		yyc3723 = true
 	}
 
-	if yyl3719 == 0 {
-		if len(yyv3719) != 0 {
-			yyv3719 = yyv3719[:0]
-			yyc3719 = true
+	if yyl3723 == 0 {
+		if len(yyv3723) != 0 {
+			yyv3723 = yyv3723[:0]
+			yyc3723 = true
 		}
-	} else if yyl3719 > 0 {
+	} else if yyl3723 > 0 {
 
-		if yyl3719 > cap(yyv3719) {
-			yyrl3719, yyrt3719 = z.DecInferLen(yyl3719, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3719 = make([]ComponentCondition, yyrl3719)
-			yyc3719 = true
+		if yyl3723 > cap(yyv3723) {
+			yyrl3723, yyrt3723 = z.DecInferLen(yyl3723, z.DecBasicHandle().MaxInitLen, 64)
+			yyv3723 = make([]ComponentCondition, yyrl3723)
+			yyc3723 = true
 
-			yyrr3719 = len(yyv3719)
-		} else if yyl3719 != len(yyv3719) {
-			yyv3719 = yyv3719[:yyl3719]
-			yyc3719 = true
+			yyrr3723 = len(yyv3723)
+		} else if yyl3723 != len(yyv3723) {
+			yyv3723 = yyv3723[:yyl3723]
+			yyc3723 = true
 		}
-		yyj3719 := 0
-		for ; yyj3719 < yyrr3719; yyj3719++ {
+		yyj3723 := 0
+		for ; yyj3723 < yyrr3723; yyj3723++ {
 			if r.TryDecodeAsNil() {
-				yyv3719[yyj3719] = ComponentCondition{}
+				yyv3723[yyj3723] = ComponentCondition{}
 			} else {
-				yyv3720 := &yyv3719[yyj3719]
-				yyv3720.CodecDecodeSelf(d)
+				yyv3724 := &yyv3723[yyj3723]
+				yyv3724.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3719 {
-			for ; yyj3719 < yyl3719; yyj3719++ {
-				yyv3719 = append(yyv3719, ComponentCondition{})
+		if yyrt3723 {
+			for ; yyj3723 < yyl3723; yyj3723++ {
+				yyv3723 = append(yyv3723, ComponentCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3719[yyj3719] = ComponentCondition{}
+					yyv3723[yyj3723] = ComponentCondition{}
 				} else {
-					yyv3721 := &yyv3719[yyj3719]
-					yyv3721.CodecDecodeSelf(d)
+					yyv3725 := &yyv3723[yyj3723]
+					yyv3725.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3719 := 0; !r.CheckBreak(); yyj3719++ {
-			if yyj3719 >= len(yyv3719) {
-				yyv3719 = append(yyv3719, ComponentCondition{}) // var yyz3719 ComponentCondition
-				yyc3719 = true
+		for yyj3723 := 0; !r.CheckBreak(); yyj3723++ {
+			if yyj3723 >= len(yyv3723) {
+				yyv3723 = append(yyv3723, ComponentCondition{}) // var yyz3723 ComponentCondition
+				yyc3723 = true
 			}
 
-			if yyj3719 < len(yyv3719) {
+			if yyj3723 < len(yyv3723) {
 				if r.TryDecodeAsNil() {
-					yyv3719[yyj3719] = ComponentCondition{}
+					yyv3723[yyj3723] = ComponentCondition{}
 				} else {
-					yyv3722 := &yyv3719[yyj3719]
-					yyv3722.CodecDecodeSelf(d)
+					yyv3726 := &yyv3723[yyj3723]
+					yyv3726.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -44016,10 +44046,10 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 			}
 
 		}
-		yyh3719.End()
+		yyh3723.End()
 	}
-	if yyc3719 {
-		*v = yyv3719
+	if yyc3723 {
+		*v = yyv3723
 	}
 
 }
@@ -44029,9 +44059,9 @@ func (x codecSelfer1234) encSliceComponentStatus(v []ComponentStatus, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3723 := range v {
-		yy3724 := &yyv3723
-		yy3724.CodecEncodeSelf(e)
+	for _, yyv3727 := range v {
+		yy3728 := &yyv3727
+		yy3728.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -44041,75 +44071,75 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3725 := *v
-	yyh3725, yyl3725 := z.DecSliceHelperStart()
+	yyv3729 := *v
+	yyh3729, yyl3729 := z.DecSliceHelperStart()
 
-	var yyrr3725, yyrl3725 int
-	var yyc3725, yyrt3725 bool
-	_, _, _ = yyc3725, yyrt3725, yyrl3725
-	yyrr3725 = yyl3725
+	var yyrr3729, yyrl3729 int
+	var yyc3729, yyrt3729 bool
+	_, _, _ = yyc3729, yyrt3729, yyrl3729
+	yyrr3729 = yyl3729
 
-	if yyv3725 == nil {
-		if yyrl3725, yyrt3725 = z.DecInferLen(yyl3725, z.DecBasicHandle().MaxInitLen, 216); yyrt3725 {
-			yyrr3725 = yyrl3725
+	if yyv3729 == nil {
+		if yyrl3729, yyrt3729 = z.DecInferLen(yyl3729, z.DecBasicHandle().MaxInitLen, 216); yyrt3729 {
+			yyrr3729 = yyrl3729
 		}
-		yyv3725 = make([]ComponentStatus, yyrl3725)
-		yyc3725 = true
+		yyv3729 = make([]ComponentStatus, yyrl3729)
+		yyc3729 = true
 	}
 
-	if yyl3725 == 0 {
-		if len(yyv3725) != 0 {
-			yyv3725 = yyv3725[:0]
-			yyc3725 = true
+	if yyl3729 == 0 {
+		if len(yyv3729) != 0 {
+			yyv3729 = yyv3729[:0]
+			yyc3729 = true
 		}
-	} else if yyl3725 > 0 {
+	} else if yyl3729 > 0 {
 
-		if yyl3725 > cap(yyv3725) {
-			yyrl3725, yyrt3725 = z.DecInferLen(yyl3725, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3725 = make([]ComponentStatus, yyrl3725)
-			yyc3725 = true
+		if yyl3729 > cap(yyv3729) {
+			yyrl3729, yyrt3729 = z.DecInferLen(yyl3729, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3729 = make([]ComponentStatus, yyrl3729)
+			yyc3729 = true
 
-			yyrr3725 = len(yyv3725)
-		} else if yyl3725 != len(yyv3725) {
-			yyv3725 = yyv3725[:yyl3725]
-			yyc3725 = true
+			yyrr3729 = len(yyv3729)
+		} else if yyl3729 != len(yyv3729) {
+			yyv3729 = yyv3729[:yyl3729]
+			yyc3729 = true
 		}
-		yyj3725 := 0
-		for ; yyj3725 < yyrr3725; yyj3725++ {
+		yyj3729 := 0
+		for ; yyj3729 < yyrr3729; yyj3729++ {
 			if r.TryDecodeAsNil() {
-				yyv3725[yyj3725] = ComponentStatus{}
+				yyv3729[yyj3729] = ComponentStatus{}
 			} else {
-				yyv3726 := &yyv3725[yyj3725]
-				yyv3726.CodecDecodeSelf(d)
+				yyv3730 := &yyv3729[yyj3729]
+				yyv3730.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3725 {
-			for ; yyj3725 < yyl3725; yyj3725++ {
-				yyv3725 = append(yyv3725, ComponentStatus{})
+		if yyrt3729 {
+			for ; yyj3729 < yyl3729; yyj3729++ {
+				yyv3729 = append(yyv3729, ComponentStatus{})
 				if r.TryDecodeAsNil() {
-					yyv3725[yyj3725] = ComponentStatus{}
+					yyv3729[yyj3729] = ComponentStatus{}
 				} else {
-					yyv3727 := &yyv3725[yyj3725]
-					yyv3727.CodecDecodeSelf(d)
+					yyv3731 := &yyv3729[yyj3729]
+					yyv3731.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3725 := 0; !r.CheckBreak(); yyj3725++ {
-			if yyj3725 >= len(yyv3725) {
-				yyv3725 = append(yyv3725, ComponentStatus{}) // var yyz3725 ComponentStatus
-				yyc3725 = true
+		for yyj3729 := 0; !r.CheckBreak(); yyj3729++ {
+			if yyj3729 >= len(yyv3729) {
+				yyv3729 = append(yyv3729, ComponentStatus{}) // var yyz3729 ComponentStatus
+				yyc3729 = true
 			}
 
-			if yyj3725 < len(yyv3725) {
+			if yyj3729 < len(yyv3729) {
 				if r.TryDecodeAsNil() {
-					yyv3725[yyj3725] = ComponentStatus{}
+					yyv3729[yyj3729] = ComponentStatus{}
 				} else {
-					yyv3728 := &yyv3725[yyj3725]
-					yyv3728.CodecDecodeSelf(d)
+					yyv3732 := &yyv3729[yyj3729]
+					yyv3732.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -44117,10 +44147,10 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 			}
 
 		}
-		yyh3725.End()
+		yyh3729.End()
 	}
-	if yyc3725 {
-		*v = yyv3725
+	if yyc3729 {
+		*v = yyv3729
 	}
 
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -990,7 +990,7 @@ type PodSpec struct {
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod
 	// The pod will be allowed to use secrets referenced by the ServiceAccount
-	ServiceAccountName string `json:"serviceAccountName"`
+	ServiceAccountName *string `json:"serviceAccountName"`
 
 	// NodeName is a request to schedule this pod onto a specific node.  If it is non-empty,
 	// the scheduler simply schedules this pod onto that node, assuming that it fits resource

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -289,9 +289,16 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
-	// DeprecatedServiceAccount is an alias for ServiceAccountName.
-	out.DeprecatedServiceAccount = in.ServiceAccountName
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+		// DeprecatedServiceAccount is an alias for ServiceAccountName.
+		out.DeprecatedServiceAccount = new(string)
+		*out.DeprecatedServiceAccount = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+		out.DeprecatedServiceAccount = nil
+	}
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(PodSecurityContext)
@@ -365,10 +372,15 @@ func convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversi
 		out.NodeSelector = nil
 	}
 	// We support DeprecatedServiceAccount as an alias for ServiceAccountName.
-	// If both are specified, ServiceAccountName (the new field) wins.
-	out.ServiceAccountName = in.ServiceAccountName
-	if in.ServiceAccountName == "" {
-		out.ServiceAccountName = in.DeprecatedServiceAccount
+	// If ServiceAccountName is unspecified, then use the old field.
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		if in.DeprecatedServiceAccount != nil {
+			out.ServiceAccountName = new(string)
+			*out.ServiceAccountName = *in.DeprecatedServiceAccount
+		}
 	}
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -2085,7 +2085,12 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+	}
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
 		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
@@ -5109,7 +5114,12 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conv
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+	}
 	// in.DeprecatedServiceAccount has no peer in out
 	out.NodeName = in.NodeName
 	// in.HostNetwork has no peer in out

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1587,8 +1587,18 @@ func deepCopy_v1_PodSpec(in PodSpec, out *PodSpec, c *conversion.Cloner) error {
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
-	out.DeprecatedServiceAccount = in.DeprecatedServiceAccount
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+	}
+	if in.DeprecatedServiceAccount != nil {
+		out.DeprecatedServiceAccount = new(string)
+		*out.DeprecatedServiceAccount = *in.DeprecatedServiceAccount
+	} else {
+		out.DeprecatedServiceAccount = nil
+	}
 	out.NodeName = in.NodeName
 	out.HostNetwork = in.HostNetwork
 	out.HostPID = in.HostPID

--- a/pkg/api/v1/types.generated.go
+++ b/pkg/api/v1/types.generated.go
@@ -17220,8 +17220,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq1359[4] = x.ActiveDeadlineSeconds != nil
 			yyq1359[5] = x.DNSPolicy != ""
 			yyq1359[6] = len(x.NodeSelector) != 0
-			yyq1359[7] = x.ServiceAccountName != ""
-			yyq1359[8] = x.DeprecatedServiceAccount != ""
+			yyq1359[7] = x.ServiceAccountName != nil
+			yyq1359[8] = x.DeprecatedServiceAccount != nil
 			yyq1359[9] = x.NodeName != ""
 			yyq1359[10] = x.HostNetwork != false
 			yyq1359[11] = x.HostPID != false
@@ -17413,52 +17413,72 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1359 || yy2arr1359 {
 				if yyq1359[7] {
-					yym1382 := z.EncBinary()
-					_ = yym1382
-					if false {
+					if x.ServiceAccountName == nil {
+						r.EncodeNil()
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ServiceAccountName))
+						yy1382 := *x.ServiceAccountName
+						yym1383 := z.EncBinary()
+						_ = yym1383
+						if false {
+						} else {
+							r.EncodeString(codecSelferC_UTF81234, string(yy1382))
+						}
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1359[7] {
 					r.EncodeString(codecSelferC_UTF81234, string("serviceAccountName"))
-					yym1383 := z.EncBinary()
-					_ = yym1383
-					if false {
+					if x.ServiceAccountName == nil {
+						r.EncodeNil()
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ServiceAccountName))
+						yy1384 := *x.ServiceAccountName
+						yym1385 := z.EncBinary()
+						_ = yym1385
+						if false {
+						} else {
+							r.EncodeString(codecSelferC_UTF81234, string(yy1384))
+						}
 					}
 				}
 			}
 			if yyr1359 || yy2arr1359 {
 				if yyq1359[8] {
-					yym1385 := z.EncBinary()
-					_ = yym1385
-					if false {
+					if x.DeprecatedServiceAccount == nil {
+						r.EncodeNil()
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.DeprecatedServiceAccount))
+						yy1387 := *x.DeprecatedServiceAccount
+						yym1388 := z.EncBinary()
+						_ = yym1388
+						if false {
+						} else {
+							r.EncodeString(codecSelferC_UTF81234, string(yy1387))
+						}
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1359[8] {
 					r.EncodeString(codecSelferC_UTF81234, string("serviceAccount"))
-					yym1386 := z.EncBinary()
-					_ = yym1386
-					if false {
+					if x.DeprecatedServiceAccount == nil {
+						r.EncodeNil()
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.DeprecatedServiceAccount))
+						yy1389 := *x.DeprecatedServiceAccount
+						yym1390 := z.EncBinary()
+						_ = yym1390
+						if false {
+						} else {
+							r.EncodeString(codecSelferC_UTF81234, string(yy1389))
+						}
 					}
 				}
 			}
 			if yyr1359 || yy2arr1359 {
 				if yyq1359[9] {
-					yym1388 := z.EncBinary()
-					_ = yym1388
+					yym1392 := z.EncBinary()
+					_ = yym1392
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.NodeName))
@@ -17469,8 +17489,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1359[9] {
 					r.EncodeString(codecSelferC_UTF81234, string("nodeName"))
-					yym1389 := z.EncBinary()
-					_ = yym1389
+					yym1393 := z.EncBinary()
+					_ = yym1393
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.NodeName))
@@ -17479,8 +17499,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1359 || yy2arr1359 {
 				if yyq1359[10] {
-					yym1391 := z.EncBinary()
-					_ = yym1391
+					yym1395 := z.EncBinary()
+					_ = yym1395
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostNetwork))
@@ -17491,8 +17511,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1359[10] {
 					r.EncodeString(codecSelferC_UTF81234, string("hostNetwork"))
-					yym1392 := z.EncBinary()
-					_ = yym1392
+					yym1396 := z.EncBinary()
+					_ = yym1396
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostNetwork))
@@ -17501,8 +17521,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1359 || yy2arr1359 {
 				if yyq1359[11] {
-					yym1394 := z.EncBinary()
-					_ = yym1394
+					yym1398 := z.EncBinary()
+					_ = yym1398
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostPID))
@@ -17513,8 +17533,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1359[11] {
 					r.EncodeString(codecSelferC_UTF81234, string("hostPID"))
-					yym1395 := z.EncBinary()
-					_ = yym1395
+					yym1399 := z.EncBinary()
+					_ = yym1399
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostPID))
@@ -17523,8 +17543,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1359 || yy2arr1359 {
 				if yyq1359[12] {
-					yym1397 := z.EncBinary()
-					_ = yym1397
+					yym1401 := z.EncBinary()
+					_ = yym1401
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostIPC))
@@ -17535,8 +17555,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1359[12] {
 					r.EncodeString(codecSelferC_UTF81234, string("hostIPC"))
-					yym1398 := z.EncBinary()
-					_ = yym1398
+					yym1402 := z.EncBinary()
+					_ = yym1402
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostIPC))
@@ -17568,8 +17588,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym1401 := z.EncBinary()
-						_ = yym1401
+						yym1405 := z.EncBinary()
+						_ = yym1405
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -17584,8 +17604,8 @@ func (x *PodSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym1402 := z.EncBinary()
-						_ = yym1402
+						yym1406 := z.EncBinary()
+						_ = yym1406
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -17604,24 +17624,24 @@ func (x *PodSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1403 := z.DecBinary()
-	_ = yym1403
+	yym1407 := z.DecBinary()
+	_ = yym1407
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1404 := r.ReadMapStart()
-			if yyl1404 == 0 {
+			yyl1408 := r.ReadMapStart()
+			if yyl1408 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1404, d)
+				x.codecDecodeSelfFromMap(yyl1408, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1404 := r.ReadArrayStart()
-			if yyl1404 == 0 {
+			yyl1408 := r.ReadArrayStart()
+			if yyl1408 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1404, d)
+				x.codecDecodeSelfFromArray(yyl1408, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -17633,12 +17653,12 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1405Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1405Slc
-	var yyhl1405 bool = l >= 0
-	for yyj1405 := 0; ; yyj1405++ {
-		if yyhl1405 {
-			if yyj1405 >= l {
+	var yys1409Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1409Slc
+	var yyhl1409 bool = l >= 0
+	for yyj1409 := 0; ; yyj1409++ {
+		if yyhl1409 {
+			if yyj1409 >= l {
 				break
 			}
 		} else {
@@ -17646,31 +17666,31 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1405Slc = r.DecodeBytes(yys1405Slc, true, true)
-		yys1405 := string(yys1405Slc)
-		switch yys1405 {
+		yys1409Slc = r.DecodeBytes(yys1409Slc, true, true)
+		yys1409 := string(yys1409Slc)
+		switch yys1409 {
 		case "volumes":
 			if r.TryDecodeAsNil() {
 				x.Volumes = nil
 			} else {
-				yyv1406 := &x.Volumes
-				yym1407 := z.DecBinary()
-				_ = yym1407
+				yyv1410 := &x.Volumes
+				yym1411 := z.DecBinary()
+				_ = yym1411
 				if false {
 				} else {
-					h.decSliceVolume((*[]Volume)(yyv1406), d)
+					h.decSliceVolume((*[]Volume)(yyv1410), d)
 				}
 			}
 		case "containers":
 			if r.TryDecodeAsNil() {
 				x.Containers = nil
 			} else {
-				yyv1408 := &x.Containers
-				yym1409 := z.DecBinary()
-				_ = yym1409
+				yyv1412 := &x.Containers
+				yym1413 := z.DecBinary()
+				_ = yym1413
 				if false {
 				} else {
-					h.decSliceContainer((*[]Container)(yyv1408), d)
+					h.decSliceContainer((*[]Container)(yyv1412), d)
 				}
 			}
 		case "restartPolicy":
@@ -17688,8 +17708,8 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TerminationGracePeriodSeconds == nil {
 					x.TerminationGracePeriodSeconds = new(int64)
 				}
-				yym1412 := z.DecBinary()
-				_ = yym1412
+				yym1416 := z.DecBinary()
+				_ = yym1416
 				if false {
 				} else {
 					*((*int64)(x.TerminationGracePeriodSeconds)) = int64(r.DecodeInt(64))
@@ -17704,8 +17724,8 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.ActiveDeadlineSeconds == nil {
 					x.ActiveDeadlineSeconds = new(int64)
 				}
-				yym1414 := z.DecBinary()
-				_ = yym1414
+				yym1418 := z.DecBinary()
+				_ = yym1418
 				if false {
 				} else {
 					*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
@@ -17721,25 +17741,45 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.NodeSelector = nil
 			} else {
-				yyv1416 := &x.NodeSelector
-				yym1417 := z.DecBinary()
-				_ = yym1417
+				yyv1420 := &x.NodeSelector
+				yym1421 := z.DecBinary()
+				_ = yym1421
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1416, false, d)
+					z.F.DecMapStringStringX(yyv1420, false, d)
 				}
 			}
 		case "serviceAccountName":
 			if r.TryDecodeAsNil() {
-				x.ServiceAccountName = ""
+				if x.ServiceAccountName != nil {
+					x.ServiceAccountName = nil
+				}
 			} else {
-				x.ServiceAccountName = string(r.DecodeString())
+				if x.ServiceAccountName == nil {
+					x.ServiceAccountName = new(string)
+				}
+				yym1423 := z.DecBinary()
+				_ = yym1423
+				if false {
+				} else {
+					*((*string)(x.ServiceAccountName)) = r.DecodeString()
+				}
 			}
 		case "serviceAccount":
 			if r.TryDecodeAsNil() {
-				x.DeprecatedServiceAccount = ""
+				if x.DeprecatedServiceAccount != nil {
+					x.DeprecatedServiceAccount = nil
+				}
 			} else {
-				x.DeprecatedServiceAccount = string(r.DecodeString())
+				if x.DeprecatedServiceAccount == nil {
+					x.DeprecatedServiceAccount = new(string)
+				}
+				yym1425 := z.DecBinary()
+				_ = yym1425
+				if false {
+				} else {
+					*((*string)(x.DeprecatedServiceAccount)) = r.DecodeString()
+				}
 			}
 		case "nodeName":
 			if r.TryDecodeAsNil() {
@@ -17780,19 +17820,19 @@ func (x *PodSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ImagePullSecrets = nil
 			} else {
-				yyv1425 := &x.ImagePullSecrets
-				yym1426 := z.DecBinary()
-				_ = yym1426
+				yyv1431 := &x.ImagePullSecrets
+				yym1432 := z.DecBinary()
+				_ = yym1432
 				if false {
 				} else {
-					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv1425), d)
+					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv1431), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1405)
-		} // end switch yys1405
-	} // end for yyj1405
-	if !yyhl1405 {
+			z.DecStructFieldNotFound(-1, yys1409)
+		} // end switch yys1409
+	} // end for yyj1409
+	if !yyhl1409 {
 		r.ReadEnd()
 	}
 }
@@ -17801,58 +17841,58 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1427 int
-	var yyb1427 bool
-	var yyhl1427 bool = l >= 0
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	var yyj1433 int
+	var yyb1433 bool
+	var yyhl1433 bool = l >= 0
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Volumes = nil
 	} else {
-		yyv1428 := &x.Volumes
-		yym1429 := z.DecBinary()
-		_ = yym1429
+		yyv1434 := &x.Volumes
+		yym1435 := z.DecBinary()
+		_ = yym1435
 		if false {
 		} else {
-			h.decSliceVolume((*[]Volume)(yyv1428), d)
+			h.decSliceVolume((*[]Volume)(yyv1434), d)
 		}
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Containers = nil
 	} else {
-		yyv1430 := &x.Containers
-		yym1431 := z.DecBinary()
-		_ = yym1431
+		yyv1436 := &x.Containers
+		yym1437 := z.DecBinary()
+		_ = yym1437
 		if false {
 		} else {
-			h.decSliceContainer((*[]Container)(yyv1430), d)
+			h.decSliceContainer((*[]Container)(yyv1436), d)
 		}
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
@@ -17861,13 +17901,13 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.RestartPolicy = RestartPolicy(r.DecodeString())
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
@@ -17879,20 +17919,20 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TerminationGracePeriodSeconds == nil {
 			x.TerminationGracePeriodSeconds = new(int64)
 		}
-		yym1434 := z.DecBinary()
-		_ = yym1434
+		yym1440 := z.DecBinary()
+		_ = yym1440
 		if false {
 		} else {
 			*((*int64)(x.TerminationGracePeriodSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
@@ -17904,20 +17944,20 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.ActiveDeadlineSeconds == nil {
 			x.ActiveDeadlineSeconds = new(int64)
 		}
-		yym1436 := z.DecBinary()
-		_ = yym1436
+		yym1442 := z.DecBinary()
+		_ = yym1442
 		if false {
 		} else {
 			*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
@@ -17926,64 +17966,84 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.DNSPolicy = DNSPolicy(r.DecodeString())
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.NodeSelector = nil
 	} else {
-		yyv1438 := &x.NodeSelector
-		yym1439 := z.DecBinary()
-		_ = yym1439
+		yyv1444 := &x.NodeSelector
+		yym1445 := z.DecBinary()
+		_ = yym1445
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1438, false, d)
+			z.F.DecMapStringStringX(yyv1444, false, d)
 		}
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.ServiceAccountName = ""
+		if x.ServiceAccountName != nil {
+			x.ServiceAccountName = nil
+		}
 	} else {
-		x.ServiceAccountName = string(r.DecodeString())
+		if x.ServiceAccountName == nil {
+			x.ServiceAccountName = new(string)
+		}
+		yym1447 := z.DecBinary()
+		_ = yym1447
+		if false {
+		} else {
+			*((*string)(x.ServiceAccountName)) = r.DecodeString()
+		}
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.DeprecatedServiceAccount = ""
+		if x.DeprecatedServiceAccount != nil {
+			x.DeprecatedServiceAccount = nil
+		}
 	} else {
-		x.DeprecatedServiceAccount = string(r.DecodeString())
+		if x.DeprecatedServiceAccount == nil {
+			x.DeprecatedServiceAccount = new(string)
+		}
+		yym1449 := z.DecBinary()
+		_ = yym1449
+		if false {
+		} else {
+			*((*string)(x.DeprecatedServiceAccount)) = r.DecodeString()
+		}
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
@@ -17992,13 +18052,13 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.NodeName = string(r.DecodeString())
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
@@ -18007,13 +18067,13 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.HostNetwork = bool(r.DecodeBool())
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
@@ -18022,13 +18082,13 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.HostPID = bool(r.DecodeBool())
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
@@ -18037,13 +18097,13 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.HostIPC = bool(r.DecodeBool())
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
@@ -18057,38 +18117,38 @@ func (x *PodSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.SecurityContext.CodecDecodeSelf(d)
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1433++
+	if yyhl1433 {
+		yyb1433 = yyj1433 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1433 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1433 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ImagePullSecrets = nil
 	} else {
-		yyv1447 := &x.ImagePullSecrets
-		yym1448 := z.DecBinary()
-		_ = yym1448
+		yyv1455 := &x.ImagePullSecrets
+		yym1456 := z.DecBinary()
+		_ = yym1456
 		if false {
 		} else {
-			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv1447), d)
+			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv1455), d)
 		}
 	}
 	for {
-		yyj1427++
-		if yyhl1427 {
-			yyb1427 = yyj1427 > l
+		yyj1433++
+		if yyhl1433 {
+			yyb1433 = yyj1433 > l
 		} else {
-			yyb1427 = r.CheckBreak()
+			yyb1433 = r.CheckBreak()
 		}
-		if yyb1427 {
+		if yyb1433 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1427-1, "")
+		z.DecStructFieldNotFound(yyj1433-1, "")
 	}
 	r.ReadEnd()
 }
@@ -18100,34 +18160,34 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1449 := z.EncBinary()
-		_ = yym1449
+		yym1457 := z.EncBinary()
+		_ = yym1457
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1450 := !z.EncBinary()
-			yy2arr1450 := z.EncBasicHandle().StructToArray
-			var yyq1450 [5]bool
-			_, _, _ = yysep1450, yyq1450, yy2arr1450
-			const yyr1450 bool = false
-			yyq1450[0] = x.SELinuxOptions != nil
-			yyq1450[1] = x.RunAsUser != nil
-			yyq1450[2] = x.RunAsNonRoot != nil
-			yyq1450[3] = len(x.SupplementalGroups) != 0
-			yyq1450[4] = x.FSGroup != nil
-			if yyr1450 || yy2arr1450 {
+			yysep1458 := !z.EncBinary()
+			yy2arr1458 := z.EncBasicHandle().StructToArray
+			var yyq1458 [5]bool
+			_, _, _ = yysep1458, yyq1458, yy2arr1458
+			const yyr1458 bool = false
+			yyq1458[0] = x.SELinuxOptions != nil
+			yyq1458[1] = x.RunAsUser != nil
+			yyq1458[2] = x.RunAsNonRoot != nil
+			yyq1458[3] = len(x.SupplementalGroups) != 0
+			yyq1458[4] = x.FSGroup != nil
+			if yyr1458 || yy2arr1458 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1450 int = 0
-				for _, b := range yyq1450 {
+				var yynn1458 int = 0
+				for _, b := range yyq1458 {
 					if b {
-						yynn1450++
+						yynn1458++
 					}
 				}
-				r.EncodeMapStart(yynn1450)
+				r.EncodeMapStart(yynn1458)
 			}
-			if yyr1450 || yy2arr1450 {
-				if yyq1450[0] {
+			if yyr1458 || yy2arr1458 {
+				if yyq1458[0] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -18137,7 +18197,7 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1450[0] {
+				if yyq1458[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -18146,133 +18206,133 @@ func (x *PodSecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1450 || yy2arr1450 {
-				if yyq1450[1] {
+			if yyr1458 || yy2arr1458 {
+				if yyq1458[1] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy1453 := *x.RunAsUser
-						yym1454 := z.EncBinary()
-						_ = yym1454
+						yy1461 := *x.RunAsUser
+						yym1462 := z.EncBinary()
+						_ = yym1462
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1453))
+							r.EncodeInt(int64(yy1461))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1450[1] {
+				if yyq1458[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy1455 := *x.RunAsUser
-						yym1456 := z.EncBinary()
-						_ = yym1456
-						if false {
-						} else {
-							r.EncodeInt(int64(yy1455))
-						}
-					}
-				}
-			}
-			if yyr1450 || yy2arr1450 {
-				if yyq1450[2] {
-					if x.RunAsNonRoot == nil {
-						r.EncodeNil()
-					} else {
-						yy1458 := *x.RunAsNonRoot
-						yym1459 := z.EncBinary()
-						_ = yym1459
-						if false {
-						} else {
-							r.EncodeBool(bool(yy1458))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1450[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
-					if x.RunAsNonRoot == nil {
-						r.EncodeNil()
-					} else {
-						yy1460 := *x.RunAsNonRoot
-						yym1461 := z.EncBinary()
-						_ = yym1461
-						if false {
-						} else {
-							r.EncodeBool(bool(yy1460))
-						}
-					}
-				}
-			}
-			if yyr1450 || yy2arr1450 {
-				if yyq1450[3] {
-					if x.SupplementalGroups == nil {
-						r.EncodeNil()
-					} else {
-						yym1463 := z.EncBinary()
-						_ = yym1463
-						if false {
-						} else {
-							z.F.EncSliceInt64V(x.SupplementalGroups, false, e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1450[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("supplementalGroups"))
-					if x.SupplementalGroups == nil {
-						r.EncodeNil()
-					} else {
+						yy1463 := *x.RunAsUser
 						yym1464 := z.EncBinary()
 						_ = yym1464
 						if false {
 						} else {
-							z.F.EncSliceInt64V(x.SupplementalGroups, false, e)
+							r.EncodeInt(int64(yy1463))
 						}
 					}
 				}
 			}
-			if yyr1450 || yy2arr1450 {
-				if yyq1450[4] {
-					if x.FSGroup == nil {
+			if yyr1458 || yy2arr1458 {
+				if yyq1458[2] {
+					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
-						yy1466 := *x.FSGroup
+						yy1466 := *x.RunAsNonRoot
 						yym1467 := z.EncBinary()
 						_ = yym1467
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1466))
+							r.EncodeBool(bool(yy1466))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1450[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("fsGroup"))
-					if x.FSGroup == nil {
+				if yyq1458[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
+					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
-						yy1468 := *x.FSGroup
+						yy1468 := *x.RunAsNonRoot
 						yym1469 := z.EncBinary()
 						_ = yym1469
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1468))
+							r.EncodeBool(bool(yy1468))
 						}
 					}
 				}
 			}
-			if yysep1450 {
+			if yyr1458 || yy2arr1458 {
+				if yyq1458[3] {
+					if x.SupplementalGroups == nil {
+						r.EncodeNil()
+					} else {
+						yym1471 := z.EncBinary()
+						_ = yym1471
+						if false {
+						} else {
+							z.F.EncSliceInt64V(x.SupplementalGroups, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1458[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("supplementalGroups"))
+					if x.SupplementalGroups == nil {
+						r.EncodeNil()
+					} else {
+						yym1472 := z.EncBinary()
+						_ = yym1472
+						if false {
+						} else {
+							z.F.EncSliceInt64V(x.SupplementalGroups, false, e)
+						}
+					}
+				}
+			}
+			if yyr1458 || yy2arr1458 {
+				if yyq1458[4] {
+					if x.FSGroup == nil {
+						r.EncodeNil()
+					} else {
+						yy1474 := *x.FSGroup
+						yym1475 := z.EncBinary()
+						_ = yym1475
+						if false {
+						} else {
+							r.EncodeInt(int64(yy1474))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1458[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("fsGroup"))
+					if x.FSGroup == nil {
+						r.EncodeNil()
+					} else {
+						yy1476 := *x.FSGroup
+						yym1477 := z.EncBinary()
+						_ = yym1477
+						if false {
+						} else {
+							r.EncodeInt(int64(yy1476))
+						}
+					}
+				}
+			}
+			if yysep1458 {
 				r.EncodeEnd()
 			}
 		}
@@ -18283,24 +18343,24 @@ func (x *PodSecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1470 := z.DecBinary()
-	_ = yym1470
+	yym1478 := z.DecBinary()
+	_ = yym1478
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1471 := r.ReadMapStart()
-			if yyl1471 == 0 {
+			yyl1479 := r.ReadMapStart()
+			if yyl1479 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1471, d)
+				x.codecDecodeSelfFromMap(yyl1479, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1471 := r.ReadArrayStart()
-			if yyl1471 == 0 {
+			yyl1479 := r.ReadArrayStart()
+			if yyl1479 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1471, d)
+				x.codecDecodeSelfFromArray(yyl1479, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -18312,12 +18372,12 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1472Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1472Slc
-	var yyhl1472 bool = l >= 0
-	for yyj1472 := 0; ; yyj1472++ {
-		if yyhl1472 {
-			if yyj1472 >= l {
+	var yys1480Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1480Slc
+	var yyhl1480 bool = l >= 0
+	for yyj1480 := 0; ; yyj1480++ {
+		if yyhl1480 {
+			if yyj1480 >= l {
 				break
 			}
 		} else {
@@ -18325,9 +18385,9 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys1472Slc = r.DecodeBytes(yys1472Slc, true, true)
-		yys1472 := string(yys1472Slc)
-		switch yys1472 {
+		yys1480Slc = r.DecodeBytes(yys1480Slc, true, true)
+		yys1480 := string(yys1480Slc)
+		switch yys1480 {
 		case "seLinuxOptions":
 			if r.TryDecodeAsNil() {
 				if x.SELinuxOptions != nil {
@@ -18348,8 +18408,8 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.RunAsUser == nil {
 					x.RunAsUser = new(int64)
 				}
-				yym1475 := z.DecBinary()
-				_ = yym1475
+				yym1483 := z.DecBinary()
+				_ = yym1483
 				if false {
 				} else {
 					*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
@@ -18364,8 +18424,8 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.RunAsNonRoot == nil {
 					x.RunAsNonRoot = new(bool)
 				}
-				yym1477 := z.DecBinary()
-				_ = yym1477
+				yym1485 := z.DecBinary()
+				_ = yym1485
 				if false {
 				} else {
 					*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
@@ -18375,12 +18435,12 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.SupplementalGroups = nil
 			} else {
-				yyv1478 := &x.SupplementalGroups
-				yym1479 := z.DecBinary()
-				_ = yym1479
+				yyv1486 := &x.SupplementalGroups
+				yym1487 := z.DecBinary()
+				_ = yym1487
 				if false {
 				} else {
-					z.F.DecSliceInt64X(yyv1478, false, d)
+					z.F.DecSliceInt64X(yyv1486, false, d)
 				}
 			}
 		case "fsGroup":
@@ -18392,18 +18452,18 @@ func (x *PodSecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.FSGroup == nil {
 					x.FSGroup = new(int64)
 				}
-				yym1481 := z.DecBinary()
-				_ = yym1481
+				yym1489 := z.DecBinary()
+				_ = yym1489
 				if false {
 				} else {
 					*((*int64)(x.FSGroup)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1472)
-		} // end switch yys1472
-	} // end for yyj1472
-	if !yyhl1472 {
+			z.DecStructFieldNotFound(-1, yys1480)
+		} // end switch yys1480
+	} // end for yyj1480
+	if !yyhl1480 {
 		r.ReadEnd()
 	}
 }
@@ -18412,16 +18472,16 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1482 int
-	var yyb1482 bool
-	var yyhl1482 bool = l >= 0
-	yyj1482++
-	if yyhl1482 {
-		yyb1482 = yyj1482 > l
+	var yyj1490 int
+	var yyb1490 bool
+	var yyhl1490 bool = l >= 0
+	yyj1490++
+	if yyhl1490 {
+		yyb1490 = yyj1490 > l
 	} else {
-		yyb1482 = r.CheckBreak()
+		yyb1490 = r.CheckBreak()
 	}
-	if yyb1482 {
+	if yyb1490 {
 		r.ReadEnd()
 		return
 	}
@@ -18435,13 +18495,13 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		}
 		x.SELinuxOptions.CodecDecodeSelf(d)
 	}
-	yyj1482++
-	if yyhl1482 {
-		yyb1482 = yyj1482 > l
+	yyj1490++
+	if yyhl1490 {
+		yyb1490 = yyj1490 > l
 	} else {
-		yyb1482 = r.CheckBreak()
+		yyb1490 = r.CheckBreak()
 	}
-	if yyb1482 {
+	if yyb1490 {
 		r.ReadEnd()
 		return
 	}
@@ -18453,20 +18513,20 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.RunAsUser == nil {
 			x.RunAsUser = new(int64)
 		}
-		yym1485 := z.DecBinary()
-		_ = yym1485
+		yym1493 := z.DecBinary()
+		_ = yym1493
 		if false {
 		} else {
 			*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj1482++
-	if yyhl1482 {
-		yyb1482 = yyj1482 > l
+	yyj1490++
+	if yyhl1490 {
+		yyb1490 = yyj1490 > l
 	} else {
-		yyb1482 = r.CheckBreak()
+		yyb1490 = r.CheckBreak()
 	}
-	if yyb1482 {
+	if yyb1490 {
 		r.ReadEnd()
 		return
 	}
@@ -18478,41 +18538,41 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.RunAsNonRoot == nil {
 			x.RunAsNonRoot = new(bool)
 		}
-		yym1487 := z.DecBinary()
-		_ = yym1487
+		yym1495 := z.DecBinary()
+		_ = yym1495
 		if false {
 		} else {
 			*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 		}
 	}
-	yyj1482++
-	if yyhl1482 {
-		yyb1482 = yyj1482 > l
+	yyj1490++
+	if yyhl1490 {
+		yyb1490 = yyj1490 > l
 	} else {
-		yyb1482 = r.CheckBreak()
+		yyb1490 = r.CheckBreak()
 	}
-	if yyb1482 {
+	if yyb1490 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SupplementalGroups = nil
 	} else {
-		yyv1488 := &x.SupplementalGroups
-		yym1489 := z.DecBinary()
-		_ = yym1489
+		yyv1496 := &x.SupplementalGroups
+		yym1497 := z.DecBinary()
+		_ = yym1497
 		if false {
 		} else {
-			z.F.DecSliceInt64X(yyv1488, false, d)
+			z.F.DecSliceInt64X(yyv1496, false, d)
 		}
 	}
-	yyj1482++
-	if yyhl1482 {
-		yyb1482 = yyj1482 > l
+	yyj1490++
+	if yyhl1490 {
+		yyb1490 = yyj1490 > l
 	} else {
-		yyb1482 = r.CheckBreak()
+		yyb1490 = r.CheckBreak()
 	}
-	if yyb1482 {
+	if yyb1490 {
 		r.ReadEnd()
 		return
 	}
@@ -18524,24 +18584,24 @@ func (x *PodSecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.FSGroup == nil {
 			x.FSGroup = new(int64)
 		}
-		yym1491 := z.DecBinary()
-		_ = yym1491
+		yym1499 := z.DecBinary()
+		_ = yym1499
 		if false {
 		} else {
 			*((*int64)(x.FSGroup)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj1482++
-		if yyhl1482 {
-			yyb1482 = yyj1482 > l
+		yyj1490++
+		if yyhl1490 {
+			yyb1490 = yyj1490 > l
 		} else {
-			yyb1482 = r.CheckBreak()
+			yyb1490 = r.CheckBreak()
 		}
-		if yyb1482 {
+		if yyb1490 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1482-1, "")
+		z.DecStructFieldNotFound(yyj1490-1, "")
 	}
 	r.ReadEnd()
 }
@@ -18553,54 +18613,54 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1492 := z.EncBinary()
-		_ = yym1492
+		yym1500 := z.EncBinary()
+		_ = yym1500
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1493 := !z.EncBinary()
-			yy2arr1493 := z.EncBasicHandle().StructToArray
-			var yyq1493 [8]bool
-			_, _, _ = yysep1493, yyq1493, yy2arr1493
-			const yyr1493 bool = false
-			yyq1493[0] = x.Phase != ""
-			yyq1493[1] = len(x.Conditions) != 0
-			yyq1493[2] = x.Message != ""
-			yyq1493[3] = x.Reason != ""
-			yyq1493[4] = x.HostIP != ""
-			yyq1493[5] = x.PodIP != ""
-			yyq1493[6] = x.StartTime != nil
-			yyq1493[7] = len(x.ContainerStatuses) != 0
-			if yyr1493 || yy2arr1493 {
+			yysep1501 := !z.EncBinary()
+			yy2arr1501 := z.EncBasicHandle().StructToArray
+			var yyq1501 [8]bool
+			_, _, _ = yysep1501, yyq1501, yy2arr1501
+			const yyr1501 bool = false
+			yyq1501[0] = x.Phase != ""
+			yyq1501[1] = len(x.Conditions) != 0
+			yyq1501[2] = x.Message != ""
+			yyq1501[3] = x.Reason != ""
+			yyq1501[4] = x.HostIP != ""
+			yyq1501[5] = x.PodIP != ""
+			yyq1501[6] = x.StartTime != nil
+			yyq1501[7] = len(x.ContainerStatuses) != 0
+			if yyr1501 || yy2arr1501 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1493 int = 0
-				for _, b := range yyq1493 {
+				var yynn1501 int = 0
+				for _, b := range yyq1501 {
 					if b {
-						yynn1493++
+						yynn1501++
 					}
 				}
-				r.EncodeMapStart(yynn1493)
+				r.EncodeMapStart(yynn1501)
 			}
-			if yyr1493 || yy2arr1493 {
-				if yyq1493[0] {
+			if yyr1501 || yy2arr1501 {
+				if yyq1501[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1493[0] {
+				if yyq1501[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1493 || yy2arr1493 {
-				if yyq1493[1] {
+			if yyr1501 || yy2arr1501 {
+				if yyq1501[1] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym1496 := z.EncBinary()
-						_ = yym1496
+						yym1504 := z.EncBinary()
+						_ = yym1504
 						if false {
 						} else {
 							h.encSlicePodCondition(([]PodCondition)(x.Conditions), e)
@@ -18610,13 +18670,13 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1493[1] {
+				if yyq1501[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym1497 := z.EncBinary()
-						_ = yym1497
+						yym1505 := z.EncBinary()
+						_ = yym1505
 						if false {
 						} else {
 							h.encSlicePodCondition(([]PodCondition)(x.Conditions), e)
@@ -18624,10 +18684,10 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1493 || yy2arr1493 {
-				if yyq1493[2] {
-					yym1499 := z.EncBinary()
-					_ = yym1499
+			if yyr1501 || yy2arr1501 {
+				if yyq1501[2] {
+					yym1507 := z.EncBinary()
+					_ = yym1507
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -18636,94 +18696,94 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1493[2] {
+				if yyq1501[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym1500 := z.EncBinary()
-					_ = yym1500
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
-				}
-			}
-			if yyr1493 || yy2arr1493 {
-				if yyq1493[3] {
-					yym1502 := z.EncBinary()
-					_ = yym1502
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1493[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym1503 := z.EncBinary()
-					_ = yym1503
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				}
-			}
-			if yyr1493 || yy2arr1493 {
-				if yyq1493[4] {
-					yym1505 := z.EncBinary()
-					_ = yym1505
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.HostIP))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1493[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("hostIP"))
-					yym1506 := z.EncBinary()
-					_ = yym1506
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.HostIP))
-					}
-				}
-			}
-			if yyr1493 || yy2arr1493 {
-				if yyq1493[5] {
 					yym1508 := z.EncBinary()
 					_ = yym1508
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
+					}
+				}
+			}
+			if yyr1501 || yy2arr1501 {
+				if yyq1501[3] {
+					yym1510 := z.EncBinary()
+					_ = yym1510
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1501[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					yym1511 := z.EncBinary()
+					_ = yym1511
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				}
+			}
+			if yyr1501 || yy2arr1501 {
+				if yyq1501[4] {
+					yym1513 := z.EncBinary()
+					_ = yym1513
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.HostIP))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1501[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("hostIP"))
+					yym1514 := z.EncBinary()
+					_ = yym1514
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.HostIP))
+					}
+				}
+			}
+			if yyr1501 || yy2arr1501 {
+				if yyq1501[5] {
+					yym1516 := z.EncBinary()
+					_ = yym1516
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.PodIP))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1493[5] {
+				if yyq1501[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("podIP"))
-					yym1509 := z.EncBinary()
-					_ = yym1509
+					yym1517 := z.EncBinary()
+					_ = yym1517
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.PodIP))
 					}
 				}
 			}
-			if yyr1493 || yy2arr1493 {
-				if yyq1493[6] {
+			if yyr1501 || yy2arr1501 {
+				if yyq1501[6] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym1511 := z.EncBinary()
-						_ = yym1511
+						yym1519 := z.EncBinary()
+						_ = yym1519
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym1511 {
+						} else if yym1519 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym1511 && z.IsJSONHandle() {
+						} else if !yym1519 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -18733,18 +18793,18 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1493[6] {
+				if yyq1501[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym1512 := z.EncBinary()
-						_ = yym1512
+						yym1520 := z.EncBinary()
+						_ = yym1520
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym1512 {
+						} else if yym1520 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym1512 && z.IsJSONHandle() {
+						} else if !yym1520 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -18752,13 +18812,13 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1493 || yy2arr1493 {
-				if yyq1493[7] {
+			if yyr1501 || yy2arr1501 {
+				if yyq1501[7] {
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
 					} else {
-						yym1514 := z.EncBinary()
-						_ = yym1514
+						yym1522 := z.EncBinary()
+						_ = yym1522
 						if false {
 						} else {
 							h.encSliceContainerStatus(([]ContainerStatus)(x.ContainerStatuses), e)
@@ -18768,13 +18828,13 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1493[7] {
+				if yyq1501[7] {
 					r.EncodeString(codecSelferC_UTF81234, string("containerStatuses"))
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
 					} else {
-						yym1515 := z.EncBinary()
-						_ = yym1515
+						yym1523 := z.EncBinary()
+						_ = yym1523
 						if false {
 						} else {
 							h.encSliceContainerStatus(([]ContainerStatus)(x.ContainerStatuses), e)
@@ -18782,7 +18842,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1493 {
+			if yysep1501 {
 				r.EncodeEnd()
 			}
 		}
@@ -18793,24 +18853,24 @@ func (x *PodStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1516 := z.DecBinary()
-	_ = yym1516
+	yym1524 := z.DecBinary()
+	_ = yym1524
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1517 := r.ReadMapStart()
-			if yyl1517 == 0 {
+			yyl1525 := r.ReadMapStart()
+			if yyl1525 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1517, d)
+				x.codecDecodeSelfFromMap(yyl1525, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1517 := r.ReadArrayStart()
-			if yyl1517 == 0 {
+			yyl1525 := r.ReadArrayStart()
+			if yyl1525 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1517, d)
+				x.codecDecodeSelfFromArray(yyl1525, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -18822,12 +18882,12 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1518Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1518Slc
-	var yyhl1518 bool = l >= 0
-	for yyj1518 := 0; ; yyj1518++ {
-		if yyhl1518 {
-			if yyj1518 >= l {
+	var yys1526Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1526Slc
+	var yyhl1526 bool = l >= 0
+	for yyj1526 := 0; ; yyj1526++ {
+		if yyhl1526 {
+			if yyj1526 >= l {
 				break
 			}
 		} else {
@@ -18835,9 +18895,9 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1518Slc = r.DecodeBytes(yys1518Slc, true, true)
-		yys1518 := string(yys1518Slc)
-		switch yys1518 {
+		yys1526Slc = r.DecodeBytes(yys1526Slc, true, true)
+		yys1526 := string(yys1526Slc)
+		switch yys1526 {
 		case "phase":
 			if r.TryDecodeAsNil() {
 				x.Phase = ""
@@ -18848,12 +18908,12 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv1520 := &x.Conditions
-				yym1521 := z.DecBinary()
-				_ = yym1521
+				yyv1528 := &x.Conditions
+				yym1529 := z.DecBinary()
+				_ = yym1529
 				if false {
 				} else {
-					h.decSlicePodCondition((*[]PodCondition)(yyv1520), d)
+					h.decSlicePodCondition((*[]PodCondition)(yyv1528), d)
 				}
 			}
 		case "message":
@@ -18889,13 +18949,13 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg2_unversioned.Time)
 				}
-				yym1527 := z.DecBinary()
-				_ = yym1527
+				yym1535 := z.DecBinary()
+				_ = yym1535
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym1527 {
+				} else if yym1535 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym1527 && z.IsJSONHandle() {
+				} else if !yym1535 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -18905,19 +18965,19 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ContainerStatuses = nil
 			} else {
-				yyv1528 := &x.ContainerStatuses
-				yym1529 := z.DecBinary()
-				_ = yym1529
+				yyv1536 := &x.ContainerStatuses
+				yym1537 := z.DecBinary()
+				_ = yym1537
 				if false {
 				} else {
-					h.decSliceContainerStatus((*[]ContainerStatus)(yyv1528), d)
+					h.decSliceContainerStatus((*[]ContainerStatus)(yyv1536), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1518)
-		} // end switch yys1518
-	} // end for yyj1518
-	if !yyhl1518 {
+			z.DecStructFieldNotFound(-1, yys1526)
+		} // end switch yys1526
+	} // end for yyj1526
+	if !yyhl1526 {
 		r.ReadEnd()
 	}
 }
@@ -18926,16 +18986,16 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1530 int
-	var yyb1530 bool
-	var yyhl1530 bool = l >= 0
-	yyj1530++
-	if yyhl1530 {
-		yyb1530 = yyj1530 > l
+	var yyj1538 int
+	var yyb1538 bool
+	var yyhl1538 bool = l >= 0
+	yyj1538++
+	if yyhl1538 {
+		yyb1538 = yyj1538 > l
 	} else {
-		yyb1530 = r.CheckBreak()
+		yyb1538 = r.CheckBreak()
 	}
-	if yyb1530 {
+	if yyb1538 {
 		r.ReadEnd()
 		return
 	}
@@ -18944,34 +19004,34 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Phase = PodPhase(r.DecodeString())
 	}
-	yyj1530++
-	if yyhl1530 {
-		yyb1530 = yyj1530 > l
+	yyj1538++
+	if yyhl1538 {
+		yyb1538 = yyj1538 > l
 	} else {
-		yyb1530 = r.CheckBreak()
+		yyb1538 = r.CheckBreak()
 	}
-	if yyb1530 {
+	if yyb1538 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv1532 := &x.Conditions
-		yym1533 := z.DecBinary()
-		_ = yym1533
+		yyv1540 := &x.Conditions
+		yym1541 := z.DecBinary()
+		_ = yym1541
 		if false {
 		} else {
-			h.decSlicePodCondition((*[]PodCondition)(yyv1532), d)
+			h.decSlicePodCondition((*[]PodCondition)(yyv1540), d)
 		}
 	}
-	yyj1530++
-	if yyhl1530 {
-		yyb1530 = yyj1530 > l
+	yyj1538++
+	if yyhl1538 {
+		yyb1538 = yyj1538 > l
 	} else {
-		yyb1530 = r.CheckBreak()
+		yyb1538 = r.CheckBreak()
 	}
-	if yyb1530 {
+	if yyb1538 {
 		r.ReadEnd()
 		return
 	}
@@ -18980,13 +19040,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj1530++
-	if yyhl1530 {
-		yyb1530 = yyj1530 > l
+	yyj1538++
+	if yyhl1538 {
+		yyb1538 = yyj1538 > l
 	} else {
-		yyb1530 = r.CheckBreak()
+		yyb1538 = r.CheckBreak()
 	}
-	if yyb1530 {
+	if yyb1538 {
 		r.ReadEnd()
 		return
 	}
@@ -18995,13 +19055,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj1530++
-	if yyhl1530 {
-		yyb1530 = yyj1530 > l
+	yyj1538++
+	if yyhl1538 {
+		yyb1538 = yyj1538 > l
 	} else {
-		yyb1530 = r.CheckBreak()
+		yyb1538 = r.CheckBreak()
 	}
-	if yyb1530 {
+	if yyb1538 {
 		r.ReadEnd()
 		return
 	}
@@ -19010,13 +19070,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.HostIP = string(r.DecodeString())
 	}
-	yyj1530++
-	if yyhl1530 {
-		yyb1530 = yyj1530 > l
+	yyj1538++
+	if yyhl1538 {
+		yyb1538 = yyj1538 > l
 	} else {
-		yyb1530 = r.CheckBreak()
+		yyb1538 = r.CheckBreak()
 	}
-	if yyb1530 {
+	if yyb1538 {
 		r.ReadEnd()
 		return
 	}
@@ -19025,13 +19085,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.PodIP = string(r.DecodeString())
 	}
-	yyj1530++
-	if yyhl1530 {
-		yyb1530 = yyj1530 > l
+	yyj1538++
+	if yyhl1538 {
+		yyb1538 = yyj1538 > l
 	} else {
-		yyb1530 = r.CheckBreak()
+		yyb1538 = r.CheckBreak()
 	}
-	if yyb1530 {
+	if yyb1538 {
 		r.ReadEnd()
 		return
 	}
@@ -19043,50 +19103,50 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg2_unversioned.Time)
 		}
-		yym1539 := z.DecBinary()
-		_ = yym1539
+		yym1547 := z.DecBinary()
+		_ = yym1547
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym1539 {
+		} else if yym1547 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym1539 && z.IsJSONHandle() {
+		} else if !yym1547 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj1530++
-	if yyhl1530 {
-		yyb1530 = yyj1530 > l
+	yyj1538++
+	if yyhl1538 {
+		yyb1538 = yyj1538 > l
 	} else {
-		yyb1530 = r.CheckBreak()
+		yyb1538 = r.CheckBreak()
 	}
-	if yyb1530 {
+	if yyb1538 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ContainerStatuses = nil
 	} else {
-		yyv1540 := &x.ContainerStatuses
-		yym1541 := z.DecBinary()
-		_ = yym1541
+		yyv1548 := &x.ContainerStatuses
+		yym1549 := z.DecBinary()
+		_ = yym1549
 		if false {
 		} else {
-			h.decSliceContainerStatus((*[]ContainerStatus)(yyv1540), d)
+			h.decSliceContainerStatus((*[]ContainerStatus)(yyv1548), d)
 		}
 	}
 	for {
-		yyj1530++
-		if yyhl1530 {
-			yyb1530 = yyj1530 > l
+		yyj1538++
+		if yyhl1538 {
+			yyb1538 = yyj1538 > l
 		} else {
-			yyb1530 = r.CheckBreak()
+			yyb1538 = r.CheckBreak()
 		}
-		if yyb1530 {
+		if yyb1538 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1530-1, "")
+		z.DecStructFieldNotFound(yyj1538-1, "")
 	}
 	r.ReadEnd()
 }
@@ -19098,35 +19158,35 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1542 := z.EncBinary()
-		_ = yym1542
+		yym1550 := z.EncBinary()
+		_ = yym1550
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1543 := !z.EncBinary()
-			yy2arr1543 := z.EncBasicHandle().StructToArray
-			var yyq1543 [4]bool
-			_, _, _ = yysep1543, yyq1543, yy2arr1543
-			const yyr1543 bool = false
-			yyq1543[0] = x.Kind != ""
-			yyq1543[1] = x.APIVersion != ""
-			yyq1543[2] = true
-			yyq1543[3] = true
-			if yyr1543 || yy2arr1543 {
+			yysep1551 := !z.EncBinary()
+			yy2arr1551 := z.EncBasicHandle().StructToArray
+			var yyq1551 [4]bool
+			_, _, _ = yysep1551, yyq1551, yy2arr1551
+			const yyr1551 bool = false
+			yyq1551[0] = x.Kind != ""
+			yyq1551[1] = x.APIVersion != ""
+			yyq1551[2] = true
+			yyq1551[3] = true
+			if yyr1551 || yy2arr1551 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1543 int = 0
-				for _, b := range yyq1543 {
+				var yynn1551 int = 0
+				for _, b := range yyq1551 {
 					if b {
-						yynn1543++
+						yynn1551++
 					}
 				}
-				r.EncodeMapStart(yynn1543)
+				r.EncodeMapStart(yynn1551)
 			}
-			if yyr1543 || yy2arr1543 {
-				if yyq1543[0] {
-					yym1545 := z.EncBinary()
-					_ = yym1545
+			if yyr1551 || yy2arr1551 {
+				if yyq1551[0] {
+					yym1553 := z.EncBinary()
+					_ = yym1553
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -19135,20 +19195,20 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1543[0] {
+				if yyq1551[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1546 := z.EncBinary()
-					_ = yym1546
+					yym1554 := z.EncBinary()
+					_ = yym1554
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1543 || yy2arr1543 {
-				if yyq1543[1] {
-					yym1548 := z.EncBinary()
-					_ = yym1548
+			if yyr1551 || yy2arr1551 {
+				if yyq1551[1] {
+					yym1556 := z.EncBinary()
+					_ = yym1556
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -19157,45 +19217,45 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1543[1] {
+				if yyq1551[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1549 := z.EncBinary()
-					_ = yym1549
+					yym1557 := z.EncBinary()
+					_ = yym1557
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1543 || yy2arr1543 {
-				if yyq1543[2] {
-					yy1551 := &x.ObjectMeta
-					yy1551.CodecEncodeSelf(e)
+			if yyr1551 || yy2arr1551 {
+				if yyq1551[2] {
+					yy1559 := &x.ObjectMeta
+					yy1559.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1543[2] {
+				if yyq1551[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1552 := &x.ObjectMeta
-					yy1552.CodecEncodeSelf(e)
+					yy1560 := &x.ObjectMeta
+					yy1560.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1543 || yy2arr1543 {
-				if yyq1543[3] {
-					yy1554 := &x.Status
-					yy1554.CodecEncodeSelf(e)
+			if yyr1551 || yy2arr1551 {
+				if yyq1551[3] {
+					yy1562 := &x.Status
+					yy1562.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1543[3] {
+				if yyq1551[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy1555 := &x.Status
-					yy1555.CodecEncodeSelf(e)
+					yy1563 := &x.Status
+					yy1563.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1543 {
+			if yysep1551 {
 				r.EncodeEnd()
 			}
 		}
@@ -19206,24 +19266,24 @@ func (x *PodStatusResult) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1556 := z.DecBinary()
-	_ = yym1556
+	yym1564 := z.DecBinary()
+	_ = yym1564
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1557 := r.ReadMapStart()
-			if yyl1557 == 0 {
+			yyl1565 := r.ReadMapStart()
+			if yyl1565 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1557, d)
+				x.codecDecodeSelfFromMap(yyl1565, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1557 := r.ReadArrayStart()
-			if yyl1557 == 0 {
+			yyl1565 := r.ReadArrayStart()
+			if yyl1565 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1557, d)
+				x.codecDecodeSelfFromArray(yyl1565, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -19235,12 +19295,12 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1558Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1558Slc
-	var yyhl1558 bool = l >= 0
-	for yyj1558 := 0; ; yyj1558++ {
-		if yyhl1558 {
-			if yyj1558 >= l {
+	var yys1566Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1566Slc
+	var yyhl1566 bool = l >= 0
+	for yyj1566 := 0; ; yyj1566++ {
+		if yyhl1566 {
+			if yyj1566 >= l {
 				break
 			}
 		} else {
@@ -19248,9 +19308,9 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1558Slc = r.DecodeBytes(yys1558Slc, true, true)
-		yys1558 := string(yys1558Slc)
-		switch yys1558 {
+		yys1566Slc = r.DecodeBytes(yys1566Slc, true, true)
+		yys1566 := string(yys1566Slc)
+		switch yys1566 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -19267,21 +19327,21 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1561 := &x.ObjectMeta
-				yyv1561.CodecDecodeSelf(d)
+				yyv1569 := &x.ObjectMeta
+				yyv1569.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = PodStatus{}
 			} else {
-				yyv1562 := &x.Status
-				yyv1562.CodecDecodeSelf(d)
+				yyv1570 := &x.Status
+				yyv1570.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1558)
-		} // end switch yys1558
-	} // end for yyj1558
-	if !yyhl1558 {
+			z.DecStructFieldNotFound(-1, yys1566)
+		} // end switch yys1566
+	} // end for yyj1566
+	if !yyhl1566 {
 		r.ReadEnd()
 	}
 }
@@ -19290,16 +19350,16 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1563 int
-	var yyb1563 bool
-	var yyhl1563 bool = l >= 0
-	yyj1563++
-	if yyhl1563 {
-		yyb1563 = yyj1563 > l
+	var yyj1571 int
+	var yyb1571 bool
+	var yyhl1571 bool = l >= 0
+	yyj1571++
+	if yyhl1571 {
+		yyb1571 = yyj1571 > l
 	} else {
-		yyb1563 = r.CheckBreak()
+		yyb1571 = r.CheckBreak()
 	}
-	if yyb1563 {
+	if yyb1571 {
 		r.ReadEnd()
 		return
 	}
@@ -19308,13 +19368,13 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1563++
-	if yyhl1563 {
-		yyb1563 = yyj1563 > l
+	yyj1571++
+	if yyhl1571 {
+		yyb1571 = yyj1571 > l
 	} else {
-		yyb1563 = r.CheckBreak()
+		yyb1571 = r.CheckBreak()
 	}
-	if yyb1563 {
+	if yyb1571 {
 		r.ReadEnd()
 		return
 	}
@@ -19323,49 +19383,49 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1563++
-	if yyhl1563 {
-		yyb1563 = yyj1563 > l
+	yyj1571++
+	if yyhl1571 {
+		yyb1571 = yyj1571 > l
 	} else {
-		yyb1563 = r.CheckBreak()
+		yyb1571 = r.CheckBreak()
 	}
-	if yyb1563 {
+	if yyb1571 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1566 := &x.ObjectMeta
-		yyv1566.CodecDecodeSelf(d)
+		yyv1574 := &x.ObjectMeta
+		yyv1574.CodecDecodeSelf(d)
 	}
-	yyj1563++
-	if yyhl1563 {
-		yyb1563 = yyj1563 > l
+	yyj1571++
+	if yyhl1571 {
+		yyb1571 = yyj1571 > l
 	} else {
-		yyb1563 = r.CheckBreak()
+		yyb1571 = r.CheckBreak()
 	}
-	if yyb1563 {
+	if yyb1571 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = PodStatus{}
 	} else {
-		yyv1567 := &x.Status
-		yyv1567.CodecDecodeSelf(d)
+		yyv1575 := &x.Status
+		yyv1575.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1563++
-		if yyhl1563 {
-			yyb1563 = yyj1563 > l
+		yyj1571++
+		if yyhl1571 {
+			yyb1571 = yyj1571 > l
 		} else {
-			yyb1563 = r.CheckBreak()
+			yyb1571 = r.CheckBreak()
 		}
-		if yyb1563 {
+		if yyb1571 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1563-1, "")
+		z.DecStructFieldNotFound(yyj1571-1, "")
 	}
 	r.ReadEnd()
 }
@@ -19377,36 +19437,36 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1568 := z.EncBinary()
-		_ = yym1568
+		yym1576 := z.EncBinary()
+		_ = yym1576
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1569 := !z.EncBinary()
-			yy2arr1569 := z.EncBasicHandle().StructToArray
-			var yyq1569 [5]bool
-			_, _, _ = yysep1569, yyq1569, yy2arr1569
-			const yyr1569 bool = false
-			yyq1569[0] = x.Kind != ""
-			yyq1569[1] = x.APIVersion != ""
-			yyq1569[2] = true
-			yyq1569[3] = true
-			yyq1569[4] = true
-			if yyr1569 || yy2arr1569 {
+			yysep1577 := !z.EncBinary()
+			yy2arr1577 := z.EncBasicHandle().StructToArray
+			var yyq1577 [5]bool
+			_, _, _ = yysep1577, yyq1577, yy2arr1577
+			const yyr1577 bool = false
+			yyq1577[0] = x.Kind != ""
+			yyq1577[1] = x.APIVersion != ""
+			yyq1577[2] = true
+			yyq1577[3] = true
+			yyq1577[4] = true
+			if yyr1577 || yy2arr1577 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1569 int = 0
-				for _, b := range yyq1569 {
+				var yynn1577 int = 0
+				for _, b := range yyq1577 {
 					if b {
-						yynn1569++
+						yynn1577++
 					}
 				}
-				r.EncodeMapStart(yynn1569)
+				r.EncodeMapStart(yynn1577)
 			}
-			if yyr1569 || yy2arr1569 {
-				if yyq1569[0] {
-					yym1571 := z.EncBinary()
-					_ = yym1571
+			if yyr1577 || yy2arr1577 {
+				if yyq1577[0] {
+					yym1579 := z.EncBinary()
+					_ = yym1579
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -19415,20 +19475,20 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1569[0] {
+				if yyq1577[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1572 := z.EncBinary()
-					_ = yym1572
+					yym1580 := z.EncBinary()
+					_ = yym1580
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1569 || yy2arr1569 {
-				if yyq1569[1] {
-					yym1574 := z.EncBinary()
-					_ = yym1574
+			if yyr1577 || yy2arr1577 {
+				if yyq1577[1] {
+					yym1582 := z.EncBinary()
+					_ = yym1582
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -19437,59 +19497,59 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1569[1] {
+				if yyq1577[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1575 := z.EncBinary()
-					_ = yym1575
+					yym1583 := z.EncBinary()
+					_ = yym1583
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1569 || yy2arr1569 {
-				if yyq1569[2] {
-					yy1577 := &x.ObjectMeta
-					yy1577.CodecEncodeSelf(e)
+			if yyr1577 || yy2arr1577 {
+				if yyq1577[2] {
+					yy1585 := &x.ObjectMeta
+					yy1585.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1569[2] {
+				if yyq1577[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1578 := &x.ObjectMeta
-					yy1578.CodecEncodeSelf(e)
+					yy1586 := &x.ObjectMeta
+					yy1586.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1569 || yy2arr1569 {
-				if yyq1569[3] {
-					yy1580 := &x.Spec
-					yy1580.CodecEncodeSelf(e)
+			if yyr1577 || yy2arr1577 {
+				if yyq1577[3] {
+					yy1588 := &x.Spec
+					yy1588.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1569[3] {
+				if yyq1577[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1581 := &x.Spec
-					yy1581.CodecEncodeSelf(e)
+					yy1589 := &x.Spec
+					yy1589.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1569 || yy2arr1569 {
-				if yyq1569[4] {
-					yy1583 := &x.Status
-					yy1583.CodecEncodeSelf(e)
+			if yyr1577 || yy2arr1577 {
+				if yyq1577[4] {
+					yy1591 := &x.Status
+					yy1591.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1569[4] {
+				if yyq1577[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy1584 := &x.Status
-					yy1584.CodecEncodeSelf(e)
+					yy1592 := &x.Status
+					yy1592.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1569 {
+			if yysep1577 {
 				r.EncodeEnd()
 			}
 		}
@@ -19500,24 +19560,24 @@ func (x *Pod) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1585 := z.DecBinary()
-	_ = yym1585
+	yym1593 := z.DecBinary()
+	_ = yym1593
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1586 := r.ReadMapStart()
-			if yyl1586 == 0 {
+			yyl1594 := r.ReadMapStart()
+			if yyl1594 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1586, d)
+				x.codecDecodeSelfFromMap(yyl1594, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1586 := r.ReadArrayStart()
-			if yyl1586 == 0 {
+			yyl1594 := r.ReadArrayStart()
+			if yyl1594 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1586, d)
+				x.codecDecodeSelfFromArray(yyl1594, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -19529,12 +19589,12 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1587Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1587Slc
-	var yyhl1587 bool = l >= 0
-	for yyj1587 := 0; ; yyj1587++ {
-		if yyhl1587 {
-			if yyj1587 >= l {
+	var yys1595Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1595Slc
+	var yyhl1595 bool = l >= 0
+	for yyj1595 := 0; ; yyj1595++ {
+		if yyhl1595 {
+			if yyj1595 >= l {
 				break
 			}
 		} else {
@@ -19542,9 +19602,9 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1587Slc = r.DecodeBytes(yys1587Slc, true, true)
-		yys1587 := string(yys1587Slc)
-		switch yys1587 {
+		yys1595Slc = r.DecodeBytes(yys1595Slc, true, true)
+		yys1595 := string(yys1595Slc)
+		switch yys1595 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -19561,28 +19621,28 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1590 := &x.ObjectMeta
-				yyv1590.CodecDecodeSelf(d)
+				yyv1598 := &x.ObjectMeta
+				yyv1598.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = PodSpec{}
 			} else {
-				yyv1591 := &x.Spec
-				yyv1591.CodecDecodeSelf(d)
+				yyv1599 := &x.Spec
+				yyv1599.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = PodStatus{}
 			} else {
-				yyv1592 := &x.Status
-				yyv1592.CodecDecodeSelf(d)
+				yyv1600 := &x.Status
+				yyv1600.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1587)
-		} // end switch yys1587
-	} // end for yyj1587
-	if !yyhl1587 {
+			z.DecStructFieldNotFound(-1, yys1595)
+		} // end switch yys1595
+	} // end for yyj1595
+	if !yyhl1595 {
 		r.ReadEnd()
 	}
 }
@@ -19591,16 +19651,16 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1593 int
-	var yyb1593 bool
-	var yyhl1593 bool = l >= 0
-	yyj1593++
-	if yyhl1593 {
-		yyb1593 = yyj1593 > l
+	var yyj1601 int
+	var yyb1601 bool
+	var yyhl1601 bool = l >= 0
+	yyj1601++
+	if yyhl1601 {
+		yyb1601 = yyj1601 > l
 	} else {
-		yyb1593 = r.CheckBreak()
+		yyb1601 = r.CheckBreak()
 	}
-	if yyb1593 {
+	if yyb1601 {
 		r.ReadEnd()
 		return
 	}
@@ -19609,13 +19669,13 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1593++
-	if yyhl1593 {
-		yyb1593 = yyj1593 > l
+	yyj1601++
+	if yyhl1601 {
+		yyb1601 = yyj1601 > l
 	} else {
-		yyb1593 = r.CheckBreak()
+		yyb1601 = r.CheckBreak()
 	}
-	if yyb1593 {
+	if yyb1601 {
 		r.ReadEnd()
 		return
 	}
@@ -19624,65 +19684,65 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1593++
-	if yyhl1593 {
-		yyb1593 = yyj1593 > l
+	yyj1601++
+	if yyhl1601 {
+		yyb1601 = yyj1601 > l
 	} else {
-		yyb1593 = r.CheckBreak()
+		yyb1601 = r.CheckBreak()
 	}
-	if yyb1593 {
+	if yyb1601 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1596 := &x.ObjectMeta
-		yyv1596.CodecDecodeSelf(d)
+		yyv1604 := &x.ObjectMeta
+		yyv1604.CodecDecodeSelf(d)
 	}
-	yyj1593++
-	if yyhl1593 {
-		yyb1593 = yyj1593 > l
+	yyj1601++
+	if yyhl1601 {
+		yyb1601 = yyj1601 > l
 	} else {
-		yyb1593 = r.CheckBreak()
+		yyb1601 = r.CheckBreak()
 	}
-	if yyb1593 {
+	if yyb1601 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSpec{}
 	} else {
-		yyv1597 := &x.Spec
-		yyv1597.CodecDecodeSelf(d)
+		yyv1605 := &x.Spec
+		yyv1605.CodecDecodeSelf(d)
 	}
-	yyj1593++
-	if yyhl1593 {
-		yyb1593 = yyj1593 > l
+	yyj1601++
+	if yyhl1601 {
+		yyb1601 = yyj1601 > l
 	} else {
-		yyb1593 = r.CheckBreak()
+		yyb1601 = r.CheckBreak()
 	}
-	if yyb1593 {
+	if yyb1601 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = PodStatus{}
 	} else {
-		yyv1598 := &x.Status
-		yyv1598.CodecDecodeSelf(d)
+		yyv1606 := &x.Status
+		yyv1606.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1593++
-		if yyhl1593 {
-			yyb1593 = yyj1593 > l
+		yyj1601++
+		if yyhl1601 {
+			yyb1601 = yyj1601 > l
 		} else {
-			yyb1593 = r.CheckBreak()
+			yyb1601 = r.CheckBreak()
 		}
-		if yyb1593 {
+		if yyb1601 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1593-1, "")
+		z.DecStructFieldNotFound(yyj1601-1, "")
 	}
 	r.ReadEnd()
 }
@@ -19694,34 +19754,34 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1599 := z.EncBinary()
-		_ = yym1599
+		yym1607 := z.EncBinary()
+		_ = yym1607
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1600 := !z.EncBinary()
-			yy2arr1600 := z.EncBasicHandle().StructToArray
-			var yyq1600 [4]bool
-			_, _, _ = yysep1600, yyq1600, yy2arr1600
-			const yyr1600 bool = false
-			yyq1600[0] = x.Kind != ""
-			yyq1600[1] = x.APIVersion != ""
-			yyq1600[2] = true
-			if yyr1600 || yy2arr1600 {
+			yysep1608 := !z.EncBinary()
+			yy2arr1608 := z.EncBasicHandle().StructToArray
+			var yyq1608 [4]bool
+			_, _, _ = yysep1608, yyq1608, yy2arr1608
+			const yyr1608 bool = false
+			yyq1608[0] = x.Kind != ""
+			yyq1608[1] = x.APIVersion != ""
+			yyq1608[2] = true
+			if yyr1608 || yy2arr1608 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1600 int = 1
-				for _, b := range yyq1600 {
+				var yynn1608 int = 1
+				for _, b := range yyq1608 {
 					if b {
-						yynn1600++
+						yynn1608++
 					}
 				}
-				r.EncodeMapStart(yynn1600)
+				r.EncodeMapStart(yynn1608)
 			}
-			if yyr1600 || yy2arr1600 {
-				if yyq1600[0] {
-					yym1602 := z.EncBinary()
-					_ = yym1602
+			if yyr1608 || yy2arr1608 {
+				if yyq1608[0] {
+					yym1610 := z.EncBinary()
+					_ = yym1610
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -19730,70 +19790,70 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1600[0] {
+				if yyq1608[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1603 := z.EncBinary()
-					_ = yym1603
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1600 || yy2arr1600 {
-				if yyq1600[1] {
-					yym1605 := z.EncBinary()
-					_ = yym1605
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1600[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1606 := z.EncBinary()
-					_ = yym1606
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1600 || yy2arr1600 {
-				if yyq1600[2] {
-					yy1608 := &x.ListMeta
-					yym1609 := z.EncBinary()
-					_ = yym1609
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1608) {
-					} else {
-						z.EncFallback(yy1608)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1600[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1610 := &x.ListMeta
 					yym1611 := z.EncBinary()
 					_ = yym1611
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1610) {
 					} else {
-						z.EncFallback(yy1610)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1600 || yy2arr1600 {
+			if yyr1608 || yy2arr1608 {
+				if yyq1608[1] {
+					yym1613 := z.EncBinary()
+					_ = yym1613
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1608[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1614 := z.EncBinary()
+					_ = yym1614
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1608 || yy2arr1608 {
+				if yyq1608[2] {
+					yy1616 := &x.ListMeta
+					yym1617 := z.EncBinary()
+					_ = yym1617
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1616) {
+					} else {
+						z.EncFallback(yy1616)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1608[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1618 := &x.ListMeta
+					yym1619 := z.EncBinary()
+					_ = yym1619
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1618) {
+					} else {
+						z.EncFallback(yy1618)
+					}
+				}
+			}
+			if yyr1608 || yy2arr1608 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1613 := z.EncBinary()
-					_ = yym1613
+					yym1621 := z.EncBinary()
+					_ = yym1621
 					if false {
 					} else {
 						h.encSlicePod(([]Pod)(x.Items), e)
@@ -19804,15 +19864,15 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1614 := z.EncBinary()
-					_ = yym1614
+					yym1622 := z.EncBinary()
+					_ = yym1622
 					if false {
 					} else {
 						h.encSlicePod(([]Pod)(x.Items), e)
 					}
 				}
 			}
-			if yysep1600 {
+			if yysep1608 {
 				r.EncodeEnd()
 			}
 		}
@@ -19823,24 +19883,24 @@ func (x *PodList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1615 := z.DecBinary()
-	_ = yym1615
+	yym1623 := z.DecBinary()
+	_ = yym1623
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1616 := r.ReadMapStart()
-			if yyl1616 == 0 {
+			yyl1624 := r.ReadMapStart()
+			if yyl1624 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1616, d)
+				x.codecDecodeSelfFromMap(yyl1624, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1616 := r.ReadArrayStart()
-			if yyl1616 == 0 {
+			yyl1624 := r.ReadArrayStart()
+			if yyl1624 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1616, d)
+				x.codecDecodeSelfFromArray(yyl1624, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -19852,12 +19912,12 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1617Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1617Slc
-	var yyhl1617 bool = l >= 0
-	for yyj1617 := 0; ; yyj1617++ {
-		if yyhl1617 {
-			if yyj1617 >= l {
+	var yys1625Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1625Slc
+	var yyhl1625 bool = l >= 0
+	for yyj1625 := 0; ; yyj1625++ {
+		if yyhl1625 {
+			if yyj1625 >= l {
 				break
 			}
 		} else {
@@ -19865,9 +19925,9 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1617Slc = r.DecodeBytes(yys1617Slc, true, true)
-		yys1617 := string(yys1617Slc)
-		switch yys1617 {
+		yys1625Slc = r.DecodeBytes(yys1625Slc, true, true)
+		yys1625 := string(yys1625Slc)
+		switch yys1625 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -19884,32 +19944,32 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv1620 := &x.ListMeta
-				yym1621 := z.DecBinary()
-				_ = yym1621
+				yyv1628 := &x.ListMeta
+				yym1629 := z.DecBinary()
+				_ = yym1629
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1620) {
+				} else if z.HasExtensions() && z.DecExt(yyv1628) {
 				} else {
-					z.DecFallback(yyv1620, false)
+					z.DecFallback(yyv1628, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1622 := &x.Items
-				yym1623 := z.DecBinary()
-				_ = yym1623
+				yyv1630 := &x.Items
+				yym1631 := z.DecBinary()
+				_ = yym1631
 				if false {
 				} else {
-					h.decSlicePod((*[]Pod)(yyv1622), d)
+					h.decSlicePod((*[]Pod)(yyv1630), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1617)
-		} // end switch yys1617
-	} // end for yyj1617
-	if !yyhl1617 {
+			z.DecStructFieldNotFound(-1, yys1625)
+		} // end switch yys1625
+	} // end for yyj1625
+	if !yyhl1625 {
 		r.ReadEnd()
 	}
 }
@@ -19918,16 +19978,16 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1624 int
-	var yyb1624 bool
-	var yyhl1624 bool = l >= 0
-	yyj1624++
-	if yyhl1624 {
-		yyb1624 = yyj1624 > l
+	var yyj1632 int
+	var yyb1632 bool
+	var yyhl1632 bool = l >= 0
+	yyj1632++
+	if yyhl1632 {
+		yyb1632 = yyj1632 > l
 	} else {
-		yyb1624 = r.CheckBreak()
+		yyb1632 = r.CheckBreak()
 	}
-	if yyb1624 {
+	if yyb1632 {
 		r.ReadEnd()
 		return
 	}
@@ -19936,13 +19996,13 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1624++
-	if yyhl1624 {
-		yyb1624 = yyj1624 > l
+	yyj1632++
+	if yyhl1632 {
+		yyb1632 = yyj1632 > l
 	} else {
-		yyb1624 = r.CheckBreak()
+		yyb1632 = r.CheckBreak()
 	}
-	if yyb1624 {
+	if yyb1632 {
 		r.ReadEnd()
 		return
 	}
@@ -19951,60 +20011,60 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1624++
-	if yyhl1624 {
-		yyb1624 = yyj1624 > l
+	yyj1632++
+	if yyhl1632 {
+		yyb1632 = yyj1632 > l
 	} else {
-		yyb1624 = r.CheckBreak()
+		yyb1632 = r.CheckBreak()
 	}
-	if yyb1624 {
+	if yyb1632 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv1627 := &x.ListMeta
-		yym1628 := z.DecBinary()
-		_ = yym1628
+		yyv1635 := &x.ListMeta
+		yym1636 := z.DecBinary()
+		_ = yym1636
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1627) {
+		} else if z.HasExtensions() && z.DecExt(yyv1635) {
 		} else {
-			z.DecFallback(yyv1627, false)
+			z.DecFallback(yyv1635, false)
 		}
 	}
-	yyj1624++
-	if yyhl1624 {
-		yyb1624 = yyj1624 > l
+	yyj1632++
+	if yyhl1632 {
+		yyb1632 = yyj1632 > l
 	} else {
-		yyb1624 = r.CheckBreak()
+		yyb1632 = r.CheckBreak()
 	}
-	if yyb1624 {
+	if yyb1632 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1629 := &x.Items
-		yym1630 := z.DecBinary()
-		_ = yym1630
+		yyv1637 := &x.Items
+		yym1638 := z.DecBinary()
+		_ = yym1638
 		if false {
 		} else {
-			h.decSlicePod((*[]Pod)(yyv1629), d)
+			h.decSlicePod((*[]Pod)(yyv1637), d)
 		}
 	}
 	for {
-		yyj1624++
-		if yyhl1624 {
-			yyb1624 = yyj1624 > l
+		yyj1632++
+		if yyhl1632 {
+			yyb1632 = yyj1632 > l
 		} else {
-			yyb1624 = r.CheckBreak()
+			yyb1632 = r.CheckBreak()
 		}
-		if yyb1624 {
+		if yyb1632 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1624-1, "")
+		z.DecStructFieldNotFound(yyj1632-1, "")
 	}
 	r.ReadEnd()
 }
@@ -20016,58 +20076,58 @@ func (x *PodTemplateSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1631 := z.EncBinary()
-		_ = yym1631
+		yym1639 := z.EncBinary()
+		_ = yym1639
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1632 := !z.EncBinary()
-			yy2arr1632 := z.EncBasicHandle().StructToArray
-			var yyq1632 [2]bool
-			_, _, _ = yysep1632, yyq1632, yy2arr1632
-			const yyr1632 bool = false
-			yyq1632[0] = true
-			yyq1632[1] = true
-			if yyr1632 || yy2arr1632 {
+			yysep1640 := !z.EncBinary()
+			yy2arr1640 := z.EncBasicHandle().StructToArray
+			var yyq1640 [2]bool
+			_, _, _ = yysep1640, yyq1640, yy2arr1640
+			const yyr1640 bool = false
+			yyq1640[0] = true
+			yyq1640[1] = true
+			if yyr1640 || yy2arr1640 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1632 int = 0
-				for _, b := range yyq1632 {
+				var yynn1640 int = 0
+				for _, b := range yyq1640 {
 					if b {
-						yynn1632++
+						yynn1640++
 					}
 				}
-				r.EncodeMapStart(yynn1632)
+				r.EncodeMapStart(yynn1640)
 			}
-			if yyr1632 || yy2arr1632 {
-				if yyq1632[0] {
-					yy1634 := &x.ObjectMeta
-					yy1634.CodecEncodeSelf(e)
+			if yyr1640 || yy2arr1640 {
+				if yyq1640[0] {
+					yy1642 := &x.ObjectMeta
+					yy1642.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1632[0] {
+				if yyq1640[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1635 := &x.ObjectMeta
-					yy1635.CodecEncodeSelf(e)
+					yy1643 := &x.ObjectMeta
+					yy1643.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1632 || yy2arr1632 {
-				if yyq1632[1] {
-					yy1637 := &x.Spec
-					yy1637.CodecEncodeSelf(e)
+			if yyr1640 || yy2arr1640 {
+				if yyq1640[1] {
+					yy1645 := &x.Spec
+					yy1645.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1632[1] {
+				if yyq1640[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1638 := &x.Spec
-					yy1638.CodecEncodeSelf(e)
+					yy1646 := &x.Spec
+					yy1646.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1632 {
+			if yysep1640 {
 				r.EncodeEnd()
 			}
 		}
@@ -20078,24 +20138,24 @@ func (x *PodTemplateSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1639 := z.DecBinary()
-	_ = yym1639
+	yym1647 := z.DecBinary()
+	_ = yym1647
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1640 := r.ReadMapStart()
-			if yyl1640 == 0 {
+			yyl1648 := r.ReadMapStart()
+			if yyl1648 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1640, d)
+				x.codecDecodeSelfFromMap(yyl1648, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1640 := r.ReadArrayStart()
-			if yyl1640 == 0 {
+			yyl1648 := r.ReadArrayStart()
+			if yyl1648 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1640, d)
+				x.codecDecodeSelfFromArray(yyl1648, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -20107,12 +20167,12 @@ func (x *PodTemplateSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1641Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1641Slc
-	var yyhl1641 bool = l >= 0
-	for yyj1641 := 0; ; yyj1641++ {
-		if yyhl1641 {
-			if yyj1641 >= l {
+	var yys1649Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1649Slc
+	var yyhl1649 bool = l >= 0
+	for yyj1649 := 0; ; yyj1649++ {
+		if yyhl1649 {
+			if yyj1649 >= l {
 				break
 			}
 		} else {
@@ -20120,28 +20180,28 @@ func (x *PodTemplateSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1641Slc = r.DecodeBytes(yys1641Slc, true, true)
-		yys1641 := string(yys1641Slc)
-		switch yys1641 {
+		yys1649Slc = r.DecodeBytes(yys1649Slc, true, true)
+		yys1649 := string(yys1649Slc)
+		switch yys1649 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1642 := &x.ObjectMeta
-				yyv1642.CodecDecodeSelf(d)
+				yyv1650 := &x.ObjectMeta
+				yyv1650.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = PodSpec{}
 			} else {
-				yyv1643 := &x.Spec
-				yyv1643.CodecDecodeSelf(d)
+				yyv1651 := &x.Spec
+				yyv1651.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1641)
-		} // end switch yys1641
-	} // end for yyj1641
-	if !yyhl1641 {
+			z.DecStructFieldNotFound(-1, yys1649)
+		} // end switch yys1649
+	} // end for yyj1649
+	if !yyhl1649 {
 		r.ReadEnd()
 	}
 }
@@ -20150,52 +20210,52 @@ func (x *PodTemplateSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1644 int
-	var yyb1644 bool
-	var yyhl1644 bool = l >= 0
-	yyj1644++
-	if yyhl1644 {
-		yyb1644 = yyj1644 > l
+	var yyj1652 int
+	var yyb1652 bool
+	var yyhl1652 bool = l >= 0
+	yyj1652++
+	if yyhl1652 {
+		yyb1652 = yyj1652 > l
 	} else {
-		yyb1644 = r.CheckBreak()
+		yyb1652 = r.CheckBreak()
 	}
-	if yyb1644 {
+	if yyb1652 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1645 := &x.ObjectMeta
-		yyv1645.CodecDecodeSelf(d)
+		yyv1653 := &x.ObjectMeta
+		yyv1653.CodecDecodeSelf(d)
 	}
-	yyj1644++
-	if yyhl1644 {
-		yyb1644 = yyj1644 > l
+	yyj1652++
+	if yyhl1652 {
+		yyb1652 = yyj1652 > l
 	} else {
-		yyb1644 = r.CheckBreak()
+		yyb1652 = r.CheckBreak()
 	}
-	if yyb1644 {
+	if yyb1652 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSpec{}
 	} else {
-		yyv1646 := &x.Spec
-		yyv1646.CodecDecodeSelf(d)
+		yyv1654 := &x.Spec
+		yyv1654.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1644++
-		if yyhl1644 {
-			yyb1644 = yyj1644 > l
+		yyj1652++
+		if yyhl1652 {
+			yyb1652 = yyj1652 > l
 		} else {
-			yyb1644 = r.CheckBreak()
+			yyb1652 = r.CheckBreak()
 		}
-		if yyb1644 {
+		if yyb1652 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1644-1, "")
+		z.DecStructFieldNotFound(yyj1652-1, "")
 	}
 	r.ReadEnd()
 }
@@ -20207,35 +20267,35 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1647 := z.EncBinary()
-		_ = yym1647
+		yym1655 := z.EncBinary()
+		_ = yym1655
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1648 := !z.EncBinary()
-			yy2arr1648 := z.EncBasicHandle().StructToArray
-			var yyq1648 [4]bool
-			_, _, _ = yysep1648, yyq1648, yy2arr1648
-			const yyr1648 bool = false
-			yyq1648[0] = x.Kind != ""
-			yyq1648[1] = x.APIVersion != ""
-			yyq1648[2] = true
-			yyq1648[3] = true
-			if yyr1648 || yy2arr1648 {
+			yysep1656 := !z.EncBinary()
+			yy2arr1656 := z.EncBasicHandle().StructToArray
+			var yyq1656 [4]bool
+			_, _, _ = yysep1656, yyq1656, yy2arr1656
+			const yyr1656 bool = false
+			yyq1656[0] = x.Kind != ""
+			yyq1656[1] = x.APIVersion != ""
+			yyq1656[2] = true
+			yyq1656[3] = true
+			if yyr1656 || yy2arr1656 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1648 int = 0
-				for _, b := range yyq1648 {
+				var yynn1656 int = 0
+				for _, b := range yyq1656 {
 					if b {
-						yynn1648++
+						yynn1656++
 					}
 				}
-				r.EncodeMapStart(yynn1648)
+				r.EncodeMapStart(yynn1656)
 			}
-			if yyr1648 || yy2arr1648 {
-				if yyq1648[0] {
-					yym1650 := z.EncBinary()
-					_ = yym1650
+			if yyr1656 || yy2arr1656 {
+				if yyq1656[0] {
+					yym1658 := z.EncBinary()
+					_ = yym1658
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -20244,20 +20304,20 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1648[0] {
+				if yyq1656[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1651 := z.EncBinary()
-					_ = yym1651
+					yym1659 := z.EncBinary()
+					_ = yym1659
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1648 || yy2arr1648 {
-				if yyq1648[1] {
-					yym1653 := z.EncBinary()
-					_ = yym1653
+			if yyr1656 || yy2arr1656 {
+				if yyq1656[1] {
+					yym1661 := z.EncBinary()
+					_ = yym1661
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -20266,45 +20326,45 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1648[1] {
+				if yyq1656[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1654 := z.EncBinary()
-					_ = yym1654
+					yym1662 := z.EncBinary()
+					_ = yym1662
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1648 || yy2arr1648 {
-				if yyq1648[2] {
-					yy1656 := &x.ObjectMeta
-					yy1656.CodecEncodeSelf(e)
+			if yyr1656 || yy2arr1656 {
+				if yyq1656[2] {
+					yy1664 := &x.ObjectMeta
+					yy1664.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1648[2] {
+				if yyq1656[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1657 := &x.ObjectMeta
-					yy1657.CodecEncodeSelf(e)
+					yy1665 := &x.ObjectMeta
+					yy1665.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1648 || yy2arr1648 {
-				if yyq1648[3] {
-					yy1659 := &x.Template
-					yy1659.CodecEncodeSelf(e)
+			if yyr1656 || yy2arr1656 {
+				if yyq1656[3] {
+					yy1667 := &x.Template
+					yy1667.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1648[3] {
+				if yyq1656[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
-					yy1660 := &x.Template
-					yy1660.CodecEncodeSelf(e)
+					yy1668 := &x.Template
+					yy1668.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1648 {
+			if yysep1656 {
 				r.EncodeEnd()
 			}
 		}
@@ -20315,24 +20375,24 @@ func (x *PodTemplate) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1661 := z.DecBinary()
-	_ = yym1661
+	yym1669 := z.DecBinary()
+	_ = yym1669
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1662 := r.ReadMapStart()
-			if yyl1662 == 0 {
+			yyl1670 := r.ReadMapStart()
+			if yyl1670 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1662, d)
+				x.codecDecodeSelfFromMap(yyl1670, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1662 := r.ReadArrayStart()
-			if yyl1662 == 0 {
+			yyl1670 := r.ReadArrayStart()
+			if yyl1670 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1662, d)
+				x.codecDecodeSelfFromArray(yyl1670, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -20344,12 +20404,12 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1663Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1663Slc
-	var yyhl1663 bool = l >= 0
-	for yyj1663 := 0; ; yyj1663++ {
-		if yyhl1663 {
-			if yyj1663 >= l {
+	var yys1671Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1671Slc
+	var yyhl1671 bool = l >= 0
+	for yyj1671 := 0; ; yyj1671++ {
+		if yyhl1671 {
+			if yyj1671 >= l {
 				break
 			}
 		} else {
@@ -20357,9 +20417,9 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1663Slc = r.DecodeBytes(yys1663Slc, true, true)
-		yys1663 := string(yys1663Slc)
-		switch yys1663 {
+		yys1671Slc = r.DecodeBytes(yys1671Slc, true, true)
+		yys1671 := string(yys1671Slc)
+		switch yys1671 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -20376,21 +20436,21 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1666 := &x.ObjectMeta
-				yyv1666.CodecDecodeSelf(d)
+				yyv1674 := &x.ObjectMeta
+				yyv1674.CodecDecodeSelf(d)
 			}
 		case "template":
 			if r.TryDecodeAsNil() {
 				x.Template = PodTemplateSpec{}
 			} else {
-				yyv1667 := &x.Template
-				yyv1667.CodecDecodeSelf(d)
+				yyv1675 := &x.Template
+				yyv1675.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1663)
-		} // end switch yys1663
-	} // end for yyj1663
-	if !yyhl1663 {
+			z.DecStructFieldNotFound(-1, yys1671)
+		} // end switch yys1671
+	} // end for yyj1671
+	if !yyhl1671 {
 		r.ReadEnd()
 	}
 }
@@ -20399,16 +20459,16 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1668 int
-	var yyb1668 bool
-	var yyhl1668 bool = l >= 0
-	yyj1668++
-	if yyhl1668 {
-		yyb1668 = yyj1668 > l
+	var yyj1676 int
+	var yyb1676 bool
+	var yyhl1676 bool = l >= 0
+	yyj1676++
+	if yyhl1676 {
+		yyb1676 = yyj1676 > l
 	} else {
-		yyb1668 = r.CheckBreak()
+		yyb1676 = r.CheckBreak()
 	}
-	if yyb1668 {
+	if yyb1676 {
 		r.ReadEnd()
 		return
 	}
@@ -20417,13 +20477,13 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1668++
-	if yyhl1668 {
-		yyb1668 = yyj1668 > l
+	yyj1676++
+	if yyhl1676 {
+		yyb1676 = yyj1676 > l
 	} else {
-		yyb1668 = r.CheckBreak()
+		yyb1676 = r.CheckBreak()
 	}
-	if yyb1668 {
+	if yyb1676 {
 		r.ReadEnd()
 		return
 	}
@@ -20432,49 +20492,49 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1668++
-	if yyhl1668 {
-		yyb1668 = yyj1668 > l
+	yyj1676++
+	if yyhl1676 {
+		yyb1676 = yyj1676 > l
 	} else {
-		yyb1668 = r.CheckBreak()
+		yyb1676 = r.CheckBreak()
 	}
-	if yyb1668 {
+	if yyb1676 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1671 := &x.ObjectMeta
-		yyv1671.CodecDecodeSelf(d)
+		yyv1679 := &x.ObjectMeta
+		yyv1679.CodecDecodeSelf(d)
 	}
-	yyj1668++
-	if yyhl1668 {
-		yyb1668 = yyj1668 > l
+	yyj1676++
+	if yyhl1676 {
+		yyb1676 = yyj1676 > l
 	} else {
-		yyb1668 = r.CheckBreak()
+		yyb1676 = r.CheckBreak()
 	}
-	if yyb1668 {
+	if yyb1676 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = PodTemplateSpec{}
 	} else {
-		yyv1672 := &x.Template
-		yyv1672.CodecDecodeSelf(d)
+		yyv1680 := &x.Template
+		yyv1680.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1668++
-		if yyhl1668 {
-			yyb1668 = yyj1668 > l
+		yyj1676++
+		if yyhl1676 {
+			yyb1676 = yyj1676 > l
 		} else {
-			yyb1668 = r.CheckBreak()
+			yyb1676 = r.CheckBreak()
 		}
-		if yyb1668 {
+		if yyb1676 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1668-1, "")
+		z.DecStructFieldNotFound(yyj1676-1, "")
 	}
 	r.ReadEnd()
 }
@@ -20486,34 +20546,34 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1673 := z.EncBinary()
-		_ = yym1673
+		yym1681 := z.EncBinary()
+		_ = yym1681
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1674 := !z.EncBinary()
-			yy2arr1674 := z.EncBasicHandle().StructToArray
-			var yyq1674 [4]bool
-			_, _, _ = yysep1674, yyq1674, yy2arr1674
-			const yyr1674 bool = false
-			yyq1674[0] = x.Kind != ""
-			yyq1674[1] = x.APIVersion != ""
-			yyq1674[2] = true
-			if yyr1674 || yy2arr1674 {
+			yysep1682 := !z.EncBinary()
+			yy2arr1682 := z.EncBasicHandle().StructToArray
+			var yyq1682 [4]bool
+			_, _, _ = yysep1682, yyq1682, yy2arr1682
+			const yyr1682 bool = false
+			yyq1682[0] = x.Kind != ""
+			yyq1682[1] = x.APIVersion != ""
+			yyq1682[2] = true
+			if yyr1682 || yy2arr1682 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1674 int = 1
-				for _, b := range yyq1674 {
+				var yynn1682 int = 1
+				for _, b := range yyq1682 {
 					if b {
-						yynn1674++
+						yynn1682++
 					}
 				}
-				r.EncodeMapStart(yynn1674)
+				r.EncodeMapStart(yynn1682)
 			}
-			if yyr1674 || yy2arr1674 {
-				if yyq1674[0] {
-					yym1676 := z.EncBinary()
-					_ = yym1676
+			if yyr1682 || yy2arr1682 {
+				if yyq1682[0] {
+					yym1684 := z.EncBinary()
+					_ = yym1684
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -20522,70 +20582,70 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1674[0] {
+				if yyq1682[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1677 := z.EncBinary()
-					_ = yym1677
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1674 || yy2arr1674 {
-				if yyq1674[1] {
-					yym1679 := z.EncBinary()
-					_ = yym1679
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1674[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1680 := z.EncBinary()
-					_ = yym1680
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1674 || yy2arr1674 {
-				if yyq1674[2] {
-					yy1682 := &x.ListMeta
-					yym1683 := z.EncBinary()
-					_ = yym1683
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1682) {
-					} else {
-						z.EncFallback(yy1682)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1674[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1684 := &x.ListMeta
 					yym1685 := z.EncBinary()
 					_ = yym1685
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1684) {
 					} else {
-						z.EncFallback(yy1684)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1674 || yy2arr1674 {
+			if yyr1682 || yy2arr1682 {
+				if yyq1682[1] {
+					yym1687 := z.EncBinary()
+					_ = yym1687
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1682[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1688 := z.EncBinary()
+					_ = yym1688
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1682 || yy2arr1682 {
+				if yyq1682[2] {
+					yy1690 := &x.ListMeta
+					yym1691 := z.EncBinary()
+					_ = yym1691
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1690) {
+					} else {
+						z.EncFallback(yy1690)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1682[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1692 := &x.ListMeta
+					yym1693 := z.EncBinary()
+					_ = yym1693
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1692) {
+					} else {
+						z.EncFallback(yy1692)
+					}
+				}
+			}
+			if yyr1682 || yy2arr1682 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1687 := z.EncBinary()
-					_ = yym1687
+					yym1695 := z.EncBinary()
+					_ = yym1695
 					if false {
 					} else {
 						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
@@ -20596,15 +20656,15 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1688 := z.EncBinary()
-					_ = yym1688
+					yym1696 := z.EncBinary()
+					_ = yym1696
 					if false {
 					} else {
 						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
 					}
 				}
 			}
-			if yysep1674 {
+			if yysep1682 {
 				r.EncodeEnd()
 			}
 		}
@@ -20615,24 +20675,24 @@ func (x *PodTemplateList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1689 := z.DecBinary()
-	_ = yym1689
+	yym1697 := z.DecBinary()
+	_ = yym1697
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1690 := r.ReadMapStart()
-			if yyl1690 == 0 {
+			yyl1698 := r.ReadMapStart()
+			if yyl1698 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1690, d)
+				x.codecDecodeSelfFromMap(yyl1698, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1690 := r.ReadArrayStart()
-			if yyl1690 == 0 {
+			yyl1698 := r.ReadArrayStart()
+			if yyl1698 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1690, d)
+				x.codecDecodeSelfFromArray(yyl1698, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -20644,12 +20704,12 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1691Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1691Slc
-	var yyhl1691 bool = l >= 0
-	for yyj1691 := 0; ; yyj1691++ {
-		if yyhl1691 {
-			if yyj1691 >= l {
+	var yys1699Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1699Slc
+	var yyhl1699 bool = l >= 0
+	for yyj1699 := 0; ; yyj1699++ {
+		if yyhl1699 {
+			if yyj1699 >= l {
 				break
 			}
 		} else {
@@ -20657,9 +20717,9 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1691Slc = r.DecodeBytes(yys1691Slc, true, true)
-		yys1691 := string(yys1691Slc)
-		switch yys1691 {
+		yys1699Slc = r.DecodeBytes(yys1699Slc, true, true)
+		yys1699 := string(yys1699Slc)
+		switch yys1699 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -20676,32 +20736,32 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv1694 := &x.ListMeta
-				yym1695 := z.DecBinary()
-				_ = yym1695
+				yyv1702 := &x.ListMeta
+				yym1703 := z.DecBinary()
+				_ = yym1703
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1694) {
+				} else if z.HasExtensions() && z.DecExt(yyv1702) {
 				} else {
-					z.DecFallback(yyv1694, false)
+					z.DecFallback(yyv1702, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1696 := &x.Items
-				yym1697 := z.DecBinary()
-				_ = yym1697
+				yyv1704 := &x.Items
+				yym1705 := z.DecBinary()
+				_ = yym1705
 				if false {
 				} else {
-					h.decSlicePodTemplate((*[]PodTemplate)(yyv1696), d)
+					h.decSlicePodTemplate((*[]PodTemplate)(yyv1704), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1691)
-		} // end switch yys1691
-	} // end for yyj1691
-	if !yyhl1691 {
+			z.DecStructFieldNotFound(-1, yys1699)
+		} // end switch yys1699
+	} // end for yyj1699
+	if !yyhl1699 {
 		r.ReadEnd()
 	}
 }
@@ -20710,16 +20770,16 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1698 int
-	var yyb1698 bool
-	var yyhl1698 bool = l >= 0
-	yyj1698++
-	if yyhl1698 {
-		yyb1698 = yyj1698 > l
+	var yyj1706 int
+	var yyb1706 bool
+	var yyhl1706 bool = l >= 0
+	yyj1706++
+	if yyhl1706 {
+		yyb1706 = yyj1706 > l
 	} else {
-		yyb1698 = r.CheckBreak()
+		yyb1706 = r.CheckBreak()
 	}
-	if yyb1698 {
+	if yyb1706 {
 		r.ReadEnd()
 		return
 	}
@@ -20728,13 +20788,13 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1698++
-	if yyhl1698 {
-		yyb1698 = yyj1698 > l
+	yyj1706++
+	if yyhl1706 {
+		yyb1706 = yyj1706 > l
 	} else {
-		yyb1698 = r.CheckBreak()
+		yyb1706 = r.CheckBreak()
 	}
-	if yyb1698 {
+	if yyb1706 {
 		r.ReadEnd()
 		return
 	}
@@ -20743,60 +20803,60 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1698++
-	if yyhl1698 {
-		yyb1698 = yyj1698 > l
+	yyj1706++
+	if yyhl1706 {
+		yyb1706 = yyj1706 > l
 	} else {
-		yyb1698 = r.CheckBreak()
+		yyb1706 = r.CheckBreak()
 	}
-	if yyb1698 {
+	if yyb1706 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv1701 := &x.ListMeta
-		yym1702 := z.DecBinary()
-		_ = yym1702
+		yyv1709 := &x.ListMeta
+		yym1710 := z.DecBinary()
+		_ = yym1710
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1701) {
+		} else if z.HasExtensions() && z.DecExt(yyv1709) {
 		} else {
-			z.DecFallback(yyv1701, false)
+			z.DecFallback(yyv1709, false)
 		}
 	}
-	yyj1698++
-	if yyhl1698 {
-		yyb1698 = yyj1698 > l
+	yyj1706++
+	if yyhl1706 {
+		yyb1706 = yyj1706 > l
 	} else {
-		yyb1698 = r.CheckBreak()
+		yyb1706 = r.CheckBreak()
 	}
-	if yyb1698 {
+	if yyb1706 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1703 := &x.Items
-		yym1704 := z.DecBinary()
-		_ = yym1704
+		yyv1711 := &x.Items
+		yym1712 := z.DecBinary()
+		_ = yym1712
 		if false {
 		} else {
-			h.decSlicePodTemplate((*[]PodTemplate)(yyv1703), d)
+			h.decSlicePodTemplate((*[]PodTemplate)(yyv1711), d)
 		}
 	}
 	for {
-		yyj1698++
-		if yyhl1698 {
-			yyb1698 = yyj1698 > l
+		yyj1706++
+		if yyhl1706 {
+			yyb1706 = yyj1706 > l
 		} else {
-			yyb1698 = r.CheckBreak()
+			yyb1706 = r.CheckBreak()
 		}
-		if yyb1698 {
+		if yyb1706 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1698-1, "")
+		z.DecStructFieldNotFound(yyj1706-1, "")
 	}
 	r.ReadEnd()
 }
@@ -20808,69 +20868,69 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1705 := z.EncBinary()
-		_ = yym1705
+		yym1713 := z.EncBinary()
+		_ = yym1713
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1706 := !z.EncBinary()
-			yy2arr1706 := z.EncBasicHandle().StructToArray
-			var yyq1706 [3]bool
-			_, _, _ = yysep1706, yyq1706, yy2arr1706
-			const yyr1706 bool = false
-			yyq1706[0] = x.Replicas != nil
-			yyq1706[1] = len(x.Selector) != 0
-			yyq1706[2] = x.Template != nil
-			if yyr1706 || yy2arr1706 {
+			yysep1714 := !z.EncBinary()
+			yy2arr1714 := z.EncBasicHandle().StructToArray
+			var yyq1714 [3]bool
+			_, _, _ = yysep1714, yyq1714, yy2arr1714
+			const yyr1714 bool = false
+			yyq1714[0] = x.Replicas != nil
+			yyq1714[1] = len(x.Selector) != 0
+			yyq1714[2] = x.Template != nil
+			if yyr1714 || yy2arr1714 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1706 int = 0
-				for _, b := range yyq1706 {
+				var yynn1714 int = 0
+				for _, b := range yyq1714 {
 					if b {
-						yynn1706++
+						yynn1714++
 					}
 				}
-				r.EncodeMapStart(yynn1706)
+				r.EncodeMapStart(yynn1714)
 			}
-			if yyr1706 || yy2arr1706 {
-				if yyq1706[0] {
+			if yyr1714 || yy2arr1714 {
+				if yyq1714[0] {
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
-						yy1708 := *x.Replicas
-						yym1709 := z.EncBinary()
-						_ = yym1709
+						yy1716 := *x.Replicas
+						yym1717 := z.EncBinary()
+						_ = yym1717
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1708))
+							r.EncodeInt(int64(yy1716))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1706[0] {
+				if yyq1714[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
-						yy1710 := *x.Replicas
-						yym1711 := z.EncBinary()
-						_ = yym1711
+						yy1718 := *x.Replicas
+						yym1719 := z.EncBinary()
+						_ = yym1719
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1710))
+							r.EncodeInt(int64(yy1718))
 						}
 					}
 				}
 			}
-			if yyr1706 || yy2arr1706 {
-				if yyq1706[1] {
+			if yyr1714 || yy2arr1714 {
+				if yyq1714[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym1713 := z.EncBinary()
-						_ = yym1713
+						yym1721 := z.EncBinary()
+						_ = yym1721
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -20880,13 +20940,13 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1706[1] {
+				if yyq1714[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym1714 := z.EncBinary()
-						_ = yym1714
+						yym1722 := z.EncBinary()
+						_ = yym1722
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -20894,8 +20954,8 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1706 || yy2arr1706 {
-				if yyq1706[2] {
+			if yyr1714 || yy2arr1714 {
+				if yyq1714[2] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -20905,7 +20965,7 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1706[2] {
+				if yyq1714[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					if x.Template == nil {
 						r.EncodeNil()
@@ -20914,7 +20974,7 @@ func (x *ReplicationControllerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1706 {
+			if yysep1714 {
 				r.EncodeEnd()
 			}
 		}
@@ -20925,24 +20985,24 @@ func (x *ReplicationControllerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1716 := z.DecBinary()
-	_ = yym1716
+	yym1724 := z.DecBinary()
+	_ = yym1724
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1717 := r.ReadMapStart()
-			if yyl1717 == 0 {
+			yyl1725 := r.ReadMapStart()
+			if yyl1725 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1717, d)
+				x.codecDecodeSelfFromMap(yyl1725, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1717 := r.ReadArrayStart()
-			if yyl1717 == 0 {
+			yyl1725 := r.ReadArrayStart()
+			if yyl1725 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1717, d)
+				x.codecDecodeSelfFromArray(yyl1725, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -20954,12 +21014,12 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1718Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1718Slc
-	var yyhl1718 bool = l >= 0
-	for yyj1718 := 0; ; yyj1718++ {
-		if yyhl1718 {
-			if yyj1718 >= l {
+	var yys1726Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1726Slc
+	var yyhl1726 bool = l >= 0
+	for yyj1726 := 0; ; yyj1726++ {
+		if yyhl1726 {
+			if yyj1726 >= l {
 				break
 			}
 		} else {
@@ -20967,9 +21027,9 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
-		yys1718Slc = r.DecodeBytes(yys1718Slc, true, true)
-		yys1718 := string(yys1718Slc)
-		switch yys1718 {
+		yys1726Slc = r.DecodeBytes(yys1726Slc, true, true)
+		yys1726 := string(yys1726Slc)
+		switch yys1726 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				if x.Replicas != nil {
@@ -20979,8 +21039,8 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				if x.Replicas == nil {
 					x.Replicas = new(int)
 				}
-				yym1720 := z.DecBinary()
-				_ = yym1720
+				yym1728 := z.DecBinary()
+				_ = yym1728
 				if false {
 				} else {
 					*((*int)(x.Replicas)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -20990,12 +21050,12 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv1721 := &x.Selector
-				yym1722 := z.DecBinary()
-				_ = yym1722
+				yyv1729 := &x.Selector
+				yym1730 := z.DecBinary()
+				_ = yym1730
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1721, false, d)
+					z.F.DecMapStringStringX(yyv1729, false, d)
 				}
 			}
 		case "template":
@@ -21010,10 +21070,10 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromMap(l int, d *codec1978.D
 				x.Template.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1718)
-		} // end switch yys1718
-	} // end for yyj1718
-	if !yyhl1718 {
+			z.DecStructFieldNotFound(-1, yys1726)
+		} // end switch yys1726
+	} // end for yyj1726
+	if !yyhl1726 {
 		r.ReadEnd()
 	}
 }
@@ -21022,16 +21082,16 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1724 int
-	var yyb1724 bool
-	var yyhl1724 bool = l >= 0
-	yyj1724++
-	if yyhl1724 {
-		yyb1724 = yyj1724 > l
+	var yyj1732 int
+	var yyb1732 bool
+	var yyhl1732 bool = l >= 0
+	yyj1732++
+	if yyhl1732 {
+		yyb1732 = yyj1732 > l
 	} else {
-		yyb1724 = r.CheckBreak()
+		yyb1732 = r.CheckBreak()
 	}
-	if yyb1724 {
+	if yyb1732 {
 		r.ReadEnd()
 		return
 	}
@@ -21043,41 +21103,41 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		if x.Replicas == nil {
 			x.Replicas = new(int)
 		}
-		yym1726 := z.DecBinary()
-		_ = yym1726
+		yym1734 := z.DecBinary()
+		_ = yym1734
 		if false {
 		} else {
 			*((*int)(x.Replicas)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj1724++
-	if yyhl1724 {
-		yyb1724 = yyj1724 > l
+	yyj1732++
+	if yyhl1732 {
+		yyb1732 = yyj1732 > l
 	} else {
-		yyb1724 = r.CheckBreak()
+		yyb1732 = r.CheckBreak()
 	}
-	if yyb1724 {
+	if yyb1732 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv1727 := &x.Selector
-		yym1728 := z.DecBinary()
-		_ = yym1728
+		yyv1735 := &x.Selector
+		yym1736 := z.DecBinary()
+		_ = yym1736
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1727, false, d)
+			z.F.DecMapStringStringX(yyv1735, false, d)
 		}
 	}
-	yyj1724++
-	if yyhl1724 {
-		yyb1724 = yyj1724 > l
+	yyj1732++
+	if yyhl1732 {
+		yyb1732 = yyj1732 > l
 	} else {
-		yyb1724 = r.CheckBreak()
+		yyb1732 = r.CheckBreak()
 	}
-	if yyb1724 {
+	if yyb1732 {
 		r.ReadEnd()
 		return
 	}
@@ -21092,16 +21152,16 @@ func (x *ReplicationControllerSpec) codecDecodeSelfFromArray(l int, d *codec1978
 		x.Template.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1724++
-		if yyhl1724 {
-			yyb1724 = yyj1724 > l
+		yyj1732++
+		if yyhl1732 {
+			yyb1732 = yyj1732 > l
 		} else {
-			yyb1724 = r.CheckBreak()
+			yyb1732 = r.CheckBreak()
 		}
-		if yyb1724 {
+		if yyb1732 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1724-1, "")
+		z.DecStructFieldNotFound(yyj1732-1, "")
 	}
 	r.ReadEnd()
 }
@@ -21113,48 +21173,48 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1730 := z.EncBinary()
-		_ = yym1730
+		yym1738 := z.EncBinary()
+		_ = yym1738
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1731 := !z.EncBinary()
-			yy2arr1731 := z.EncBasicHandle().StructToArray
-			var yyq1731 [2]bool
-			_, _, _ = yysep1731, yyq1731, yy2arr1731
-			const yyr1731 bool = false
-			yyq1731[1] = x.ObservedGeneration != 0
-			if yyr1731 || yy2arr1731 {
+			yysep1739 := !z.EncBinary()
+			yy2arr1739 := z.EncBasicHandle().StructToArray
+			var yyq1739 [2]bool
+			_, _, _ = yysep1739, yyq1739, yy2arr1739
+			const yyr1739 bool = false
+			yyq1739[1] = x.ObservedGeneration != 0
+			if yyr1739 || yy2arr1739 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1731 int = 1
-				for _, b := range yyq1731 {
+				var yynn1739 int = 1
+				for _, b := range yyq1739 {
 					if b {
-						yynn1731++
+						yynn1739++
 					}
 				}
-				r.EncodeMapStart(yynn1731)
+				r.EncodeMapStart(yynn1739)
 			}
-			if yyr1731 || yy2arr1731 {
-				yym1733 := z.EncBinary()
-				_ = yym1733
+			if yyr1739 || yy2arr1739 {
+				yym1741 := z.EncBinary()
+				_ = yym1741
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-				yym1734 := z.EncBinary()
-				_ = yym1734
+				yym1742 := z.EncBinary()
+				_ = yym1742
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			}
-			if yyr1731 || yy2arr1731 {
-				if yyq1731[1] {
-					yym1736 := z.EncBinary()
-					_ = yym1736
+			if yyr1739 || yy2arr1739 {
+				if yyq1739[1] {
+					yym1744 := z.EncBinary()
+					_ = yym1744
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
@@ -21163,17 +21223,17 @@ func (x *ReplicationControllerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1731[1] {
+				if yyq1739[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
-					yym1737 := z.EncBinary()
-					_ = yym1737
+					yym1745 := z.EncBinary()
+					_ = yym1745
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
 					}
 				}
 			}
-			if yysep1731 {
+			if yysep1739 {
 				r.EncodeEnd()
 			}
 		}
@@ -21184,24 +21244,24 @@ func (x *ReplicationControllerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1738 := z.DecBinary()
-	_ = yym1738
+	yym1746 := z.DecBinary()
+	_ = yym1746
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1739 := r.ReadMapStart()
-			if yyl1739 == 0 {
+			yyl1747 := r.ReadMapStart()
+			if yyl1747 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1739, d)
+				x.codecDecodeSelfFromMap(yyl1747, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1739 := r.ReadArrayStart()
-			if yyl1739 == 0 {
+			yyl1747 := r.ReadArrayStart()
+			if yyl1747 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1739, d)
+				x.codecDecodeSelfFromArray(yyl1747, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -21213,12 +21273,12 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1740Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1740Slc
-	var yyhl1740 bool = l >= 0
-	for yyj1740 := 0; ; yyj1740++ {
-		if yyhl1740 {
-			if yyj1740 >= l {
+	var yys1748Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1748Slc
+	var yyhl1748 bool = l >= 0
+	for yyj1748 := 0; ; yyj1748++ {
+		if yyhl1748 {
+			if yyj1748 >= l {
 				break
 			}
 		} else {
@@ -21226,9 +21286,9 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys1740Slc = r.DecodeBytes(yys1740Slc, true, true)
-		yys1740 := string(yys1740Slc)
-		switch yys1740 {
+		yys1748Slc = r.DecodeBytes(yys1748Slc, true, true)
+		yys1748 := string(yys1748Slc)
+		switch yys1748 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -21242,10 +21302,10 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromMap(l int, d *codec1978
 				x.ObservedGeneration = int64(r.DecodeInt(64))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1740)
-		} // end switch yys1740
-	} // end for yyj1740
-	if !yyhl1740 {
+			z.DecStructFieldNotFound(-1, yys1748)
+		} // end switch yys1748
+	} // end for yyj1748
+	if !yyhl1748 {
 		r.ReadEnd()
 	}
 }
@@ -21254,16 +21314,16 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1743 int
-	var yyb1743 bool
-	var yyhl1743 bool = l >= 0
-	yyj1743++
-	if yyhl1743 {
-		yyb1743 = yyj1743 > l
+	var yyj1751 int
+	var yyb1751 bool
+	var yyhl1751 bool = l >= 0
+	yyj1751++
+	if yyhl1751 {
+		yyb1751 = yyj1751 > l
 	} else {
-		yyb1743 = r.CheckBreak()
+		yyb1751 = r.CheckBreak()
 	}
-	if yyb1743 {
+	if yyb1751 {
 		r.ReadEnd()
 		return
 	}
@@ -21272,13 +21332,13 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1743++
-	if yyhl1743 {
-		yyb1743 = yyj1743 > l
+	yyj1751++
+	if yyhl1751 {
+		yyb1751 = yyj1751 > l
 	} else {
-		yyb1743 = r.CheckBreak()
+		yyb1751 = r.CheckBreak()
 	}
-	if yyb1743 {
+	if yyb1751 {
 		r.ReadEnd()
 		return
 	}
@@ -21288,16 +21348,16 @@ func (x *ReplicationControllerStatus) codecDecodeSelfFromArray(l int, d *codec19
 		x.ObservedGeneration = int64(r.DecodeInt(64))
 	}
 	for {
-		yyj1743++
-		if yyhl1743 {
-			yyb1743 = yyj1743 > l
+		yyj1751++
+		if yyhl1751 {
+			yyb1751 = yyj1751 > l
 		} else {
-			yyb1743 = r.CheckBreak()
+			yyb1751 = r.CheckBreak()
 		}
-		if yyb1743 {
+		if yyb1751 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1743-1, "")
+		z.DecStructFieldNotFound(yyj1751-1, "")
 	}
 	r.ReadEnd()
 }
@@ -21309,36 +21369,36 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1746 := z.EncBinary()
-		_ = yym1746
+		yym1754 := z.EncBinary()
+		_ = yym1754
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1747 := !z.EncBinary()
-			yy2arr1747 := z.EncBasicHandle().StructToArray
-			var yyq1747 [5]bool
-			_, _, _ = yysep1747, yyq1747, yy2arr1747
-			const yyr1747 bool = false
-			yyq1747[0] = x.Kind != ""
-			yyq1747[1] = x.APIVersion != ""
-			yyq1747[2] = true
-			yyq1747[3] = true
-			yyq1747[4] = true
-			if yyr1747 || yy2arr1747 {
+			yysep1755 := !z.EncBinary()
+			yy2arr1755 := z.EncBasicHandle().StructToArray
+			var yyq1755 [5]bool
+			_, _, _ = yysep1755, yyq1755, yy2arr1755
+			const yyr1755 bool = false
+			yyq1755[0] = x.Kind != ""
+			yyq1755[1] = x.APIVersion != ""
+			yyq1755[2] = true
+			yyq1755[3] = true
+			yyq1755[4] = true
+			if yyr1755 || yy2arr1755 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1747 int = 0
-				for _, b := range yyq1747 {
+				var yynn1755 int = 0
+				for _, b := range yyq1755 {
 					if b {
-						yynn1747++
+						yynn1755++
 					}
 				}
-				r.EncodeMapStart(yynn1747)
+				r.EncodeMapStart(yynn1755)
 			}
-			if yyr1747 || yy2arr1747 {
-				if yyq1747[0] {
-					yym1749 := z.EncBinary()
-					_ = yym1749
+			if yyr1755 || yy2arr1755 {
+				if yyq1755[0] {
+					yym1757 := z.EncBinary()
+					_ = yym1757
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -21347,20 +21407,20 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1747[0] {
+				if yyq1755[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1750 := z.EncBinary()
-					_ = yym1750
+					yym1758 := z.EncBinary()
+					_ = yym1758
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1747 || yy2arr1747 {
-				if yyq1747[1] {
-					yym1752 := z.EncBinary()
-					_ = yym1752
+			if yyr1755 || yy2arr1755 {
+				if yyq1755[1] {
+					yym1760 := z.EncBinary()
+					_ = yym1760
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -21369,59 +21429,59 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1747[1] {
+				if yyq1755[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1753 := z.EncBinary()
-					_ = yym1753
+					yym1761 := z.EncBinary()
+					_ = yym1761
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1747 || yy2arr1747 {
-				if yyq1747[2] {
-					yy1755 := &x.ObjectMeta
-					yy1755.CodecEncodeSelf(e)
+			if yyr1755 || yy2arr1755 {
+				if yyq1755[2] {
+					yy1763 := &x.ObjectMeta
+					yy1763.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1747[2] {
+				if yyq1755[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1756 := &x.ObjectMeta
-					yy1756.CodecEncodeSelf(e)
+					yy1764 := &x.ObjectMeta
+					yy1764.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1747 || yy2arr1747 {
-				if yyq1747[3] {
-					yy1758 := &x.Spec
-					yy1758.CodecEncodeSelf(e)
+			if yyr1755 || yy2arr1755 {
+				if yyq1755[3] {
+					yy1766 := &x.Spec
+					yy1766.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1747[3] {
+				if yyq1755[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1759 := &x.Spec
-					yy1759.CodecEncodeSelf(e)
+					yy1767 := &x.Spec
+					yy1767.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1747 || yy2arr1747 {
-				if yyq1747[4] {
-					yy1761 := &x.Status
-					yy1761.CodecEncodeSelf(e)
+			if yyr1755 || yy2arr1755 {
+				if yyq1755[4] {
+					yy1769 := &x.Status
+					yy1769.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1747[4] {
+				if yyq1755[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy1762 := &x.Status
-					yy1762.CodecEncodeSelf(e)
+					yy1770 := &x.Status
+					yy1770.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1747 {
+			if yysep1755 {
 				r.EncodeEnd()
 			}
 		}
@@ -21432,24 +21492,24 @@ func (x *ReplicationController) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1763 := z.DecBinary()
-	_ = yym1763
+	yym1771 := z.DecBinary()
+	_ = yym1771
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1764 := r.ReadMapStart()
-			if yyl1764 == 0 {
+			yyl1772 := r.ReadMapStart()
+			if yyl1772 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1764, d)
+				x.codecDecodeSelfFromMap(yyl1772, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1764 := r.ReadArrayStart()
-			if yyl1764 == 0 {
+			yyl1772 := r.ReadArrayStart()
+			if yyl1772 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1764, d)
+				x.codecDecodeSelfFromArray(yyl1772, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -21461,12 +21521,12 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1765Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1765Slc
-	var yyhl1765 bool = l >= 0
-	for yyj1765 := 0; ; yyj1765++ {
-		if yyhl1765 {
-			if yyj1765 >= l {
+	var yys1773Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1773Slc
+	var yyhl1773 bool = l >= 0
+	for yyj1773 := 0; ; yyj1773++ {
+		if yyhl1773 {
+			if yyj1773 >= l {
 				break
 			}
 		} else {
@@ -21474,9 +21534,9 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1765Slc = r.DecodeBytes(yys1765Slc, true, true)
-		yys1765 := string(yys1765Slc)
-		switch yys1765 {
+		yys1773Slc = r.DecodeBytes(yys1773Slc, true, true)
+		yys1773 := string(yys1773Slc)
+		switch yys1773 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -21493,28 +21553,28 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1768 := &x.ObjectMeta
-				yyv1768.CodecDecodeSelf(d)
+				yyv1776 := &x.ObjectMeta
+				yyv1776.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ReplicationControllerSpec{}
 			} else {
-				yyv1769 := &x.Spec
-				yyv1769.CodecDecodeSelf(d)
+				yyv1777 := &x.Spec
+				yyv1777.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ReplicationControllerStatus{}
 			} else {
-				yyv1770 := &x.Status
-				yyv1770.CodecDecodeSelf(d)
+				yyv1778 := &x.Status
+				yyv1778.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1765)
-		} // end switch yys1765
-	} // end for yyj1765
-	if !yyhl1765 {
+			z.DecStructFieldNotFound(-1, yys1773)
+		} // end switch yys1773
+	} // end for yyj1773
+	if !yyhl1773 {
 		r.ReadEnd()
 	}
 }
@@ -21523,16 +21583,16 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1771 int
-	var yyb1771 bool
-	var yyhl1771 bool = l >= 0
-	yyj1771++
-	if yyhl1771 {
-		yyb1771 = yyj1771 > l
+	var yyj1779 int
+	var yyb1779 bool
+	var yyhl1779 bool = l >= 0
+	yyj1779++
+	if yyhl1779 {
+		yyb1779 = yyj1779 > l
 	} else {
-		yyb1771 = r.CheckBreak()
+		yyb1779 = r.CheckBreak()
 	}
-	if yyb1771 {
+	if yyb1779 {
 		r.ReadEnd()
 		return
 	}
@@ -21541,13 +21601,13 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1771++
-	if yyhl1771 {
-		yyb1771 = yyj1771 > l
+	yyj1779++
+	if yyhl1779 {
+		yyb1779 = yyj1779 > l
 	} else {
-		yyb1771 = r.CheckBreak()
+		yyb1779 = r.CheckBreak()
 	}
-	if yyb1771 {
+	if yyb1779 {
 		r.ReadEnd()
 		return
 	}
@@ -21556,65 +21616,65 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1771++
-	if yyhl1771 {
-		yyb1771 = yyj1771 > l
+	yyj1779++
+	if yyhl1779 {
+		yyb1779 = yyj1779 > l
 	} else {
-		yyb1771 = r.CheckBreak()
+		yyb1779 = r.CheckBreak()
 	}
-	if yyb1771 {
+	if yyb1779 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1774 := &x.ObjectMeta
-		yyv1774.CodecDecodeSelf(d)
+		yyv1782 := &x.ObjectMeta
+		yyv1782.CodecDecodeSelf(d)
 	}
-	yyj1771++
-	if yyhl1771 {
-		yyb1771 = yyj1771 > l
+	yyj1779++
+	if yyhl1779 {
+		yyb1779 = yyj1779 > l
 	} else {
-		yyb1771 = r.CheckBreak()
+		yyb1779 = r.CheckBreak()
 	}
-	if yyb1771 {
+	if yyb1779 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ReplicationControllerSpec{}
 	} else {
-		yyv1775 := &x.Spec
-		yyv1775.CodecDecodeSelf(d)
+		yyv1783 := &x.Spec
+		yyv1783.CodecDecodeSelf(d)
 	}
-	yyj1771++
-	if yyhl1771 {
-		yyb1771 = yyj1771 > l
+	yyj1779++
+	if yyhl1779 {
+		yyb1779 = yyj1779 > l
 	} else {
-		yyb1771 = r.CheckBreak()
+		yyb1779 = r.CheckBreak()
 	}
-	if yyb1771 {
+	if yyb1779 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ReplicationControllerStatus{}
 	} else {
-		yyv1776 := &x.Status
-		yyv1776.CodecDecodeSelf(d)
+		yyv1784 := &x.Status
+		yyv1784.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1771++
-		if yyhl1771 {
-			yyb1771 = yyj1771 > l
+		yyj1779++
+		if yyhl1779 {
+			yyb1779 = yyj1779 > l
 		} else {
-			yyb1771 = r.CheckBreak()
+			yyb1779 = r.CheckBreak()
 		}
-		if yyb1771 {
+		if yyb1779 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1771-1, "")
+		z.DecStructFieldNotFound(yyj1779-1, "")
 	}
 	r.ReadEnd()
 }
@@ -21626,34 +21686,34 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1777 := z.EncBinary()
-		_ = yym1777
+		yym1785 := z.EncBinary()
+		_ = yym1785
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1778 := !z.EncBinary()
-			yy2arr1778 := z.EncBasicHandle().StructToArray
-			var yyq1778 [4]bool
-			_, _, _ = yysep1778, yyq1778, yy2arr1778
-			const yyr1778 bool = false
-			yyq1778[0] = x.Kind != ""
-			yyq1778[1] = x.APIVersion != ""
-			yyq1778[2] = true
-			if yyr1778 || yy2arr1778 {
+			yysep1786 := !z.EncBinary()
+			yy2arr1786 := z.EncBasicHandle().StructToArray
+			var yyq1786 [4]bool
+			_, _, _ = yysep1786, yyq1786, yy2arr1786
+			const yyr1786 bool = false
+			yyq1786[0] = x.Kind != ""
+			yyq1786[1] = x.APIVersion != ""
+			yyq1786[2] = true
+			if yyr1786 || yy2arr1786 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1778 int = 1
-				for _, b := range yyq1778 {
+				var yynn1786 int = 1
+				for _, b := range yyq1786 {
 					if b {
-						yynn1778++
+						yynn1786++
 					}
 				}
-				r.EncodeMapStart(yynn1778)
+				r.EncodeMapStart(yynn1786)
 			}
-			if yyr1778 || yy2arr1778 {
-				if yyq1778[0] {
-					yym1780 := z.EncBinary()
-					_ = yym1780
+			if yyr1786 || yy2arr1786 {
+				if yyq1786[0] {
+					yym1788 := z.EncBinary()
+					_ = yym1788
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -21662,70 +21722,70 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1778[0] {
+				if yyq1786[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1781 := z.EncBinary()
-					_ = yym1781
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1778 || yy2arr1778 {
-				if yyq1778[1] {
-					yym1783 := z.EncBinary()
-					_ = yym1783
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1778[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1784 := z.EncBinary()
-					_ = yym1784
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1778 || yy2arr1778 {
-				if yyq1778[2] {
-					yy1786 := &x.ListMeta
-					yym1787 := z.EncBinary()
-					_ = yym1787
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1786) {
-					} else {
-						z.EncFallback(yy1786)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1778[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1788 := &x.ListMeta
 					yym1789 := z.EncBinary()
 					_ = yym1789
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1788) {
 					} else {
-						z.EncFallback(yy1788)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1778 || yy2arr1778 {
+			if yyr1786 || yy2arr1786 {
+				if yyq1786[1] {
+					yym1791 := z.EncBinary()
+					_ = yym1791
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1786[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1792 := z.EncBinary()
+					_ = yym1792
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1786 || yy2arr1786 {
+				if yyq1786[2] {
+					yy1794 := &x.ListMeta
+					yym1795 := z.EncBinary()
+					_ = yym1795
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1794) {
+					} else {
+						z.EncFallback(yy1794)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1786[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1796 := &x.ListMeta
+					yym1797 := z.EncBinary()
+					_ = yym1797
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1796) {
+					} else {
+						z.EncFallback(yy1796)
+					}
+				}
+			}
+			if yyr1786 || yy2arr1786 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1791 := z.EncBinary()
-					_ = yym1791
+					yym1799 := z.EncBinary()
+					_ = yym1799
 					if false {
 					} else {
 						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
@@ -21736,15 +21796,15 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1792 := z.EncBinary()
-					_ = yym1792
+					yym1800 := z.EncBinary()
+					_ = yym1800
 					if false {
 					} else {
 						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
 					}
 				}
 			}
-			if yysep1778 {
+			if yysep1786 {
 				r.EncodeEnd()
 			}
 		}
@@ -21755,24 +21815,24 @@ func (x *ReplicationControllerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1793 := z.DecBinary()
-	_ = yym1793
+	yym1801 := z.DecBinary()
+	_ = yym1801
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1794 := r.ReadMapStart()
-			if yyl1794 == 0 {
+			yyl1802 := r.ReadMapStart()
+			if yyl1802 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1794, d)
+				x.codecDecodeSelfFromMap(yyl1802, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1794 := r.ReadArrayStart()
-			if yyl1794 == 0 {
+			yyl1802 := r.ReadArrayStart()
+			if yyl1802 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1794, d)
+				x.codecDecodeSelfFromArray(yyl1802, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -21784,12 +21844,12 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1795Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1795Slc
-	var yyhl1795 bool = l >= 0
-	for yyj1795 := 0; ; yyj1795++ {
-		if yyhl1795 {
-			if yyj1795 >= l {
+	var yys1803Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1803Slc
+	var yyhl1803 bool = l >= 0
+	for yyj1803 := 0; ; yyj1803++ {
+		if yyhl1803 {
+			if yyj1803 >= l {
 				break
 			}
 		} else {
@@ -21797,9 +21857,9 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				break
 			}
 		}
-		yys1795Slc = r.DecodeBytes(yys1795Slc, true, true)
-		yys1795 := string(yys1795Slc)
-		switch yys1795 {
+		yys1803Slc = r.DecodeBytes(yys1803Slc, true, true)
+		yys1803 := string(yys1803Slc)
+		switch yys1803 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -21816,32 +21876,32 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv1798 := &x.ListMeta
-				yym1799 := z.DecBinary()
-				_ = yym1799
+				yyv1806 := &x.ListMeta
+				yym1807 := z.DecBinary()
+				_ = yym1807
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1798) {
+				} else if z.HasExtensions() && z.DecExt(yyv1806) {
 				} else {
-					z.DecFallback(yyv1798, false)
+					z.DecFallback(yyv1806, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1800 := &x.Items
-				yym1801 := z.DecBinary()
-				_ = yym1801
+				yyv1808 := &x.Items
+				yym1809 := z.DecBinary()
+				_ = yym1809
 				if false {
 				} else {
-					h.decSliceReplicationController((*[]ReplicationController)(yyv1800), d)
+					h.decSliceReplicationController((*[]ReplicationController)(yyv1808), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1795)
-		} // end switch yys1795
-	} // end for yyj1795
-	if !yyhl1795 {
+			z.DecStructFieldNotFound(-1, yys1803)
+		} // end switch yys1803
+	} // end for yyj1803
+	if !yyhl1803 {
 		r.ReadEnd()
 	}
 }
@@ -21850,16 +21910,16 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1802 int
-	var yyb1802 bool
-	var yyhl1802 bool = l >= 0
-	yyj1802++
-	if yyhl1802 {
-		yyb1802 = yyj1802 > l
+	var yyj1810 int
+	var yyb1810 bool
+	var yyhl1810 bool = l >= 0
+	yyj1810++
+	if yyhl1810 {
+		yyb1810 = yyj1810 > l
 	} else {
-		yyb1802 = r.CheckBreak()
+		yyb1810 = r.CheckBreak()
 	}
-	if yyb1802 {
+	if yyb1810 {
 		r.ReadEnd()
 		return
 	}
@@ -21868,13 +21928,13 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1802++
-	if yyhl1802 {
-		yyb1802 = yyj1802 > l
+	yyj1810++
+	if yyhl1810 {
+		yyb1810 = yyj1810 > l
 	} else {
-		yyb1802 = r.CheckBreak()
+		yyb1810 = r.CheckBreak()
 	}
-	if yyb1802 {
+	if yyb1810 {
 		r.ReadEnd()
 		return
 	}
@@ -21883,60 +21943,60 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1802++
-	if yyhl1802 {
-		yyb1802 = yyj1802 > l
+	yyj1810++
+	if yyhl1810 {
+		yyb1810 = yyj1810 > l
 	} else {
-		yyb1802 = r.CheckBreak()
+		yyb1810 = r.CheckBreak()
 	}
-	if yyb1802 {
+	if yyb1810 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv1805 := &x.ListMeta
-		yym1806 := z.DecBinary()
-		_ = yym1806
+		yyv1813 := &x.ListMeta
+		yym1814 := z.DecBinary()
+		_ = yym1814
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1805) {
+		} else if z.HasExtensions() && z.DecExt(yyv1813) {
 		} else {
-			z.DecFallback(yyv1805, false)
+			z.DecFallback(yyv1813, false)
 		}
 	}
-	yyj1802++
-	if yyhl1802 {
-		yyb1802 = yyj1802 > l
+	yyj1810++
+	if yyhl1810 {
+		yyb1810 = yyj1810 > l
 	} else {
-		yyb1802 = r.CheckBreak()
+		yyb1810 = r.CheckBreak()
 	}
-	if yyb1802 {
+	if yyb1810 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1807 := &x.Items
-		yym1808 := z.DecBinary()
-		_ = yym1808
+		yyv1815 := &x.Items
+		yym1816 := z.DecBinary()
+		_ = yym1816
 		if false {
 		} else {
-			h.decSliceReplicationController((*[]ReplicationController)(yyv1807), d)
+			h.decSliceReplicationController((*[]ReplicationController)(yyv1815), d)
 		}
 	}
 	for {
-		yyj1802++
-		if yyhl1802 {
-			yyb1802 = yyj1802 > l
+		yyj1810++
+		if yyhl1810 {
+			yyb1810 = yyj1810 > l
 		} else {
-			yyb1802 = r.CheckBreak()
+			yyb1810 = r.CheckBreak()
 		}
-		if yyb1802 {
+		if yyb1810 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1802-1, "")
+		z.DecStructFieldNotFound(yyj1810-1, "")
 	}
 	r.ReadEnd()
 }
@@ -21945,8 +22005,8 @@ func (x ServiceAffinity) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1809 := z.EncBinary()
-	_ = yym1809
+	yym1817 := z.EncBinary()
+	_ = yym1817
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -21958,8 +22018,8 @@ func (x *ServiceAffinity) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1810 := z.DecBinary()
-	_ = yym1810
+	yym1818 := z.DecBinary()
+	_ = yym1818
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -21971,8 +22031,8 @@ func (x ServiceType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1811 := z.EncBinary()
-	_ = yym1811
+	yym1819 := z.EncBinary()
+	_ = yym1819
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -21984,8 +22044,8 @@ func (x *ServiceType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1812 := z.DecBinary()
-	_ = yym1812
+	yym1820 := z.DecBinary()
+	_ = yym1820
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -22000,43 +22060,43 @@ func (x *ServiceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1813 := z.EncBinary()
-		_ = yym1813
+		yym1821 := z.EncBinary()
+		_ = yym1821
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1814 := !z.EncBinary()
-			yy2arr1814 := z.EncBasicHandle().StructToArray
-			var yyq1814 [1]bool
-			_, _, _ = yysep1814, yyq1814, yy2arr1814
-			const yyr1814 bool = false
-			yyq1814[0] = true
-			if yyr1814 || yy2arr1814 {
+			yysep1822 := !z.EncBinary()
+			yy2arr1822 := z.EncBasicHandle().StructToArray
+			var yyq1822 [1]bool
+			_, _, _ = yysep1822, yyq1822, yy2arr1822
+			const yyr1822 bool = false
+			yyq1822[0] = true
+			if yyr1822 || yy2arr1822 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1814 int = 0
-				for _, b := range yyq1814 {
+				var yynn1822 int = 0
+				for _, b := range yyq1822 {
 					if b {
-						yynn1814++
+						yynn1822++
 					}
 				}
-				r.EncodeMapStart(yynn1814)
+				r.EncodeMapStart(yynn1822)
 			}
-			if yyr1814 || yy2arr1814 {
-				if yyq1814[0] {
-					yy1816 := &x.LoadBalancer
-					yy1816.CodecEncodeSelf(e)
+			if yyr1822 || yy2arr1822 {
+				if yyq1822[0] {
+					yy1824 := &x.LoadBalancer
+					yy1824.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1814[0] {
+				if yyq1822[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
-					yy1817 := &x.LoadBalancer
-					yy1817.CodecEncodeSelf(e)
+					yy1825 := &x.LoadBalancer
+					yy1825.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1814 {
+			if yysep1822 {
 				r.EncodeEnd()
 			}
 		}
@@ -22047,24 +22107,24 @@ func (x *ServiceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1818 := z.DecBinary()
-	_ = yym1818
+	yym1826 := z.DecBinary()
+	_ = yym1826
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1819 := r.ReadMapStart()
-			if yyl1819 == 0 {
+			yyl1827 := r.ReadMapStart()
+			if yyl1827 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1819, d)
+				x.codecDecodeSelfFromMap(yyl1827, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1819 := r.ReadArrayStart()
-			if yyl1819 == 0 {
+			yyl1827 := r.ReadArrayStart()
+			if yyl1827 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1819, d)
+				x.codecDecodeSelfFromArray(yyl1827, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -22076,12 +22136,12 @@ func (x *ServiceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1820Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1820Slc
-	var yyhl1820 bool = l >= 0
-	for yyj1820 := 0; ; yyj1820++ {
-		if yyhl1820 {
-			if yyj1820 >= l {
+	var yys1828Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1828Slc
+	var yyhl1828 bool = l >= 0
+	for yyj1828 := 0; ; yyj1828++ {
+		if yyhl1828 {
+			if yyj1828 >= l {
 				break
 			}
 		} else {
@@ -22089,21 +22149,21 @@ func (x *ServiceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1820Slc = r.DecodeBytes(yys1820Slc, true, true)
-		yys1820 := string(yys1820Slc)
-		switch yys1820 {
+		yys1828Slc = r.DecodeBytes(yys1828Slc, true, true)
+		yys1828 := string(yys1828Slc)
+		switch yys1828 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = LoadBalancerStatus{}
 			} else {
-				yyv1821 := &x.LoadBalancer
-				yyv1821.CodecDecodeSelf(d)
+				yyv1829 := &x.LoadBalancer
+				yyv1829.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1820)
-		} // end switch yys1820
-	} // end for yyj1820
-	if !yyhl1820 {
+			z.DecStructFieldNotFound(-1, yys1828)
+		} // end switch yys1828
+	} // end for yyj1828
+	if !yyhl1828 {
 		r.ReadEnd()
 	}
 }
@@ -22112,36 +22172,36 @@ func (x *ServiceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1822 int
-	var yyb1822 bool
-	var yyhl1822 bool = l >= 0
-	yyj1822++
-	if yyhl1822 {
-		yyb1822 = yyj1822 > l
+	var yyj1830 int
+	var yyb1830 bool
+	var yyhl1830 bool = l >= 0
+	yyj1830++
+	if yyhl1830 {
+		yyb1830 = yyj1830 > l
 	} else {
-		yyb1822 = r.CheckBreak()
+		yyb1830 = r.CheckBreak()
 	}
-	if yyb1822 {
+	if yyb1830 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = LoadBalancerStatus{}
 	} else {
-		yyv1823 := &x.LoadBalancer
-		yyv1823.CodecDecodeSelf(d)
+		yyv1831 := &x.LoadBalancer
+		yyv1831.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1822++
-		if yyhl1822 {
-			yyb1822 = yyj1822 > l
+		yyj1830++
+		if yyhl1830 {
+			yyb1830 = yyj1830 > l
 		} else {
-			yyb1822 = r.CheckBreak()
+			yyb1830 = r.CheckBreak()
 		}
-		if yyb1822 {
+		if yyb1830 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1822-1, "")
+		z.DecStructFieldNotFound(yyj1830-1, "")
 	}
 	r.ReadEnd()
 }
@@ -22153,35 +22213,35 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1824 := z.EncBinary()
-		_ = yym1824
+		yym1832 := z.EncBinary()
+		_ = yym1832
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1825 := !z.EncBinary()
-			yy2arr1825 := z.EncBasicHandle().StructToArray
-			var yyq1825 [1]bool
-			_, _, _ = yysep1825, yyq1825, yy2arr1825
-			const yyr1825 bool = false
-			yyq1825[0] = len(x.Ingress) != 0
-			if yyr1825 || yy2arr1825 {
+			yysep1833 := !z.EncBinary()
+			yy2arr1833 := z.EncBasicHandle().StructToArray
+			var yyq1833 [1]bool
+			_, _, _ = yysep1833, yyq1833, yy2arr1833
+			const yyr1833 bool = false
+			yyq1833[0] = len(x.Ingress) != 0
+			if yyr1833 || yy2arr1833 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn1825 int = 0
-				for _, b := range yyq1825 {
+				var yynn1833 int = 0
+				for _, b := range yyq1833 {
 					if b {
-						yynn1825++
+						yynn1833++
 					}
 				}
-				r.EncodeMapStart(yynn1825)
+				r.EncodeMapStart(yynn1833)
 			}
-			if yyr1825 || yy2arr1825 {
-				if yyq1825[0] {
+			if yyr1833 || yy2arr1833 {
+				if yyq1833[0] {
 					if x.Ingress == nil {
 						r.EncodeNil()
 					} else {
-						yym1827 := z.EncBinary()
-						_ = yym1827
+						yym1835 := z.EncBinary()
+						_ = yym1835
 						if false {
 						} else {
 							h.encSliceLoadBalancerIngress(([]LoadBalancerIngress)(x.Ingress), e)
@@ -22191,13 +22251,13 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1825[0] {
+				if yyq1833[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("ingress"))
 					if x.Ingress == nil {
 						r.EncodeNil()
 					} else {
-						yym1828 := z.EncBinary()
-						_ = yym1828
+						yym1836 := z.EncBinary()
+						_ = yym1836
 						if false {
 						} else {
 							h.encSliceLoadBalancerIngress(([]LoadBalancerIngress)(x.Ingress), e)
@@ -22205,7 +22265,7 @@ func (x *LoadBalancerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1825 {
+			if yysep1833 {
 				r.EncodeEnd()
 			}
 		}
@@ -22216,24 +22276,24 @@ func (x *LoadBalancerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1829 := z.DecBinary()
-	_ = yym1829
+	yym1837 := z.DecBinary()
+	_ = yym1837
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1830 := r.ReadMapStart()
-			if yyl1830 == 0 {
+			yyl1838 := r.ReadMapStart()
+			if yyl1838 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1830, d)
+				x.codecDecodeSelfFromMap(yyl1838, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1830 := r.ReadArrayStart()
-			if yyl1830 == 0 {
+			yyl1838 := r.ReadArrayStart()
+			if yyl1838 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1830, d)
+				x.codecDecodeSelfFromArray(yyl1838, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -22245,12 +22305,12 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1831Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1831Slc
-	var yyhl1831 bool = l >= 0
-	for yyj1831 := 0; ; yyj1831++ {
-		if yyhl1831 {
-			if yyj1831 >= l {
+	var yys1839Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1839Slc
+	var yyhl1839 bool = l >= 0
+	for yyj1839 := 0; ; yyj1839++ {
+		if yyhl1839 {
+			if yyj1839 >= l {
 				break
 			}
 		} else {
@@ -22258,26 +22318,26 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys1831Slc = r.DecodeBytes(yys1831Slc, true, true)
-		yys1831 := string(yys1831Slc)
-		switch yys1831 {
+		yys1839Slc = r.DecodeBytes(yys1839Slc, true, true)
+		yys1839 := string(yys1839Slc)
+		switch yys1839 {
 		case "ingress":
 			if r.TryDecodeAsNil() {
 				x.Ingress = nil
 			} else {
-				yyv1832 := &x.Ingress
-				yym1833 := z.DecBinary()
-				_ = yym1833
+				yyv1840 := &x.Ingress
+				yym1841 := z.DecBinary()
+				_ = yym1841
 				if false {
 				} else {
-					h.decSliceLoadBalancerIngress((*[]LoadBalancerIngress)(yyv1832), d)
+					h.decSliceLoadBalancerIngress((*[]LoadBalancerIngress)(yyv1840), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1831)
-		} // end switch yys1831
-	} // end for yyj1831
-	if !yyhl1831 {
+			z.DecStructFieldNotFound(-1, yys1839)
+		} // end switch yys1839
+	} // end for yyj1839
+	if !yyhl1839 {
 		r.ReadEnd()
 	}
 }
@@ -22286,41 +22346,41 @@ func (x *LoadBalancerStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1834 int
-	var yyb1834 bool
-	var yyhl1834 bool = l >= 0
-	yyj1834++
-	if yyhl1834 {
-		yyb1834 = yyj1834 > l
+	var yyj1842 int
+	var yyb1842 bool
+	var yyhl1842 bool = l >= 0
+	yyj1842++
+	if yyhl1842 {
+		yyb1842 = yyj1842 > l
 	} else {
-		yyb1834 = r.CheckBreak()
+		yyb1842 = r.CheckBreak()
 	}
-	if yyb1834 {
+	if yyb1842 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Ingress = nil
 	} else {
-		yyv1835 := &x.Ingress
-		yym1836 := z.DecBinary()
-		_ = yym1836
+		yyv1843 := &x.Ingress
+		yym1844 := z.DecBinary()
+		_ = yym1844
 		if false {
 		} else {
-			h.decSliceLoadBalancerIngress((*[]LoadBalancerIngress)(yyv1835), d)
+			h.decSliceLoadBalancerIngress((*[]LoadBalancerIngress)(yyv1843), d)
 		}
 	}
 	for {
-		yyj1834++
-		if yyhl1834 {
-			yyb1834 = yyj1834 > l
+		yyj1842++
+		if yyhl1842 {
+			yyb1842 = yyj1842 > l
 		} else {
-			yyb1834 = r.CheckBreak()
+			yyb1842 = r.CheckBreak()
 		}
-		if yyb1834 {
+		if yyb1842 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1834-1, "")
+		z.DecStructFieldNotFound(yyj1842-1, "")
 	}
 	r.ReadEnd()
 }
@@ -22332,33 +22392,33 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1837 := z.EncBinary()
-		_ = yym1837
+		yym1845 := z.EncBinary()
+		_ = yym1845
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1838 := !z.EncBinary()
-			yy2arr1838 := z.EncBasicHandle().StructToArray
-			var yyq1838 [2]bool
-			_, _, _ = yysep1838, yyq1838, yy2arr1838
-			const yyr1838 bool = false
-			yyq1838[0] = x.IP != ""
-			yyq1838[1] = x.Hostname != ""
-			if yyr1838 || yy2arr1838 {
+			yysep1846 := !z.EncBinary()
+			yy2arr1846 := z.EncBasicHandle().StructToArray
+			var yyq1846 [2]bool
+			_, _, _ = yysep1846, yyq1846, yy2arr1846
+			const yyr1846 bool = false
+			yyq1846[0] = x.IP != ""
+			yyq1846[1] = x.Hostname != ""
+			if yyr1846 || yy2arr1846 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1838 int = 0
-				for _, b := range yyq1838 {
+				var yynn1846 int = 0
+				for _, b := range yyq1846 {
 					if b {
-						yynn1838++
+						yynn1846++
 					}
 				}
-				r.EncodeMapStart(yynn1838)
+				r.EncodeMapStart(yynn1846)
 			}
-			if yyr1838 || yy2arr1838 {
-				if yyq1838[0] {
-					yym1840 := z.EncBinary()
-					_ = yym1840
+			if yyr1846 || yy2arr1846 {
+				if yyq1846[0] {
+					yym1848 := z.EncBinary()
+					_ = yym1848
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.IP))
@@ -22367,20 +22427,20 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1838[0] {
+				if yyq1846[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("ip"))
-					yym1841 := z.EncBinary()
-					_ = yym1841
+					yym1849 := z.EncBinary()
+					_ = yym1849
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.IP))
 					}
 				}
 			}
-			if yyr1838 || yy2arr1838 {
-				if yyq1838[1] {
-					yym1843 := z.EncBinary()
-					_ = yym1843
+			if yyr1846 || yy2arr1846 {
+				if yyq1846[1] {
+					yym1851 := z.EncBinary()
+					_ = yym1851
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Hostname))
@@ -22389,17 +22449,17 @@ func (x *LoadBalancerIngress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1838[1] {
+				if yyq1846[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("hostname"))
-					yym1844 := z.EncBinary()
-					_ = yym1844
+					yym1852 := z.EncBinary()
+					_ = yym1852
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Hostname))
 					}
 				}
 			}
-			if yysep1838 {
+			if yysep1846 {
 				r.EncodeEnd()
 			}
 		}
@@ -22410,24 +22470,24 @@ func (x *LoadBalancerIngress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1845 := z.DecBinary()
-	_ = yym1845
+	yym1853 := z.DecBinary()
+	_ = yym1853
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1846 := r.ReadMapStart()
-			if yyl1846 == 0 {
+			yyl1854 := r.ReadMapStart()
+			if yyl1854 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1846, d)
+				x.codecDecodeSelfFromMap(yyl1854, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1846 := r.ReadArrayStart()
-			if yyl1846 == 0 {
+			yyl1854 := r.ReadArrayStart()
+			if yyl1854 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1846, d)
+				x.codecDecodeSelfFromArray(yyl1854, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -22439,12 +22499,12 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1847Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1847Slc
-	var yyhl1847 bool = l >= 0
-	for yyj1847 := 0; ; yyj1847++ {
-		if yyhl1847 {
-			if yyj1847 >= l {
+	var yys1855Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1855Slc
+	var yyhl1855 bool = l >= 0
+	for yyj1855 := 0; ; yyj1855++ {
+		if yyhl1855 {
+			if yyj1855 >= l {
 				break
 			}
 		} else {
@@ -22452,9 +22512,9 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys1847Slc = r.DecodeBytes(yys1847Slc, true, true)
-		yys1847 := string(yys1847Slc)
-		switch yys1847 {
+		yys1855Slc = r.DecodeBytes(yys1855Slc, true, true)
+		yys1855 := string(yys1855Slc)
+		switch yys1855 {
 		case "ip":
 			if r.TryDecodeAsNil() {
 				x.IP = ""
@@ -22468,10 +22528,10 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.Hostname = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1847)
-		} // end switch yys1847
-	} // end for yyj1847
-	if !yyhl1847 {
+			z.DecStructFieldNotFound(-1, yys1855)
+		} // end switch yys1855
+	} // end for yyj1855
+	if !yyhl1855 {
 		r.ReadEnd()
 	}
 }
@@ -22480,16 +22540,16 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1850 int
-	var yyb1850 bool
-	var yyhl1850 bool = l >= 0
-	yyj1850++
-	if yyhl1850 {
-		yyb1850 = yyj1850 > l
+	var yyj1858 int
+	var yyb1858 bool
+	var yyhl1858 bool = l >= 0
+	yyj1858++
+	if yyhl1858 {
+		yyb1858 = yyj1858 > l
 	} else {
-		yyb1850 = r.CheckBreak()
+		yyb1858 = r.CheckBreak()
 	}
-	if yyb1850 {
+	if yyb1858 {
 		r.ReadEnd()
 		return
 	}
@@ -22498,13 +22558,13 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.IP = string(r.DecodeString())
 	}
-	yyj1850++
-	if yyhl1850 {
-		yyb1850 = yyj1850 > l
+	yyj1858++
+	if yyhl1858 {
+		yyb1858 = yyj1858 > l
 	} else {
-		yyb1850 = r.CheckBreak()
+		yyb1858 = r.CheckBreak()
 	}
-	if yyb1850 {
+	if yyb1858 {
 		r.ReadEnd()
 		return
 	}
@@ -22514,16 +22574,16 @@ func (x *LoadBalancerIngress) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.Hostname = string(r.DecodeString())
 	}
 	for {
-		yyj1850++
-		if yyhl1850 {
-			yyb1850 = yyj1850 > l
+		yyj1858++
+		if yyhl1858 {
+			yyb1858 = yyj1858 > l
 		} else {
-			yyb1850 = r.CheckBreak()
+			yyb1858 = r.CheckBreak()
 		}
-		if yyb1850 {
+		if yyb1858 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1850-1, "")
+		z.DecStructFieldNotFound(yyj1858-1, "")
 	}
 	r.ReadEnd()
 }
@@ -22535,40 +22595,40 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1853 := z.EncBinary()
-		_ = yym1853
+		yym1861 := z.EncBinary()
+		_ = yym1861
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1854 := !z.EncBinary()
-			yy2arr1854 := z.EncBasicHandle().StructToArray
-			var yyq1854 [8]bool
-			_, _, _ = yysep1854, yyq1854, yy2arr1854
-			const yyr1854 bool = false
-			yyq1854[1] = len(x.Selector) != 0
-			yyq1854[2] = x.ClusterIP != ""
-			yyq1854[3] = x.Type != ""
-			yyq1854[4] = len(x.ExternalIPs) != 0
-			yyq1854[5] = len(x.DeprecatedPublicIPs) != 0
-			yyq1854[6] = x.SessionAffinity != ""
-			yyq1854[7] = x.LoadBalancerIP != ""
-			if yyr1854 || yy2arr1854 {
+			yysep1862 := !z.EncBinary()
+			yy2arr1862 := z.EncBasicHandle().StructToArray
+			var yyq1862 [8]bool
+			_, _, _ = yysep1862, yyq1862, yy2arr1862
+			const yyr1862 bool = false
+			yyq1862[1] = len(x.Selector) != 0
+			yyq1862[2] = x.ClusterIP != ""
+			yyq1862[3] = x.Type != ""
+			yyq1862[4] = len(x.ExternalIPs) != 0
+			yyq1862[5] = len(x.DeprecatedPublicIPs) != 0
+			yyq1862[6] = x.SessionAffinity != ""
+			yyq1862[7] = x.LoadBalancerIP != ""
+			if yyr1862 || yy2arr1862 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn1854 int = 1
-				for _, b := range yyq1854 {
+				var yynn1862 int = 1
+				for _, b := range yyq1862 {
 					if b {
-						yynn1854++
+						yynn1862++
 					}
 				}
-				r.EncodeMapStart(yynn1854)
+				r.EncodeMapStart(yynn1862)
 			}
-			if yyr1854 || yy2arr1854 {
+			if yyr1862 || yy2arr1862 {
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
-					yym1856 := z.EncBinary()
-					_ = yym1856
+					yym1864 := z.EncBinary()
+					_ = yym1864
 					if false {
 					} else {
 						h.encSliceServicePort(([]ServicePort)(x.Ports), e)
@@ -22579,115 +22639,115 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Ports == nil {
 					r.EncodeNil()
 				} else {
-					yym1857 := z.EncBinary()
-					_ = yym1857
+					yym1865 := z.EncBinary()
+					_ = yym1865
 					if false {
 					} else {
 						h.encSliceServicePort(([]ServicePort)(x.Ports), e)
 					}
 				}
 			}
-			if yyr1854 || yy2arr1854 {
-				if yyq1854[1] {
+			if yyr1862 || yy2arr1862 {
+				if yyq1862[1] {
 					if x.Selector == nil {
-						r.EncodeNil()
-					} else {
-						yym1859 := z.EncBinary()
-						_ = yym1859
-						if false {
-						} else {
-							z.F.EncMapStringStringV(x.Selector, false, e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1854[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("selector"))
-					if x.Selector == nil {
-						r.EncodeNil()
-					} else {
-						yym1860 := z.EncBinary()
-						_ = yym1860
-						if false {
-						} else {
-							z.F.EncMapStringStringV(x.Selector, false, e)
-						}
-					}
-				}
-			}
-			if yyr1854 || yy2arr1854 {
-				if yyq1854[2] {
-					yym1862 := z.EncBinary()
-					_ = yym1862
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ClusterIP))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1854[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("clusterIP"))
-					yym1863 := z.EncBinary()
-					_ = yym1863
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ClusterIP))
-					}
-				}
-			}
-			if yyr1854 || yy2arr1854 {
-				if yyq1854[3] {
-					x.Type.CodecEncodeSelf(e)
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1854[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
-					x.Type.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1854 || yy2arr1854 {
-				if yyq1854[4] {
-					if x.ExternalIPs == nil {
-						r.EncodeNil()
-					} else {
-						yym1866 := z.EncBinary()
-						_ = yym1866
-						if false {
-						} else {
-							z.F.EncSliceStringV(x.ExternalIPs, false, e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1854[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("externalIPs"))
-					if x.ExternalIPs == nil {
 						r.EncodeNil()
 					} else {
 						yym1867 := z.EncBinary()
 						_ = yym1867
 						if false {
 						} else {
+							z.F.EncMapStringStringV(x.Selector, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1862[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("selector"))
+					if x.Selector == nil {
+						r.EncodeNil()
+					} else {
+						yym1868 := z.EncBinary()
+						_ = yym1868
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.Selector, false, e)
+						}
+					}
+				}
+			}
+			if yyr1862 || yy2arr1862 {
+				if yyq1862[2] {
+					yym1870 := z.EncBinary()
+					_ = yym1870
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ClusterIP))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1862[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("clusterIP"))
+					yym1871 := z.EncBinary()
+					_ = yym1871
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ClusterIP))
+					}
+				}
+			}
+			if yyr1862 || yy2arr1862 {
+				if yyq1862[3] {
+					x.Type.CodecEncodeSelf(e)
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1862[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					x.Type.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1862 || yy2arr1862 {
+				if yyq1862[4] {
+					if x.ExternalIPs == nil {
+						r.EncodeNil()
+					} else {
+						yym1874 := z.EncBinary()
+						_ = yym1874
+						if false {
+						} else {
+							z.F.EncSliceStringV(x.ExternalIPs, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1862[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("externalIPs"))
+					if x.ExternalIPs == nil {
+						r.EncodeNil()
+					} else {
+						yym1875 := z.EncBinary()
+						_ = yym1875
+						if false {
+						} else {
 							z.F.EncSliceStringV(x.ExternalIPs, false, e)
 						}
 					}
 				}
 			}
-			if yyr1854 || yy2arr1854 {
-				if yyq1854[5] {
+			if yyr1862 || yy2arr1862 {
+				if yyq1862[5] {
 					if x.DeprecatedPublicIPs == nil {
 						r.EncodeNil()
 					} else {
-						yym1869 := z.EncBinary()
-						_ = yym1869
+						yym1877 := z.EncBinary()
+						_ = yym1877
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.DeprecatedPublicIPs, false, e)
@@ -22697,13 +22757,13 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1854[5] {
+				if yyq1862[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("deprecatedPublicIPs"))
 					if x.DeprecatedPublicIPs == nil {
 						r.EncodeNil()
 					} else {
-						yym1870 := z.EncBinary()
-						_ = yym1870
+						yym1878 := z.EncBinary()
+						_ = yym1878
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.DeprecatedPublicIPs, false, e)
@@ -22711,22 +22771,22 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1854 || yy2arr1854 {
-				if yyq1854[6] {
+			if yyr1862 || yy2arr1862 {
+				if yyq1862[6] {
 					x.SessionAffinity.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1854[6] {
+				if yyq1862[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("sessionAffinity"))
 					x.SessionAffinity.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1854 || yy2arr1854 {
-				if yyq1854[7] {
-					yym1873 := z.EncBinary()
-					_ = yym1873
+			if yyr1862 || yy2arr1862 {
+				if yyq1862[7] {
+					yym1881 := z.EncBinary()
+					_ = yym1881
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.LoadBalancerIP))
@@ -22735,17 +22795,17 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1854[7] {
+				if yyq1862[7] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancerIP"))
-					yym1874 := z.EncBinary()
-					_ = yym1874
+					yym1882 := z.EncBinary()
+					_ = yym1882
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.LoadBalancerIP))
 					}
 				}
 			}
-			if yysep1854 {
+			if yysep1862 {
 				r.EncodeEnd()
 			}
 		}
@@ -22756,24 +22816,24 @@ func (x *ServiceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1875 := z.DecBinary()
-	_ = yym1875
+	yym1883 := z.DecBinary()
+	_ = yym1883
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1876 := r.ReadMapStart()
-			if yyl1876 == 0 {
+			yyl1884 := r.ReadMapStart()
+			if yyl1884 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1876, d)
+				x.codecDecodeSelfFromMap(yyl1884, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1876 := r.ReadArrayStart()
-			if yyl1876 == 0 {
+			yyl1884 := r.ReadArrayStart()
+			if yyl1884 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1876, d)
+				x.codecDecodeSelfFromArray(yyl1884, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -22785,12 +22845,12 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1877Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1877Slc
-	var yyhl1877 bool = l >= 0
-	for yyj1877 := 0; ; yyj1877++ {
-		if yyhl1877 {
-			if yyj1877 >= l {
+	var yys1885Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1885Slc
+	var yyhl1885 bool = l >= 0
+	for yyj1885 := 0; ; yyj1885++ {
+		if yyhl1885 {
+			if yyj1885 >= l {
 				break
 			}
 		} else {
@@ -22798,31 +22858,31 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1877Slc = r.DecodeBytes(yys1877Slc, true, true)
-		yys1877 := string(yys1877Slc)
-		switch yys1877 {
+		yys1885Slc = r.DecodeBytes(yys1885Slc, true, true)
+		yys1885 := string(yys1885Slc)
+		switch yys1885 {
 		case "ports":
 			if r.TryDecodeAsNil() {
 				x.Ports = nil
 			} else {
-				yyv1878 := &x.Ports
-				yym1879 := z.DecBinary()
-				_ = yym1879
+				yyv1886 := &x.Ports
+				yym1887 := z.DecBinary()
+				_ = yym1887
 				if false {
 				} else {
-					h.decSliceServicePort((*[]ServicePort)(yyv1878), d)
+					h.decSliceServicePort((*[]ServicePort)(yyv1886), d)
 				}
 			}
 		case "selector":
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv1880 := &x.Selector
-				yym1881 := z.DecBinary()
-				_ = yym1881
+				yyv1888 := &x.Selector
+				yym1889 := z.DecBinary()
+				_ = yym1889
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1880, false, d)
+					z.F.DecMapStringStringX(yyv1888, false, d)
 				}
 			}
 		case "clusterIP":
@@ -22841,24 +22901,24 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ExternalIPs = nil
 			} else {
-				yyv1884 := &x.ExternalIPs
-				yym1885 := z.DecBinary()
-				_ = yym1885
+				yyv1892 := &x.ExternalIPs
+				yym1893 := z.DecBinary()
+				_ = yym1893
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1884, false, d)
+					z.F.DecSliceStringX(yyv1892, false, d)
 				}
 			}
 		case "deprecatedPublicIPs":
 			if r.TryDecodeAsNil() {
 				x.DeprecatedPublicIPs = nil
 			} else {
-				yyv1886 := &x.DeprecatedPublicIPs
-				yym1887 := z.DecBinary()
-				_ = yym1887
+				yyv1894 := &x.DeprecatedPublicIPs
+				yym1895 := z.DecBinary()
+				_ = yym1895
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1886, false, d)
+					z.F.DecSliceStringX(yyv1894, false, d)
 				}
 			}
 		case "sessionAffinity":
@@ -22874,10 +22934,10 @@ func (x *ServiceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.LoadBalancerIP = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1877)
-		} // end switch yys1877
-	} // end for yyj1877
-	if !yyhl1877 {
+			z.DecStructFieldNotFound(-1, yys1885)
+		} // end switch yys1885
+	} // end for yyj1885
+	if !yyhl1885 {
 		r.ReadEnd()
 	}
 }
@@ -22886,58 +22946,58 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1890 int
-	var yyb1890 bool
-	var yyhl1890 bool = l >= 0
-	yyj1890++
-	if yyhl1890 {
-		yyb1890 = yyj1890 > l
+	var yyj1898 int
+	var yyb1898 bool
+	var yyhl1898 bool = l >= 0
+	yyj1898++
+	if yyhl1898 {
+		yyb1898 = yyj1898 > l
 	} else {
-		yyb1890 = r.CheckBreak()
+		yyb1898 = r.CheckBreak()
 	}
-	if yyb1890 {
+	if yyb1898 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
-		yyv1891 := &x.Ports
-		yym1892 := z.DecBinary()
-		_ = yym1892
+		yyv1899 := &x.Ports
+		yym1900 := z.DecBinary()
+		_ = yym1900
 		if false {
 		} else {
-			h.decSliceServicePort((*[]ServicePort)(yyv1891), d)
+			h.decSliceServicePort((*[]ServicePort)(yyv1899), d)
 		}
 	}
-	yyj1890++
-	if yyhl1890 {
-		yyb1890 = yyj1890 > l
+	yyj1898++
+	if yyhl1898 {
+		yyb1898 = yyj1898 > l
 	} else {
-		yyb1890 = r.CheckBreak()
+		yyb1898 = r.CheckBreak()
 	}
-	if yyb1890 {
+	if yyb1898 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv1893 := &x.Selector
-		yym1894 := z.DecBinary()
-		_ = yym1894
+		yyv1901 := &x.Selector
+		yym1902 := z.DecBinary()
+		_ = yym1902
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1893, false, d)
+			z.F.DecMapStringStringX(yyv1901, false, d)
 		}
 	}
-	yyj1890++
-	if yyhl1890 {
-		yyb1890 = yyj1890 > l
+	yyj1898++
+	if yyhl1898 {
+		yyb1898 = yyj1898 > l
 	} else {
-		yyb1890 = r.CheckBreak()
+		yyb1898 = r.CheckBreak()
 	}
-	if yyb1890 {
+	if yyb1898 {
 		r.ReadEnd()
 		return
 	}
@@ -22946,13 +23006,13 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ClusterIP = string(r.DecodeString())
 	}
-	yyj1890++
-	if yyhl1890 {
-		yyb1890 = yyj1890 > l
+	yyj1898++
+	if yyhl1898 {
+		yyb1898 = yyj1898 > l
 	} else {
-		yyb1890 = r.CheckBreak()
+		yyb1898 = r.CheckBreak()
 	}
-	if yyb1890 {
+	if yyb1898 {
 		r.ReadEnd()
 		return
 	}
@@ -22961,55 +23021,55 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = ServiceType(r.DecodeString())
 	}
-	yyj1890++
-	if yyhl1890 {
-		yyb1890 = yyj1890 > l
+	yyj1898++
+	if yyhl1898 {
+		yyb1898 = yyj1898 > l
 	} else {
-		yyb1890 = r.CheckBreak()
+		yyb1898 = r.CheckBreak()
 	}
-	if yyb1890 {
+	if yyb1898 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ExternalIPs = nil
 	} else {
-		yyv1897 := &x.ExternalIPs
-		yym1898 := z.DecBinary()
-		_ = yym1898
+		yyv1905 := &x.ExternalIPs
+		yym1906 := z.DecBinary()
+		_ = yym1906
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1897, false, d)
+			z.F.DecSliceStringX(yyv1905, false, d)
 		}
 	}
-	yyj1890++
-	if yyhl1890 {
-		yyb1890 = yyj1890 > l
+	yyj1898++
+	if yyhl1898 {
+		yyb1898 = yyj1898 > l
 	} else {
-		yyb1890 = r.CheckBreak()
+		yyb1898 = r.CheckBreak()
 	}
-	if yyb1890 {
+	if yyb1898 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.DeprecatedPublicIPs = nil
 	} else {
-		yyv1899 := &x.DeprecatedPublicIPs
-		yym1900 := z.DecBinary()
-		_ = yym1900
+		yyv1907 := &x.DeprecatedPublicIPs
+		yym1908 := z.DecBinary()
+		_ = yym1908
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1899, false, d)
+			z.F.DecSliceStringX(yyv1907, false, d)
 		}
 	}
-	yyj1890++
-	if yyhl1890 {
-		yyb1890 = yyj1890 > l
+	yyj1898++
+	if yyhl1898 {
+		yyb1898 = yyj1898 > l
 	} else {
-		yyb1890 = r.CheckBreak()
+		yyb1898 = r.CheckBreak()
 	}
-	if yyb1890 {
+	if yyb1898 {
 		r.ReadEnd()
 		return
 	}
@@ -23018,13 +23078,13 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.SessionAffinity = ServiceAffinity(r.DecodeString())
 	}
-	yyj1890++
-	if yyhl1890 {
-		yyb1890 = yyj1890 > l
+	yyj1898++
+	if yyhl1898 {
+		yyb1898 = yyj1898 > l
 	} else {
-		yyb1890 = r.CheckBreak()
+		yyb1898 = r.CheckBreak()
 	}
-	if yyb1890 {
+	if yyb1898 {
 		r.ReadEnd()
 		return
 	}
@@ -23034,16 +23094,16 @@ func (x *ServiceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.LoadBalancerIP = string(r.DecodeString())
 	}
 	for {
-		yyj1890++
-		if yyhl1890 {
-			yyb1890 = yyj1890 > l
+		yyj1898++
+		if yyhl1898 {
+			yyb1898 = yyj1898 > l
 		} else {
-			yyb1890 = r.CheckBreak()
+			yyb1898 = r.CheckBreak()
 		}
-		if yyb1890 {
+		if yyb1898 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1890-1, "")
+		z.DecStructFieldNotFound(yyj1898-1, "")
 	}
 	r.ReadEnd()
 }
@@ -23055,35 +23115,35 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1903 := z.EncBinary()
-		_ = yym1903
+		yym1911 := z.EncBinary()
+		_ = yym1911
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1904 := !z.EncBinary()
-			yy2arr1904 := z.EncBasicHandle().StructToArray
-			var yyq1904 [5]bool
-			_, _, _ = yysep1904, yyq1904, yy2arr1904
-			const yyr1904 bool = false
-			yyq1904[0] = x.Name != ""
-			yyq1904[1] = x.Protocol != ""
-			yyq1904[3] = true
-			yyq1904[4] = x.NodePort != 0
-			if yyr1904 || yy2arr1904 {
+			yysep1912 := !z.EncBinary()
+			yy2arr1912 := z.EncBasicHandle().StructToArray
+			var yyq1912 [5]bool
+			_, _, _ = yysep1912, yyq1912, yy2arr1912
+			const yyr1912 bool = false
+			yyq1912[0] = x.Name != ""
+			yyq1912[1] = x.Protocol != ""
+			yyq1912[3] = true
+			yyq1912[4] = x.NodePort != 0
+			if yyr1912 || yy2arr1912 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1904 int = 1
-				for _, b := range yyq1904 {
+				var yynn1912 int = 1
+				for _, b := range yyq1912 {
 					if b {
-						yynn1904++
+						yynn1912++
 					}
 				}
-				r.EncodeMapStart(yynn1904)
+				r.EncodeMapStart(yynn1912)
 			}
-			if yyr1904 || yy2arr1904 {
-				if yyq1904[0] {
-					yym1906 := z.EncBinary()
-					_ = yym1906
+			if yyr1912 || yy2arr1912 {
+				if yyq1912[0] {
+					yym1914 := z.EncBinary()
+					_ = yym1914
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -23092,78 +23152,78 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1904[0] {
+				if yyq1912[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym1907 := z.EncBinary()
-					_ = yym1907
+					yym1915 := z.EncBinary()
+					_ = yym1915
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yyr1904 || yy2arr1904 {
-				if yyq1904[1] {
+			if yyr1912 || yy2arr1912 {
+				if yyq1912[1] {
 					x.Protocol.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1904[1] {
+				if yyq1912[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("protocol"))
 					x.Protocol.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1904 || yy2arr1904 {
-				yym1910 := z.EncBinary()
-				_ = yym1910
+			if yyr1912 || yy2arr1912 {
+				yym1918 := z.EncBinary()
+				_ = yym1918
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
-				yym1911 := z.EncBinary()
-				_ = yym1911
+				yym1919 := z.EncBinary()
+				_ = yym1919
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yyr1904 || yy2arr1904 {
-				if yyq1904[3] {
-					yy1913 := &x.TargetPort
-					yym1914 := z.EncBinary()
-					_ = yym1914
+			if yyr1912 || yy2arr1912 {
+				if yyq1912[3] {
+					yy1921 := &x.TargetPort
+					yym1922 := z.EncBinary()
+					_ = yym1922
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1913) {
-					} else if !yym1914 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy1913)
+					} else if z.HasExtensions() && z.EncExt(yy1921) {
+					} else if !yym1922 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy1921)
 					} else {
-						z.EncFallback(yy1913)
+						z.EncFallback(yy1921)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1904[3] {
+				if yyq1912[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("targetPort"))
-					yy1915 := &x.TargetPort
-					yym1916 := z.EncBinary()
-					_ = yym1916
+					yy1923 := &x.TargetPort
+					yym1924 := z.EncBinary()
+					_ = yym1924
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1915) {
-					} else if !yym1916 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy1915)
+					} else if z.HasExtensions() && z.EncExt(yy1923) {
+					} else if !yym1924 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy1923)
 					} else {
-						z.EncFallback(yy1915)
+						z.EncFallback(yy1923)
 					}
 				}
 			}
-			if yyr1904 || yy2arr1904 {
-				if yyq1904[4] {
-					yym1918 := z.EncBinary()
-					_ = yym1918
+			if yyr1912 || yy2arr1912 {
+				if yyq1912[4] {
+					yym1926 := z.EncBinary()
+					_ = yym1926
 					if false {
 					} else {
 						r.EncodeInt(int64(x.NodePort))
@@ -23172,17 +23232,17 @@ func (x *ServicePort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1904[4] {
+				if yyq1912[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("nodePort"))
-					yym1919 := z.EncBinary()
-					_ = yym1919
+					yym1927 := z.EncBinary()
+					_ = yym1927
 					if false {
 					} else {
 						r.EncodeInt(int64(x.NodePort))
 					}
 				}
 			}
-			if yysep1904 {
+			if yysep1912 {
 				r.EncodeEnd()
 			}
 		}
@@ -23193,24 +23253,24 @@ func (x *ServicePort) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1920 := z.DecBinary()
-	_ = yym1920
+	yym1928 := z.DecBinary()
+	_ = yym1928
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1921 := r.ReadMapStart()
-			if yyl1921 == 0 {
+			yyl1929 := r.ReadMapStart()
+			if yyl1929 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1921, d)
+				x.codecDecodeSelfFromMap(yyl1929, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1921 := r.ReadArrayStart()
-			if yyl1921 == 0 {
+			yyl1929 := r.ReadArrayStart()
+			if yyl1929 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1921, d)
+				x.codecDecodeSelfFromArray(yyl1929, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -23222,12 +23282,12 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1922Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1922Slc
-	var yyhl1922 bool = l >= 0
-	for yyj1922 := 0; ; yyj1922++ {
-		if yyhl1922 {
-			if yyj1922 >= l {
+	var yys1930Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1930Slc
+	var yyhl1930 bool = l >= 0
+	for yyj1930 := 0; ; yyj1930++ {
+		if yyhl1930 {
+			if yyj1930 >= l {
 				break
 			}
 		} else {
@@ -23235,9 +23295,9 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1922Slc = r.DecodeBytes(yys1922Slc, true, true)
-		yys1922 := string(yys1922Slc)
-		switch yys1922 {
+		yys1930Slc = r.DecodeBytes(yys1930Slc, true, true)
+		yys1930 := string(yys1930Slc)
+		switch yys1930 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -23260,15 +23320,15 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.TargetPort = pkg5_intstr.IntOrString{}
 			} else {
-				yyv1926 := &x.TargetPort
-				yym1927 := z.DecBinary()
-				_ = yym1927
+				yyv1934 := &x.TargetPort
+				yym1935 := z.DecBinary()
+				_ = yym1935
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1926) {
-				} else if !yym1927 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1926)
+				} else if z.HasExtensions() && z.DecExt(yyv1934) {
+				} else if !yym1935 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1934)
 				} else {
-					z.DecFallback(yyv1926, false)
+					z.DecFallback(yyv1934, false)
 				}
 			}
 		case "nodePort":
@@ -23278,10 +23338,10 @@ func (x *ServicePort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.NodePort = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1922)
-		} // end switch yys1922
-	} // end for yyj1922
-	if !yyhl1922 {
+			z.DecStructFieldNotFound(-1, yys1930)
+		} // end switch yys1930
+	} // end for yyj1930
+	if !yyhl1930 {
 		r.ReadEnd()
 	}
 }
@@ -23290,16 +23350,16 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1929 int
-	var yyb1929 bool
-	var yyhl1929 bool = l >= 0
-	yyj1929++
-	if yyhl1929 {
-		yyb1929 = yyj1929 > l
+	var yyj1937 int
+	var yyb1937 bool
+	var yyhl1937 bool = l >= 0
+	yyj1937++
+	if yyhl1937 {
+		yyb1937 = yyj1937 > l
 	} else {
-		yyb1929 = r.CheckBreak()
+		yyb1937 = r.CheckBreak()
 	}
-	if yyb1929 {
+	if yyb1937 {
 		r.ReadEnd()
 		return
 	}
@@ -23308,13 +23368,13 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj1929++
-	if yyhl1929 {
-		yyb1929 = yyj1929 > l
+	yyj1937++
+	if yyhl1937 {
+		yyb1937 = yyj1937 > l
 	} else {
-		yyb1929 = r.CheckBreak()
+		yyb1937 = r.CheckBreak()
 	}
-	if yyb1929 {
+	if yyb1937 {
 		r.ReadEnd()
 		return
 	}
@@ -23323,13 +23383,13 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Protocol = Protocol(r.DecodeString())
 	}
-	yyj1929++
-	if yyhl1929 {
-		yyb1929 = yyj1929 > l
+	yyj1937++
+	if yyhl1937 {
+		yyb1937 = yyj1937 > l
 	} else {
-		yyb1929 = r.CheckBreak()
+		yyb1937 = r.CheckBreak()
 	}
-	if yyb1929 {
+	if yyb1937 {
 		r.ReadEnd()
 		return
 	}
@@ -23338,37 +23398,37 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Port = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1929++
-	if yyhl1929 {
-		yyb1929 = yyj1929 > l
+	yyj1937++
+	if yyhl1937 {
+		yyb1937 = yyj1937 > l
 	} else {
-		yyb1929 = r.CheckBreak()
+		yyb1937 = r.CheckBreak()
 	}
-	if yyb1929 {
+	if yyb1937 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.TargetPort = pkg5_intstr.IntOrString{}
 	} else {
-		yyv1933 := &x.TargetPort
-		yym1934 := z.DecBinary()
-		_ = yym1934
+		yyv1941 := &x.TargetPort
+		yym1942 := z.DecBinary()
+		_ = yym1942
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1933) {
-		} else if !yym1934 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1933)
+		} else if z.HasExtensions() && z.DecExt(yyv1941) {
+		} else if !yym1942 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1941)
 		} else {
-			z.DecFallback(yyv1933, false)
+			z.DecFallback(yyv1941, false)
 		}
 	}
-	yyj1929++
-	if yyhl1929 {
-		yyb1929 = yyj1929 > l
+	yyj1937++
+	if yyhl1937 {
+		yyb1937 = yyj1937 > l
 	} else {
-		yyb1929 = r.CheckBreak()
+		yyb1937 = r.CheckBreak()
 	}
-	if yyb1929 {
+	if yyb1937 {
 		r.ReadEnd()
 		return
 	}
@@ -23378,16 +23438,16 @@ func (x *ServicePort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.NodePort = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj1929++
-		if yyhl1929 {
-			yyb1929 = yyj1929 > l
+		yyj1937++
+		if yyhl1937 {
+			yyb1937 = yyj1937 > l
 		} else {
-			yyb1929 = r.CheckBreak()
+			yyb1937 = r.CheckBreak()
 		}
-		if yyb1929 {
+		if yyb1937 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1929-1, "")
+		z.DecStructFieldNotFound(yyj1937-1, "")
 	}
 	r.ReadEnd()
 }
@@ -23399,36 +23459,36 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1936 := z.EncBinary()
-		_ = yym1936
+		yym1944 := z.EncBinary()
+		_ = yym1944
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1937 := !z.EncBinary()
-			yy2arr1937 := z.EncBasicHandle().StructToArray
-			var yyq1937 [5]bool
-			_, _, _ = yysep1937, yyq1937, yy2arr1937
-			const yyr1937 bool = false
-			yyq1937[0] = x.Kind != ""
-			yyq1937[1] = x.APIVersion != ""
-			yyq1937[2] = true
-			yyq1937[3] = true
-			yyq1937[4] = true
-			if yyr1937 || yy2arr1937 {
+			yysep1945 := !z.EncBinary()
+			yy2arr1945 := z.EncBasicHandle().StructToArray
+			var yyq1945 [5]bool
+			_, _, _ = yysep1945, yyq1945, yy2arr1945
+			const yyr1945 bool = false
+			yyq1945[0] = x.Kind != ""
+			yyq1945[1] = x.APIVersion != ""
+			yyq1945[2] = true
+			yyq1945[3] = true
+			yyq1945[4] = true
+			if yyr1945 || yy2arr1945 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn1937 int = 0
-				for _, b := range yyq1937 {
+				var yynn1945 int = 0
+				for _, b := range yyq1945 {
 					if b {
-						yynn1937++
+						yynn1945++
 					}
 				}
-				r.EncodeMapStart(yynn1937)
+				r.EncodeMapStart(yynn1945)
 			}
-			if yyr1937 || yy2arr1937 {
-				if yyq1937[0] {
-					yym1939 := z.EncBinary()
-					_ = yym1939
+			if yyr1945 || yy2arr1945 {
+				if yyq1945[0] {
+					yym1947 := z.EncBinary()
+					_ = yym1947
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -23437,20 +23497,20 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1937[0] {
+				if yyq1945[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1940 := z.EncBinary()
-					_ = yym1940
+					yym1948 := z.EncBinary()
+					_ = yym1948
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1937 || yy2arr1937 {
-				if yyq1937[1] {
-					yym1942 := z.EncBinary()
-					_ = yym1942
+			if yyr1945 || yy2arr1945 {
+				if yyq1945[1] {
+					yym1950 := z.EncBinary()
+					_ = yym1950
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -23459,59 +23519,59 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1937[1] {
+				if yyq1945[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1943 := z.EncBinary()
-					_ = yym1943
+					yym1951 := z.EncBinary()
+					_ = yym1951
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1937 || yy2arr1937 {
-				if yyq1937[2] {
-					yy1945 := &x.ObjectMeta
-					yy1945.CodecEncodeSelf(e)
+			if yyr1945 || yy2arr1945 {
+				if yyq1945[2] {
+					yy1953 := &x.ObjectMeta
+					yy1953.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1937[2] {
+				if yyq1945[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1946 := &x.ObjectMeta
-					yy1946.CodecEncodeSelf(e)
+					yy1954 := &x.ObjectMeta
+					yy1954.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1937 || yy2arr1937 {
-				if yyq1937[3] {
-					yy1948 := &x.Spec
-					yy1948.CodecEncodeSelf(e)
+			if yyr1945 || yy2arr1945 {
+				if yyq1945[3] {
+					yy1956 := &x.Spec
+					yy1956.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1937[3] {
+				if yyq1945[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1949 := &x.Spec
-					yy1949.CodecEncodeSelf(e)
+					yy1957 := &x.Spec
+					yy1957.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1937 || yy2arr1937 {
-				if yyq1937[4] {
-					yy1951 := &x.Status
-					yy1951.CodecEncodeSelf(e)
+			if yyr1945 || yy2arr1945 {
+				if yyq1945[4] {
+					yy1959 := &x.Status
+					yy1959.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1937[4] {
+				if yyq1945[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy1952 := &x.Status
-					yy1952.CodecEncodeSelf(e)
+					yy1960 := &x.Status
+					yy1960.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1937 {
+			if yysep1945 {
 				r.EncodeEnd()
 			}
 		}
@@ -23522,24 +23582,24 @@ func (x *Service) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1953 := z.DecBinary()
-	_ = yym1953
+	yym1961 := z.DecBinary()
+	_ = yym1961
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1954 := r.ReadMapStart()
-			if yyl1954 == 0 {
+			yyl1962 := r.ReadMapStart()
+			if yyl1962 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1954, d)
+				x.codecDecodeSelfFromMap(yyl1962, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1954 := r.ReadArrayStart()
-			if yyl1954 == 0 {
+			yyl1962 := r.ReadArrayStart()
+			if yyl1962 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1954, d)
+				x.codecDecodeSelfFromArray(yyl1962, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -23551,12 +23611,12 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1955Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1955Slc
-	var yyhl1955 bool = l >= 0
-	for yyj1955 := 0; ; yyj1955++ {
-		if yyhl1955 {
-			if yyj1955 >= l {
+	var yys1963Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1963Slc
+	var yyhl1963 bool = l >= 0
+	for yyj1963 := 0; ; yyj1963++ {
+		if yyhl1963 {
+			if yyj1963 >= l {
 				break
 			}
 		} else {
@@ -23564,9 +23624,9 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1955Slc = r.DecodeBytes(yys1955Slc, true, true)
-		yys1955 := string(yys1955Slc)
-		switch yys1955 {
+		yys1963Slc = r.DecodeBytes(yys1963Slc, true, true)
+		yys1963 := string(yys1963Slc)
+		switch yys1963 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -23583,28 +23643,28 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv1958 := &x.ObjectMeta
-				yyv1958.CodecDecodeSelf(d)
+				yyv1966 := &x.ObjectMeta
+				yyv1966.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ServiceSpec{}
 			} else {
-				yyv1959 := &x.Spec
-				yyv1959.CodecDecodeSelf(d)
+				yyv1967 := &x.Spec
+				yyv1967.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ServiceStatus{}
 			} else {
-				yyv1960 := &x.Status
-				yyv1960.CodecDecodeSelf(d)
+				yyv1968 := &x.Status
+				yyv1968.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1955)
-		} // end switch yys1955
-	} // end for yyj1955
-	if !yyhl1955 {
+			z.DecStructFieldNotFound(-1, yys1963)
+		} // end switch yys1963
+	} // end for yyj1963
+	if !yyhl1963 {
 		r.ReadEnd()
 	}
 }
@@ -23613,16 +23673,16 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1961 int
-	var yyb1961 bool
-	var yyhl1961 bool = l >= 0
-	yyj1961++
-	if yyhl1961 {
-		yyb1961 = yyj1961 > l
+	var yyj1969 int
+	var yyb1969 bool
+	var yyhl1969 bool = l >= 0
+	yyj1969++
+	if yyhl1969 {
+		yyb1969 = yyj1969 > l
 	} else {
-		yyb1961 = r.CheckBreak()
+		yyb1969 = r.CheckBreak()
 	}
-	if yyb1961 {
+	if yyb1969 {
 		r.ReadEnd()
 		return
 	}
@@ -23631,13 +23691,13 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1961++
-	if yyhl1961 {
-		yyb1961 = yyj1961 > l
+	yyj1969++
+	if yyhl1969 {
+		yyb1969 = yyj1969 > l
 	} else {
-		yyb1961 = r.CheckBreak()
+		yyb1969 = r.CheckBreak()
 	}
-	if yyb1961 {
+	if yyb1969 {
 		r.ReadEnd()
 		return
 	}
@@ -23646,65 +23706,65 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1961++
-	if yyhl1961 {
-		yyb1961 = yyj1961 > l
+	yyj1969++
+	if yyhl1969 {
+		yyb1969 = yyj1969 > l
 	} else {
-		yyb1961 = r.CheckBreak()
+		yyb1969 = r.CheckBreak()
 	}
-	if yyb1961 {
+	if yyb1969 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv1964 := &x.ObjectMeta
-		yyv1964.CodecDecodeSelf(d)
+		yyv1972 := &x.ObjectMeta
+		yyv1972.CodecDecodeSelf(d)
 	}
-	yyj1961++
-	if yyhl1961 {
-		yyb1961 = yyj1961 > l
+	yyj1969++
+	if yyhl1969 {
+		yyb1969 = yyj1969 > l
 	} else {
-		yyb1961 = r.CheckBreak()
+		yyb1969 = r.CheckBreak()
 	}
-	if yyb1961 {
+	if yyb1969 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ServiceSpec{}
 	} else {
-		yyv1965 := &x.Spec
-		yyv1965.CodecDecodeSelf(d)
+		yyv1973 := &x.Spec
+		yyv1973.CodecDecodeSelf(d)
 	}
-	yyj1961++
-	if yyhl1961 {
-		yyb1961 = yyj1961 > l
+	yyj1969++
+	if yyhl1969 {
+		yyb1969 = yyj1969 > l
 	} else {
-		yyb1961 = r.CheckBreak()
+		yyb1969 = r.CheckBreak()
 	}
-	if yyb1961 {
+	if yyb1969 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ServiceStatus{}
 	} else {
-		yyv1966 := &x.Status
-		yyv1966.CodecDecodeSelf(d)
+		yyv1974 := &x.Status
+		yyv1974.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1961++
-		if yyhl1961 {
-			yyb1961 = yyj1961 > l
+		yyj1969++
+		if yyhl1969 {
+			yyb1969 = yyj1969 > l
 		} else {
-			yyb1961 = r.CheckBreak()
+			yyb1969 = r.CheckBreak()
 		}
-		if yyb1961 {
+		if yyb1969 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1961-1, "")
+		z.DecStructFieldNotFound(yyj1969-1, "")
 	}
 	r.ReadEnd()
 }
@@ -23716,34 +23776,34 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1967 := z.EncBinary()
-		_ = yym1967
+		yym1975 := z.EncBinary()
+		_ = yym1975
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1968 := !z.EncBinary()
-			yy2arr1968 := z.EncBasicHandle().StructToArray
-			var yyq1968 [4]bool
-			_, _, _ = yysep1968, yyq1968, yy2arr1968
-			const yyr1968 bool = false
-			yyq1968[0] = x.Kind != ""
-			yyq1968[1] = x.APIVersion != ""
-			yyq1968[2] = true
-			if yyr1968 || yy2arr1968 {
+			yysep1976 := !z.EncBinary()
+			yy2arr1976 := z.EncBasicHandle().StructToArray
+			var yyq1976 [4]bool
+			_, _, _ = yysep1976, yyq1976, yy2arr1976
+			const yyr1976 bool = false
+			yyq1976[0] = x.Kind != ""
+			yyq1976[1] = x.APIVersion != ""
+			yyq1976[2] = true
+			if yyr1976 || yy2arr1976 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1968 int = 1
-				for _, b := range yyq1968 {
+				var yynn1976 int = 1
+				for _, b := range yyq1976 {
 					if b {
-						yynn1968++
+						yynn1976++
 					}
 				}
-				r.EncodeMapStart(yynn1968)
+				r.EncodeMapStart(yynn1976)
 			}
-			if yyr1968 || yy2arr1968 {
-				if yyq1968[0] {
-					yym1970 := z.EncBinary()
-					_ = yym1970
+			if yyr1976 || yy2arr1976 {
+				if yyq1976[0] {
+					yym1978 := z.EncBinary()
+					_ = yym1978
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -23752,70 +23812,70 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1968[0] {
+				if yyq1976[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1971 := z.EncBinary()
-					_ = yym1971
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1968 || yy2arr1968 {
-				if yyq1968[1] {
-					yym1973 := z.EncBinary()
-					_ = yym1973
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1968[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1974 := z.EncBinary()
-					_ = yym1974
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1968 || yy2arr1968 {
-				if yyq1968[2] {
-					yy1976 := &x.ListMeta
-					yym1977 := z.EncBinary()
-					_ = yym1977
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1976) {
-					} else {
-						z.EncFallback(yy1976)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1968[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1978 := &x.ListMeta
 					yym1979 := z.EncBinary()
 					_ = yym1979
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1978) {
 					} else {
-						z.EncFallback(yy1978)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1968 || yy2arr1968 {
+			if yyr1976 || yy2arr1976 {
+				if yyq1976[1] {
+					yym1981 := z.EncBinary()
+					_ = yym1981
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1976[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1982 := z.EncBinary()
+					_ = yym1982
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1976 || yy2arr1976 {
+				if yyq1976[2] {
+					yy1984 := &x.ListMeta
+					yym1985 := z.EncBinary()
+					_ = yym1985
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1984) {
+					} else {
+						z.EncFallback(yy1984)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1976[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1986 := &x.ListMeta
+					yym1987 := z.EncBinary()
+					_ = yym1987
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1986) {
+					} else {
+						z.EncFallback(yy1986)
+					}
+				}
+			}
+			if yyr1976 || yy2arr1976 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1981 := z.EncBinary()
-					_ = yym1981
+					yym1989 := z.EncBinary()
+					_ = yym1989
 					if false {
 					} else {
 						h.encSliceService(([]Service)(x.Items), e)
@@ -23826,15 +23886,15 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1982 := z.EncBinary()
-					_ = yym1982
+					yym1990 := z.EncBinary()
+					_ = yym1990
 					if false {
 					} else {
 						h.encSliceService(([]Service)(x.Items), e)
 					}
 				}
 			}
-			if yysep1968 {
+			if yysep1976 {
 				r.EncodeEnd()
 			}
 		}
@@ -23845,24 +23905,24 @@ func (x *ServiceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1983 := z.DecBinary()
-	_ = yym1983
+	yym1991 := z.DecBinary()
+	_ = yym1991
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1984 := r.ReadMapStart()
-			if yyl1984 == 0 {
+			yyl1992 := r.ReadMapStart()
+			if yyl1992 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1984, d)
+				x.codecDecodeSelfFromMap(yyl1992, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1984 := r.ReadArrayStart()
-			if yyl1984 == 0 {
+			yyl1992 := r.ReadArrayStart()
+			if yyl1992 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1984, d)
+				x.codecDecodeSelfFromArray(yyl1992, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -23874,12 +23934,12 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1985Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1985Slc
-	var yyhl1985 bool = l >= 0
-	for yyj1985 := 0; ; yyj1985++ {
-		if yyhl1985 {
-			if yyj1985 >= l {
+	var yys1993Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1993Slc
+	var yyhl1993 bool = l >= 0
+	for yyj1993 := 0; ; yyj1993++ {
+		if yyhl1993 {
+			if yyj1993 >= l {
 				break
 			}
 		} else {
@@ -23887,9 +23947,9 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1985Slc = r.DecodeBytes(yys1985Slc, true, true)
-		yys1985 := string(yys1985Slc)
-		switch yys1985 {
+		yys1993Slc = r.DecodeBytes(yys1993Slc, true, true)
+		yys1993 := string(yys1993Slc)
+		switch yys1993 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -23906,32 +23966,32 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv1988 := &x.ListMeta
-				yym1989 := z.DecBinary()
-				_ = yym1989
+				yyv1996 := &x.ListMeta
+				yym1997 := z.DecBinary()
+				_ = yym1997
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1988) {
+				} else if z.HasExtensions() && z.DecExt(yyv1996) {
 				} else {
-					z.DecFallback(yyv1988, false)
+					z.DecFallback(yyv1996, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1990 := &x.Items
-				yym1991 := z.DecBinary()
-				_ = yym1991
+				yyv1998 := &x.Items
+				yym1999 := z.DecBinary()
+				_ = yym1999
 				if false {
 				} else {
-					h.decSliceService((*[]Service)(yyv1990), d)
+					h.decSliceService((*[]Service)(yyv1998), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1985)
-		} // end switch yys1985
-	} // end for yyj1985
-	if !yyhl1985 {
+			z.DecStructFieldNotFound(-1, yys1993)
+		} // end switch yys1993
+	} // end for yyj1993
+	if !yyhl1993 {
 		r.ReadEnd()
 	}
 }
@@ -23940,16 +24000,16 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1992 int
-	var yyb1992 bool
-	var yyhl1992 bool = l >= 0
-	yyj1992++
-	if yyhl1992 {
-		yyb1992 = yyj1992 > l
+	var yyj2000 int
+	var yyb2000 bool
+	var yyhl2000 bool = l >= 0
+	yyj2000++
+	if yyhl2000 {
+		yyb2000 = yyj2000 > l
 	} else {
-		yyb1992 = r.CheckBreak()
+		yyb2000 = r.CheckBreak()
 	}
-	if yyb1992 {
+	if yyb2000 {
 		r.ReadEnd()
 		return
 	}
@@ -23958,13 +24018,13 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1992++
-	if yyhl1992 {
-		yyb1992 = yyj1992 > l
+	yyj2000++
+	if yyhl2000 {
+		yyb2000 = yyj2000 > l
 	} else {
-		yyb1992 = r.CheckBreak()
+		yyb2000 = r.CheckBreak()
 	}
-	if yyb1992 {
+	if yyb2000 {
 		r.ReadEnd()
 		return
 	}
@@ -23973,60 +24033,60 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1992++
-	if yyhl1992 {
-		yyb1992 = yyj1992 > l
+	yyj2000++
+	if yyhl2000 {
+		yyb2000 = yyj2000 > l
 	} else {
-		yyb1992 = r.CheckBreak()
+		yyb2000 = r.CheckBreak()
 	}
-	if yyb1992 {
+	if yyb2000 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv1995 := &x.ListMeta
-		yym1996 := z.DecBinary()
-		_ = yym1996
+		yyv2003 := &x.ListMeta
+		yym2004 := z.DecBinary()
+		_ = yym2004
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1995) {
+		} else if z.HasExtensions() && z.DecExt(yyv2003) {
 		} else {
-			z.DecFallback(yyv1995, false)
+			z.DecFallback(yyv2003, false)
 		}
 	}
-	yyj1992++
-	if yyhl1992 {
-		yyb1992 = yyj1992 > l
+	yyj2000++
+	if yyhl2000 {
+		yyb2000 = yyj2000 > l
 	} else {
-		yyb1992 = r.CheckBreak()
+		yyb2000 = r.CheckBreak()
 	}
-	if yyb1992 {
+	if yyb2000 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1997 := &x.Items
-		yym1998 := z.DecBinary()
-		_ = yym1998
+		yyv2005 := &x.Items
+		yym2006 := z.DecBinary()
+		_ = yym2006
 		if false {
 		} else {
-			h.decSliceService((*[]Service)(yyv1997), d)
+			h.decSliceService((*[]Service)(yyv2005), d)
 		}
 	}
 	for {
-		yyj1992++
-		if yyhl1992 {
-			yyb1992 = yyj1992 > l
+		yyj2000++
+		if yyhl2000 {
+			yyb2000 = yyj2000 > l
 		} else {
-			yyb1992 = r.CheckBreak()
+			yyb2000 = r.CheckBreak()
 		}
-		if yyb1992 {
+		if yyb2000 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1992-1, "")
+		z.DecStructFieldNotFound(yyj2000-1, "")
 	}
 	r.ReadEnd()
 }
@@ -24038,36 +24098,36 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1999 := z.EncBinary()
-		_ = yym1999
+		yym2007 := z.EncBinary()
+		_ = yym2007
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2000 := !z.EncBinary()
-			yy2arr2000 := z.EncBasicHandle().StructToArray
-			var yyq2000 [5]bool
-			_, _, _ = yysep2000, yyq2000, yy2arr2000
-			const yyr2000 bool = false
-			yyq2000[0] = x.Kind != ""
-			yyq2000[1] = x.APIVersion != ""
-			yyq2000[2] = true
-			yyq2000[3] = len(x.Secrets) != 0
-			yyq2000[4] = len(x.ImagePullSecrets) != 0
-			if yyr2000 || yy2arr2000 {
+			yysep2008 := !z.EncBinary()
+			yy2arr2008 := z.EncBasicHandle().StructToArray
+			var yyq2008 [5]bool
+			_, _, _ = yysep2008, yyq2008, yy2arr2008
+			const yyr2008 bool = false
+			yyq2008[0] = x.Kind != ""
+			yyq2008[1] = x.APIVersion != ""
+			yyq2008[2] = true
+			yyq2008[3] = len(x.Secrets) != 0
+			yyq2008[4] = len(x.ImagePullSecrets) != 0
+			if yyr2008 || yy2arr2008 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2000 int = 0
-				for _, b := range yyq2000 {
+				var yynn2008 int = 0
+				for _, b := range yyq2008 {
 					if b {
-						yynn2000++
+						yynn2008++
 					}
 				}
-				r.EncodeMapStart(yynn2000)
+				r.EncodeMapStart(yynn2008)
 			}
-			if yyr2000 || yy2arr2000 {
-				if yyq2000[0] {
-					yym2002 := z.EncBinary()
-					_ = yym2002
+			if yyr2008 || yy2arr2008 {
+				if yyq2008[0] {
+					yym2010 := z.EncBinary()
+					_ = yym2010
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -24076,20 +24136,20 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2000[0] {
+				if yyq2008[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2003 := z.EncBinary()
-					_ = yym2003
+					yym2011 := z.EncBinary()
+					_ = yym2011
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2000 || yy2arr2000 {
-				if yyq2000[1] {
-					yym2005 := z.EncBinary()
-					_ = yym2005
+			if yyr2008 || yy2arr2008 {
+				if yyq2008[1] {
+					yym2013 := z.EncBinary()
+					_ = yym2013
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -24098,37 +24158,37 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2000[1] {
+				if yyq2008[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2006 := z.EncBinary()
-					_ = yym2006
+					yym2014 := z.EncBinary()
+					_ = yym2014
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2000 || yy2arr2000 {
-				if yyq2000[2] {
-					yy2008 := &x.ObjectMeta
-					yy2008.CodecEncodeSelf(e)
+			if yyr2008 || yy2arr2008 {
+				if yyq2008[2] {
+					yy2016 := &x.ObjectMeta
+					yy2016.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2000[2] {
+				if yyq2008[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2009 := &x.ObjectMeta
-					yy2009.CodecEncodeSelf(e)
+					yy2017 := &x.ObjectMeta
+					yy2017.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2000 || yy2arr2000 {
-				if yyq2000[3] {
+			if yyr2008 || yy2arr2008 {
+				if yyq2008[3] {
 					if x.Secrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2011 := z.EncBinary()
-						_ = yym2011
+						yym2019 := z.EncBinary()
+						_ = yym2019
 						if false {
 						} else {
 							h.encSliceObjectReference(([]ObjectReference)(x.Secrets), e)
@@ -24138,13 +24198,13 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2000[3] {
+				if yyq2008[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("secrets"))
 					if x.Secrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2012 := z.EncBinary()
-						_ = yym2012
+						yym2020 := z.EncBinary()
+						_ = yym2020
 						if false {
 						} else {
 							h.encSliceObjectReference(([]ObjectReference)(x.Secrets), e)
@@ -24152,13 +24212,13 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2000 || yy2arr2000 {
-				if yyq2000[4] {
+			if yyr2008 || yy2arr2008 {
+				if yyq2008[4] {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2014 := z.EncBinary()
-						_ = yym2014
+						yym2022 := z.EncBinary()
+						_ = yym2022
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -24168,13 +24228,13 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2000[4] {
+				if yyq2008[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("imagePullSecrets"))
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2015 := z.EncBinary()
-						_ = yym2015
+						yym2023 := z.EncBinary()
+						_ = yym2023
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -24182,7 +24242,7 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2000 {
+			if yysep2008 {
 				r.EncodeEnd()
 			}
 		}
@@ -24193,24 +24253,24 @@ func (x *ServiceAccount) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2016 := z.DecBinary()
-	_ = yym2016
+	yym2024 := z.DecBinary()
+	_ = yym2024
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2017 := r.ReadMapStart()
-			if yyl2017 == 0 {
+			yyl2025 := r.ReadMapStart()
+			if yyl2025 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2017, d)
+				x.codecDecodeSelfFromMap(yyl2025, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2017 := r.ReadArrayStart()
-			if yyl2017 == 0 {
+			yyl2025 := r.ReadArrayStart()
+			if yyl2025 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2017, d)
+				x.codecDecodeSelfFromArray(yyl2025, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -24222,12 +24282,12 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2018Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2018Slc
-	var yyhl2018 bool = l >= 0
-	for yyj2018 := 0; ; yyj2018++ {
-		if yyhl2018 {
-			if yyj2018 >= l {
+	var yys2026Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2026Slc
+	var yyhl2026 bool = l >= 0
+	for yyj2026 := 0; ; yyj2026++ {
+		if yyhl2026 {
+			if yyj2026 >= l {
 				break
 			}
 		} else {
@@ -24235,9 +24295,9 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2018Slc = r.DecodeBytes(yys2018Slc, true, true)
-		yys2018 := string(yys2018Slc)
-		switch yys2018 {
+		yys2026Slc = r.DecodeBytes(yys2026Slc, true, true)
+		yys2026 := string(yys2026Slc)
+		switch yys2026 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24254,38 +24314,38 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2021 := &x.ObjectMeta
-				yyv2021.CodecDecodeSelf(d)
+				yyv2029 := &x.ObjectMeta
+				yyv2029.CodecDecodeSelf(d)
 			}
 		case "secrets":
 			if r.TryDecodeAsNil() {
 				x.Secrets = nil
 			} else {
-				yyv2022 := &x.Secrets
-				yym2023 := z.DecBinary()
-				_ = yym2023
+				yyv2030 := &x.Secrets
+				yym2031 := z.DecBinary()
+				_ = yym2031
 				if false {
 				} else {
-					h.decSliceObjectReference((*[]ObjectReference)(yyv2022), d)
+					h.decSliceObjectReference((*[]ObjectReference)(yyv2030), d)
 				}
 			}
 		case "imagePullSecrets":
 			if r.TryDecodeAsNil() {
 				x.ImagePullSecrets = nil
 			} else {
-				yyv2024 := &x.ImagePullSecrets
-				yym2025 := z.DecBinary()
-				_ = yym2025
+				yyv2032 := &x.ImagePullSecrets
+				yym2033 := z.DecBinary()
+				_ = yym2033
 				if false {
 				} else {
-					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2024), d)
+					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2032), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2018)
-		} // end switch yys2018
-	} // end for yyj2018
-	if !yyhl2018 {
+			z.DecStructFieldNotFound(-1, yys2026)
+		} // end switch yys2026
+	} // end for yyj2026
+	if !yyhl2026 {
 		r.ReadEnd()
 	}
 }
@@ -24294,16 +24354,16 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2026 int
-	var yyb2026 bool
-	var yyhl2026 bool = l >= 0
-	yyj2026++
-	if yyhl2026 {
-		yyb2026 = yyj2026 > l
+	var yyj2034 int
+	var yyb2034 bool
+	var yyhl2034 bool = l >= 0
+	yyj2034++
+	if yyhl2034 {
+		yyb2034 = yyj2034 > l
 	} else {
-		yyb2026 = r.CheckBreak()
+		yyb2034 = r.CheckBreak()
 	}
-	if yyb2026 {
+	if yyb2034 {
 		r.ReadEnd()
 		return
 	}
@@ -24312,13 +24372,13 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2026++
-	if yyhl2026 {
-		yyb2026 = yyj2026 > l
+	yyj2034++
+	if yyhl2034 {
+		yyb2034 = yyj2034 > l
 	} else {
-		yyb2026 = r.CheckBreak()
+		yyb2034 = r.CheckBreak()
 	}
-	if yyb2026 {
+	if yyb2034 {
 		r.ReadEnd()
 		return
 	}
@@ -24327,75 +24387,75 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2026++
-	if yyhl2026 {
-		yyb2026 = yyj2026 > l
+	yyj2034++
+	if yyhl2034 {
+		yyb2034 = yyj2034 > l
 	} else {
-		yyb2026 = r.CheckBreak()
+		yyb2034 = r.CheckBreak()
 	}
-	if yyb2026 {
+	if yyb2034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2029 := &x.ObjectMeta
-		yyv2029.CodecDecodeSelf(d)
+		yyv2037 := &x.ObjectMeta
+		yyv2037.CodecDecodeSelf(d)
 	}
-	yyj2026++
-	if yyhl2026 {
-		yyb2026 = yyj2026 > l
+	yyj2034++
+	if yyhl2034 {
+		yyb2034 = yyj2034 > l
 	} else {
-		yyb2026 = r.CheckBreak()
+		yyb2034 = r.CheckBreak()
 	}
-	if yyb2026 {
+	if yyb2034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Secrets = nil
 	} else {
-		yyv2030 := &x.Secrets
-		yym2031 := z.DecBinary()
-		_ = yym2031
+		yyv2038 := &x.Secrets
+		yym2039 := z.DecBinary()
+		_ = yym2039
 		if false {
 		} else {
-			h.decSliceObjectReference((*[]ObjectReference)(yyv2030), d)
+			h.decSliceObjectReference((*[]ObjectReference)(yyv2038), d)
 		}
 	}
-	yyj2026++
-	if yyhl2026 {
-		yyb2026 = yyj2026 > l
+	yyj2034++
+	if yyhl2034 {
+		yyb2034 = yyj2034 > l
 	} else {
-		yyb2026 = r.CheckBreak()
+		yyb2034 = r.CheckBreak()
 	}
-	if yyb2026 {
+	if yyb2034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ImagePullSecrets = nil
 	} else {
-		yyv2032 := &x.ImagePullSecrets
-		yym2033 := z.DecBinary()
-		_ = yym2033
+		yyv2040 := &x.ImagePullSecrets
+		yym2041 := z.DecBinary()
+		_ = yym2041
 		if false {
 		} else {
-			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2032), d)
+			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2040), d)
 		}
 	}
 	for {
-		yyj2026++
-		if yyhl2026 {
-			yyb2026 = yyj2026 > l
+		yyj2034++
+		if yyhl2034 {
+			yyb2034 = yyj2034 > l
 		} else {
-			yyb2026 = r.CheckBreak()
+			yyb2034 = r.CheckBreak()
 		}
-		if yyb2026 {
+		if yyb2034 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2026-1, "")
+		z.DecStructFieldNotFound(yyj2034-1, "")
 	}
 	r.ReadEnd()
 }
@@ -24407,34 +24467,34 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2034 := z.EncBinary()
-		_ = yym2034
+		yym2042 := z.EncBinary()
+		_ = yym2042
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2035 := !z.EncBinary()
-			yy2arr2035 := z.EncBasicHandle().StructToArray
-			var yyq2035 [4]bool
-			_, _, _ = yysep2035, yyq2035, yy2arr2035
-			const yyr2035 bool = false
-			yyq2035[0] = x.Kind != ""
-			yyq2035[1] = x.APIVersion != ""
-			yyq2035[2] = true
-			if yyr2035 || yy2arr2035 {
+			yysep2043 := !z.EncBinary()
+			yy2arr2043 := z.EncBasicHandle().StructToArray
+			var yyq2043 [4]bool
+			_, _, _ = yysep2043, yyq2043, yy2arr2043
+			const yyr2043 bool = false
+			yyq2043[0] = x.Kind != ""
+			yyq2043[1] = x.APIVersion != ""
+			yyq2043[2] = true
+			if yyr2043 || yy2arr2043 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2035 int = 1
-				for _, b := range yyq2035 {
+				var yynn2043 int = 1
+				for _, b := range yyq2043 {
 					if b {
-						yynn2035++
+						yynn2043++
 					}
 				}
-				r.EncodeMapStart(yynn2035)
+				r.EncodeMapStart(yynn2043)
 			}
-			if yyr2035 || yy2arr2035 {
-				if yyq2035[0] {
-					yym2037 := z.EncBinary()
-					_ = yym2037
+			if yyr2043 || yy2arr2043 {
+				if yyq2043[0] {
+					yym2045 := z.EncBinary()
+					_ = yym2045
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -24443,70 +24503,70 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2035[0] {
+				if yyq2043[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2038 := z.EncBinary()
-					_ = yym2038
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2035 || yy2arr2035 {
-				if yyq2035[1] {
-					yym2040 := z.EncBinary()
-					_ = yym2040
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2035[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2041 := z.EncBinary()
-					_ = yym2041
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2035 || yy2arr2035 {
-				if yyq2035[2] {
-					yy2043 := &x.ListMeta
-					yym2044 := z.EncBinary()
-					_ = yym2044
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2043) {
-					} else {
-						z.EncFallback(yy2043)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2035[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2045 := &x.ListMeta
 					yym2046 := z.EncBinary()
 					_ = yym2046
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2045) {
 					} else {
-						z.EncFallback(yy2045)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2035 || yy2arr2035 {
+			if yyr2043 || yy2arr2043 {
+				if yyq2043[1] {
+					yym2048 := z.EncBinary()
+					_ = yym2048
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2043[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2049 := z.EncBinary()
+					_ = yym2049
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2043 || yy2arr2043 {
+				if yyq2043[2] {
+					yy2051 := &x.ListMeta
+					yym2052 := z.EncBinary()
+					_ = yym2052
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2051) {
+					} else {
+						z.EncFallback(yy2051)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2043[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2053 := &x.ListMeta
+					yym2054 := z.EncBinary()
+					_ = yym2054
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2053) {
+					} else {
+						z.EncFallback(yy2053)
+					}
+				}
+			}
+			if yyr2043 || yy2arr2043 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2048 := z.EncBinary()
-					_ = yym2048
+					yym2056 := z.EncBinary()
+					_ = yym2056
 					if false {
 					} else {
 						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
@@ -24517,15 +24577,15 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2049 := z.EncBinary()
-					_ = yym2049
+					yym2057 := z.EncBinary()
+					_ = yym2057
 					if false {
 					} else {
 						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
 					}
 				}
 			}
-			if yysep2035 {
+			if yysep2043 {
 				r.EncodeEnd()
 			}
 		}
@@ -24536,24 +24596,24 @@ func (x *ServiceAccountList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2050 := z.DecBinary()
-	_ = yym2050
+	yym2058 := z.DecBinary()
+	_ = yym2058
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2051 := r.ReadMapStart()
-			if yyl2051 == 0 {
+			yyl2059 := r.ReadMapStart()
+			if yyl2059 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2051, d)
+				x.codecDecodeSelfFromMap(yyl2059, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2051 := r.ReadArrayStart()
-			if yyl2051 == 0 {
+			yyl2059 := r.ReadArrayStart()
+			if yyl2059 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2051, d)
+				x.codecDecodeSelfFromArray(yyl2059, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -24565,12 +24625,12 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2052Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2052Slc
-	var yyhl2052 bool = l >= 0
-	for yyj2052 := 0; ; yyj2052++ {
-		if yyhl2052 {
-			if yyj2052 >= l {
+	var yys2060Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2060Slc
+	var yyhl2060 bool = l >= 0
+	for yyj2060 := 0; ; yyj2060++ {
+		if yyhl2060 {
+			if yyj2060 >= l {
 				break
 			}
 		} else {
@@ -24578,9 +24638,9 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys2052Slc = r.DecodeBytes(yys2052Slc, true, true)
-		yys2052 := string(yys2052Slc)
-		switch yys2052 {
+		yys2060Slc = r.DecodeBytes(yys2060Slc, true, true)
+		yys2060 := string(yys2060Slc)
+		switch yys2060 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24597,32 +24657,32 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2055 := &x.ListMeta
-				yym2056 := z.DecBinary()
-				_ = yym2056
+				yyv2063 := &x.ListMeta
+				yym2064 := z.DecBinary()
+				_ = yym2064
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2055) {
+				} else if z.HasExtensions() && z.DecExt(yyv2063) {
 				} else {
-					z.DecFallback(yyv2055, false)
+					z.DecFallback(yyv2063, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2057 := &x.Items
-				yym2058 := z.DecBinary()
-				_ = yym2058
+				yyv2065 := &x.Items
+				yym2066 := z.DecBinary()
+				_ = yym2066
 				if false {
 				} else {
-					h.decSliceServiceAccount((*[]ServiceAccount)(yyv2057), d)
+					h.decSliceServiceAccount((*[]ServiceAccount)(yyv2065), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2052)
-		} // end switch yys2052
-	} // end for yyj2052
-	if !yyhl2052 {
+			z.DecStructFieldNotFound(-1, yys2060)
+		} // end switch yys2060
+	} // end for yyj2060
+	if !yyhl2060 {
 		r.ReadEnd()
 	}
 }
@@ -24631,16 +24691,16 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2059 int
-	var yyb2059 bool
-	var yyhl2059 bool = l >= 0
-	yyj2059++
-	if yyhl2059 {
-		yyb2059 = yyj2059 > l
+	var yyj2067 int
+	var yyb2067 bool
+	var yyhl2067 bool = l >= 0
+	yyj2067++
+	if yyhl2067 {
+		yyb2067 = yyj2067 > l
 	} else {
-		yyb2059 = r.CheckBreak()
+		yyb2067 = r.CheckBreak()
 	}
-	if yyb2059 {
+	if yyb2067 {
 		r.ReadEnd()
 		return
 	}
@@ -24649,13 +24709,13 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2059++
-	if yyhl2059 {
-		yyb2059 = yyj2059 > l
+	yyj2067++
+	if yyhl2067 {
+		yyb2067 = yyj2067 > l
 	} else {
-		yyb2059 = r.CheckBreak()
+		yyb2067 = r.CheckBreak()
 	}
-	if yyb2059 {
+	if yyb2067 {
 		r.ReadEnd()
 		return
 	}
@@ -24664,60 +24724,60 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2059++
-	if yyhl2059 {
-		yyb2059 = yyj2059 > l
+	yyj2067++
+	if yyhl2067 {
+		yyb2067 = yyj2067 > l
 	} else {
-		yyb2059 = r.CheckBreak()
+		yyb2067 = r.CheckBreak()
 	}
-	if yyb2059 {
+	if yyb2067 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2062 := &x.ListMeta
-		yym2063 := z.DecBinary()
-		_ = yym2063
+		yyv2070 := &x.ListMeta
+		yym2071 := z.DecBinary()
+		_ = yym2071
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2062) {
+		} else if z.HasExtensions() && z.DecExt(yyv2070) {
 		} else {
-			z.DecFallback(yyv2062, false)
+			z.DecFallback(yyv2070, false)
 		}
 	}
-	yyj2059++
-	if yyhl2059 {
-		yyb2059 = yyj2059 > l
+	yyj2067++
+	if yyhl2067 {
+		yyb2067 = yyj2067 > l
 	} else {
-		yyb2059 = r.CheckBreak()
+		yyb2067 = r.CheckBreak()
 	}
-	if yyb2059 {
+	if yyb2067 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2064 := &x.Items
-		yym2065 := z.DecBinary()
-		_ = yym2065
+		yyv2072 := &x.Items
+		yym2073 := z.DecBinary()
+		_ = yym2073
 		if false {
 		} else {
-			h.decSliceServiceAccount((*[]ServiceAccount)(yyv2064), d)
+			h.decSliceServiceAccount((*[]ServiceAccount)(yyv2072), d)
 		}
 	}
 	for {
-		yyj2059++
-		if yyhl2059 {
-			yyb2059 = yyj2059 > l
+		yyj2067++
+		if yyhl2067 {
+			yyb2067 = yyj2067 > l
 		} else {
-			yyb2059 = r.CheckBreak()
+			yyb2067 = r.CheckBreak()
 		}
-		if yyb2059 {
+		if yyb2067 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2059-1, "")
+		z.DecStructFieldNotFound(yyj2067-1, "")
 	}
 	r.ReadEnd()
 }
@@ -24729,34 +24789,34 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2066 := z.EncBinary()
-		_ = yym2066
+		yym2074 := z.EncBinary()
+		_ = yym2074
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2067 := !z.EncBinary()
-			yy2arr2067 := z.EncBasicHandle().StructToArray
-			var yyq2067 [4]bool
-			_, _, _ = yysep2067, yyq2067, yy2arr2067
-			const yyr2067 bool = false
-			yyq2067[0] = x.Kind != ""
-			yyq2067[1] = x.APIVersion != ""
-			yyq2067[2] = true
-			if yyr2067 || yy2arr2067 {
+			yysep2075 := !z.EncBinary()
+			yy2arr2075 := z.EncBasicHandle().StructToArray
+			var yyq2075 [4]bool
+			_, _, _ = yysep2075, yyq2075, yy2arr2075
+			const yyr2075 bool = false
+			yyq2075[0] = x.Kind != ""
+			yyq2075[1] = x.APIVersion != ""
+			yyq2075[2] = true
+			if yyr2075 || yy2arr2075 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2067 int = 1
-				for _, b := range yyq2067 {
+				var yynn2075 int = 1
+				for _, b := range yyq2075 {
 					if b {
-						yynn2067++
+						yynn2075++
 					}
 				}
-				r.EncodeMapStart(yynn2067)
+				r.EncodeMapStart(yynn2075)
 			}
-			if yyr2067 || yy2arr2067 {
-				if yyq2067[0] {
-					yym2069 := z.EncBinary()
-					_ = yym2069
+			if yyr2075 || yy2arr2075 {
+				if yyq2075[0] {
+					yym2077 := z.EncBinary()
+					_ = yym2077
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -24765,20 +24825,20 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2067[0] {
+				if yyq2075[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2070 := z.EncBinary()
-					_ = yym2070
+					yym2078 := z.EncBinary()
+					_ = yym2078
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2067 || yy2arr2067 {
-				if yyq2067[1] {
-					yym2072 := z.EncBinary()
-					_ = yym2072
+			if yyr2075 || yy2arr2075 {
+				if yyq2075[1] {
+					yym2080 := z.EncBinary()
+					_ = yym2080
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -24787,36 +24847,36 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2067[1] {
+				if yyq2075[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2073 := z.EncBinary()
-					_ = yym2073
+					yym2081 := z.EncBinary()
+					_ = yym2081
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2067 || yy2arr2067 {
-				if yyq2067[2] {
-					yy2075 := &x.ObjectMeta
-					yy2075.CodecEncodeSelf(e)
+			if yyr2075 || yy2arr2075 {
+				if yyq2075[2] {
+					yy2083 := &x.ObjectMeta
+					yy2083.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2067[2] {
+				if yyq2075[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2076 := &x.ObjectMeta
-					yy2076.CodecEncodeSelf(e)
+					yy2084 := &x.ObjectMeta
+					yy2084.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2067 || yy2arr2067 {
+			if yyr2075 || yy2arr2075 {
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
-					yym2078 := z.EncBinary()
-					_ = yym2078
+					yym2086 := z.EncBinary()
+					_ = yym2086
 					if false {
 					} else {
 						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
@@ -24827,15 +24887,15 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
-					yym2079 := z.EncBinary()
-					_ = yym2079
+					yym2087 := z.EncBinary()
+					_ = yym2087
 					if false {
 					} else {
 						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
 					}
 				}
 			}
-			if yysep2067 {
+			if yysep2075 {
 				r.EncodeEnd()
 			}
 		}
@@ -24846,24 +24906,24 @@ func (x *Endpoints) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2080 := z.DecBinary()
-	_ = yym2080
+	yym2088 := z.DecBinary()
+	_ = yym2088
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2081 := r.ReadMapStart()
-			if yyl2081 == 0 {
+			yyl2089 := r.ReadMapStart()
+			if yyl2089 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2081, d)
+				x.codecDecodeSelfFromMap(yyl2089, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2081 := r.ReadArrayStart()
-			if yyl2081 == 0 {
+			yyl2089 := r.ReadArrayStart()
+			if yyl2089 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2081, d)
+				x.codecDecodeSelfFromArray(yyl2089, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -24875,12 +24935,12 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2082Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2082Slc
-	var yyhl2082 bool = l >= 0
-	for yyj2082 := 0; ; yyj2082++ {
-		if yyhl2082 {
-			if yyj2082 >= l {
+	var yys2090Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2090Slc
+	var yyhl2090 bool = l >= 0
+	for yyj2090 := 0; ; yyj2090++ {
+		if yyhl2090 {
+			if yyj2090 >= l {
 				break
 			}
 		} else {
@@ -24888,9 +24948,9 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2082Slc = r.DecodeBytes(yys2082Slc, true, true)
-		yys2082 := string(yys2082Slc)
-		switch yys2082 {
+		yys2090Slc = r.DecodeBytes(yys2090Slc, true, true)
+		yys2090 := string(yys2090Slc)
+		switch yys2090 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24907,26 +24967,26 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2085 := &x.ObjectMeta
-				yyv2085.CodecDecodeSelf(d)
+				yyv2093 := &x.ObjectMeta
+				yyv2093.CodecDecodeSelf(d)
 			}
 		case "subsets":
 			if r.TryDecodeAsNil() {
 				x.Subsets = nil
 			} else {
-				yyv2086 := &x.Subsets
-				yym2087 := z.DecBinary()
-				_ = yym2087
+				yyv2094 := &x.Subsets
+				yym2095 := z.DecBinary()
+				_ = yym2095
 				if false {
 				} else {
-					h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2086), d)
+					h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2094), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2082)
-		} // end switch yys2082
-	} // end for yyj2082
-	if !yyhl2082 {
+			z.DecStructFieldNotFound(-1, yys2090)
+		} // end switch yys2090
+	} // end for yyj2090
+	if !yyhl2090 {
 		r.ReadEnd()
 	}
 }
@@ -24935,16 +24995,16 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2088 int
-	var yyb2088 bool
-	var yyhl2088 bool = l >= 0
-	yyj2088++
-	if yyhl2088 {
-		yyb2088 = yyj2088 > l
+	var yyj2096 int
+	var yyb2096 bool
+	var yyhl2096 bool = l >= 0
+	yyj2096++
+	if yyhl2096 {
+		yyb2096 = yyj2096 > l
 	} else {
-		yyb2088 = r.CheckBreak()
+		yyb2096 = r.CheckBreak()
 	}
-	if yyb2088 {
+	if yyb2096 {
 		r.ReadEnd()
 		return
 	}
@@ -24953,13 +25013,13 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2088++
-	if yyhl2088 {
-		yyb2088 = yyj2088 > l
+	yyj2096++
+	if yyhl2096 {
+		yyb2096 = yyj2096 > l
 	} else {
-		yyb2088 = r.CheckBreak()
+		yyb2096 = r.CheckBreak()
 	}
-	if yyb2088 {
+	if yyb2096 {
 		r.ReadEnd()
 		return
 	}
@@ -24968,54 +25028,54 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2088++
-	if yyhl2088 {
-		yyb2088 = yyj2088 > l
+	yyj2096++
+	if yyhl2096 {
+		yyb2096 = yyj2096 > l
 	} else {
-		yyb2088 = r.CheckBreak()
+		yyb2096 = r.CheckBreak()
 	}
-	if yyb2088 {
+	if yyb2096 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2091 := &x.ObjectMeta
-		yyv2091.CodecDecodeSelf(d)
+		yyv2099 := &x.ObjectMeta
+		yyv2099.CodecDecodeSelf(d)
 	}
-	yyj2088++
-	if yyhl2088 {
-		yyb2088 = yyj2088 > l
+	yyj2096++
+	if yyhl2096 {
+		yyb2096 = yyj2096 > l
 	} else {
-		yyb2088 = r.CheckBreak()
+		yyb2096 = r.CheckBreak()
 	}
-	if yyb2088 {
+	if yyb2096 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Subsets = nil
 	} else {
-		yyv2092 := &x.Subsets
-		yym2093 := z.DecBinary()
-		_ = yym2093
+		yyv2100 := &x.Subsets
+		yym2101 := z.DecBinary()
+		_ = yym2101
 		if false {
 		} else {
-			h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2092), d)
+			h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2100), d)
 		}
 	}
 	for {
-		yyj2088++
-		if yyhl2088 {
-			yyb2088 = yyj2088 > l
+		yyj2096++
+		if yyhl2096 {
+			yyb2096 = yyj2096 > l
 		} else {
-			yyb2088 = r.CheckBreak()
+			yyb2096 = r.CheckBreak()
 		}
-		if yyb2088 {
+		if yyb2096 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2088-1, "")
+		z.DecStructFieldNotFound(yyj2096-1, "")
 	}
 	r.ReadEnd()
 }
@@ -25027,37 +25087,37 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2094 := z.EncBinary()
-		_ = yym2094
+		yym2102 := z.EncBinary()
+		_ = yym2102
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2095 := !z.EncBinary()
-			yy2arr2095 := z.EncBasicHandle().StructToArray
-			var yyq2095 [3]bool
-			_, _, _ = yysep2095, yyq2095, yy2arr2095
-			const yyr2095 bool = false
-			yyq2095[0] = len(x.Addresses) != 0
-			yyq2095[1] = len(x.NotReadyAddresses) != 0
-			yyq2095[2] = len(x.Ports) != 0
-			if yyr2095 || yy2arr2095 {
+			yysep2103 := !z.EncBinary()
+			yy2arr2103 := z.EncBasicHandle().StructToArray
+			var yyq2103 [3]bool
+			_, _, _ = yysep2103, yyq2103, yy2arr2103
+			const yyr2103 bool = false
+			yyq2103[0] = len(x.Addresses) != 0
+			yyq2103[1] = len(x.NotReadyAddresses) != 0
+			yyq2103[2] = len(x.Ports) != 0
+			if yyr2103 || yy2arr2103 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2095 int = 0
-				for _, b := range yyq2095 {
+				var yynn2103 int = 0
+				for _, b := range yyq2103 {
 					if b {
-						yynn2095++
+						yynn2103++
 					}
 				}
-				r.EncodeMapStart(yynn2095)
+				r.EncodeMapStart(yynn2103)
 			}
-			if yyr2095 || yy2arr2095 {
-				if yyq2095[0] {
+			if yyr2103 || yy2arr2103 {
+				if yyq2103[0] {
 					if x.Addresses == nil {
 						r.EncodeNil()
 					} else {
-						yym2097 := z.EncBinary()
-						_ = yym2097
+						yym2105 := z.EncBinary()
+						_ = yym2105
 						if false {
 						} else {
 							h.encSliceEndpointAddress(([]EndpointAddress)(x.Addresses), e)
@@ -25067,13 +25127,13 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2095[0] {
+				if yyq2103[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("addresses"))
 					if x.Addresses == nil {
 						r.EncodeNil()
 					} else {
-						yym2098 := z.EncBinary()
-						_ = yym2098
+						yym2106 := z.EncBinary()
+						_ = yym2106
 						if false {
 						} else {
 							h.encSliceEndpointAddress(([]EndpointAddress)(x.Addresses), e)
@@ -25081,13 +25141,13 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2095 || yy2arr2095 {
-				if yyq2095[1] {
+			if yyr2103 || yy2arr2103 {
+				if yyq2103[1] {
 					if x.NotReadyAddresses == nil {
 						r.EncodeNil()
 					} else {
-						yym2100 := z.EncBinary()
-						_ = yym2100
+						yym2108 := z.EncBinary()
+						_ = yym2108
 						if false {
 						} else {
 							h.encSliceEndpointAddress(([]EndpointAddress)(x.NotReadyAddresses), e)
@@ -25097,13 +25157,13 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2095[1] {
+				if yyq2103[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("notReadyAddresses"))
 					if x.NotReadyAddresses == nil {
 						r.EncodeNil()
 					} else {
-						yym2101 := z.EncBinary()
-						_ = yym2101
+						yym2109 := z.EncBinary()
+						_ = yym2109
 						if false {
 						} else {
 							h.encSliceEndpointAddress(([]EndpointAddress)(x.NotReadyAddresses), e)
@@ -25111,13 +25171,13 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2095 || yy2arr2095 {
-				if yyq2095[2] {
+			if yyr2103 || yy2arr2103 {
+				if yyq2103[2] {
 					if x.Ports == nil {
 						r.EncodeNil()
 					} else {
-						yym2103 := z.EncBinary()
-						_ = yym2103
+						yym2111 := z.EncBinary()
+						_ = yym2111
 						if false {
 						} else {
 							h.encSliceEndpointPort(([]EndpointPort)(x.Ports), e)
@@ -25127,13 +25187,13 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2095[2] {
+				if yyq2103[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("ports"))
 					if x.Ports == nil {
 						r.EncodeNil()
 					} else {
-						yym2104 := z.EncBinary()
-						_ = yym2104
+						yym2112 := z.EncBinary()
+						_ = yym2112
 						if false {
 						} else {
 							h.encSliceEndpointPort(([]EndpointPort)(x.Ports), e)
@@ -25141,7 +25201,7 @@ func (x *EndpointSubset) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2095 {
+			if yysep2103 {
 				r.EncodeEnd()
 			}
 		}
@@ -25152,24 +25212,24 @@ func (x *EndpointSubset) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2105 := z.DecBinary()
-	_ = yym2105
+	yym2113 := z.DecBinary()
+	_ = yym2113
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2106 := r.ReadMapStart()
-			if yyl2106 == 0 {
+			yyl2114 := r.ReadMapStart()
+			if yyl2114 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2106, d)
+				x.codecDecodeSelfFromMap(yyl2114, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2106 := r.ReadArrayStart()
-			if yyl2106 == 0 {
+			yyl2114 := r.ReadArrayStart()
+			if yyl2114 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2106, d)
+				x.codecDecodeSelfFromArray(yyl2114, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -25181,12 +25241,12 @@ func (x *EndpointSubset) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2107Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2107Slc
-	var yyhl2107 bool = l >= 0
-	for yyj2107 := 0; ; yyj2107++ {
-		if yyhl2107 {
-			if yyj2107 >= l {
+	var yys2115Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2115Slc
+	var yyhl2115 bool = l >= 0
+	for yyj2115 := 0; ; yyj2115++ {
+		if yyhl2115 {
+			if yyj2115 >= l {
 				break
 			}
 		} else {
@@ -25194,50 +25254,50 @@ func (x *EndpointSubset) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2107Slc = r.DecodeBytes(yys2107Slc, true, true)
-		yys2107 := string(yys2107Slc)
-		switch yys2107 {
+		yys2115Slc = r.DecodeBytes(yys2115Slc, true, true)
+		yys2115 := string(yys2115Slc)
+		switch yys2115 {
 		case "addresses":
 			if r.TryDecodeAsNil() {
 				x.Addresses = nil
 			} else {
-				yyv2108 := &x.Addresses
-				yym2109 := z.DecBinary()
-				_ = yym2109
+				yyv2116 := &x.Addresses
+				yym2117 := z.DecBinary()
+				_ = yym2117
 				if false {
 				} else {
-					h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2108), d)
+					h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2116), d)
 				}
 			}
 		case "notReadyAddresses":
 			if r.TryDecodeAsNil() {
 				x.NotReadyAddresses = nil
 			} else {
-				yyv2110 := &x.NotReadyAddresses
-				yym2111 := z.DecBinary()
-				_ = yym2111
+				yyv2118 := &x.NotReadyAddresses
+				yym2119 := z.DecBinary()
+				_ = yym2119
 				if false {
 				} else {
-					h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2110), d)
+					h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2118), d)
 				}
 			}
 		case "ports":
 			if r.TryDecodeAsNil() {
 				x.Ports = nil
 			} else {
-				yyv2112 := &x.Ports
-				yym2113 := z.DecBinary()
-				_ = yym2113
+				yyv2120 := &x.Ports
+				yym2121 := z.DecBinary()
+				_ = yym2121
 				if false {
 				} else {
-					h.decSliceEndpointPort((*[]EndpointPort)(yyv2112), d)
+					h.decSliceEndpointPort((*[]EndpointPort)(yyv2120), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2107)
-		} // end switch yys2107
-	} // end for yyj2107
-	if !yyhl2107 {
+			z.DecStructFieldNotFound(-1, yys2115)
+		} // end switch yys2115
+	} // end for yyj2115
+	if !yyhl2115 {
 		r.ReadEnd()
 	}
 }
@@ -25246,83 +25306,83 @@ func (x *EndpointSubset) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2114 int
-	var yyb2114 bool
-	var yyhl2114 bool = l >= 0
-	yyj2114++
-	if yyhl2114 {
-		yyb2114 = yyj2114 > l
+	var yyj2122 int
+	var yyb2122 bool
+	var yyhl2122 bool = l >= 0
+	yyj2122++
+	if yyhl2122 {
+		yyb2122 = yyj2122 > l
 	} else {
-		yyb2114 = r.CheckBreak()
+		yyb2122 = r.CheckBreak()
 	}
-	if yyb2114 {
+	if yyb2122 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Addresses = nil
 	} else {
-		yyv2115 := &x.Addresses
-		yym2116 := z.DecBinary()
-		_ = yym2116
+		yyv2123 := &x.Addresses
+		yym2124 := z.DecBinary()
+		_ = yym2124
 		if false {
 		} else {
-			h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2115), d)
+			h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2123), d)
 		}
 	}
-	yyj2114++
-	if yyhl2114 {
-		yyb2114 = yyj2114 > l
+	yyj2122++
+	if yyhl2122 {
+		yyb2122 = yyj2122 > l
 	} else {
-		yyb2114 = r.CheckBreak()
+		yyb2122 = r.CheckBreak()
 	}
-	if yyb2114 {
+	if yyb2122 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.NotReadyAddresses = nil
 	} else {
-		yyv2117 := &x.NotReadyAddresses
-		yym2118 := z.DecBinary()
-		_ = yym2118
+		yyv2125 := &x.NotReadyAddresses
+		yym2126 := z.DecBinary()
+		_ = yym2126
 		if false {
 		} else {
-			h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2117), d)
+			h.decSliceEndpointAddress((*[]EndpointAddress)(yyv2125), d)
 		}
 	}
-	yyj2114++
-	if yyhl2114 {
-		yyb2114 = yyj2114 > l
+	yyj2122++
+	if yyhl2122 {
+		yyb2122 = yyj2122 > l
 	} else {
-		yyb2114 = r.CheckBreak()
+		yyb2122 = r.CheckBreak()
 	}
-	if yyb2114 {
+	if yyb2122 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Ports = nil
 	} else {
-		yyv2119 := &x.Ports
-		yym2120 := z.DecBinary()
-		_ = yym2120
+		yyv2127 := &x.Ports
+		yym2128 := z.DecBinary()
+		_ = yym2128
 		if false {
 		} else {
-			h.decSliceEndpointPort((*[]EndpointPort)(yyv2119), d)
+			h.decSliceEndpointPort((*[]EndpointPort)(yyv2127), d)
 		}
 	}
 	for {
-		yyj2114++
-		if yyhl2114 {
-			yyb2114 = yyj2114 > l
+		yyj2122++
+		if yyhl2122 {
+			yyb2122 = yyj2122 > l
 		} else {
-			yyb2114 = r.CheckBreak()
+			yyb2122 = r.CheckBreak()
 		}
-		if yyb2114 {
+		if yyb2122 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2114-1, "")
+		z.DecStructFieldNotFound(yyj2122-1, "")
 	}
 	r.ReadEnd()
 }
@@ -25334,46 +25394,46 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2121 := z.EncBinary()
-		_ = yym2121
+		yym2129 := z.EncBinary()
+		_ = yym2129
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2122 := !z.EncBinary()
-			yy2arr2122 := z.EncBasicHandle().StructToArray
-			var yyq2122 [2]bool
-			_, _, _ = yysep2122, yyq2122, yy2arr2122
-			const yyr2122 bool = false
-			yyq2122[1] = x.TargetRef != nil
-			if yyr2122 || yy2arr2122 {
+			yysep2130 := !z.EncBinary()
+			yy2arr2130 := z.EncBasicHandle().StructToArray
+			var yyq2130 [2]bool
+			_, _, _ = yysep2130, yyq2130, yy2arr2130
+			const yyr2130 bool = false
+			yyq2130[1] = x.TargetRef != nil
+			if yyr2130 || yy2arr2130 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2122 int = 1
-				for _, b := range yyq2122 {
+				var yynn2130 int = 1
+				for _, b := range yyq2130 {
 					if b {
-						yynn2122++
+						yynn2130++
 					}
 				}
-				r.EncodeMapStart(yynn2122)
+				r.EncodeMapStart(yynn2130)
 			}
-			if yyr2122 || yy2arr2122 {
-				yym2124 := z.EncBinary()
-				_ = yym2124
+			if yyr2130 || yy2arr2130 {
+				yym2132 := z.EncBinary()
+				_ = yym2132
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.IP))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("ip"))
-				yym2125 := z.EncBinary()
-				_ = yym2125
+				yym2133 := z.EncBinary()
+				_ = yym2133
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.IP))
 				}
 			}
-			if yyr2122 || yy2arr2122 {
-				if yyq2122[1] {
+			if yyr2130 || yy2arr2130 {
+				if yyq2130[1] {
 					if x.TargetRef == nil {
 						r.EncodeNil()
 					} else {
@@ -25383,7 +25443,7 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2122[1] {
+				if yyq2130[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("targetRef"))
 					if x.TargetRef == nil {
 						r.EncodeNil()
@@ -25392,7 +25452,7 @@ func (x *EndpointAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2122 {
+			if yysep2130 {
 				r.EncodeEnd()
 			}
 		}
@@ -25403,24 +25463,24 @@ func (x *EndpointAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2127 := z.DecBinary()
-	_ = yym2127
+	yym2135 := z.DecBinary()
+	_ = yym2135
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2128 := r.ReadMapStart()
-			if yyl2128 == 0 {
+			yyl2136 := r.ReadMapStart()
+			if yyl2136 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2128, d)
+				x.codecDecodeSelfFromMap(yyl2136, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2128 := r.ReadArrayStart()
-			if yyl2128 == 0 {
+			yyl2136 := r.ReadArrayStart()
+			if yyl2136 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2128, d)
+				x.codecDecodeSelfFromArray(yyl2136, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -25432,12 +25492,12 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2129Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2129Slc
-	var yyhl2129 bool = l >= 0
-	for yyj2129 := 0; ; yyj2129++ {
-		if yyhl2129 {
-			if yyj2129 >= l {
+	var yys2137Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2137Slc
+	var yyhl2137 bool = l >= 0
+	for yyj2137 := 0; ; yyj2137++ {
+		if yyhl2137 {
+			if yyj2137 >= l {
 				break
 			}
 		} else {
@@ -25445,9 +25505,9 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2129Slc = r.DecodeBytes(yys2129Slc, true, true)
-		yys2129 := string(yys2129Slc)
-		switch yys2129 {
+		yys2137Slc = r.DecodeBytes(yys2137Slc, true, true)
+		yys2137 := string(yys2137Slc)
+		switch yys2137 {
 		case "ip":
 			if r.TryDecodeAsNil() {
 				x.IP = ""
@@ -25466,10 +25526,10 @@ func (x *EndpointAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.TargetRef.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2129)
-		} // end switch yys2129
-	} // end for yyj2129
-	if !yyhl2129 {
+			z.DecStructFieldNotFound(-1, yys2137)
+		} // end switch yys2137
+	} // end for yyj2137
+	if !yyhl2137 {
 		r.ReadEnd()
 	}
 }
@@ -25478,16 +25538,16 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2132 int
-	var yyb2132 bool
-	var yyhl2132 bool = l >= 0
-	yyj2132++
-	if yyhl2132 {
-		yyb2132 = yyj2132 > l
+	var yyj2140 int
+	var yyb2140 bool
+	var yyhl2140 bool = l >= 0
+	yyj2140++
+	if yyhl2140 {
+		yyb2140 = yyj2140 > l
 	} else {
-		yyb2132 = r.CheckBreak()
+		yyb2140 = r.CheckBreak()
 	}
-	if yyb2132 {
+	if yyb2140 {
 		r.ReadEnd()
 		return
 	}
@@ -25496,13 +25556,13 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.IP = string(r.DecodeString())
 	}
-	yyj2132++
-	if yyhl2132 {
-		yyb2132 = yyj2132 > l
+	yyj2140++
+	if yyhl2140 {
+		yyb2140 = yyj2140 > l
 	} else {
-		yyb2132 = r.CheckBreak()
+		yyb2140 = r.CheckBreak()
 	}
-	if yyb2132 {
+	if yyb2140 {
 		r.ReadEnd()
 		return
 	}
@@ -25517,16 +25577,16 @@ func (x *EndpointAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.TargetRef.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2132++
-		if yyhl2132 {
-			yyb2132 = yyj2132 > l
+		yyj2140++
+		if yyhl2140 {
+			yyb2140 = yyj2140 > l
 		} else {
-			yyb2132 = r.CheckBreak()
+			yyb2140 = r.CheckBreak()
 		}
-		if yyb2132 {
+		if yyb2140 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2132-1, "")
+		z.DecStructFieldNotFound(yyj2140-1, "")
 	}
 	r.ReadEnd()
 }
@@ -25538,33 +25598,33 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2135 := z.EncBinary()
-		_ = yym2135
+		yym2143 := z.EncBinary()
+		_ = yym2143
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2136 := !z.EncBinary()
-			yy2arr2136 := z.EncBasicHandle().StructToArray
-			var yyq2136 [3]bool
-			_, _, _ = yysep2136, yyq2136, yy2arr2136
-			const yyr2136 bool = false
-			yyq2136[0] = x.Name != ""
-			yyq2136[2] = x.Protocol != ""
-			if yyr2136 || yy2arr2136 {
+			yysep2144 := !z.EncBinary()
+			yy2arr2144 := z.EncBasicHandle().StructToArray
+			var yyq2144 [3]bool
+			_, _, _ = yysep2144, yyq2144, yy2arr2144
+			const yyr2144 bool = false
+			yyq2144[0] = x.Name != ""
+			yyq2144[2] = x.Protocol != ""
+			if yyr2144 || yy2arr2144 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2136 int = 1
-				for _, b := range yyq2136 {
+				var yynn2144 int = 1
+				for _, b := range yyq2144 {
 					if b {
-						yynn2136++
+						yynn2144++
 					}
 				}
-				r.EncodeMapStart(yynn2136)
+				r.EncodeMapStart(yynn2144)
 			}
-			if yyr2136 || yy2arr2136 {
-				if yyq2136[0] {
-					yym2138 := z.EncBinary()
-					_ = yym2138
+			if yyr2144 || yy2arr2144 {
+				if yyq2144[0] {
+					yym2146 := z.EncBinary()
+					_ = yym2146
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -25573,45 +25633,45 @@ func (x *EndpointPort) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2136[0] {
+				if yyq2144[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym2139 := z.EncBinary()
-					_ = yym2139
+					yym2147 := z.EncBinary()
+					_ = yym2147
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yyr2136 || yy2arr2136 {
-				yym2141 := z.EncBinary()
-				_ = yym2141
+			if yyr2144 || yy2arr2144 {
+				yym2149 := z.EncBinary()
+				_ = yym2149
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
-				yym2142 := z.EncBinary()
-				_ = yym2142
+				yym2150 := z.EncBinary()
+				_ = yym2150
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yyr2136 || yy2arr2136 {
-				if yyq2136[2] {
+			if yyr2144 || yy2arr2144 {
+				if yyq2144[2] {
 					x.Protocol.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2136[2] {
+				if yyq2144[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("protocol"))
 					x.Protocol.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2136 {
+			if yysep2144 {
 				r.EncodeEnd()
 			}
 		}
@@ -25622,24 +25682,24 @@ func (x *EndpointPort) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2144 := z.DecBinary()
-	_ = yym2144
+	yym2152 := z.DecBinary()
+	_ = yym2152
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2145 := r.ReadMapStart()
-			if yyl2145 == 0 {
+			yyl2153 := r.ReadMapStart()
+			if yyl2153 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2145, d)
+				x.codecDecodeSelfFromMap(yyl2153, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2145 := r.ReadArrayStart()
-			if yyl2145 == 0 {
+			yyl2153 := r.ReadArrayStart()
+			if yyl2153 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2145, d)
+				x.codecDecodeSelfFromArray(yyl2153, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -25651,12 +25711,12 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2146Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2146Slc
-	var yyhl2146 bool = l >= 0
-	for yyj2146 := 0; ; yyj2146++ {
-		if yyhl2146 {
-			if yyj2146 >= l {
+	var yys2154Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2154Slc
+	var yyhl2154 bool = l >= 0
+	for yyj2154 := 0; ; yyj2154++ {
+		if yyhl2154 {
+			if yyj2154 >= l {
 				break
 			}
 		} else {
@@ -25664,9 +25724,9 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2146Slc = r.DecodeBytes(yys2146Slc, true, true)
-		yys2146 := string(yys2146Slc)
-		switch yys2146 {
+		yys2154Slc = r.DecodeBytes(yys2154Slc, true, true)
+		yys2154 := string(yys2154Slc)
+		switch yys2154 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -25686,10 +25746,10 @@ func (x *EndpointPort) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Protocol = Protocol(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2146)
-		} // end switch yys2146
-	} // end for yyj2146
-	if !yyhl2146 {
+			z.DecStructFieldNotFound(-1, yys2154)
+		} // end switch yys2154
+	} // end for yyj2154
+	if !yyhl2154 {
 		r.ReadEnd()
 	}
 }
@@ -25698,16 +25758,16 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2150 int
-	var yyb2150 bool
-	var yyhl2150 bool = l >= 0
-	yyj2150++
-	if yyhl2150 {
-		yyb2150 = yyj2150 > l
+	var yyj2158 int
+	var yyb2158 bool
+	var yyhl2158 bool = l >= 0
+	yyj2158++
+	if yyhl2158 {
+		yyb2158 = yyj2158 > l
 	} else {
-		yyb2150 = r.CheckBreak()
+		yyb2158 = r.CheckBreak()
 	}
-	if yyb2150 {
+	if yyb2158 {
 		r.ReadEnd()
 		return
 	}
@@ -25716,13 +25776,13 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj2150++
-	if yyhl2150 {
-		yyb2150 = yyj2150 > l
+	yyj2158++
+	if yyhl2158 {
+		yyb2158 = yyj2158 > l
 	} else {
-		yyb2150 = r.CheckBreak()
+		yyb2158 = r.CheckBreak()
 	}
-	if yyb2150 {
+	if yyb2158 {
 		r.ReadEnd()
 		return
 	}
@@ -25731,13 +25791,13 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Port = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj2150++
-	if yyhl2150 {
-		yyb2150 = yyj2150 > l
+	yyj2158++
+	if yyhl2158 {
+		yyb2158 = yyj2158 > l
 	} else {
-		yyb2150 = r.CheckBreak()
+		yyb2158 = r.CheckBreak()
 	}
-	if yyb2150 {
+	if yyb2158 {
 		r.ReadEnd()
 		return
 	}
@@ -25747,16 +25807,16 @@ func (x *EndpointPort) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Protocol = Protocol(r.DecodeString())
 	}
 	for {
-		yyj2150++
-		if yyhl2150 {
-			yyb2150 = yyj2150 > l
+		yyj2158++
+		if yyhl2158 {
+			yyb2158 = yyj2158 > l
 		} else {
-			yyb2150 = r.CheckBreak()
+			yyb2158 = r.CheckBreak()
 		}
-		if yyb2150 {
+		if yyb2158 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2150-1, "")
+		z.DecStructFieldNotFound(yyj2158-1, "")
 	}
 	r.ReadEnd()
 }
@@ -25768,34 +25828,34 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2154 := z.EncBinary()
-		_ = yym2154
+		yym2162 := z.EncBinary()
+		_ = yym2162
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2155 := !z.EncBinary()
-			yy2arr2155 := z.EncBasicHandle().StructToArray
-			var yyq2155 [4]bool
-			_, _, _ = yysep2155, yyq2155, yy2arr2155
-			const yyr2155 bool = false
-			yyq2155[0] = x.Kind != ""
-			yyq2155[1] = x.APIVersion != ""
-			yyq2155[2] = true
-			if yyr2155 || yy2arr2155 {
+			yysep2163 := !z.EncBinary()
+			yy2arr2163 := z.EncBasicHandle().StructToArray
+			var yyq2163 [4]bool
+			_, _, _ = yysep2163, yyq2163, yy2arr2163
+			const yyr2163 bool = false
+			yyq2163[0] = x.Kind != ""
+			yyq2163[1] = x.APIVersion != ""
+			yyq2163[2] = true
+			if yyr2163 || yy2arr2163 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2155 int = 1
-				for _, b := range yyq2155 {
+				var yynn2163 int = 1
+				for _, b := range yyq2163 {
 					if b {
-						yynn2155++
+						yynn2163++
 					}
 				}
-				r.EncodeMapStart(yynn2155)
+				r.EncodeMapStart(yynn2163)
 			}
-			if yyr2155 || yy2arr2155 {
-				if yyq2155[0] {
-					yym2157 := z.EncBinary()
-					_ = yym2157
+			if yyr2163 || yy2arr2163 {
+				if yyq2163[0] {
+					yym2165 := z.EncBinary()
+					_ = yym2165
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -25804,70 +25864,70 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2155[0] {
+				if yyq2163[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2158 := z.EncBinary()
-					_ = yym2158
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2155 || yy2arr2155 {
-				if yyq2155[1] {
-					yym2160 := z.EncBinary()
-					_ = yym2160
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2155[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2161 := z.EncBinary()
-					_ = yym2161
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2155 || yy2arr2155 {
-				if yyq2155[2] {
-					yy2163 := &x.ListMeta
-					yym2164 := z.EncBinary()
-					_ = yym2164
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2163) {
-					} else {
-						z.EncFallback(yy2163)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2155[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2165 := &x.ListMeta
 					yym2166 := z.EncBinary()
 					_ = yym2166
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2165) {
 					} else {
-						z.EncFallback(yy2165)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2155 || yy2arr2155 {
+			if yyr2163 || yy2arr2163 {
+				if yyq2163[1] {
+					yym2168 := z.EncBinary()
+					_ = yym2168
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2163[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2169 := z.EncBinary()
+					_ = yym2169
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2163 || yy2arr2163 {
+				if yyq2163[2] {
+					yy2171 := &x.ListMeta
+					yym2172 := z.EncBinary()
+					_ = yym2172
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2171) {
+					} else {
+						z.EncFallback(yy2171)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2163[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2173 := &x.ListMeta
+					yym2174 := z.EncBinary()
+					_ = yym2174
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2173) {
+					} else {
+						z.EncFallback(yy2173)
+					}
+				}
+			}
+			if yyr2163 || yy2arr2163 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2168 := z.EncBinary()
-					_ = yym2168
+					yym2176 := z.EncBinary()
+					_ = yym2176
 					if false {
 					} else {
 						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
@@ -25878,15 +25938,15 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2169 := z.EncBinary()
-					_ = yym2169
+					yym2177 := z.EncBinary()
+					_ = yym2177
 					if false {
 					} else {
 						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
 					}
 				}
 			}
-			if yysep2155 {
+			if yysep2163 {
 				r.EncodeEnd()
 			}
 		}
@@ -25897,24 +25957,24 @@ func (x *EndpointsList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2170 := z.DecBinary()
-	_ = yym2170
+	yym2178 := z.DecBinary()
+	_ = yym2178
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2171 := r.ReadMapStart()
-			if yyl2171 == 0 {
+			yyl2179 := r.ReadMapStart()
+			if yyl2179 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2171, d)
+				x.codecDecodeSelfFromMap(yyl2179, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2171 := r.ReadArrayStart()
-			if yyl2171 == 0 {
+			yyl2179 := r.ReadArrayStart()
+			if yyl2179 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2171, d)
+				x.codecDecodeSelfFromArray(yyl2179, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -25926,12 +25986,12 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2172Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2172Slc
-	var yyhl2172 bool = l >= 0
-	for yyj2172 := 0; ; yyj2172++ {
-		if yyhl2172 {
-			if yyj2172 >= l {
+	var yys2180Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2180Slc
+	var yyhl2180 bool = l >= 0
+	for yyj2180 := 0; ; yyj2180++ {
+		if yyhl2180 {
+			if yyj2180 >= l {
 				break
 			}
 		} else {
@@ -25939,9 +25999,9 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2172Slc = r.DecodeBytes(yys2172Slc, true, true)
-		yys2172 := string(yys2172Slc)
-		switch yys2172 {
+		yys2180Slc = r.DecodeBytes(yys2180Slc, true, true)
+		yys2180 := string(yys2180Slc)
+		switch yys2180 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -25958,32 +26018,32 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2175 := &x.ListMeta
-				yym2176 := z.DecBinary()
-				_ = yym2176
+				yyv2183 := &x.ListMeta
+				yym2184 := z.DecBinary()
+				_ = yym2184
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2175) {
+				} else if z.HasExtensions() && z.DecExt(yyv2183) {
 				} else {
-					z.DecFallback(yyv2175, false)
+					z.DecFallback(yyv2183, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2177 := &x.Items
-				yym2178 := z.DecBinary()
-				_ = yym2178
+				yyv2185 := &x.Items
+				yym2186 := z.DecBinary()
+				_ = yym2186
 				if false {
 				} else {
-					h.decSliceEndpoints((*[]Endpoints)(yyv2177), d)
+					h.decSliceEndpoints((*[]Endpoints)(yyv2185), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2172)
-		} // end switch yys2172
-	} // end for yyj2172
-	if !yyhl2172 {
+			z.DecStructFieldNotFound(-1, yys2180)
+		} // end switch yys2180
+	} // end for yyj2180
+	if !yyhl2180 {
 		r.ReadEnd()
 	}
 }
@@ -25992,16 +26052,16 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2179 int
-	var yyb2179 bool
-	var yyhl2179 bool = l >= 0
-	yyj2179++
-	if yyhl2179 {
-		yyb2179 = yyj2179 > l
+	var yyj2187 int
+	var yyb2187 bool
+	var yyhl2187 bool = l >= 0
+	yyj2187++
+	if yyhl2187 {
+		yyb2187 = yyj2187 > l
 	} else {
-		yyb2179 = r.CheckBreak()
+		yyb2187 = r.CheckBreak()
 	}
-	if yyb2179 {
+	if yyb2187 {
 		r.ReadEnd()
 		return
 	}
@@ -26010,13 +26070,13 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2179++
-	if yyhl2179 {
-		yyb2179 = yyj2179 > l
+	yyj2187++
+	if yyhl2187 {
+		yyb2187 = yyj2187 > l
 	} else {
-		yyb2179 = r.CheckBreak()
+		yyb2187 = r.CheckBreak()
 	}
-	if yyb2179 {
+	if yyb2187 {
 		r.ReadEnd()
 		return
 	}
@@ -26025,60 +26085,60 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2179++
-	if yyhl2179 {
-		yyb2179 = yyj2179 > l
+	yyj2187++
+	if yyhl2187 {
+		yyb2187 = yyj2187 > l
 	} else {
-		yyb2179 = r.CheckBreak()
+		yyb2187 = r.CheckBreak()
 	}
-	if yyb2179 {
+	if yyb2187 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2182 := &x.ListMeta
-		yym2183 := z.DecBinary()
-		_ = yym2183
+		yyv2190 := &x.ListMeta
+		yym2191 := z.DecBinary()
+		_ = yym2191
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2182) {
+		} else if z.HasExtensions() && z.DecExt(yyv2190) {
 		} else {
-			z.DecFallback(yyv2182, false)
+			z.DecFallback(yyv2190, false)
 		}
 	}
-	yyj2179++
-	if yyhl2179 {
-		yyb2179 = yyj2179 > l
+	yyj2187++
+	if yyhl2187 {
+		yyb2187 = yyj2187 > l
 	} else {
-		yyb2179 = r.CheckBreak()
+		yyb2187 = r.CheckBreak()
 	}
-	if yyb2179 {
+	if yyb2187 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2184 := &x.Items
-		yym2185 := z.DecBinary()
-		_ = yym2185
+		yyv2192 := &x.Items
+		yym2193 := z.DecBinary()
+		_ = yym2193
 		if false {
 		} else {
-			h.decSliceEndpoints((*[]Endpoints)(yyv2184), d)
+			h.decSliceEndpoints((*[]Endpoints)(yyv2192), d)
 		}
 	}
 	for {
-		yyj2179++
-		if yyhl2179 {
-			yyb2179 = yyj2179 > l
+		yyj2187++
+		if yyhl2187 {
+			yyb2187 = yyj2187 > l
 		} else {
-			yyb2179 = r.CheckBreak()
+			yyb2187 = r.CheckBreak()
 		}
-		if yyb2179 {
+		if yyb2187 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2179-1, "")
+		z.DecStructFieldNotFound(yyj2187-1, "")
 	}
 	r.ReadEnd()
 }
@@ -26090,35 +26150,35 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2186 := z.EncBinary()
-		_ = yym2186
+		yym2194 := z.EncBinary()
+		_ = yym2194
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2187 := !z.EncBinary()
-			yy2arr2187 := z.EncBasicHandle().StructToArray
-			var yyq2187 [4]bool
-			_, _, _ = yysep2187, yyq2187, yy2arr2187
-			const yyr2187 bool = false
-			yyq2187[0] = x.PodCIDR != ""
-			yyq2187[1] = x.ExternalID != ""
-			yyq2187[2] = x.ProviderID != ""
-			yyq2187[3] = x.Unschedulable != false
-			if yyr2187 || yy2arr2187 {
+			yysep2195 := !z.EncBinary()
+			yy2arr2195 := z.EncBasicHandle().StructToArray
+			var yyq2195 [4]bool
+			_, _, _ = yysep2195, yyq2195, yy2arr2195
+			const yyr2195 bool = false
+			yyq2195[0] = x.PodCIDR != ""
+			yyq2195[1] = x.ExternalID != ""
+			yyq2195[2] = x.ProviderID != ""
+			yyq2195[3] = x.Unschedulable != false
+			if yyr2195 || yy2arr2195 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2187 int = 0
-				for _, b := range yyq2187 {
+				var yynn2195 int = 0
+				for _, b := range yyq2195 {
 					if b {
-						yynn2187++
+						yynn2195++
 					}
 				}
-				r.EncodeMapStart(yynn2187)
+				r.EncodeMapStart(yynn2195)
 			}
-			if yyr2187 || yy2arr2187 {
-				if yyq2187[0] {
-					yym2189 := z.EncBinary()
-					_ = yym2189
+			if yyr2195 || yy2arr2195 {
+				if yyq2195[0] {
+					yym2197 := z.EncBinary()
+					_ = yym2197
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
@@ -26127,64 +26187,64 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2187[0] {
+				if yyq2195[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("podCIDR"))
-					yym2190 := z.EncBinary()
-					_ = yym2190
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
-					}
-				}
-			}
-			if yyr2187 || yy2arr2187 {
-				if yyq2187[1] {
-					yym2192 := z.EncBinary()
-					_ = yym2192
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ExternalID))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2187[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("externalID"))
-					yym2193 := z.EncBinary()
-					_ = yym2193
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ExternalID))
-					}
-				}
-			}
-			if yyr2187 || yy2arr2187 {
-				if yyq2187[2] {
-					yym2195 := z.EncBinary()
-					_ = yym2195
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ProviderID))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2187[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("providerID"))
-					yym2196 := z.EncBinary()
-					_ = yym2196
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ProviderID))
-					}
-				}
-			}
-			if yyr2187 || yy2arr2187 {
-				if yyq2187[3] {
 					yym2198 := z.EncBinary()
 					_ = yym2198
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodCIDR))
+					}
+				}
+			}
+			if yyr2195 || yy2arr2195 {
+				if yyq2195[1] {
+					yym2200 := z.EncBinary()
+					_ = yym2200
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ExternalID))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2195[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("externalID"))
+					yym2201 := z.EncBinary()
+					_ = yym2201
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ExternalID))
+					}
+				}
+			}
+			if yyr2195 || yy2arr2195 {
+				if yyq2195[2] {
+					yym2203 := z.EncBinary()
+					_ = yym2203
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ProviderID))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2195[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("providerID"))
+					yym2204 := z.EncBinary()
+					_ = yym2204
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ProviderID))
+					}
+				}
+			}
+			if yyr2195 || yy2arr2195 {
+				if yyq2195[3] {
+					yym2206 := z.EncBinary()
+					_ = yym2206
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Unschedulable))
@@ -26193,17 +26253,17 @@ func (x *NodeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2187[3] {
+				if yyq2195[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("unschedulable"))
-					yym2199 := z.EncBinary()
-					_ = yym2199
+					yym2207 := z.EncBinary()
+					_ = yym2207
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Unschedulable))
 					}
 				}
 			}
-			if yysep2187 {
+			if yysep2195 {
 				r.EncodeEnd()
 			}
 		}
@@ -26214,24 +26274,24 @@ func (x *NodeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2200 := z.DecBinary()
-	_ = yym2200
+	yym2208 := z.DecBinary()
+	_ = yym2208
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2201 := r.ReadMapStart()
-			if yyl2201 == 0 {
+			yyl2209 := r.ReadMapStart()
+			if yyl2209 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2201, d)
+				x.codecDecodeSelfFromMap(yyl2209, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2201 := r.ReadArrayStart()
-			if yyl2201 == 0 {
+			yyl2209 := r.ReadArrayStart()
+			if yyl2209 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2201, d)
+				x.codecDecodeSelfFromArray(yyl2209, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -26243,12 +26303,12 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2202Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2202Slc
-	var yyhl2202 bool = l >= 0
-	for yyj2202 := 0; ; yyj2202++ {
-		if yyhl2202 {
-			if yyj2202 >= l {
+	var yys2210Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2210Slc
+	var yyhl2210 bool = l >= 0
+	for yyj2210 := 0; ; yyj2210++ {
+		if yyhl2210 {
+			if yyj2210 >= l {
 				break
 			}
 		} else {
@@ -26256,9 +26316,9 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2202Slc = r.DecodeBytes(yys2202Slc, true, true)
-		yys2202 := string(yys2202Slc)
-		switch yys2202 {
+		yys2210Slc = r.DecodeBytes(yys2210Slc, true, true)
+		yys2210 := string(yys2210Slc)
+		switch yys2210 {
 		case "podCIDR":
 			if r.TryDecodeAsNil() {
 				x.PodCIDR = ""
@@ -26284,10 +26344,10 @@ func (x *NodeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Unschedulable = bool(r.DecodeBool())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2202)
-		} // end switch yys2202
-	} // end for yyj2202
-	if !yyhl2202 {
+			z.DecStructFieldNotFound(-1, yys2210)
+		} // end switch yys2210
+	} // end for yyj2210
+	if !yyhl2210 {
 		r.ReadEnd()
 	}
 }
@@ -26296,16 +26356,16 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2207 int
-	var yyb2207 bool
-	var yyhl2207 bool = l >= 0
-	yyj2207++
-	if yyhl2207 {
-		yyb2207 = yyj2207 > l
+	var yyj2215 int
+	var yyb2215 bool
+	var yyhl2215 bool = l >= 0
+	yyj2215++
+	if yyhl2215 {
+		yyb2215 = yyj2215 > l
 	} else {
-		yyb2207 = r.CheckBreak()
+		yyb2215 = r.CheckBreak()
 	}
-	if yyb2207 {
+	if yyb2215 {
 		r.ReadEnd()
 		return
 	}
@@ -26314,13 +26374,13 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.PodCIDR = string(r.DecodeString())
 	}
-	yyj2207++
-	if yyhl2207 {
-		yyb2207 = yyj2207 > l
+	yyj2215++
+	if yyhl2215 {
+		yyb2215 = yyj2215 > l
 	} else {
-		yyb2207 = r.CheckBreak()
+		yyb2215 = r.CheckBreak()
 	}
-	if yyb2207 {
+	if yyb2215 {
 		r.ReadEnd()
 		return
 	}
@@ -26329,13 +26389,13 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ExternalID = string(r.DecodeString())
 	}
-	yyj2207++
-	if yyhl2207 {
-		yyb2207 = yyj2207 > l
+	yyj2215++
+	if yyhl2215 {
+		yyb2215 = yyj2215 > l
 	} else {
-		yyb2207 = r.CheckBreak()
+		yyb2215 = r.CheckBreak()
 	}
-	if yyb2207 {
+	if yyb2215 {
 		r.ReadEnd()
 		return
 	}
@@ -26344,13 +26404,13 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ProviderID = string(r.DecodeString())
 	}
-	yyj2207++
-	if yyhl2207 {
-		yyb2207 = yyj2207 > l
+	yyj2215++
+	if yyhl2215 {
+		yyb2215 = yyj2215 > l
 	} else {
-		yyb2207 = r.CheckBreak()
+		yyb2215 = r.CheckBreak()
 	}
-	if yyb2207 {
+	if yyb2215 {
 		r.ReadEnd()
 		return
 	}
@@ -26360,16 +26420,16 @@ func (x *NodeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Unschedulable = bool(r.DecodeBool())
 	}
 	for {
-		yyj2207++
-		if yyhl2207 {
-			yyb2207 = yyj2207 > l
+		yyj2215++
+		if yyhl2215 {
+			yyb2215 = yyj2215 > l
 		} else {
-			yyb2207 = r.CheckBreak()
+			yyb2215 = r.CheckBreak()
 		}
-		if yyb2207 {
+		if yyb2215 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2207-1, "")
+		z.DecStructFieldNotFound(yyj2215-1, "")
 	}
 	r.ReadEnd()
 }
@@ -26381,44 +26441,44 @@ func (x *DaemonEndpoint) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2212 := z.EncBinary()
-		_ = yym2212
+		yym2220 := z.EncBinary()
+		_ = yym2220
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2213 := !z.EncBinary()
-			yy2arr2213 := z.EncBasicHandle().StructToArray
-			var yyq2213 [1]bool
-			_, _, _ = yysep2213, yyq2213, yy2arr2213
-			const yyr2213 bool = false
-			if yyr2213 || yy2arr2213 {
+			yysep2221 := !z.EncBinary()
+			yy2arr2221 := z.EncBasicHandle().StructToArray
+			var yyq2221 [1]bool
+			_, _, _ = yysep2221, yyq2221, yy2arr2221
+			const yyr2221 bool = false
+			if yyr2221 || yy2arr2221 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2213 int = 1
-				for _, b := range yyq2213 {
+				var yynn2221 int = 1
+				for _, b := range yyq2221 {
 					if b {
-						yynn2213++
+						yynn2221++
 					}
 				}
-				r.EncodeMapStart(yynn2213)
+				r.EncodeMapStart(yynn2221)
 			}
-			if yyr2213 || yy2arr2213 {
-				yym2215 := z.EncBinary()
-				_ = yym2215
+			if yyr2221 || yy2arr2221 {
+				yym2223 := z.EncBinary()
+				_ = yym2223
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Port"))
-				yym2216 := z.EncBinary()
-				_ = yym2216
+				yym2224 := z.EncBinary()
+				_ = yym2224
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
 				}
 			}
-			if yysep2213 {
+			if yysep2221 {
 				r.EncodeEnd()
 			}
 		}
@@ -26429,24 +26489,24 @@ func (x *DaemonEndpoint) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2217 := z.DecBinary()
-	_ = yym2217
+	yym2225 := z.DecBinary()
+	_ = yym2225
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2218 := r.ReadMapStart()
-			if yyl2218 == 0 {
+			yyl2226 := r.ReadMapStart()
+			if yyl2226 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2218, d)
+				x.codecDecodeSelfFromMap(yyl2226, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2218 := r.ReadArrayStart()
-			if yyl2218 == 0 {
+			yyl2226 := r.ReadArrayStart()
+			if yyl2226 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2218, d)
+				x.codecDecodeSelfFromArray(yyl2226, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -26458,12 +26518,12 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2219Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2219Slc
-	var yyhl2219 bool = l >= 0
-	for yyj2219 := 0; ; yyj2219++ {
-		if yyhl2219 {
-			if yyj2219 >= l {
+	var yys2227Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2227Slc
+	var yyhl2227 bool = l >= 0
+	for yyj2227 := 0; ; yyj2227++ {
+		if yyhl2227 {
+			if yyj2227 >= l {
 				break
 			}
 		} else {
@@ -26471,9 +26531,9 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2219Slc = r.DecodeBytes(yys2219Slc, true, true)
-		yys2219 := string(yys2219Slc)
-		switch yys2219 {
+		yys2227Slc = r.DecodeBytes(yys2227Slc, true, true)
+		yys2227 := string(yys2227Slc)
+		switch yys2227 {
 		case "Port":
 			if r.TryDecodeAsNil() {
 				x.Port = 0
@@ -26481,10 +26541,10 @@ func (x *DaemonEndpoint) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Port = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2219)
-		} // end switch yys2219
-	} // end for yyj2219
-	if !yyhl2219 {
+			z.DecStructFieldNotFound(-1, yys2227)
+		} // end switch yys2227
+	} // end for yyj2227
+	if !yyhl2227 {
 		r.ReadEnd()
 	}
 }
@@ -26493,16 +26553,16 @@ func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2221 int
-	var yyb2221 bool
-	var yyhl2221 bool = l >= 0
-	yyj2221++
-	if yyhl2221 {
-		yyb2221 = yyj2221 > l
+	var yyj2229 int
+	var yyb2229 bool
+	var yyhl2229 bool = l >= 0
+	yyj2229++
+	if yyhl2229 {
+		yyb2229 = yyj2229 > l
 	} else {
-		yyb2221 = r.CheckBreak()
+		yyb2229 = r.CheckBreak()
 	}
-	if yyb2221 {
+	if yyb2229 {
 		r.ReadEnd()
 		return
 	}
@@ -26512,16 +26572,16 @@ func (x *DaemonEndpoint) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Port = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj2221++
-		if yyhl2221 {
-			yyb2221 = yyj2221 > l
+		yyj2229++
+		if yyhl2229 {
+			yyb2229 = yyj2229 > l
 		} else {
-			yyb2221 = r.CheckBreak()
+			yyb2229 = r.CheckBreak()
 		}
-		if yyb2221 {
+		if yyb2229 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2221-1, "")
+		z.DecStructFieldNotFound(yyj2229-1, "")
 	}
 	r.ReadEnd()
 }
@@ -26533,43 +26593,43 @@ func (x *NodeDaemonEndpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2223 := z.EncBinary()
-		_ = yym2223
+		yym2231 := z.EncBinary()
+		_ = yym2231
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2224 := !z.EncBinary()
-			yy2arr2224 := z.EncBasicHandle().StructToArray
-			var yyq2224 [1]bool
-			_, _, _ = yysep2224, yyq2224, yy2arr2224
-			const yyr2224 bool = false
-			yyq2224[0] = true
-			if yyr2224 || yy2arr2224 {
+			yysep2232 := !z.EncBinary()
+			yy2arr2232 := z.EncBasicHandle().StructToArray
+			var yyq2232 [1]bool
+			_, _, _ = yysep2232, yyq2232, yy2arr2232
+			const yyr2232 bool = false
+			yyq2232[0] = true
+			if yyr2232 || yy2arr2232 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2224 int = 0
-				for _, b := range yyq2224 {
+				var yynn2232 int = 0
+				for _, b := range yyq2232 {
 					if b {
-						yynn2224++
+						yynn2232++
 					}
 				}
-				r.EncodeMapStart(yynn2224)
+				r.EncodeMapStart(yynn2232)
 			}
-			if yyr2224 || yy2arr2224 {
-				if yyq2224[0] {
-					yy2226 := &x.KubeletEndpoint
-					yy2226.CodecEncodeSelf(e)
+			if yyr2232 || yy2arr2232 {
+				if yyq2232[0] {
+					yy2234 := &x.KubeletEndpoint
+					yy2234.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2224[0] {
+				if yyq2232[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kubeletEndpoint"))
-					yy2227 := &x.KubeletEndpoint
-					yy2227.CodecEncodeSelf(e)
+					yy2235 := &x.KubeletEndpoint
+					yy2235.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2224 {
+			if yysep2232 {
 				r.EncodeEnd()
 			}
 		}
@@ -26580,24 +26640,24 @@ func (x *NodeDaemonEndpoints) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2228 := z.DecBinary()
-	_ = yym2228
+	yym2236 := z.DecBinary()
+	_ = yym2236
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2229 := r.ReadMapStart()
-			if yyl2229 == 0 {
+			yyl2237 := r.ReadMapStart()
+			if yyl2237 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2229, d)
+				x.codecDecodeSelfFromMap(yyl2237, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2229 := r.ReadArrayStart()
-			if yyl2229 == 0 {
+			yyl2237 := r.ReadArrayStart()
+			if yyl2237 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2229, d)
+				x.codecDecodeSelfFromArray(yyl2237, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -26609,12 +26669,12 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2230Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2230Slc
-	var yyhl2230 bool = l >= 0
-	for yyj2230 := 0; ; yyj2230++ {
-		if yyhl2230 {
-			if yyj2230 >= l {
+	var yys2238Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2238Slc
+	var yyhl2238 bool = l >= 0
+	for yyj2238 := 0; ; yyj2238++ {
+		if yyhl2238 {
+			if yyj2238 >= l {
 				break
 			}
 		} else {
@@ -26622,21 +26682,21 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys2230Slc = r.DecodeBytes(yys2230Slc, true, true)
-		yys2230 := string(yys2230Slc)
-		switch yys2230 {
+		yys2238Slc = r.DecodeBytes(yys2238Slc, true, true)
+		yys2238 := string(yys2238Slc)
+		switch yys2238 {
 		case "kubeletEndpoint":
 			if r.TryDecodeAsNil() {
 				x.KubeletEndpoint = DaemonEndpoint{}
 			} else {
-				yyv2231 := &x.KubeletEndpoint
-				yyv2231.CodecDecodeSelf(d)
+				yyv2239 := &x.KubeletEndpoint
+				yyv2239.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2230)
-		} // end switch yys2230
-	} // end for yyj2230
-	if !yyhl2230 {
+			z.DecStructFieldNotFound(-1, yys2238)
+		} // end switch yys2238
+	} // end for yyj2238
+	if !yyhl2238 {
 		r.ReadEnd()
 	}
 }
@@ -26645,36 +26705,36 @@ func (x *NodeDaemonEndpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2232 int
-	var yyb2232 bool
-	var yyhl2232 bool = l >= 0
-	yyj2232++
-	if yyhl2232 {
-		yyb2232 = yyj2232 > l
+	var yyj2240 int
+	var yyb2240 bool
+	var yyhl2240 bool = l >= 0
+	yyj2240++
+	if yyhl2240 {
+		yyb2240 = yyj2240 > l
 	} else {
-		yyb2232 = r.CheckBreak()
+		yyb2240 = r.CheckBreak()
 	}
-	if yyb2232 {
+	if yyb2240 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.KubeletEndpoint = DaemonEndpoint{}
 	} else {
-		yyv2233 := &x.KubeletEndpoint
-		yyv2233.CodecDecodeSelf(d)
+		yyv2241 := &x.KubeletEndpoint
+		yyv2241.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2232++
-		if yyhl2232 {
-			yyb2232 = yyj2232 > l
+		yyj2240++
+		if yyhl2240 {
+			yyb2240 = yyj2240 > l
 		} else {
-			yyb2232 = r.CheckBreak()
+			yyb2240 = r.CheckBreak()
 		}
-		if yyb2232 {
+		if yyb2240 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2232-1, "")
+		z.DecStructFieldNotFound(yyj2240-1, "")
 	}
 	r.ReadEnd()
 }
@@ -26686,156 +26746,156 @@ func (x *NodeSystemInfo) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2234 := z.EncBinary()
-		_ = yym2234
+		yym2242 := z.EncBinary()
+		_ = yym2242
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2235 := !z.EncBinary()
-			yy2arr2235 := z.EncBasicHandle().StructToArray
-			var yyq2235 [8]bool
-			_, _, _ = yysep2235, yyq2235, yy2arr2235
-			const yyr2235 bool = false
-			if yyr2235 || yy2arr2235 {
+			yysep2243 := !z.EncBinary()
+			yy2arr2243 := z.EncBasicHandle().StructToArray
+			var yyq2243 [8]bool
+			_, _, _ = yysep2243, yyq2243, yy2arr2243
+			const yyr2243 bool = false
+			if yyr2243 || yy2arr2243 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2235 int = 8
-				for _, b := range yyq2235 {
+				var yynn2243 int = 8
+				for _, b := range yyq2243 {
 					if b {
-						yynn2235++
+						yynn2243++
 					}
 				}
-				r.EncodeMapStart(yynn2235)
+				r.EncodeMapStart(yynn2243)
 			}
-			if yyr2235 || yy2arr2235 {
-				yym2237 := z.EncBinary()
-				_ = yym2237
+			if yyr2243 || yy2arr2243 {
+				yym2245 := z.EncBinary()
+				_ = yym2245
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MachineID))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("machineID"))
-				yym2238 := z.EncBinary()
-				_ = yym2238
+				yym2246 := z.EncBinary()
+				_ = yym2246
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.MachineID))
 				}
 			}
-			if yyr2235 || yy2arr2235 {
-				yym2240 := z.EncBinary()
-				_ = yym2240
+			if yyr2243 || yy2arr2243 {
+				yym2248 := z.EncBinary()
+				_ = yym2248
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SystemUUID))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("systemUUID"))
-				yym2241 := z.EncBinary()
-				_ = yym2241
+				yym2249 := z.EncBinary()
+				_ = yym2249
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SystemUUID))
 				}
 			}
-			if yyr2235 || yy2arr2235 {
-				yym2243 := z.EncBinary()
-				_ = yym2243
+			if yyr2243 || yy2arr2243 {
+				yym2251 := z.EncBinary()
+				_ = yym2251
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BootID))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("bootID"))
-				yym2244 := z.EncBinary()
-				_ = yym2244
+				yym2252 := z.EncBinary()
+				_ = yym2252
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BootID))
 				}
 			}
-			if yyr2235 || yy2arr2235 {
-				yym2246 := z.EncBinary()
-				_ = yym2246
+			if yyr2243 || yy2arr2243 {
+				yym2254 := z.EncBinary()
+				_ = yym2254
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KernelVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("kernelVersion"))
-				yym2247 := z.EncBinary()
-				_ = yym2247
+				yym2255 := z.EncBinary()
+				_ = yym2255
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KernelVersion))
 				}
 			}
-			if yyr2235 || yy2arr2235 {
-				yym2249 := z.EncBinary()
-				_ = yym2249
+			if yyr2243 || yy2arr2243 {
+				yym2257 := z.EncBinary()
+				_ = yym2257
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.OsImage))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("osImage"))
-				yym2250 := z.EncBinary()
-				_ = yym2250
+				yym2258 := z.EncBinary()
+				_ = yym2258
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.OsImage))
 				}
 			}
-			if yyr2235 || yy2arr2235 {
-				yym2252 := z.EncBinary()
-				_ = yym2252
+			if yyr2243 || yy2arr2243 {
+				yym2260 := z.EncBinary()
+				_ = yym2260
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntimeVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("containerRuntimeVersion"))
-				yym2253 := z.EncBinary()
-				_ = yym2253
+				yym2261 := z.EncBinary()
+				_ = yym2261
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ContainerRuntimeVersion))
 				}
 			}
-			if yyr2235 || yy2arr2235 {
-				yym2255 := z.EncBinary()
-				_ = yym2255
+			if yyr2243 || yy2arr2243 {
+				yym2263 := z.EncBinary()
+				_ = yym2263
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeletVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("kubeletVersion"))
-				yym2256 := z.EncBinary()
-				_ = yym2256
+				yym2264 := z.EncBinary()
+				_ = yym2264
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeletVersion))
 				}
 			}
-			if yyr2235 || yy2arr2235 {
-				yym2258 := z.EncBinary()
-				_ = yym2258
+			if yyr2243 || yy2arr2243 {
+				yym2266 := z.EncBinary()
+				_ = yym2266
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeProxyVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("kubeProxyVersion"))
-				yym2259 := z.EncBinary()
-				_ = yym2259
+				yym2267 := z.EncBinary()
+				_ = yym2267
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeProxyVersion))
 				}
 			}
-			if yysep2235 {
+			if yysep2243 {
 				r.EncodeEnd()
 			}
 		}
@@ -26846,24 +26906,24 @@ func (x *NodeSystemInfo) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2260 := z.DecBinary()
-	_ = yym2260
+	yym2268 := z.DecBinary()
+	_ = yym2268
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2261 := r.ReadMapStart()
-			if yyl2261 == 0 {
+			yyl2269 := r.ReadMapStart()
+			if yyl2269 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2261, d)
+				x.codecDecodeSelfFromMap(yyl2269, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2261 := r.ReadArrayStart()
-			if yyl2261 == 0 {
+			yyl2269 := r.ReadArrayStart()
+			if yyl2269 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2261, d)
+				x.codecDecodeSelfFromArray(yyl2269, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -26875,12 +26935,12 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2262Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2262Slc
-	var yyhl2262 bool = l >= 0
-	for yyj2262 := 0; ; yyj2262++ {
-		if yyhl2262 {
-			if yyj2262 >= l {
+	var yys2270Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2270Slc
+	var yyhl2270 bool = l >= 0
+	for yyj2270 := 0; ; yyj2270++ {
+		if yyhl2270 {
+			if yyj2270 >= l {
 				break
 			}
 		} else {
@@ -26888,9 +26948,9 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2262Slc = r.DecodeBytes(yys2262Slc, true, true)
-		yys2262 := string(yys2262Slc)
-		switch yys2262 {
+		yys2270Slc = r.DecodeBytes(yys2270Slc, true, true)
+		yys2270 := string(yys2270Slc)
+		switch yys2270 {
 		case "machineID":
 			if r.TryDecodeAsNil() {
 				x.MachineID = ""
@@ -26940,10 +27000,10 @@ func (x *NodeSystemInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.KubeProxyVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2262)
-		} // end switch yys2262
-	} // end for yyj2262
-	if !yyhl2262 {
+			z.DecStructFieldNotFound(-1, yys2270)
+		} // end switch yys2270
+	} // end for yyj2270
+	if !yyhl2270 {
 		r.ReadEnd()
 	}
 }
@@ -26952,16 +27012,16 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2271 int
-	var yyb2271 bool
-	var yyhl2271 bool = l >= 0
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
+	var yyj2279 int
+	var yyb2279 bool
+	var yyhl2279 bool = l >= 0
+	yyj2279++
+	if yyhl2279 {
+		yyb2279 = yyj2279 > l
 	} else {
-		yyb2271 = r.CheckBreak()
+		yyb2279 = r.CheckBreak()
 	}
-	if yyb2271 {
+	if yyb2279 {
 		r.ReadEnd()
 		return
 	}
@@ -26970,13 +27030,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.MachineID = string(r.DecodeString())
 	}
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
+	yyj2279++
+	if yyhl2279 {
+		yyb2279 = yyj2279 > l
 	} else {
-		yyb2271 = r.CheckBreak()
+		yyb2279 = r.CheckBreak()
 	}
-	if yyb2271 {
+	if yyb2279 {
 		r.ReadEnd()
 		return
 	}
@@ -26985,13 +27045,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.SystemUUID = string(r.DecodeString())
 	}
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
+	yyj2279++
+	if yyhl2279 {
+		yyb2279 = yyj2279 > l
 	} else {
-		yyb2271 = r.CheckBreak()
+		yyb2279 = r.CheckBreak()
 	}
-	if yyb2271 {
+	if yyb2279 {
 		r.ReadEnd()
 		return
 	}
@@ -27000,13 +27060,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.BootID = string(r.DecodeString())
 	}
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
+	yyj2279++
+	if yyhl2279 {
+		yyb2279 = yyj2279 > l
 	} else {
-		yyb2271 = r.CheckBreak()
+		yyb2279 = r.CheckBreak()
 	}
-	if yyb2271 {
+	if yyb2279 {
 		r.ReadEnd()
 		return
 	}
@@ -27015,13 +27075,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.KernelVersion = string(r.DecodeString())
 	}
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
+	yyj2279++
+	if yyhl2279 {
+		yyb2279 = yyj2279 > l
 	} else {
-		yyb2271 = r.CheckBreak()
+		yyb2279 = r.CheckBreak()
 	}
-	if yyb2271 {
+	if yyb2279 {
 		r.ReadEnd()
 		return
 	}
@@ -27030,13 +27090,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.OsImage = string(r.DecodeString())
 	}
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
+	yyj2279++
+	if yyhl2279 {
+		yyb2279 = yyj2279 > l
 	} else {
-		yyb2271 = r.CheckBreak()
+		yyb2279 = r.CheckBreak()
 	}
-	if yyb2271 {
+	if yyb2279 {
 		r.ReadEnd()
 		return
 	}
@@ -27045,13 +27105,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ContainerRuntimeVersion = string(r.DecodeString())
 	}
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
+	yyj2279++
+	if yyhl2279 {
+		yyb2279 = yyj2279 > l
 	} else {
-		yyb2271 = r.CheckBreak()
+		yyb2279 = r.CheckBreak()
 	}
-	if yyb2271 {
+	if yyb2279 {
 		r.ReadEnd()
 		return
 	}
@@ -27060,13 +27120,13 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.KubeletVersion = string(r.DecodeString())
 	}
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
+	yyj2279++
+	if yyhl2279 {
+		yyb2279 = yyj2279 > l
 	} else {
-		yyb2271 = r.CheckBreak()
+		yyb2279 = r.CheckBreak()
 	}
-	if yyb2271 {
+	if yyb2279 {
 		r.ReadEnd()
 		return
 	}
@@ -27076,16 +27136,16 @@ func (x *NodeSystemInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.KubeProxyVersion = string(r.DecodeString())
 	}
 	for {
-		yyj2271++
-		if yyhl2271 {
-			yyb2271 = yyj2271 > l
+		yyj2279++
+		if yyhl2279 {
+			yyb2279 = yyj2279 > l
 		} else {
-			yyb2271 = r.CheckBreak()
+			yyb2279 = r.CheckBreak()
 		}
-		if yyb2271 {
+		if yyb2279 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2271-1, "")
+		z.DecStructFieldNotFound(yyj2279-1, "")
 	}
 	r.ReadEnd()
 }
@@ -27097,35 +27157,35 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2280 := z.EncBinary()
-		_ = yym2280
+		yym2288 := z.EncBinary()
+		_ = yym2288
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2281 := !z.EncBinary()
-			yy2arr2281 := z.EncBasicHandle().StructToArray
-			var yyq2281 [6]bool
-			_, _, _ = yysep2281, yyq2281, yy2arr2281
-			const yyr2281 bool = false
-			yyq2281[0] = len(x.Capacity) != 0
-			yyq2281[1] = x.Phase != ""
-			yyq2281[2] = len(x.Conditions) != 0
-			yyq2281[3] = len(x.Addresses) != 0
-			yyq2281[4] = true
-			yyq2281[5] = true
-			if yyr2281 || yy2arr2281 {
+			yysep2289 := !z.EncBinary()
+			yy2arr2289 := z.EncBasicHandle().StructToArray
+			var yyq2289 [6]bool
+			_, _, _ = yysep2289, yyq2289, yy2arr2289
+			const yyr2289 bool = false
+			yyq2289[0] = len(x.Capacity) != 0
+			yyq2289[1] = x.Phase != ""
+			yyq2289[2] = len(x.Conditions) != 0
+			yyq2289[3] = len(x.Addresses) != 0
+			yyq2289[4] = true
+			yyq2289[5] = true
+			if yyr2289 || yy2arr2289 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn2281 int = 0
-				for _, b := range yyq2281 {
+				var yynn2289 int = 0
+				for _, b := range yyq2289 {
 					if b {
-						yynn2281++
+						yynn2289++
 					}
 				}
-				r.EncodeMapStart(yynn2281)
+				r.EncodeMapStart(yynn2289)
 			}
-			if yyr2281 || yy2arr2281 {
-				if yyq2281[0] {
+			if yyr2289 || yy2arr2289 {
+				if yyq2289[0] {
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -27135,7 +27195,7 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2281[0] {
+				if yyq2289[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -27144,25 +27204,25 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2281 || yy2arr2281 {
-				if yyq2281[1] {
+			if yyr2289 || yy2arr2289 {
+				if yyq2289[1] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2281[1] {
+				if yyq2289[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2281 || yy2arr2281 {
-				if yyq2281[2] {
+			if yyr2289 || yy2arr2289 {
+				if yyq2289[2] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym2285 := z.EncBinary()
-						_ = yym2285
+						yym2293 := z.EncBinary()
+						_ = yym2293
 						if false {
 						} else {
 							h.encSliceNodeCondition(([]NodeCondition)(x.Conditions), e)
@@ -27172,13 +27232,13 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2281[2] {
+				if yyq2289[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym2286 := z.EncBinary()
-						_ = yym2286
+						yym2294 := z.EncBinary()
+						_ = yym2294
 						if false {
 						} else {
 							h.encSliceNodeCondition(([]NodeCondition)(x.Conditions), e)
@@ -27186,13 +27246,13 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2281 || yy2arr2281 {
-				if yyq2281[3] {
+			if yyr2289 || yy2arr2289 {
+				if yyq2289[3] {
 					if x.Addresses == nil {
 						r.EncodeNil()
 					} else {
-						yym2288 := z.EncBinary()
-						_ = yym2288
+						yym2296 := z.EncBinary()
+						_ = yym2296
 						if false {
 						} else {
 							h.encSliceNodeAddress(([]NodeAddress)(x.Addresses), e)
@@ -27202,13 +27262,13 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2281[3] {
+				if yyq2289[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("addresses"))
 					if x.Addresses == nil {
 						r.EncodeNil()
 					} else {
-						yym2289 := z.EncBinary()
-						_ = yym2289
+						yym2297 := z.EncBinary()
+						_ = yym2297
 						if false {
 						} else {
 							h.encSliceNodeAddress(([]NodeAddress)(x.Addresses), e)
@@ -27216,35 +27276,35 @@ func (x *NodeStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2281 || yy2arr2281 {
-				if yyq2281[4] {
-					yy2291 := &x.DaemonEndpoints
-					yy2291.CodecEncodeSelf(e)
+			if yyr2289 || yy2arr2289 {
+				if yyq2289[4] {
+					yy2299 := &x.DaemonEndpoints
+					yy2299.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2281[4] {
+				if yyq2289[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("daemonEndpoints"))
-					yy2292 := &x.DaemonEndpoints
-					yy2292.CodecEncodeSelf(e)
+					yy2300 := &x.DaemonEndpoints
+					yy2300.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2281 || yy2arr2281 {
-				if yyq2281[5] {
-					yy2294 := &x.NodeInfo
-					yy2294.CodecEncodeSelf(e)
+			if yyr2289 || yy2arr2289 {
+				if yyq2289[5] {
+					yy2302 := &x.NodeInfo
+					yy2302.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2281[5] {
+				if yyq2289[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("nodeInfo"))
-					yy2295 := &x.NodeInfo
-					yy2295.CodecEncodeSelf(e)
+					yy2303 := &x.NodeInfo
+					yy2303.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2281 {
+			if yysep2289 {
 				r.EncodeEnd()
 			}
 		}
@@ -27255,24 +27315,24 @@ func (x *NodeStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2296 := z.DecBinary()
-	_ = yym2296
+	yym2304 := z.DecBinary()
+	_ = yym2304
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2297 := r.ReadMapStart()
-			if yyl2297 == 0 {
+			yyl2305 := r.ReadMapStart()
+			if yyl2305 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2297, d)
+				x.codecDecodeSelfFromMap(yyl2305, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2297 := r.ReadArrayStart()
-			if yyl2297 == 0 {
+			yyl2305 := r.ReadArrayStart()
+			if yyl2305 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2297, d)
+				x.codecDecodeSelfFromArray(yyl2305, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -27284,12 +27344,12 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2298Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2298Slc
-	var yyhl2298 bool = l >= 0
-	for yyj2298 := 0; ; yyj2298++ {
-		if yyhl2298 {
-			if yyj2298 >= l {
+	var yys2306Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2306Slc
+	var yyhl2306 bool = l >= 0
+	for yyj2306 := 0; ; yyj2306++ {
+		if yyhl2306 {
+			if yyj2306 >= l {
 				break
 			}
 		} else {
@@ -27297,15 +27357,15 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2298Slc = r.DecodeBytes(yys2298Slc, true, true)
-		yys2298 := string(yys2298Slc)
-		switch yys2298 {
+		yys2306Slc = r.DecodeBytes(yys2306Slc, true, true)
+		yys2306 := string(yys2306Slc)
+		switch yys2306 {
 		case "capacity":
 			if r.TryDecodeAsNil() {
 				x.Capacity = nil
 			} else {
-				yyv2299 := &x.Capacity
-				yyv2299.CodecDecodeSelf(d)
+				yyv2307 := &x.Capacity
+				yyv2307.CodecDecodeSelf(d)
 			}
 		case "phase":
 			if r.TryDecodeAsNil() {
@@ -27317,45 +27377,45 @@ func (x *NodeStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv2301 := &x.Conditions
-				yym2302 := z.DecBinary()
-				_ = yym2302
+				yyv2309 := &x.Conditions
+				yym2310 := z.DecBinary()
+				_ = yym2310
 				if false {
 				} else {
-					h.decSliceNodeCondition((*[]NodeCondition)(yyv2301), d)
+					h.decSliceNodeCondition((*[]NodeCondition)(yyv2309), d)
 				}
 			}
 		case "addresses":
 			if r.TryDecodeAsNil() {
 				x.Addresses = nil
 			} else {
-				yyv2303 := &x.Addresses
-				yym2304 := z.DecBinary()
-				_ = yym2304
+				yyv2311 := &x.Addresses
+				yym2312 := z.DecBinary()
+				_ = yym2312
 				if false {
 				} else {
-					h.decSliceNodeAddress((*[]NodeAddress)(yyv2303), d)
+					h.decSliceNodeAddress((*[]NodeAddress)(yyv2311), d)
 				}
 			}
 		case "daemonEndpoints":
 			if r.TryDecodeAsNil() {
 				x.DaemonEndpoints = NodeDaemonEndpoints{}
 			} else {
-				yyv2305 := &x.DaemonEndpoints
-				yyv2305.CodecDecodeSelf(d)
+				yyv2313 := &x.DaemonEndpoints
+				yyv2313.CodecDecodeSelf(d)
 			}
 		case "nodeInfo":
 			if r.TryDecodeAsNil() {
 				x.NodeInfo = NodeSystemInfo{}
 			} else {
-				yyv2306 := &x.NodeInfo
-				yyv2306.CodecDecodeSelf(d)
+				yyv2314 := &x.NodeInfo
+				yyv2314.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2298)
-		} // end switch yys2298
-	} // end for yyj2298
-	if !yyhl2298 {
+			z.DecStructFieldNotFound(-1, yys2306)
+		} // end switch yys2306
+	} // end for yyj2306
+	if !yyhl2306 {
 		r.ReadEnd()
 	}
 }
@@ -27364,32 +27424,32 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2307 int
-	var yyb2307 bool
-	var yyhl2307 bool = l >= 0
-	yyj2307++
-	if yyhl2307 {
-		yyb2307 = yyj2307 > l
+	var yyj2315 int
+	var yyb2315 bool
+	var yyhl2315 bool = l >= 0
+	yyj2315++
+	if yyhl2315 {
+		yyb2315 = yyj2315 > l
 	} else {
-		yyb2307 = r.CheckBreak()
+		yyb2315 = r.CheckBreak()
 	}
-	if yyb2307 {
+	if yyb2315 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
-		yyv2308 := &x.Capacity
-		yyv2308.CodecDecodeSelf(d)
+		yyv2316 := &x.Capacity
+		yyv2316.CodecDecodeSelf(d)
 	}
-	yyj2307++
-	if yyhl2307 {
-		yyb2307 = yyj2307 > l
+	yyj2315++
+	if yyhl2315 {
+		yyb2315 = yyj2315 > l
 	} else {
-		yyb2307 = r.CheckBreak()
+		yyb2315 = r.CheckBreak()
 	}
-	if yyb2307 {
+	if yyb2315 {
 		r.ReadEnd()
 		return
 	}
@@ -27398,91 +27458,91 @@ func (x *NodeStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Phase = NodePhase(r.DecodeString())
 	}
-	yyj2307++
-	if yyhl2307 {
-		yyb2307 = yyj2307 > l
+	yyj2315++
+	if yyhl2315 {
+		yyb2315 = yyj2315 > l
 	} else {
-		yyb2307 = r.CheckBreak()
+		yyb2315 = r.CheckBreak()
 	}
-	if yyb2307 {
+	if yyb2315 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv2310 := &x.Conditions
-		yym2311 := z.DecBinary()
-		_ = yym2311
+		yyv2318 := &x.Conditions
+		yym2319 := z.DecBinary()
+		_ = yym2319
 		if false {
 		} else {
-			h.decSliceNodeCondition((*[]NodeCondition)(yyv2310), d)
+			h.decSliceNodeCondition((*[]NodeCondition)(yyv2318), d)
 		}
 	}
-	yyj2307++
-	if yyhl2307 {
-		yyb2307 = yyj2307 > l
+	yyj2315++
+	if yyhl2315 {
+		yyb2315 = yyj2315 > l
 	} else {
-		yyb2307 = r.CheckBreak()
+		yyb2315 = r.CheckBreak()
 	}
-	if yyb2307 {
+	if yyb2315 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Addresses = nil
 	} else {
-		yyv2312 := &x.Addresses
-		yym2313 := z.DecBinary()
-		_ = yym2313
+		yyv2320 := &x.Addresses
+		yym2321 := z.DecBinary()
+		_ = yym2321
 		if false {
 		} else {
-			h.decSliceNodeAddress((*[]NodeAddress)(yyv2312), d)
+			h.decSliceNodeAddress((*[]NodeAddress)(yyv2320), d)
 		}
 	}
-	yyj2307++
-	if yyhl2307 {
-		yyb2307 = yyj2307 > l
+	yyj2315++
+	if yyhl2315 {
+		yyb2315 = yyj2315 > l
 	} else {
-		yyb2307 = r.CheckBreak()
+		yyb2315 = r.CheckBreak()
 	}
-	if yyb2307 {
+	if yyb2315 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.DaemonEndpoints = NodeDaemonEndpoints{}
 	} else {
-		yyv2314 := &x.DaemonEndpoints
-		yyv2314.CodecDecodeSelf(d)
+		yyv2322 := &x.DaemonEndpoints
+		yyv2322.CodecDecodeSelf(d)
 	}
-	yyj2307++
-	if yyhl2307 {
-		yyb2307 = yyj2307 > l
+	yyj2315++
+	if yyhl2315 {
+		yyb2315 = yyj2315 > l
 	} else {
-		yyb2307 = r.CheckBreak()
+		yyb2315 = r.CheckBreak()
 	}
-	if yyb2307 {
+	if yyb2315 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.NodeInfo = NodeSystemInfo{}
 	} else {
-		yyv2315 := &x.NodeInfo
-		yyv2315.CodecDecodeSelf(d)
+		yyv2323 := &x.NodeInfo
+		yyv2323.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2307++
-		if yyhl2307 {
-			yyb2307 = yyj2307 > l
+		yyj2315++
+		if yyhl2315 {
+			yyb2315 = yyj2315 > l
 		} else {
-			yyb2307 = r.CheckBreak()
+			yyb2315 = r.CheckBreak()
 		}
-		if yyb2307 {
+		if yyb2315 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2307-1, "")
+		z.DecStructFieldNotFound(yyj2315-1, "")
 	}
 	r.ReadEnd()
 }
@@ -27491,8 +27551,8 @@ func (x NodePhase) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2316 := z.EncBinary()
-	_ = yym2316
+	yym2324 := z.EncBinary()
+	_ = yym2324
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -27504,8 +27564,8 @@ func (x *NodePhase) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2317 := z.DecBinary()
-	_ = yym2317
+	yym2325 := z.DecBinary()
+	_ = yym2325
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -27517,8 +27577,8 @@ func (x NodeConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2318 := z.EncBinary()
-	_ = yym2318
+	yym2326 := z.EncBinary()
+	_ = yym2326
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -27530,8 +27590,8 @@ func (x *NodeConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2319 := z.DecBinary()
-	_ = yym2319
+	yym2327 := z.DecBinary()
+	_ = yym2327
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -27546,137 +27606,137 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2320 := z.EncBinary()
-		_ = yym2320
+		yym2328 := z.EncBinary()
+		_ = yym2328
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2321 := !z.EncBinary()
-			yy2arr2321 := z.EncBasicHandle().StructToArray
-			var yyq2321 [6]bool
-			_, _, _ = yysep2321, yyq2321, yy2arr2321
-			const yyr2321 bool = false
-			yyq2321[2] = true
-			yyq2321[3] = true
-			yyq2321[4] = x.Reason != ""
-			yyq2321[5] = x.Message != ""
-			if yyr2321 || yy2arr2321 {
+			yysep2329 := !z.EncBinary()
+			yy2arr2329 := z.EncBasicHandle().StructToArray
+			var yyq2329 [6]bool
+			_, _, _ = yysep2329, yyq2329, yy2arr2329
+			const yyr2329 bool = false
+			yyq2329[2] = true
+			yyq2329[3] = true
+			yyq2329[4] = x.Reason != ""
+			yyq2329[5] = x.Message != ""
+			if yyr2329 || yy2arr2329 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn2321 int = 2
-				for _, b := range yyq2321 {
+				var yynn2329 int = 2
+				for _, b := range yyq2329 {
 					if b {
-						yynn2321++
+						yynn2329++
 					}
 				}
-				r.EncodeMapStart(yynn2321)
+				r.EncodeMapStart(yynn2329)
 			}
-			if yyr2321 || yy2arr2321 {
+			if yyr2329 || yy2arr2329 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr2321 || yy2arr2321 {
+			if yyr2329 || yy2arr2329 {
 				x.Status.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
 				x.Status.CodecEncodeSelf(e)
 			}
-			if yyr2321 || yy2arr2321 {
-				if yyq2321[2] {
-					yy2325 := &x.LastHeartbeatTime
-					yym2326 := z.EncBinary()
-					_ = yym2326
+			if yyr2329 || yy2arr2329 {
+				if yyq2329[2] {
+					yy2333 := &x.LastHeartbeatTime
+					yym2334 := z.EncBinary()
+					_ = yym2334
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2325) {
-					} else if yym2326 {
-						z.EncBinaryMarshal(yy2325)
-					} else if !yym2326 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2325)
+					} else if z.HasExtensions() && z.EncExt(yy2333) {
+					} else if yym2334 {
+						z.EncBinaryMarshal(yy2333)
+					} else if !yym2334 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2333)
 					} else {
-						z.EncFallback(yy2325)
+						z.EncFallback(yy2333)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2321[2] {
+				if yyq2329[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastHeartbeatTime"))
-					yy2327 := &x.LastHeartbeatTime
-					yym2328 := z.EncBinary()
-					_ = yym2328
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2327) {
-					} else if yym2328 {
-						z.EncBinaryMarshal(yy2327)
-					} else if !yym2328 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2327)
-					} else {
-						z.EncFallback(yy2327)
-					}
-				}
-			}
-			if yyr2321 || yy2arr2321 {
-				if yyq2321[3] {
-					yy2330 := &x.LastTransitionTime
-					yym2331 := z.EncBinary()
-					_ = yym2331
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2330) {
-					} else if yym2331 {
-						z.EncBinaryMarshal(yy2330)
-					} else if !yym2331 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2330)
-					} else {
-						z.EncFallback(yy2330)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2321[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
-					yy2332 := &x.LastTransitionTime
-					yym2333 := z.EncBinary()
-					_ = yym2333
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2332) {
-					} else if yym2333 {
-						z.EncBinaryMarshal(yy2332)
-					} else if !yym2333 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2332)
-					} else {
-						z.EncFallback(yy2332)
-					}
-				}
-			}
-			if yyr2321 || yy2arr2321 {
-				if yyq2321[4] {
-					yym2335 := z.EncBinary()
-					_ = yym2335
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2321[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					yy2335 := &x.LastHeartbeatTime
 					yym2336 := z.EncBinary()
 					_ = yym2336
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2335) {
+					} else if yym2336 {
+						z.EncBinaryMarshal(yy2335)
+					} else if !yym2336 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2335)
+					} else {
+						z.EncFallback(yy2335)
+					}
+				}
+			}
+			if yyr2329 || yy2arr2329 {
+				if yyq2329[3] {
+					yy2338 := &x.LastTransitionTime
+					yym2339 := z.EncBinary()
+					_ = yym2339
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2338) {
+					} else if yym2339 {
+						z.EncBinaryMarshal(yy2338)
+					} else if !yym2339 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2338)
+					} else {
+						z.EncFallback(yy2338)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2329[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					yy2340 := &x.LastTransitionTime
+					yym2341 := z.EncBinary()
+					_ = yym2341
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2340) {
+					} else if yym2341 {
+						z.EncBinaryMarshal(yy2340)
+					} else if !yym2341 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2340)
+					} else {
+						z.EncFallback(yy2340)
+					}
+				}
+			}
+			if yyr2329 || yy2arr2329 {
+				if yyq2329[4] {
+					yym2343 := z.EncBinary()
+					_ = yym2343
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2329[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					yym2344 := z.EncBinary()
+					_ = yym2344
+					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr2321 || yy2arr2321 {
-				if yyq2321[5] {
-					yym2338 := z.EncBinary()
-					_ = yym2338
+			if yyr2329 || yy2arr2329 {
+				if yyq2329[5] {
+					yym2346 := z.EncBinary()
+					_ = yym2346
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -27685,17 +27745,17 @@ func (x *NodeCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2321[5] {
+				if yyq2329[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym2339 := z.EncBinary()
-					_ = yym2339
+					yym2347 := z.EncBinary()
+					_ = yym2347
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yysep2321 {
+			if yysep2329 {
 				r.EncodeEnd()
 			}
 		}
@@ -27706,24 +27766,24 @@ func (x *NodeCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2340 := z.DecBinary()
-	_ = yym2340
+	yym2348 := z.DecBinary()
+	_ = yym2348
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2341 := r.ReadMapStart()
-			if yyl2341 == 0 {
+			yyl2349 := r.ReadMapStart()
+			if yyl2349 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2341, d)
+				x.codecDecodeSelfFromMap(yyl2349, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2341 := r.ReadArrayStart()
-			if yyl2341 == 0 {
+			yyl2349 := r.ReadArrayStart()
+			if yyl2349 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2341, d)
+				x.codecDecodeSelfFromArray(yyl2349, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -27735,12 +27795,12 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2342Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2342Slc
-	var yyhl2342 bool = l >= 0
-	for yyj2342 := 0; ; yyj2342++ {
-		if yyhl2342 {
-			if yyj2342 >= l {
+	var yys2350Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2350Slc
+	var yyhl2350 bool = l >= 0
+	for yyj2350 := 0; ; yyj2350++ {
+		if yyhl2350 {
+			if yyj2350 >= l {
 				break
 			}
 		} else {
@@ -27748,9 +27808,9 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2342Slc = r.DecodeBytes(yys2342Slc, true, true)
-		yys2342 := string(yys2342Slc)
-		switch yys2342 {
+		yys2350Slc = r.DecodeBytes(yys2350Slc, true, true)
+		yys2350 := string(yys2350Slc)
+		switch yys2350 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -27767,34 +27827,34 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastHeartbeatTime = pkg2_unversioned.Time{}
 			} else {
-				yyv2345 := &x.LastHeartbeatTime
-				yym2346 := z.DecBinary()
-				_ = yym2346
+				yyv2353 := &x.LastHeartbeatTime
+				yym2354 := z.DecBinary()
+				_ = yym2354
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2345) {
-				} else if yym2346 {
-					z.DecBinaryUnmarshal(yyv2345)
-				} else if !yym2346 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2345)
+				} else if z.HasExtensions() && z.DecExt(yyv2353) {
+				} else if yym2354 {
+					z.DecBinaryUnmarshal(yyv2353)
+				} else if !yym2354 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2353)
 				} else {
-					z.DecFallback(yyv2345, false)
+					z.DecFallback(yyv2353, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg2_unversioned.Time{}
 			} else {
-				yyv2347 := &x.LastTransitionTime
-				yym2348 := z.DecBinary()
-				_ = yym2348
+				yyv2355 := &x.LastTransitionTime
+				yym2356 := z.DecBinary()
+				_ = yym2356
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2347) {
-				} else if yym2348 {
-					z.DecBinaryUnmarshal(yyv2347)
-				} else if !yym2348 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2347)
+				} else if z.HasExtensions() && z.DecExt(yyv2355) {
+				} else if yym2356 {
+					z.DecBinaryUnmarshal(yyv2355)
+				} else if !yym2356 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2355)
 				} else {
-					z.DecFallback(yyv2347, false)
+					z.DecFallback(yyv2355, false)
 				}
 			}
 		case "reason":
@@ -27810,10 +27870,10 @@ func (x *NodeCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2342)
-		} // end switch yys2342
-	} // end for yyj2342
-	if !yyhl2342 {
+			z.DecStructFieldNotFound(-1, yys2350)
+		} // end switch yys2350
+	} // end for yyj2350
+	if !yyhl2350 {
 		r.ReadEnd()
 	}
 }
@@ -27822,16 +27882,16 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2351 int
-	var yyb2351 bool
-	var yyhl2351 bool = l >= 0
-	yyj2351++
-	if yyhl2351 {
-		yyb2351 = yyj2351 > l
+	var yyj2359 int
+	var yyb2359 bool
+	var yyhl2359 bool = l >= 0
+	yyj2359++
+	if yyhl2359 {
+		yyb2359 = yyj2359 > l
 	} else {
-		yyb2351 = r.CheckBreak()
+		yyb2359 = r.CheckBreak()
 	}
-	if yyb2351 {
+	if yyb2359 {
 		r.ReadEnd()
 		return
 	}
@@ -27840,13 +27900,13 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = NodeConditionType(r.DecodeString())
 	}
-	yyj2351++
-	if yyhl2351 {
-		yyb2351 = yyj2351 > l
+	yyj2359++
+	if yyhl2359 {
+		yyb2359 = yyj2359 > l
 	} else {
-		yyb2351 = r.CheckBreak()
+		yyb2359 = r.CheckBreak()
 	}
-	if yyb2351 {
+	if yyb2359 {
 		r.ReadEnd()
 		return
 	}
@@ -27855,65 +27915,65 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = ConditionStatus(r.DecodeString())
 	}
-	yyj2351++
-	if yyhl2351 {
-		yyb2351 = yyj2351 > l
+	yyj2359++
+	if yyhl2359 {
+		yyb2359 = yyj2359 > l
 	} else {
-		yyb2351 = r.CheckBreak()
+		yyb2359 = r.CheckBreak()
 	}
-	if yyb2351 {
+	if yyb2359 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastHeartbeatTime = pkg2_unversioned.Time{}
 	} else {
-		yyv2354 := &x.LastHeartbeatTime
-		yym2355 := z.DecBinary()
-		_ = yym2355
+		yyv2362 := &x.LastHeartbeatTime
+		yym2363 := z.DecBinary()
+		_ = yym2363
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2354) {
-		} else if yym2355 {
-			z.DecBinaryUnmarshal(yyv2354)
-		} else if !yym2355 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2354)
+		} else if z.HasExtensions() && z.DecExt(yyv2362) {
+		} else if yym2363 {
+			z.DecBinaryUnmarshal(yyv2362)
+		} else if !yym2363 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2362)
 		} else {
-			z.DecFallback(yyv2354, false)
+			z.DecFallback(yyv2362, false)
 		}
 	}
-	yyj2351++
-	if yyhl2351 {
-		yyb2351 = yyj2351 > l
+	yyj2359++
+	if yyhl2359 {
+		yyb2359 = yyj2359 > l
 	} else {
-		yyb2351 = r.CheckBreak()
+		yyb2359 = r.CheckBreak()
 	}
-	if yyb2351 {
+	if yyb2359 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg2_unversioned.Time{}
 	} else {
-		yyv2356 := &x.LastTransitionTime
-		yym2357 := z.DecBinary()
-		_ = yym2357
+		yyv2364 := &x.LastTransitionTime
+		yym2365 := z.DecBinary()
+		_ = yym2365
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2356) {
-		} else if yym2357 {
-			z.DecBinaryUnmarshal(yyv2356)
-		} else if !yym2357 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2356)
+		} else if z.HasExtensions() && z.DecExt(yyv2364) {
+		} else if yym2365 {
+			z.DecBinaryUnmarshal(yyv2364)
+		} else if !yym2365 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2364)
 		} else {
-			z.DecFallback(yyv2356, false)
+			z.DecFallback(yyv2364, false)
 		}
 	}
-	yyj2351++
-	if yyhl2351 {
-		yyb2351 = yyj2351 > l
+	yyj2359++
+	if yyhl2359 {
+		yyb2359 = yyj2359 > l
 	} else {
-		yyb2351 = r.CheckBreak()
+		yyb2359 = r.CheckBreak()
 	}
-	if yyb2351 {
+	if yyb2359 {
 		r.ReadEnd()
 		return
 	}
@@ -27922,13 +27982,13 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj2351++
-	if yyhl2351 {
-		yyb2351 = yyj2351 > l
+	yyj2359++
+	if yyhl2359 {
+		yyb2359 = yyj2359 > l
 	} else {
-		yyb2351 = r.CheckBreak()
+		yyb2359 = r.CheckBreak()
 	}
-	if yyb2351 {
+	if yyb2359 {
 		r.ReadEnd()
 		return
 	}
@@ -27938,16 +27998,16 @@ func (x *NodeCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj2351++
-		if yyhl2351 {
-			yyb2351 = yyj2351 > l
+		yyj2359++
+		if yyhl2359 {
+			yyb2359 = yyj2359 > l
 		} else {
-			yyb2351 = r.CheckBreak()
+			yyb2359 = r.CheckBreak()
 		}
-		if yyb2351 {
+		if yyb2359 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2351-1, "")
+		z.DecStructFieldNotFound(yyj2359-1, "")
 	}
 	r.ReadEnd()
 }
@@ -27956,8 +28016,8 @@ func (x NodeAddressType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2360 := z.EncBinary()
-	_ = yym2360
+	yym2368 := z.EncBinary()
+	_ = yym2368
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -27969,8 +28029,8 @@ func (x *NodeAddressType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2361 := z.DecBinary()
-	_ = yym2361
+	yym2369 := z.DecBinary()
+	_ = yym2369
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -27985,50 +28045,50 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2362 := z.EncBinary()
-		_ = yym2362
+		yym2370 := z.EncBinary()
+		_ = yym2370
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2363 := !z.EncBinary()
-			yy2arr2363 := z.EncBasicHandle().StructToArray
-			var yyq2363 [2]bool
-			_, _, _ = yysep2363, yyq2363, yy2arr2363
-			const yyr2363 bool = false
-			if yyr2363 || yy2arr2363 {
+			yysep2371 := !z.EncBinary()
+			yy2arr2371 := z.EncBasicHandle().StructToArray
+			var yyq2371 [2]bool
+			_, _, _ = yysep2371, yyq2371, yy2arr2371
+			const yyr2371 bool = false
+			if yyr2371 || yy2arr2371 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2363 int = 2
-				for _, b := range yyq2363 {
+				var yynn2371 int = 2
+				for _, b := range yyq2371 {
 					if b {
-						yynn2363++
+						yynn2371++
 					}
 				}
-				r.EncodeMapStart(yynn2363)
+				r.EncodeMapStart(yynn2371)
 			}
-			if yyr2363 || yy2arr2363 {
+			if yyr2371 || yy2arr2371 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr2363 || yy2arr2363 {
-				yym2366 := z.EncBinary()
-				_ = yym2366
+			if yyr2371 || yy2arr2371 {
+				yym2374 := z.EncBinary()
+				_ = yym2374
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
-				yym2367 := z.EncBinary()
-				_ = yym2367
+				yym2375 := z.EncBinary()
+				_ = yym2375
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
-			if yysep2363 {
+			if yysep2371 {
 				r.EncodeEnd()
 			}
 		}
@@ -28039,24 +28099,24 @@ func (x *NodeAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2368 := z.DecBinary()
-	_ = yym2368
+	yym2376 := z.DecBinary()
+	_ = yym2376
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2369 := r.ReadMapStart()
-			if yyl2369 == 0 {
+			yyl2377 := r.ReadMapStart()
+			if yyl2377 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2369, d)
+				x.codecDecodeSelfFromMap(yyl2377, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2369 := r.ReadArrayStart()
-			if yyl2369 == 0 {
+			yyl2377 := r.ReadArrayStart()
+			if yyl2377 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2369, d)
+				x.codecDecodeSelfFromArray(yyl2377, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28068,12 +28128,12 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2370Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2370Slc
-	var yyhl2370 bool = l >= 0
-	for yyj2370 := 0; ; yyj2370++ {
-		if yyhl2370 {
-			if yyj2370 >= l {
+	var yys2378Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2378Slc
+	var yyhl2378 bool = l >= 0
+	for yyj2378 := 0; ; yyj2378++ {
+		if yyhl2378 {
+			if yyj2378 >= l {
 				break
 			}
 		} else {
@@ -28081,9 +28141,9 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2370Slc = r.DecodeBytes(yys2370Slc, true, true)
-		yys2370 := string(yys2370Slc)
-		switch yys2370 {
+		yys2378Slc = r.DecodeBytes(yys2378Slc, true, true)
+		yys2378 := string(yys2378Slc)
+		switch yys2378 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -28097,10 +28157,10 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Address = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2370)
-		} // end switch yys2370
-	} // end for yyj2370
-	if !yyhl2370 {
+			z.DecStructFieldNotFound(-1, yys2378)
+		} // end switch yys2378
+	} // end for yyj2378
+	if !yyhl2378 {
 		r.ReadEnd()
 	}
 }
@@ -28109,16 +28169,16 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2373 int
-	var yyb2373 bool
-	var yyhl2373 bool = l >= 0
-	yyj2373++
-	if yyhl2373 {
-		yyb2373 = yyj2373 > l
+	var yyj2381 int
+	var yyb2381 bool
+	var yyhl2381 bool = l >= 0
+	yyj2381++
+	if yyhl2381 {
+		yyb2381 = yyj2381 > l
 	} else {
-		yyb2373 = r.CheckBreak()
+		yyb2381 = r.CheckBreak()
 	}
-	if yyb2373 {
+	if yyb2381 {
 		r.ReadEnd()
 		return
 	}
@@ -28127,13 +28187,13 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = NodeAddressType(r.DecodeString())
 	}
-	yyj2373++
-	if yyhl2373 {
-		yyb2373 = yyj2373 > l
+	yyj2381++
+	if yyhl2381 {
+		yyb2381 = yyj2381 > l
 	} else {
-		yyb2373 = r.CheckBreak()
+		yyb2381 = r.CheckBreak()
 	}
-	if yyb2373 {
+	if yyb2381 {
 		r.ReadEnd()
 		return
 	}
@@ -28143,16 +28203,16 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Address = string(r.DecodeString())
 	}
 	for {
-		yyj2373++
-		if yyhl2373 {
-			yyb2373 = yyj2373 > l
+		yyj2381++
+		if yyhl2381 {
+			yyb2381 = yyj2381 > l
 		} else {
-			yyb2373 = r.CheckBreak()
+			yyb2381 = r.CheckBreak()
 		}
-		if yyb2373 {
+		if yyb2381 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2373-1, "")
+		z.DecStructFieldNotFound(yyj2381-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28161,8 +28221,8 @@ func (x ResourceName) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2376 := z.EncBinary()
-	_ = yym2376
+	yym2384 := z.EncBinary()
+	_ = yym2384
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -28174,8 +28234,8 @@ func (x *ResourceName) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2377 := z.DecBinary()
-	_ = yym2377
+	yym2385 := z.DecBinary()
+	_ = yym2385
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28190,8 +28250,8 @@ func (x ResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2378 := z.EncBinary()
-		_ = yym2378
+		yym2386 := z.EncBinary()
+		_ = yym2386
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
@@ -28204,8 +28264,8 @@ func (x *ResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2379 := z.DecBinary()
-	_ = yym2379
+	yym2387 := z.DecBinary()
+	_ = yym2387
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28220,36 +28280,36 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2380 := z.EncBinary()
-		_ = yym2380
+		yym2388 := z.EncBinary()
+		_ = yym2388
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2381 := !z.EncBinary()
-			yy2arr2381 := z.EncBasicHandle().StructToArray
-			var yyq2381 [5]bool
-			_, _, _ = yysep2381, yyq2381, yy2arr2381
-			const yyr2381 bool = false
-			yyq2381[0] = x.Kind != ""
-			yyq2381[1] = x.APIVersion != ""
-			yyq2381[2] = true
-			yyq2381[3] = true
-			yyq2381[4] = true
-			if yyr2381 || yy2arr2381 {
+			yysep2389 := !z.EncBinary()
+			yy2arr2389 := z.EncBasicHandle().StructToArray
+			var yyq2389 [5]bool
+			_, _, _ = yysep2389, yyq2389, yy2arr2389
+			const yyr2389 bool = false
+			yyq2389[0] = x.Kind != ""
+			yyq2389[1] = x.APIVersion != ""
+			yyq2389[2] = true
+			yyq2389[3] = true
+			yyq2389[4] = true
+			if yyr2389 || yy2arr2389 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2381 int = 0
-				for _, b := range yyq2381 {
+				var yynn2389 int = 0
+				for _, b := range yyq2389 {
 					if b {
-						yynn2381++
+						yynn2389++
 					}
 				}
-				r.EncodeMapStart(yynn2381)
+				r.EncodeMapStart(yynn2389)
 			}
-			if yyr2381 || yy2arr2381 {
-				if yyq2381[0] {
-					yym2383 := z.EncBinary()
-					_ = yym2383
+			if yyr2389 || yy2arr2389 {
+				if yyq2389[0] {
+					yym2391 := z.EncBinary()
+					_ = yym2391
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -28258,20 +28318,20 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2381[0] {
+				if yyq2389[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2384 := z.EncBinary()
-					_ = yym2384
+					yym2392 := z.EncBinary()
+					_ = yym2392
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2381 || yy2arr2381 {
-				if yyq2381[1] {
-					yym2386 := z.EncBinary()
-					_ = yym2386
+			if yyr2389 || yy2arr2389 {
+				if yyq2389[1] {
+					yym2394 := z.EncBinary()
+					_ = yym2394
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -28280,59 +28340,59 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2381[1] {
+				if yyq2389[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2387 := z.EncBinary()
-					_ = yym2387
+					yym2395 := z.EncBinary()
+					_ = yym2395
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2381 || yy2arr2381 {
-				if yyq2381[2] {
-					yy2389 := &x.ObjectMeta
-					yy2389.CodecEncodeSelf(e)
+			if yyr2389 || yy2arr2389 {
+				if yyq2389[2] {
+					yy2397 := &x.ObjectMeta
+					yy2397.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2381[2] {
+				if yyq2389[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2390 := &x.ObjectMeta
-					yy2390.CodecEncodeSelf(e)
+					yy2398 := &x.ObjectMeta
+					yy2398.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2381 || yy2arr2381 {
-				if yyq2381[3] {
-					yy2392 := &x.Spec
-					yy2392.CodecEncodeSelf(e)
+			if yyr2389 || yy2arr2389 {
+				if yyq2389[3] {
+					yy2400 := &x.Spec
+					yy2400.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2381[3] {
+				if yyq2389[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy2393 := &x.Spec
-					yy2393.CodecEncodeSelf(e)
+					yy2401 := &x.Spec
+					yy2401.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2381 || yy2arr2381 {
-				if yyq2381[4] {
-					yy2395 := &x.Status
-					yy2395.CodecEncodeSelf(e)
+			if yyr2389 || yy2arr2389 {
+				if yyq2389[4] {
+					yy2403 := &x.Status
+					yy2403.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2381[4] {
+				if yyq2389[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy2396 := &x.Status
-					yy2396.CodecEncodeSelf(e)
+					yy2404 := &x.Status
+					yy2404.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2381 {
+			if yysep2389 {
 				r.EncodeEnd()
 			}
 		}
@@ -28343,24 +28403,24 @@ func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2397 := z.DecBinary()
-	_ = yym2397
+	yym2405 := z.DecBinary()
+	_ = yym2405
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2398 := r.ReadMapStart()
-			if yyl2398 == 0 {
+			yyl2406 := r.ReadMapStart()
+			if yyl2406 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2398, d)
+				x.codecDecodeSelfFromMap(yyl2406, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2398 := r.ReadArrayStart()
-			if yyl2398 == 0 {
+			yyl2406 := r.ReadArrayStart()
+			if yyl2406 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2398, d)
+				x.codecDecodeSelfFromArray(yyl2406, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28372,12 +28432,12 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2399Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2399Slc
-	var yyhl2399 bool = l >= 0
-	for yyj2399 := 0; ; yyj2399++ {
-		if yyhl2399 {
-			if yyj2399 >= l {
+	var yys2407Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2407Slc
+	var yyhl2407 bool = l >= 0
+	for yyj2407 := 0; ; yyj2407++ {
+		if yyhl2407 {
+			if yyj2407 >= l {
 				break
 			}
 		} else {
@@ -28385,9 +28445,9 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2399Slc = r.DecodeBytes(yys2399Slc, true, true)
-		yys2399 := string(yys2399Slc)
-		switch yys2399 {
+		yys2407Slc = r.DecodeBytes(yys2407Slc, true, true)
+		yys2407 := string(yys2407Slc)
+		switch yys2407 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28404,28 +28464,28 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2402 := &x.ObjectMeta
-				yyv2402.CodecDecodeSelf(d)
+				yyv2410 := &x.ObjectMeta
+				yyv2410.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = NodeSpec{}
 			} else {
-				yyv2403 := &x.Spec
-				yyv2403.CodecDecodeSelf(d)
+				yyv2411 := &x.Spec
+				yyv2411.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = NodeStatus{}
 			} else {
-				yyv2404 := &x.Status
-				yyv2404.CodecDecodeSelf(d)
+				yyv2412 := &x.Status
+				yyv2412.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2399)
-		} // end switch yys2399
-	} // end for yyj2399
-	if !yyhl2399 {
+			z.DecStructFieldNotFound(-1, yys2407)
+		} // end switch yys2407
+	} // end for yyj2407
+	if !yyhl2407 {
 		r.ReadEnd()
 	}
 }
@@ -28434,16 +28494,16 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2405 int
-	var yyb2405 bool
-	var yyhl2405 bool = l >= 0
-	yyj2405++
-	if yyhl2405 {
-		yyb2405 = yyj2405 > l
+	var yyj2413 int
+	var yyb2413 bool
+	var yyhl2413 bool = l >= 0
+	yyj2413++
+	if yyhl2413 {
+		yyb2413 = yyj2413 > l
 	} else {
-		yyb2405 = r.CheckBreak()
+		yyb2413 = r.CheckBreak()
 	}
-	if yyb2405 {
+	if yyb2413 {
 		r.ReadEnd()
 		return
 	}
@@ -28452,13 +28512,13 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2405++
-	if yyhl2405 {
-		yyb2405 = yyj2405 > l
+	yyj2413++
+	if yyhl2413 {
+		yyb2413 = yyj2413 > l
 	} else {
-		yyb2405 = r.CheckBreak()
+		yyb2413 = r.CheckBreak()
 	}
-	if yyb2405 {
+	if yyb2413 {
 		r.ReadEnd()
 		return
 	}
@@ -28467,65 +28527,65 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2405++
-	if yyhl2405 {
-		yyb2405 = yyj2405 > l
+	yyj2413++
+	if yyhl2413 {
+		yyb2413 = yyj2413 > l
 	} else {
-		yyb2405 = r.CheckBreak()
+		yyb2413 = r.CheckBreak()
 	}
-	if yyb2405 {
+	if yyb2413 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2408 := &x.ObjectMeta
-		yyv2408.CodecDecodeSelf(d)
+		yyv2416 := &x.ObjectMeta
+		yyv2416.CodecDecodeSelf(d)
 	}
-	yyj2405++
-	if yyhl2405 {
-		yyb2405 = yyj2405 > l
+	yyj2413++
+	if yyhl2413 {
+		yyb2413 = yyj2413 > l
 	} else {
-		yyb2405 = r.CheckBreak()
+		yyb2413 = r.CheckBreak()
 	}
-	if yyb2405 {
+	if yyb2413 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = NodeSpec{}
 	} else {
-		yyv2409 := &x.Spec
-		yyv2409.CodecDecodeSelf(d)
+		yyv2417 := &x.Spec
+		yyv2417.CodecDecodeSelf(d)
 	}
-	yyj2405++
-	if yyhl2405 {
-		yyb2405 = yyj2405 > l
+	yyj2413++
+	if yyhl2413 {
+		yyb2413 = yyj2413 > l
 	} else {
-		yyb2405 = r.CheckBreak()
+		yyb2413 = r.CheckBreak()
 	}
-	if yyb2405 {
+	if yyb2413 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = NodeStatus{}
 	} else {
-		yyv2410 := &x.Status
-		yyv2410.CodecDecodeSelf(d)
+		yyv2418 := &x.Status
+		yyv2418.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2405++
-		if yyhl2405 {
-			yyb2405 = yyj2405 > l
+		yyj2413++
+		if yyhl2413 {
+			yyb2413 = yyj2413 > l
 		} else {
-			yyb2405 = r.CheckBreak()
+			yyb2413 = r.CheckBreak()
 		}
-		if yyb2405 {
+		if yyb2413 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2405-1, "")
+		z.DecStructFieldNotFound(yyj2413-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28537,34 +28597,34 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2411 := z.EncBinary()
-		_ = yym2411
+		yym2419 := z.EncBinary()
+		_ = yym2419
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2412 := !z.EncBinary()
-			yy2arr2412 := z.EncBasicHandle().StructToArray
-			var yyq2412 [4]bool
-			_, _, _ = yysep2412, yyq2412, yy2arr2412
-			const yyr2412 bool = false
-			yyq2412[0] = x.Kind != ""
-			yyq2412[1] = x.APIVersion != ""
-			yyq2412[2] = true
-			if yyr2412 || yy2arr2412 {
+			yysep2420 := !z.EncBinary()
+			yy2arr2420 := z.EncBasicHandle().StructToArray
+			var yyq2420 [4]bool
+			_, _, _ = yysep2420, yyq2420, yy2arr2420
+			const yyr2420 bool = false
+			yyq2420[0] = x.Kind != ""
+			yyq2420[1] = x.APIVersion != ""
+			yyq2420[2] = true
+			if yyr2420 || yy2arr2420 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2412 int = 1
-				for _, b := range yyq2412 {
+				var yynn2420 int = 1
+				for _, b := range yyq2420 {
 					if b {
-						yynn2412++
+						yynn2420++
 					}
 				}
-				r.EncodeMapStart(yynn2412)
+				r.EncodeMapStart(yynn2420)
 			}
-			if yyr2412 || yy2arr2412 {
-				if yyq2412[0] {
-					yym2414 := z.EncBinary()
-					_ = yym2414
+			if yyr2420 || yy2arr2420 {
+				if yyq2420[0] {
+					yym2422 := z.EncBinary()
+					_ = yym2422
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -28573,70 +28633,70 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2412[0] {
+				if yyq2420[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2415 := z.EncBinary()
-					_ = yym2415
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2412 || yy2arr2412 {
-				if yyq2412[1] {
-					yym2417 := z.EncBinary()
-					_ = yym2417
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2412[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2418 := z.EncBinary()
-					_ = yym2418
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2412 || yy2arr2412 {
-				if yyq2412[2] {
-					yy2420 := &x.ListMeta
-					yym2421 := z.EncBinary()
-					_ = yym2421
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2420) {
-					} else {
-						z.EncFallback(yy2420)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2412[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2422 := &x.ListMeta
 					yym2423 := z.EncBinary()
 					_ = yym2423
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2422) {
 					} else {
-						z.EncFallback(yy2422)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2412 || yy2arr2412 {
+			if yyr2420 || yy2arr2420 {
+				if yyq2420[1] {
+					yym2425 := z.EncBinary()
+					_ = yym2425
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2420[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2426 := z.EncBinary()
+					_ = yym2426
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2420 || yy2arr2420 {
+				if yyq2420[2] {
+					yy2428 := &x.ListMeta
+					yym2429 := z.EncBinary()
+					_ = yym2429
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2428) {
+					} else {
+						z.EncFallback(yy2428)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2420[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2430 := &x.ListMeta
+					yym2431 := z.EncBinary()
+					_ = yym2431
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2430) {
+					} else {
+						z.EncFallback(yy2430)
+					}
+				}
+			}
+			if yyr2420 || yy2arr2420 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2425 := z.EncBinary()
-					_ = yym2425
+					yym2433 := z.EncBinary()
+					_ = yym2433
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
@@ -28647,15 +28707,15 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2426 := z.EncBinary()
-					_ = yym2426
+					yym2434 := z.EncBinary()
+					_ = yym2434
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
 					}
 				}
 			}
-			if yysep2412 {
+			if yysep2420 {
 				r.EncodeEnd()
 			}
 		}
@@ -28666,24 +28726,24 @@ func (x *NodeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2427 := z.DecBinary()
-	_ = yym2427
+	yym2435 := z.DecBinary()
+	_ = yym2435
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2428 := r.ReadMapStart()
-			if yyl2428 == 0 {
+			yyl2436 := r.ReadMapStart()
+			if yyl2436 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2428, d)
+				x.codecDecodeSelfFromMap(yyl2436, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2428 := r.ReadArrayStart()
-			if yyl2428 == 0 {
+			yyl2436 := r.ReadArrayStart()
+			if yyl2436 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2428, d)
+				x.codecDecodeSelfFromArray(yyl2436, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28695,12 +28755,12 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2429Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2429Slc
-	var yyhl2429 bool = l >= 0
-	for yyj2429 := 0; ; yyj2429++ {
-		if yyhl2429 {
-			if yyj2429 >= l {
+	var yys2437Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2437Slc
+	var yyhl2437 bool = l >= 0
+	for yyj2437 := 0; ; yyj2437++ {
+		if yyhl2437 {
+			if yyj2437 >= l {
 				break
 			}
 		} else {
@@ -28708,9 +28768,9 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2429Slc = r.DecodeBytes(yys2429Slc, true, true)
-		yys2429 := string(yys2429Slc)
-		switch yys2429 {
+		yys2437Slc = r.DecodeBytes(yys2437Slc, true, true)
+		yys2437 := string(yys2437Slc)
+		switch yys2437 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28727,32 +28787,32 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2432 := &x.ListMeta
-				yym2433 := z.DecBinary()
-				_ = yym2433
+				yyv2440 := &x.ListMeta
+				yym2441 := z.DecBinary()
+				_ = yym2441
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2432) {
+				} else if z.HasExtensions() && z.DecExt(yyv2440) {
 				} else {
-					z.DecFallback(yyv2432, false)
+					z.DecFallback(yyv2440, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2434 := &x.Items
-				yym2435 := z.DecBinary()
-				_ = yym2435
+				yyv2442 := &x.Items
+				yym2443 := z.DecBinary()
+				_ = yym2443
 				if false {
 				} else {
-					h.decSliceNode((*[]Node)(yyv2434), d)
+					h.decSliceNode((*[]Node)(yyv2442), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2429)
-		} // end switch yys2429
-	} // end for yyj2429
-	if !yyhl2429 {
+			z.DecStructFieldNotFound(-1, yys2437)
+		} // end switch yys2437
+	} // end for yyj2437
+	if !yyhl2437 {
 		r.ReadEnd()
 	}
 }
@@ -28761,16 +28821,16 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2436 int
-	var yyb2436 bool
-	var yyhl2436 bool = l >= 0
-	yyj2436++
-	if yyhl2436 {
-		yyb2436 = yyj2436 > l
+	var yyj2444 int
+	var yyb2444 bool
+	var yyhl2444 bool = l >= 0
+	yyj2444++
+	if yyhl2444 {
+		yyb2444 = yyj2444 > l
 	} else {
-		yyb2436 = r.CheckBreak()
+		yyb2444 = r.CheckBreak()
 	}
-	if yyb2436 {
+	if yyb2444 {
 		r.ReadEnd()
 		return
 	}
@@ -28779,13 +28839,13 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2436++
-	if yyhl2436 {
-		yyb2436 = yyj2436 > l
+	yyj2444++
+	if yyhl2444 {
+		yyb2444 = yyj2444 > l
 	} else {
-		yyb2436 = r.CheckBreak()
+		yyb2444 = r.CheckBreak()
 	}
-	if yyb2436 {
+	if yyb2444 {
 		r.ReadEnd()
 		return
 	}
@@ -28794,60 +28854,60 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2436++
-	if yyhl2436 {
-		yyb2436 = yyj2436 > l
+	yyj2444++
+	if yyhl2444 {
+		yyb2444 = yyj2444 > l
 	} else {
-		yyb2436 = r.CheckBreak()
+		yyb2444 = r.CheckBreak()
 	}
-	if yyb2436 {
+	if yyb2444 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2439 := &x.ListMeta
-		yym2440 := z.DecBinary()
-		_ = yym2440
+		yyv2447 := &x.ListMeta
+		yym2448 := z.DecBinary()
+		_ = yym2448
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2439) {
+		} else if z.HasExtensions() && z.DecExt(yyv2447) {
 		} else {
-			z.DecFallback(yyv2439, false)
+			z.DecFallback(yyv2447, false)
 		}
 	}
-	yyj2436++
-	if yyhl2436 {
-		yyb2436 = yyj2436 > l
+	yyj2444++
+	if yyhl2444 {
+		yyb2444 = yyj2444 > l
 	} else {
-		yyb2436 = r.CheckBreak()
+		yyb2444 = r.CheckBreak()
 	}
-	if yyb2436 {
+	if yyb2444 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2441 := &x.Items
-		yym2442 := z.DecBinary()
-		_ = yym2442
+		yyv2449 := &x.Items
+		yym2450 := z.DecBinary()
+		_ = yym2450
 		if false {
 		} else {
-			h.decSliceNode((*[]Node)(yyv2441), d)
+			h.decSliceNode((*[]Node)(yyv2449), d)
 		}
 	}
 	for {
-		yyj2436++
-		if yyhl2436 {
-			yyb2436 = yyj2436 > l
+		yyj2444++
+		if yyhl2444 {
+			yyb2444 = yyj2444 > l
 		} else {
-			yyb2436 = r.CheckBreak()
+			yyb2444 = r.CheckBreak()
 		}
-		if yyb2436 {
+		if yyb2444 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2436-1, "")
+		z.DecStructFieldNotFound(yyj2444-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28856,8 +28916,8 @@ func (x FinalizerName) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2443 := z.EncBinary()
-	_ = yym2443
+	yym2451 := z.EncBinary()
+	_ = yym2451
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -28869,8 +28929,8 @@ func (x *FinalizerName) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2444 := z.DecBinary()
-	_ = yym2444
+	yym2452 := z.DecBinary()
+	_ = yym2452
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28885,35 +28945,35 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2445 := z.EncBinary()
-		_ = yym2445
+		yym2453 := z.EncBinary()
+		_ = yym2453
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2446 := !z.EncBinary()
-			yy2arr2446 := z.EncBasicHandle().StructToArray
-			var yyq2446 [1]bool
-			_, _, _ = yysep2446, yyq2446, yy2arr2446
-			const yyr2446 bool = false
-			yyq2446[0] = len(x.Finalizers) != 0
-			if yyr2446 || yy2arr2446 {
+			yysep2454 := !z.EncBinary()
+			yy2arr2454 := z.EncBasicHandle().StructToArray
+			var yyq2454 [1]bool
+			_, _, _ = yysep2454, yyq2454, yy2arr2454
+			const yyr2454 bool = false
+			yyq2454[0] = len(x.Finalizers) != 0
+			if yyr2454 || yy2arr2454 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2446 int = 0
-				for _, b := range yyq2446 {
+				var yynn2454 int = 0
+				for _, b := range yyq2454 {
 					if b {
-						yynn2446++
+						yynn2454++
 					}
 				}
-				r.EncodeMapStart(yynn2446)
+				r.EncodeMapStart(yynn2454)
 			}
-			if yyr2446 || yy2arr2446 {
-				if yyq2446[0] {
+			if yyr2454 || yy2arr2454 {
+				if yyq2454[0] {
 					if x.Finalizers == nil {
 						r.EncodeNil()
 					} else {
-						yym2448 := z.EncBinary()
-						_ = yym2448
+						yym2456 := z.EncBinary()
+						_ = yym2456
 						if false {
 						} else {
 							h.encSliceFinalizerName(([]FinalizerName)(x.Finalizers), e)
@@ -28923,13 +28983,13 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2446[0] {
+				if yyq2454[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("finalizers"))
 					if x.Finalizers == nil {
 						r.EncodeNil()
 					} else {
-						yym2449 := z.EncBinary()
-						_ = yym2449
+						yym2457 := z.EncBinary()
+						_ = yym2457
 						if false {
 						} else {
 							h.encSliceFinalizerName(([]FinalizerName)(x.Finalizers), e)
@@ -28937,7 +28997,7 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2446 {
+			if yysep2454 {
 				r.EncodeEnd()
 			}
 		}
@@ -28948,24 +29008,24 @@ func (x *NamespaceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2450 := z.DecBinary()
-	_ = yym2450
+	yym2458 := z.DecBinary()
+	_ = yym2458
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2451 := r.ReadMapStart()
-			if yyl2451 == 0 {
+			yyl2459 := r.ReadMapStart()
+			if yyl2459 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2451, d)
+				x.codecDecodeSelfFromMap(yyl2459, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2451 := r.ReadArrayStart()
-			if yyl2451 == 0 {
+			yyl2459 := r.ReadArrayStart()
+			if yyl2459 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2451, d)
+				x.codecDecodeSelfFromArray(yyl2459, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28977,12 +29037,12 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2452Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2452Slc
-	var yyhl2452 bool = l >= 0
-	for yyj2452 := 0; ; yyj2452++ {
-		if yyhl2452 {
-			if yyj2452 >= l {
+	var yys2460Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2460Slc
+	var yyhl2460 bool = l >= 0
+	for yyj2460 := 0; ; yyj2460++ {
+		if yyhl2460 {
+			if yyj2460 >= l {
 				break
 			}
 		} else {
@@ -28990,26 +29050,26 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2452Slc = r.DecodeBytes(yys2452Slc, true, true)
-		yys2452 := string(yys2452Slc)
-		switch yys2452 {
+		yys2460Slc = r.DecodeBytes(yys2460Slc, true, true)
+		yys2460 := string(yys2460Slc)
+		switch yys2460 {
 		case "finalizers":
 			if r.TryDecodeAsNil() {
 				x.Finalizers = nil
 			} else {
-				yyv2453 := &x.Finalizers
-				yym2454 := z.DecBinary()
-				_ = yym2454
+				yyv2461 := &x.Finalizers
+				yym2462 := z.DecBinary()
+				_ = yym2462
 				if false {
 				} else {
-					h.decSliceFinalizerName((*[]FinalizerName)(yyv2453), d)
+					h.decSliceFinalizerName((*[]FinalizerName)(yyv2461), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2452)
-		} // end switch yys2452
-	} // end for yyj2452
-	if !yyhl2452 {
+			z.DecStructFieldNotFound(-1, yys2460)
+		} // end switch yys2460
+	} // end for yyj2460
+	if !yyhl2460 {
 		r.ReadEnd()
 	}
 }
@@ -29018,41 +29078,41 @@ func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2455 int
-	var yyb2455 bool
-	var yyhl2455 bool = l >= 0
-	yyj2455++
-	if yyhl2455 {
-		yyb2455 = yyj2455 > l
+	var yyj2463 int
+	var yyb2463 bool
+	var yyhl2463 bool = l >= 0
+	yyj2463++
+	if yyhl2463 {
+		yyb2463 = yyj2463 > l
 	} else {
-		yyb2455 = r.CheckBreak()
+		yyb2463 = r.CheckBreak()
 	}
-	if yyb2455 {
+	if yyb2463 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Finalizers = nil
 	} else {
-		yyv2456 := &x.Finalizers
-		yym2457 := z.DecBinary()
-		_ = yym2457
+		yyv2464 := &x.Finalizers
+		yym2465 := z.DecBinary()
+		_ = yym2465
 		if false {
 		} else {
-			h.decSliceFinalizerName((*[]FinalizerName)(yyv2456), d)
+			h.decSliceFinalizerName((*[]FinalizerName)(yyv2464), d)
 		}
 	}
 	for {
-		yyj2455++
-		if yyhl2455 {
-			yyb2455 = yyj2455 > l
+		yyj2463++
+		if yyhl2463 {
+			yyb2463 = yyj2463 > l
 		} else {
-			yyb2455 = r.CheckBreak()
+			yyb2463 = r.CheckBreak()
 		}
-		if yyb2455 {
+		if yyb2463 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2455-1, "")
+		z.DecStructFieldNotFound(yyj2463-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29064,41 +29124,41 @@ func (x *NamespaceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2458 := z.EncBinary()
-		_ = yym2458
+		yym2466 := z.EncBinary()
+		_ = yym2466
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2459 := !z.EncBinary()
-			yy2arr2459 := z.EncBasicHandle().StructToArray
-			var yyq2459 [1]bool
-			_, _, _ = yysep2459, yyq2459, yy2arr2459
-			const yyr2459 bool = false
-			yyq2459[0] = x.Phase != ""
-			if yyr2459 || yy2arr2459 {
+			yysep2467 := !z.EncBinary()
+			yy2arr2467 := z.EncBasicHandle().StructToArray
+			var yyq2467 [1]bool
+			_, _, _ = yysep2467, yyq2467, yy2arr2467
+			const yyr2467 bool = false
+			yyq2467[0] = x.Phase != ""
+			if yyr2467 || yy2arr2467 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2459 int = 0
-				for _, b := range yyq2459 {
+				var yynn2467 int = 0
+				for _, b := range yyq2467 {
 					if b {
-						yynn2459++
+						yynn2467++
 					}
 				}
-				r.EncodeMapStart(yynn2459)
+				r.EncodeMapStart(yynn2467)
 			}
-			if yyr2459 || yy2arr2459 {
-				if yyq2459[0] {
+			if yyr2467 || yy2arr2467 {
+				if yyq2467[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2459[0] {
+				if yyq2467[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2459 {
+			if yysep2467 {
 				r.EncodeEnd()
 			}
 		}
@@ -29109,24 +29169,24 @@ func (x *NamespaceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2461 := z.DecBinary()
-	_ = yym2461
+	yym2469 := z.DecBinary()
+	_ = yym2469
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2462 := r.ReadMapStart()
-			if yyl2462 == 0 {
+			yyl2470 := r.ReadMapStart()
+			if yyl2470 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2462, d)
+				x.codecDecodeSelfFromMap(yyl2470, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2462 := r.ReadArrayStart()
-			if yyl2462 == 0 {
+			yyl2470 := r.ReadArrayStart()
+			if yyl2470 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2462, d)
+				x.codecDecodeSelfFromArray(yyl2470, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29138,12 +29198,12 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2463Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2463Slc
-	var yyhl2463 bool = l >= 0
-	for yyj2463 := 0; ; yyj2463++ {
-		if yyhl2463 {
-			if yyj2463 >= l {
+	var yys2471Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2471Slc
+	var yyhl2471 bool = l >= 0
+	for yyj2471 := 0; ; yyj2471++ {
+		if yyhl2471 {
+			if yyj2471 >= l {
 				break
 			}
 		} else {
@@ -29151,9 +29211,9 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2463Slc = r.DecodeBytes(yys2463Slc, true, true)
-		yys2463 := string(yys2463Slc)
-		switch yys2463 {
+		yys2471Slc = r.DecodeBytes(yys2471Slc, true, true)
+		yys2471 := string(yys2471Slc)
+		switch yys2471 {
 		case "phase":
 			if r.TryDecodeAsNil() {
 				x.Phase = ""
@@ -29161,10 +29221,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Phase = NamespacePhase(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2463)
-		} // end switch yys2463
-	} // end for yyj2463
-	if !yyhl2463 {
+			z.DecStructFieldNotFound(-1, yys2471)
+		} // end switch yys2471
+	} // end for yyj2471
+	if !yyhl2471 {
 		r.ReadEnd()
 	}
 }
@@ -29173,16 +29233,16 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2465 int
-	var yyb2465 bool
-	var yyhl2465 bool = l >= 0
-	yyj2465++
-	if yyhl2465 {
-		yyb2465 = yyj2465 > l
+	var yyj2473 int
+	var yyb2473 bool
+	var yyhl2473 bool = l >= 0
+	yyj2473++
+	if yyhl2473 {
+		yyb2473 = yyj2473 > l
 	} else {
-		yyb2465 = r.CheckBreak()
+		yyb2473 = r.CheckBreak()
 	}
-	if yyb2465 {
+	if yyb2473 {
 		r.ReadEnd()
 		return
 	}
@@ -29192,16 +29252,16 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Phase = NamespacePhase(r.DecodeString())
 	}
 	for {
-		yyj2465++
-		if yyhl2465 {
-			yyb2465 = yyj2465 > l
+		yyj2473++
+		if yyhl2473 {
+			yyb2473 = yyj2473 > l
 		} else {
-			yyb2465 = r.CheckBreak()
+			yyb2473 = r.CheckBreak()
 		}
-		if yyb2465 {
+		if yyb2473 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2465-1, "")
+		z.DecStructFieldNotFound(yyj2473-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29210,8 +29270,8 @@ func (x NamespacePhase) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2467 := z.EncBinary()
-	_ = yym2467
+	yym2475 := z.EncBinary()
+	_ = yym2475
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -29223,8 +29283,8 @@ func (x *NamespacePhase) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2468 := z.DecBinary()
-	_ = yym2468
+	yym2476 := z.DecBinary()
+	_ = yym2476
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -29239,36 +29299,36 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2469 := z.EncBinary()
-		_ = yym2469
+		yym2477 := z.EncBinary()
+		_ = yym2477
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2470 := !z.EncBinary()
-			yy2arr2470 := z.EncBasicHandle().StructToArray
-			var yyq2470 [5]bool
-			_, _, _ = yysep2470, yyq2470, yy2arr2470
-			const yyr2470 bool = false
-			yyq2470[0] = x.Kind != ""
-			yyq2470[1] = x.APIVersion != ""
-			yyq2470[2] = true
-			yyq2470[3] = true
-			yyq2470[4] = true
-			if yyr2470 || yy2arr2470 {
+			yysep2478 := !z.EncBinary()
+			yy2arr2478 := z.EncBasicHandle().StructToArray
+			var yyq2478 [5]bool
+			_, _, _ = yysep2478, yyq2478, yy2arr2478
+			const yyr2478 bool = false
+			yyq2478[0] = x.Kind != ""
+			yyq2478[1] = x.APIVersion != ""
+			yyq2478[2] = true
+			yyq2478[3] = true
+			yyq2478[4] = true
+			if yyr2478 || yy2arr2478 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2470 int = 0
-				for _, b := range yyq2470 {
+				var yynn2478 int = 0
+				for _, b := range yyq2478 {
 					if b {
-						yynn2470++
+						yynn2478++
 					}
 				}
-				r.EncodeMapStart(yynn2470)
+				r.EncodeMapStart(yynn2478)
 			}
-			if yyr2470 || yy2arr2470 {
-				if yyq2470[0] {
-					yym2472 := z.EncBinary()
-					_ = yym2472
+			if yyr2478 || yy2arr2478 {
+				if yyq2478[0] {
+					yym2480 := z.EncBinary()
+					_ = yym2480
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -29277,20 +29337,20 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2470[0] {
+				if yyq2478[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2473 := z.EncBinary()
-					_ = yym2473
+					yym2481 := z.EncBinary()
+					_ = yym2481
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2470 || yy2arr2470 {
-				if yyq2470[1] {
-					yym2475 := z.EncBinary()
-					_ = yym2475
+			if yyr2478 || yy2arr2478 {
+				if yyq2478[1] {
+					yym2483 := z.EncBinary()
+					_ = yym2483
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -29299,59 +29359,59 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2470[1] {
+				if yyq2478[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2476 := z.EncBinary()
-					_ = yym2476
+					yym2484 := z.EncBinary()
+					_ = yym2484
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2470 || yy2arr2470 {
-				if yyq2470[2] {
-					yy2478 := &x.ObjectMeta
-					yy2478.CodecEncodeSelf(e)
+			if yyr2478 || yy2arr2478 {
+				if yyq2478[2] {
+					yy2486 := &x.ObjectMeta
+					yy2486.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2470[2] {
+				if yyq2478[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2479 := &x.ObjectMeta
-					yy2479.CodecEncodeSelf(e)
+					yy2487 := &x.ObjectMeta
+					yy2487.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2470 || yy2arr2470 {
-				if yyq2470[3] {
-					yy2481 := &x.Spec
-					yy2481.CodecEncodeSelf(e)
+			if yyr2478 || yy2arr2478 {
+				if yyq2478[3] {
+					yy2489 := &x.Spec
+					yy2489.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2470[3] {
+				if yyq2478[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy2482 := &x.Spec
-					yy2482.CodecEncodeSelf(e)
+					yy2490 := &x.Spec
+					yy2490.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2470 || yy2arr2470 {
-				if yyq2470[4] {
-					yy2484 := &x.Status
-					yy2484.CodecEncodeSelf(e)
+			if yyr2478 || yy2arr2478 {
+				if yyq2478[4] {
+					yy2492 := &x.Status
+					yy2492.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2470[4] {
+				if yyq2478[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy2485 := &x.Status
-					yy2485.CodecEncodeSelf(e)
+					yy2493 := &x.Status
+					yy2493.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2470 {
+			if yysep2478 {
 				r.EncodeEnd()
 			}
 		}
@@ -29362,24 +29422,24 @@ func (x *Namespace) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2486 := z.DecBinary()
-	_ = yym2486
+	yym2494 := z.DecBinary()
+	_ = yym2494
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2487 := r.ReadMapStart()
-			if yyl2487 == 0 {
+			yyl2495 := r.ReadMapStart()
+			if yyl2495 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2487, d)
+				x.codecDecodeSelfFromMap(yyl2495, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2487 := r.ReadArrayStart()
-			if yyl2487 == 0 {
+			yyl2495 := r.ReadArrayStart()
+			if yyl2495 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2487, d)
+				x.codecDecodeSelfFromArray(yyl2495, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29391,12 +29451,12 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2488Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2488Slc
-	var yyhl2488 bool = l >= 0
-	for yyj2488 := 0; ; yyj2488++ {
-		if yyhl2488 {
-			if yyj2488 >= l {
+	var yys2496Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2496Slc
+	var yyhl2496 bool = l >= 0
+	for yyj2496 := 0; ; yyj2496++ {
+		if yyhl2496 {
+			if yyj2496 >= l {
 				break
 			}
 		} else {
@@ -29404,9 +29464,9 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2488Slc = r.DecodeBytes(yys2488Slc, true, true)
-		yys2488 := string(yys2488Slc)
-		switch yys2488 {
+		yys2496Slc = r.DecodeBytes(yys2496Slc, true, true)
+		yys2496 := string(yys2496Slc)
+		switch yys2496 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29423,28 +29483,28 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2491 := &x.ObjectMeta
-				yyv2491.CodecDecodeSelf(d)
+				yyv2499 := &x.ObjectMeta
+				yyv2499.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = NamespaceSpec{}
 			} else {
-				yyv2492 := &x.Spec
-				yyv2492.CodecDecodeSelf(d)
+				yyv2500 := &x.Spec
+				yyv2500.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = NamespaceStatus{}
 			} else {
-				yyv2493 := &x.Status
-				yyv2493.CodecDecodeSelf(d)
+				yyv2501 := &x.Status
+				yyv2501.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2488)
-		} // end switch yys2488
-	} // end for yyj2488
-	if !yyhl2488 {
+			z.DecStructFieldNotFound(-1, yys2496)
+		} // end switch yys2496
+	} // end for yyj2496
+	if !yyhl2496 {
 		r.ReadEnd()
 	}
 }
@@ -29453,16 +29513,16 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2494 int
-	var yyb2494 bool
-	var yyhl2494 bool = l >= 0
-	yyj2494++
-	if yyhl2494 {
-		yyb2494 = yyj2494 > l
+	var yyj2502 int
+	var yyb2502 bool
+	var yyhl2502 bool = l >= 0
+	yyj2502++
+	if yyhl2502 {
+		yyb2502 = yyj2502 > l
 	} else {
-		yyb2494 = r.CheckBreak()
+		yyb2502 = r.CheckBreak()
 	}
-	if yyb2494 {
+	if yyb2502 {
 		r.ReadEnd()
 		return
 	}
@@ -29471,13 +29531,13 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2494++
-	if yyhl2494 {
-		yyb2494 = yyj2494 > l
+	yyj2502++
+	if yyhl2502 {
+		yyb2502 = yyj2502 > l
 	} else {
-		yyb2494 = r.CheckBreak()
+		yyb2502 = r.CheckBreak()
 	}
-	if yyb2494 {
+	if yyb2502 {
 		r.ReadEnd()
 		return
 	}
@@ -29486,65 +29546,65 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2494++
-	if yyhl2494 {
-		yyb2494 = yyj2494 > l
+	yyj2502++
+	if yyhl2502 {
+		yyb2502 = yyj2502 > l
 	} else {
-		yyb2494 = r.CheckBreak()
+		yyb2502 = r.CheckBreak()
 	}
-	if yyb2494 {
+	if yyb2502 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2497 := &x.ObjectMeta
-		yyv2497.CodecDecodeSelf(d)
+		yyv2505 := &x.ObjectMeta
+		yyv2505.CodecDecodeSelf(d)
 	}
-	yyj2494++
-	if yyhl2494 {
-		yyb2494 = yyj2494 > l
+	yyj2502++
+	if yyhl2502 {
+		yyb2502 = yyj2502 > l
 	} else {
-		yyb2494 = r.CheckBreak()
+		yyb2502 = r.CheckBreak()
 	}
-	if yyb2494 {
+	if yyb2502 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = NamespaceSpec{}
 	} else {
-		yyv2498 := &x.Spec
-		yyv2498.CodecDecodeSelf(d)
+		yyv2506 := &x.Spec
+		yyv2506.CodecDecodeSelf(d)
 	}
-	yyj2494++
-	if yyhl2494 {
-		yyb2494 = yyj2494 > l
+	yyj2502++
+	if yyhl2502 {
+		yyb2502 = yyj2502 > l
 	} else {
-		yyb2494 = r.CheckBreak()
+		yyb2502 = r.CheckBreak()
 	}
-	if yyb2494 {
+	if yyb2502 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = NamespaceStatus{}
 	} else {
-		yyv2499 := &x.Status
-		yyv2499.CodecDecodeSelf(d)
+		yyv2507 := &x.Status
+		yyv2507.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2494++
-		if yyhl2494 {
-			yyb2494 = yyj2494 > l
+		yyj2502++
+		if yyhl2502 {
+			yyb2502 = yyj2502 > l
 		} else {
-			yyb2494 = r.CheckBreak()
+			yyb2502 = r.CheckBreak()
 		}
-		if yyb2494 {
+		if yyb2502 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2494-1, "")
+		z.DecStructFieldNotFound(yyj2502-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29556,34 +29616,34 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2500 := z.EncBinary()
-		_ = yym2500
+		yym2508 := z.EncBinary()
+		_ = yym2508
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2501 := !z.EncBinary()
-			yy2arr2501 := z.EncBasicHandle().StructToArray
-			var yyq2501 [4]bool
-			_, _, _ = yysep2501, yyq2501, yy2arr2501
-			const yyr2501 bool = false
-			yyq2501[0] = x.Kind != ""
-			yyq2501[1] = x.APIVersion != ""
-			yyq2501[2] = true
-			if yyr2501 || yy2arr2501 {
+			yysep2509 := !z.EncBinary()
+			yy2arr2509 := z.EncBasicHandle().StructToArray
+			var yyq2509 [4]bool
+			_, _, _ = yysep2509, yyq2509, yy2arr2509
+			const yyr2509 bool = false
+			yyq2509[0] = x.Kind != ""
+			yyq2509[1] = x.APIVersion != ""
+			yyq2509[2] = true
+			if yyr2509 || yy2arr2509 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2501 int = 1
-				for _, b := range yyq2501 {
+				var yynn2509 int = 1
+				for _, b := range yyq2509 {
 					if b {
-						yynn2501++
+						yynn2509++
 					}
 				}
-				r.EncodeMapStart(yynn2501)
+				r.EncodeMapStart(yynn2509)
 			}
-			if yyr2501 || yy2arr2501 {
-				if yyq2501[0] {
-					yym2503 := z.EncBinary()
-					_ = yym2503
+			if yyr2509 || yy2arr2509 {
+				if yyq2509[0] {
+					yym2511 := z.EncBinary()
+					_ = yym2511
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -29592,70 +29652,70 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2501[0] {
+				if yyq2509[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2504 := z.EncBinary()
-					_ = yym2504
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2501 || yy2arr2501 {
-				if yyq2501[1] {
-					yym2506 := z.EncBinary()
-					_ = yym2506
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2501[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2507 := z.EncBinary()
-					_ = yym2507
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2501 || yy2arr2501 {
-				if yyq2501[2] {
-					yy2509 := &x.ListMeta
-					yym2510 := z.EncBinary()
-					_ = yym2510
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2509) {
-					} else {
-						z.EncFallback(yy2509)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2501[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2511 := &x.ListMeta
 					yym2512 := z.EncBinary()
 					_ = yym2512
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2511) {
 					} else {
-						z.EncFallback(yy2511)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2501 || yy2arr2501 {
+			if yyr2509 || yy2arr2509 {
+				if yyq2509[1] {
+					yym2514 := z.EncBinary()
+					_ = yym2514
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2509[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2515 := z.EncBinary()
+					_ = yym2515
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2509 || yy2arr2509 {
+				if yyq2509[2] {
+					yy2517 := &x.ListMeta
+					yym2518 := z.EncBinary()
+					_ = yym2518
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2517) {
+					} else {
+						z.EncFallback(yy2517)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2509[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2519 := &x.ListMeta
+					yym2520 := z.EncBinary()
+					_ = yym2520
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2519) {
+					} else {
+						z.EncFallback(yy2519)
+					}
+				}
+			}
+			if yyr2509 || yy2arr2509 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2514 := z.EncBinary()
-					_ = yym2514
+					yym2522 := z.EncBinary()
+					_ = yym2522
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
@@ -29666,15 +29726,15 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2515 := z.EncBinary()
-					_ = yym2515
+					yym2523 := z.EncBinary()
+					_ = yym2523
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
 					}
 				}
 			}
-			if yysep2501 {
+			if yysep2509 {
 				r.EncodeEnd()
 			}
 		}
@@ -29685,24 +29745,24 @@ func (x *NamespaceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2516 := z.DecBinary()
-	_ = yym2516
+	yym2524 := z.DecBinary()
+	_ = yym2524
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2517 := r.ReadMapStart()
-			if yyl2517 == 0 {
+			yyl2525 := r.ReadMapStart()
+			if yyl2525 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2517, d)
+				x.codecDecodeSelfFromMap(yyl2525, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2517 := r.ReadArrayStart()
-			if yyl2517 == 0 {
+			yyl2525 := r.ReadArrayStart()
+			if yyl2525 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2517, d)
+				x.codecDecodeSelfFromArray(yyl2525, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29714,12 +29774,12 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2518Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2518Slc
-	var yyhl2518 bool = l >= 0
-	for yyj2518 := 0; ; yyj2518++ {
-		if yyhl2518 {
-			if yyj2518 >= l {
+	var yys2526Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2526Slc
+	var yyhl2526 bool = l >= 0
+	for yyj2526 := 0; ; yyj2526++ {
+		if yyhl2526 {
+			if yyj2526 >= l {
 				break
 			}
 		} else {
@@ -29727,9 +29787,9 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2518Slc = r.DecodeBytes(yys2518Slc, true, true)
-		yys2518 := string(yys2518Slc)
-		switch yys2518 {
+		yys2526Slc = r.DecodeBytes(yys2526Slc, true, true)
+		yys2526 := string(yys2526Slc)
+		switch yys2526 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29746,32 +29806,32 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2521 := &x.ListMeta
-				yym2522 := z.DecBinary()
-				_ = yym2522
+				yyv2529 := &x.ListMeta
+				yym2530 := z.DecBinary()
+				_ = yym2530
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2521) {
+				} else if z.HasExtensions() && z.DecExt(yyv2529) {
 				} else {
-					z.DecFallback(yyv2521, false)
+					z.DecFallback(yyv2529, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2523 := &x.Items
-				yym2524 := z.DecBinary()
-				_ = yym2524
+				yyv2531 := &x.Items
+				yym2532 := z.DecBinary()
+				_ = yym2532
 				if false {
 				} else {
-					h.decSliceNamespace((*[]Namespace)(yyv2523), d)
+					h.decSliceNamespace((*[]Namespace)(yyv2531), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2518)
-		} // end switch yys2518
-	} // end for yyj2518
-	if !yyhl2518 {
+			z.DecStructFieldNotFound(-1, yys2526)
+		} // end switch yys2526
+	} // end for yyj2526
+	if !yyhl2526 {
 		r.ReadEnd()
 	}
 }
@@ -29780,16 +29840,16 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2525 int
-	var yyb2525 bool
-	var yyhl2525 bool = l >= 0
-	yyj2525++
-	if yyhl2525 {
-		yyb2525 = yyj2525 > l
+	var yyj2533 int
+	var yyb2533 bool
+	var yyhl2533 bool = l >= 0
+	yyj2533++
+	if yyhl2533 {
+		yyb2533 = yyj2533 > l
 	} else {
-		yyb2525 = r.CheckBreak()
+		yyb2533 = r.CheckBreak()
 	}
-	if yyb2525 {
+	if yyb2533 {
 		r.ReadEnd()
 		return
 	}
@@ -29798,13 +29858,13 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2525++
-	if yyhl2525 {
-		yyb2525 = yyj2525 > l
+	yyj2533++
+	if yyhl2533 {
+		yyb2533 = yyj2533 > l
 	} else {
-		yyb2525 = r.CheckBreak()
+		yyb2533 = r.CheckBreak()
 	}
-	if yyb2525 {
+	if yyb2533 {
 		r.ReadEnd()
 		return
 	}
@@ -29813,60 +29873,60 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2525++
-	if yyhl2525 {
-		yyb2525 = yyj2525 > l
+	yyj2533++
+	if yyhl2533 {
+		yyb2533 = yyj2533 > l
 	} else {
-		yyb2525 = r.CheckBreak()
+		yyb2533 = r.CheckBreak()
 	}
-	if yyb2525 {
+	if yyb2533 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2528 := &x.ListMeta
-		yym2529 := z.DecBinary()
-		_ = yym2529
+		yyv2536 := &x.ListMeta
+		yym2537 := z.DecBinary()
+		_ = yym2537
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2528) {
+		} else if z.HasExtensions() && z.DecExt(yyv2536) {
 		} else {
-			z.DecFallback(yyv2528, false)
+			z.DecFallback(yyv2536, false)
 		}
 	}
-	yyj2525++
-	if yyhl2525 {
-		yyb2525 = yyj2525 > l
+	yyj2533++
+	if yyhl2533 {
+		yyb2533 = yyj2533 > l
 	} else {
-		yyb2525 = r.CheckBreak()
+		yyb2533 = r.CheckBreak()
 	}
-	if yyb2525 {
+	if yyb2533 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2530 := &x.Items
-		yym2531 := z.DecBinary()
-		_ = yym2531
+		yyv2538 := &x.Items
+		yym2539 := z.DecBinary()
+		_ = yym2539
 		if false {
 		} else {
-			h.decSliceNamespace((*[]Namespace)(yyv2530), d)
+			h.decSliceNamespace((*[]Namespace)(yyv2538), d)
 		}
 	}
 	for {
-		yyj2525++
-		if yyhl2525 {
-			yyb2525 = yyj2525 > l
+		yyj2533++
+		if yyhl2533 {
+			yyb2533 = yyj2533 > l
 		} else {
-			yyb2525 = r.CheckBreak()
+			yyb2533 = r.CheckBreak()
 		}
-		if yyb2525 {
+		if yyb2533 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2525-1, "")
+		z.DecStructFieldNotFound(yyj2533-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29878,34 +29938,34 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2532 := z.EncBinary()
-		_ = yym2532
+		yym2540 := z.EncBinary()
+		_ = yym2540
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2533 := !z.EncBinary()
-			yy2arr2533 := z.EncBasicHandle().StructToArray
-			var yyq2533 [4]bool
-			_, _, _ = yysep2533, yyq2533, yy2arr2533
-			const yyr2533 bool = false
-			yyq2533[0] = x.Kind != ""
-			yyq2533[1] = x.APIVersion != ""
-			yyq2533[2] = true
-			if yyr2533 || yy2arr2533 {
+			yysep2541 := !z.EncBinary()
+			yy2arr2541 := z.EncBasicHandle().StructToArray
+			var yyq2541 [4]bool
+			_, _, _ = yysep2541, yyq2541, yy2arr2541
+			const yyr2541 bool = false
+			yyq2541[0] = x.Kind != ""
+			yyq2541[1] = x.APIVersion != ""
+			yyq2541[2] = true
+			if yyr2541 || yy2arr2541 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2533 int = 1
-				for _, b := range yyq2533 {
+				var yynn2541 int = 1
+				for _, b := range yyq2541 {
 					if b {
-						yynn2533++
+						yynn2541++
 					}
 				}
-				r.EncodeMapStart(yynn2533)
+				r.EncodeMapStart(yynn2541)
 			}
-			if yyr2533 || yy2arr2533 {
-				if yyq2533[0] {
-					yym2535 := z.EncBinary()
-					_ = yym2535
+			if yyr2541 || yy2arr2541 {
+				if yyq2541[0] {
+					yym2543 := z.EncBinary()
+					_ = yym2543
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -29914,20 +29974,20 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2533[0] {
+				if yyq2541[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2536 := z.EncBinary()
-					_ = yym2536
+					yym2544 := z.EncBinary()
+					_ = yym2544
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2533 || yy2arr2533 {
-				if yyq2533[1] {
-					yym2538 := z.EncBinary()
-					_ = yym2538
+			if yyr2541 || yy2arr2541 {
+				if yyq2541[1] {
+					yym2546 := z.EncBinary()
+					_ = yym2546
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -29936,39 +29996,39 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2533[1] {
+				if yyq2541[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2539 := z.EncBinary()
-					_ = yym2539
+					yym2547 := z.EncBinary()
+					_ = yym2547
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2533 || yy2arr2533 {
-				if yyq2533[2] {
-					yy2541 := &x.ObjectMeta
-					yy2541.CodecEncodeSelf(e)
+			if yyr2541 || yy2arr2541 {
+				if yyq2541[2] {
+					yy2549 := &x.ObjectMeta
+					yy2549.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2533[2] {
+				if yyq2541[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2542 := &x.ObjectMeta
-					yy2542.CodecEncodeSelf(e)
+					yy2550 := &x.ObjectMeta
+					yy2550.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2533 || yy2arr2533 {
-				yy2544 := &x.Target
-				yy2544.CodecEncodeSelf(e)
+			if yyr2541 || yy2arr2541 {
+				yy2552 := &x.Target
+				yy2552.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
-				yy2545 := &x.Target
-				yy2545.CodecEncodeSelf(e)
+				yy2553 := &x.Target
+				yy2553.CodecEncodeSelf(e)
 			}
-			if yysep2533 {
+			if yysep2541 {
 				r.EncodeEnd()
 			}
 		}
@@ -29979,24 +30039,24 @@ func (x *Binding) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2546 := z.DecBinary()
-	_ = yym2546
+	yym2554 := z.DecBinary()
+	_ = yym2554
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2547 := r.ReadMapStart()
-			if yyl2547 == 0 {
+			yyl2555 := r.ReadMapStart()
+			if yyl2555 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2547, d)
+				x.codecDecodeSelfFromMap(yyl2555, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2547 := r.ReadArrayStart()
-			if yyl2547 == 0 {
+			yyl2555 := r.ReadArrayStart()
+			if yyl2555 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2547, d)
+				x.codecDecodeSelfFromArray(yyl2555, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30008,12 +30068,12 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2548Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2548Slc
-	var yyhl2548 bool = l >= 0
-	for yyj2548 := 0; ; yyj2548++ {
-		if yyhl2548 {
-			if yyj2548 >= l {
+	var yys2556Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2556Slc
+	var yyhl2556 bool = l >= 0
+	for yyj2556 := 0; ; yyj2556++ {
+		if yyhl2556 {
+			if yyj2556 >= l {
 				break
 			}
 		} else {
@@ -30021,9 +30081,9 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2548Slc = r.DecodeBytes(yys2548Slc, true, true)
-		yys2548 := string(yys2548Slc)
-		switch yys2548 {
+		yys2556Slc = r.DecodeBytes(yys2556Slc, true, true)
+		yys2556 := string(yys2556Slc)
+		switch yys2556 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30040,21 +30100,21 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2551 := &x.ObjectMeta
-				yyv2551.CodecDecodeSelf(d)
+				yyv2559 := &x.ObjectMeta
+				yyv2559.CodecDecodeSelf(d)
 			}
 		case "target":
 			if r.TryDecodeAsNil() {
 				x.Target = ObjectReference{}
 			} else {
-				yyv2552 := &x.Target
-				yyv2552.CodecDecodeSelf(d)
+				yyv2560 := &x.Target
+				yyv2560.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2548)
-		} // end switch yys2548
-	} // end for yyj2548
-	if !yyhl2548 {
+			z.DecStructFieldNotFound(-1, yys2556)
+		} // end switch yys2556
+	} // end for yyj2556
+	if !yyhl2556 {
 		r.ReadEnd()
 	}
 }
@@ -30063,16 +30123,16 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2553 int
-	var yyb2553 bool
-	var yyhl2553 bool = l >= 0
-	yyj2553++
-	if yyhl2553 {
-		yyb2553 = yyj2553 > l
+	var yyj2561 int
+	var yyb2561 bool
+	var yyhl2561 bool = l >= 0
+	yyj2561++
+	if yyhl2561 {
+		yyb2561 = yyj2561 > l
 	} else {
-		yyb2553 = r.CheckBreak()
+		yyb2561 = r.CheckBreak()
 	}
-	if yyb2553 {
+	if yyb2561 {
 		r.ReadEnd()
 		return
 	}
@@ -30081,13 +30141,13 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2553++
-	if yyhl2553 {
-		yyb2553 = yyj2553 > l
+	yyj2561++
+	if yyhl2561 {
+		yyb2561 = yyj2561 > l
 	} else {
-		yyb2553 = r.CheckBreak()
+		yyb2561 = r.CheckBreak()
 	}
-	if yyb2553 {
+	if yyb2561 {
 		r.ReadEnd()
 		return
 	}
@@ -30096,49 +30156,49 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2553++
-	if yyhl2553 {
-		yyb2553 = yyj2553 > l
+	yyj2561++
+	if yyhl2561 {
+		yyb2561 = yyj2561 > l
 	} else {
-		yyb2553 = r.CheckBreak()
+		yyb2561 = r.CheckBreak()
 	}
-	if yyb2553 {
+	if yyb2561 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2556 := &x.ObjectMeta
-		yyv2556.CodecDecodeSelf(d)
+		yyv2564 := &x.ObjectMeta
+		yyv2564.CodecDecodeSelf(d)
 	}
-	yyj2553++
-	if yyhl2553 {
-		yyb2553 = yyj2553 > l
+	yyj2561++
+	if yyhl2561 {
+		yyb2561 = yyj2561 > l
 	} else {
-		yyb2553 = r.CheckBreak()
+		yyb2561 = r.CheckBreak()
 	}
-	if yyb2553 {
+	if yyb2561 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Target = ObjectReference{}
 	} else {
-		yyv2557 := &x.Target
-		yyv2557.CodecDecodeSelf(d)
+		yyv2565 := &x.Target
+		yyv2565.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2553++
-		if yyhl2553 {
-			yyb2553 = yyj2553 > l
+		yyj2561++
+		if yyhl2561 {
+			yyb2561 = yyj2561 > l
 		} else {
-			yyb2553 = r.CheckBreak()
+			yyb2561 = r.CheckBreak()
 		}
-		if yyb2553 {
+		if yyb2561 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2553-1, "")
+		z.DecStructFieldNotFound(yyj2561-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30150,33 +30210,33 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2558 := z.EncBinary()
-		_ = yym2558
+		yym2566 := z.EncBinary()
+		_ = yym2566
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2559 := !z.EncBinary()
-			yy2arr2559 := z.EncBasicHandle().StructToArray
-			var yyq2559 [3]bool
-			_, _, _ = yysep2559, yyq2559, yy2arr2559
-			const yyr2559 bool = false
-			yyq2559[0] = x.Kind != ""
-			yyq2559[1] = x.APIVersion != ""
-			if yyr2559 || yy2arr2559 {
+			yysep2567 := !z.EncBinary()
+			yy2arr2567 := z.EncBasicHandle().StructToArray
+			var yyq2567 [3]bool
+			_, _, _ = yysep2567, yyq2567, yy2arr2567
+			const yyr2567 bool = false
+			yyq2567[0] = x.Kind != ""
+			yyq2567[1] = x.APIVersion != ""
+			if yyr2567 || yy2arr2567 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2559 int = 1
-				for _, b := range yyq2559 {
+				var yynn2567 int = 1
+				for _, b := range yyq2567 {
 					if b {
-						yynn2559++
+						yynn2567++
 					}
 				}
-				r.EncodeMapStart(yynn2559)
+				r.EncodeMapStart(yynn2567)
 			}
-			if yyr2559 || yy2arr2559 {
-				if yyq2559[0] {
-					yym2561 := z.EncBinary()
-					_ = yym2561
+			if yyr2567 || yy2arr2567 {
+				if yyq2567[0] {
+					yym2569 := z.EncBinary()
+					_ = yym2569
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -30185,20 +30245,20 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2559[0] {
+				if yyq2567[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2562 := z.EncBinary()
-					_ = yym2562
+					yym2570 := z.EncBinary()
+					_ = yym2570
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2559 || yy2arr2559 {
-				if yyq2559[1] {
-					yym2564 := z.EncBinary()
-					_ = yym2564
+			if yyr2567 || yy2arr2567 {
+				if yyq2567[1] {
+					yym2572 := z.EncBinary()
+					_ = yym2572
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -30207,26 +30267,26 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2559[1] {
+				if yyq2567[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2565 := z.EncBinary()
-					_ = yym2565
+					yym2573 := z.EncBinary()
+					_ = yym2573
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2559 || yy2arr2559 {
+			if yyr2567 || yy2arr2567 {
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2567 := *x.GracePeriodSeconds
-					yym2568 := z.EncBinary()
-					_ = yym2568
+					yy2575 := *x.GracePeriodSeconds
+					yym2576 := z.EncBinary()
+					_ = yym2576
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2567))
+						r.EncodeInt(int64(yy2575))
 					}
 				}
 			} else {
@@ -30234,16 +30294,16 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2569 := *x.GracePeriodSeconds
-					yym2570 := z.EncBinary()
-					_ = yym2570
+					yy2577 := *x.GracePeriodSeconds
+					yym2578 := z.EncBinary()
+					_ = yym2578
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2569))
+						r.EncodeInt(int64(yy2577))
 					}
 				}
 			}
-			if yysep2559 {
+			if yysep2567 {
 				r.EncodeEnd()
 			}
 		}
@@ -30254,24 +30314,24 @@ func (x *DeleteOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2571 := z.DecBinary()
-	_ = yym2571
+	yym2579 := z.DecBinary()
+	_ = yym2579
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2572 := r.ReadMapStart()
-			if yyl2572 == 0 {
+			yyl2580 := r.ReadMapStart()
+			if yyl2580 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2572, d)
+				x.codecDecodeSelfFromMap(yyl2580, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2572 := r.ReadArrayStart()
-			if yyl2572 == 0 {
+			yyl2580 := r.ReadArrayStart()
+			if yyl2580 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2572, d)
+				x.codecDecodeSelfFromArray(yyl2580, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30283,12 +30343,12 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2573Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2573Slc
-	var yyhl2573 bool = l >= 0
-	for yyj2573 := 0; ; yyj2573++ {
-		if yyhl2573 {
-			if yyj2573 >= l {
+	var yys2581Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2581Slc
+	var yyhl2581 bool = l >= 0
+	for yyj2581 := 0; ; yyj2581++ {
+		if yyhl2581 {
+			if yyj2581 >= l {
 				break
 			}
 		} else {
@@ -30296,9 +30356,9 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2573Slc = r.DecodeBytes(yys2573Slc, true, true)
-		yys2573 := string(yys2573Slc)
-		switch yys2573 {
+		yys2581Slc = r.DecodeBytes(yys2581Slc, true, true)
+		yys2581 := string(yys2581Slc)
+		switch yys2581 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30320,18 +30380,18 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.GracePeriodSeconds == nil {
 					x.GracePeriodSeconds = new(int64)
 				}
-				yym2577 := z.DecBinary()
-				_ = yym2577
+				yym2585 := z.DecBinary()
+				_ = yym2585
 				if false {
 				} else {
 					*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2573)
-		} // end switch yys2573
-	} // end for yyj2573
-	if !yyhl2573 {
+			z.DecStructFieldNotFound(-1, yys2581)
+		} // end switch yys2581
+	} // end for yyj2581
+	if !yyhl2581 {
 		r.ReadEnd()
 	}
 }
@@ -30340,16 +30400,16 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2578 int
-	var yyb2578 bool
-	var yyhl2578 bool = l >= 0
-	yyj2578++
-	if yyhl2578 {
-		yyb2578 = yyj2578 > l
+	var yyj2586 int
+	var yyb2586 bool
+	var yyhl2586 bool = l >= 0
+	yyj2586++
+	if yyhl2586 {
+		yyb2586 = yyj2586 > l
 	} else {
-		yyb2578 = r.CheckBreak()
+		yyb2586 = r.CheckBreak()
 	}
-	if yyb2578 {
+	if yyb2586 {
 		r.ReadEnd()
 		return
 	}
@@ -30358,13 +30418,13 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2578++
-	if yyhl2578 {
-		yyb2578 = yyj2578 > l
+	yyj2586++
+	if yyhl2586 {
+		yyb2586 = yyj2586 > l
 	} else {
-		yyb2578 = r.CheckBreak()
+		yyb2586 = r.CheckBreak()
 	}
-	if yyb2578 {
+	if yyb2586 {
 		r.ReadEnd()
 		return
 	}
@@ -30373,13 +30433,13 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2578++
-	if yyhl2578 {
-		yyb2578 = yyj2578 > l
+	yyj2586++
+	if yyhl2586 {
+		yyb2586 = yyj2586 > l
 	} else {
-		yyb2578 = r.CheckBreak()
+		yyb2586 = r.CheckBreak()
 	}
-	if yyb2578 {
+	if yyb2586 {
 		r.ReadEnd()
 		return
 	}
@@ -30391,24 +30451,24 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.GracePeriodSeconds == nil {
 			x.GracePeriodSeconds = new(int64)
 		}
-		yym2582 := z.DecBinary()
-		_ = yym2582
+		yym2590 := z.DecBinary()
+		_ = yym2590
 		if false {
 		} else {
 			*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2578++
-		if yyhl2578 {
-			yyb2578 = yyj2578 > l
+		yyj2586++
+		if yyhl2586 {
+			yyb2586 = yyj2586 > l
 		} else {
-			yyb2578 = r.CheckBreak()
+			yyb2586 = r.CheckBreak()
 		}
-		if yyb2578 {
+		if yyb2586 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2578-1, "")
+		z.DecStructFieldNotFound(yyj2586-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30420,38 +30480,38 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2583 := z.EncBinary()
-		_ = yym2583
+		yym2591 := z.EncBinary()
+		_ = yym2591
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2584 := !z.EncBinary()
-			yy2arr2584 := z.EncBasicHandle().StructToArray
-			var yyq2584 [7]bool
-			_, _, _ = yysep2584, yyq2584, yy2arr2584
-			const yyr2584 bool = false
-			yyq2584[0] = x.Kind != ""
-			yyq2584[1] = x.APIVersion != ""
-			yyq2584[2] = x.LabelSelector != ""
-			yyq2584[3] = x.FieldSelector != ""
-			yyq2584[4] = x.Watch != false
-			yyq2584[5] = x.ResourceVersion != ""
-			yyq2584[6] = x.TimeoutSeconds != nil
-			if yyr2584 || yy2arr2584 {
+			yysep2592 := !z.EncBinary()
+			yy2arr2592 := z.EncBasicHandle().StructToArray
+			var yyq2592 [7]bool
+			_, _, _ = yysep2592, yyq2592, yy2arr2592
+			const yyr2592 bool = false
+			yyq2592[0] = x.Kind != ""
+			yyq2592[1] = x.APIVersion != ""
+			yyq2592[2] = x.LabelSelector != ""
+			yyq2592[3] = x.FieldSelector != ""
+			yyq2592[4] = x.Watch != false
+			yyq2592[5] = x.ResourceVersion != ""
+			yyq2592[6] = x.TimeoutSeconds != nil
+			if yyr2592 || yy2arr2592 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2584 int = 0
-				for _, b := range yyq2584 {
+				var yynn2592 int = 0
+				for _, b := range yyq2592 {
 					if b {
-						yynn2584++
+						yynn2592++
 					}
 				}
-				r.EncodeMapStart(yynn2584)
+				r.EncodeMapStart(yynn2592)
 			}
-			if yyr2584 || yy2arr2584 {
-				if yyq2584[0] {
-					yym2586 := z.EncBinary()
-					_ = yym2586
+			if yyr2592 || yy2arr2592 {
+				if yyq2592[0] {
+					yym2594 := z.EncBinary()
+					_ = yym2594
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -30460,86 +30520,86 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2584[0] {
+				if yyq2592[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2587 := z.EncBinary()
-					_ = yym2587
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2584 || yy2arr2584 {
-				if yyq2584[1] {
-					yym2589 := z.EncBinary()
-					_ = yym2589
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2584[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2590 := z.EncBinary()
-					_ = yym2590
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2584 || yy2arr2584 {
-				if yyq2584[2] {
-					yym2592 := z.EncBinary()
-					_ = yym2592
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2584[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
-					yym2593 := z.EncBinary()
-					_ = yym2593
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
-					}
-				}
-			}
-			if yyr2584 || yy2arr2584 {
-				if yyq2584[3] {
 					yym2595 := z.EncBinary()
 					_ = yym2595
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2592 || yy2arr2592 {
+				if yyq2592[1] {
+					yym2597 := z.EncBinary()
+					_ = yym2597
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2592[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2598 := z.EncBinary()
+					_ = yym2598
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2592 || yy2arr2592 {
+				if yyq2592[2] {
+					yym2600 := z.EncBinary()
+					_ = yym2600
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2592[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
+					yym2601 := z.EncBinary()
+					_ = yym2601
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
+					}
+				}
+			}
+			if yyr2592 || yy2arr2592 {
+				if yyq2592[3] {
+					yym2603 := z.EncBinary()
+					_ = yym2603
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2584[3] {
+				if yyq2592[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("fieldSelector"))
-					yym2596 := z.EncBinary()
-					_ = yym2596
+					yym2604 := z.EncBinary()
+					_ = yym2604
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				}
 			}
-			if yyr2584 || yy2arr2584 {
-				if yyq2584[4] {
-					yym2598 := z.EncBinary()
-					_ = yym2598
+			if yyr2592 || yy2arr2592 {
+				if yyq2592[4] {
+					yym2606 := z.EncBinary()
+					_ = yym2606
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Watch))
@@ -30548,20 +30608,20 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2584[4] {
+				if yyq2592[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("watch"))
-					yym2599 := z.EncBinary()
-					_ = yym2599
+					yym2607 := z.EncBinary()
+					_ = yym2607
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Watch))
 					}
 				}
 			}
-			if yyr2584 || yy2arr2584 {
-				if yyq2584[5] {
-					yym2601 := z.EncBinary()
-					_ = yym2601
+			if yyr2592 || yy2arr2592 {
+				if yyq2592[5] {
+					yym2609 := z.EncBinary()
+					_ = yym2609
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
@@ -30570,49 +30630,49 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2584[5] {
+				if yyq2592[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
-					yym2602 := z.EncBinary()
-					_ = yym2602
+					yym2610 := z.EncBinary()
+					_ = yym2610
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 					}
 				}
 			}
-			if yyr2584 || yy2arr2584 {
-				if yyq2584[6] {
+			if yyr2592 || yy2arr2592 {
+				if yyq2592[6] {
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2604 := *x.TimeoutSeconds
-						yym2605 := z.EncBinary()
-						_ = yym2605
+						yy2612 := *x.TimeoutSeconds
+						yym2613 := z.EncBinary()
+						_ = yym2613
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2604))
+							r.EncodeInt(int64(yy2612))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2584[6] {
+				if yyq2592[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2606 := *x.TimeoutSeconds
-						yym2607 := z.EncBinary()
-						_ = yym2607
+						yy2614 := *x.TimeoutSeconds
+						yym2615 := z.EncBinary()
+						_ = yym2615
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2606))
+							r.EncodeInt(int64(yy2614))
 						}
 					}
 				}
 			}
-			if yysep2584 {
+			if yysep2592 {
 				r.EncodeEnd()
 			}
 		}
@@ -30623,24 +30683,24 @@ func (x *ListOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2608 := z.DecBinary()
-	_ = yym2608
+	yym2616 := z.DecBinary()
+	_ = yym2616
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2609 := r.ReadMapStart()
-			if yyl2609 == 0 {
+			yyl2617 := r.ReadMapStart()
+			if yyl2617 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2609, d)
+				x.codecDecodeSelfFromMap(yyl2617, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2609 := r.ReadArrayStart()
-			if yyl2609 == 0 {
+			yyl2617 := r.ReadArrayStart()
+			if yyl2617 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2609, d)
+				x.codecDecodeSelfFromArray(yyl2617, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30652,12 +30712,12 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2610Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2610Slc
-	var yyhl2610 bool = l >= 0
-	for yyj2610 := 0; ; yyj2610++ {
-		if yyhl2610 {
-			if yyj2610 >= l {
+	var yys2618Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2618Slc
+	var yyhl2618 bool = l >= 0
+	for yyj2618 := 0; ; yyj2618++ {
+		if yyhl2618 {
+			if yyj2618 >= l {
 				break
 			}
 		} else {
@@ -30665,9 +30725,9 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2610Slc = r.DecodeBytes(yys2610Slc, true, true)
-		yys2610 := string(yys2610Slc)
-		switch yys2610 {
+		yys2618Slc = r.DecodeBytes(yys2618Slc, true, true)
+		yys2618 := string(yys2618Slc)
+		switch yys2618 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30713,18 +30773,18 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TimeoutSeconds == nil {
 					x.TimeoutSeconds = new(int64)
 				}
-				yym2618 := z.DecBinary()
-				_ = yym2618
+				yym2626 := z.DecBinary()
+				_ = yym2626
 				if false {
 				} else {
 					*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2610)
-		} // end switch yys2610
-	} // end for yyj2610
-	if !yyhl2610 {
+			z.DecStructFieldNotFound(-1, yys2618)
+		} // end switch yys2618
+	} // end for yyj2618
+	if !yyhl2618 {
 		r.ReadEnd()
 	}
 }
@@ -30733,16 +30793,16 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2619 int
-	var yyb2619 bool
-	var yyhl2619 bool = l >= 0
-	yyj2619++
-	if yyhl2619 {
-		yyb2619 = yyj2619 > l
+	var yyj2627 int
+	var yyb2627 bool
+	var yyhl2627 bool = l >= 0
+	yyj2627++
+	if yyhl2627 {
+		yyb2627 = yyj2627 > l
 	} else {
-		yyb2619 = r.CheckBreak()
+		yyb2627 = r.CheckBreak()
 	}
-	if yyb2619 {
+	if yyb2627 {
 		r.ReadEnd()
 		return
 	}
@@ -30751,13 +30811,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2619++
-	if yyhl2619 {
-		yyb2619 = yyj2619 > l
+	yyj2627++
+	if yyhl2627 {
+		yyb2627 = yyj2627 > l
 	} else {
-		yyb2619 = r.CheckBreak()
+		yyb2627 = r.CheckBreak()
 	}
-	if yyb2619 {
+	if yyb2627 {
 		r.ReadEnd()
 		return
 	}
@@ -30766,13 +30826,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2619++
-	if yyhl2619 {
-		yyb2619 = yyj2619 > l
+	yyj2627++
+	if yyhl2627 {
+		yyb2627 = yyj2627 > l
 	} else {
-		yyb2619 = r.CheckBreak()
+		yyb2627 = r.CheckBreak()
 	}
-	if yyb2619 {
+	if yyb2627 {
 		r.ReadEnd()
 		return
 	}
@@ -30781,13 +30841,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.LabelSelector = string(r.DecodeString())
 	}
-	yyj2619++
-	if yyhl2619 {
-		yyb2619 = yyj2619 > l
+	yyj2627++
+	if yyhl2627 {
+		yyb2627 = yyj2627 > l
 	} else {
-		yyb2619 = r.CheckBreak()
+		yyb2627 = r.CheckBreak()
 	}
-	if yyb2619 {
+	if yyb2627 {
 		r.ReadEnd()
 		return
 	}
@@ -30796,13 +30856,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.FieldSelector = string(r.DecodeString())
 	}
-	yyj2619++
-	if yyhl2619 {
-		yyb2619 = yyj2619 > l
+	yyj2627++
+	if yyhl2627 {
+		yyb2627 = yyj2627 > l
 	} else {
-		yyb2619 = r.CheckBreak()
+		yyb2627 = r.CheckBreak()
 	}
-	if yyb2619 {
+	if yyb2627 {
 		r.ReadEnd()
 		return
 	}
@@ -30811,13 +30871,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Watch = bool(r.DecodeBool())
 	}
-	yyj2619++
-	if yyhl2619 {
-		yyb2619 = yyj2619 > l
+	yyj2627++
+	if yyhl2627 {
+		yyb2627 = yyj2627 > l
 	} else {
-		yyb2619 = r.CheckBreak()
+		yyb2627 = r.CheckBreak()
 	}
-	if yyb2619 {
+	if yyb2627 {
 		r.ReadEnd()
 		return
 	}
@@ -30826,13 +30886,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj2619++
-	if yyhl2619 {
-		yyb2619 = yyj2619 > l
+	yyj2627++
+	if yyhl2627 {
+		yyb2627 = yyj2627 > l
 	} else {
-		yyb2619 = r.CheckBreak()
+		yyb2627 = r.CheckBreak()
 	}
-	if yyb2619 {
+	if yyb2627 {
 		r.ReadEnd()
 		return
 	}
@@ -30844,24 +30904,24 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TimeoutSeconds == nil {
 			x.TimeoutSeconds = new(int64)
 		}
-		yym2627 := z.DecBinary()
-		_ = yym2627
+		yym2635 := z.DecBinary()
+		_ = yym2635
 		if false {
 		} else {
 			*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2619++
-		if yyhl2619 {
-			yyb2619 = yyj2619 > l
+		yyj2627++
+		if yyhl2627 {
+			yyb2627 = yyj2627 > l
 		} else {
-			yyb2619 = r.CheckBreak()
+			yyb2627 = r.CheckBreak()
 		}
-		if yyb2619 {
+		if yyb2627 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2619-1, "")
+		z.DecStructFieldNotFound(yyj2627-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30873,41 +30933,41 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2628 := z.EncBinary()
-		_ = yym2628
+		yym2636 := z.EncBinary()
+		_ = yym2636
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2629 := !z.EncBinary()
-			yy2arr2629 := z.EncBasicHandle().StructToArray
-			var yyq2629 [10]bool
-			_, _, _ = yysep2629, yyq2629, yy2arr2629
-			const yyr2629 bool = false
-			yyq2629[0] = x.Kind != ""
-			yyq2629[1] = x.APIVersion != ""
-			yyq2629[2] = x.Container != ""
-			yyq2629[3] = x.Follow != false
-			yyq2629[4] = x.Previous != false
-			yyq2629[5] = x.SinceSeconds != nil
-			yyq2629[6] = x.SinceTime != nil
-			yyq2629[7] = x.Timestamps != false
-			yyq2629[8] = x.TailLines != nil
-			yyq2629[9] = x.LimitBytes != nil
-			if yyr2629 || yy2arr2629 {
+			yysep2637 := !z.EncBinary()
+			yy2arr2637 := z.EncBasicHandle().StructToArray
+			var yyq2637 [10]bool
+			_, _, _ = yysep2637, yyq2637, yy2arr2637
+			const yyr2637 bool = false
+			yyq2637[0] = x.Kind != ""
+			yyq2637[1] = x.APIVersion != ""
+			yyq2637[2] = x.Container != ""
+			yyq2637[3] = x.Follow != false
+			yyq2637[4] = x.Previous != false
+			yyq2637[5] = x.SinceSeconds != nil
+			yyq2637[6] = x.SinceTime != nil
+			yyq2637[7] = x.Timestamps != false
+			yyq2637[8] = x.TailLines != nil
+			yyq2637[9] = x.LimitBytes != nil
+			if yyr2637 || yy2arr2637 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2629 int = 0
-				for _, b := range yyq2629 {
+				var yynn2637 int = 0
+				for _, b := range yyq2637 {
 					if b {
-						yynn2629++
+						yynn2637++
 					}
 				}
-				r.EncodeMapStart(yynn2629)
+				r.EncodeMapStart(yynn2637)
 			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[0] {
-					yym2631 := z.EncBinary()
-					_ = yym2631
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[0] {
+					yym2639 := z.EncBinary()
+					_ = yym2639
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -30916,148 +30976,148 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2629[0] {
+				if yyq2637[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2632 := z.EncBinary()
-					_ = yym2632
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[1] {
-					yym2634 := z.EncBinary()
-					_ = yym2634
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2629[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2635 := z.EncBinary()
-					_ = yym2635
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[2] {
-					yym2637 := z.EncBinary()
-					_ = yym2637
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2629[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("container"))
-					yym2638 := z.EncBinary()
-					_ = yym2638
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
-					}
-				}
-			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[3] {
 					yym2640 := z.EncBinary()
 					_ = yym2640
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Follow))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2629[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("follow"))
-					yym2641 := z.EncBinary()
-					_ = yym2641
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Follow))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[4] {
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[1] {
+					yym2642 := z.EncBinary()
+					_ = yym2642
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2637[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym2643 := z.EncBinary()
 					_ = yym2643
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[2] {
+					yym2645 := z.EncBinary()
+					_ = yym2645
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2637[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("container"))
+					yym2646 := z.EncBinary()
+					_ = yym2646
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
+					}
+				}
+			}
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[3] {
+					yym2648 := z.EncBinary()
+					_ = yym2648
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Follow))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2637[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("follow"))
+					yym2649 := z.EncBinary()
+					_ = yym2649
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Follow))
+					}
+				}
+			}
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[4] {
+					yym2651 := z.EncBinary()
+					_ = yym2651
+					if false {
+					} else {
 						r.EncodeBool(bool(x.Previous))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2629[4] {
+				if yyq2637[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("previous"))
-					yym2644 := z.EncBinary()
-					_ = yym2644
+					yym2652 := z.EncBinary()
+					_ = yym2652
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Previous))
 					}
 				}
 			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[5] {
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[5] {
 					if x.SinceSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2646 := *x.SinceSeconds
-						yym2647 := z.EncBinary()
-						_ = yym2647
+						yy2654 := *x.SinceSeconds
+						yym2655 := z.EncBinary()
+						_ = yym2655
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2646))
+							r.EncodeInt(int64(yy2654))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2629[5] {
+				if yyq2637[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceSeconds"))
 					if x.SinceSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2648 := *x.SinceSeconds
-						yym2649 := z.EncBinary()
-						_ = yym2649
+						yy2656 := *x.SinceSeconds
+						yym2657 := z.EncBinary()
+						_ = yym2657
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2648))
+							r.EncodeInt(int64(yy2656))
 						}
 					}
 				}
 			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[6] {
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[6] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym2651 := z.EncBinary()
-						_ = yym2651
+						yym2659 := z.EncBinary()
+						_ = yym2659
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym2651 {
+						} else if yym2659 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym2651 && z.IsJSONHandle() {
+						} else if !yym2659 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -31067,18 +31127,18 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2629[6] {
+				if yyq2637[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym2652 := z.EncBinary()
-						_ = yym2652
+						yym2660 := z.EncBinary()
+						_ = yym2660
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym2652 {
+						} else if yym2660 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym2652 && z.IsJSONHandle() {
+						} else if !yym2660 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -31086,10 +31146,10 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[7] {
-					yym2654 := z.EncBinary()
-					_ = yym2654
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[7] {
+					yym2662 := z.EncBinary()
+					_ = yym2662
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Timestamps))
@@ -31098,81 +31158,81 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2629[7] {
+				if yyq2637[7] {
 					r.EncodeString(codecSelferC_UTF81234, string("timestamps"))
-					yym2655 := z.EncBinary()
-					_ = yym2655
+					yym2663 := z.EncBinary()
+					_ = yym2663
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Timestamps))
 					}
 				}
 			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[8] {
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[8] {
 					if x.TailLines == nil {
 						r.EncodeNil()
 					} else {
-						yy2657 := *x.TailLines
-						yym2658 := z.EncBinary()
-						_ = yym2658
+						yy2665 := *x.TailLines
+						yym2666 := z.EncBinary()
+						_ = yym2666
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2657))
+							r.EncodeInt(int64(yy2665))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2629[8] {
+				if yyq2637[8] {
 					r.EncodeString(codecSelferC_UTF81234, string("tailLines"))
 					if x.TailLines == nil {
 						r.EncodeNil()
 					} else {
-						yy2659 := *x.TailLines
-						yym2660 := z.EncBinary()
-						_ = yym2660
+						yy2667 := *x.TailLines
+						yym2668 := z.EncBinary()
+						_ = yym2668
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2659))
+							r.EncodeInt(int64(yy2667))
 						}
 					}
 				}
 			}
-			if yyr2629 || yy2arr2629 {
-				if yyq2629[9] {
+			if yyr2637 || yy2arr2637 {
+				if yyq2637[9] {
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yy2662 := *x.LimitBytes
-						yym2663 := z.EncBinary()
-						_ = yym2663
+						yy2670 := *x.LimitBytes
+						yym2671 := z.EncBinary()
+						_ = yym2671
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2662))
+							r.EncodeInt(int64(yy2670))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2629[9] {
+				if yyq2637[9] {
 					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yy2664 := *x.LimitBytes
-						yym2665 := z.EncBinary()
-						_ = yym2665
+						yy2672 := *x.LimitBytes
+						yym2673 := z.EncBinary()
+						_ = yym2673
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2664))
+							r.EncodeInt(int64(yy2672))
 						}
 					}
 				}
 			}
-			if yysep2629 {
+			if yysep2637 {
 				r.EncodeEnd()
 			}
 		}
@@ -31183,24 +31243,24 @@ func (x *PodLogOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2666 := z.DecBinary()
-	_ = yym2666
+	yym2674 := z.DecBinary()
+	_ = yym2674
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2667 := r.ReadMapStart()
-			if yyl2667 == 0 {
+			yyl2675 := r.ReadMapStart()
+			if yyl2675 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2667, d)
+				x.codecDecodeSelfFromMap(yyl2675, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2667 := r.ReadArrayStart()
-			if yyl2667 == 0 {
+			yyl2675 := r.ReadArrayStart()
+			if yyl2675 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2667, d)
+				x.codecDecodeSelfFromArray(yyl2675, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -31212,12 +31272,12 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2668Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2668Slc
-	var yyhl2668 bool = l >= 0
-	for yyj2668 := 0; ; yyj2668++ {
-		if yyhl2668 {
-			if yyj2668 >= l {
+	var yys2676Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2676Slc
+	var yyhl2676 bool = l >= 0
+	for yyj2676 := 0; ; yyj2676++ {
+		if yyhl2676 {
+			if yyj2676 >= l {
 				break
 			}
 		} else {
@@ -31225,9 +31285,9 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2668Slc = r.DecodeBytes(yys2668Slc, true, true)
-		yys2668 := string(yys2668Slc)
-		switch yys2668 {
+		yys2676Slc = r.DecodeBytes(yys2676Slc, true, true)
+		yys2676 := string(yys2676Slc)
+		switch yys2676 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -31267,8 +31327,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceSeconds == nil {
 					x.SinceSeconds = new(int64)
 				}
-				yym2675 := z.DecBinary()
-				_ = yym2675
+				yym2683 := z.DecBinary()
+				_ = yym2683
 				if false {
 				} else {
 					*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
@@ -31283,13 +31343,13 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg2_unversioned.Time)
 				}
-				yym2677 := z.DecBinary()
-				_ = yym2677
+				yym2685 := z.DecBinary()
+				_ = yym2685
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym2677 {
+				} else if yym2685 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym2677 && z.IsJSONHandle() {
+				} else if !yym2685 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -31310,8 +31370,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TailLines == nil {
 					x.TailLines = new(int64)
 				}
-				yym2680 := z.DecBinary()
-				_ = yym2680
+				yym2688 := z.DecBinary()
+				_ = yym2688
 				if false {
 				} else {
 					*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
@@ -31326,18 +31386,18 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(int64)
 				}
-				yym2682 := z.DecBinary()
-				_ = yym2682
+				yym2690 := z.DecBinary()
+				_ = yym2690
 				if false {
 				} else {
 					*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2668)
-		} // end switch yys2668
-	} // end for yyj2668
-	if !yyhl2668 {
+			z.DecStructFieldNotFound(-1, yys2676)
+		} // end switch yys2676
+	} // end for yyj2676
+	if !yyhl2676 {
 		r.ReadEnd()
 	}
 }
@@ -31346,16 +31406,16 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2683 int
-	var yyb2683 bool
-	var yyhl2683 bool = l >= 0
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	var yyj2691 int
+	var yyb2691 bool
+	var yyhl2691 bool = l >= 0
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31364,13 +31424,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31379,13 +31439,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31394,13 +31454,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Container = string(r.DecodeString())
 	}
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31409,13 +31469,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Follow = bool(r.DecodeBool())
 	}
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31424,13 +31484,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Previous = bool(r.DecodeBool())
 	}
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31442,20 +31502,20 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceSeconds == nil {
 			x.SinceSeconds = new(int64)
 		}
-		yym2690 := z.DecBinary()
-		_ = yym2690
+		yym2698 := z.DecBinary()
+		_ = yym2698
 		if false {
 		} else {
 			*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31467,25 +31527,25 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg2_unversioned.Time)
 		}
-		yym2692 := z.DecBinary()
-		_ = yym2692
+		yym2700 := z.DecBinary()
+		_ = yym2700
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym2692 {
+		} else if yym2700 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym2692 && z.IsJSONHandle() {
+		} else if !yym2700 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31494,13 +31554,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Timestamps = bool(r.DecodeBool())
 	}
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31512,20 +31572,20 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TailLines == nil {
 			x.TailLines = new(int64)
 		}
-		yym2695 := z.DecBinary()
-		_ = yym2695
+		yym2703 := z.DecBinary()
+		_ = yym2703
 		if false {
 		} else {
 			*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj2683++
-	if yyhl2683 {
-		yyb2683 = yyj2683 > l
+	yyj2691++
+	if yyhl2691 {
+		yyb2691 = yyj2691 > l
 	} else {
-		yyb2683 = r.CheckBreak()
+		yyb2691 = r.CheckBreak()
 	}
-	if yyb2683 {
+	if yyb2691 {
 		r.ReadEnd()
 		return
 	}
@@ -31537,24 +31597,24 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(int64)
 		}
-		yym2697 := z.DecBinary()
-		_ = yym2697
+		yym2705 := z.DecBinary()
+		_ = yym2705
 		if false {
 		} else {
 			*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2683++
-		if yyhl2683 {
-			yyb2683 = yyj2683 > l
+		yyj2691++
+		if yyhl2691 {
+			yyb2691 = yyj2691 > l
 		} else {
-			yyb2683 = r.CheckBreak()
+			yyb2691 = r.CheckBreak()
 		}
-		if yyb2683 {
+		if yyb2691 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2683-1, "")
+		z.DecStructFieldNotFound(yyj2691-1, "")
 	}
 	r.ReadEnd()
 }
@@ -31566,38 +31626,38 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2698 := z.EncBinary()
-		_ = yym2698
+		yym2706 := z.EncBinary()
+		_ = yym2706
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2699 := !z.EncBinary()
-			yy2arr2699 := z.EncBasicHandle().StructToArray
-			var yyq2699 [7]bool
-			_, _, _ = yysep2699, yyq2699, yy2arr2699
-			const yyr2699 bool = false
-			yyq2699[0] = x.Kind != ""
-			yyq2699[1] = x.APIVersion != ""
-			yyq2699[2] = x.Stdin != false
-			yyq2699[3] = x.Stdout != false
-			yyq2699[4] = x.Stderr != false
-			yyq2699[5] = x.TTY != false
-			yyq2699[6] = x.Container != ""
-			if yyr2699 || yy2arr2699 {
+			yysep2707 := !z.EncBinary()
+			yy2arr2707 := z.EncBasicHandle().StructToArray
+			var yyq2707 [7]bool
+			_, _, _ = yysep2707, yyq2707, yy2arr2707
+			const yyr2707 bool = false
+			yyq2707[0] = x.Kind != ""
+			yyq2707[1] = x.APIVersion != ""
+			yyq2707[2] = x.Stdin != false
+			yyq2707[3] = x.Stdout != false
+			yyq2707[4] = x.Stderr != false
+			yyq2707[5] = x.TTY != false
+			yyq2707[6] = x.Container != ""
+			if yyr2707 || yy2arr2707 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2699 int = 0
-				for _, b := range yyq2699 {
+				var yynn2707 int = 0
+				for _, b := range yyq2707 {
 					if b {
-						yynn2699++
+						yynn2707++
 					}
 				}
-				r.EncodeMapStart(yynn2699)
+				r.EncodeMapStart(yynn2707)
 			}
-			if yyr2699 || yy2arr2699 {
-				if yyq2699[0] {
-					yym2701 := z.EncBinary()
-					_ = yym2701
+			if yyr2707 || yy2arr2707 {
+				if yyq2707[0] {
+					yym2709 := z.EncBinary()
+					_ = yym2709
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -31606,130 +31666,130 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2699[0] {
+				if yyq2707[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2702 := z.EncBinary()
-					_ = yym2702
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2699 || yy2arr2699 {
-				if yyq2699[1] {
-					yym2704 := z.EncBinary()
-					_ = yym2704
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2699[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2705 := z.EncBinary()
-					_ = yym2705
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2699 || yy2arr2699 {
-				if yyq2699[2] {
-					yym2707 := z.EncBinary()
-					_ = yym2707
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdin))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2699[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
-					yym2708 := z.EncBinary()
-					_ = yym2708
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdin))
-					}
-				}
-			}
-			if yyr2699 || yy2arr2699 {
-				if yyq2699[3] {
 					yym2710 := z.EncBinary()
 					_ = yym2710
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2699[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
-					yym2711 := z.EncBinary()
-					_ = yym2711
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2699 || yy2arr2699 {
-				if yyq2699[4] {
+			if yyr2707 || yy2arr2707 {
+				if yyq2707[1] {
+					yym2712 := z.EncBinary()
+					_ = yym2712
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2707[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym2713 := z.EncBinary()
 					_ = yym2713
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2707 || yy2arr2707 {
+				if yyq2707[2] {
+					yym2715 := z.EncBinary()
+					_ = yym2715
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdin))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2699[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
-					yym2714 := z.EncBinary()
-					_ = yym2714
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stderr))
-					}
-				}
-			}
-			if yyr2699 || yy2arr2699 {
-				if yyq2699[5] {
+				if yyq2707[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
 					yym2716 := z.EncBinary()
 					_ = yym2716
 					if false {
 					} else {
+						r.EncodeBool(bool(x.Stdin))
+					}
+				}
+			}
+			if yyr2707 || yy2arr2707 {
+				if yyq2707[3] {
+					yym2718 := z.EncBinary()
+					_ = yym2718
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdout))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2707[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+					yym2719 := z.EncBinary()
+					_ = yym2719
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdout))
+					}
+				}
+			}
+			if yyr2707 || yy2arr2707 {
+				if yyq2707[4] {
+					yym2721 := z.EncBinary()
+					_ = yym2721
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2707[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					yym2722 := z.EncBinary()
+					_ = yym2722
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				}
+			}
+			if yyr2707 || yy2arr2707 {
+				if yyq2707[5] {
+					yym2724 := z.EncBinary()
+					_ = yym2724
+					if false {
+					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2699[5] {
+				if yyq2707[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
-					yym2717 := z.EncBinary()
-					_ = yym2717
+					yym2725 := z.EncBinary()
+					_ = yym2725
 					if false {
 					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				}
 			}
-			if yyr2699 || yy2arr2699 {
-				if yyq2699[6] {
-					yym2719 := z.EncBinary()
-					_ = yym2719
+			if yyr2707 || yy2arr2707 {
+				if yyq2707[6] {
+					yym2727 := z.EncBinary()
+					_ = yym2727
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -31738,17 +31798,17 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2699[6] {
+				if yyq2707[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
-					yym2720 := z.EncBinary()
-					_ = yym2720
+					yym2728 := z.EncBinary()
+					_ = yym2728
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
-			if yysep2699 {
+			if yysep2707 {
 				r.EncodeEnd()
 			}
 		}
@@ -31759,24 +31819,24 @@ func (x *PodAttachOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2721 := z.DecBinary()
-	_ = yym2721
+	yym2729 := z.DecBinary()
+	_ = yym2729
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2722 := r.ReadMapStart()
-			if yyl2722 == 0 {
+			yyl2730 := r.ReadMapStart()
+			if yyl2730 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2722, d)
+				x.codecDecodeSelfFromMap(yyl2730, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2722 := r.ReadArrayStart()
-			if yyl2722 == 0 {
+			yyl2730 := r.ReadArrayStart()
+			if yyl2730 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2722, d)
+				x.codecDecodeSelfFromArray(yyl2730, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -31788,12 +31848,12 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2723Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2723Slc
-	var yyhl2723 bool = l >= 0
-	for yyj2723 := 0; ; yyj2723++ {
-		if yyhl2723 {
-			if yyj2723 >= l {
+	var yys2731Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2731Slc
+	var yyhl2731 bool = l >= 0
+	for yyj2731 := 0; ; yyj2731++ {
+		if yyhl2731 {
+			if yyj2731 >= l {
 				break
 			}
 		} else {
@@ -31801,9 +31861,9 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2723Slc = r.DecodeBytes(yys2723Slc, true, true)
-		yys2723 := string(yys2723Slc)
-		switch yys2723 {
+		yys2731Slc = r.DecodeBytes(yys2731Slc, true, true)
+		yys2731 := string(yys2731Slc)
+		switch yys2731 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -31847,10 +31907,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Container = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2723)
-		} // end switch yys2723
-	} // end for yyj2723
-	if !yyhl2723 {
+			z.DecStructFieldNotFound(-1, yys2731)
+		} // end switch yys2731
+	} // end for yyj2731
+	if !yyhl2731 {
 		r.ReadEnd()
 	}
 }
@@ -31859,16 +31919,16 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2731 int
-	var yyb2731 bool
-	var yyhl2731 bool = l >= 0
-	yyj2731++
-	if yyhl2731 {
-		yyb2731 = yyj2731 > l
+	var yyj2739 int
+	var yyb2739 bool
+	var yyhl2739 bool = l >= 0
+	yyj2739++
+	if yyhl2739 {
+		yyb2739 = yyj2739 > l
 	} else {
-		yyb2731 = r.CheckBreak()
+		yyb2739 = r.CheckBreak()
 	}
-	if yyb2731 {
+	if yyb2739 {
 		r.ReadEnd()
 		return
 	}
@@ -31877,13 +31937,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2731++
-	if yyhl2731 {
-		yyb2731 = yyj2731 > l
+	yyj2739++
+	if yyhl2739 {
+		yyb2739 = yyj2739 > l
 	} else {
-		yyb2731 = r.CheckBreak()
+		yyb2739 = r.CheckBreak()
 	}
-	if yyb2731 {
+	if yyb2739 {
 		r.ReadEnd()
 		return
 	}
@@ -31892,13 +31952,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2731++
-	if yyhl2731 {
-		yyb2731 = yyj2731 > l
+	yyj2739++
+	if yyhl2739 {
+		yyb2739 = yyj2739 > l
 	} else {
-		yyb2731 = r.CheckBreak()
+		yyb2739 = r.CheckBreak()
 	}
-	if yyb2731 {
+	if yyb2739 {
 		r.ReadEnd()
 		return
 	}
@@ -31907,13 +31967,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stdin = bool(r.DecodeBool())
 	}
-	yyj2731++
-	if yyhl2731 {
-		yyb2731 = yyj2731 > l
+	yyj2739++
+	if yyhl2739 {
+		yyb2739 = yyj2739 > l
 	} else {
-		yyb2731 = r.CheckBreak()
+		yyb2739 = r.CheckBreak()
 	}
-	if yyb2731 {
+	if yyb2739 {
 		r.ReadEnd()
 		return
 	}
@@ -31922,13 +31982,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stdout = bool(r.DecodeBool())
 	}
-	yyj2731++
-	if yyhl2731 {
-		yyb2731 = yyj2731 > l
+	yyj2739++
+	if yyhl2739 {
+		yyb2739 = yyj2739 > l
 	} else {
-		yyb2731 = r.CheckBreak()
+		yyb2739 = r.CheckBreak()
 	}
-	if yyb2731 {
+	if yyb2739 {
 		r.ReadEnd()
 		return
 	}
@@ -31937,13 +31997,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stderr = bool(r.DecodeBool())
 	}
-	yyj2731++
-	if yyhl2731 {
-		yyb2731 = yyj2731 > l
+	yyj2739++
+	if yyhl2739 {
+		yyb2739 = yyj2739 > l
 	} else {
-		yyb2731 = r.CheckBreak()
+		yyb2739 = r.CheckBreak()
 	}
-	if yyb2731 {
+	if yyb2739 {
 		r.ReadEnd()
 		return
 	}
@@ -31952,13 +32012,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.TTY = bool(r.DecodeBool())
 	}
-	yyj2731++
-	if yyhl2731 {
-		yyb2731 = yyj2731 > l
+	yyj2739++
+	if yyhl2739 {
+		yyb2739 = yyj2739 > l
 	} else {
-		yyb2731 = r.CheckBreak()
+		yyb2739 = r.CheckBreak()
 	}
-	if yyb2731 {
+	if yyb2739 {
 		r.ReadEnd()
 		return
 	}
@@ -31968,16 +32028,16 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.Container = string(r.DecodeString())
 	}
 	for {
-		yyj2731++
-		if yyhl2731 {
-			yyb2731 = yyj2731 > l
+		yyj2739++
+		if yyhl2739 {
+			yyb2739 = yyj2739 > l
 		} else {
-			yyb2731 = r.CheckBreak()
+			yyb2739 = r.CheckBreak()
 		}
-		if yyb2731 {
+		if yyb2739 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2731-1, "")
+		z.DecStructFieldNotFound(yyj2739-1, "")
 	}
 	r.ReadEnd()
 }
@@ -31989,38 +32049,38 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2739 := z.EncBinary()
-		_ = yym2739
+		yym2747 := z.EncBinary()
+		_ = yym2747
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2740 := !z.EncBinary()
-			yy2arr2740 := z.EncBasicHandle().StructToArray
-			var yyq2740 [8]bool
-			_, _, _ = yysep2740, yyq2740, yy2arr2740
-			const yyr2740 bool = false
-			yyq2740[0] = x.Kind != ""
-			yyq2740[1] = x.APIVersion != ""
-			yyq2740[2] = x.Stdin != false
-			yyq2740[3] = x.Stdout != false
-			yyq2740[4] = x.Stderr != false
-			yyq2740[5] = x.TTY != false
-			yyq2740[6] = x.Container != ""
-			if yyr2740 || yy2arr2740 {
+			yysep2748 := !z.EncBinary()
+			yy2arr2748 := z.EncBasicHandle().StructToArray
+			var yyq2748 [8]bool
+			_, _, _ = yysep2748, yyq2748, yy2arr2748
+			const yyr2748 bool = false
+			yyq2748[0] = x.Kind != ""
+			yyq2748[1] = x.APIVersion != ""
+			yyq2748[2] = x.Stdin != false
+			yyq2748[3] = x.Stdout != false
+			yyq2748[4] = x.Stderr != false
+			yyq2748[5] = x.TTY != false
+			yyq2748[6] = x.Container != ""
+			if yyr2748 || yy2arr2748 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2740 int = 1
-				for _, b := range yyq2740 {
+				var yynn2748 int = 1
+				for _, b := range yyq2748 {
 					if b {
-						yynn2740++
+						yynn2748++
 					}
 				}
-				r.EncodeMapStart(yynn2740)
+				r.EncodeMapStart(yynn2748)
 			}
-			if yyr2740 || yy2arr2740 {
-				if yyq2740[0] {
-					yym2742 := z.EncBinary()
-					_ = yym2742
+			if yyr2748 || yy2arr2748 {
+				if yyq2748[0] {
+					yym2750 := z.EncBinary()
+					_ = yym2750
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -32029,130 +32089,130 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2740[0] {
+				if yyq2748[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2743 := z.EncBinary()
-					_ = yym2743
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2740 || yy2arr2740 {
-				if yyq2740[1] {
-					yym2745 := z.EncBinary()
-					_ = yym2745
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2740[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2746 := z.EncBinary()
-					_ = yym2746
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2740 || yy2arr2740 {
-				if yyq2740[2] {
-					yym2748 := z.EncBinary()
-					_ = yym2748
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdin))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2740[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
-					yym2749 := z.EncBinary()
-					_ = yym2749
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdin))
-					}
-				}
-			}
-			if yyr2740 || yy2arr2740 {
-				if yyq2740[3] {
 					yym2751 := z.EncBinary()
 					_ = yym2751
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2740[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
-					yym2752 := z.EncBinary()
-					_ = yym2752
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2740 || yy2arr2740 {
-				if yyq2740[4] {
+			if yyr2748 || yy2arr2748 {
+				if yyq2748[1] {
+					yym2753 := z.EncBinary()
+					_ = yym2753
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2748[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym2754 := z.EncBinary()
 					_ = yym2754
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2748 || yy2arr2748 {
+				if yyq2748[2] {
+					yym2756 := z.EncBinary()
+					_ = yym2756
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdin))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2740[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
-					yym2755 := z.EncBinary()
-					_ = yym2755
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stderr))
-					}
-				}
-			}
-			if yyr2740 || yy2arr2740 {
-				if yyq2740[5] {
+				if yyq2748[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
 					yym2757 := z.EncBinary()
 					_ = yym2757
 					if false {
 					} else {
+						r.EncodeBool(bool(x.Stdin))
+					}
+				}
+			}
+			if yyr2748 || yy2arr2748 {
+				if yyq2748[3] {
+					yym2759 := z.EncBinary()
+					_ = yym2759
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdout))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2748[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+					yym2760 := z.EncBinary()
+					_ = yym2760
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdout))
+					}
+				}
+			}
+			if yyr2748 || yy2arr2748 {
+				if yyq2748[4] {
+					yym2762 := z.EncBinary()
+					_ = yym2762
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2748[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					yym2763 := z.EncBinary()
+					_ = yym2763
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				}
+			}
+			if yyr2748 || yy2arr2748 {
+				if yyq2748[5] {
+					yym2765 := z.EncBinary()
+					_ = yym2765
+					if false {
+					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2740[5] {
+				if yyq2748[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
-					yym2758 := z.EncBinary()
-					_ = yym2758
+					yym2766 := z.EncBinary()
+					_ = yym2766
 					if false {
 					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				}
 			}
-			if yyr2740 || yy2arr2740 {
-				if yyq2740[6] {
-					yym2760 := z.EncBinary()
-					_ = yym2760
+			if yyr2748 || yy2arr2748 {
+				if yyq2748[6] {
+					yym2768 := z.EncBinary()
+					_ = yym2768
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -32161,22 +32221,22 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2740[6] {
+				if yyq2748[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
-					yym2761 := z.EncBinary()
-					_ = yym2761
+					yym2769 := z.EncBinary()
+					_ = yym2769
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
-			if yyr2740 || yy2arr2740 {
+			if yyr2748 || yy2arr2748 {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym2763 := z.EncBinary()
-					_ = yym2763
+					yym2771 := z.EncBinary()
+					_ = yym2771
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
@@ -32187,15 +32247,15 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym2764 := z.EncBinary()
-					_ = yym2764
+					yym2772 := z.EncBinary()
+					_ = yym2772
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
 					}
 				}
 			}
-			if yysep2740 {
+			if yysep2748 {
 				r.EncodeEnd()
 			}
 		}
@@ -32206,24 +32266,24 @@ func (x *PodExecOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2765 := z.DecBinary()
-	_ = yym2765
+	yym2773 := z.DecBinary()
+	_ = yym2773
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2766 := r.ReadMapStart()
-			if yyl2766 == 0 {
+			yyl2774 := r.ReadMapStart()
+			if yyl2774 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2766, d)
+				x.codecDecodeSelfFromMap(yyl2774, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2766 := r.ReadArrayStart()
-			if yyl2766 == 0 {
+			yyl2774 := r.ReadArrayStart()
+			if yyl2774 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2766, d)
+				x.codecDecodeSelfFromArray(yyl2774, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32235,12 +32295,12 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2767Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2767Slc
-	var yyhl2767 bool = l >= 0
-	for yyj2767 := 0; ; yyj2767++ {
-		if yyhl2767 {
-			if yyj2767 >= l {
+	var yys2775Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2775Slc
+	var yyhl2775 bool = l >= 0
+	for yyj2775 := 0; ; yyj2775++ {
+		if yyhl2775 {
+			if yyj2775 >= l {
 				break
 			}
 		} else {
@@ -32248,9 +32308,9 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2767Slc = r.DecodeBytes(yys2767Slc, true, true)
-		yys2767 := string(yys2767Slc)
-		switch yys2767 {
+		yys2775Slc = r.DecodeBytes(yys2775Slc, true, true)
+		yys2775 := string(yys2775Slc)
+		switch yys2775 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32297,19 +32357,19 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Command = nil
 			} else {
-				yyv2775 := &x.Command
-				yym2776 := z.DecBinary()
-				_ = yym2776
+				yyv2783 := &x.Command
+				yym2784 := z.DecBinary()
+				_ = yym2784
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv2775, false, d)
+					z.F.DecSliceStringX(yyv2783, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2767)
-		} // end switch yys2767
-	} // end for yyj2767
-	if !yyhl2767 {
+			z.DecStructFieldNotFound(-1, yys2775)
+		} // end switch yys2775
+	} // end for yyj2775
+	if !yyhl2775 {
 		r.ReadEnd()
 	}
 }
@@ -32318,16 +32378,16 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2777 int
-	var yyb2777 bool
-	var yyhl2777 bool = l >= 0
-	yyj2777++
-	if yyhl2777 {
-		yyb2777 = yyj2777 > l
+	var yyj2785 int
+	var yyb2785 bool
+	var yyhl2785 bool = l >= 0
+	yyj2785++
+	if yyhl2785 {
+		yyb2785 = yyj2785 > l
 	} else {
-		yyb2777 = r.CheckBreak()
+		yyb2785 = r.CheckBreak()
 	}
-	if yyb2777 {
+	if yyb2785 {
 		r.ReadEnd()
 		return
 	}
@@ -32336,13 +32396,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2777++
-	if yyhl2777 {
-		yyb2777 = yyj2777 > l
+	yyj2785++
+	if yyhl2785 {
+		yyb2785 = yyj2785 > l
 	} else {
-		yyb2777 = r.CheckBreak()
+		yyb2785 = r.CheckBreak()
 	}
-	if yyb2777 {
+	if yyb2785 {
 		r.ReadEnd()
 		return
 	}
@@ -32351,13 +32411,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2777++
-	if yyhl2777 {
-		yyb2777 = yyj2777 > l
+	yyj2785++
+	if yyhl2785 {
+		yyb2785 = yyj2785 > l
 	} else {
-		yyb2777 = r.CheckBreak()
+		yyb2785 = r.CheckBreak()
 	}
-	if yyb2777 {
+	if yyb2785 {
 		r.ReadEnd()
 		return
 	}
@@ -32366,13 +32426,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stdin = bool(r.DecodeBool())
 	}
-	yyj2777++
-	if yyhl2777 {
-		yyb2777 = yyj2777 > l
+	yyj2785++
+	if yyhl2785 {
+		yyb2785 = yyj2785 > l
 	} else {
-		yyb2777 = r.CheckBreak()
+		yyb2785 = r.CheckBreak()
 	}
-	if yyb2777 {
+	if yyb2785 {
 		r.ReadEnd()
 		return
 	}
@@ -32381,13 +32441,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stdout = bool(r.DecodeBool())
 	}
-	yyj2777++
-	if yyhl2777 {
-		yyb2777 = yyj2777 > l
+	yyj2785++
+	if yyhl2785 {
+		yyb2785 = yyj2785 > l
 	} else {
-		yyb2777 = r.CheckBreak()
+		yyb2785 = r.CheckBreak()
 	}
-	if yyb2777 {
+	if yyb2785 {
 		r.ReadEnd()
 		return
 	}
@@ -32396,13 +32456,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stderr = bool(r.DecodeBool())
 	}
-	yyj2777++
-	if yyhl2777 {
-		yyb2777 = yyj2777 > l
+	yyj2785++
+	if yyhl2785 {
+		yyb2785 = yyj2785 > l
 	} else {
-		yyb2777 = r.CheckBreak()
+		yyb2785 = r.CheckBreak()
 	}
-	if yyb2777 {
+	if yyb2785 {
 		r.ReadEnd()
 		return
 	}
@@ -32411,13 +32471,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.TTY = bool(r.DecodeBool())
 	}
-	yyj2777++
-	if yyhl2777 {
-		yyb2777 = yyj2777 > l
+	yyj2785++
+	if yyhl2785 {
+		yyb2785 = yyj2785 > l
 	} else {
-		yyb2777 = r.CheckBreak()
+		yyb2785 = r.CheckBreak()
 	}
-	if yyb2777 {
+	if yyb2785 {
 		r.ReadEnd()
 		return
 	}
@@ -32426,38 +32486,38 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Container = string(r.DecodeString())
 	}
-	yyj2777++
-	if yyhl2777 {
-		yyb2777 = yyj2777 > l
+	yyj2785++
+	if yyhl2785 {
+		yyb2785 = yyj2785 > l
 	} else {
-		yyb2777 = r.CheckBreak()
+		yyb2785 = r.CheckBreak()
 	}
-	if yyb2777 {
+	if yyb2785 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
-		yyv2785 := &x.Command
-		yym2786 := z.DecBinary()
-		_ = yym2786
+		yyv2793 := &x.Command
+		yym2794 := z.DecBinary()
+		_ = yym2794
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv2785, false, d)
+			z.F.DecSliceStringX(yyv2793, false, d)
 		}
 	}
 	for {
-		yyj2777++
-		if yyhl2777 {
-			yyb2777 = yyj2777 > l
+		yyj2785++
+		if yyhl2785 {
+			yyb2785 = yyj2785 > l
 		} else {
-			yyb2777 = r.CheckBreak()
+			yyb2785 = r.CheckBreak()
 		}
-		if yyb2777 {
+		if yyb2785 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2777-1, "")
+		z.DecStructFieldNotFound(yyj2785-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32469,34 +32529,34 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2787 := z.EncBinary()
-		_ = yym2787
+		yym2795 := z.EncBinary()
+		_ = yym2795
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2788 := !z.EncBinary()
-			yy2arr2788 := z.EncBasicHandle().StructToArray
-			var yyq2788 [3]bool
-			_, _, _ = yysep2788, yyq2788, yy2arr2788
-			const yyr2788 bool = false
-			yyq2788[0] = x.Kind != ""
-			yyq2788[1] = x.APIVersion != ""
-			yyq2788[2] = x.Path != ""
-			if yyr2788 || yy2arr2788 {
+			yysep2796 := !z.EncBinary()
+			yy2arr2796 := z.EncBasicHandle().StructToArray
+			var yyq2796 [3]bool
+			_, _, _ = yysep2796, yyq2796, yy2arr2796
+			const yyr2796 bool = false
+			yyq2796[0] = x.Kind != ""
+			yyq2796[1] = x.APIVersion != ""
+			yyq2796[2] = x.Path != ""
+			if yyr2796 || yy2arr2796 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2788 int = 0
-				for _, b := range yyq2788 {
+				var yynn2796 int = 0
+				for _, b := range yyq2796 {
 					if b {
-						yynn2788++
+						yynn2796++
 					}
 				}
-				r.EncodeMapStart(yynn2788)
+				r.EncodeMapStart(yynn2796)
 			}
-			if yyr2788 || yy2arr2788 {
-				if yyq2788[0] {
-					yym2790 := z.EncBinary()
-					_ = yym2790
+			if yyr2796 || yy2arr2796 {
+				if yyq2796[0] {
+					yym2798 := z.EncBinary()
+					_ = yym2798
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -32505,20 +32565,20 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2788[0] {
+				if yyq2796[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2791 := z.EncBinary()
-					_ = yym2791
+					yym2799 := z.EncBinary()
+					_ = yym2799
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2788 || yy2arr2788 {
-				if yyq2788[1] {
-					yym2793 := z.EncBinary()
-					_ = yym2793
+			if yyr2796 || yy2arr2796 {
+				if yyq2796[1] {
+					yym2801 := z.EncBinary()
+					_ = yym2801
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -32527,20 +32587,20 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2788[1] {
+				if yyq2796[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2794 := z.EncBinary()
-					_ = yym2794
+					yym2802 := z.EncBinary()
+					_ = yym2802
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2788 || yy2arr2788 {
-				if yyq2788[2] {
-					yym2796 := z.EncBinary()
-					_ = yym2796
+			if yyr2796 || yy2arr2796 {
+				if yyq2796[2] {
+					yym2804 := z.EncBinary()
+					_ = yym2804
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
@@ -32549,17 +32609,17 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2788[2] {
+				if yyq2796[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
-					yym2797 := z.EncBinary()
-					_ = yym2797
+					yym2805 := z.EncBinary()
+					_ = yym2805
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
-			if yysep2788 {
+			if yysep2796 {
 				r.EncodeEnd()
 			}
 		}
@@ -32570,24 +32630,24 @@ func (x *PodProxyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2798 := z.DecBinary()
-	_ = yym2798
+	yym2806 := z.DecBinary()
+	_ = yym2806
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2799 := r.ReadMapStart()
-			if yyl2799 == 0 {
+			yyl2807 := r.ReadMapStart()
+			if yyl2807 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2799, d)
+				x.codecDecodeSelfFromMap(yyl2807, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2799 := r.ReadArrayStart()
-			if yyl2799 == 0 {
+			yyl2807 := r.ReadArrayStart()
+			if yyl2807 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2799, d)
+				x.codecDecodeSelfFromArray(yyl2807, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32599,12 +32659,12 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2800Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2800Slc
-	var yyhl2800 bool = l >= 0
-	for yyj2800 := 0; ; yyj2800++ {
-		if yyhl2800 {
-			if yyj2800 >= l {
+	var yys2808Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2808Slc
+	var yyhl2808 bool = l >= 0
+	for yyj2808 := 0; ; yyj2808++ {
+		if yyhl2808 {
+			if yyj2808 >= l {
 				break
 			}
 		} else {
@@ -32612,9 +32672,9 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2800Slc = r.DecodeBytes(yys2800Slc, true, true)
-		yys2800 := string(yys2800Slc)
-		switch yys2800 {
+		yys2808Slc = r.DecodeBytes(yys2808Slc, true, true)
+		yys2808 := string(yys2808Slc)
+		switch yys2808 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32634,10 +32694,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Path = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2800)
-		} // end switch yys2800
-	} // end for yyj2800
-	if !yyhl2800 {
+			z.DecStructFieldNotFound(-1, yys2808)
+		} // end switch yys2808
+	} // end for yyj2808
+	if !yyhl2808 {
 		r.ReadEnd()
 	}
 }
@@ -32646,16 +32706,16 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2804 int
-	var yyb2804 bool
-	var yyhl2804 bool = l >= 0
-	yyj2804++
-	if yyhl2804 {
-		yyb2804 = yyj2804 > l
+	var yyj2812 int
+	var yyb2812 bool
+	var yyhl2812 bool = l >= 0
+	yyj2812++
+	if yyhl2812 {
+		yyb2812 = yyj2812 > l
 	} else {
-		yyb2804 = r.CheckBreak()
+		yyb2812 = r.CheckBreak()
 	}
-	if yyb2804 {
+	if yyb2812 {
 		r.ReadEnd()
 		return
 	}
@@ -32664,13 +32724,13 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2804++
-	if yyhl2804 {
-		yyb2804 = yyj2804 > l
+	yyj2812++
+	if yyhl2812 {
+		yyb2812 = yyj2812 > l
 	} else {
-		yyb2804 = r.CheckBreak()
+		yyb2812 = r.CheckBreak()
 	}
-	if yyb2804 {
+	if yyb2812 {
 		r.ReadEnd()
 		return
 	}
@@ -32679,13 +32739,13 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2804++
-	if yyhl2804 {
-		yyb2804 = yyj2804 > l
+	yyj2812++
+	if yyhl2812 {
+		yyb2812 = yyj2812 > l
 	} else {
-		yyb2804 = r.CheckBreak()
+		yyb2812 = r.CheckBreak()
 	}
-	if yyb2804 {
+	if yyb2812 {
 		r.ReadEnd()
 		return
 	}
@@ -32695,16 +32755,16 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Path = string(r.DecodeString())
 	}
 	for {
-		yyj2804++
-		if yyhl2804 {
-			yyb2804 = yyj2804 > l
+		yyj2812++
+		if yyhl2812 {
+			yyb2812 = yyj2812 > l
 		} else {
-			yyb2804 = r.CheckBreak()
+			yyb2812 = r.CheckBreak()
 		}
-		if yyb2804 {
+		if yyb2812 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2804-1, "")
+		z.DecStructFieldNotFound(yyj2812-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32716,38 +32776,38 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2808 := z.EncBinary()
-		_ = yym2808
+		yym2816 := z.EncBinary()
+		_ = yym2816
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2809 := !z.EncBinary()
-			yy2arr2809 := z.EncBasicHandle().StructToArray
-			var yyq2809 [7]bool
-			_, _, _ = yysep2809, yyq2809, yy2arr2809
-			const yyr2809 bool = false
-			yyq2809[0] = x.Kind != ""
-			yyq2809[1] = x.Namespace != ""
-			yyq2809[2] = x.Name != ""
-			yyq2809[3] = x.UID != ""
-			yyq2809[4] = x.APIVersion != ""
-			yyq2809[5] = x.ResourceVersion != ""
-			yyq2809[6] = x.FieldPath != ""
-			if yyr2809 || yy2arr2809 {
+			yysep2817 := !z.EncBinary()
+			yy2arr2817 := z.EncBasicHandle().StructToArray
+			var yyq2817 [7]bool
+			_, _, _ = yysep2817, yyq2817, yy2arr2817
+			const yyr2817 bool = false
+			yyq2817[0] = x.Kind != ""
+			yyq2817[1] = x.Namespace != ""
+			yyq2817[2] = x.Name != ""
+			yyq2817[3] = x.UID != ""
+			yyq2817[4] = x.APIVersion != ""
+			yyq2817[5] = x.ResourceVersion != ""
+			yyq2817[6] = x.FieldPath != ""
+			if yyr2817 || yy2arr2817 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2809 int = 0
-				for _, b := range yyq2809 {
+				var yynn2817 int = 0
+				for _, b := range yyq2817 {
 					if b {
-						yynn2809++
+						yynn2817++
 					}
 				}
-				r.EncodeMapStart(yynn2809)
+				r.EncodeMapStart(yynn2817)
 			}
-			if yyr2809 || yy2arr2809 {
-				if yyq2809[0] {
-					yym2811 := z.EncBinary()
-					_ = yym2811
+			if yyr2817 || yy2arr2817 {
+				if yyq2817[0] {
+					yym2819 := z.EncBinary()
+					_ = yym2819
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -32756,133 +32816,133 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2809[0] {
+				if yyq2817[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2812 := z.EncBinary()
-					_ = yym2812
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2809 || yy2arr2809 {
-				if yyq2809[1] {
-					yym2814 := z.EncBinary()
-					_ = yym2814
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2809[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
-					yym2815 := z.EncBinary()
-					_ = yym2815
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				}
-			}
-			if yyr2809 || yy2arr2809 {
-				if yyq2809[2] {
-					yym2817 := z.EncBinary()
-					_ = yym2817
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2809[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym2818 := z.EncBinary()
-					_ = yym2818
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				}
-			}
-			if yyr2809 || yy2arr2809 {
-				if yyq2809[3] {
 					yym2820 := z.EncBinary()
 					_ = yym2820
 					if false {
-					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2817 || yy2arr2817 {
+				if yyq2817[1] {
+					yym2822 := z.EncBinary()
+					_ = yym2822
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2809[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("uid"))
-					yym2821 := z.EncBinary()
-					_ = yym2821
-					if false {
-					} else if z.HasExtensions() && z.EncExt(x.UID) {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
-					}
-				}
-			}
-			if yyr2809 || yy2arr2809 {
-				if yyq2809[4] {
+				if yyq2817[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
 					yym2823 := z.EncBinary()
 					_ = yym2823
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+					}
+				}
+			}
+			if yyr2817 || yy2arr2817 {
+				if yyq2817[2] {
+					yym2825 := z.EncBinary()
+					_ = yym2825
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2809[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2824 := z.EncBinary()
-					_ = yym2824
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2809 || yy2arr2809 {
-				if yyq2809[5] {
+				if yyq2817[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					yym2826 := z.EncBinary()
 					_ = yym2826
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				}
+			}
+			if yyr2817 || yy2arr2817 {
+				if yyq2817[3] {
+					yym2828 := z.EncBinary()
+					_ = yym2828
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2809[5] {
-					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
-					yym2827 := z.EncBinary()
-					_ = yym2827
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
-					}
-				}
-			}
-			if yyr2809 || yy2arr2809 {
-				if yyq2809[6] {
+				if yyq2817[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("uid"))
 					yym2829 := z.EncBinary()
 					_ = yym2829
 					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+					}
+				}
+			}
+			if yyr2817 || yy2arr2817 {
+				if yyq2817[4] {
+					yym2831 := z.EncBinary()
+					_ = yym2831
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2817[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2832 := z.EncBinary()
+					_ = yym2832
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2817 || yy2arr2817 {
+				if yyq2817[5] {
+					yym2834 := z.EncBinary()
+					_ = yym2834
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2817[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					yym2835 := z.EncBinary()
+					_ = yym2835
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+					}
+				}
+			}
+			if yyr2817 || yy2arr2817 {
+				if yyq2817[6] {
+					yym2837 := z.EncBinary()
+					_ = yym2837
+					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 					}
@@ -32890,17 +32950,17 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2809[6] {
+				if yyq2817[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("fieldPath"))
-					yym2830 := z.EncBinary()
-					_ = yym2830
+					yym2838 := z.EncBinary()
+					_ = yym2838
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 					}
 				}
 			}
-			if yysep2809 {
+			if yysep2817 {
 				r.EncodeEnd()
 			}
 		}
@@ -32911,24 +32971,24 @@ func (x *ObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2831 := z.DecBinary()
-	_ = yym2831
+	yym2839 := z.DecBinary()
+	_ = yym2839
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2832 := r.ReadMapStart()
-			if yyl2832 == 0 {
+			yyl2840 := r.ReadMapStart()
+			if yyl2840 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2832, d)
+				x.codecDecodeSelfFromMap(yyl2840, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2832 := r.ReadArrayStart()
-			if yyl2832 == 0 {
+			yyl2840 := r.ReadArrayStart()
+			if yyl2840 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2832, d)
+				x.codecDecodeSelfFromArray(yyl2840, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32940,12 +33000,12 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2833Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2833Slc
-	var yyhl2833 bool = l >= 0
-	for yyj2833 := 0; ; yyj2833++ {
-		if yyhl2833 {
-			if yyj2833 >= l {
+	var yys2841Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2841Slc
+	var yyhl2841 bool = l >= 0
+	for yyj2841 := 0; ; yyj2841++ {
+		if yyhl2841 {
+			if yyj2841 >= l {
 				break
 			}
 		} else {
@@ -32953,9 +33013,9 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2833Slc = r.DecodeBytes(yys2833Slc, true, true)
-		yys2833 := string(yys2833Slc)
-		switch yys2833 {
+		yys2841Slc = r.DecodeBytes(yys2841Slc, true, true)
+		yys2841 := string(yys2841Slc)
+		switch yys2841 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32999,10 +33059,10 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.FieldPath = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2833)
-		} // end switch yys2833
-	} // end for yyj2833
-	if !yyhl2833 {
+			z.DecStructFieldNotFound(-1, yys2841)
+		} // end switch yys2841
+	} // end for yyj2841
+	if !yyhl2841 {
 		r.ReadEnd()
 	}
 }
@@ -33011,16 +33071,16 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2841 int
-	var yyb2841 bool
-	var yyhl2841 bool = l >= 0
-	yyj2841++
-	if yyhl2841 {
-		yyb2841 = yyj2841 > l
+	var yyj2849 int
+	var yyb2849 bool
+	var yyhl2849 bool = l >= 0
+	yyj2849++
+	if yyhl2849 {
+		yyb2849 = yyj2849 > l
 	} else {
-		yyb2841 = r.CheckBreak()
+		yyb2849 = r.CheckBreak()
 	}
-	if yyb2841 {
+	if yyb2849 {
 		r.ReadEnd()
 		return
 	}
@@ -33029,13 +33089,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2841++
-	if yyhl2841 {
-		yyb2841 = yyj2841 > l
+	yyj2849++
+	if yyhl2849 {
+		yyb2849 = yyj2849 > l
 	} else {
-		yyb2841 = r.CheckBreak()
+		yyb2849 = r.CheckBreak()
 	}
-	if yyb2841 {
+	if yyb2849 {
 		r.ReadEnd()
 		return
 	}
@@ -33044,13 +33104,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Namespace = string(r.DecodeString())
 	}
-	yyj2841++
-	if yyhl2841 {
-		yyb2841 = yyj2841 > l
+	yyj2849++
+	if yyhl2849 {
+		yyb2849 = yyj2849 > l
 	} else {
-		yyb2841 = r.CheckBreak()
+		yyb2849 = r.CheckBreak()
 	}
-	if yyb2841 {
+	if yyb2849 {
 		r.ReadEnd()
 		return
 	}
@@ -33059,13 +33119,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj2841++
-	if yyhl2841 {
-		yyb2841 = yyj2841 > l
+	yyj2849++
+	if yyhl2849 {
+		yyb2849 = yyj2849 > l
 	} else {
-		yyb2841 = r.CheckBreak()
+		yyb2849 = r.CheckBreak()
 	}
-	if yyb2841 {
+	if yyb2849 {
 		r.ReadEnd()
 		return
 	}
@@ -33074,13 +33134,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.UID = pkg1_types.UID(r.DecodeString())
 	}
-	yyj2841++
-	if yyhl2841 {
-		yyb2841 = yyj2841 > l
+	yyj2849++
+	if yyhl2849 {
+		yyb2849 = yyj2849 > l
 	} else {
-		yyb2841 = r.CheckBreak()
+		yyb2849 = r.CheckBreak()
 	}
-	if yyb2841 {
+	if yyb2849 {
 		r.ReadEnd()
 		return
 	}
@@ -33089,13 +33149,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2841++
-	if yyhl2841 {
-		yyb2841 = yyj2841 > l
+	yyj2849++
+	if yyhl2849 {
+		yyb2849 = yyj2849 > l
 	} else {
-		yyb2841 = r.CheckBreak()
+		yyb2849 = r.CheckBreak()
 	}
-	if yyb2841 {
+	if yyb2849 {
 		r.ReadEnd()
 		return
 	}
@@ -33104,13 +33164,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj2841++
-	if yyhl2841 {
-		yyb2841 = yyj2841 > l
+	yyj2849++
+	if yyhl2849 {
+		yyb2849 = yyj2849 > l
 	} else {
-		yyb2841 = r.CheckBreak()
+		yyb2849 = r.CheckBreak()
 	}
-	if yyb2841 {
+	if yyb2849 {
 		r.ReadEnd()
 		return
 	}
@@ -33120,16 +33180,16 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.FieldPath = string(r.DecodeString())
 	}
 	for {
-		yyj2841++
-		if yyhl2841 {
-			yyb2841 = yyj2841 > l
+		yyj2849++
+		if yyhl2849 {
+			yyb2849 = yyj2849 > l
 		} else {
-			yyb2841 = r.CheckBreak()
+			yyb2849 = r.CheckBreak()
 		}
-		if yyb2841 {
+		if yyb2849 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2841-1, "")
+		z.DecStructFieldNotFound(yyj2849-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33141,32 +33201,32 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2849 := z.EncBinary()
-		_ = yym2849
+		yym2857 := z.EncBinary()
+		_ = yym2857
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2850 := !z.EncBinary()
-			yy2arr2850 := z.EncBasicHandle().StructToArray
-			var yyq2850 [1]bool
-			_, _, _ = yysep2850, yyq2850, yy2arr2850
-			const yyr2850 bool = false
-			yyq2850[0] = x.Name != ""
-			if yyr2850 || yy2arr2850 {
+			yysep2858 := !z.EncBinary()
+			yy2arr2858 := z.EncBasicHandle().StructToArray
+			var yyq2858 [1]bool
+			_, _, _ = yysep2858, yyq2858, yy2arr2858
+			const yyr2858 bool = false
+			yyq2858[0] = x.Name != ""
+			if yyr2858 || yy2arr2858 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2850 int = 0
-				for _, b := range yyq2850 {
+				var yynn2858 int = 0
+				for _, b := range yyq2858 {
 					if b {
-						yynn2850++
+						yynn2858++
 					}
 				}
-				r.EncodeMapStart(yynn2850)
+				r.EncodeMapStart(yynn2858)
 			}
-			if yyr2850 || yy2arr2850 {
-				if yyq2850[0] {
-					yym2852 := z.EncBinary()
-					_ = yym2852
+			if yyr2858 || yy2arr2858 {
+				if yyq2858[0] {
+					yym2860 := z.EncBinary()
+					_ = yym2860
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -33175,17 +33235,17 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2850[0] {
+				if yyq2858[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym2853 := z.EncBinary()
-					_ = yym2853
+					yym2861 := z.EncBinary()
+					_ = yym2861
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yysep2850 {
+			if yysep2858 {
 				r.EncodeEnd()
 			}
 		}
@@ -33196,24 +33256,24 @@ func (x *LocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2854 := z.DecBinary()
-	_ = yym2854
+	yym2862 := z.DecBinary()
+	_ = yym2862
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2855 := r.ReadMapStart()
-			if yyl2855 == 0 {
+			yyl2863 := r.ReadMapStart()
+			if yyl2863 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2855, d)
+				x.codecDecodeSelfFromMap(yyl2863, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2855 := r.ReadArrayStart()
-			if yyl2855 == 0 {
+			yyl2863 := r.ReadArrayStart()
+			if yyl2863 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2855, d)
+				x.codecDecodeSelfFromArray(yyl2863, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33225,12 +33285,12 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2856Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2856Slc
-	var yyhl2856 bool = l >= 0
-	for yyj2856 := 0; ; yyj2856++ {
-		if yyhl2856 {
-			if yyj2856 >= l {
+	var yys2864Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2864Slc
+	var yyhl2864 bool = l >= 0
+	for yyj2864 := 0; ; yyj2864++ {
+		if yyhl2864 {
+			if yyj2864 >= l {
 				break
 			}
 		} else {
@@ -33238,9 +33298,9 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys2856Slc = r.DecodeBytes(yys2856Slc, true, true)
-		yys2856 := string(yys2856Slc)
-		switch yys2856 {
+		yys2864Slc = r.DecodeBytes(yys2864Slc, true, true)
+		yys2864 := string(yys2864Slc)
+		switch yys2864 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -33248,10 +33308,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.Name = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2856)
-		} // end switch yys2856
-	} // end for yyj2856
-	if !yyhl2856 {
+			z.DecStructFieldNotFound(-1, yys2864)
+		} // end switch yys2864
+	} // end for yyj2864
+	if !yyhl2864 {
 		r.ReadEnd()
 	}
 }
@@ -33260,16 +33320,16 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2858 int
-	var yyb2858 bool
-	var yyhl2858 bool = l >= 0
-	yyj2858++
-	if yyhl2858 {
-		yyb2858 = yyj2858 > l
+	var yyj2866 int
+	var yyb2866 bool
+	var yyhl2866 bool = l >= 0
+	yyj2866++
+	if yyhl2866 {
+		yyb2866 = yyj2866 > l
 	} else {
-		yyb2858 = r.CheckBreak()
+		yyb2866 = r.CheckBreak()
 	}
-	if yyb2858 {
+	if yyb2866 {
 		r.ReadEnd()
 		return
 	}
@@ -33279,16 +33339,16 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.Name = string(r.DecodeString())
 	}
 	for {
-		yyj2858++
-		if yyhl2858 {
-			yyb2858 = yyj2858 > l
+		yyj2866++
+		if yyhl2866 {
+			yyb2866 = yyj2866 > l
 		} else {
-			yyb2858 = r.CheckBreak()
+			yyb2866 = r.CheckBreak()
 		}
-		if yyb2858 {
+		if yyb2866 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2858-1, "")
+		z.DecStructFieldNotFound(yyj2866-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33300,34 +33360,34 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2860 := z.EncBinary()
-		_ = yym2860
+		yym2868 := z.EncBinary()
+		_ = yym2868
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2861 := !z.EncBinary()
-			yy2arr2861 := z.EncBasicHandle().StructToArray
-			var yyq2861 [3]bool
-			_, _, _ = yysep2861, yyq2861, yy2arr2861
-			const yyr2861 bool = false
-			yyq2861[0] = x.Kind != ""
-			yyq2861[1] = x.APIVersion != ""
-			yyq2861[2] = true
-			if yyr2861 || yy2arr2861 {
+			yysep2869 := !z.EncBinary()
+			yy2arr2869 := z.EncBasicHandle().StructToArray
+			var yyq2869 [3]bool
+			_, _, _ = yysep2869, yyq2869, yy2arr2869
+			const yyr2869 bool = false
+			yyq2869[0] = x.Kind != ""
+			yyq2869[1] = x.APIVersion != ""
+			yyq2869[2] = true
+			if yyr2869 || yy2arr2869 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2861 int = 0
-				for _, b := range yyq2861 {
+				var yynn2869 int = 0
+				for _, b := range yyq2869 {
 					if b {
-						yynn2861++
+						yynn2869++
 					}
 				}
-				r.EncodeMapStart(yynn2861)
+				r.EncodeMapStart(yynn2869)
 			}
-			if yyr2861 || yy2arr2861 {
-				if yyq2861[0] {
-					yym2863 := z.EncBinary()
-					_ = yym2863
+			if yyr2869 || yy2arr2869 {
+				if yyq2869[0] {
+					yym2871 := z.EncBinary()
+					_ = yym2871
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -33336,20 +33396,20 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2861[0] {
+				if yyq2869[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2864 := z.EncBinary()
-					_ = yym2864
+					yym2872 := z.EncBinary()
+					_ = yym2872
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2861 || yy2arr2861 {
-				if yyq2861[1] {
-					yym2866 := z.EncBinary()
-					_ = yym2866
+			if yyr2869 || yy2arr2869 {
+				if yyq2869[1] {
+					yym2874 := z.EncBinary()
+					_ = yym2874
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -33358,31 +33418,31 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2861[1] {
+				if yyq2869[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2867 := z.EncBinary()
-					_ = yym2867
+					yym2875 := z.EncBinary()
+					_ = yym2875
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2861 || yy2arr2861 {
-				if yyq2861[2] {
-					yy2869 := &x.Reference
-					yy2869.CodecEncodeSelf(e)
+			if yyr2869 || yy2arr2869 {
+				if yyq2869[2] {
+					yy2877 := &x.Reference
+					yy2877.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2861[2] {
+				if yyq2869[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("reference"))
-					yy2870 := &x.Reference
-					yy2870.CodecEncodeSelf(e)
+					yy2878 := &x.Reference
+					yy2878.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2861 {
+			if yysep2869 {
 				r.EncodeEnd()
 			}
 		}
@@ -33393,24 +33453,24 @@ func (x *SerializedReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2871 := z.DecBinary()
-	_ = yym2871
+	yym2879 := z.DecBinary()
+	_ = yym2879
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2872 := r.ReadMapStart()
-			if yyl2872 == 0 {
+			yyl2880 := r.ReadMapStart()
+			if yyl2880 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2872, d)
+				x.codecDecodeSelfFromMap(yyl2880, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2872 := r.ReadArrayStart()
-			if yyl2872 == 0 {
+			yyl2880 := r.ReadArrayStart()
+			if yyl2880 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2872, d)
+				x.codecDecodeSelfFromArray(yyl2880, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33422,12 +33482,12 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2873Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2873Slc
-	var yyhl2873 bool = l >= 0
-	for yyj2873 := 0; ; yyj2873++ {
-		if yyhl2873 {
-			if yyj2873 >= l {
+	var yys2881Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2881Slc
+	var yyhl2881 bool = l >= 0
+	for yyj2881 := 0; ; yyj2881++ {
+		if yyhl2881 {
+			if yyj2881 >= l {
 				break
 			}
 		} else {
@@ -33435,9 +33495,9 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys2873Slc = r.DecodeBytes(yys2873Slc, true, true)
-		yys2873 := string(yys2873Slc)
-		switch yys2873 {
+		yys2881Slc = r.DecodeBytes(yys2881Slc, true, true)
+		yys2881 := string(yys2881Slc)
+		switch yys2881 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -33454,14 +33514,14 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.Reference = ObjectReference{}
 			} else {
-				yyv2876 := &x.Reference
-				yyv2876.CodecDecodeSelf(d)
+				yyv2884 := &x.Reference
+				yyv2884.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2873)
-		} // end switch yys2873
-	} // end for yyj2873
-	if !yyhl2873 {
+			z.DecStructFieldNotFound(-1, yys2881)
+		} // end switch yys2881
+	} // end for yyj2881
+	if !yyhl2881 {
 		r.ReadEnd()
 	}
 }
@@ -33470,16 +33530,16 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2877 int
-	var yyb2877 bool
-	var yyhl2877 bool = l >= 0
-	yyj2877++
-	if yyhl2877 {
-		yyb2877 = yyj2877 > l
+	var yyj2885 int
+	var yyb2885 bool
+	var yyhl2885 bool = l >= 0
+	yyj2885++
+	if yyhl2885 {
+		yyb2885 = yyj2885 > l
 	} else {
-		yyb2877 = r.CheckBreak()
+		yyb2885 = r.CheckBreak()
 	}
-	if yyb2877 {
+	if yyb2885 {
 		r.ReadEnd()
 		return
 	}
@@ -33488,13 +33548,13 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2877++
-	if yyhl2877 {
-		yyb2877 = yyj2877 > l
+	yyj2885++
+	if yyhl2885 {
+		yyb2885 = yyj2885 > l
 	} else {
-		yyb2877 = r.CheckBreak()
+		yyb2885 = r.CheckBreak()
 	}
-	if yyb2877 {
+	if yyb2885 {
 		r.ReadEnd()
 		return
 	}
@@ -33503,33 +33563,33 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2877++
-	if yyhl2877 {
-		yyb2877 = yyj2877 > l
+	yyj2885++
+	if yyhl2885 {
+		yyb2885 = yyj2885 > l
 	} else {
-		yyb2877 = r.CheckBreak()
+		yyb2885 = r.CheckBreak()
 	}
-	if yyb2877 {
+	if yyb2885 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Reference = ObjectReference{}
 	} else {
-		yyv2880 := &x.Reference
-		yyv2880.CodecDecodeSelf(d)
+		yyv2888 := &x.Reference
+		yyv2888.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2877++
-		if yyhl2877 {
-			yyb2877 = yyj2877 > l
+		yyj2885++
+		if yyhl2885 {
+			yyb2885 = yyj2885 > l
 		} else {
-			yyb2877 = r.CheckBreak()
+			yyb2885 = r.CheckBreak()
 		}
-		if yyb2877 {
+		if yyb2885 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2877-1, "")
+		z.DecStructFieldNotFound(yyj2885-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33541,33 +33601,33 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2881 := z.EncBinary()
-		_ = yym2881
+		yym2889 := z.EncBinary()
+		_ = yym2889
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2882 := !z.EncBinary()
-			yy2arr2882 := z.EncBasicHandle().StructToArray
-			var yyq2882 [2]bool
-			_, _, _ = yysep2882, yyq2882, yy2arr2882
-			const yyr2882 bool = false
-			yyq2882[0] = x.Component != ""
-			yyq2882[1] = x.Host != ""
-			if yyr2882 || yy2arr2882 {
+			yysep2890 := !z.EncBinary()
+			yy2arr2890 := z.EncBasicHandle().StructToArray
+			var yyq2890 [2]bool
+			_, _, _ = yysep2890, yyq2890, yy2arr2890
+			const yyr2890 bool = false
+			yyq2890[0] = x.Component != ""
+			yyq2890[1] = x.Host != ""
+			if yyr2890 || yy2arr2890 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2882 int = 0
-				for _, b := range yyq2882 {
+				var yynn2890 int = 0
+				for _, b := range yyq2890 {
 					if b {
-						yynn2882++
+						yynn2890++
 					}
 				}
-				r.EncodeMapStart(yynn2882)
+				r.EncodeMapStart(yynn2890)
 			}
-			if yyr2882 || yy2arr2882 {
-				if yyq2882[0] {
-					yym2884 := z.EncBinary()
-					_ = yym2884
+			if yyr2890 || yy2arr2890 {
+				if yyq2890[0] {
+					yym2892 := z.EncBinary()
+					_ = yym2892
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
@@ -33576,20 +33636,20 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2882[0] {
+				if yyq2890[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("component"))
-					yym2885 := z.EncBinary()
-					_ = yym2885
+					yym2893 := z.EncBinary()
+					_ = yym2893
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
 					}
 				}
 			}
-			if yyr2882 || yy2arr2882 {
-				if yyq2882[1] {
-					yym2887 := z.EncBinary()
-					_ = yym2887
+			if yyr2890 || yy2arr2890 {
+				if yyq2890[1] {
+					yym2895 := z.EncBinary()
+					_ = yym2895
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -33598,17 +33658,17 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2882[1] {
+				if yyq2890[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
-					yym2888 := z.EncBinary()
-					_ = yym2888
+					yym2896 := z.EncBinary()
+					_ = yym2896
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			if yysep2882 {
+			if yysep2890 {
 				r.EncodeEnd()
 			}
 		}
@@ -33619,24 +33679,24 @@ func (x *EventSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2889 := z.DecBinary()
-	_ = yym2889
+	yym2897 := z.DecBinary()
+	_ = yym2897
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2890 := r.ReadMapStart()
-			if yyl2890 == 0 {
+			yyl2898 := r.ReadMapStart()
+			if yyl2898 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2890, d)
+				x.codecDecodeSelfFromMap(yyl2898, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2890 := r.ReadArrayStart()
-			if yyl2890 == 0 {
+			yyl2898 := r.ReadArrayStart()
+			if yyl2898 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2890, d)
+				x.codecDecodeSelfFromArray(yyl2898, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33648,12 +33708,12 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2891Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2891Slc
-	var yyhl2891 bool = l >= 0
-	for yyj2891 := 0; ; yyj2891++ {
-		if yyhl2891 {
-			if yyj2891 >= l {
+	var yys2899Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2899Slc
+	var yyhl2899 bool = l >= 0
+	for yyj2899 := 0; ; yyj2899++ {
+		if yyhl2899 {
+			if yyj2899 >= l {
 				break
 			}
 		} else {
@@ -33661,9 +33721,9 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2891Slc = r.DecodeBytes(yys2891Slc, true, true)
-		yys2891 := string(yys2891Slc)
-		switch yys2891 {
+		yys2899Slc = r.DecodeBytes(yys2899Slc, true, true)
+		yys2899 := string(yys2899Slc)
+		switch yys2899 {
 		case "component":
 			if r.TryDecodeAsNil() {
 				x.Component = ""
@@ -33677,10 +33737,10 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Host = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2891)
-		} // end switch yys2891
-	} // end for yyj2891
-	if !yyhl2891 {
+			z.DecStructFieldNotFound(-1, yys2899)
+		} // end switch yys2899
+	} // end for yyj2899
+	if !yyhl2899 {
 		r.ReadEnd()
 	}
 }
@@ -33689,16 +33749,16 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2894 int
-	var yyb2894 bool
-	var yyhl2894 bool = l >= 0
-	yyj2894++
-	if yyhl2894 {
-		yyb2894 = yyj2894 > l
+	var yyj2902 int
+	var yyb2902 bool
+	var yyhl2902 bool = l >= 0
+	yyj2902++
+	if yyhl2902 {
+		yyb2902 = yyj2902 > l
 	} else {
-		yyb2894 = r.CheckBreak()
+		yyb2902 = r.CheckBreak()
 	}
-	if yyb2894 {
+	if yyb2902 {
 		r.ReadEnd()
 		return
 	}
@@ -33707,13 +33767,13 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Component = string(r.DecodeString())
 	}
-	yyj2894++
-	if yyhl2894 {
-		yyb2894 = yyj2894 > l
+	yyj2902++
+	if yyhl2902 {
+		yyb2902 = yyj2902 > l
 	} else {
-		yyb2894 = r.CheckBreak()
+		yyb2902 = r.CheckBreak()
 	}
-	if yyb2894 {
+	if yyb2902 {
 		r.ReadEnd()
 		return
 	}
@@ -33723,16 +33783,16 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Host = string(r.DecodeString())
 	}
 	for {
-		yyj2894++
-		if yyhl2894 {
-			yyb2894 = yyj2894 > l
+		yyj2902++
+		if yyhl2902 {
+			yyb2902 = yyj2902 > l
 		} else {
-			yyb2894 = r.CheckBreak()
+			yyb2902 = r.CheckBreak()
 		}
-		if yyb2894 {
+		if yyb2902 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2894-1, "")
+		z.DecStructFieldNotFound(yyj2902-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33744,39 +33804,39 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2897 := z.EncBinary()
-		_ = yym2897
+		yym2905 := z.EncBinary()
+		_ = yym2905
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2898 := !z.EncBinary()
-			yy2arr2898 := z.EncBasicHandle().StructToArray
-			var yyq2898 [10]bool
-			_, _, _ = yysep2898, yyq2898, yy2arr2898
-			const yyr2898 bool = false
-			yyq2898[0] = x.Kind != ""
-			yyq2898[1] = x.APIVersion != ""
-			yyq2898[4] = x.Reason != ""
-			yyq2898[5] = x.Message != ""
-			yyq2898[6] = true
-			yyq2898[7] = true
-			yyq2898[8] = true
-			yyq2898[9] = x.Count != 0
-			if yyr2898 || yy2arr2898 {
+			yysep2906 := !z.EncBinary()
+			yy2arr2906 := z.EncBasicHandle().StructToArray
+			var yyq2906 [10]bool
+			_, _, _ = yysep2906, yyq2906, yy2arr2906
+			const yyr2906 bool = false
+			yyq2906[0] = x.Kind != ""
+			yyq2906[1] = x.APIVersion != ""
+			yyq2906[4] = x.Reason != ""
+			yyq2906[5] = x.Message != ""
+			yyq2906[6] = true
+			yyq2906[7] = true
+			yyq2906[8] = true
+			yyq2906[9] = x.Count != 0
+			if yyr2906 || yy2arr2906 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2898 int = 2
-				for _, b := range yyq2898 {
+				var yynn2906 int = 2
+				for _, b := range yyq2906 {
 					if b {
-						yynn2898++
+						yynn2906++
 					}
 				}
-				r.EncodeMapStart(yynn2898)
+				r.EncodeMapStart(yynn2906)
 			}
-			if yyr2898 || yy2arr2898 {
-				if yyq2898[0] {
-					yym2900 := z.EncBinary()
-					_ = yym2900
+			if yyr2906 || yy2arr2906 {
+				if yyq2906[0] {
+					yym2908 := z.EncBinary()
+					_ = yym2908
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -33785,20 +33845,20 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2898[0] {
+				if yyq2906[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2901 := z.EncBinary()
-					_ = yym2901
+					yym2909 := z.EncBinary()
+					_ = yym2909
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2898 || yy2arr2898 {
-				if yyq2898[1] {
-					yym2903 := z.EncBinary()
-					_ = yym2903
+			if yyr2906 || yy2arr2906 {
+				if yyq2906[1] {
+					yym2911 := z.EncBinary()
+					_ = yym2911
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -33807,58 +33867,58 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2898[1] {
+				if yyq2906[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2904 := z.EncBinary()
-					_ = yym2904
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2898 || yy2arr2898 {
-				yy2906 := &x.ObjectMeta
-				yy2906.CodecEncodeSelf(e)
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy2907 := &x.ObjectMeta
-				yy2907.CodecEncodeSelf(e)
-			}
-			if yyr2898 || yy2arr2898 {
-				yy2909 := &x.InvolvedObject
-				yy2909.CodecEncodeSelf(e)
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
-				yy2910 := &x.InvolvedObject
-				yy2910.CodecEncodeSelf(e)
-			}
-			if yyr2898 || yy2arr2898 {
-				if yyq2898[4] {
 					yym2912 := z.EncBinary()
 					_ = yym2912
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2906 || yy2arr2906 {
+				yy2914 := &x.ObjectMeta
+				yy2914.CodecEncodeSelf(e)
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				yy2915 := &x.ObjectMeta
+				yy2915.CodecEncodeSelf(e)
+			}
+			if yyr2906 || yy2arr2906 {
+				yy2917 := &x.InvolvedObject
+				yy2917.CodecEncodeSelf(e)
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
+				yy2918 := &x.InvolvedObject
+				yy2918.CodecEncodeSelf(e)
+			}
+			if yyr2906 || yy2arr2906 {
+				if yyq2906[4] {
+					yym2920 := z.EncBinary()
+					_ = yym2920
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2898[4] {
+				if yyq2906[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym2913 := z.EncBinary()
-					_ = yym2913
+					yym2921 := z.EncBinary()
+					_ = yym2921
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr2898 || yy2arr2898 {
-				if yyq2898[5] {
-					yym2915 := z.EncBinary()
-					_ = yym2915
+			if yyr2906 || yy2arr2906 {
+				if yyq2906[5] {
+					yym2923 := z.EncBinary()
+					_ = yym2923
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -33867,102 +33927,102 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2898[5] {
+				if yyq2906[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym2916 := z.EncBinary()
-					_ = yym2916
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
-				}
-			}
-			if yyr2898 || yy2arr2898 {
-				if yyq2898[6] {
-					yy2918 := &x.Source
-					yy2918.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2898[6] {
-					r.EncodeString(codecSelferC_UTF81234, string("source"))
-					yy2919 := &x.Source
-					yy2919.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2898 || yy2arr2898 {
-				if yyq2898[7] {
-					yy2921 := &x.FirstTimestamp
-					yym2922 := z.EncBinary()
-					_ = yym2922
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2921) {
-					} else if yym2922 {
-						z.EncBinaryMarshal(yy2921)
-					} else if !yym2922 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2921)
-					} else {
-						z.EncFallback(yy2921)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2898[7] {
-					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
-					yy2923 := &x.FirstTimestamp
 					yym2924 := z.EncBinary()
 					_ = yym2924
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2923) {
-					} else if yym2924 {
-						z.EncBinaryMarshal(yy2923)
-					} else if !yym2924 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2923)
 					} else {
-						z.EncFallback(yy2923)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr2898 || yy2arr2898 {
-				if yyq2898[8] {
-					yy2926 := &x.LastTimestamp
-					yym2927 := z.EncBinary()
-					_ = yym2927
+			if yyr2906 || yy2arr2906 {
+				if yyq2906[6] {
+					yy2926 := &x.Source
+					yy2926.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2906[6] {
+					r.EncodeString(codecSelferC_UTF81234, string("source"))
+					yy2927 := &x.Source
+					yy2927.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2906 || yy2arr2906 {
+				if yyq2906[7] {
+					yy2929 := &x.FirstTimestamp
+					yym2930 := z.EncBinary()
+					_ = yym2930
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2926) {
-					} else if yym2927 {
-						z.EncBinaryMarshal(yy2926)
-					} else if !yym2927 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2926)
+					} else if z.HasExtensions() && z.EncExt(yy2929) {
+					} else if yym2930 {
+						z.EncBinaryMarshal(yy2929)
+					} else if !yym2930 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2929)
 					} else {
-						z.EncFallback(yy2926)
+						z.EncFallback(yy2929)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2898[8] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
-					yy2928 := &x.LastTimestamp
-					yym2929 := z.EncBinary()
-					_ = yym2929
+				if yyq2906[7] {
+					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
+					yy2931 := &x.FirstTimestamp
+					yym2932 := z.EncBinary()
+					_ = yym2932
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2928) {
-					} else if yym2929 {
-						z.EncBinaryMarshal(yy2928)
-					} else if !yym2929 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2928)
+					} else if z.HasExtensions() && z.EncExt(yy2931) {
+					} else if yym2932 {
+						z.EncBinaryMarshal(yy2931)
+					} else if !yym2932 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2931)
 					} else {
-						z.EncFallback(yy2928)
+						z.EncFallback(yy2931)
 					}
 				}
 			}
-			if yyr2898 || yy2arr2898 {
-				if yyq2898[9] {
-					yym2931 := z.EncBinary()
-					_ = yym2931
+			if yyr2906 || yy2arr2906 {
+				if yyq2906[8] {
+					yy2934 := &x.LastTimestamp
+					yym2935 := z.EncBinary()
+					_ = yym2935
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2934) {
+					} else if yym2935 {
+						z.EncBinaryMarshal(yy2934)
+					} else if !yym2935 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2934)
+					} else {
+						z.EncFallback(yy2934)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2906[8] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					yy2936 := &x.LastTimestamp
+					yym2937 := z.EncBinary()
+					_ = yym2937
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2936) {
+					} else if yym2937 {
+						z.EncBinaryMarshal(yy2936)
+					} else if !yym2937 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2936)
+					} else {
+						z.EncFallback(yy2936)
+					}
+				}
+			}
+			if yyr2906 || yy2arr2906 {
+				if yyq2906[9] {
+					yym2939 := z.EncBinary()
+					_ = yym2939
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Count))
@@ -33971,17 +34031,17 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq2898[9] {
+				if yyq2906[9] {
 					r.EncodeString(codecSelferC_UTF81234, string("count"))
-					yym2932 := z.EncBinary()
-					_ = yym2932
+					yym2940 := z.EncBinary()
+					_ = yym2940
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Count))
 					}
 				}
 			}
-			if yysep2898 {
+			if yysep2906 {
 				r.EncodeEnd()
 			}
 		}
@@ -33992,24 +34052,24 @@ func (x *Event) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2933 := z.DecBinary()
-	_ = yym2933
+	yym2941 := z.DecBinary()
+	_ = yym2941
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2934 := r.ReadMapStart()
-			if yyl2934 == 0 {
+			yyl2942 := r.ReadMapStart()
+			if yyl2942 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2934, d)
+				x.codecDecodeSelfFromMap(yyl2942, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2934 := r.ReadArrayStart()
-			if yyl2934 == 0 {
+			yyl2942 := r.ReadArrayStart()
+			if yyl2942 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2934, d)
+				x.codecDecodeSelfFromArray(yyl2942, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34021,12 +34081,12 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2935Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2935Slc
-	var yyhl2935 bool = l >= 0
-	for yyj2935 := 0; ; yyj2935++ {
-		if yyhl2935 {
-			if yyj2935 >= l {
+	var yys2943Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2943Slc
+	var yyhl2943 bool = l >= 0
+	for yyj2943 := 0; ; yyj2943++ {
+		if yyhl2943 {
+			if yyj2943 >= l {
 				break
 			}
 		} else {
@@ -34034,9 +34094,9 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2935Slc = r.DecodeBytes(yys2935Slc, true, true)
-		yys2935 := string(yys2935Slc)
-		switch yys2935 {
+		yys2943Slc = r.DecodeBytes(yys2943Slc, true, true)
+		yys2943 := string(yys2943Slc)
+		switch yys2943 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34053,15 +34113,15 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2938 := &x.ObjectMeta
-				yyv2938.CodecDecodeSelf(d)
+				yyv2946 := &x.ObjectMeta
+				yyv2946.CodecDecodeSelf(d)
 			}
 		case "involvedObject":
 			if r.TryDecodeAsNil() {
 				x.InvolvedObject = ObjectReference{}
 			} else {
-				yyv2939 := &x.InvolvedObject
-				yyv2939.CodecDecodeSelf(d)
+				yyv2947 := &x.InvolvedObject
+				yyv2947.CodecDecodeSelf(d)
 			}
 		case "reason":
 			if r.TryDecodeAsNil() {
@@ -34079,41 +34139,41 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Source = EventSource{}
 			} else {
-				yyv2942 := &x.Source
-				yyv2942.CodecDecodeSelf(d)
+				yyv2950 := &x.Source
+				yyv2950.CodecDecodeSelf(d)
 			}
 		case "firstTimestamp":
 			if r.TryDecodeAsNil() {
 				x.FirstTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv2943 := &x.FirstTimestamp
-				yym2944 := z.DecBinary()
-				_ = yym2944
+				yyv2951 := &x.FirstTimestamp
+				yym2952 := z.DecBinary()
+				_ = yym2952
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2943) {
-				} else if yym2944 {
-					z.DecBinaryUnmarshal(yyv2943)
-				} else if !yym2944 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2943)
+				} else if z.HasExtensions() && z.DecExt(yyv2951) {
+				} else if yym2952 {
+					z.DecBinaryUnmarshal(yyv2951)
+				} else if !yym2952 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2951)
 				} else {
-					z.DecFallback(yyv2943, false)
+					z.DecFallback(yyv2951, false)
 				}
 			}
 		case "lastTimestamp":
 			if r.TryDecodeAsNil() {
 				x.LastTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv2945 := &x.LastTimestamp
-				yym2946 := z.DecBinary()
-				_ = yym2946
+				yyv2953 := &x.LastTimestamp
+				yym2954 := z.DecBinary()
+				_ = yym2954
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2945) {
-				} else if yym2946 {
-					z.DecBinaryUnmarshal(yyv2945)
-				} else if !yym2946 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2945)
+				} else if z.HasExtensions() && z.DecExt(yyv2953) {
+				} else if yym2954 {
+					z.DecBinaryUnmarshal(yyv2953)
+				} else if !yym2954 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2953)
 				} else {
-					z.DecFallback(yyv2945, false)
+					z.DecFallback(yyv2953, false)
 				}
 			}
 		case "count":
@@ -34123,10 +34183,10 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Count = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2935)
-		} // end switch yys2935
-	} // end for yyj2935
-	if !yyhl2935 {
+			z.DecStructFieldNotFound(-1, yys2943)
+		} // end switch yys2943
+	} // end for yyj2943
+	if !yyhl2943 {
 		r.ReadEnd()
 	}
 }
@@ -34135,16 +34195,16 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2948 int
-	var yyb2948 bool
-	var yyhl2948 bool = l >= 0
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	var yyj2956 int
+	var yyb2956 bool
+	var yyhl2956 bool = l >= 0
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
@@ -34153,13 +34213,13 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
@@ -34168,45 +34228,45 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2951 := &x.ObjectMeta
-		yyv2951.CodecDecodeSelf(d)
+		yyv2959 := &x.ObjectMeta
+		yyv2959.CodecDecodeSelf(d)
 	}
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.InvolvedObject = ObjectReference{}
 	} else {
-		yyv2952 := &x.InvolvedObject
-		yyv2952.CodecDecodeSelf(d)
+		yyv2960 := &x.InvolvedObject
+		yyv2960.CodecDecodeSelf(d)
 	}
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
@@ -34215,13 +34275,13 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
@@ -34230,81 +34290,81 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Source = EventSource{}
 	} else {
-		yyv2955 := &x.Source
-		yyv2955.CodecDecodeSelf(d)
+		yyv2963 := &x.Source
+		yyv2963.CodecDecodeSelf(d)
 	}
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.FirstTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv2956 := &x.FirstTimestamp
-		yym2957 := z.DecBinary()
-		_ = yym2957
+		yyv2964 := &x.FirstTimestamp
+		yym2965 := z.DecBinary()
+		_ = yym2965
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2956) {
-		} else if yym2957 {
-			z.DecBinaryUnmarshal(yyv2956)
-		} else if !yym2957 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2956)
+		} else if z.HasExtensions() && z.DecExt(yyv2964) {
+		} else if yym2965 {
+			z.DecBinaryUnmarshal(yyv2964)
+		} else if !yym2965 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2964)
 		} else {
-			z.DecFallback(yyv2956, false)
+			z.DecFallback(yyv2964, false)
 		}
 	}
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv2958 := &x.LastTimestamp
-		yym2959 := z.DecBinary()
-		_ = yym2959
+		yyv2966 := &x.LastTimestamp
+		yym2967 := z.DecBinary()
+		_ = yym2967
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2958) {
-		} else if yym2959 {
-			z.DecBinaryUnmarshal(yyv2958)
-		} else if !yym2959 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2958)
+		} else if z.HasExtensions() && z.DecExt(yyv2966) {
+		} else if yym2967 {
+			z.DecBinaryUnmarshal(yyv2966)
+		} else if !yym2967 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2966)
 		} else {
-			z.DecFallback(yyv2958, false)
+			z.DecFallback(yyv2966, false)
 		}
 	}
-	yyj2948++
-	if yyhl2948 {
-		yyb2948 = yyj2948 > l
+	yyj2956++
+	if yyhl2956 {
+		yyb2956 = yyj2956 > l
 	} else {
-		yyb2948 = r.CheckBreak()
+		yyb2956 = r.CheckBreak()
 	}
-	if yyb2948 {
+	if yyb2956 {
 		r.ReadEnd()
 		return
 	}
@@ -34314,16 +34374,16 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Count = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj2948++
-		if yyhl2948 {
-			yyb2948 = yyj2948 > l
+		yyj2956++
+		if yyhl2956 {
+			yyb2956 = yyj2956 > l
 		} else {
-			yyb2948 = r.CheckBreak()
+			yyb2956 = r.CheckBreak()
 		}
-		if yyb2948 {
+		if yyb2956 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2948-1, "")
+		z.DecStructFieldNotFound(yyj2956-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34335,34 +34395,34 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2961 := z.EncBinary()
-		_ = yym2961
+		yym2969 := z.EncBinary()
+		_ = yym2969
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2962 := !z.EncBinary()
-			yy2arr2962 := z.EncBasicHandle().StructToArray
-			var yyq2962 [4]bool
-			_, _, _ = yysep2962, yyq2962, yy2arr2962
-			const yyr2962 bool = false
-			yyq2962[0] = x.Kind != ""
-			yyq2962[1] = x.APIVersion != ""
-			yyq2962[2] = true
-			if yyr2962 || yy2arr2962 {
+			yysep2970 := !z.EncBinary()
+			yy2arr2970 := z.EncBasicHandle().StructToArray
+			var yyq2970 [4]bool
+			_, _, _ = yysep2970, yyq2970, yy2arr2970
+			const yyr2970 bool = false
+			yyq2970[0] = x.Kind != ""
+			yyq2970[1] = x.APIVersion != ""
+			yyq2970[2] = true
+			if yyr2970 || yy2arr2970 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2962 int = 1
-				for _, b := range yyq2962 {
+				var yynn2970 int = 1
+				for _, b := range yyq2970 {
 					if b {
-						yynn2962++
+						yynn2970++
 					}
 				}
-				r.EncodeMapStart(yynn2962)
+				r.EncodeMapStart(yynn2970)
 			}
-			if yyr2962 || yy2arr2962 {
-				if yyq2962[0] {
-					yym2964 := z.EncBinary()
-					_ = yym2964
+			if yyr2970 || yy2arr2970 {
+				if yyq2970[0] {
+					yym2972 := z.EncBinary()
+					_ = yym2972
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -34371,70 +34431,70 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2962[0] {
+				if yyq2970[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2965 := z.EncBinary()
-					_ = yym2965
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2962 || yy2arr2962 {
-				if yyq2962[1] {
-					yym2967 := z.EncBinary()
-					_ = yym2967
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2962[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2968 := z.EncBinary()
-					_ = yym2968
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2962 || yy2arr2962 {
-				if yyq2962[2] {
-					yy2970 := &x.ListMeta
-					yym2971 := z.EncBinary()
-					_ = yym2971
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2970) {
-					} else {
-						z.EncFallback(yy2970)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2962[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2972 := &x.ListMeta
 					yym2973 := z.EncBinary()
 					_ = yym2973
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2972) {
 					} else {
-						z.EncFallback(yy2972)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2962 || yy2arr2962 {
+			if yyr2970 || yy2arr2970 {
+				if yyq2970[1] {
+					yym2975 := z.EncBinary()
+					_ = yym2975
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2970[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2976 := z.EncBinary()
+					_ = yym2976
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2970 || yy2arr2970 {
+				if yyq2970[2] {
+					yy2978 := &x.ListMeta
+					yym2979 := z.EncBinary()
+					_ = yym2979
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2978) {
+					} else {
+						z.EncFallback(yy2978)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2970[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2980 := &x.ListMeta
+					yym2981 := z.EncBinary()
+					_ = yym2981
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2980) {
+					} else {
+						z.EncFallback(yy2980)
+					}
+				}
+			}
+			if yyr2970 || yy2arr2970 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2975 := z.EncBinary()
-					_ = yym2975
+					yym2983 := z.EncBinary()
+					_ = yym2983
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
@@ -34445,15 +34505,15 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2976 := z.EncBinary()
-					_ = yym2976
+					yym2984 := z.EncBinary()
+					_ = yym2984
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
 					}
 				}
 			}
-			if yysep2962 {
+			if yysep2970 {
 				r.EncodeEnd()
 			}
 		}
@@ -34464,24 +34524,24 @@ func (x *EventList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2977 := z.DecBinary()
-	_ = yym2977
+	yym2985 := z.DecBinary()
+	_ = yym2985
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2978 := r.ReadMapStart()
-			if yyl2978 == 0 {
+			yyl2986 := r.ReadMapStart()
+			if yyl2986 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2978, d)
+				x.codecDecodeSelfFromMap(yyl2986, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2978 := r.ReadArrayStart()
-			if yyl2978 == 0 {
+			yyl2986 := r.ReadArrayStart()
+			if yyl2986 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2978, d)
+				x.codecDecodeSelfFromArray(yyl2986, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34493,12 +34553,12 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2979Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2979Slc
-	var yyhl2979 bool = l >= 0
-	for yyj2979 := 0; ; yyj2979++ {
-		if yyhl2979 {
-			if yyj2979 >= l {
+	var yys2987Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2987Slc
+	var yyhl2987 bool = l >= 0
+	for yyj2987 := 0; ; yyj2987++ {
+		if yyhl2987 {
+			if yyj2987 >= l {
 				break
 			}
 		} else {
@@ -34506,9 +34566,9 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2979Slc = r.DecodeBytes(yys2979Slc, true, true)
-		yys2979 := string(yys2979Slc)
-		switch yys2979 {
+		yys2987Slc = r.DecodeBytes(yys2987Slc, true, true)
+		yys2987 := string(yys2987Slc)
+		switch yys2987 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34525,32 +34585,32 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2982 := &x.ListMeta
-				yym2983 := z.DecBinary()
-				_ = yym2983
+				yyv2990 := &x.ListMeta
+				yym2991 := z.DecBinary()
+				_ = yym2991
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2982) {
+				} else if z.HasExtensions() && z.DecExt(yyv2990) {
 				} else {
-					z.DecFallback(yyv2982, false)
+					z.DecFallback(yyv2990, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2984 := &x.Items
-				yym2985 := z.DecBinary()
-				_ = yym2985
+				yyv2992 := &x.Items
+				yym2993 := z.DecBinary()
+				_ = yym2993
 				if false {
 				} else {
-					h.decSliceEvent((*[]Event)(yyv2984), d)
+					h.decSliceEvent((*[]Event)(yyv2992), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2979)
-		} // end switch yys2979
-	} // end for yyj2979
-	if !yyhl2979 {
+			z.DecStructFieldNotFound(-1, yys2987)
+		} // end switch yys2987
+	} // end for yyj2987
+	if !yyhl2987 {
 		r.ReadEnd()
 	}
 }
@@ -34559,16 +34619,16 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2986 int
-	var yyb2986 bool
-	var yyhl2986 bool = l >= 0
-	yyj2986++
-	if yyhl2986 {
-		yyb2986 = yyj2986 > l
+	var yyj2994 int
+	var yyb2994 bool
+	var yyhl2994 bool = l >= 0
+	yyj2994++
+	if yyhl2994 {
+		yyb2994 = yyj2994 > l
 	} else {
-		yyb2986 = r.CheckBreak()
+		yyb2994 = r.CheckBreak()
 	}
-	if yyb2986 {
+	if yyb2994 {
 		r.ReadEnd()
 		return
 	}
@@ -34577,13 +34637,13 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2986++
-	if yyhl2986 {
-		yyb2986 = yyj2986 > l
+	yyj2994++
+	if yyhl2994 {
+		yyb2994 = yyj2994 > l
 	} else {
-		yyb2986 = r.CheckBreak()
+		yyb2994 = r.CheckBreak()
 	}
-	if yyb2986 {
+	if yyb2994 {
 		r.ReadEnd()
 		return
 	}
@@ -34592,60 +34652,60 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2986++
-	if yyhl2986 {
-		yyb2986 = yyj2986 > l
+	yyj2994++
+	if yyhl2994 {
+		yyb2994 = yyj2994 > l
 	} else {
-		yyb2986 = r.CheckBreak()
+		yyb2994 = r.CheckBreak()
 	}
-	if yyb2986 {
+	if yyb2994 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2989 := &x.ListMeta
-		yym2990 := z.DecBinary()
-		_ = yym2990
+		yyv2997 := &x.ListMeta
+		yym2998 := z.DecBinary()
+		_ = yym2998
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2989) {
+		} else if z.HasExtensions() && z.DecExt(yyv2997) {
 		} else {
-			z.DecFallback(yyv2989, false)
+			z.DecFallback(yyv2997, false)
 		}
 	}
-	yyj2986++
-	if yyhl2986 {
-		yyb2986 = yyj2986 > l
+	yyj2994++
+	if yyhl2994 {
+		yyb2994 = yyj2994 > l
 	} else {
-		yyb2986 = r.CheckBreak()
+		yyb2994 = r.CheckBreak()
 	}
-	if yyb2986 {
+	if yyb2994 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2991 := &x.Items
-		yym2992 := z.DecBinary()
-		_ = yym2992
+		yyv2999 := &x.Items
+		yym3000 := z.DecBinary()
+		_ = yym3000
 		if false {
 		} else {
-			h.decSliceEvent((*[]Event)(yyv2991), d)
+			h.decSliceEvent((*[]Event)(yyv2999), d)
 		}
 	}
 	for {
-		yyj2986++
-		if yyhl2986 {
-			yyb2986 = yyj2986 > l
+		yyj2994++
+		if yyhl2994 {
+			yyb2994 = yyj2994 > l
 		} else {
-			yyb2986 = r.CheckBreak()
+			yyb2994 = r.CheckBreak()
 		}
-		if yyb2986 {
+		if yyb2994 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2986-1, "")
+		z.DecStructFieldNotFound(yyj2994-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34657,34 +34717,34 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2993 := z.EncBinary()
-		_ = yym2993
+		yym3001 := z.EncBinary()
+		_ = yym3001
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2994 := !z.EncBinary()
-			yy2arr2994 := z.EncBasicHandle().StructToArray
-			var yyq2994 [4]bool
-			_, _, _ = yysep2994, yyq2994, yy2arr2994
-			const yyr2994 bool = false
-			yyq2994[0] = x.Kind != ""
-			yyq2994[1] = x.APIVersion != ""
-			yyq2994[2] = true
-			if yyr2994 || yy2arr2994 {
+			yysep3002 := !z.EncBinary()
+			yy2arr3002 := z.EncBasicHandle().StructToArray
+			var yyq3002 [4]bool
+			_, _, _ = yysep3002, yyq3002, yy2arr3002
+			const yyr3002 bool = false
+			yyq3002[0] = x.Kind != ""
+			yyq3002[1] = x.APIVersion != ""
+			yyq3002[2] = true
+			if yyr3002 || yy2arr3002 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2994 int = 1
-				for _, b := range yyq2994 {
+				var yynn3002 int = 1
+				for _, b := range yyq3002 {
 					if b {
-						yynn2994++
+						yynn3002++
 					}
 				}
-				r.EncodeMapStart(yynn2994)
+				r.EncodeMapStart(yynn3002)
 			}
-			if yyr2994 || yy2arr2994 {
-				if yyq2994[0] {
-					yym2996 := z.EncBinary()
-					_ = yym2996
+			if yyr3002 || yy2arr3002 {
+				if yyq3002[0] {
+					yym3004 := z.EncBinary()
+					_ = yym3004
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -34693,70 +34753,70 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2994[0] {
+				if yyq3002[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2997 := z.EncBinary()
-					_ = yym2997
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2994 || yy2arr2994 {
-				if yyq2994[1] {
-					yym2999 := z.EncBinary()
-					_ = yym2999
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2994[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3000 := z.EncBinary()
-					_ = yym3000
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2994 || yy2arr2994 {
-				if yyq2994[2] {
-					yy3002 := &x.ListMeta
-					yym3003 := z.EncBinary()
-					_ = yym3003
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3002) {
-					} else {
-						z.EncFallback(yy3002)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2994[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3004 := &x.ListMeta
 					yym3005 := z.EncBinary()
 					_ = yym3005
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3004) {
 					} else {
-						z.EncFallback(yy3004)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2994 || yy2arr2994 {
+			if yyr3002 || yy2arr3002 {
+				if yyq3002[1] {
+					yym3007 := z.EncBinary()
+					_ = yym3007
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3002[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3008 := z.EncBinary()
+					_ = yym3008
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr3002 || yy2arr3002 {
+				if yyq3002[2] {
+					yy3010 := &x.ListMeta
+					yym3011 := z.EncBinary()
+					_ = yym3011
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3010) {
+					} else {
+						z.EncFallback(yy3010)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3002[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3012 := &x.ListMeta
+					yym3013 := z.EncBinary()
+					_ = yym3013
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3012) {
+					} else {
+						z.EncFallback(yy3012)
+					}
+				}
+			}
+			if yyr3002 || yy2arr3002 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3007 := z.EncBinary()
-					_ = yym3007
+					yym3015 := z.EncBinary()
+					_ = yym3015
 					if false {
 					} else {
 						h.encSliceruntime_RawExtension(([]pkg6_runtime.RawExtension)(x.Items), e)
@@ -34767,15 +34827,15 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3008 := z.EncBinary()
-					_ = yym3008
+					yym3016 := z.EncBinary()
+					_ = yym3016
 					if false {
 					} else {
 						h.encSliceruntime_RawExtension(([]pkg6_runtime.RawExtension)(x.Items), e)
 					}
 				}
 			}
-			if yysep2994 {
+			if yysep3002 {
 				r.EncodeEnd()
 			}
 		}
@@ -34786,24 +34846,24 @@ func (x *List) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3009 := z.DecBinary()
-	_ = yym3009
+	yym3017 := z.DecBinary()
+	_ = yym3017
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3010 := r.ReadMapStart()
-			if yyl3010 == 0 {
+			yyl3018 := r.ReadMapStart()
+			if yyl3018 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3010, d)
+				x.codecDecodeSelfFromMap(yyl3018, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3010 := r.ReadArrayStart()
-			if yyl3010 == 0 {
+			yyl3018 := r.ReadArrayStart()
+			if yyl3018 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3010, d)
+				x.codecDecodeSelfFromArray(yyl3018, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34815,12 +34875,12 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3011Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3011Slc
-	var yyhl3011 bool = l >= 0
-	for yyj3011 := 0; ; yyj3011++ {
-		if yyhl3011 {
-			if yyj3011 >= l {
+	var yys3019Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3019Slc
+	var yyhl3019 bool = l >= 0
+	for yyj3019 := 0; ; yyj3019++ {
+		if yyhl3019 {
+			if yyj3019 >= l {
 				break
 			}
 		} else {
@@ -34828,9 +34888,9 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3011Slc = r.DecodeBytes(yys3011Slc, true, true)
-		yys3011 := string(yys3011Slc)
-		switch yys3011 {
+		yys3019Slc = r.DecodeBytes(yys3019Slc, true, true)
+		yys3019 := string(yys3019Slc)
+		switch yys3019 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34847,32 +34907,32 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3014 := &x.ListMeta
-				yym3015 := z.DecBinary()
-				_ = yym3015
+				yyv3022 := &x.ListMeta
+				yym3023 := z.DecBinary()
+				_ = yym3023
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3014) {
+				} else if z.HasExtensions() && z.DecExt(yyv3022) {
 				} else {
-					z.DecFallback(yyv3014, false)
+					z.DecFallback(yyv3022, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3016 := &x.Items
-				yym3017 := z.DecBinary()
-				_ = yym3017
+				yyv3024 := &x.Items
+				yym3025 := z.DecBinary()
+				_ = yym3025
 				if false {
 				} else {
-					h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3016), d)
+					h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3024), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3011)
-		} // end switch yys3011
-	} // end for yyj3011
-	if !yyhl3011 {
+			z.DecStructFieldNotFound(-1, yys3019)
+		} // end switch yys3019
+	} // end for yyj3019
+	if !yyhl3019 {
 		r.ReadEnd()
 	}
 }
@@ -34881,16 +34941,16 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3018 int
-	var yyb3018 bool
-	var yyhl3018 bool = l >= 0
-	yyj3018++
-	if yyhl3018 {
-		yyb3018 = yyj3018 > l
+	var yyj3026 int
+	var yyb3026 bool
+	var yyhl3026 bool = l >= 0
+	yyj3026++
+	if yyhl3026 {
+		yyb3026 = yyj3026 > l
 	} else {
-		yyb3018 = r.CheckBreak()
+		yyb3026 = r.CheckBreak()
 	}
-	if yyb3018 {
+	if yyb3026 {
 		r.ReadEnd()
 		return
 	}
@@ -34899,13 +34959,13 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3018++
-	if yyhl3018 {
-		yyb3018 = yyj3018 > l
+	yyj3026++
+	if yyhl3026 {
+		yyb3026 = yyj3026 > l
 	} else {
-		yyb3018 = r.CheckBreak()
+		yyb3026 = r.CheckBreak()
 	}
-	if yyb3018 {
+	if yyb3026 {
 		r.ReadEnd()
 		return
 	}
@@ -34914,60 +34974,60 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3018++
-	if yyhl3018 {
-		yyb3018 = yyj3018 > l
+	yyj3026++
+	if yyhl3026 {
+		yyb3026 = yyj3026 > l
 	} else {
-		yyb3018 = r.CheckBreak()
+		yyb3026 = r.CheckBreak()
 	}
-	if yyb3018 {
+	if yyb3026 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3021 := &x.ListMeta
-		yym3022 := z.DecBinary()
-		_ = yym3022
+		yyv3029 := &x.ListMeta
+		yym3030 := z.DecBinary()
+		_ = yym3030
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3021) {
+		} else if z.HasExtensions() && z.DecExt(yyv3029) {
 		} else {
-			z.DecFallback(yyv3021, false)
+			z.DecFallback(yyv3029, false)
 		}
 	}
-	yyj3018++
-	if yyhl3018 {
-		yyb3018 = yyj3018 > l
+	yyj3026++
+	if yyhl3026 {
+		yyb3026 = yyj3026 > l
 	} else {
-		yyb3018 = r.CheckBreak()
+		yyb3026 = r.CheckBreak()
 	}
-	if yyb3018 {
+	if yyb3026 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3023 := &x.Items
-		yym3024 := z.DecBinary()
-		_ = yym3024
+		yyv3031 := &x.Items
+		yym3032 := z.DecBinary()
+		_ = yym3032
 		if false {
 		} else {
-			h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3023), d)
+			h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3031), d)
 		}
 	}
 	for {
-		yyj3018++
-		if yyhl3018 {
-			yyb3018 = yyj3018 > l
+		yyj3026++
+		if yyhl3026 {
+			yyb3026 = yyj3026 > l
 		} else {
-			yyb3018 = r.CheckBreak()
+			yyb3026 = r.CheckBreak()
 		}
-		if yyb3018 {
+		if yyb3026 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3018-1, "")
+		z.DecStructFieldNotFound(yyj3026-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34976,8 +35036,8 @@ func (x LimitType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3025 := z.EncBinary()
-	_ = yym3025
+	yym3033 := z.EncBinary()
+	_ = yym3033
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -34989,8 +35049,8 @@ func (x *LimitType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3026 := z.DecBinary()
-	_ = yym3026
+	yym3034 := z.DecBinary()
+	_ = yym3034
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -35005,47 +35065,47 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3027 := z.EncBinary()
-		_ = yym3027
+		yym3035 := z.EncBinary()
+		_ = yym3035
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3028 := !z.EncBinary()
-			yy2arr3028 := z.EncBasicHandle().StructToArray
-			var yyq3028 [6]bool
-			_, _, _ = yysep3028, yyq3028, yy2arr3028
-			const yyr3028 bool = false
-			yyq3028[0] = x.Type != ""
-			yyq3028[1] = len(x.Max) != 0
-			yyq3028[2] = len(x.Min) != 0
-			yyq3028[3] = len(x.Default) != 0
-			yyq3028[4] = len(x.DefaultRequest) != 0
-			yyq3028[5] = len(x.MaxLimitRequestRatio) != 0
-			if yyr3028 || yy2arr3028 {
+			yysep3036 := !z.EncBinary()
+			yy2arr3036 := z.EncBasicHandle().StructToArray
+			var yyq3036 [6]bool
+			_, _, _ = yysep3036, yyq3036, yy2arr3036
+			const yyr3036 bool = false
+			yyq3036[0] = x.Type != ""
+			yyq3036[1] = len(x.Max) != 0
+			yyq3036[2] = len(x.Min) != 0
+			yyq3036[3] = len(x.Default) != 0
+			yyq3036[4] = len(x.DefaultRequest) != 0
+			yyq3036[5] = len(x.MaxLimitRequestRatio) != 0
+			if yyr3036 || yy2arr3036 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn3028 int = 0
-				for _, b := range yyq3028 {
+				var yynn3036 int = 0
+				for _, b := range yyq3036 {
 					if b {
-						yynn3028++
+						yynn3036++
 					}
 				}
-				r.EncodeMapStart(yynn3028)
+				r.EncodeMapStart(yynn3036)
 			}
-			if yyr3028 || yy2arr3028 {
-				if yyq3028[0] {
+			if yyr3036 || yy2arr3036 {
+				if yyq3036[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3028[0] {
+				if yyq3036[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3028 || yy2arr3028 {
-				if yyq3028[1] {
+			if yyr3036 || yy2arr3036 {
+				if yyq3036[1] {
 					if x.Max == nil {
 						r.EncodeNil()
 					} else {
@@ -35055,7 +35115,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3028[1] {
+				if yyq3036[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("max"))
 					if x.Max == nil {
 						r.EncodeNil()
@@ -35064,8 +35124,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3028 || yy2arr3028 {
-				if yyq3028[2] {
+			if yyr3036 || yy2arr3036 {
+				if yyq3036[2] {
 					if x.Min == nil {
 						r.EncodeNil()
 					} else {
@@ -35075,7 +35135,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3028[2] {
+				if yyq3036[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("min"))
 					if x.Min == nil {
 						r.EncodeNil()
@@ -35084,8 +35144,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3028 || yy2arr3028 {
-				if yyq3028[3] {
+			if yyr3036 || yy2arr3036 {
+				if yyq3036[3] {
 					if x.Default == nil {
 						r.EncodeNil()
 					} else {
@@ -35095,7 +35155,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3028[3] {
+				if yyq3036[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("default"))
 					if x.Default == nil {
 						r.EncodeNil()
@@ -35104,8 +35164,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3028 || yy2arr3028 {
-				if yyq3028[4] {
+			if yyr3036 || yy2arr3036 {
+				if yyq3036[4] {
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
 					} else {
@@ -35115,7 +35175,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3028[4] {
+				if yyq3036[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("defaultRequest"))
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
@@ -35124,8 +35184,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3028 || yy2arr3028 {
-				if yyq3028[5] {
+			if yyr3036 || yy2arr3036 {
+				if yyq3036[5] {
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
 					} else {
@@ -35135,7 +35195,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3028[5] {
+				if yyq3036[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxLimitRequestRatio"))
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
@@ -35144,7 +35204,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3028 {
+			if yysep3036 {
 				r.EncodeEnd()
 			}
 		}
@@ -35155,24 +35215,24 @@ func (x *LimitRangeItem) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3035 := z.DecBinary()
-	_ = yym3035
+	yym3043 := z.DecBinary()
+	_ = yym3043
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3036 := r.ReadMapStart()
-			if yyl3036 == 0 {
+			yyl3044 := r.ReadMapStart()
+			if yyl3044 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3036, d)
+				x.codecDecodeSelfFromMap(yyl3044, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3036 := r.ReadArrayStart()
-			if yyl3036 == 0 {
+			yyl3044 := r.ReadArrayStart()
+			if yyl3044 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3036, d)
+				x.codecDecodeSelfFromArray(yyl3044, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35184,12 +35244,12 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3037Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3037Slc
-	var yyhl3037 bool = l >= 0
-	for yyj3037 := 0; ; yyj3037++ {
-		if yyhl3037 {
-			if yyj3037 >= l {
+	var yys3045Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3045Slc
+	var yyhl3045 bool = l >= 0
+	for yyj3045 := 0; ; yyj3045++ {
+		if yyhl3045 {
+			if yyj3045 >= l {
 				break
 			}
 		} else {
@@ -35197,9 +35257,9 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3037Slc = r.DecodeBytes(yys3037Slc, true, true)
-		yys3037 := string(yys3037Slc)
-		switch yys3037 {
+		yys3045Slc = r.DecodeBytes(yys3045Slc, true, true)
+		yys3045 := string(yys3045Slc)
+		switch yys3045 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -35210,42 +35270,42 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Max = nil
 			} else {
-				yyv3039 := &x.Max
-				yyv3039.CodecDecodeSelf(d)
+				yyv3047 := &x.Max
+				yyv3047.CodecDecodeSelf(d)
 			}
 		case "min":
 			if r.TryDecodeAsNil() {
 				x.Min = nil
 			} else {
-				yyv3040 := &x.Min
-				yyv3040.CodecDecodeSelf(d)
+				yyv3048 := &x.Min
+				yyv3048.CodecDecodeSelf(d)
 			}
 		case "default":
 			if r.TryDecodeAsNil() {
 				x.Default = nil
 			} else {
-				yyv3041 := &x.Default
-				yyv3041.CodecDecodeSelf(d)
+				yyv3049 := &x.Default
+				yyv3049.CodecDecodeSelf(d)
 			}
 		case "defaultRequest":
 			if r.TryDecodeAsNil() {
 				x.DefaultRequest = nil
 			} else {
-				yyv3042 := &x.DefaultRequest
-				yyv3042.CodecDecodeSelf(d)
+				yyv3050 := &x.DefaultRequest
+				yyv3050.CodecDecodeSelf(d)
 			}
 		case "maxLimitRequestRatio":
 			if r.TryDecodeAsNil() {
 				x.MaxLimitRequestRatio = nil
 			} else {
-				yyv3043 := &x.MaxLimitRequestRatio
-				yyv3043.CodecDecodeSelf(d)
+				yyv3051 := &x.MaxLimitRequestRatio
+				yyv3051.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3037)
-		} // end switch yys3037
-	} // end for yyj3037
-	if !yyhl3037 {
+			z.DecStructFieldNotFound(-1, yys3045)
+		} // end switch yys3045
+	} // end for yyj3045
+	if !yyhl3045 {
 		r.ReadEnd()
 	}
 }
@@ -35254,16 +35314,16 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3044 int
-	var yyb3044 bool
-	var yyhl3044 bool = l >= 0
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	var yyj3052 int
+	var yyb3052 bool
+	var yyhl3052 bool = l >= 0
+	yyj3052++
+	if yyhl3052 {
+		yyb3052 = yyj3052 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3052 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3052 {
 		r.ReadEnd()
 		return
 	}
@@ -35272,97 +35332,97 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = LimitType(r.DecodeString())
 	}
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	yyj3052++
+	if yyhl3052 {
+		yyb3052 = yyj3052 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3052 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3052 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Max = nil
 	} else {
-		yyv3046 := &x.Max
-		yyv3046.CodecDecodeSelf(d)
+		yyv3054 := &x.Max
+		yyv3054.CodecDecodeSelf(d)
 	}
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	yyj3052++
+	if yyhl3052 {
+		yyb3052 = yyj3052 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3052 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3052 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Min = nil
 	} else {
-		yyv3047 := &x.Min
-		yyv3047.CodecDecodeSelf(d)
+		yyv3055 := &x.Min
+		yyv3055.CodecDecodeSelf(d)
 	}
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	yyj3052++
+	if yyhl3052 {
+		yyb3052 = yyj3052 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3052 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3052 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Default = nil
 	} else {
-		yyv3048 := &x.Default
-		yyv3048.CodecDecodeSelf(d)
+		yyv3056 := &x.Default
+		yyv3056.CodecDecodeSelf(d)
 	}
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	yyj3052++
+	if yyhl3052 {
+		yyb3052 = yyj3052 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3052 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3052 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.DefaultRequest = nil
 	} else {
-		yyv3049 := &x.DefaultRequest
-		yyv3049.CodecDecodeSelf(d)
+		yyv3057 := &x.DefaultRequest
+		yyv3057.CodecDecodeSelf(d)
 	}
-	yyj3044++
-	if yyhl3044 {
-		yyb3044 = yyj3044 > l
+	yyj3052++
+	if yyhl3052 {
+		yyb3052 = yyj3052 > l
 	} else {
-		yyb3044 = r.CheckBreak()
+		yyb3052 = r.CheckBreak()
 	}
-	if yyb3044 {
+	if yyb3052 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxLimitRequestRatio = nil
 	} else {
-		yyv3050 := &x.MaxLimitRequestRatio
-		yyv3050.CodecDecodeSelf(d)
+		yyv3058 := &x.MaxLimitRequestRatio
+		yyv3058.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3044++
-		if yyhl3044 {
-			yyb3044 = yyj3044 > l
+		yyj3052++
+		if yyhl3052 {
+			yyb3052 = yyj3052 > l
 		} else {
-			yyb3044 = r.CheckBreak()
+			yyb3052 = r.CheckBreak()
 		}
-		if yyb3044 {
+		if yyb3052 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3044-1, "")
+		z.DecStructFieldNotFound(yyj3052-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35374,33 +35434,33 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3051 := z.EncBinary()
-		_ = yym3051
+		yym3059 := z.EncBinary()
+		_ = yym3059
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3052 := !z.EncBinary()
-			yy2arr3052 := z.EncBasicHandle().StructToArray
-			var yyq3052 [1]bool
-			_, _, _ = yysep3052, yyq3052, yy2arr3052
-			const yyr3052 bool = false
-			if yyr3052 || yy2arr3052 {
+			yysep3060 := !z.EncBinary()
+			yy2arr3060 := z.EncBasicHandle().StructToArray
+			var yyq3060 [1]bool
+			_, _, _ = yysep3060, yyq3060, yy2arr3060
+			const yyr3060 bool = false
+			if yyr3060 || yy2arr3060 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3052 int = 1
-				for _, b := range yyq3052 {
+				var yynn3060 int = 1
+				for _, b := range yyq3060 {
 					if b {
-						yynn3052++
+						yynn3060++
 					}
 				}
-				r.EncodeMapStart(yynn3052)
+				r.EncodeMapStart(yynn3060)
 			}
-			if yyr3052 || yy2arr3052 {
+			if yyr3060 || yy2arr3060 {
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
-					yym3054 := z.EncBinary()
-					_ = yym3054
+					yym3062 := z.EncBinary()
+					_ = yym3062
 					if false {
 					} else {
 						h.encSliceLimitRangeItem(([]LimitRangeItem)(x.Limits), e)
@@ -35411,15 +35471,15 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
-					yym3055 := z.EncBinary()
-					_ = yym3055
+					yym3063 := z.EncBinary()
+					_ = yym3063
 					if false {
 					} else {
 						h.encSliceLimitRangeItem(([]LimitRangeItem)(x.Limits), e)
 					}
 				}
 			}
-			if yysep3052 {
+			if yysep3060 {
 				r.EncodeEnd()
 			}
 		}
@@ -35430,24 +35490,24 @@ func (x *LimitRangeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3056 := z.DecBinary()
-	_ = yym3056
+	yym3064 := z.DecBinary()
+	_ = yym3064
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3057 := r.ReadMapStart()
-			if yyl3057 == 0 {
+			yyl3065 := r.ReadMapStart()
+			if yyl3065 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3057, d)
+				x.codecDecodeSelfFromMap(yyl3065, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3057 := r.ReadArrayStart()
-			if yyl3057 == 0 {
+			yyl3065 := r.ReadArrayStart()
+			if yyl3065 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3057, d)
+				x.codecDecodeSelfFromArray(yyl3065, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35459,12 +35519,12 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3058Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3058Slc
-	var yyhl3058 bool = l >= 0
-	for yyj3058 := 0; ; yyj3058++ {
-		if yyhl3058 {
-			if yyj3058 >= l {
+	var yys3066Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3066Slc
+	var yyhl3066 bool = l >= 0
+	for yyj3066 := 0; ; yyj3066++ {
+		if yyhl3066 {
+			if yyj3066 >= l {
 				break
 			}
 		} else {
@@ -35472,26 +35532,26 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3058Slc = r.DecodeBytes(yys3058Slc, true, true)
-		yys3058 := string(yys3058Slc)
-		switch yys3058 {
+		yys3066Slc = r.DecodeBytes(yys3066Slc, true, true)
+		yys3066 := string(yys3066Slc)
+		switch yys3066 {
 		case "limits":
 			if r.TryDecodeAsNil() {
 				x.Limits = nil
 			} else {
-				yyv3059 := &x.Limits
-				yym3060 := z.DecBinary()
-				_ = yym3060
+				yyv3067 := &x.Limits
+				yym3068 := z.DecBinary()
+				_ = yym3068
 				if false {
 				} else {
-					h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3059), d)
+					h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3067), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3058)
-		} // end switch yys3058
-	} // end for yyj3058
-	if !yyhl3058 {
+			z.DecStructFieldNotFound(-1, yys3066)
+		} // end switch yys3066
+	} // end for yyj3066
+	if !yyhl3066 {
 		r.ReadEnd()
 	}
 }
@@ -35500,41 +35560,41 @@ func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3061 int
-	var yyb3061 bool
-	var yyhl3061 bool = l >= 0
-	yyj3061++
-	if yyhl3061 {
-		yyb3061 = yyj3061 > l
+	var yyj3069 int
+	var yyb3069 bool
+	var yyhl3069 bool = l >= 0
+	yyj3069++
+	if yyhl3069 {
+		yyb3069 = yyj3069 > l
 	} else {
-		yyb3061 = r.CheckBreak()
+		yyb3069 = r.CheckBreak()
 	}
-	if yyb3061 {
+	if yyb3069 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Limits = nil
 	} else {
-		yyv3062 := &x.Limits
-		yym3063 := z.DecBinary()
-		_ = yym3063
+		yyv3070 := &x.Limits
+		yym3071 := z.DecBinary()
+		_ = yym3071
 		if false {
 		} else {
-			h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3062), d)
+			h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3070), d)
 		}
 	}
 	for {
-		yyj3061++
-		if yyhl3061 {
-			yyb3061 = yyj3061 > l
+		yyj3069++
+		if yyhl3069 {
+			yyb3069 = yyj3069 > l
 		} else {
-			yyb3061 = r.CheckBreak()
+			yyb3069 = r.CheckBreak()
 		}
-		if yyb3061 {
+		if yyb3069 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3061-1, "")
+		z.DecStructFieldNotFound(yyj3069-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35546,35 +35606,35 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3064 := z.EncBinary()
-		_ = yym3064
+		yym3072 := z.EncBinary()
+		_ = yym3072
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3065 := !z.EncBinary()
-			yy2arr3065 := z.EncBasicHandle().StructToArray
-			var yyq3065 [4]bool
-			_, _, _ = yysep3065, yyq3065, yy2arr3065
-			const yyr3065 bool = false
-			yyq3065[0] = x.Kind != ""
-			yyq3065[1] = x.APIVersion != ""
-			yyq3065[2] = true
-			yyq3065[3] = true
-			if yyr3065 || yy2arr3065 {
+			yysep3073 := !z.EncBinary()
+			yy2arr3073 := z.EncBasicHandle().StructToArray
+			var yyq3073 [4]bool
+			_, _, _ = yysep3073, yyq3073, yy2arr3073
+			const yyr3073 bool = false
+			yyq3073[0] = x.Kind != ""
+			yyq3073[1] = x.APIVersion != ""
+			yyq3073[2] = true
+			yyq3073[3] = true
+			if yyr3073 || yy2arr3073 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3065 int = 0
-				for _, b := range yyq3065 {
+				var yynn3073 int = 0
+				for _, b := range yyq3073 {
 					if b {
-						yynn3065++
+						yynn3073++
 					}
 				}
-				r.EncodeMapStart(yynn3065)
+				r.EncodeMapStart(yynn3073)
 			}
-			if yyr3065 || yy2arr3065 {
-				if yyq3065[0] {
-					yym3067 := z.EncBinary()
-					_ = yym3067
+			if yyr3073 || yy2arr3073 {
+				if yyq3073[0] {
+					yym3075 := z.EncBinary()
+					_ = yym3075
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -35583,20 +35643,20 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3065[0] {
+				if yyq3073[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3068 := z.EncBinary()
-					_ = yym3068
+					yym3076 := z.EncBinary()
+					_ = yym3076
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3065 || yy2arr3065 {
-				if yyq3065[1] {
-					yym3070 := z.EncBinary()
-					_ = yym3070
+			if yyr3073 || yy2arr3073 {
+				if yyq3073[1] {
+					yym3078 := z.EncBinary()
+					_ = yym3078
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -35605,45 +35665,45 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3065[1] {
+				if yyq3073[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3071 := z.EncBinary()
-					_ = yym3071
+					yym3079 := z.EncBinary()
+					_ = yym3079
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3065 || yy2arr3065 {
-				if yyq3065[2] {
-					yy3073 := &x.ObjectMeta
-					yy3073.CodecEncodeSelf(e)
+			if yyr3073 || yy2arr3073 {
+				if yyq3073[2] {
+					yy3081 := &x.ObjectMeta
+					yy3081.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3065[2] {
+				if yyq3073[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3074 := &x.ObjectMeta
-					yy3074.CodecEncodeSelf(e)
+					yy3082 := &x.ObjectMeta
+					yy3082.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3065 || yy2arr3065 {
-				if yyq3065[3] {
-					yy3076 := &x.Spec
-					yy3076.CodecEncodeSelf(e)
+			if yyr3073 || yy2arr3073 {
+				if yyq3073[3] {
+					yy3084 := &x.Spec
+					yy3084.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3065[3] {
+				if yyq3073[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy3077 := &x.Spec
-					yy3077.CodecEncodeSelf(e)
+					yy3085 := &x.Spec
+					yy3085.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3065 {
+			if yysep3073 {
 				r.EncodeEnd()
 			}
 		}
@@ -35654,24 +35714,24 @@ func (x *LimitRange) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3078 := z.DecBinary()
-	_ = yym3078
+	yym3086 := z.DecBinary()
+	_ = yym3086
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3079 := r.ReadMapStart()
-			if yyl3079 == 0 {
+			yyl3087 := r.ReadMapStart()
+			if yyl3087 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3079, d)
+				x.codecDecodeSelfFromMap(yyl3087, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3079 := r.ReadArrayStart()
-			if yyl3079 == 0 {
+			yyl3087 := r.ReadArrayStart()
+			if yyl3087 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3079, d)
+				x.codecDecodeSelfFromArray(yyl3087, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35683,12 +35743,12 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3080Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3080Slc
-	var yyhl3080 bool = l >= 0
-	for yyj3080 := 0; ; yyj3080++ {
-		if yyhl3080 {
-			if yyj3080 >= l {
+	var yys3088Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3088Slc
+	var yyhl3088 bool = l >= 0
+	for yyj3088 := 0; ; yyj3088++ {
+		if yyhl3088 {
+			if yyj3088 >= l {
 				break
 			}
 		} else {
@@ -35696,9 +35756,9 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3080Slc = r.DecodeBytes(yys3080Slc, true, true)
-		yys3080 := string(yys3080Slc)
-		switch yys3080 {
+		yys3088Slc = r.DecodeBytes(yys3088Slc, true, true)
+		yys3088 := string(yys3088Slc)
+		switch yys3088 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35715,21 +35775,21 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3083 := &x.ObjectMeta
-				yyv3083.CodecDecodeSelf(d)
+				yyv3091 := &x.ObjectMeta
+				yyv3091.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = LimitRangeSpec{}
 			} else {
-				yyv3084 := &x.Spec
-				yyv3084.CodecDecodeSelf(d)
+				yyv3092 := &x.Spec
+				yyv3092.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3080)
-		} // end switch yys3080
-	} // end for yyj3080
-	if !yyhl3080 {
+			z.DecStructFieldNotFound(-1, yys3088)
+		} // end switch yys3088
+	} // end for yyj3088
+	if !yyhl3088 {
 		r.ReadEnd()
 	}
 }
@@ -35738,16 +35798,16 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3085 int
-	var yyb3085 bool
-	var yyhl3085 bool = l >= 0
-	yyj3085++
-	if yyhl3085 {
-		yyb3085 = yyj3085 > l
+	var yyj3093 int
+	var yyb3093 bool
+	var yyhl3093 bool = l >= 0
+	yyj3093++
+	if yyhl3093 {
+		yyb3093 = yyj3093 > l
 	} else {
-		yyb3085 = r.CheckBreak()
+		yyb3093 = r.CheckBreak()
 	}
-	if yyb3085 {
+	if yyb3093 {
 		r.ReadEnd()
 		return
 	}
@@ -35756,13 +35816,13 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3085++
-	if yyhl3085 {
-		yyb3085 = yyj3085 > l
+	yyj3093++
+	if yyhl3093 {
+		yyb3093 = yyj3093 > l
 	} else {
-		yyb3085 = r.CheckBreak()
+		yyb3093 = r.CheckBreak()
 	}
-	if yyb3085 {
+	if yyb3093 {
 		r.ReadEnd()
 		return
 	}
@@ -35771,49 +35831,49 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3085++
-	if yyhl3085 {
-		yyb3085 = yyj3085 > l
+	yyj3093++
+	if yyhl3093 {
+		yyb3093 = yyj3093 > l
 	} else {
-		yyb3085 = r.CheckBreak()
+		yyb3093 = r.CheckBreak()
 	}
-	if yyb3085 {
+	if yyb3093 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3088 := &x.ObjectMeta
-		yyv3088.CodecDecodeSelf(d)
+		yyv3096 := &x.ObjectMeta
+		yyv3096.CodecDecodeSelf(d)
 	}
-	yyj3085++
-	if yyhl3085 {
-		yyb3085 = yyj3085 > l
+	yyj3093++
+	if yyhl3093 {
+		yyb3093 = yyj3093 > l
 	} else {
-		yyb3085 = r.CheckBreak()
+		yyb3093 = r.CheckBreak()
 	}
-	if yyb3085 {
+	if yyb3093 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = LimitRangeSpec{}
 	} else {
-		yyv3089 := &x.Spec
-		yyv3089.CodecDecodeSelf(d)
+		yyv3097 := &x.Spec
+		yyv3097.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3085++
-		if yyhl3085 {
-			yyb3085 = yyj3085 > l
+		yyj3093++
+		if yyhl3093 {
+			yyb3093 = yyj3093 > l
 		} else {
-			yyb3085 = r.CheckBreak()
+			yyb3093 = r.CheckBreak()
 		}
-		if yyb3085 {
+		if yyb3093 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3085-1, "")
+		z.DecStructFieldNotFound(yyj3093-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35825,34 +35885,34 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3090 := z.EncBinary()
-		_ = yym3090
+		yym3098 := z.EncBinary()
+		_ = yym3098
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3091 := !z.EncBinary()
-			yy2arr3091 := z.EncBasicHandle().StructToArray
-			var yyq3091 [4]bool
-			_, _, _ = yysep3091, yyq3091, yy2arr3091
-			const yyr3091 bool = false
-			yyq3091[0] = x.Kind != ""
-			yyq3091[1] = x.APIVersion != ""
-			yyq3091[2] = true
-			if yyr3091 || yy2arr3091 {
+			yysep3099 := !z.EncBinary()
+			yy2arr3099 := z.EncBasicHandle().StructToArray
+			var yyq3099 [4]bool
+			_, _, _ = yysep3099, yyq3099, yy2arr3099
+			const yyr3099 bool = false
+			yyq3099[0] = x.Kind != ""
+			yyq3099[1] = x.APIVersion != ""
+			yyq3099[2] = true
+			if yyr3099 || yy2arr3099 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3091 int = 1
-				for _, b := range yyq3091 {
+				var yynn3099 int = 1
+				for _, b := range yyq3099 {
 					if b {
-						yynn3091++
+						yynn3099++
 					}
 				}
-				r.EncodeMapStart(yynn3091)
+				r.EncodeMapStart(yynn3099)
 			}
-			if yyr3091 || yy2arr3091 {
-				if yyq3091[0] {
-					yym3093 := z.EncBinary()
-					_ = yym3093
+			if yyr3099 || yy2arr3099 {
+				if yyq3099[0] {
+					yym3101 := z.EncBinary()
+					_ = yym3101
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -35861,70 +35921,70 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3091[0] {
+				if yyq3099[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3094 := z.EncBinary()
-					_ = yym3094
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3091 || yy2arr3091 {
-				if yyq3091[1] {
-					yym3096 := z.EncBinary()
-					_ = yym3096
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3091[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3097 := z.EncBinary()
-					_ = yym3097
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3091 || yy2arr3091 {
-				if yyq3091[2] {
-					yy3099 := &x.ListMeta
-					yym3100 := z.EncBinary()
-					_ = yym3100
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3099) {
-					} else {
-						z.EncFallback(yy3099)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3091[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3101 := &x.ListMeta
 					yym3102 := z.EncBinary()
 					_ = yym3102
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3101) {
 					} else {
-						z.EncFallback(yy3101)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3091 || yy2arr3091 {
+			if yyr3099 || yy2arr3099 {
+				if yyq3099[1] {
+					yym3104 := z.EncBinary()
+					_ = yym3104
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3099[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3105 := z.EncBinary()
+					_ = yym3105
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr3099 || yy2arr3099 {
+				if yyq3099[2] {
+					yy3107 := &x.ListMeta
+					yym3108 := z.EncBinary()
+					_ = yym3108
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3107) {
+					} else {
+						z.EncFallback(yy3107)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3099[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3109 := &x.ListMeta
+					yym3110 := z.EncBinary()
+					_ = yym3110
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3109) {
+					} else {
+						z.EncFallback(yy3109)
+					}
+				}
+			}
+			if yyr3099 || yy2arr3099 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3104 := z.EncBinary()
-					_ = yym3104
+					yym3112 := z.EncBinary()
+					_ = yym3112
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
@@ -35935,15 +35995,15 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3105 := z.EncBinary()
-					_ = yym3105
+					yym3113 := z.EncBinary()
+					_ = yym3113
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
 					}
 				}
 			}
-			if yysep3091 {
+			if yysep3099 {
 				r.EncodeEnd()
 			}
 		}
@@ -35954,24 +36014,24 @@ func (x *LimitRangeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3106 := z.DecBinary()
-	_ = yym3106
+	yym3114 := z.DecBinary()
+	_ = yym3114
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3107 := r.ReadMapStart()
-			if yyl3107 == 0 {
+			yyl3115 := r.ReadMapStart()
+			if yyl3115 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3107, d)
+				x.codecDecodeSelfFromMap(yyl3115, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3107 := r.ReadArrayStart()
-			if yyl3107 == 0 {
+			yyl3115 := r.ReadArrayStart()
+			if yyl3115 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3107, d)
+				x.codecDecodeSelfFromArray(yyl3115, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35983,12 +36043,12 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3108Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3108Slc
-	var yyhl3108 bool = l >= 0
-	for yyj3108 := 0; ; yyj3108++ {
-		if yyhl3108 {
-			if yyj3108 >= l {
+	var yys3116Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3116Slc
+	var yyhl3116 bool = l >= 0
+	for yyj3116 := 0; ; yyj3116++ {
+		if yyhl3116 {
+			if yyj3116 >= l {
 				break
 			}
 		} else {
@@ -35996,9 +36056,9 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3108Slc = r.DecodeBytes(yys3108Slc, true, true)
-		yys3108 := string(yys3108Slc)
-		switch yys3108 {
+		yys3116Slc = r.DecodeBytes(yys3116Slc, true, true)
+		yys3116 := string(yys3116Slc)
+		switch yys3116 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -36015,32 +36075,32 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3111 := &x.ListMeta
-				yym3112 := z.DecBinary()
-				_ = yym3112
+				yyv3119 := &x.ListMeta
+				yym3120 := z.DecBinary()
+				_ = yym3120
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3111) {
+				} else if z.HasExtensions() && z.DecExt(yyv3119) {
 				} else {
-					z.DecFallback(yyv3111, false)
+					z.DecFallback(yyv3119, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3113 := &x.Items
-				yym3114 := z.DecBinary()
-				_ = yym3114
+				yyv3121 := &x.Items
+				yym3122 := z.DecBinary()
+				_ = yym3122
 				if false {
 				} else {
-					h.decSliceLimitRange((*[]LimitRange)(yyv3113), d)
+					h.decSliceLimitRange((*[]LimitRange)(yyv3121), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3108)
-		} // end switch yys3108
-	} // end for yyj3108
-	if !yyhl3108 {
+			z.DecStructFieldNotFound(-1, yys3116)
+		} // end switch yys3116
+	} // end for yyj3116
+	if !yyhl3116 {
 		r.ReadEnd()
 	}
 }
@@ -36049,16 +36109,16 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3115 int
-	var yyb3115 bool
-	var yyhl3115 bool = l >= 0
-	yyj3115++
-	if yyhl3115 {
-		yyb3115 = yyj3115 > l
+	var yyj3123 int
+	var yyb3123 bool
+	var yyhl3123 bool = l >= 0
+	yyj3123++
+	if yyhl3123 {
+		yyb3123 = yyj3123 > l
 	} else {
-		yyb3115 = r.CheckBreak()
+		yyb3123 = r.CheckBreak()
 	}
-	if yyb3115 {
+	if yyb3123 {
 		r.ReadEnd()
 		return
 	}
@@ -36067,13 +36127,13 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3115++
-	if yyhl3115 {
-		yyb3115 = yyj3115 > l
+	yyj3123++
+	if yyhl3123 {
+		yyb3123 = yyj3123 > l
 	} else {
-		yyb3115 = r.CheckBreak()
+		yyb3123 = r.CheckBreak()
 	}
-	if yyb3115 {
+	if yyb3123 {
 		r.ReadEnd()
 		return
 	}
@@ -36082,60 +36142,60 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3115++
-	if yyhl3115 {
-		yyb3115 = yyj3115 > l
+	yyj3123++
+	if yyhl3123 {
+		yyb3123 = yyj3123 > l
 	} else {
-		yyb3115 = r.CheckBreak()
+		yyb3123 = r.CheckBreak()
 	}
-	if yyb3115 {
+	if yyb3123 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3118 := &x.ListMeta
-		yym3119 := z.DecBinary()
-		_ = yym3119
+		yyv3126 := &x.ListMeta
+		yym3127 := z.DecBinary()
+		_ = yym3127
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3118) {
+		} else if z.HasExtensions() && z.DecExt(yyv3126) {
 		} else {
-			z.DecFallback(yyv3118, false)
+			z.DecFallback(yyv3126, false)
 		}
 	}
-	yyj3115++
-	if yyhl3115 {
-		yyb3115 = yyj3115 > l
+	yyj3123++
+	if yyhl3123 {
+		yyb3123 = yyj3123 > l
 	} else {
-		yyb3115 = r.CheckBreak()
+		yyb3123 = r.CheckBreak()
 	}
-	if yyb3115 {
+	if yyb3123 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3120 := &x.Items
-		yym3121 := z.DecBinary()
-		_ = yym3121
+		yyv3128 := &x.Items
+		yym3129 := z.DecBinary()
+		_ = yym3129
 		if false {
 		} else {
-			h.decSliceLimitRange((*[]LimitRange)(yyv3120), d)
+			h.decSliceLimitRange((*[]LimitRange)(yyv3128), d)
 		}
 	}
 	for {
-		yyj3115++
-		if yyhl3115 {
-			yyb3115 = yyj3115 > l
+		yyj3123++
+		if yyhl3123 {
+			yyb3123 = yyj3123 > l
 		} else {
-			yyb3115 = r.CheckBreak()
+			yyb3123 = r.CheckBreak()
 		}
-		if yyb3115 {
+		if yyb3123 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3115-1, "")
+		z.DecStructFieldNotFound(yyj3123-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36147,30 +36207,30 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3122 := z.EncBinary()
-		_ = yym3122
+		yym3130 := z.EncBinary()
+		_ = yym3130
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3123 := !z.EncBinary()
-			yy2arr3123 := z.EncBasicHandle().StructToArray
-			var yyq3123 [1]bool
-			_, _, _ = yysep3123, yyq3123, yy2arr3123
-			const yyr3123 bool = false
-			yyq3123[0] = len(x.Hard) != 0
-			if yyr3123 || yy2arr3123 {
+			yysep3131 := !z.EncBinary()
+			yy2arr3131 := z.EncBasicHandle().StructToArray
+			var yyq3131 [1]bool
+			_, _, _ = yysep3131, yyq3131, yy2arr3131
+			const yyr3131 bool = false
+			yyq3131[0] = len(x.Hard) != 0
+			if yyr3131 || yy2arr3131 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3123 int = 0
-				for _, b := range yyq3123 {
+				var yynn3131 int = 0
+				for _, b := range yyq3131 {
 					if b {
-						yynn3123++
+						yynn3131++
 					}
 				}
-				r.EncodeMapStart(yynn3123)
+				r.EncodeMapStart(yynn3131)
 			}
-			if yyr3123 || yy2arr3123 {
-				if yyq3123[0] {
+			if yyr3131 || yy2arr3131 {
+				if yyq3131[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36180,7 +36240,7 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3123[0] {
+				if yyq3131[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36189,7 +36249,7 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3123 {
+			if yysep3131 {
 				r.EncodeEnd()
 			}
 		}
@@ -36200,24 +36260,24 @@ func (x *ResourceQuotaSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3125 := z.DecBinary()
-	_ = yym3125
+	yym3133 := z.DecBinary()
+	_ = yym3133
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3126 := r.ReadMapStart()
-			if yyl3126 == 0 {
+			yyl3134 := r.ReadMapStart()
+			if yyl3134 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3126, d)
+				x.codecDecodeSelfFromMap(yyl3134, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3126 := r.ReadArrayStart()
-			if yyl3126 == 0 {
+			yyl3134 := r.ReadArrayStart()
+			if yyl3134 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3126, d)
+				x.codecDecodeSelfFromArray(yyl3134, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36229,12 +36289,12 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3127Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3127Slc
-	var yyhl3127 bool = l >= 0
-	for yyj3127 := 0; ; yyj3127++ {
-		if yyhl3127 {
-			if yyj3127 >= l {
+	var yys3135Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3135Slc
+	var yyhl3135 bool = l >= 0
+	for yyj3135 := 0; ; yyj3135++ {
+		if yyhl3135 {
+			if yyj3135 >= l {
 				break
 			}
 		} else {
@@ -36242,21 +36302,21 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys3127Slc = r.DecodeBytes(yys3127Slc, true, true)
-		yys3127 := string(yys3127Slc)
-		switch yys3127 {
+		yys3135Slc = r.DecodeBytes(yys3135Slc, true, true)
+		yys3135 := string(yys3135Slc)
+		switch yys3135 {
 		case "hard":
 			if r.TryDecodeAsNil() {
 				x.Hard = nil
 			} else {
-				yyv3128 := &x.Hard
-				yyv3128.CodecDecodeSelf(d)
+				yyv3136 := &x.Hard
+				yyv3136.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3127)
-		} // end switch yys3127
-	} // end for yyj3127
-	if !yyhl3127 {
+			z.DecStructFieldNotFound(-1, yys3135)
+		} // end switch yys3135
+	} // end for yyj3135
+	if !yyhl3135 {
 		r.ReadEnd()
 	}
 }
@@ -36265,36 +36325,36 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3129 int
-	var yyb3129 bool
-	var yyhl3129 bool = l >= 0
-	yyj3129++
-	if yyhl3129 {
-		yyb3129 = yyj3129 > l
+	var yyj3137 int
+	var yyb3137 bool
+	var yyhl3137 bool = l >= 0
+	yyj3137++
+	if yyhl3137 {
+		yyb3137 = yyj3137 > l
 	} else {
-		yyb3129 = r.CheckBreak()
+		yyb3137 = r.CheckBreak()
 	}
-	if yyb3129 {
+	if yyb3137 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
-		yyv3130 := &x.Hard
-		yyv3130.CodecDecodeSelf(d)
+		yyv3138 := &x.Hard
+		yyv3138.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3129++
-		if yyhl3129 {
-			yyb3129 = yyj3129 > l
+		yyj3137++
+		if yyhl3137 {
+			yyb3137 = yyj3137 > l
 		} else {
-			yyb3129 = r.CheckBreak()
+			yyb3137 = r.CheckBreak()
 		}
-		if yyb3129 {
+		if yyb3137 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3129-1, "")
+		z.DecStructFieldNotFound(yyj3137-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36306,31 +36366,31 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3131 := z.EncBinary()
-		_ = yym3131
+		yym3139 := z.EncBinary()
+		_ = yym3139
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3132 := !z.EncBinary()
-			yy2arr3132 := z.EncBasicHandle().StructToArray
-			var yyq3132 [2]bool
-			_, _, _ = yysep3132, yyq3132, yy2arr3132
-			const yyr3132 bool = false
-			yyq3132[0] = len(x.Hard) != 0
-			yyq3132[1] = len(x.Used) != 0
-			if yyr3132 || yy2arr3132 {
+			yysep3140 := !z.EncBinary()
+			yy2arr3140 := z.EncBasicHandle().StructToArray
+			var yyq3140 [2]bool
+			_, _, _ = yysep3140, yyq3140, yy2arr3140
+			const yyr3140 bool = false
+			yyq3140[0] = len(x.Hard) != 0
+			yyq3140[1] = len(x.Used) != 0
+			if yyr3140 || yy2arr3140 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn3132 int = 0
-				for _, b := range yyq3132 {
+				var yynn3140 int = 0
+				for _, b := range yyq3140 {
 					if b {
-						yynn3132++
+						yynn3140++
 					}
 				}
-				r.EncodeMapStart(yynn3132)
+				r.EncodeMapStart(yynn3140)
 			}
-			if yyr3132 || yy2arr3132 {
-				if yyq3132[0] {
+			if yyr3140 || yy2arr3140 {
+				if yyq3140[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36340,7 +36400,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3132[0] {
+				if yyq3140[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36349,8 +36409,8 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3132 || yy2arr3132 {
-				if yyq3132[1] {
+			if yyr3140 || yy2arr3140 {
+				if yyq3140[1] {
 					if x.Used == nil {
 						r.EncodeNil()
 					} else {
@@ -36360,7 +36420,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3132[1] {
+				if yyq3140[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("used"))
 					if x.Used == nil {
 						r.EncodeNil()
@@ -36369,7 +36429,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3132 {
+			if yysep3140 {
 				r.EncodeEnd()
 			}
 		}
@@ -36380,24 +36440,24 @@ func (x *ResourceQuotaStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3135 := z.DecBinary()
-	_ = yym3135
+	yym3143 := z.DecBinary()
+	_ = yym3143
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3136 := r.ReadMapStart()
-			if yyl3136 == 0 {
+			yyl3144 := r.ReadMapStart()
+			if yyl3144 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3136, d)
+				x.codecDecodeSelfFromMap(yyl3144, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3136 := r.ReadArrayStart()
-			if yyl3136 == 0 {
+			yyl3144 := r.ReadArrayStart()
+			if yyl3144 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3136, d)
+				x.codecDecodeSelfFromArray(yyl3144, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36409,12 +36469,12 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3137Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3137Slc
-	var yyhl3137 bool = l >= 0
-	for yyj3137 := 0; ; yyj3137++ {
-		if yyhl3137 {
-			if yyj3137 >= l {
+	var yys3145Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3145Slc
+	var yyhl3145 bool = l >= 0
+	for yyj3145 := 0; ; yyj3145++ {
+		if yyhl3145 {
+			if yyj3145 >= l {
 				break
 			}
 		} else {
@@ -36422,28 +36482,28 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys3137Slc = r.DecodeBytes(yys3137Slc, true, true)
-		yys3137 := string(yys3137Slc)
-		switch yys3137 {
+		yys3145Slc = r.DecodeBytes(yys3145Slc, true, true)
+		yys3145 := string(yys3145Slc)
+		switch yys3145 {
 		case "hard":
 			if r.TryDecodeAsNil() {
 				x.Hard = nil
 			} else {
-				yyv3138 := &x.Hard
-				yyv3138.CodecDecodeSelf(d)
+				yyv3146 := &x.Hard
+				yyv3146.CodecDecodeSelf(d)
 			}
 		case "used":
 			if r.TryDecodeAsNil() {
 				x.Used = nil
 			} else {
-				yyv3139 := &x.Used
-				yyv3139.CodecDecodeSelf(d)
+				yyv3147 := &x.Used
+				yyv3147.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3137)
-		} // end switch yys3137
-	} // end for yyj3137
-	if !yyhl3137 {
+			z.DecStructFieldNotFound(-1, yys3145)
+		} // end switch yys3145
+	} // end for yyj3145
+	if !yyhl3145 {
 		r.ReadEnd()
 	}
 }
@@ -36452,52 +36512,52 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3140 int
-	var yyb3140 bool
-	var yyhl3140 bool = l >= 0
-	yyj3140++
-	if yyhl3140 {
-		yyb3140 = yyj3140 > l
+	var yyj3148 int
+	var yyb3148 bool
+	var yyhl3148 bool = l >= 0
+	yyj3148++
+	if yyhl3148 {
+		yyb3148 = yyj3148 > l
 	} else {
-		yyb3140 = r.CheckBreak()
+		yyb3148 = r.CheckBreak()
 	}
-	if yyb3140 {
+	if yyb3148 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
-		yyv3141 := &x.Hard
-		yyv3141.CodecDecodeSelf(d)
+		yyv3149 := &x.Hard
+		yyv3149.CodecDecodeSelf(d)
 	}
-	yyj3140++
-	if yyhl3140 {
-		yyb3140 = yyj3140 > l
+	yyj3148++
+	if yyhl3148 {
+		yyb3148 = yyj3148 > l
 	} else {
-		yyb3140 = r.CheckBreak()
+		yyb3148 = r.CheckBreak()
 	}
-	if yyb3140 {
+	if yyb3148 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Used = nil
 	} else {
-		yyv3142 := &x.Used
-		yyv3142.CodecDecodeSelf(d)
+		yyv3150 := &x.Used
+		yyv3150.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3140++
-		if yyhl3140 {
-			yyb3140 = yyj3140 > l
+		yyj3148++
+		if yyhl3148 {
+			yyb3148 = yyj3148 > l
 		} else {
-			yyb3140 = r.CheckBreak()
+			yyb3148 = r.CheckBreak()
 		}
-		if yyb3140 {
+		if yyb3148 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3140-1, "")
+		z.DecStructFieldNotFound(yyj3148-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36509,36 +36569,36 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3143 := z.EncBinary()
-		_ = yym3143
+		yym3151 := z.EncBinary()
+		_ = yym3151
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3144 := !z.EncBinary()
-			yy2arr3144 := z.EncBasicHandle().StructToArray
-			var yyq3144 [5]bool
-			_, _, _ = yysep3144, yyq3144, yy2arr3144
-			const yyr3144 bool = false
-			yyq3144[0] = x.Kind != ""
-			yyq3144[1] = x.APIVersion != ""
-			yyq3144[2] = true
-			yyq3144[3] = true
-			yyq3144[4] = true
-			if yyr3144 || yy2arr3144 {
+			yysep3152 := !z.EncBinary()
+			yy2arr3152 := z.EncBasicHandle().StructToArray
+			var yyq3152 [5]bool
+			_, _, _ = yysep3152, yyq3152, yy2arr3152
+			const yyr3152 bool = false
+			yyq3152[0] = x.Kind != ""
+			yyq3152[1] = x.APIVersion != ""
+			yyq3152[2] = true
+			yyq3152[3] = true
+			yyq3152[4] = true
+			if yyr3152 || yy2arr3152 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3144 int = 0
-				for _, b := range yyq3144 {
+				var yynn3152 int = 0
+				for _, b := range yyq3152 {
 					if b {
-						yynn3144++
+						yynn3152++
 					}
 				}
-				r.EncodeMapStart(yynn3144)
+				r.EncodeMapStart(yynn3152)
 			}
-			if yyr3144 || yy2arr3144 {
-				if yyq3144[0] {
-					yym3146 := z.EncBinary()
-					_ = yym3146
+			if yyr3152 || yy2arr3152 {
+				if yyq3152[0] {
+					yym3154 := z.EncBinary()
+					_ = yym3154
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -36547,20 +36607,20 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3144[0] {
+				if yyq3152[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3147 := z.EncBinary()
-					_ = yym3147
+					yym3155 := z.EncBinary()
+					_ = yym3155
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3144 || yy2arr3144 {
-				if yyq3144[1] {
-					yym3149 := z.EncBinary()
-					_ = yym3149
+			if yyr3152 || yy2arr3152 {
+				if yyq3152[1] {
+					yym3157 := z.EncBinary()
+					_ = yym3157
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -36569,59 +36629,59 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3144[1] {
+				if yyq3152[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3150 := z.EncBinary()
-					_ = yym3150
+					yym3158 := z.EncBinary()
+					_ = yym3158
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3144 || yy2arr3144 {
-				if yyq3144[2] {
-					yy3152 := &x.ObjectMeta
-					yy3152.CodecEncodeSelf(e)
+			if yyr3152 || yy2arr3152 {
+				if yyq3152[2] {
+					yy3160 := &x.ObjectMeta
+					yy3160.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3144[2] {
+				if yyq3152[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3153 := &x.ObjectMeta
-					yy3153.CodecEncodeSelf(e)
+					yy3161 := &x.ObjectMeta
+					yy3161.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3144 || yy2arr3144 {
-				if yyq3144[3] {
-					yy3155 := &x.Spec
-					yy3155.CodecEncodeSelf(e)
+			if yyr3152 || yy2arr3152 {
+				if yyq3152[3] {
+					yy3163 := &x.Spec
+					yy3163.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3144[3] {
+				if yyq3152[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy3156 := &x.Spec
-					yy3156.CodecEncodeSelf(e)
+					yy3164 := &x.Spec
+					yy3164.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3144 || yy2arr3144 {
-				if yyq3144[4] {
-					yy3158 := &x.Status
-					yy3158.CodecEncodeSelf(e)
+			if yyr3152 || yy2arr3152 {
+				if yyq3152[4] {
+					yy3166 := &x.Status
+					yy3166.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3144[4] {
+				if yyq3152[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy3159 := &x.Status
-					yy3159.CodecEncodeSelf(e)
+					yy3167 := &x.Status
+					yy3167.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3144 {
+			if yysep3152 {
 				r.EncodeEnd()
 			}
 		}
@@ -36632,24 +36692,24 @@ func (x *ResourceQuota) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3160 := z.DecBinary()
-	_ = yym3160
+	yym3168 := z.DecBinary()
+	_ = yym3168
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3161 := r.ReadMapStart()
-			if yyl3161 == 0 {
+			yyl3169 := r.ReadMapStart()
+			if yyl3169 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3161, d)
+				x.codecDecodeSelfFromMap(yyl3169, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3161 := r.ReadArrayStart()
-			if yyl3161 == 0 {
+			yyl3169 := r.ReadArrayStart()
+			if yyl3169 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3161, d)
+				x.codecDecodeSelfFromArray(yyl3169, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36661,12 +36721,12 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3162Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3162Slc
-	var yyhl3162 bool = l >= 0
-	for yyj3162 := 0; ; yyj3162++ {
-		if yyhl3162 {
-			if yyj3162 >= l {
+	var yys3170Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3170Slc
+	var yyhl3170 bool = l >= 0
+	for yyj3170 := 0; ; yyj3170++ {
+		if yyhl3170 {
+			if yyj3170 >= l {
 				break
 			}
 		} else {
@@ -36674,9 +36734,9 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3162Slc = r.DecodeBytes(yys3162Slc, true, true)
-		yys3162 := string(yys3162Slc)
-		switch yys3162 {
+		yys3170Slc = r.DecodeBytes(yys3170Slc, true, true)
+		yys3170 := string(yys3170Slc)
+		switch yys3170 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -36693,28 +36753,28 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3165 := &x.ObjectMeta
-				yyv3165.CodecDecodeSelf(d)
+				yyv3173 := &x.ObjectMeta
+				yyv3173.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ResourceQuotaSpec{}
 			} else {
-				yyv3166 := &x.Spec
-				yyv3166.CodecDecodeSelf(d)
+				yyv3174 := &x.Spec
+				yyv3174.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ResourceQuotaStatus{}
 			} else {
-				yyv3167 := &x.Status
-				yyv3167.CodecDecodeSelf(d)
+				yyv3175 := &x.Status
+				yyv3175.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3162)
-		} // end switch yys3162
-	} // end for yyj3162
-	if !yyhl3162 {
+			z.DecStructFieldNotFound(-1, yys3170)
+		} // end switch yys3170
+	} // end for yyj3170
+	if !yyhl3170 {
 		r.ReadEnd()
 	}
 }
@@ -36723,16 +36783,16 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3168 int
-	var yyb3168 bool
-	var yyhl3168 bool = l >= 0
-	yyj3168++
-	if yyhl3168 {
-		yyb3168 = yyj3168 > l
+	var yyj3176 int
+	var yyb3176 bool
+	var yyhl3176 bool = l >= 0
+	yyj3176++
+	if yyhl3176 {
+		yyb3176 = yyj3176 > l
 	} else {
-		yyb3168 = r.CheckBreak()
+		yyb3176 = r.CheckBreak()
 	}
-	if yyb3168 {
+	if yyb3176 {
 		r.ReadEnd()
 		return
 	}
@@ -36741,13 +36801,13 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3168++
-	if yyhl3168 {
-		yyb3168 = yyj3168 > l
+	yyj3176++
+	if yyhl3176 {
+		yyb3176 = yyj3176 > l
 	} else {
-		yyb3168 = r.CheckBreak()
+		yyb3176 = r.CheckBreak()
 	}
-	if yyb3168 {
+	if yyb3176 {
 		r.ReadEnd()
 		return
 	}
@@ -36756,65 +36816,65 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3168++
-	if yyhl3168 {
-		yyb3168 = yyj3168 > l
+	yyj3176++
+	if yyhl3176 {
+		yyb3176 = yyj3176 > l
 	} else {
-		yyb3168 = r.CheckBreak()
+		yyb3176 = r.CheckBreak()
 	}
-	if yyb3168 {
+	if yyb3176 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3171 := &x.ObjectMeta
-		yyv3171.CodecDecodeSelf(d)
+		yyv3179 := &x.ObjectMeta
+		yyv3179.CodecDecodeSelf(d)
 	}
-	yyj3168++
-	if yyhl3168 {
-		yyb3168 = yyj3168 > l
+	yyj3176++
+	if yyhl3176 {
+		yyb3176 = yyj3176 > l
 	} else {
-		yyb3168 = r.CheckBreak()
+		yyb3176 = r.CheckBreak()
 	}
-	if yyb3168 {
+	if yyb3176 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ResourceQuotaSpec{}
 	} else {
-		yyv3172 := &x.Spec
-		yyv3172.CodecDecodeSelf(d)
+		yyv3180 := &x.Spec
+		yyv3180.CodecDecodeSelf(d)
 	}
-	yyj3168++
-	if yyhl3168 {
-		yyb3168 = yyj3168 > l
+	yyj3176++
+	if yyhl3176 {
+		yyb3176 = yyj3176 > l
 	} else {
-		yyb3168 = r.CheckBreak()
+		yyb3176 = r.CheckBreak()
 	}
-	if yyb3168 {
+	if yyb3176 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ResourceQuotaStatus{}
 	} else {
-		yyv3173 := &x.Status
-		yyv3173.CodecDecodeSelf(d)
+		yyv3181 := &x.Status
+		yyv3181.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3168++
-		if yyhl3168 {
-			yyb3168 = yyj3168 > l
+		yyj3176++
+		if yyhl3176 {
+			yyb3176 = yyj3176 > l
 		} else {
-			yyb3168 = r.CheckBreak()
+			yyb3176 = r.CheckBreak()
 		}
-		if yyb3168 {
+		if yyb3176 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3168-1, "")
+		z.DecStructFieldNotFound(yyj3176-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36826,34 +36886,34 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3174 := z.EncBinary()
-		_ = yym3174
+		yym3182 := z.EncBinary()
+		_ = yym3182
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3175 := !z.EncBinary()
-			yy2arr3175 := z.EncBasicHandle().StructToArray
-			var yyq3175 [4]bool
-			_, _, _ = yysep3175, yyq3175, yy2arr3175
-			const yyr3175 bool = false
-			yyq3175[0] = x.Kind != ""
-			yyq3175[1] = x.APIVersion != ""
-			yyq3175[2] = true
-			if yyr3175 || yy2arr3175 {
+			yysep3183 := !z.EncBinary()
+			yy2arr3183 := z.EncBasicHandle().StructToArray
+			var yyq3183 [4]bool
+			_, _, _ = yysep3183, yyq3183, yy2arr3183
+			const yyr3183 bool = false
+			yyq3183[0] = x.Kind != ""
+			yyq3183[1] = x.APIVersion != ""
+			yyq3183[2] = true
+			if yyr3183 || yy2arr3183 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3175 int = 1
-				for _, b := range yyq3175 {
+				var yynn3183 int = 1
+				for _, b := range yyq3183 {
 					if b {
-						yynn3175++
+						yynn3183++
 					}
 				}
-				r.EncodeMapStart(yynn3175)
+				r.EncodeMapStart(yynn3183)
 			}
-			if yyr3175 || yy2arr3175 {
-				if yyq3175[0] {
-					yym3177 := z.EncBinary()
-					_ = yym3177
+			if yyr3183 || yy2arr3183 {
+				if yyq3183[0] {
+					yym3185 := z.EncBinary()
+					_ = yym3185
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -36862,70 +36922,70 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3175[0] {
+				if yyq3183[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3178 := z.EncBinary()
-					_ = yym3178
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3175 || yy2arr3175 {
-				if yyq3175[1] {
-					yym3180 := z.EncBinary()
-					_ = yym3180
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3175[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3181 := z.EncBinary()
-					_ = yym3181
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3175 || yy2arr3175 {
-				if yyq3175[2] {
-					yy3183 := &x.ListMeta
-					yym3184 := z.EncBinary()
-					_ = yym3184
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3183) {
-					} else {
-						z.EncFallback(yy3183)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3175[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3185 := &x.ListMeta
 					yym3186 := z.EncBinary()
 					_ = yym3186
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3185) {
 					} else {
-						z.EncFallback(yy3185)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3175 || yy2arr3175 {
+			if yyr3183 || yy2arr3183 {
+				if yyq3183[1] {
+					yym3188 := z.EncBinary()
+					_ = yym3188
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3183[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3189 := z.EncBinary()
+					_ = yym3189
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr3183 || yy2arr3183 {
+				if yyq3183[2] {
+					yy3191 := &x.ListMeta
+					yym3192 := z.EncBinary()
+					_ = yym3192
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3191) {
+					} else {
+						z.EncFallback(yy3191)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3183[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3193 := &x.ListMeta
+					yym3194 := z.EncBinary()
+					_ = yym3194
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3193) {
+					} else {
+						z.EncFallback(yy3193)
+					}
+				}
+			}
+			if yyr3183 || yy2arr3183 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3188 := z.EncBinary()
-					_ = yym3188
+					yym3196 := z.EncBinary()
+					_ = yym3196
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
@@ -36936,15 +36996,15 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3189 := z.EncBinary()
-					_ = yym3189
+					yym3197 := z.EncBinary()
+					_ = yym3197
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
 					}
 				}
 			}
-			if yysep3175 {
+			if yysep3183 {
 				r.EncodeEnd()
 			}
 		}
@@ -36955,24 +37015,24 @@ func (x *ResourceQuotaList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3190 := z.DecBinary()
-	_ = yym3190
+	yym3198 := z.DecBinary()
+	_ = yym3198
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3191 := r.ReadMapStart()
-			if yyl3191 == 0 {
+			yyl3199 := r.ReadMapStart()
+			if yyl3199 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3191, d)
+				x.codecDecodeSelfFromMap(yyl3199, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3191 := r.ReadArrayStart()
-			if yyl3191 == 0 {
+			yyl3199 := r.ReadArrayStart()
+			if yyl3199 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3191, d)
+				x.codecDecodeSelfFromArray(yyl3199, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36984,12 +37044,12 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3192Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3192Slc
-	var yyhl3192 bool = l >= 0
-	for yyj3192 := 0; ; yyj3192++ {
-		if yyhl3192 {
-			if yyj3192 >= l {
+	var yys3200Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3200Slc
+	var yyhl3200 bool = l >= 0
+	for yyj3200 := 0; ; yyj3200++ {
+		if yyhl3200 {
+			if yyj3200 >= l {
 				break
 			}
 		} else {
@@ -36997,9 +37057,9 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys3192Slc = r.DecodeBytes(yys3192Slc, true, true)
-		yys3192 := string(yys3192Slc)
-		switch yys3192 {
+		yys3200Slc = r.DecodeBytes(yys3200Slc, true, true)
+		yys3200 := string(yys3200Slc)
+		switch yys3200 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37016,32 +37076,32 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3195 := &x.ListMeta
-				yym3196 := z.DecBinary()
-				_ = yym3196
+				yyv3203 := &x.ListMeta
+				yym3204 := z.DecBinary()
+				_ = yym3204
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3195) {
+				} else if z.HasExtensions() && z.DecExt(yyv3203) {
 				} else {
-					z.DecFallback(yyv3195, false)
+					z.DecFallback(yyv3203, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3197 := &x.Items
-				yym3198 := z.DecBinary()
-				_ = yym3198
+				yyv3205 := &x.Items
+				yym3206 := z.DecBinary()
+				_ = yym3206
 				if false {
 				} else {
-					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3197), d)
+					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3205), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3192)
-		} // end switch yys3192
-	} // end for yyj3192
-	if !yyhl3192 {
+			z.DecStructFieldNotFound(-1, yys3200)
+		} // end switch yys3200
+	} // end for yyj3200
+	if !yyhl3200 {
 		r.ReadEnd()
 	}
 }
@@ -37050,16 +37110,16 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3199 int
-	var yyb3199 bool
-	var yyhl3199 bool = l >= 0
-	yyj3199++
-	if yyhl3199 {
-		yyb3199 = yyj3199 > l
+	var yyj3207 int
+	var yyb3207 bool
+	var yyhl3207 bool = l >= 0
+	yyj3207++
+	if yyhl3207 {
+		yyb3207 = yyj3207 > l
 	} else {
-		yyb3199 = r.CheckBreak()
+		yyb3207 = r.CheckBreak()
 	}
-	if yyb3199 {
+	if yyb3207 {
 		r.ReadEnd()
 		return
 	}
@@ -37068,13 +37128,13 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3199++
-	if yyhl3199 {
-		yyb3199 = yyj3199 > l
+	yyj3207++
+	if yyhl3207 {
+		yyb3207 = yyj3207 > l
 	} else {
-		yyb3199 = r.CheckBreak()
+		yyb3207 = r.CheckBreak()
 	}
-	if yyb3199 {
+	if yyb3207 {
 		r.ReadEnd()
 		return
 	}
@@ -37083,60 +37143,60 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3199++
-	if yyhl3199 {
-		yyb3199 = yyj3199 > l
+	yyj3207++
+	if yyhl3207 {
+		yyb3207 = yyj3207 > l
 	} else {
-		yyb3199 = r.CheckBreak()
+		yyb3207 = r.CheckBreak()
 	}
-	if yyb3199 {
+	if yyb3207 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3202 := &x.ListMeta
-		yym3203 := z.DecBinary()
-		_ = yym3203
+		yyv3210 := &x.ListMeta
+		yym3211 := z.DecBinary()
+		_ = yym3211
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3202) {
+		} else if z.HasExtensions() && z.DecExt(yyv3210) {
 		} else {
-			z.DecFallback(yyv3202, false)
+			z.DecFallback(yyv3210, false)
 		}
 	}
-	yyj3199++
-	if yyhl3199 {
-		yyb3199 = yyj3199 > l
+	yyj3207++
+	if yyhl3207 {
+		yyb3207 = yyj3207 > l
 	} else {
-		yyb3199 = r.CheckBreak()
+		yyb3207 = r.CheckBreak()
 	}
-	if yyb3199 {
+	if yyb3207 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3204 := &x.Items
-		yym3205 := z.DecBinary()
-		_ = yym3205
+		yyv3212 := &x.Items
+		yym3213 := z.DecBinary()
+		_ = yym3213
 		if false {
 		} else {
-			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3204), d)
+			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3212), d)
 		}
 	}
 	for {
-		yyj3199++
-		if yyhl3199 {
-			yyb3199 = yyj3199 > l
+		yyj3207++
+		if yyhl3207 {
+			yyb3207 = yyj3207 > l
 		} else {
-			yyb3199 = r.CheckBreak()
+			yyb3207 = r.CheckBreak()
 		}
-		if yyb3199 {
+		if yyb3207 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3199-1, "")
+		z.DecStructFieldNotFound(yyj3207-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37148,36 +37208,36 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3206 := z.EncBinary()
-		_ = yym3206
+		yym3214 := z.EncBinary()
+		_ = yym3214
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3207 := !z.EncBinary()
-			yy2arr3207 := z.EncBasicHandle().StructToArray
-			var yyq3207 [5]bool
-			_, _, _ = yysep3207, yyq3207, yy2arr3207
-			const yyr3207 bool = false
-			yyq3207[0] = x.Kind != ""
-			yyq3207[1] = x.APIVersion != ""
-			yyq3207[2] = true
-			yyq3207[3] = len(x.Data) != 0
-			yyq3207[4] = x.Type != ""
-			if yyr3207 || yy2arr3207 {
+			yysep3215 := !z.EncBinary()
+			yy2arr3215 := z.EncBasicHandle().StructToArray
+			var yyq3215 [5]bool
+			_, _, _ = yysep3215, yyq3215, yy2arr3215
+			const yyr3215 bool = false
+			yyq3215[0] = x.Kind != ""
+			yyq3215[1] = x.APIVersion != ""
+			yyq3215[2] = true
+			yyq3215[3] = len(x.Data) != 0
+			yyq3215[4] = x.Type != ""
+			if yyr3215 || yy2arr3215 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3207 int = 0
-				for _, b := range yyq3207 {
+				var yynn3215 int = 0
+				for _, b := range yyq3215 {
 					if b {
-						yynn3207++
+						yynn3215++
 					}
 				}
-				r.EncodeMapStart(yynn3207)
+				r.EncodeMapStart(yynn3215)
 			}
-			if yyr3207 || yy2arr3207 {
-				if yyq3207[0] {
-					yym3209 := z.EncBinary()
-					_ = yym3209
+			if yyr3215 || yy2arr3215 {
+				if yyq3215[0] {
+					yym3217 := z.EncBinary()
+					_ = yym3217
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -37186,20 +37246,20 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3207[0] {
+				if yyq3215[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3210 := z.EncBinary()
-					_ = yym3210
+					yym3218 := z.EncBinary()
+					_ = yym3218
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3207 || yy2arr3207 {
-				if yyq3207[1] {
-					yym3212 := z.EncBinary()
-					_ = yym3212
+			if yyr3215 || yy2arr3215 {
+				if yyq3215[1] {
+					yym3220 := z.EncBinary()
+					_ = yym3220
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -37208,37 +37268,37 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3207[1] {
+				if yyq3215[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3213 := z.EncBinary()
-					_ = yym3213
+					yym3221 := z.EncBinary()
+					_ = yym3221
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3207 || yy2arr3207 {
-				if yyq3207[2] {
-					yy3215 := &x.ObjectMeta
-					yy3215.CodecEncodeSelf(e)
+			if yyr3215 || yy2arr3215 {
+				if yyq3215[2] {
+					yy3223 := &x.ObjectMeta
+					yy3223.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3207[2] {
+				if yyq3215[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3216 := &x.ObjectMeta
-					yy3216.CodecEncodeSelf(e)
+					yy3224 := &x.ObjectMeta
+					yy3224.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3207 || yy2arr3207 {
-				if yyq3207[3] {
+			if yyr3215 || yy2arr3215 {
+				if yyq3215[3] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3218 := z.EncBinary()
-						_ = yym3218
+						yym3226 := z.EncBinary()
+						_ = yym3226
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -37248,13 +37308,13 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3207[3] {
+				if yyq3215[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3219 := z.EncBinary()
-						_ = yym3219
+						yym3227 := z.EncBinary()
+						_ = yym3227
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -37262,19 +37322,19 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3207 || yy2arr3207 {
-				if yyq3207[4] {
+			if yyr3215 || yy2arr3215 {
+				if yyq3215[4] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3207[4] {
+				if yyq3215[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3207 {
+			if yysep3215 {
 				r.EncodeEnd()
 			}
 		}
@@ -37285,24 +37345,24 @@ func (x *Secret) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3221 := z.DecBinary()
-	_ = yym3221
+	yym3229 := z.DecBinary()
+	_ = yym3229
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3222 := r.ReadMapStart()
-			if yyl3222 == 0 {
+			yyl3230 := r.ReadMapStart()
+			if yyl3230 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3222, d)
+				x.codecDecodeSelfFromMap(yyl3230, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3222 := r.ReadArrayStart()
-			if yyl3222 == 0 {
+			yyl3230 := r.ReadArrayStart()
+			if yyl3230 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3222, d)
+				x.codecDecodeSelfFromArray(yyl3230, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37314,12 +37374,12 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3223Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3223Slc
-	var yyhl3223 bool = l >= 0
-	for yyj3223 := 0; ; yyj3223++ {
-		if yyhl3223 {
-			if yyj3223 >= l {
+	var yys3231Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3231Slc
+	var yyhl3231 bool = l >= 0
+	for yyj3231 := 0; ; yyj3231++ {
+		if yyhl3231 {
+			if yyj3231 >= l {
 				break
 			}
 		} else {
@@ -37327,9 +37387,9 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3223Slc = r.DecodeBytes(yys3223Slc, true, true)
-		yys3223 := string(yys3223Slc)
-		switch yys3223 {
+		yys3231Slc = r.DecodeBytes(yys3231Slc, true, true)
+		yys3231 := string(yys3231Slc)
+		switch yys3231 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37346,19 +37406,19 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3226 := &x.ObjectMeta
-				yyv3226.CodecDecodeSelf(d)
+				yyv3234 := &x.ObjectMeta
+				yyv3234.CodecDecodeSelf(d)
 			}
 		case "data":
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3227 := &x.Data
-				yym3228 := z.DecBinary()
-				_ = yym3228
+				yyv3235 := &x.Data
+				yym3236 := z.DecBinary()
+				_ = yym3236
 				if false {
 				} else {
-					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3227), d)
+					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3235), d)
 				}
 			}
 		case "type":
@@ -37368,10 +37428,10 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Type = SecretType(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3223)
-		} // end switch yys3223
-	} // end for yyj3223
-	if !yyhl3223 {
+			z.DecStructFieldNotFound(-1, yys3231)
+		} // end switch yys3231
+	} // end for yyj3231
+	if !yyhl3231 {
 		r.ReadEnd()
 	}
 }
@@ -37380,16 +37440,16 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3230 int
-	var yyb3230 bool
-	var yyhl3230 bool = l >= 0
-	yyj3230++
-	if yyhl3230 {
-		yyb3230 = yyj3230 > l
+	var yyj3238 int
+	var yyb3238 bool
+	var yyhl3238 bool = l >= 0
+	yyj3238++
+	if yyhl3238 {
+		yyb3238 = yyj3238 > l
 	} else {
-		yyb3230 = r.CheckBreak()
+		yyb3238 = r.CheckBreak()
 	}
-	if yyb3230 {
+	if yyb3238 {
 		r.ReadEnd()
 		return
 	}
@@ -37398,13 +37458,13 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3230++
-	if yyhl3230 {
-		yyb3230 = yyj3230 > l
+	yyj3238++
+	if yyhl3238 {
+		yyb3238 = yyj3238 > l
 	} else {
-		yyb3230 = r.CheckBreak()
+		yyb3238 = r.CheckBreak()
 	}
-	if yyb3230 {
+	if yyb3238 {
 		r.ReadEnd()
 		return
 	}
@@ -37413,50 +37473,50 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3230++
-	if yyhl3230 {
-		yyb3230 = yyj3230 > l
+	yyj3238++
+	if yyhl3238 {
+		yyb3238 = yyj3238 > l
 	} else {
-		yyb3230 = r.CheckBreak()
+		yyb3238 = r.CheckBreak()
 	}
-	if yyb3230 {
+	if yyb3238 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3233 := &x.ObjectMeta
-		yyv3233.CodecDecodeSelf(d)
+		yyv3241 := &x.ObjectMeta
+		yyv3241.CodecDecodeSelf(d)
 	}
-	yyj3230++
-	if yyhl3230 {
-		yyb3230 = yyj3230 > l
+	yyj3238++
+	if yyhl3238 {
+		yyb3238 = yyj3238 > l
 	} else {
-		yyb3230 = r.CheckBreak()
+		yyb3238 = r.CheckBreak()
 	}
-	if yyb3230 {
+	if yyb3238 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3234 := &x.Data
-		yym3235 := z.DecBinary()
-		_ = yym3235
+		yyv3242 := &x.Data
+		yym3243 := z.DecBinary()
+		_ = yym3243
 		if false {
 		} else {
-			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3234), d)
+			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3242), d)
 		}
 	}
-	yyj3230++
-	if yyhl3230 {
-		yyb3230 = yyj3230 > l
+	yyj3238++
+	if yyhl3238 {
+		yyb3238 = yyj3238 > l
 	} else {
-		yyb3230 = r.CheckBreak()
+		yyb3238 = r.CheckBreak()
 	}
-	if yyb3230 {
+	if yyb3238 {
 		r.ReadEnd()
 		return
 	}
@@ -37466,16 +37526,16 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Type = SecretType(r.DecodeString())
 	}
 	for {
-		yyj3230++
-		if yyhl3230 {
-			yyb3230 = yyj3230 > l
+		yyj3238++
+		if yyhl3238 {
+			yyb3238 = yyj3238 > l
 		} else {
-			yyb3230 = r.CheckBreak()
+			yyb3238 = r.CheckBreak()
 		}
-		if yyb3230 {
+		if yyb3238 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3230-1, "")
+		z.DecStructFieldNotFound(yyj3238-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37484,8 +37544,8 @@ func (x SecretType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3237 := z.EncBinary()
-	_ = yym3237
+	yym3245 := z.EncBinary()
+	_ = yym3245
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -37497,8 +37557,8 @@ func (x *SecretType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3238 := z.DecBinary()
-	_ = yym3238
+	yym3246 := z.DecBinary()
+	_ = yym3246
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -37513,34 +37573,34 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3239 := z.EncBinary()
-		_ = yym3239
+		yym3247 := z.EncBinary()
+		_ = yym3247
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3240 := !z.EncBinary()
-			yy2arr3240 := z.EncBasicHandle().StructToArray
-			var yyq3240 [4]bool
-			_, _, _ = yysep3240, yyq3240, yy2arr3240
-			const yyr3240 bool = false
-			yyq3240[0] = x.Kind != ""
-			yyq3240[1] = x.APIVersion != ""
-			yyq3240[2] = true
-			if yyr3240 || yy2arr3240 {
+			yysep3248 := !z.EncBinary()
+			yy2arr3248 := z.EncBasicHandle().StructToArray
+			var yyq3248 [4]bool
+			_, _, _ = yysep3248, yyq3248, yy2arr3248
+			const yyr3248 bool = false
+			yyq3248[0] = x.Kind != ""
+			yyq3248[1] = x.APIVersion != ""
+			yyq3248[2] = true
+			if yyr3248 || yy2arr3248 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3240 int = 1
-				for _, b := range yyq3240 {
+				var yynn3248 int = 1
+				for _, b := range yyq3248 {
 					if b {
-						yynn3240++
+						yynn3248++
 					}
 				}
-				r.EncodeMapStart(yynn3240)
+				r.EncodeMapStart(yynn3248)
 			}
-			if yyr3240 || yy2arr3240 {
-				if yyq3240[0] {
-					yym3242 := z.EncBinary()
-					_ = yym3242
+			if yyr3248 || yy2arr3248 {
+				if yyq3248[0] {
+					yym3250 := z.EncBinary()
+					_ = yym3250
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -37549,70 +37609,70 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3240[0] {
+				if yyq3248[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3243 := z.EncBinary()
-					_ = yym3243
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3240 || yy2arr3240 {
-				if yyq3240[1] {
-					yym3245 := z.EncBinary()
-					_ = yym3245
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3240[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3246 := z.EncBinary()
-					_ = yym3246
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3240 || yy2arr3240 {
-				if yyq3240[2] {
-					yy3248 := &x.ListMeta
-					yym3249 := z.EncBinary()
-					_ = yym3249
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3248) {
-					} else {
-						z.EncFallback(yy3248)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3240[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3250 := &x.ListMeta
 					yym3251 := z.EncBinary()
 					_ = yym3251
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3250) {
 					} else {
-						z.EncFallback(yy3250)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3240 || yy2arr3240 {
+			if yyr3248 || yy2arr3248 {
+				if yyq3248[1] {
+					yym3253 := z.EncBinary()
+					_ = yym3253
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3248[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3254 := z.EncBinary()
+					_ = yym3254
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr3248 || yy2arr3248 {
+				if yyq3248[2] {
+					yy3256 := &x.ListMeta
+					yym3257 := z.EncBinary()
+					_ = yym3257
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3256) {
+					} else {
+						z.EncFallback(yy3256)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3248[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3258 := &x.ListMeta
+					yym3259 := z.EncBinary()
+					_ = yym3259
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3258) {
+					} else {
+						z.EncFallback(yy3258)
+					}
+				}
+			}
+			if yyr3248 || yy2arr3248 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3253 := z.EncBinary()
-					_ = yym3253
+					yym3261 := z.EncBinary()
+					_ = yym3261
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
@@ -37623,15 +37683,15 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3254 := z.EncBinary()
-					_ = yym3254
+					yym3262 := z.EncBinary()
+					_ = yym3262
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
 					}
 				}
 			}
-			if yysep3240 {
+			if yysep3248 {
 				r.EncodeEnd()
 			}
 		}
@@ -37642,24 +37702,24 @@ func (x *SecretList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3255 := z.DecBinary()
-	_ = yym3255
+	yym3263 := z.DecBinary()
+	_ = yym3263
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3256 := r.ReadMapStart()
-			if yyl3256 == 0 {
+			yyl3264 := r.ReadMapStart()
+			if yyl3264 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3256, d)
+				x.codecDecodeSelfFromMap(yyl3264, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3256 := r.ReadArrayStart()
-			if yyl3256 == 0 {
+			yyl3264 := r.ReadArrayStart()
+			if yyl3264 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3256, d)
+				x.codecDecodeSelfFromArray(yyl3264, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37671,12 +37731,12 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3257Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3257Slc
-	var yyhl3257 bool = l >= 0
-	for yyj3257 := 0; ; yyj3257++ {
-		if yyhl3257 {
-			if yyj3257 >= l {
+	var yys3265Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3265Slc
+	var yyhl3265 bool = l >= 0
+	for yyj3265 := 0; ; yyj3265++ {
+		if yyhl3265 {
+			if yyj3265 >= l {
 				break
 			}
 		} else {
@@ -37684,9 +37744,9 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3257Slc = r.DecodeBytes(yys3257Slc, true, true)
-		yys3257 := string(yys3257Slc)
-		switch yys3257 {
+		yys3265Slc = r.DecodeBytes(yys3265Slc, true, true)
+		yys3265 := string(yys3265Slc)
+		switch yys3265 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37703,32 +37763,32 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3260 := &x.ListMeta
-				yym3261 := z.DecBinary()
-				_ = yym3261
+				yyv3268 := &x.ListMeta
+				yym3269 := z.DecBinary()
+				_ = yym3269
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3260) {
+				} else if z.HasExtensions() && z.DecExt(yyv3268) {
 				} else {
-					z.DecFallback(yyv3260, false)
+					z.DecFallback(yyv3268, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3262 := &x.Items
-				yym3263 := z.DecBinary()
-				_ = yym3263
+				yyv3270 := &x.Items
+				yym3271 := z.DecBinary()
+				_ = yym3271
 				if false {
 				} else {
-					h.decSliceSecret((*[]Secret)(yyv3262), d)
+					h.decSliceSecret((*[]Secret)(yyv3270), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3257)
-		} // end switch yys3257
-	} // end for yyj3257
-	if !yyhl3257 {
+			z.DecStructFieldNotFound(-1, yys3265)
+		} // end switch yys3265
+	} // end for yyj3265
+	if !yyhl3265 {
 		r.ReadEnd()
 	}
 }
@@ -37737,16 +37797,16 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3264 int
-	var yyb3264 bool
-	var yyhl3264 bool = l >= 0
-	yyj3264++
-	if yyhl3264 {
-		yyb3264 = yyj3264 > l
+	var yyj3272 int
+	var yyb3272 bool
+	var yyhl3272 bool = l >= 0
+	yyj3272++
+	if yyhl3272 {
+		yyb3272 = yyj3272 > l
 	} else {
-		yyb3264 = r.CheckBreak()
+		yyb3272 = r.CheckBreak()
 	}
-	if yyb3264 {
+	if yyb3272 {
 		r.ReadEnd()
 		return
 	}
@@ -37755,13 +37815,13 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3264++
-	if yyhl3264 {
-		yyb3264 = yyj3264 > l
+	yyj3272++
+	if yyhl3272 {
+		yyb3272 = yyj3272 > l
 	} else {
-		yyb3264 = r.CheckBreak()
+		yyb3272 = r.CheckBreak()
 	}
-	if yyb3264 {
+	if yyb3272 {
 		r.ReadEnd()
 		return
 	}
@@ -37770,60 +37830,60 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3264++
-	if yyhl3264 {
-		yyb3264 = yyj3264 > l
+	yyj3272++
+	if yyhl3272 {
+		yyb3272 = yyj3272 > l
 	} else {
-		yyb3264 = r.CheckBreak()
+		yyb3272 = r.CheckBreak()
 	}
-	if yyb3264 {
+	if yyb3272 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3267 := &x.ListMeta
-		yym3268 := z.DecBinary()
-		_ = yym3268
+		yyv3275 := &x.ListMeta
+		yym3276 := z.DecBinary()
+		_ = yym3276
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3267) {
+		} else if z.HasExtensions() && z.DecExt(yyv3275) {
 		} else {
-			z.DecFallback(yyv3267, false)
+			z.DecFallback(yyv3275, false)
 		}
 	}
-	yyj3264++
-	if yyhl3264 {
-		yyb3264 = yyj3264 > l
+	yyj3272++
+	if yyhl3272 {
+		yyb3272 = yyj3272 > l
 	} else {
-		yyb3264 = r.CheckBreak()
+		yyb3272 = r.CheckBreak()
 	}
-	if yyb3264 {
+	if yyb3272 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3269 := &x.Items
-		yym3270 := z.DecBinary()
-		_ = yym3270
+		yyv3277 := &x.Items
+		yym3278 := z.DecBinary()
+		_ = yym3278
 		if false {
 		} else {
-			h.decSliceSecret((*[]Secret)(yyv3269), d)
+			h.decSliceSecret((*[]Secret)(yyv3277), d)
 		}
 	}
 	for {
-		yyj3264++
-		if yyhl3264 {
-			yyb3264 = yyj3264 > l
+		yyj3272++
+		if yyhl3272 {
+			yyb3272 = yyj3272 > l
 		} else {
-			yyb3264 = r.CheckBreak()
+			yyb3272 = r.CheckBreak()
 		}
-		if yyb3264 {
+		if yyb3272 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3264-1, "")
+		z.DecStructFieldNotFound(yyj3272-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37832,8 +37892,8 @@ func (x ComponentConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3271 := z.EncBinary()
-	_ = yym3271
+	yym3279 := z.EncBinary()
+	_ = yym3279
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -37845,8 +37905,8 @@ func (x *ComponentConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3272 := z.DecBinary()
-	_ = yym3272
+	yym3280 := z.DecBinary()
+	_ = yym3280
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -37861,45 +37921,45 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3273 := z.EncBinary()
-		_ = yym3273
+		yym3281 := z.EncBinary()
+		_ = yym3281
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3274 := !z.EncBinary()
-			yy2arr3274 := z.EncBasicHandle().StructToArray
-			var yyq3274 [4]bool
-			_, _, _ = yysep3274, yyq3274, yy2arr3274
-			const yyr3274 bool = false
-			yyq3274[2] = x.Message != ""
-			yyq3274[3] = x.Error != ""
-			if yyr3274 || yy2arr3274 {
+			yysep3282 := !z.EncBinary()
+			yy2arr3282 := z.EncBasicHandle().StructToArray
+			var yyq3282 [4]bool
+			_, _, _ = yysep3282, yyq3282, yy2arr3282
+			const yyr3282 bool = false
+			yyq3282[2] = x.Message != ""
+			yyq3282[3] = x.Error != ""
+			if yyr3282 || yy2arr3282 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3274 int = 2
-				for _, b := range yyq3274 {
+				var yynn3282 int = 2
+				for _, b := range yyq3282 {
 					if b {
-						yynn3274++
+						yynn3282++
 					}
 				}
-				r.EncodeMapStart(yynn3274)
+				r.EncodeMapStart(yynn3282)
 			}
-			if yyr3274 || yy2arr3274 {
+			if yyr3282 || yy2arr3282 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr3274 || yy2arr3274 {
+			if yyr3282 || yy2arr3282 {
 				x.Status.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
 				x.Status.CodecEncodeSelf(e)
 			}
-			if yyr3274 || yy2arr3274 {
-				if yyq3274[2] {
-					yym3278 := z.EncBinary()
-					_ = yym3278
+			if yyr3282 || yy2arr3282 {
+				if yyq3282[2] {
+					yym3286 := z.EncBinary()
+					_ = yym3286
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -37908,20 +37968,20 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3274[2] {
+				if yyq3282[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym3279 := z.EncBinary()
-					_ = yym3279
+					yym3287 := z.EncBinary()
+					_ = yym3287
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr3274 || yy2arr3274 {
-				if yyq3274[3] {
-					yym3281 := z.EncBinary()
-					_ = yym3281
+			if yyr3282 || yy2arr3282 {
+				if yyq3282[3] {
+					yym3289 := z.EncBinary()
+					_ = yym3289
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Error))
@@ -37930,17 +37990,17 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3274[3] {
+				if yyq3282[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("error"))
-					yym3282 := z.EncBinary()
-					_ = yym3282
+					yym3290 := z.EncBinary()
+					_ = yym3290
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Error))
 					}
 				}
 			}
-			if yysep3274 {
+			if yysep3282 {
 				r.EncodeEnd()
 			}
 		}
@@ -37951,24 +38011,24 @@ func (x *ComponentCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3283 := z.DecBinary()
-	_ = yym3283
+	yym3291 := z.DecBinary()
+	_ = yym3291
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3284 := r.ReadMapStart()
-			if yyl3284 == 0 {
+			yyl3292 := r.ReadMapStart()
+			if yyl3292 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3284, d)
+				x.codecDecodeSelfFromMap(yyl3292, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3284 := r.ReadArrayStart()
-			if yyl3284 == 0 {
+			yyl3292 := r.ReadArrayStart()
+			if yyl3292 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3284, d)
+				x.codecDecodeSelfFromArray(yyl3292, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37980,12 +38040,12 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3285Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3285Slc
-	var yyhl3285 bool = l >= 0
-	for yyj3285 := 0; ; yyj3285++ {
-		if yyhl3285 {
-			if yyj3285 >= l {
+	var yys3293Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3293Slc
+	var yyhl3293 bool = l >= 0
+	for yyj3293 := 0; ; yyj3293++ {
+		if yyhl3293 {
+			if yyj3293 >= l {
 				break
 			}
 		} else {
@@ -37993,9 +38053,9 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys3285Slc = r.DecodeBytes(yys3285Slc, true, true)
-		yys3285 := string(yys3285Slc)
-		switch yys3285 {
+		yys3293Slc = r.DecodeBytes(yys3293Slc, true, true)
+		yys3293 := string(yys3293Slc)
+		switch yys3293 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -38021,10 +38081,10 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.Error = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3285)
-		} // end switch yys3285
-	} // end for yyj3285
-	if !yyhl3285 {
+			z.DecStructFieldNotFound(-1, yys3293)
+		} // end switch yys3293
+	} // end for yyj3293
+	if !yyhl3293 {
 		r.ReadEnd()
 	}
 }
@@ -38033,16 +38093,16 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3290 int
-	var yyb3290 bool
-	var yyhl3290 bool = l >= 0
-	yyj3290++
-	if yyhl3290 {
-		yyb3290 = yyj3290 > l
+	var yyj3298 int
+	var yyb3298 bool
+	var yyhl3298 bool = l >= 0
+	yyj3298++
+	if yyhl3298 {
+		yyb3298 = yyj3298 > l
 	} else {
-		yyb3290 = r.CheckBreak()
+		yyb3298 = r.CheckBreak()
 	}
-	if yyb3290 {
+	if yyb3298 {
 		r.ReadEnd()
 		return
 	}
@@ -38051,13 +38111,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = ComponentConditionType(r.DecodeString())
 	}
-	yyj3290++
-	if yyhl3290 {
-		yyb3290 = yyj3290 > l
+	yyj3298++
+	if yyhl3298 {
+		yyb3298 = yyj3298 > l
 	} else {
-		yyb3290 = r.CheckBreak()
+		yyb3298 = r.CheckBreak()
 	}
-	if yyb3290 {
+	if yyb3298 {
 		r.ReadEnd()
 		return
 	}
@@ -38066,13 +38126,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Status = ConditionStatus(r.DecodeString())
 	}
-	yyj3290++
-	if yyhl3290 {
-		yyb3290 = yyj3290 > l
+	yyj3298++
+	if yyhl3298 {
+		yyb3298 = yyj3298 > l
 	} else {
-		yyb3290 = r.CheckBreak()
+		yyb3298 = r.CheckBreak()
 	}
-	if yyb3290 {
+	if yyb3298 {
 		r.ReadEnd()
 		return
 	}
@@ -38081,13 +38141,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj3290++
-	if yyhl3290 {
-		yyb3290 = yyj3290 > l
+	yyj3298++
+	if yyhl3298 {
+		yyb3298 = yyj3298 > l
 	} else {
-		yyb3290 = r.CheckBreak()
+		yyb3298 = r.CheckBreak()
 	}
-	if yyb3290 {
+	if yyb3298 {
 		r.ReadEnd()
 		return
 	}
@@ -38097,16 +38157,16 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.Error = string(r.DecodeString())
 	}
 	for {
-		yyj3290++
-		if yyhl3290 {
-			yyb3290 = yyj3290 > l
+		yyj3298++
+		if yyhl3298 {
+			yyb3298 = yyj3298 > l
 		} else {
-			yyb3290 = r.CheckBreak()
+			yyb3298 = r.CheckBreak()
 		}
-		if yyb3290 {
+		if yyb3298 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3290-1, "")
+		z.DecStructFieldNotFound(yyj3298-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38118,35 +38178,35 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3295 := z.EncBinary()
-		_ = yym3295
+		yym3303 := z.EncBinary()
+		_ = yym3303
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3296 := !z.EncBinary()
-			yy2arr3296 := z.EncBasicHandle().StructToArray
-			var yyq3296 [4]bool
-			_, _, _ = yysep3296, yyq3296, yy2arr3296
-			const yyr3296 bool = false
-			yyq3296[0] = x.Kind != ""
-			yyq3296[1] = x.APIVersion != ""
-			yyq3296[2] = true
-			yyq3296[3] = len(x.Conditions) != 0
-			if yyr3296 || yy2arr3296 {
+			yysep3304 := !z.EncBinary()
+			yy2arr3304 := z.EncBasicHandle().StructToArray
+			var yyq3304 [4]bool
+			_, _, _ = yysep3304, yyq3304, yy2arr3304
+			const yyr3304 bool = false
+			yyq3304[0] = x.Kind != ""
+			yyq3304[1] = x.APIVersion != ""
+			yyq3304[2] = true
+			yyq3304[3] = len(x.Conditions) != 0
+			if yyr3304 || yy2arr3304 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3296 int = 0
-				for _, b := range yyq3296 {
+				var yynn3304 int = 0
+				for _, b := range yyq3304 {
 					if b {
-						yynn3296++
+						yynn3304++
 					}
 				}
-				r.EncodeMapStart(yynn3296)
+				r.EncodeMapStart(yynn3304)
 			}
-			if yyr3296 || yy2arr3296 {
-				if yyq3296[0] {
-					yym3298 := z.EncBinary()
-					_ = yym3298
+			if yyr3304 || yy2arr3304 {
+				if yyq3304[0] {
+					yym3306 := z.EncBinary()
+					_ = yym3306
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -38155,20 +38215,20 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3296[0] {
+				if yyq3304[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3299 := z.EncBinary()
-					_ = yym3299
+					yym3307 := z.EncBinary()
+					_ = yym3307
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3296 || yy2arr3296 {
-				if yyq3296[1] {
-					yym3301 := z.EncBinary()
-					_ = yym3301
+			if yyr3304 || yy2arr3304 {
+				if yyq3304[1] {
+					yym3309 := z.EncBinary()
+					_ = yym3309
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -38177,37 +38237,37 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3296[1] {
+				if yyq3304[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3302 := z.EncBinary()
-					_ = yym3302
+					yym3310 := z.EncBinary()
+					_ = yym3310
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3296 || yy2arr3296 {
-				if yyq3296[2] {
-					yy3304 := &x.ObjectMeta
-					yy3304.CodecEncodeSelf(e)
+			if yyr3304 || yy2arr3304 {
+				if yyq3304[2] {
+					yy3312 := &x.ObjectMeta
+					yy3312.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3296[2] {
+				if yyq3304[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3305 := &x.ObjectMeta
-					yy3305.CodecEncodeSelf(e)
+					yy3313 := &x.ObjectMeta
+					yy3313.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3296 || yy2arr3296 {
-				if yyq3296[3] {
+			if yyr3304 || yy2arr3304 {
+				if yyq3304[3] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3307 := z.EncBinary()
-						_ = yym3307
+						yym3315 := z.EncBinary()
+						_ = yym3315
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -38217,13 +38277,13 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3296[3] {
+				if yyq3304[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3308 := z.EncBinary()
-						_ = yym3308
+						yym3316 := z.EncBinary()
+						_ = yym3316
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -38231,7 +38291,7 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3296 {
+			if yysep3304 {
 				r.EncodeEnd()
 			}
 		}
@@ -38242,24 +38302,24 @@ func (x *ComponentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3309 := z.DecBinary()
-	_ = yym3309
+	yym3317 := z.DecBinary()
+	_ = yym3317
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3310 := r.ReadMapStart()
-			if yyl3310 == 0 {
+			yyl3318 := r.ReadMapStart()
+			if yyl3318 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3310, d)
+				x.codecDecodeSelfFromMap(yyl3318, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3310 := r.ReadArrayStart()
-			if yyl3310 == 0 {
+			yyl3318 := r.ReadArrayStart()
+			if yyl3318 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3310, d)
+				x.codecDecodeSelfFromArray(yyl3318, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38271,12 +38331,12 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3311Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3311Slc
-	var yyhl3311 bool = l >= 0
-	for yyj3311 := 0; ; yyj3311++ {
-		if yyhl3311 {
-			if yyj3311 >= l {
+	var yys3319Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3319Slc
+	var yyhl3319 bool = l >= 0
+	for yyj3319 := 0; ; yyj3319++ {
+		if yyhl3319 {
+			if yyj3319 >= l {
 				break
 			}
 		} else {
@@ -38284,9 +38344,9 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3311Slc = r.DecodeBytes(yys3311Slc, true, true)
-		yys3311 := string(yys3311Slc)
-		switch yys3311 {
+		yys3319Slc = r.DecodeBytes(yys3319Slc, true, true)
+		yys3319 := string(yys3319Slc)
+		switch yys3319 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38303,26 +38363,26 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3314 := &x.ObjectMeta
-				yyv3314.CodecDecodeSelf(d)
+				yyv3322 := &x.ObjectMeta
+				yyv3322.CodecDecodeSelf(d)
 			}
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv3315 := &x.Conditions
-				yym3316 := z.DecBinary()
-				_ = yym3316
+				yyv3323 := &x.Conditions
+				yym3324 := z.DecBinary()
+				_ = yym3324
 				if false {
 				} else {
-					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3315), d)
+					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3323), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3311)
-		} // end switch yys3311
-	} // end for yyj3311
-	if !yyhl3311 {
+			z.DecStructFieldNotFound(-1, yys3319)
+		} // end switch yys3319
+	} // end for yyj3319
+	if !yyhl3319 {
 		r.ReadEnd()
 	}
 }
@@ -38331,16 +38391,16 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3317 int
-	var yyb3317 bool
-	var yyhl3317 bool = l >= 0
-	yyj3317++
-	if yyhl3317 {
-		yyb3317 = yyj3317 > l
+	var yyj3325 int
+	var yyb3325 bool
+	var yyhl3325 bool = l >= 0
+	yyj3325++
+	if yyhl3325 {
+		yyb3325 = yyj3325 > l
 	} else {
-		yyb3317 = r.CheckBreak()
+		yyb3325 = r.CheckBreak()
 	}
-	if yyb3317 {
+	if yyb3325 {
 		r.ReadEnd()
 		return
 	}
@@ -38349,13 +38409,13 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3317++
-	if yyhl3317 {
-		yyb3317 = yyj3317 > l
+	yyj3325++
+	if yyhl3325 {
+		yyb3325 = yyj3325 > l
 	} else {
-		yyb3317 = r.CheckBreak()
+		yyb3325 = r.CheckBreak()
 	}
-	if yyb3317 {
+	if yyb3325 {
 		r.ReadEnd()
 		return
 	}
@@ -38364,54 +38424,54 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3317++
-	if yyhl3317 {
-		yyb3317 = yyj3317 > l
+	yyj3325++
+	if yyhl3325 {
+		yyb3325 = yyj3325 > l
 	} else {
-		yyb3317 = r.CheckBreak()
+		yyb3325 = r.CheckBreak()
 	}
-	if yyb3317 {
+	if yyb3325 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3320 := &x.ObjectMeta
-		yyv3320.CodecDecodeSelf(d)
+		yyv3328 := &x.ObjectMeta
+		yyv3328.CodecDecodeSelf(d)
 	}
-	yyj3317++
-	if yyhl3317 {
-		yyb3317 = yyj3317 > l
+	yyj3325++
+	if yyhl3325 {
+		yyb3325 = yyj3325 > l
 	} else {
-		yyb3317 = r.CheckBreak()
+		yyb3325 = r.CheckBreak()
 	}
-	if yyb3317 {
+	if yyb3325 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv3321 := &x.Conditions
-		yym3322 := z.DecBinary()
-		_ = yym3322
+		yyv3329 := &x.Conditions
+		yym3330 := z.DecBinary()
+		_ = yym3330
 		if false {
 		} else {
-			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3321), d)
+			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3329), d)
 		}
 	}
 	for {
-		yyj3317++
-		if yyhl3317 {
-			yyb3317 = yyj3317 > l
+		yyj3325++
+		if yyhl3325 {
+			yyb3325 = yyj3325 > l
 		} else {
-			yyb3317 = r.CheckBreak()
+			yyb3325 = r.CheckBreak()
 		}
-		if yyb3317 {
+		if yyb3325 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3317-1, "")
+		z.DecStructFieldNotFound(yyj3325-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38423,34 +38483,34 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3323 := z.EncBinary()
-		_ = yym3323
+		yym3331 := z.EncBinary()
+		_ = yym3331
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3324 := !z.EncBinary()
-			yy2arr3324 := z.EncBasicHandle().StructToArray
-			var yyq3324 [4]bool
-			_, _, _ = yysep3324, yyq3324, yy2arr3324
-			const yyr3324 bool = false
-			yyq3324[0] = x.Kind != ""
-			yyq3324[1] = x.APIVersion != ""
-			yyq3324[2] = true
-			if yyr3324 || yy2arr3324 {
+			yysep3332 := !z.EncBinary()
+			yy2arr3332 := z.EncBasicHandle().StructToArray
+			var yyq3332 [4]bool
+			_, _, _ = yysep3332, yyq3332, yy2arr3332
+			const yyr3332 bool = false
+			yyq3332[0] = x.Kind != ""
+			yyq3332[1] = x.APIVersion != ""
+			yyq3332[2] = true
+			if yyr3332 || yy2arr3332 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3324 int = 1
-				for _, b := range yyq3324 {
+				var yynn3332 int = 1
+				for _, b := range yyq3332 {
 					if b {
-						yynn3324++
+						yynn3332++
 					}
 				}
-				r.EncodeMapStart(yynn3324)
+				r.EncodeMapStart(yynn3332)
 			}
-			if yyr3324 || yy2arr3324 {
-				if yyq3324[0] {
-					yym3326 := z.EncBinary()
-					_ = yym3326
+			if yyr3332 || yy2arr3332 {
+				if yyq3332[0] {
+					yym3334 := z.EncBinary()
+					_ = yym3334
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -38459,70 +38519,70 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3324[0] {
+				if yyq3332[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3327 := z.EncBinary()
-					_ = yym3327
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3324 || yy2arr3324 {
-				if yyq3324[1] {
-					yym3329 := z.EncBinary()
-					_ = yym3329
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3324[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3330 := z.EncBinary()
-					_ = yym3330
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3324 || yy2arr3324 {
-				if yyq3324[2] {
-					yy3332 := &x.ListMeta
-					yym3333 := z.EncBinary()
-					_ = yym3333
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3332) {
-					} else {
-						z.EncFallback(yy3332)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3324[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3334 := &x.ListMeta
 					yym3335 := z.EncBinary()
 					_ = yym3335
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3334) {
 					} else {
-						z.EncFallback(yy3334)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3324 || yy2arr3324 {
+			if yyr3332 || yy2arr3332 {
+				if yyq3332[1] {
+					yym3337 := z.EncBinary()
+					_ = yym3337
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3332[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym3338 := z.EncBinary()
+					_ = yym3338
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr3332 || yy2arr3332 {
+				if yyq3332[2] {
+					yy3340 := &x.ListMeta
+					yym3341 := z.EncBinary()
+					_ = yym3341
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3340) {
+					} else {
+						z.EncFallback(yy3340)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3332[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3342 := &x.ListMeta
+					yym3343 := z.EncBinary()
+					_ = yym3343
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3342) {
+					} else {
+						z.EncFallback(yy3342)
+					}
+				}
+			}
+			if yyr3332 || yy2arr3332 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3337 := z.EncBinary()
-					_ = yym3337
+					yym3345 := z.EncBinary()
+					_ = yym3345
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
@@ -38533,15 +38593,15 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3338 := z.EncBinary()
-					_ = yym3338
+					yym3346 := z.EncBinary()
+					_ = yym3346
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
 					}
 				}
 			}
-			if yysep3324 {
+			if yysep3332 {
 				r.EncodeEnd()
 			}
 		}
@@ -38552,24 +38612,24 @@ func (x *ComponentStatusList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3339 := z.DecBinary()
-	_ = yym3339
+	yym3347 := z.DecBinary()
+	_ = yym3347
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3340 := r.ReadMapStart()
-			if yyl3340 == 0 {
+			yyl3348 := r.ReadMapStart()
+			if yyl3348 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3340, d)
+				x.codecDecodeSelfFromMap(yyl3348, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3340 := r.ReadArrayStart()
-			if yyl3340 == 0 {
+			yyl3348 := r.ReadArrayStart()
+			if yyl3348 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3340, d)
+				x.codecDecodeSelfFromArray(yyl3348, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38581,12 +38641,12 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3341Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3341Slc
-	var yyhl3341 bool = l >= 0
-	for yyj3341 := 0; ; yyj3341++ {
-		if yyhl3341 {
-			if yyj3341 >= l {
+	var yys3349Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3349Slc
+	var yyhl3349 bool = l >= 0
+	for yyj3349 := 0; ; yyj3349++ {
+		if yyhl3349 {
+			if yyj3349 >= l {
 				break
 			}
 		} else {
@@ -38594,9 +38654,9 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys3341Slc = r.DecodeBytes(yys3341Slc, true, true)
-		yys3341 := string(yys3341Slc)
-		switch yys3341 {
+		yys3349Slc = r.DecodeBytes(yys3349Slc, true, true)
+		yys3349 := string(yys3349Slc)
+		switch yys3349 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38613,32 +38673,32 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3344 := &x.ListMeta
-				yym3345 := z.DecBinary()
-				_ = yym3345
+				yyv3352 := &x.ListMeta
+				yym3353 := z.DecBinary()
+				_ = yym3353
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3344) {
+				} else if z.HasExtensions() && z.DecExt(yyv3352) {
 				} else {
-					z.DecFallback(yyv3344, false)
+					z.DecFallback(yyv3352, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3346 := &x.Items
-				yym3347 := z.DecBinary()
-				_ = yym3347
+				yyv3354 := &x.Items
+				yym3355 := z.DecBinary()
+				_ = yym3355
 				if false {
 				} else {
-					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3346), d)
+					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3354), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3341)
-		} // end switch yys3341
-	} // end for yyj3341
-	if !yyhl3341 {
+			z.DecStructFieldNotFound(-1, yys3349)
+		} // end switch yys3349
+	} // end for yyj3349
+	if !yyhl3349 {
 		r.ReadEnd()
 	}
 }
@@ -38647,16 +38707,16 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3348 int
-	var yyb3348 bool
-	var yyhl3348 bool = l >= 0
-	yyj3348++
-	if yyhl3348 {
-		yyb3348 = yyj3348 > l
+	var yyj3356 int
+	var yyb3356 bool
+	var yyhl3356 bool = l >= 0
+	yyj3356++
+	if yyhl3356 {
+		yyb3356 = yyj3356 > l
 	} else {
-		yyb3348 = r.CheckBreak()
+		yyb3356 = r.CheckBreak()
 	}
-	if yyb3348 {
+	if yyb3356 {
 		r.ReadEnd()
 		return
 	}
@@ -38665,13 +38725,13 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3348++
-	if yyhl3348 {
-		yyb3348 = yyj3348 > l
+	yyj3356++
+	if yyhl3356 {
+		yyb3356 = yyj3356 > l
 	} else {
-		yyb3348 = r.CheckBreak()
+		yyb3356 = r.CheckBreak()
 	}
-	if yyb3348 {
+	if yyb3356 {
 		r.ReadEnd()
 		return
 	}
@@ -38680,60 +38740,60 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3348++
-	if yyhl3348 {
-		yyb3348 = yyj3348 > l
+	yyj3356++
+	if yyhl3356 {
+		yyb3356 = yyj3356 > l
 	} else {
-		yyb3348 = r.CheckBreak()
+		yyb3356 = r.CheckBreak()
 	}
-	if yyb3348 {
+	if yyb3356 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3351 := &x.ListMeta
-		yym3352 := z.DecBinary()
-		_ = yym3352
+		yyv3359 := &x.ListMeta
+		yym3360 := z.DecBinary()
+		_ = yym3360
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3351) {
+		} else if z.HasExtensions() && z.DecExt(yyv3359) {
 		} else {
-			z.DecFallback(yyv3351, false)
+			z.DecFallback(yyv3359, false)
 		}
 	}
-	yyj3348++
-	if yyhl3348 {
-		yyb3348 = yyj3348 > l
+	yyj3356++
+	if yyhl3356 {
+		yyb3356 = yyj3356 > l
 	} else {
-		yyb3348 = r.CheckBreak()
+		yyb3356 = r.CheckBreak()
 	}
-	if yyb3348 {
+	if yyb3356 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3353 := &x.Items
-		yym3354 := z.DecBinary()
-		_ = yym3354
+		yyv3361 := &x.Items
+		yym3362 := z.DecBinary()
+		_ = yym3362
 		if false {
 		} else {
-			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3353), d)
+			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3361), d)
 		}
 	}
 	for {
-		yyj3348++
-		if yyhl3348 {
-			yyb3348 = yyj3348 > l
+		yyj3356++
+		if yyhl3356 {
+			yyb3356 = yyj3356 > l
 		} else {
-			yyb3348 = r.CheckBreak()
+			yyb3356 = r.CheckBreak()
 		}
-		if yyb3348 {
+		if yyb3356 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3348-1, "")
+		z.DecStructFieldNotFound(yyj3356-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38745,35 +38805,35 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3355 := z.EncBinary()
-		_ = yym3355
+		yym3363 := z.EncBinary()
+		_ = yym3363
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3356 := !z.EncBinary()
-			yy2arr3356 := z.EncBasicHandle().StructToArray
-			var yyq3356 [1]bool
-			_, _, _ = yysep3356, yyq3356, yy2arr3356
-			const yyr3356 bool = false
-			yyq3356[0] = len(x.Items) != 0
-			if yyr3356 || yy2arr3356 {
+			yysep3364 := !z.EncBinary()
+			yy2arr3364 := z.EncBasicHandle().StructToArray
+			var yyq3364 [1]bool
+			_, _, _ = yysep3364, yyq3364, yy2arr3364
+			const yyr3364 bool = false
+			yyq3364[0] = len(x.Items) != 0
+			if yyr3364 || yy2arr3364 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3356 int = 0
-				for _, b := range yyq3356 {
+				var yynn3364 int = 0
+				for _, b := range yyq3364 {
 					if b {
-						yynn3356++
+						yynn3364++
 					}
 				}
-				r.EncodeMapStart(yynn3356)
+				r.EncodeMapStart(yynn3364)
 			}
-			if yyr3356 || yy2arr3356 {
-				if yyq3356[0] {
+			if yyr3364 || yy2arr3364 {
+				if yyq3364[0] {
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym3358 := z.EncBinary()
-						_ = yym3358
+						yym3366 := z.EncBinary()
+						_ = yym3366
 						if false {
 						} else {
 							h.encSliceDownwardAPIVolumeFile(([]DownwardAPIVolumeFile)(x.Items), e)
@@ -38783,13 +38843,13 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3356[0] {
+				if yyq3364[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym3359 := z.EncBinary()
-						_ = yym3359
+						yym3367 := z.EncBinary()
+						_ = yym3367
 						if false {
 						} else {
 							h.encSliceDownwardAPIVolumeFile(([]DownwardAPIVolumeFile)(x.Items), e)
@@ -38797,7 +38857,7 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3356 {
+			if yysep3364 {
 				r.EncodeEnd()
 			}
 		}
@@ -38808,24 +38868,24 @@ func (x *DownwardAPIVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3360 := z.DecBinary()
-	_ = yym3360
+	yym3368 := z.DecBinary()
+	_ = yym3368
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3361 := r.ReadMapStart()
-			if yyl3361 == 0 {
+			yyl3369 := r.ReadMapStart()
+			if yyl3369 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3361, d)
+				x.codecDecodeSelfFromMap(yyl3369, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3361 := r.ReadArrayStart()
-			if yyl3361 == 0 {
+			yyl3369 := r.ReadArrayStart()
+			if yyl3369 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3361, d)
+				x.codecDecodeSelfFromArray(yyl3369, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38837,12 +38897,12 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3362Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3362Slc
-	var yyhl3362 bool = l >= 0
-	for yyj3362 := 0; ; yyj3362++ {
-		if yyhl3362 {
-			if yyj3362 >= l {
+	var yys3370Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3370Slc
+	var yyhl3370 bool = l >= 0
+	for yyj3370 := 0; ; yyj3370++ {
+		if yyhl3370 {
+			if yyj3370 >= l {
 				break
 			}
 		} else {
@@ -38850,26 +38910,26 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys3362Slc = r.DecodeBytes(yys3362Slc, true, true)
-		yys3362 := string(yys3362Slc)
-		switch yys3362 {
+		yys3370Slc = r.DecodeBytes(yys3370Slc, true, true)
+		yys3370 := string(yys3370Slc)
+		switch yys3370 {
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3363 := &x.Items
-				yym3364 := z.DecBinary()
-				_ = yym3364
+				yyv3371 := &x.Items
+				yym3372 := z.DecBinary()
+				_ = yym3372
 				if false {
 				} else {
-					h.decSliceDownwardAPIVolumeFile((*[]DownwardAPIVolumeFile)(yyv3363), d)
+					h.decSliceDownwardAPIVolumeFile((*[]DownwardAPIVolumeFile)(yyv3371), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3362)
-		} // end switch yys3362
-	} // end for yyj3362
-	if !yyhl3362 {
+			z.DecStructFieldNotFound(-1, yys3370)
+		} // end switch yys3370
+	} // end for yyj3370
+	if !yyhl3370 {
 		r.ReadEnd()
 	}
 }
@@ -38878,41 +38938,41 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3365 int
-	var yyb3365 bool
-	var yyhl3365 bool = l >= 0
-	yyj3365++
-	if yyhl3365 {
-		yyb3365 = yyj3365 > l
+	var yyj3373 int
+	var yyb3373 bool
+	var yyhl3373 bool = l >= 0
+	yyj3373++
+	if yyhl3373 {
+		yyb3373 = yyj3373 > l
 	} else {
-		yyb3365 = r.CheckBreak()
+		yyb3373 = r.CheckBreak()
 	}
-	if yyb3365 {
+	if yyb3373 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3366 := &x.Items
-		yym3367 := z.DecBinary()
-		_ = yym3367
+		yyv3374 := &x.Items
+		yym3375 := z.DecBinary()
+		_ = yym3375
 		if false {
 		} else {
-			h.decSliceDownwardAPIVolumeFile((*[]DownwardAPIVolumeFile)(yyv3366), d)
+			h.decSliceDownwardAPIVolumeFile((*[]DownwardAPIVolumeFile)(yyv3374), d)
 		}
 	}
 	for {
-		yyj3365++
-		if yyhl3365 {
-			yyb3365 = yyj3365 > l
+		yyj3373++
+		if yyhl3373 {
+			yyb3373 = yyj3373 > l
 		} else {
-			yyb3365 = r.CheckBreak()
+			yyb3373 = r.CheckBreak()
 		}
-		if yyb3365 {
+		if yyb3373 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3365-1, "")
+		z.DecStructFieldNotFound(yyj3373-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38924,52 +38984,52 @@ func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3368 := z.EncBinary()
-		_ = yym3368
+		yym3376 := z.EncBinary()
+		_ = yym3376
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3369 := !z.EncBinary()
-			yy2arr3369 := z.EncBasicHandle().StructToArray
-			var yyq3369 [2]bool
-			_, _, _ = yysep3369, yyq3369, yy2arr3369
-			const yyr3369 bool = false
-			if yyr3369 || yy2arr3369 {
+			yysep3377 := !z.EncBinary()
+			yy2arr3377 := z.EncBasicHandle().StructToArray
+			var yyq3377 [2]bool
+			_, _, _ = yysep3377, yyq3377, yy2arr3377
+			const yyr3377 bool = false
+			if yyr3377 || yy2arr3377 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn3369 int = 2
-				for _, b := range yyq3369 {
+				var yynn3377 int = 2
+				for _, b := range yyq3377 {
 					if b {
-						yynn3369++
+						yynn3377++
 					}
 				}
-				r.EncodeMapStart(yynn3369)
+				r.EncodeMapStart(yynn3377)
 			}
-			if yyr3369 || yy2arr3369 {
-				yym3371 := z.EncBinary()
-				_ = yym3371
+			if yyr3377 || yy2arr3377 {
+				yym3379 := z.EncBinary()
+				_ = yym3379
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
-				yym3372 := z.EncBinary()
-				_ = yym3372
+				yym3380 := z.EncBinary()
+				_ = yym3380
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yyr3369 || yy2arr3369 {
-				yy3374 := &x.FieldRef
-				yy3374.CodecEncodeSelf(e)
+			if yyr3377 || yy2arr3377 {
+				yy3382 := &x.FieldRef
+				yy3382.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("fieldRef"))
-				yy3375 := &x.FieldRef
-				yy3375.CodecEncodeSelf(e)
+				yy3383 := &x.FieldRef
+				yy3383.CodecEncodeSelf(e)
 			}
-			if yysep3369 {
+			if yysep3377 {
 				r.EncodeEnd()
 			}
 		}
@@ -38980,24 +39040,24 @@ func (x *DownwardAPIVolumeFile) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3376 := z.DecBinary()
-	_ = yym3376
+	yym3384 := z.DecBinary()
+	_ = yym3384
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3377 := r.ReadMapStart()
-			if yyl3377 == 0 {
+			yyl3385 := r.ReadMapStart()
+			if yyl3385 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3377, d)
+				x.codecDecodeSelfFromMap(yyl3385, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3377 := r.ReadArrayStart()
-			if yyl3377 == 0 {
+			yyl3385 := r.ReadArrayStart()
+			if yyl3385 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3377, d)
+				x.codecDecodeSelfFromArray(yyl3385, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39009,12 +39069,12 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3378Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3378Slc
-	var yyhl3378 bool = l >= 0
-	for yyj3378 := 0; ; yyj3378++ {
-		if yyhl3378 {
-			if yyj3378 >= l {
+	var yys3386Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3386Slc
+	var yyhl3386 bool = l >= 0
+	for yyj3386 := 0; ; yyj3386++ {
+		if yyhl3386 {
+			if yyj3386 >= l {
 				break
 			}
 		} else {
@@ -39022,9 +39082,9 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys3378Slc = r.DecodeBytes(yys3378Slc, true, true)
-		yys3378 := string(yys3378Slc)
-		switch yys3378 {
+		yys3386Slc = r.DecodeBytes(yys3386Slc, true, true)
+		yys3386 := string(yys3386Slc)
+		switch yys3386 {
 		case "path":
 			if r.TryDecodeAsNil() {
 				x.Path = ""
@@ -39035,14 +39095,14 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.FieldRef = ObjectFieldSelector{}
 			} else {
-				yyv3380 := &x.FieldRef
-				yyv3380.CodecDecodeSelf(d)
+				yyv3388 := &x.FieldRef
+				yyv3388.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3378)
-		} // end switch yys3378
-	} // end for yyj3378
-	if !yyhl3378 {
+			z.DecStructFieldNotFound(-1, yys3386)
+		} // end switch yys3386
+	} // end for yyj3386
+	if !yyhl3386 {
 		r.ReadEnd()
 	}
 }
@@ -39051,16 +39111,16 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3381 int
-	var yyb3381 bool
-	var yyhl3381 bool = l >= 0
-	yyj3381++
-	if yyhl3381 {
-		yyb3381 = yyj3381 > l
+	var yyj3389 int
+	var yyb3389 bool
+	var yyhl3389 bool = l >= 0
+	yyj3389++
+	if yyhl3389 {
+		yyb3389 = yyj3389 > l
 	} else {
-		yyb3381 = r.CheckBreak()
+		yyb3389 = r.CheckBreak()
 	}
-	if yyb3381 {
+	if yyb3389 {
 		r.ReadEnd()
 		return
 	}
@@ -39069,33 +39129,33 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Path = string(r.DecodeString())
 	}
-	yyj3381++
-	if yyhl3381 {
-		yyb3381 = yyj3381 > l
+	yyj3389++
+	if yyhl3389 {
+		yyb3389 = yyj3389 > l
 	} else {
-		yyb3381 = r.CheckBreak()
+		yyb3389 = r.CheckBreak()
 	}
-	if yyb3381 {
+	if yyb3389 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.FieldRef = ObjectFieldSelector{}
 	} else {
-		yyv3383 := &x.FieldRef
-		yyv3383.CodecDecodeSelf(d)
+		yyv3391 := &x.FieldRef
+		yyv3391.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3381++
-		if yyhl3381 {
-			yyb3381 = yyj3381 > l
+		yyj3389++
+		if yyhl3389 {
+			yyb3389 = yyj3389 > l
 		} else {
-			yyb3381 = r.CheckBreak()
+			yyb3389 = r.CheckBreak()
 		}
-		if yyb3381 {
+		if yyb3389 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3381-1, "")
+		z.DecStructFieldNotFound(yyj3389-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39107,34 +39167,34 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3384 := z.EncBinary()
-		_ = yym3384
+		yym3392 := z.EncBinary()
+		_ = yym3392
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3385 := !z.EncBinary()
-			yy2arr3385 := z.EncBasicHandle().StructToArray
-			var yyq3385 [5]bool
-			_, _, _ = yysep3385, yyq3385, yy2arr3385
-			const yyr3385 bool = false
-			yyq3385[0] = x.Capabilities != nil
-			yyq3385[1] = x.Privileged != nil
-			yyq3385[2] = x.SELinuxOptions != nil
-			yyq3385[3] = x.RunAsUser != nil
-			yyq3385[4] = x.RunAsNonRoot != nil
-			if yyr3385 || yy2arr3385 {
+			yysep3393 := !z.EncBinary()
+			yy2arr3393 := z.EncBasicHandle().StructToArray
+			var yyq3393 [5]bool
+			_, _, _ = yysep3393, yyq3393, yy2arr3393
+			const yyr3393 bool = false
+			yyq3393[0] = x.Capabilities != nil
+			yyq3393[1] = x.Privileged != nil
+			yyq3393[2] = x.SELinuxOptions != nil
+			yyq3393[3] = x.RunAsUser != nil
+			yyq3393[4] = x.RunAsNonRoot != nil
+			if yyr3393 || yy2arr3393 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3385 int = 0
-				for _, b := range yyq3385 {
+				var yynn3393 int = 0
+				for _, b := range yyq3393 {
 					if b {
-						yynn3385++
+						yynn3393++
 					}
 				}
-				r.EncodeMapStart(yynn3385)
+				r.EncodeMapStart(yynn3393)
 			}
-			if yyr3385 || yy2arr3385 {
-				if yyq3385[0] {
+			if yyr3393 || yy2arr3393 {
+				if yyq3393[0] {
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
@@ -39144,7 +39204,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3385[0] {
+				if yyq3393[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("capabilities"))
 					if x.Capabilities == nil {
 						r.EncodeNil()
@@ -39153,40 +39213,40 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3385 || yy2arr3385 {
-				if yyq3385[1] {
+			if yyr3393 || yy2arr3393 {
+				if yyq3393[1] {
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
-						yy3388 := *x.Privileged
-						yym3389 := z.EncBinary()
-						_ = yym3389
+						yy3396 := *x.Privileged
+						yym3397 := z.EncBinary()
+						_ = yym3397
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3388))
+							r.EncodeBool(bool(yy3396))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3385[1] {
+				if yyq3393[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("privileged"))
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
-						yy3390 := *x.Privileged
-						yym3391 := z.EncBinary()
-						_ = yym3391
+						yy3398 := *x.Privileged
+						yym3399 := z.EncBinary()
+						_ = yym3399
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3390))
+							r.EncodeBool(bool(yy3398))
 						}
 					}
 				}
 			}
-			if yyr3385 || yy2arr3385 {
-				if yyq3385[2] {
+			if yyr3393 || yy2arr3393 {
+				if yyq3393[2] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -39196,7 +39256,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3385[2] {
+				if yyq3393[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -39205,71 +39265,71 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3385 || yy2arr3385 {
-				if yyq3385[3] {
+			if yyr3393 || yy2arr3393 {
+				if yyq3393[3] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy3394 := *x.RunAsUser
-						yym3395 := z.EncBinary()
-						_ = yym3395
+						yy3402 := *x.RunAsUser
+						yym3403 := z.EncBinary()
+						_ = yym3403
 						if false {
 						} else {
-							r.EncodeInt(int64(yy3394))
+							r.EncodeInt(int64(yy3402))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3385[3] {
+				if yyq3393[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy3396 := *x.RunAsUser
-						yym3397 := z.EncBinary()
-						_ = yym3397
+						yy3404 := *x.RunAsUser
+						yym3405 := z.EncBinary()
+						_ = yym3405
 						if false {
 						} else {
-							r.EncodeInt(int64(yy3396))
+							r.EncodeInt(int64(yy3404))
 						}
 					}
 				}
 			}
-			if yyr3385 || yy2arr3385 {
-				if yyq3385[4] {
+			if yyr3393 || yy2arr3393 {
+				if yyq3393[4] {
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
-						yy3399 := *x.RunAsNonRoot
-						yym3400 := z.EncBinary()
-						_ = yym3400
+						yy3407 := *x.RunAsNonRoot
+						yym3408 := z.EncBinary()
+						_ = yym3408
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3399))
+							r.EncodeBool(bool(yy3407))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3385[4] {
+				if yyq3393[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
 					if x.RunAsNonRoot == nil {
 						r.EncodeNil()
 					} else {
-						yy3401 := *x.RunAsNonRoot
-						yym3402 := z.EncBinary()
-						_ = yym3402
+						yy3409 := *x.RunAsNonRoot
+						yym3410 := z.EncBinary()
+						_ = yym3410
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3401))
+							r.EncodeBool(bool(yy3409))
 						}
 					}
 				}
 			}
-			if yysep3385 {
+			if yysep3393 {
 				r.EncodeEnd()
 			}
 		}
@@ -39280,24 +39340,24 @@ func (x *SecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3403 := z.DecBinary()
-	_ = yym3403
+	yym3411 := z.DecBinary()
+	_ = yym3411
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3404 := r.ReadMapStart()
-			if yyl3404 == 0 {
+			yyl3412 := r.ReadMapStart()
+			if yyl3412 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3404, d)
+				x.codecDecodeSelfFromMap(yyl3412, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3404 := r.ReadArrayStart()
-			if yyl3404 == 0 {
+			yyl3412 := r.ReadArrayStart()
+			if yyl3412 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3404, d)
+				x.codecDecodeSelfFromArray(yyl3412, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39309,12 +39369,12 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3405Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3405Slc
-	var yyhl3405 bool = l >= 0
-	for yyj3405 := 0; ; yyj3405++ {
-		if yyhl3405 {
-			if yyj3405 >= l {
+	var yys3413Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3413Slc
+	var yyhl3413 bool = l >= 0
+	for yyj3413 := 0; ; yyj3413++ {
+		if yyhl3413 {
+			if yyj3413 >= l {
 				break
 			}
 		} else {
@@ -39322,9 +39382,9 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3405Slc = r.DecodeBytes(yys3405Slc, true, true)
-		yys3405 := string(yys3405Slc)
-		switch yys3405 {
+		yys3413Slc = r.DecodeBytes(yys3413Slc, true, true)
+		yys3413 := string(yys3413Slc)
+		switch yys3413 {
 		case "capabilities":
 			if r.TryDecodeAsNil() {
 				if x.Capabilities != nil {
@@ -39345,8 +39405,8 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Privileged == nil {
 					x.Privileged = new(bool)
 				}
-				yym3408 := z.DecBinary()
-				_ = yym3408
+				yym3416 := z.DecBinary()
+				_ = yym3416
 				if false {
 				} else {
 					*((*bool)(x.Privileged)) = r.DecodeBool()
@@ -39372,8 +39432,8 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RunAsUser == nil {
 					x.RunAsUser = new(int64)
 				}
-				yym3411 := z.DecBinary()
-				_ = yym3411
+				yym3419 := z.DecBinary()
+				_ = yym3419
 				if false {
 				} else {
 					*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
@@ -39388,18 +39448,18 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RunAsNonRoot == nil {
 					x.RunAsNonRoot = new(bool)
 				}
-				yym3413 := z.DecBinary()
-				_ = yym3413
+				yym3421 := z.DecBinary()
+				_ = yym3421
 				if false {
 				} else {
 					*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3405)
-		} // end switch yys3405
-	} // end for yyj3405
-	if !yyhl3405 {
+			z.DecStructFieldNotFound(-1, yys3413)
+		} // end switch yys3413
+	} // end for yyj3413
+	if !yyhl3413 {
 		r.ReadEnd()
 	}
 }
@@ -39408,16 +39468,16 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3414 int
-	var yyb3414 bool
-	var yyhl3414 bool = l >= 0
-	yyj3414++
-	if yyhl3414 {
-		yyb3414 = yyj3414 > l
+	var yyj3422 int
+	var yyb3422 bool
+	var yyhl3422 bool = l >= 0
+	yyj3422++
+	if yyhl3422 {
+		yyb3422 = yyj3422 > l
 	} else {
-		yyb3414 = r.CheckBreak()
+		yyb3422 = r.CheckBreak()
 	}
-	if yyb3414 {
+	if yyb3422 {
 		r.ReadEnd()
 		return
 	}
@@ -39431,13 +39491,13 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Capabilities.CodecDecodeSelf(d)
 	}
-	yyj3414++
-	if yyhl3414 {
-		yyb3414 = yyj3414 > l
+	yyj3422++
+	if yyhl3422 {
+		yyb3422 = yyj3422 > l
 	} else {
-		yyb3414 = r.CheckBreak()
+		yyb3422 = r.CheckBreak()
 	}
-	if yyb3414 {
+	if yyb3422 {
 		r.ReadEnd()
 		return
 	}
@@ -39449,20 +39509,20 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.Privileged == nil {
 			x.Privileged = new(bool)
 		}
-		yym3417 := z.DecBinary()
-		_ = yym3417
+		yym3425 := z.DecBinary()
+		_ = yym3425
 		if false {
 		} else {
 			*((*bool)(x.Privileged)) = r.DecodeBool()
 		}
 	}
-	yyj3414++
-	if yyhl3414 {
-		yyb3414 = yyj3414 > l
+	yyj3422++
+	if yyhl3422 {
+		yyb3422 = yyj3422 > l
 	} else {
-		yyb3414 = r.CheckBreak()
+		yyb3422 = r.CheckBreak()
 	}
-	if yyb3414 {
+	if yyb3422 {
 		r.ReadEnd()
 		return
 	}
@@ -39476,13 +39536,13 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.SELinuxOptions.CodecDecodeSelf(d)
 	}
-	yyj3414++
-	if yyhl3414 {
-		yyb3414 = yyj3414 > l
+	yyj3422++
+	if yyhl3422 {
+		yyb3422 = yyj3422 > l
 	} else {
-		yyb3414 = r.CheckBreak()
+		yyb3422 = r.CheckBreak()
 	}
-	if yyb3414 {
+	if yyb3422 {
 		r.ReadEnd()
 		return
 	}
@@ -39494,20 +39554,20 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.RunAsUser == nil {
 			x.RunAsUser = new(int64)
 		}
-		yym3420 := z.DecBinary()
-		_ = yym3420
+		yym3428 := z.DecBinary()
+		_ = yym3428
 		if false {
 		} else {
 			*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj3414++
-	if yyhl3414 {
-		yyb3414 = yyj3414 > l
+	yyj3422++
+	if yyhl3422 {
+		yyb3422 = yyj3422 > l
 	} else {
-		yyb3414 = r.CheckBreak()
+		yyb3422 = r.CheckBreak()
 	}
-	if yyb3414 {
+	if yyb3422 {
 		r.ReadEnd()
 		return
 	}
@@ -39519,24 +39579,24 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.RunAsNonRoot == nil {
 			x.RunAsNonRoot = new(bool)
 		}
-		yym3422 := z.DecBinary()
-		_ = yym3422
+		yym3430 := z.DecBinary()
+		_ = yym3430
 		if false {
 		} else {
 			*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 		}
 	}
 	for {
-		yyj3414++
-		if yyhl3414 {
-			yyb3414 = yyj3414 > l
+		yyj3422++
+		if yyhl3422 {
+			yyb3422 = yyj3422 > l
 		} else {
-			yyb3414 = r.CheckBreak()
+			yyb3422 = r.CheckBreak()
 		}
-		if yyb3414 {
+		if yyb3422 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3414-1, "")
+		z.DecStructFieldNotFound(yyj3422-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39548,35 +39608,35 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3423 := z.EncBinary()
-		_ = yym3423
+		yym3431 := z.EncBinary()
+		_ = yym3431
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3424 := !z.EncBinary()
-			yy2arr3424 := z.EncBasicHandle().StructToArray
-			var yyq3424 [4]bool
-			_, _, _ = yysep3424, yyq3424, yy2arr3424
-			const yyr3424 bool = false
-			yyq3424[0] = x.User != ""
-			yyq3424[1] = x.Role != ""
-			yyq3424[2] = x.Type != ""
-			yyq3424[3] = x.Level != ""
-			if yyr3424 || yy2arr3424 {
+			yysep3432 := !z.EncBinary()
+			yy2arr3432 := z.EncBasicHandle().StructToArray
+			var yyq3432 [4]bool
+			_, _, _ = yysep3432, yyq3432, yy2arr3432
+			const yyr3432 bool = false
+			yyq3432[0] = x.User != ""
+			yyq3432[1] = x.Role != ""
+			yyq3432[2] = x.Type != ""
+			yyq3432[3] = x.Level != ""
+			if yyr3432 || yy2arr3432 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3424 int = 0
-				for _, b := range yyq3424 {
+				var yynn3432 int = 0
+				for _, b := range yyq3432 {
 					if b {
-						yynn3424++
+						yynn3432++
 					}
 				}
-				r.EncodeMapStart(yynn3424)
+				r.EncodeMapStart(yynn3432)
 			}
-			if yyr3424 || yy2arr3424 {
-				if yyq3424[0] {
-					yym3426 := z.EncBinary()
-					_ = yym3426
+			if yyr3432 || yy2arr3432 {
+				if yyq3432[0] {
+					yym3434 := z.EncBinary()
+					_ = yym3434
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.User))
@@ -39585,83 +39645,83 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3424[0] {
+				if yyq3432[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("user"))
-					yym3427 := z.EncBinary()
-					_ = yym3427
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.User))
-					}
-				}
-			}
-			if yyr3424 || yy2arr3424 {
-				if yyq3424[1] {
-					yym3429 := z.EncBinary()
-					_ = yym3429
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3424[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("role"))
-					yym3430 := z.EncBinary()
-					_ = yym3430
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
-					}
-				}
-			}
-			if yyr3424 || yy2arr3424 {
-				if yyq3424[2] {
-					yym3432 := z.EncBinary()
-					_ = yym3432
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3424[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
-					yym3433 := z.EncBinary()
-					_ = yym3433
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
-					}
-				}
-			}
-			if yyr3424 || yy2arr3424 {
-				if yyq3424[3] {
 					yym3435 := z.EncBinary()
 					_ = yym3435
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.User))
+					}
+				}
+			}
+			if yyr3432 || yy2arr3432 {
+				if yyq3432[1] {
+					yym3437 := z.EncBinary()
+					_ = yym3437
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3432[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("role"))
+					yym3438 := z.EncBinary()
+					_ = yym3438
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
+					}
+				}
+			}
+			if yyr3432 || yy2arr3432 {
+				if yyq3432[2] {
+					yym3440 := z.EncBinary()
+					_ = yym3440
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3432[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					yym3441 := z.EncBinary()
+					_ = yym3441
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+					}
+				}
+			}
+			if yyr3432 || yy2arr3432 {
+				if yyq3432[3] {
+					yym3443 := z.EncBinary()
+					_ = yym3443
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Level))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3424[3] {
+				if yyq3432[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("level"))
-					yym3436 := z.EncBinary()
-					_ = yym3436
+					yym3444 := z.EncBinary()
+					_ = yym3444
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Level))
 					}
 				}
 			}
-			if yysep3424 {
+			if yysep3432 {
 				r.EncodeEnd()
 			}
 		}
@@ -39672,24 +39732,24 @@ func (x *SELinuxOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3437 := z.DecBinary()
-	_ = yym3437
+	yym3445 := z.DecBinary()
+	_ = yym3445
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3438 := r.ReadMapStart()
-			if yyl3438 == 0 {
+			yyl3446 := r.ReadMapStart()
+			if yyl3446 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3438, d)
+				x.codecDecodeSelfFromMap(yyl3446, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3438 := r.ReadArrayStart()
-			if yyl3438 == 0 {
+			yyl3446 := r.ReadArrayStart()
+			if yyl3446 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3438, d)
+				x.codecDecodeSelfFromArray(yyl3446, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39701,12 +39761,12 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3439Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3439Slc
-	var yyhl3439 bool = l >= 0
-	for yyj3439 := 0; ; yyj3439++ {
-		if yyhl3439 {
-			if yyj3439 >= l {
+	var yys3447Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3447Slc
+	var yyhl3447 bool = l >= 0
+	for yyj3447 := 0; ; yyj3447++ {
+		if yyhl3447 {
+			if yyj3447 >= l {
 				break
 			}
 		} else {
@@ -39714,9 +39774,9 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3439Slc = r.DecodeBytes(yys3439Slc, true, true)
-		yys3439 := string(yys3439Slc)
-		switch yys3439 {
+		yys3447Slc = r.DecodeBytes(yys3447Slc, true, true)
+		yys3447 := string(yys3447Slc)
+		switch yys3447 {
 		case "user":
 			if r.TryDecodeAsNil() {
 				x.User = ""
@@ -39742,10 +39802,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Level = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3439)
-		} // end switch yys3439
-	} // end for yyj3439
-	if !yyhl3439 {
+			z.DecStructFieldNotFound(-1, yys3447)
+		} // end switch yys3447
+	} // end for yyj3447
+	if !yyhl3447 {
 		r.ReadEnd()
 	}
 }
@@ -39754,16 +39814,16 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3444 int
-	var yyb3444 bool
-	var yyhl3444 bool = l >= 0
-	yyj3444++
-	if yyhl3444 {
-		yyb3444 = yyj3444 > l
+	var yyj3452 int
+	var yyb3452 bool
+	var yyhl3452 bool = l >= 0
+	yyj3452++
+	if yyhl3452 {
+		yyb3452 = yyj3452 > l
 	} else {
-		yyb3444 = r.CheckBreak()
+		yyb3452 = r.CheckBreak()
 	}
-	if yyb3444 {
+	if yyb3452 {
 		r.ReadEnd()
 		return
 	}
@@ -39772,13 +39832,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.User = string(r.DecodeString())
 	}
-	yyj3444++
-	if yyhl3444 {
-		yyb3444 = yyj3444 > l
+	yyj3452++
+	if yyhl3452 {
+		yyb3452 = yyj3452 > l
 	} else {
-		yyb3444 = r.CheckBreak()
+		yyb3452 = r.CheckBreak()
 	}
-	if yyb3444 {
+	if yyb3452 {
 		r.ReadEnd()
 		return
 	}
@@ -39787,13 +39847,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Role = string(r.DecodeString())
 	}
-	yyj3444++
-	if yyhl3444 {
-		yyb3444 = yyj3444 > l
+	yyj3452++
+	if yyhl3452 {
+		yyb3452 = yyj3452 > l
 	} else {
-		yyb3444 = r.CheckBreak()
+		yyb3452 = r.CheckBreak()
 	}
-	if yyb3444 {
+	if yyb3452 {
 		r.ReadEnd()
 		return
 	}
@@ -39802,13 +39862,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = string(r.DecodeString())
 	}
-	yyj3444++
-	if yyhl3444 {
-		yyb3444 = yyj3444 > l
+	yyj3452++
+	if yyhl3452 {
+		yyb3452 = yyj3452 > l
 	} else {
-		yyb3444 = r.CheckBreak()
+		yyb3452 = r.CheckBreak()
 	}
-	if yyb3444 {
+	if yyb3452 {
 		r.ReadEnd()
 		return
 	}
@@ -39818,16 +39878,16 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Level = string(r.DecodeString())
 	}
 	for {
-		yyj3444++
-		if yyhl3444 {
-			yyb3444 = yyj3444 > l
+		yyj3452++
+		if yyhl3452 {
+			yyb3452 = yyj3452 > l
 		} else {
-			yyb3444 = r.CheckBreak()
+			yyb3452 = r.CheckBreak()
 		}
-		if yyb3444 {
+		if yyb3452 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3444-1, "")
+		z.DecStructFieldNotFound(yyj3452-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39839,34 +39899,34 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3449 := z.EncBinary()
-		_ = yym3449
+		yym3457 := z.EncBinary()
+		_ = yym3457
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3450 := !z.EncBinary()
-			yy2arr3450 := z.EncBasicHandle().StructToArray
-			var yyq3450 [5]bool
-			_, _, _ = yysep3450, yyq3450, yy2arr3450
-			const yyr3450 bool = false
-			yyq3450[0] = x.Kind != ""
-			yyq3450[1] = x.APIVersion != ""
-			yyq3450[2] = true
-			if yyr3450 || yy2arr3450 {
+			yysep3458 := !z.EncBinary()
+			yy2arr3458 := z.EncBasicHandle().StructToArray
+			var yyq3458 [5]bool
+			_, _, _ = yysep3458, yyq3458, yy2arr3458
+			const yyr3458 bool = false
+			yyq3458[0] = x.Kind != ""
+			yyq3458[1] = x.APIVersion != ""
+			yyq3458[2] = true
+			if yyr3458 || yy2arr3458 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3450 int = 2
-				for _, b := range yyq3450 {
+				var yynn3458 int = 2
+				for _, b := range yyq3458 {
 					if b {
-						yynn3450++
+						yynn3458++
 					}
 				}
-				r.EncodeMapStart(yynn3450)
+				r.EncodeMapStart(yynn3458)
 			}
-			if yyr3450 || yy2arr3450 {
-				if yyq3450[0] {
-					yym3452 := z.EncBinary()
-					_ = yym3452
+			if yyr3458 || yy2arr3458 {
+				if yyq3458[0] {
+					yym3460 := z.EncBinary()
+					_ = yym3460
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -39875,20 +39935,20 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3450[0] {
+				if yyq3458[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3453 := z.EncBinary()
-					_ = yym3453
+					yym3461 := z.EncBinary()
+					_ = yym3461
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3450 || yy2arr3450 {
-				if yyq3450[1] {
-					yym3455 := z.EncBinary()
-					_ = yym3455
+			if yyr3458 || yy2arr3458 {
+				if yyq3458[1] {
+					yym3463 := z.EncBinary()
+					_ = yym3463
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -39897,52 +39957,52 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3450[1] {
+				if yyq3458[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3456 := z.EncBinary()
-					_ = yym3456
+					yym3464 := z.EncBinary()
+					_ = yym3464
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3450 || yy2arr3450 {
-				if yyq3450[2] {
-					yy3458 := &x.ObjectMeta
-					yy3458.CodecEncodeSelf(e)
+			if yyr3458 || yy2arr3458 {
+				if yyq3458[2] {
+					yy3466 := &x.ObjectMeta
+					yy3466.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3450[2] {
+				if yyq3458[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3459 := &x.ObjectMeta
-					yy3459.CodecEncodeSelf(e)
+					yy3467 := &x.ObjectMeta
+					yy3467.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3450 || yy2arr3450 {
-				yym3461 := z.EncBinary()
-				_ = yym3461
+			if yyr3458 || yy2arr3458 {
+				yym3469 := z.EncBinary()
+				_ = yym3469
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("range"))
-				yym3462 := z.EncBinary()
-				_ = yym3462
+				yym3470 := z.EncBinary()
+				_ = yym3470
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			}
-			if yyr3450 || yy2arr3450 {
+			if yyr3458 || yy2arr3458 {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3464 := z.EncBinary()
-					_ = yym3464
+					yym3472 := z.EncBinary()
+					_ = yym3472
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -39953,15 +40013,15 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3465 := z.EncBinary()
-					_ = yym3465
+					yym3473 := z.EncBinary()
+					_ = yym3473
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
 					}
 				}
 			}
-			if yysep3450 {
+			if yysep3458 {
 				r.EncodeEnd()
 			}
 		}
@@ -39972,24 +40032,24 @@ func (x *RangeAllocation) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3466 := z.DecBinary()
-	_ = yym3466
+	yym3474 := z.DecBinary()
+	_ = yym3474
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3467 := r.ReadMapStart()
-			if yyl3467 == 0 {
+			yyl3475 := r.ReadMapStart()
+			if yyl3475 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3467, d)
+				x.codecDecodeSelfFromMap(yyl3475, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3467 := r.ReadArrayStart()
-			if yyl3467 == 0 {
+			yyl3475 := r.ReadArrayStart()
+			if yyl3475 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3467, d)
+				x.codecDecodeSelfFromArray(yyl3475, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -40001,12 +40061,12 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3468Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3468Slc
-	var yyhl3468 bool = l >= 0
-	for yyj3468 := 0; ; yyj3468++ {
-		if yyhl3468 {
-			if yyj3468 >= l {
+	var yys3476Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3476Slc
+	var yyhl3476 bool = l >= 0
+	for yyj3476 := 0; ; yyj3476++ {
+		if yyhl3476 {
+			if yyj3476 >= l {
 				break
 			}
 		} else {
@@ -40014,9 +40074,9 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3468Slc = r.DecodeBytes(yys3468Slc, true, true)
-		yys3468 := string(yys3468Slc)
-		switch yys3468 {
+		yys3476Slc = r.DecodeBytes(yys3476Slc, true, true)
+		yys3476 := string(yys3476Slc)
+		switch yys3476 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -40033,8 +40093,8 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3471 := &x.ObjectMeta
-				yyv3471.CodecDecodeSelf(d)
+				yyv3479 := &x.ObjectMeta
+				yyv3479.CodecDecodeSelf(d)
 			}
 		case "range":
 			if r.TryDecodeAsNil() {
@@ -40046,19 +40106,19 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3473 := &x.Data
-				yym3474 := z.DecBinary()
-				_ = yym3474
+				yyv3481 := &x.Data
+				yym3482 := z.DecBinary()
+				_ = yym3482
 				if false {
 				} else {
-					*yyv3473 = r.DecodeBytes(*(*[]byte)(yyv3473), false, false)
+					*yyv3481 = r.DecodeBytes(*(*[]byte)(yyv3481), false, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3468)
-		} // end switch yys3468
-	} // end for yyj3468
-	if !yyhl3468 {
+			z.DecStructFieldNotFound(-1, yys3476)
+		} // end switch yys3476
+	} // end for yyj3476
+	if !yyhl3476 {
 		r.ReadEnd()
 	}
 }
@@ -40067,16 +40127,16 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3475 int
-	var yyb3475 bool
-	var yyhl3475 bool = l >= 0
-	yyj3475++
-	if yyhl3475 {
-		yyb3475 = yyj3475 > l
+	var yyj3483 int
+	var yyb3483 bool
+	var yyhl3483 bool = l >= 0
+	yyj3483++
+	if yyhl3483 {
+		yyb3483 = yyj3483 > l
 	} else {
-		yyb3475 = r.CheckBreak()
+		yyb3483 = r.CheckBreak()
 	}
-	if yyb3475 {
+	if yyb3483 {
 		r.ReadEnd()
 		return
 	}
@@ -40085,13 +40145,13 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3475++
-	if yyhl3475 {
-		yyb3475 = yyj3475 > l
+	yyj3483++
+	if yyhl3483 {
+		yyb3483 = yyj3483 > l
 	} else {
-		yyb3475 = r.CheckBreak()
+		yyb3483 = r.CheckBreak()
 	}
-	if yyb3475 {
+	if yyb3483 {
 		r.ReadEnd()
 		return
 	}
@@ -40100,29 +40160,29 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3475++
-	if yyhl3475 {
-		yyb3475 = yyj3475 > l
+	yyj3483++
+	if yyhl3483 {
+		yyb3483 = yyj3483 > l
 	} else {
-		yyb3475 = r.CheckBreak()
+		yyb3483 = r.CheckBreak()
 	}
-	if yyb3475 {
+	if yyb3483 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3478 := &x.ObjectMeta
-		yyv3478.CodecDecodeSelf(d)
+		yyv3486 := &x.ObjectMeta
+		yyv3486.CodecDecodeSelf(d)
 	}
-	yyj3475++
-	if yyhl3475 {
-		yyb3475 = yyj3475 > l
+	yyj3483++
+	if yyhl3483 {
+		yyb3483 = yyj3483 > l
 	} else {
-		yyb3475 = r.CheckBreak()
+		yyb3483 = r.CheckBreak()
 	}
-	if yyb3475 {
+	if yyb3483 {
 		r.ReadEnd()
 		return
 	}
@@ -40131,38 +40191,38 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Range = string(r.DecodeString())
 	}
-	yyj3475++
-	if yyhl3475 {
-		yyb3475 = yyj3475 > l
+	yyj3483++
+	if yyhl3483 {
+		yyb3483 = yyj3483 > l
 	} else {
-		yyb3475 = r.CheckBreak()
+		yyb3483 = r.CheckBreak()
 	}
-	if yyb3475 {
+	if yyb3483 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3480 := &x.Data
-		yym3481 := z.DecBinary()
-		_ = yym3481
+		yyv3488 := &x.Data
+		yym3489 := z.DecBinary()
+		_ = yym3489
 		if false {
 		} else {
-			*yyv3480 = r.DecodeBytes(*(*[]byte)(yyv3480), false, false)
+			*yyv3488 = r.DecodeBytes(*(*[]byte)(yyv3488), false, false)
 		}
 	}
 	for {
-		yyj3475++
-		if yyhl3475 {
-			yyb3475 = yyj3475 > l
+		yyj3483++
+		if yyhl3483 {
+			yyb3483 = yyj3483 > l
 		} else {
-			yyb3475 = r.CheckBreak()
+			yyb3483 = r.CheckBreak()
 		}
-		if yyb3475 {
+		if yyb3483 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3475-1, "")
+		z.DecStructFieldNotFound(yyj3483-1, "")
 	}
 	r.ReadEnd()
 }
@@ -40172,8 +40232,8 @@ func (x codecSelfer1234) encSlicePersistentVolumeAccessMode(v []PersistentVolume
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3482 := range v {
-		yyv3482.CodecEncodeSelf(e)
+	for _, yyv3490 := range v {
+		yyv3490.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40183,77 +40243,77 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3483 := *v
-	yyh3483, yyl3483 := z.DecSliceHelperStart()
+	yyv3491 := *v
+	yyh3491, yyl3491 := z.DecSliceHelperStart()
 
-	var yyrr3483, yyrl3483 int
-	var yyc3483, yyrt3483 bool
-	_, _, _ = yyc3483, yyrt3483, yyrl3483
-	yyrr3483 = yyl3483
+	var yyrr3491, yyrl3491 int
+	var yyc3491, yyrt3491 bool
+	_, _, _ = yyc3491, yyrt3491, yyrl3491
+	yyrr3491 = yyl3491
 
-	if yyv3483 == nil {
-		if yyrl3483, yyrt3483 = z.DecInferLen(yyl3483, z.DecBasicHandle().MaxInitLen, 16); yyrt3483 {
-			yyrr3483 = yyrl3483
+	if yyv3491 == nil {
+		if yyrl3491, yyrt3491 = z.DecInferLen(yyl3491, z.DecBasicHandle().MaxInitLen, 16); yyrt3491 {
+			yyrr3491 = yyrl3491
 		}
-		yyv3483 = make([]PersistentVolumeAccessMode, yyrl3483)
-		yyc3483 = true
+		yyv3491 = make([]PersistentVolumeAccessMode, yyrl3491)
+		yyc3491 = true
 	}
 
-	if yyl3483 == 0 {
-		if len(yyv3483) != 0 {
-			yyv3483 = yyv3483[:0]
-			yyc3483 = true
+	if yyl3491 == 0 {
+		if len(yyv3491) != 0 {
+			yyv3491 = yyv3491[:0]
+			yyc3491 = true
 		}
-	} else if yyl3483 > 0 {
+	} else if yyl3491 > 0 {
 
-		if yyl3483 > cap(yyv3483) {
-			yyrl3483, yyrt3483 = z.DecInferLen(yyl3483, z.DecBasicHandle().MaxInitLen, 16)
+		if yyl3491 > cap(yyv3491) {
+			yyrl3491, yyrt3491 = z.DecInferLen(yyl3491, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23483 := yyv3483
-			yyv3483 = make([]PersistentVolumeAccessMode, yyrl3483)
-			if len(yyv3483) > 0 {
-				copy(yyv3483, yyv23483[:cap(yyv23483)])
+			yyv23491 := yyv3491
+			yyv3491 = make([]PersistentVolumeAccessMode, yyrl3491)
+			if len(yyv3491) > 0 {
+				copy(yyv3491, yyv23491[:cap(yyv23491)])
 			}
-			yyc3483 = true
+			yyc3491 = true
 
-			yyrr3483 = len(yyv3483)
-		} else if yyl3483 != len(yyv3483) {
-			yyv3483 = yyv3483[:yyl3483]
-			yyc3483 = true
+			yyrr3491 = len(yyv3491)
+		} else if yyl3491 != len(yyv3491) {
+			yyv3491 = yyv3491[:yyl3491]
+			yyc3491 = true
 		}
-		yyj3483 := 0
-		for ; yyj3483 < yyrr3483; yyj3483++ {
+		yyj3491 := 0
+		for ; yyj3491 < yyrr3491; yyj3491++ {
 			if r.TryDecodeAsNil() {
-				yyv3483[yyj3483] = ""
+				yyv3491[yyj3491] = ""
 			} else {
-				yyv3483[yyj3483] = PersistentVolumeAccessMode(r.DecodeString())
+				yyv3491[yyj3491] = PersistentVolumeAccessMode(r.DecodeString())
 			}
 
 		}
-		if yyrt3483 {
-			for ; yyj3483 < yyl3483; yyj3483++ {
-				yyv3483 = append(yyv3483, "")
+		if yyrt3491 {
+			for ; yyj3491 < yyl3491; yyj3491++ {
+				yyv3491 = append(yyv3491, "")
 				if r.TryDecodeAsNil() {
-					yyv3483[yyj3483] = ""
+					yyv3491[yyj3491] = ""
 				} else {
-					yyv3483[yyj3483] = PersistentVolumeAccessMode(r.DecodeString())
+					yyv3491[yyj3491] = PersistentVolumeAccessMode(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3483 := 0; !r.CheckBreak(); yyj3483++ {
-			if yyj3483 >= len(yyv3483) {
-				yyv3483 = append(yyv3483, "") // var yyz3483 PersistentVolumeAccessMode
-				yyc3483 = true
+		for yyj3491 := 0; !r.CheckBreak(); yyj3491++ {
+			if yyj3491 >= len(yyv3491) {
+				yyv3491 = append(yyv3491, "") // var yyz3491 PersistentVolumeAccessMode
+				yyc3491 = true
 			}
 
-			if yyj3483 < len(yyv3483) {
+			if yyj3491 < len(yyv3491) {
 				if r.TryDecodeAsNil() {
-					yyv3483[yyj3483] = ""
+					yyv3491[yyj3491] = ""
 				} else {
-					yyv3483[yyj3483] = PersistentVolumeAccessMode(r.DecodeString())
+					yyv3491[yyj3491] = PersistentVolumeAccessMode(r.DecodeString())
 				}
 
 			} else {
@@ -40261,10 +40321,10 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 			}
 
 		}
-		yyh3483.End()
+		yyh3491.End()
 	}
-	if yyc3483 {
-		*v = yyv3483
+	if yyc3491 {
+		*v = yyv3491
 	}
 
 }
@@ -40274,9 +40334,9 @@ func (x codecSelfer1234) encSlicePersistentVolume(v []PersistentVolume, e *codec
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3487 := range v {
-		yy3488 := &yyv3487
-		yy3488.CodecEncodeSelf(e)
+	for _, yyv3495 := range v {
+		yy3496 := &yyv3495
+		yy3496.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40286,75 +40346,75 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3489 := *v
-	yyh3489, yyl3489 := z.DecSliceHelperStart()
+	yyv3497 := *v
+	yyh3497, yyl3497 := z.DecSliceHelperStart()
 
-	var yyrr3489, yyrl3489 int
-	var yyc3489, yyrt3489 bool
-	_, _, _ = yyc3489, yyrt3489, yyrl3489
-	yyrr3489 = yyl3489
+	var yyrr3497, yyrl3497 int
+	var yyc3497, yyrt3497 bool
+	_, _, _ = yyc3497, yyrt3497, yyrl3497
+	yyrr3497 = yyl3497
 
-	if yyv3489 == nil {
-		if yyrl3489, yyrt3489 = z.DecInferLen(yyl3489, z.DecBasicHandle().MaxInitLen, 384); yyrt3489 {
-			yyrr3489 = yyrl3489
+	if yyv3497 == nil {
+		if yyrl3497, yyrt3497 = z.DecInferLen(yyl3497, z.DecBasicHandle().MaxInitLen, 384); yyrt3497 {
+			yyrr3497 = yyrl3497
 		}
-		yyv3489 = make([]PersistentVolume, yyrl3489)
-		yyc3489 = true
+		yyv3497 = make([]PersistentVolume, yyrl3497)
+		yyc3497 = true
 	}
 
-	if yyl3489 == 0 {
-		if len(yyv3489) != 0 {
-			yyv3489 = yyv3489[:0]
-			yyc3489 = true
+	if yyl3497 == 0 {
+		if len(yyv3497) != 0 {
+			yyv3497 = yyv3497[:0]
+			yyc3497 = true
 		}
-	} else if yyl3489 > 0 {
+	} else if yyl3497 > 0 {
 
-		if yyl3489 > cap(yyv3489) {
-			yyrl3489, yyrt3489 = z.DecInferLen(yyl3489, z.DecBasicHandle().MaxInitLen, 384)
-			yyv3489 = make([]PersistentVolume, yyrl3489)
-			yyc3489 = true
+		if yyl3497 > cap(yyv3497) {
+			yyrl3497, yyrt3497 = z.DecInferLen(yyl3497, z.DecBasicHandle().MaxInitLen, 384)
+			yyv3497 = make([]PersistentVolume, yyrl3497)
+			yyc3497 = true
 
-			yyrr3489 = len(yyv3489)
-		} else if yyl3489 != len(yyv3489) {
-			yyv3489 = yyv3489[:yyl3489]
-			yyc3489 = true
+			yyrr3497 = len(yyv3497)
+		} else if yyl3497 != len(yyv3497) {
+			yyv3497 = yyv3497[:yyl3497]
+			yyc3497 = true
 		}
-		yyj3489 := 0
-		for ; yyj3489 < yyrr3489; yyj3489++ {
+		yyj3497 := 0
+		for ; yyj3497 < yyrr3497; yyj3497++ {
 			if r.TryDecodeAsNil() {
-				yyv3489[yyj3489] = PersistentVolume{}
+				yyv3497[yyj3497] = PersistentVolume{}
 			} else {
-				yyv3490 := &yyv3489[yyj3489]
-				yyv3490.CodecDecodeSelf(d)
+				yyv3498 := &yyv3497[yyj3497]
+				yyv3498.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3489 {
-			for ; yyj3489 < yyl3489; yyj3489++ {
-				yyv3489 = append(yyv3489, PersistentVolume{})
+		if yyrt3497 {
+			for ; yyj3497 < yyl3497; yyj3497++ {
+				yyv3497 = append(yyv3497, PersistentVolume{})
 				if r.TryDecodeAsNil() {
-					yyv3489[yyj3489] = PersistentVolume{}
+					yyv3497[yyj3497] = PersistentVolume{}
 				} else {
-					yyv3491 := &yyv3489[yyj3489]
-					yyv3491.CodecDecodeSelf(d)
+					yyv3499 := &yyv3497[yyj3497]
+					yyv3499.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3489 := 0; !r.CheckBreak(); yyj3489++ {
-			if yyj3489 >= len(yyv3489) {
-				yyv3489 = append(yyv3489, PersistentVolume{}) // var yyz3489 PersistentVolume
-				yyc3489 = true
+		for yyj3497 := 0; !r.CheckBreak(); yyj3497++ {
+			if yyj3497 >= len(yyv3497) {
+				yyv3497 = append(yyv3497, PersistentVolume{}) // var yyz3497 PersistentVolume
+				yyc3497 = true
 			}
 
-			if yyj3489 < len(yyv3489) {
+			if yyj3497 < len(yyv3497) {
 				if r.TryDecodeAsNil() {
-					yyv3489[yyj3489] = PersistentVolume{}
+					yyv3497[yyj3497] = PersistentVolume{}
 				} else {
-					yyv3492 := &yyv3489[yyj3489]
-					yyv3492.CodecDecodeSelf(d)
+					yyv3500 := &yyv3497[yyj3497]
+					yyv3500.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40362,10 +40422,10 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 			}
 
 		}
-		yyh3489.End()
+		yyh3497.End()
 	}
-	if yyc3489 {
-		*v = yyv3489
+	if yyc3497 {
+		*v = yyv3497
 	}
 
 }
@@ -40375,9 +40435,9 @@ func (x codecSelfer1234) encSlicePersistentVolumeClaim(v []PersistentVolumeClaim
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3493 := range v {
-		yy3494 := &yyv3493
-		yy3494.CodecEncodeSelf(e)
+	for _, yyv3501 := range v {
+		yy3502 := &yyv3501
+		yy3502.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40387,75 +40447,75 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3495 := *v
-	yyh3495, yyl3495 := z.DecSliceHelperStart()
+	yyv3503 := *v
+	yyh3503, yyl3503 := z.DecSliceHelperStart()
 
-	var yyrr3495, yyrl3495 int
-	var yyc3495, yyrt3495 bool
-	_, _, _ = yyc3495, yyrt3495, yyrl3495
-	yyrr3495 = yyl3495
+	var yyrr3503, yyrl3503 int
+	var yyc3503, yyrt3503 bool
+	_, _, _ = yyc3503, yyrt3503, yyrl3503
+	yyrr3503 = yyl3503
 
-	if yyv3495 == nil {
-		if yyrl3495, yyrt3495 = z.DecInferLen(yyl3495, z.DecBasicHandle().MaxInitLen, 296); yyrt3495 {
-			yyrr3495 = yyrl3495
+	if yyv3503 == nil {
+		if yyrl3503, yyrt3503 = z.DecInferLen(yyl3503, z.DecBasicHandle().MaxInitLen, 296); yyrt3503 {
+			yyrr3503 = yyrl3503
 		}
-		yyv3495 = make([]PersistentVolumeClaim, yyrl3495)
-		yyc3495 = true
+		yyv3503 = make([]PersistentVolumeClaim, yyrl3503)
+		yyc3503 = true
 	}
 
-	if yyl3495 == 0 {
-		if len(yyv3495) != 0 {
-			yyv3495 = yyv3495[:0]
-			yyc3495 = true
+	if yyl3503 == 0 {
+		if len(yyv3503) != 0 {
+			yyv3503 = yyv3503[:0]
+			yyc3503 = true
 		}
-	} else if yyl3495 > 0 {
+	} else if yyl3503 > 0 {
 
-		if yyl3495 > cap(yyv3495) {
-			yyrl3495, yyrt3495 = z.DecInferLen(yyl3495, z.DecBasicHandle().MaxInitLen, 296)
-			yyv3495 = make([]PersistentVolumeClaim, yyrl3495)
-			yyc3495 = true
+		if yyl3503 > cap(yyv3503) {
+			yyrl3503, yyrt3503 = z.DecInferLen(yyl3503, z.DecBasicHandle().MaxInitLen, 296)
+			yyv3503 = make([]PersistentVolumeClaim, yyrl3503)
+			yyc3503 = true
 
-			yyrr3495 = len(yyv3495)
-		} else if yyl3495 != len(yyv3495) {
-			yyv3495 = yyv3495[:yyl3495]
-			yyc3495 = true
+			yyrr3503 = len(yyv3503)
+		} else if yyl3503 != len(yyv3503) {
+			yyv3503 = yyv3503[:yyl3503]
+			yyc3503 = true
 		}
-		yyj3495 := 0
-		for ; yyj3495 < yyrr3495; yyj3495++ {
+		yyj3503 := 0
+		for ; yyj3503 < yyrr3503; yyj3503++ {
 			if r.TryDecodeAsNil() {
-				yyv3495[yyj3495] = PersistentVolumeClaim{}
+				yyv3503[yyj3503] = PersistentVolumeClaim{}
 			} else {
-				yyv3496 := &yyv3495[yyj3495]
-				yyv3496.CodecDecodeSelf(d)
+				yyv3504 := &yyv3503[yyj3503]
+				yyv3504.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3495 {
-			for ; yyj3495 < yyl3495; yyj3495++ {
-				yyv3495 = append(yyv3495, PersistentVolumeClaim{})
+		if yyrt3503 {
+			for ; yyj3503 < yyl3503; yyj3503++ {
+				yyv3503 = append(yyv3503, PersistentVolumeClaim{})
 				if r.TryDecodeAsNil() {
-					yyv3495[yyj3495] = PersistentVolumeClaim{}
+					yyv3503[yyj3503] = PersistentVolumeClaim{}
 				} else {
-					yyv3497 := &yyv3495[yyj3495]
-					yyv3497.CodecDecodeSelf(d)
+					yyv3505 := &yyv3503[yyj3503]
+					yyv3505.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3495 := 0; !r.CheckBreak(); yyj3495++ {
-			if yyj3495 >= len(yyv3495) {
-				yyv3495 = append(yyv3495, PersistentVolumeClaim{}) // var yyz3495 PersistentVolumeClaim
-				yyc3495 = true
+		for yyj3503 := 0; !r.CheckBreak(); yyj3503++ {
+			if yyj3503 >= len(yyv3503) {
+				yyv3503 = append(yyv3503, PersistentVolumeClaim{}) // var yyz3503 PersistentVolumeClaim
+				yyc3503 = true
 			}
 
-			if yyj3495 < len(yyv3495) {
+			if yyj3503 < len(yyv3503) {
 				if r.TryDecodeAsNil() {
-					yyv3495[yyj3495] = PersistentVolumeClaim{}
+					yyv3503[yyj3503] = PersistentVolumeClaim{}
 				} else {
-					yyv3498 := &yyv3495[yyj3495]
-					yyv3498.CodecDecodeSelf(d)
+					yyv3506 := &yyv3503[yyj3503]
+					yyv3506.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40463,10 +40523,10 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 			}
 
 		}
-		yyh3495.End()
+		yyh3503.End()
 	}
-	if yyc3495 {
-		*v = yyv3495
+	if yyc3503 {
+		*v = yyv3503
 	}
 
 }
@@ -40476,8 +40536,8 @@ func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3499 := range v {
-		yyv3499.CodecEncodeSelf(e)
+	for _, yyv3507 := range v {
+		yyv3507.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40487,77 +40547,77 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3500 := *v
-	yyh3500, yyl3500 := z.DecSliceHelperStart()
+	yyv3508 := *v
+	yyh3508, yyl3508 := z.DecSliceHelperStart()
 
-	var yyrr3500, yyrl3500 int
-	var yyc3500, yyrt3500 bool
-	_, _, _ = yyc3500, yyrt3500, yyrl3500
-	yyrr3500 = yyl3500
+	var yyrr3508, yyrl3508 int
+	var yyc3508, yyrt3508 bool
+	_, _, _ = yyc3508, yyrt3508, yyrl3508
+	yyrr3508 = yyl3508
 
-	if yyv3500 == nil {
-		if yyrl3500, yyrt3500 = z.DecInferLen(yyl3500, z.DecBasicHandle().MaxInitLen, 16); yyrt3500 {
-			yyrr3500 = yyrl3500
+	if yyv3508 == nil {
+		if yyrl3508, yyrt3508 = z.DecInferLen(yyl3508, z.DecBasicHandle().MaxInitLen, 16); yyrt3508 {
+			yyrr3508 = yyrl3508
 		}
-		yyv3500 = make([]Capability, yyrl3500)
-		yyc3500 = true
+		yyv3508 = make([]Capability, yyrl3508)
+		yyc3508 = true
 	}
 
-	if yyl3500 == 0 {
-		if len(yyv3500) != 0 {
-			yyv3500 = yyv3500[:0]
-			yyc3500 = true
+	if yyl3508 == 0 {
+		if len(yyv3508) != 0 {
+			yyv3508 = yyv3508[:0]
+			yyc3508 = true
 		}
-	} else if yyl3500 > 0 {
+	} else if yyl3508 > 0 {
 
-		if yyl3500 > cap(yyv3500) {
-			yyrl3500, yyrt3500 = z.DecInferLen(yyl3500, z.DecBasicHandle().MaxInitLen, 16)
+		if yyl3508 > cap(yyv3508) {
+			yyrl3508, yyrt3508 = z.DecInferLen(yyl3508, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23500 := yyv3500
-			yyv3500 = make([]Capability, yyrl3500)
-			if len(yyv3500) > 0 {
-				copy(yyv3500, yyv23500[:cap(yyv23500)])
+			yyv23508 := yyv3508
+			yyv3508 = make([]Capability, yyrl3508)
+			if len(yyv3508) > 0 {
+				copy(yyv3508, yyv23508[:cap(yyv23508)])
 			}
-			yyc3500 = true
+			yyc3508 = true
 
-			yyrr3500 = len(yyv3500)
-		} else if yyl3500 != len(yyv3500) {
-			yyv3500 = yyv3500[:yyl3500]
-			yyc3500 = true
+			yyrr3508 = len(yyv3508)
+		} else if yyl3508 != len(yyv3508) {
+			yyv3508 = yyv3508[:yyl3508]
+			yyc3508 = true
 		}
-		yyj3500 := 0
-		for ; yyj3500 < yyrr3500; yyj3500++ {
+		yyj3508 := 0
+		for ; yyj3508 < yyrr3508; yyj3508++ {
 			if r.TryDecodeAsNil() {
-				yyv3500[yyj3500] = ""
+				yyv3508[yyj3508] = ""
 			} else {
-				yyv3500[yyj3500] = Capability(r.DecodeString())
+				yyv3508[yyj3508] = Capability(r.DecodeString())
 			}
 
 		}
-		if yyrt3500 {
-			for ; yyj3500 < yyl3500; yyj3500++ {
-				yyv3500 = append(yyv3500, "")
+		if yyrt3508 {
+			for ; yyj3508 < yyl3508; yyj3508++ {
+				yyv3508 = append(yyv3508, "")
 				if r.TryDecodeAsNil() {
-					yyv3500[yyj3500] = ""
+					yyv3508[yyj3508] = ""
 				} else {
-					yyv3500[yyj3500] = Capability(r.DecodeString())
+					yyv3508[yyj3508] = Capability(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3500 := 0; !r.CheckBreak(); yyj3500++ {
-			if yyj3500 >= len(yyv3500) {
-				yyv3500 = append(yyv3500, "") // var yyz3500 Capability
-				yyc3500 = true
+		for yyj3508 := 0; !r.CheckBreak(); yyj3508++ {
+			if yyj3508 >= len(yyv3508) {
+				yyv3508 = append(yyv3508, "") // var yyz3508 Capability
+				yyc3508 = true
 			}
 
-			if yyj3500 < len(yyv3500) {
+			if yyj3508 < len(yyv3508) {
 				if r.TryDecodeAsNil() {
-					yyv3500[yyj3500] = ""
+					yyv3508[yyj3508] = ""
 				} else {
-					yyv3500[yyj3500] = Capability(r.DecodeString())
+					yyv3508[yyj3508] = Capability(r.DecodeString())
 				}
 
 			} else {
@@ -40565,10 +40625,10 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 			}
 
 		}
-		yyh3500.End()
+		yyh3508.End()
 	}
-	if yyc3500 {
-		*v = yyv3500
+	if yyc3508 {
+		*v = yyv3508
 	}
 
 }
@@ -40578,9 +40638,9 @@ func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3504 := range v {
-		yy3505 := &yyv3504
-		yy3505.CodecEncodeSelf(e)
+	for _, yyv3512 := range v {
+		yy3513 := &yyv3512
+		yy3513.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40590,75 +40650,75 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3506 := *v
-	yyh3506, yyl3506 := z.DecSliceHelperStart()
+	yyv3514 := *v
+	yyh3514, yyl3514 := z.DecSliceHelperStart()
 
-	var yyrr3506, yyrl3506 int
-	var yyc3506, yyrt3506 bool
-	_, _, _ = yyc3506, yyrt3506, yyrl3506
-	yyrr3506 = yyl3506
+	var yyrr3514, yyrl3514 int
+	var yyc3514, yyrt3514 bool
+	_, _, _ = yyc3514, yyrt3514, yyrl3514
+	yyrr3514 = yyl3514
 
-	if yyv3506 == nil {
-		if yyrl3506, yyrt3506 = z.DecInferLen(yyl3506, z.DecBasicHandle().MaxInitLen, 64); yyrt3506 {
-			yyrr3506 = yyrl3506
+	if yyv3514 == nil {
+		if yyrl3514, yyrt3514 = z.DecInferLen(yyl3514, z.DecBasicHandle().MaxInitLen, 64); yyrt3514 {
+			yyrr3514 = yyrl3514
 		}
-		yyv3506 = make([]ContainerPort, yyrl3506)
-		yyc3506 = true
+		yyv3514 = make([]ContainerPort, yyrl3514)
+		yyc3514 = true
 	}
 
-	if yyl3506 == 0 {
-		if len(yyv3506) != 0 {
-			yyv3506 = yyv3506[:0]
-			yyc3506 = true
+	if yyl3514 == 0 {
+		if len(yyv3514) != 0 {
+			yyv3514 = yyv3514[:0]
+			yyc3514 = true
 		}
-	} else if yyl3506 > 0 {
+	} else if yyl3514 > 0 {
 
-		if yyl3506 > cap(yyv3506) {
-			yyrl3506, yyrt3506 = z.DecInferLen(yyl3506, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3506 = make([]ContainerPort, yyrl3506)
-			yyc3506 = true
+		if yyl3514 > cap(yyv3514) {
+			yyrl3514, yyrt3514 = z.DecInferLen(yyl3514, z.DecBasicHandle().MaxInitLen, 64)
+			yyv3514 = make([]ContainerPort, yyrl3514)
+			yyc3514 = true
 
-			yyrr3506 = len(yyv3506)
-		} else if yyl3506 != len(yyv3506) {
-			yyv3506 = yyv3506[:yyl3506]
-			yyc3506 = true
+			yyrr3514 = len(yyv3514)
+		} else if yyl3514 != len(yyv3514) {
+			yyv3514 = yyv3514[:yyl3514]
+			yyc3514 = true
 		}
-		yyj3506 := 0
-		for ; yyj3506 < yyrr3506; yyj3506++ {
+		yyj3514 := 0
+		for ; yyj3514 < yyrr3514; yyj3514++ {
 			if r.TryDecodeAsNil() {
-				yyv3506[yyj3506] = ContainerPort{}
+				yyv3514[yyj3514] = ContainerPort{}
 			} else {
-				yyv3507 := &yyv3506[yyj3506]
-				yyv3507.CodecDecodeSelf(d)
+				yyv3515 := &yyv3514[yyj3514]
+				yyv3515.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3506 {
-			for ; yyj3506 < yyl3506; yyj3506++ {
-				yyv3506 = append(yyv3506, ContainerPort{})
+		if yyrt3514 {
+			for ; yyj3514 < yyl3514; yyj3514++ {
+				yyv3514 = append(yyv3514, ContainerPort{})
 				if r.TryDecodeAsNil() {
-					yyv3506[yyj3506] = ContainerPort{}
+					yyv3514[yyj3514] = ContainerPort{}
 				} else {
-					yyv3508 := &yyv3506[yyj3506]
-					yyv3508.CodecDecodeSelf(d)
+					yyv3516 := &yyv3514[yyj3514]
+					yyv3516.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3506 := 0; !r.CheckBreak(); yyj3506++ {
-			if yyj3506 >= len(yyv3506) {
-				yyv3506 = append(yyv3506, ContainerPort{}) // var yyz3506 ContainerPort
-				yyc3506 = true
+		for yyj3514 := 0; !r.CheckBreak(); yyj3514++ {
+			if yyj3514 >= len(yyv3514) {
+				yyv3514 = append(yyv3514, ContainerPort{}) // var yyz3514 ContainerPort
+				yyc3514 = true
 			}
 
-			if yyj3506 < len(yyv3506) {
+			if yyj3514 < len(yyv3514) {
 				if r.TryDecodeAsNil() {
-					yyv3506[yyj3506] = ContainerPort{}
+					yyv3514[yyj3514] = ContainerPort{}
 				} else {
-					yyv3509 := &yyv3506[yyj3506]
-					yyv3509.CodecDecodeSelf(d)
+					yyv3517 := &yyv3514[yyj3514]
+					yyv3517.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40666,10 +40726,10 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 			}
 
 		}
-		yyh3506.End()
+		yyh3514.End()
 	}
-	if yyc3506 {
-		*v = yyv3506
+	if yyc3514 {
+		*v = yyv3514
 	}
 
 }
@@ -40679,9 +40739,9 @@ func (x codecSelfer1234) encSliceEnvVar(v []EnvVar, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3510 := range v {
-		yy3511 := &yyv3510
-		yy3511.CodecEncodeSelf(e)
+	for _, yyv3518 := range v {
+		yy3519 := &yyv3518
+		yy3519.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40691,75 +40751,75 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3512 := *v
-	yyh3512, yyl3512 := z.DecSliceHelperStart()
+	yyv3520 := *v
+	yyh3520, yyl3520 := z.DecSliceHelperStart()
 
-	var yyrr3512, yyrl3512 int
-	var yyc3512, yyrt3512 bool
-	_, _, _ = yyc3512, yyrt3512, yyrl3512
-	yyrr3512 = yyl3512
+	var yyrr3520, yyrl3520 int
+	var yyc3520, yyrt3520 bool
+	_, _, _ = yyc3520, yyrt3520, yyrl3520
+	yyrr3520 = yyl3520
 
-	if yyv3512 == nil {
-		if yyrl3512, yyrt3512 = z.DecInferLen(yyl3512, z.DecBasicHandle().MaxInitLen, 40); yyrt3512 {
-			yyrr3512 = yyrl3512
+	if yyv3520 == nil {
+		if yyrl3520, yyrt3520 = z.DecInferLen(yyl3520, z.DecBasicHandle().MaxInitLen, 40); yyrt3520 {
+			yyrr3520 = yyrl3520
 		}
-		yyv3512 = make([]EnvVar, yyrl3512)
-		yyc3512 = true
+		yyv3520 = make([]EnvVar, yyrl3520)
+		yyc3520 = true
 	}
 
-	if yyl3512 == 0 {
-		if len(yyv3512) != 0 {
-			yyv3512 = yyv3512[:0]
-			yyc3512 = true
+	if yyl3520 == 0 {
+		if len(yyv3520) != 0 {
+			yyv3520 = yyv3520[:0]
+			yyc3520 = true
 		}
-	} else if yyl3512 > 0 {
+	} else if yyl3520 > 0 {
 
-		if yyl3512 > cap(yyv3512) {
-			yyrl3512, yyrt3512 = z.DecInferLen(yyl3512, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3512 = make([]EnvVar, yyrl3512)
-			yyc3512 = true
+		if yyl3520 > cap(yyv3520) {
+			yyrl3520, yyrt3520 = z.DecInferLen(yyl3520, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3520 = make([]EnvVar, yyrl3520)
+			yyc3520 = true
 
-			yyrr3512 = len(yyv3512)
-		} else if yyl3512 != len(yyv3512) {
-			yyv3512 = yyv3512[:yyl3512]
-			yyc3512 = true
+			yyrr3520 = len(yyv3520)
+		} else if yyl3520 != len(yyv3520) {
+			yyv3520 = yyv3520[:yyl3520]
+			yyc3520 = true
 		}
-		yyj3512 := 0
-		for ; yyj3512 < yyrr3512; yyj3512++ {
+		yyj3520 := 0
+		for ; yyj3520 < yyrr3520; yyj3520++ {
 			if r.TryDecodeAsNil() {
-				yyv3512[yyj3512] = EnvVar{}
+				yyv3520[yyj3520] = EnvVar{}
 			} else {
-				yyv3513 := &yyv3512[yyj3512]
-				yyv3513.CodecDecodeSelf(d)
+				yyv3521 := &yyv3520[yyj3520]
+				yyv3521.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3512 {
-			for ; yyj3512 < yyl3512; yyj3512++ {
-				yyv3512 = append(yyv3512, EnvVar{})
+		if yyrt3520 {
+			for ; yyj3520 < yyl3520; yyj3520++ {
+				yyv3520 = append(yyv3520, EnvVar{})
 				if r.TryDecodeAsNil() {
-					yyv3512[yyj3512] = EnvVar{}
+					yyv3520[yyj3520] = EnvVar{}
 				} else {
-					yyv3514 := &yyv3512[yyj3512]
-					yyv3514.CodecDecodeSelf(d)
+					yyv3522 := &yyv3520[yyj3520]
+					yyv3522.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3512 := 0; !r.CheckBreak(); yyj3512++ {
-			if yyj3512 >= len(yyv3512) {
-				yyv3512 = append(yyv3512, EnvVar{}) // var yyz3512 EnvVar
-				yyc3512 = true
+		for yyj3520 := 0; !r.CheckBreak(); yyj3520++ {
+			if yyj3520 >= len(yyv3520) {
+				yyv3520 = append(yyv3520, EnvVar{}) // var yyz3520 EnvVar
+				yyc3520 = true
 			}
 
-			if yyj3512 < len(yyv3512) {
+			if yyj3520 < len(yyv3520) {
 				if r.TryDecodeAsNil() {
-					yyv3512[yyj3512] = EnvVar{}
+					yyv3520[yyj3520] = EnvVar{}
 				} else {
-					yyv3515 := &yyv3512[yyj3512]
-					yyv3515.CodecDecodeSelf(d)
+					yyv3523 := &yyv3520[yyj3520]
+					yyv3523.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40767,10 +40827,10 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3512.End()
+		yyh3520.End()
 	}
-	if yyc3512 {
-		*v = yyv3512
+	if yyc3520 {
+		*v = yyv3520
 	}
 
 }
@@ -40780,9 +40840,9 @@ func (x codecSelfer1234) encSliceVolumeMount(v []VolumeMount, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3516 := range v {
-		yy3517 := &yyv3516
-		yy3517.CodecEncodeSelf(e)
+	for _, yyv3524 := range v {
+		yy3525 := &yyv3524
+		yy3525.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40792,75 +40852,75 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3518 := *v
-	yyh3518, yyl3518 := z.DecSliceHelperStart()
+	yyv3526 := *v
+	yyh3526, yyl3526 := z.DecSliceHelperStart()
 
-	var yyrr3518, yyrl3518 int
-	var yyc3518, yyrt3518 bool
-	_, _, _ = yyc3518, yyrt3518, yyrl3518
-	yyrr3518 = yyl3518
+	var yyrr3526, yyrl3526 int
+	var yyc3526, yyrt3526 bool
+	_, _, _ = yyc3526, yyrt3526, yyrl3526
+	yyrr3526 = yyl3526
 
-	if yyv3518 == nil {
-		if yyrl3518, yyrt3518 = z.DecInferLen(yyl3518, z.DecBasicHandle().MaxInitLen, 40); yyrt3518 {
-			yyrr3518 = yyrl3518
+	if yyv3526 == nil {
+		if yyrl3526, yyrt3526 = z.DecInferLen(yyl3526, z.DecBasicHandle().MaxInitLen, 40); yyrt3526 {
+			yyrr3526 = yyrl3526
 		}
-		yyv3518 = make([]VolumeMount, yyrl3518)
-		yyc3518 = true
+		yyv3526 = make([]VolumeMount, yyrl3526)
+		yyc3526 = true
 	}
 
-	if yyl3518 == 0 {
-		if len(yyv3518) != 0 {
-			yyv3518 = yyv3518[:0]
-			yyc3518 = true
+	if yyl3526 == 0 {
+		if len(yyv3526) != 0 {
+			yyv3526 = yyv3526[:0]
+			yyc3526 = true
 		}
-	} else if yyl3518 > 0 {
+	} else if yyl3526 > 0 {
 
-		if yyl3518 > cap(yyv3518) {
-			yyrl3518, yyrt3518 = z.DecInferLen(yyl3518, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3518 = make([]VolumeMount, yyrl3518)
-			yyc3518 = true
+		if yyl3526 > cap(yyv3526) {
+			yyrl3526, yyrt3526 = z.DecInferLen(yyl3526, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3526 = make([]VolumeMount, yyrl3526)
+			yyc3526 = true
 
-			yyrr3518 = len(yyv3518)
-		} else if yyl3518 != len(yyv3518) {
-			yyv3518 = yyv3518[:yyl3518]
-			yyc3518 = true
+			yyrr3526 = len(yyv3526)
+		} else if yyl3526 != len(yyv3526) {
+			yyv3526 = yyv3526[:yyl3526]
+			yyc3526 = true
 		}
-		yyj3518 := 0
-		for ; yyj3518 < yyrr3518; yyj3518++ {
+		yyj3526 := 0
+		for ; yyj3526 < yyrr3526; yyj3526++ {
 			if r.TryDecodeAsNil() {
-				yyv3518[yyj3518] = VolumeMount{}
+				yyv3526[yyj3526] = VolumeMount{}
 			} else {
-				yyv3519 := &yyv3518[yyj3518]
-				yyv3519.CodecDecodeSelf(d)
+				yyv3527 := &yyv3526[yyj3526]
+				yyv3527.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3518 {
-			for ; yyj3518 < yyl3518; yyj3518++ {
-				yyv3518 = append(yyv3518, VolumeMount{})
+		if yyrt3526 {
+			for ; yyj3526 < yyl3526; yyj3526++ {
+				yyv3526 = append(yyv3526, VolumeMount{})
 				if r.TryDecodeAsNil() {
-					yyv3518[yyj3518] = VolumeMount{}
+					yyv3526[yyj3526] = VolumeMount{}
 				} else {
-					yyv3520 := &yyv3518[yyj3518]
-					yyv3520.CodecDecodeSelf(d)
+					yyv3528 := &yyv3526[yyj3526]
+					yyv3528.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3518 := 0; !r.CheckBreak(); yyj3518++ {
-			if yyj3518 >= len(yyv3518) {
-				yyv3518 = append(yyv3518, VolumeMount{}) // var yyz3518 VolumeMount
-				yyc3518 = true
+		for yyj3526 := 0; !r.CheckBreak(); yyj3526++ {
+			if yyj3526 >= len(yyv3526) {
+				yyv3526 = append(yyv3526, VolumeMount{}) // var yyz3526 VolumeMount
+				yyc3526 = true
 			}
 
-			if yyj3518 < len(yyv3518) {
+			if yyj3526 < len(yyv3526) {
 				if r.TryDecodeAsNil() {
-					yyv3518[yyj3518] = VolumeMount{}
+					yyv3526[yyj3526] = VolumeMount{}
 				} else {
-					yyv3521 := &yyv3518[yyj3518]
-					yyv3521.CodecDecodeSelf(d)
+					yyv3529 := &yyv3526[yyj3526]
+					yyv3529.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40868,10 +40928,10 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 			}
 
 		}
-		yyh3518.End()
+		yyh3526.End()
 	}
-	if yyc3518 {
-		*v = yyv3518
+	if yyc3526 {
+		*v = yyv3526
 	}
 
 }
@@ -40881,9 +40941,9 @@ func (x codecSelfer1234) encSliceVolume(v []Volume, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3522 := range v {
-		yy3523 := &yyv3522
-		yy3523.CodecEncodeSelf(e)
+	for _, yyv3530 := range v {
+		yy3531 := &yyv3530
+		yy3531.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40893,75 +40953,75 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3524 := *v
-	yyh3524, yyl3524 := z.DecSliceHelperStart()
+	yyv3532 := *v
+	yyh3532, yyl3532 := z.DecSliceHelperStart()
 
-	var yyrr3524, yyrl3524 int
-	var yyc3524, yyrt3524 bool
-	_, _, _ = yyc3524, yyrt3524, yyrl3524
-	yyrr3524 = yyl3524
+	var yyrr3532, yyrl3532 int
+	var yyc3532, yyrt3532 bool
+	_, _, _ = yyc3532, yyrt3532, yyrl3532
+	yyrr3532 = yyl3532
 
-	if yyv3524 == nil {
-		if yyrl3524, yyrt3524 = z.DecInferLen(yyl3524, z.DecBasicHandle().MaxInitLen, 144); yyrt3524 {
-			yyrr3524 = yyrl3524
+	if yyv3532 == nil {
+		if yyrl3532, yyrt3532 = z.DecInferLen(yyl3532, z.DecBasicHandle().MaxInitLen, 144); yyrt3532 {
+			yyrr3532 = yyrl3532
 		}
-		yyv3524 = make([]Volume, yyrl3524)
-		yyc3524 = true
+		yyv3532 = make([]Volume, yyrl3532)
+		yyc3532 = true
 	}
 
-	if yyl3524 == 0 {
-		if len(yyv3524) != 0 {
-			yyv3524 = yyv3524[:0]
-			yyc3524 = true
+	if yyl3532 == 0 {
+		if len(yyv3532) != 0 {
+			yyv3532 = yyv3532[:0]
+			yyc3532 = true
 		}
-	} else if yyl3524 > 0 {
+	} else if yyl3532 > 0 {
 
-		if yyl3524 > cap(yyv3524) {
-			yyrl3524, yyrt3524 = z.DecInferLen(yyl3524, z.DecBasicHandle().MaxInitLen, 144)
-			yyv3524 = make([]Volume, yyrl3524)
-			yyc3524 = true
+		if yyl3532 > cap(yyv3532) {
+			yyrl3532, yyrt3532 = z.DecInferLen(yyl3532, z.DecBasicHandle().MaxInitLen, 144)
+			yyv3532 = make([]Volume, yyrl3532)
+			yyc3532 = true
 
-			yyrr3524 = len(yyv3524)
-		} else if yyl3524 != len(yyv3524) {
-			yyv3524 = yyv3524[:yyl3524]
-			yyc3524 = true
+			yyrr3532 = len(yyv3532)
+		} else if yyl3532 != len(yyv3532) {
+			yyv3532 = yyv3532[:yyl3532]
+			yyc3532 = true
 		}
-		yyj3524 := 0
-		for ; yyj3524 < yyrr3524; yyj3524++ {
+		yyj3532 := 0
+		for ; yyj3532 < yyrr3532; yyj3532++ {
 			if r.TryDecodeAsNil() {
-				yyv3524[yyj3524] = Volume{}
+				yyv3532[yyj3532] = Volume{}
 			} else {
-				yyv3525 := &yyv3524[yyj3524]
-				yyv3525.CodecDecodeSelf(d)
+				yyv3533 := &yyv3532[yyj3532]
+				yyv3533.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3524 {
-			for ; yyj3524 < yyl3524; yyj3524++ {
-				yyv3524 = append(yyv3524, Volume{})
+		if yyrt3532 {
+			for ; yyj3532 < yyl3532; yyj3532++ {
+				yyv3532 = append(yyv3532, Volume{})
 				if r.TryDecodeAsNil() {
-					yyv3524[yyj3524] = Volume{}
+					yyv3532[yyj3532] = Volume{}
 				} else {
-					yyv3526 := &yyv3524[yyj3524]
-					yyv3526.CodecDecodeSelf(d)
+					yyv3534 := &yyv3532[yyj3532]
+					yyv3534.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3524 := 0; !r.CheckBreak(); yyj3524++ {
-			if yyj3524 >= len(yyv3524) {
-				yyv3524 = append(yyv3524, Volume{}) // var yyz3524 Volume
-				yyc3524 = true
+		for yyj3532 := 0; !r.CheckBreak(); yyj3532++ {
+			if yyj3532 >= len(yyv3532) {
+				yyv3532 = append(yyv3532, Volume{}) // var yyz3532 Volume
+				yyc3532 = true
 			}
 
-			if yyj3524 < len(yyv3524) {
+			if yyj3532 < len(yyv3532) {
 				if r.TryDecodeAsNil() {
-					yyv3524[yyj3524] = Volume{}
+					yyv3532[yyj3532] = Volume{}
 				} else {
-					yyv3527 := &yyv3524[yyj3524]
-					yyv3527.CodecDecodeSelf(d)
+					yyv3535 := &yyv3532[yyj3532]
+					yyv3535.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40969,10 +41029,10 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3524.End()
+		yyh3532.End()
 	}
-	if yyc3524 {
-		*v = yyv3524
+	if yyc3532 {
+		*v = yyv3532
 	}
 
 }
@@ -40982,9 +41042,9 @@ func (x codecSelfer1234) encSliceContainer(v []Container, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3528 := range v {
-		yy3529 := &yyv3528
-		yy3529.CodecEncodeSelf(e)
+	for _, yyv3536 := range v {
+		yy3537 := &yyv3536
+		yy3537.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40994,75 +41054,75 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3530 := *v
-	yyh3530, yyl3530 := z.DecSliceHelperStart()
+	yyv3538 := *v
+	yyh3538, yyl3538 := z.DecSliceHelperStart()
 
-	var yyrr3530, yyrl3530 int
-	var yyc3530, yyrt3530 bool
-	_, _, _ = yyc3530, yyrt3530, yyrl3530
-	yyrr3530 = yyl3530
+	var yyrr3538, yyrl3538 int
+	var yyc3538, yyrt3538 bool
+	_, _, _ = yyc3538, yyrt3538, yyrl3538
+	yyrr3538 = yyl3538
 
-	if yyv3530 == nil {
-		if yyrl3530, yyrt3530 = z.DecInferLen(yyl3530, z.DecBasicHandle().MaxInitLen, 256); yyrt3530 {
-			yyrr3530 = yyrl3530
+	if yyv3538 == nil {
+		if yyrl3538, yyrt3538 = z.DecInferLen(yyl3538, z.DecBasicHandle().MaxInitLen, 256); yyrt3538 {
+			yyrr3538 = yyrl3538
 		}
-		yyv3530 = make([]Container, yyrl3530)
-		yyc3530 = true
+		yyv3538 = make([]Container, yyrl3538)
+		yyc3538 = true
 	}
 
-	if yyl3530 == 0 {
-		if len(yyv3530) != 0 {
-			yyv3530 = yyv3530[:0]
-			yyc3530 = true
+	if yyl3538 == 0 {
+		if len(yyv3538) != 0 {
+			yyv3538 = yyv3538[:0]
+			yyc3538 = true
 		}
-	} else if yyl3530 > 0 {
+	} else if yyl3538 > 0 {
 
-		if yyl3530 > cap(yyv3530) {
-			yyrl3530, yyrt3530 = z.DecInferLen(yyl3530, z.DecBasicHandle().MaxInitLen, 256)
-			yyv3530 = make([]Container, yyrl3530)
-			yyc3530 = true
+		if yyl3538 > cap(yyv3538) {
+			yyrl3538, yyrt3538 = z.DecInferLen(yyl3538, z.DecBasicHandle().MaxInitLen, 256)
+			yyv3538 = make([]Container, yyrl3538)
+			yyc3538 = true
 
-			yyrr3530 = len(yyv3530)
-		} else if yyl3530 != len(yyv3530) {
-			yyv3530 = yyv3530[:yyl3530]
-			yyc3530 = true
+			yyrr3538 = len(yyv3538)
+		} else if yyl3538 != len(yyv3538) {
+			yyv3538 = yyv3538[:yyl3538]
+			yyc3538 = true
 		}
-		yyj3530 := 0
-		for ; yyj3530 < yyrr3530; yyj3530++ {
+		yyj3538 := 0
+		for ; yyj3538 < yyrr3538; yyj3538++ {
 			if r.TryDecodeAsNil() {
-				yyv3530[yyj3530] = Container{}
+				yyv3538[yyj3538] = Container{}
 			} else {
-				yyv3531 := &yyv3530[yyj3530]
-				yyv3531.CodecDecodeSelf(d)
+				yyv3539 := &yyv3538[yyj3538]
+				yyv3539.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3530 {
-			for ; yyj3530 < yyl3530; yyj3530++ {
-				yyv3530 = append(yyv3530, Container{})
+		if yyrt3538 {
+			for ; yyj3538 < yyl3538; yyj3538++ {
+				yyv3538 = append(yyv3538, Container{})
 				if r.TryDecodeAsNil() {
-					yyv3530[yyj3530] = Container{}
+					yyv3538[yyj3538] = Container{}
 				} else {
-					yyv3532 := &yyv3530[yyj3530]
-					yyv3532.CodecDecodeSelf(d)
+					yyv3540 := &yyv3538[yyj3538]
+					yyv3540.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3530 := 0; !r.CheckBreak(); yyj3530++ {
-			if yyj3530 >= len(yyv3530) {
-				yyv3530 = append(yyv3530, Container{}) // var yyz3530 Container
-				yyc3530 = true
+		for yyj3538 := 0; !r.CheckBreak(); yyj3538++ {
+			if yyj3538 >= len(yyv3538) {
+				yyv3538 = append(yyv3538, Container{}) // var yyz3538 Container
+				yyc3538 = true
 			}
 
-			if yyj3530 < len(yyv3530) {
+			if yyj3538 < len(yyv3538) {
 				if r.TryDecodeAsNil() {
-					yyv3530[yyj3530] = Container{}
+					yyv3538[yyj3538] = Container{}
 				} else {
-					yyv3533 := &yyv3530[yyj3530]
-					yyv3533.CodecDecodeSelf(d)
+					yyv3541 := &yyv3538[yyj3538]
+					yyv3541.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41070,10 +41130,10 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3530.End()
+		yyh3538.End()
 	}
-	if yyc3530 {
-		*v = yyv3530
+	if yyc3538 {
+		*v = yyv3538
 	}
 
 }
@@ -41083,9 +41143,9 @@ func (x codecSelfer1234) encSliceLocalObjectReference(v []LocalObjectReference, 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3534 := range v {
-		yy3535 := &yyv3534
-		yy3535.CodecEncodeSelf(e)
+	for _, yyv3542 := range v {
+		yy3543 := &yyv3542
+		yy3543.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41095,75 +41155,75 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3536 := *v
-	yyh3536, yyl3536 := z.DecSliceHelperStart()
+	yyv3544 := *v
+	yyh3544, yyl3544 := z.DecSliceHelperStart()
 
-	var yyrr3536, yyrl3536 int
-	var yyc3536, yyrt3536 bool
-	_, _, _ = yyc3536, yyrt3536, yyrl3536
-	yyrr3536 = yyl3536
+	var yyrr3544, yyrl3544 int
+	var yyc3544, yyrt3544 bool
+	_, _, _ = yyc3544, yyrt3544, yyrl3544
+	yyrr3544 = yyl3544
 
-	if yyv3536 == nil {
-		if yyrl3536, yyrt3536 = z.DecInferLen(yyl3536, z.DecBasicHandle().MaxInitLen, 16); yyrt3536 {
-			yyrr3536 = yyrl3536
+	if yyv3544 == nil {
+		if yyrl3544, yyrt3544 = z.DecInferLen(yyl3544, z.DecBasicHandle().MaxInitLen, 16); yyrt3544 {
+			yyrr3544 = yyrl3544
 		}
-		yyv3536 = make([]LocalObjectReference, yyrl3536)
-		yyc3536 = true
+		yyv3544 = make([]LocalObjectReference, yyrl3544)
+		yyc3544 = true
 	}
 
-	if yyl3536 == 0 {
-		if len(yyv3536) != 0 {
-			yyv3536 = yyv3536[:0]
-			yyc3536 = true
+	if yyl3544 == 0 {
+		if len(yyv3544) != 0 {
+			yyv3544 = yyv3544[:0]
+			yyc3544 = true
 		}
-	} else if yyl3536 > 0 {
+	} else if yyl3544 > 0 {
 
-		if yyl3536 > cap(yyv3536) {
-			yyrl3536, yyrt3536 = z.DecInferLen(yyl3536, z.DecBasicHandle().MaxInitLen, 16)
-			yyv3536 = make([]LocalObjectReference, yyrl3536)
-			yyc3536 = true
+		if yyl3544 > cap(yyv3544) {
+			yyrl3544, yyrt3544 = z.DecInferLen(yyl3544, z.DecBasicHandle().MaxInitLen, 16)
+			yyv3544 = make([]LocalObjectReference, yyrl3544)
+			yyc3544 = true
 
-			yyrr3536 = len(yyv3536)
-		} else if yyl3536 != len(yyv3536) {
-			yyv3536 = yyv3536[:yyl3536]
-			yyc3536 = true
+			yyrr3544 = len(yyv3544)
+		} else if yyl3544 != len(yyv3544) {
+			yyv3544 = yyv3544[:yyl3544]
+			yyc3544 = true
 		}
-		yyj3536 := 0
-		for ; yyj3536 < yyrr3536; yyj3536++ {
+		yyj3544 := 0
+		for ; yyj3544 < yyrr3544; yyj3544++ {
 			if r.TryDecodeAsNil() {
-				yyv3536[yyj3536] = LocalObjectReference{}
+				yyv3544[yyj3544] = LocalObjectReference{}
 			} else {
-				yyv3537 := &yyv3536[yyj3536]
-				yyv3537.CodecDecodeSelf(d)
+				yyv3545 := &yyv3544[yyj3544]
+				yyv3545.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3536 {
-			for ; yyj3536 < yyl3536; yyj3536++ {
-				yyv3536 = append(yyv3536, LocalObjectReference{})
+		if yyrt3544 {
+			for ; yyj3544 < yyl3544; yyj3544++ {
+				yyv3544 = append(yyv3544, LocalObjectReference{})
 				if r.TryDecodeAsNil() {
-					yyv3536[yyj3536] = LocalObjectReference{}
+					yyv3544[yyj3544] = LocalObjectReference{}
 				} else {
-					yyv3538 := &yyv3536[yyj3536]
-					yyv3538.CodecDecodeSelf(d)
+					yyv3546 := &yyv3544[yyj3544]
+					yyv3546.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3536 := 0; !r.CheckBreak(); yyj3536++ {
-			if yyj3536 >= len(yyv3536) {
-				yyv3536 = append(yyv3536, LocalObjectReference{}) // var yyz3536 LocalObjectReference
-				yyc3536 = true
+		for yyj3544 := 0; !r.CheckBreak(); yyj3544++ {
+			if yyj3544 >= len(yyv3544) {
+				yyv3544 = append(yyv3544, LocalObjectReference{}) // var yyz3544 LocalObjectReference
+				yyc3544 = true
 			}
 
-			if yyj3536 < len(yyv3536) {
+			if yyj3544 < len(yyv3544) {
 				if r.TryDecodeAsNil() {
-					yyv3536[yyj3536] = LocalObjectReference{}
+					yyv3544[yyj3544] = LocalObjectReference{}
 				} else {
-					yyv3539 := &yyv3536[yyj3536]
-					yyv3539.CodecDecodeSelf(d)
+					yyv3547 := &yyv3544[yyj3544]
+					yyv3547.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41171,10 +41231,10 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 			}
 
 		}
-		yyh3536.End()
+		yyh3544.End()
 	}
-	if yyc3536 {
-		*v = yyv3536
+	if yyc3544 {
+		*v = yyv3544
 	}
 
 }
@@ -41184,9 +41244,9 @@ func (x codecSelfer1234) encSlicePodCondition(v []PodCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3540 := range v {
-		yy3541 := &yyv3540
-		yy3541.CodecEncodeSelf(e)
+	for _, yyv3548 := range v {
+		yy3549 := &yyv3548
+		yy3549.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41196,75 +41256,75 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3542 := *v
-	yyh3542, yyl3542 := z.DecSliceHelperStart()
+	yyv3550 := *v
+	yyh3550, yyl3550 := z.DecSliceHelperStart()
 
-	var yyrr3542, yyrl3542 int
-	var yyc3542, yyrt3542 bool
-	_, _, _ = yyc3542, yyrt3542, yyrl3542
-	yyrr3542 = yyl3542
+	var yyrr3550, yyrl3550 int
+	var yyc3550, yyrt3550 bool
+	_, _, _ = yyc3550, yyrt3550, yyrl3550
+	yyrr3550 = yyl3550
 
-	if yyv3542 == nil {
-		if yyrl3542, yyrt3542 = z.DecInferLen(yyl3542, z.DecBasicHandle().MaxInitLen, 112); yyrt3542 {
-			yyrr3542 = yyrl3542
+	if yyv3550 == nil {
+		if yyrl3550, yyrt3550 = z.DecInferLen(yyl3550, z.DecBasicHandle().MaxInitLen, 112); yyrt3550 {
+			yyrr3550 = yyrl3550
 		}
-		yyv3542 = make([]PodCondition, yyrl3542)
-		yyc3542 = true
+		yyv3550 = make([]PodCondition, yyrl3550)
+		yyc3550 = true
 	}
 
-	if yyl3542 == 0 {
-		if len(yyv3542) != 0 {
-			yyv3542 = yyv3542[:0]
-			yyc3542 = true
+	if yyl3550 == 0 {
+		if len(yyv3550) != 0 {
+			yyv3550 = yyv3550[:0]
+			yyc3550 = true
 		}
-	} else if yyl3542 > 0 {
+	} else if yyl3550 > 0 {
 
-		if yyl3542 > cap(yyv3542) {
-			yyrl3542, yyrt3542 = z.DecInferLen(yyl3542, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3542 = make([]PodCondition, yyrl3542)
-			yyc3542 = true
+		if yyl3550 > cap(yyv3550) {
+			yyrl3550, yyrt3550 = z.DecInferLen(yyl3550, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3550 = make([]PodCondition, yyrl3550)
+			yyc3550 = true
 
-			yyrr3542 = len(yyv3542)
-		} else if yyl3542 != len(yyv3542) {
-			yyv3542 = yyv3542[:yyl3542]
-			yyc3542 = true
+			yyrr3550 = len(yyv3550)
+		} else if yyl3550 != len(yyv3550) {
+			yyv3550 = yyv3550[:yyl3550]
+			yyc3550 = true
 		}
-		yyj3542 := 0
-		for ; yyj3542 < yyrr3542; yyj3542++ {
+		yyj3550 := 0
+		for ; yyj3550 < yyrr3550; yyj3550++ {
 			if r.TryDecodeAsNil() {
-				yyv3542[yyj3542] = PodCondition{}
+				yyv3550[yyj3550] = PodCondition{}
 			} else {
-				yyv3543 := &yyv3542[yyj3542]
-				yyv3543.CodecDecodeSelf(d)
+				yyv3551 := &yyv3550[yyj3550]
+				yyv3551.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3542 {
-			for ; yyj3542 < yyl3542; yyj3542++ {
-				yyv3542 = append(yyv3542, PodCondition{})
+		if yyrt3550 {
+			for ; yyj3550 < yyl3550; yyj3550++ {
+				yyv3550 = append(yyv3550, PodCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3542[yyj3542] = PodCondition{}
+					yyv3550[yyj3550] = PodCondition{}
 				} else {
-					yyv3544 := &yyv3542[yyj3542]
-					yyv3544.CodecDecodeSelf(d)
+					yyv3552 := &yyv3550[yyj3550]
+					yyv3552.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3542 := 0; !r.CheckBreak(); yyj3542++ {
-			if yyj3542 >= len(yyv3542) {
-				yyv3542 = append(yyv3542, PodCondition{}) // var yyz3542 PodCondition
-				yyc3542 = true
+		for yyj3550 := 0; !r.CheckBreak(); yyj3550++ {
+			if yyj3550 >= len(yyv3550) {
+				yyv3550 = append(yyv3550, PodCondition{}) // var yyz3550 PodCondition
+				yyc3550 = true
 			}
 
-			if yyj3542 < len(yyv3542) {
+			if yyj3550 < len(yyv3550) {
 				if r.TryDecodeAsNil() {
-					yyv3542[yyj3542] = PodCondition{}
+					yyv3550[yyj3550] = PodCondition{}
 				} else {
-					yyv3545 := &yyv3542[yyj3542]
-					yyv3545.CodecDecodeSelf(d)
+					yyv3553 := &yyv3550[yyj3550]
+					yyv3553.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41272,10 +41332,10 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 			}
 
 		}
-		yyh3542.End()
+		yyh3550.End()
 	}
-	if yyc3542 {
-		*v = yyv3542
+	if yyc3550 {
+		*v = yyv3550
 	}
 
 }
@@ -41285,9 +41345,9 @@ func (x codecSelfer1234) encSliceContainerStatus(v []ContainerStatus, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3546 := range v {
-		yy3547 := &yyv3546
-		yy3547.CodecEncodeSelf(e)
+	for _, yyv3554 := range v {
+		yy3555 := &yyv3554
+		yy3555.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41297,75 +41357,75 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3548 := *v
-	yyh3548, yyl3548 := z.DecSliceHelperStart()
+	yyv3556 := *v
+	yyh3556, yyl3556 := z.DecSliceHelperStart()
 
-	var yyrr3548, yyrl3548 int
-	var yyc3548, yyrt3548 bool
-	_, _, _ = yyc3548, yyrt3548, yyrl3548
-	yyrr3548 = yyl3548
+	var yyrr3556, yyrl3556 int
+	var yyc3556, yyrt3556 bool
+	_, _, _ = yyc3556, yyrt3556, yyrl3556
+	yyrr3556 = yyl3556
 
-	if yyv3548 == nil {
-		if yyrl3548, yyrt3548 = z.DecInferLen(yyl3548, z.DecBasicHandle().MaxInitLen, 128); yyrt3548 {
-			yyrr3548 = yyrl3548
+	if yyv3556 == nil {
+		if yyrl3556, yyrt3556 = z.DecInferLen(yyl3556, z.DecBasicHandle().MaxInitLen, 128); yyrt3556 {
+			yyrr3556 = yyrl3556
 		}
-		yyv3548 = make([]ContainerStatus, yyrl3548)
-		yyc3548 = true
+		yyv3556 = make([]ContainerStatus, yyrl3556)
+		yyc3556 = true
 	}
 
-	if yyl3548 == 0 {
-		if len(yyv3548) != 0 {
-			yyv3548 = yyv3548[:0]
-			yyc3548 = true
+	if yyl3556 == 0 {
+		if len(yyv3556) != 0 {
+			yyv3556 = yyv3556[:0]
+			yyc3556 = true
 		}
-	} else if yyl3548 > 0 {
+	} else if yyl3556 > 0 {
 
-		if yyl3548 > cap(yyv3548) {
-			yyrl3548, yyrt3548 = z.DecInferLen(yyl3548, z.DecBasicHandle().MaxInitLen, 128)
-			yyv3548 = make([]ContainerStatus, yyrl3548)
-			yyc3548 = true
+		if yyl3556 > cap(yyv3556) {
+			yyrl3556, yyrt3556 = z.DecInferLen(yyl3556, z.DecBasicHandle().MaxInitLen, 128)
+			yyv3556 = make([]ContainerStatus, yyrl3556)
+			yyc3556 = true
 
-			yyrr3548 = len(yyv3548)
-		} else if yyl3548 != len(yyv3548) {
-			yyv3548 = yyv3548[:yyl3548]
-			yyc3548 = true
+			yyrr3556 = len(yyv3556)
+		} else if yyl3556 != len(yyv3556) {
+			yyv3556 = yyv3556[:yyl3556]
+			yyc3556 = true
 		}
-		yyj3548 := 0
-		for ; yyj3548 < yyrr3548; yyj3548++ {
+		yyj3556 := 0
+		for ; yyj3556 < yyrr3556; yyj3556++ {
 			if r.TryDecodeAsNil() {
-				yyv3548[yyj3548] = ContainerStatus{}
+				yyv3556[yyj3556] = ContainerStatus{}
 			} else {
-				yyv3549 := &yyv3548[yyj3548]
-				yyv3549.CodecDecodeSelf(d)
+				yyv3557 := &yyv3556[yyj3556]
+				yyv3557.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3548 {
-			for ; yyj3548 < yyl3548; yyj3548++ {
-				yyv3548 = append(yyv3548, ContainerStatus{})
+		if yyrt3556 {
+			for ; yyj3556 < yyl3556; yyj3556++ {
+				yyv3556 = append(yyv3556, ContainerStatus{})
 				if r.TryDecodeAsNil() {
-					yyv3548[yyj3548] = ContainerStatus{}
+					yyv3556[yyj3556] = ContainerStatus{}
 				} else {
-					yyv3550 := &yyv3548[yyj3548]
-					yyv3550.CodecDecodeSelf(d)
+					yyv3558 := &yyv3556[yyj3556]
+					yyv3558.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3548 := 0; !r.CheckBreak(); yyj3548++ {
-			if yyj3548 >= len(yyv3548) {
-				yyv3548 = append(yyv3548, ContainerStatus{}) // var yyz3548 ContainerStatus
-				yyc3548 = true
+		for yyj3556 := 0; !r.CheckBreak(); yyj3556++ {
+			if yyj3556 >= len(yyv3556) {
+				yyv3556 = append(yyv3556, ContainerStatus{}) // var yyz3556 ContainerStatus
+				yyc3556 = true
 			}
 
-			if yyj3548 < len(yyv3548) {
+			if yyj3556 < len(yyv3556) {
 				if r.TryDecodeAsNil() {
-					yyv3548[yyj3548] = ContainerStatus{}
+					yyv3556[yyj3556] = ContainerStatus{}
 				} else {
-					yyv3551 := &yyv3548[yyj3548]
-					yyv3551.CodecDecodeSelf(d)
+					yyv3559 := &yyv3556[yyj3556]
+					yyv3559.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41373,10 +41433,10 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 			}
 
 		}
-		yyh3548.End()
+		yyh3556.End()
 	}
-	if yyc3548 {
-		*v = yyv3548
+	if yyc3556 {
+		*v = yyv3556
 	}
 
 }
@@ -41386,9 +41446,9 @@ func (x codecSelfer1234) encSlicePod(v []Pod, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3552 := range v {
-		yy3553 := &yyv3552
-		yy3553.CodecEncodeSelf(e)
+	for _, yyv3560 := range v {
+		yy3561 := &yyv3560
+		yy3561.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41398,75 +41458,75 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3554 := *v
-	yyh3554, yyl3554 := z.DecSliceHelperStart()
+	yyv3562 := *v
+	yyh3562, yyl3562 := z.DecSliceHelperStart()
 
-	var yyrr3554, yyrl3554 int
-	var yyc3554, yyrt3554 bool
-	_, _, _ = yyc3554, yyrt3554, yyrl3554
-	yyrr3554 = yyl3554
+	var yyrr3562, yyrl3562 int
+	var yyc3562, yyrt3562 bool
+	_, _, _ = yyc3562, yyrt3562, yyrl3562
+	yyrr3562 = yyl3562
 
-	if yyv3554 == nil {
-		if yyrl3554, yyrt3554 = z.DecInferLen(yyl3554, z.DecBasicHandle().MaxInitLen, 520); yyrt3554 {
-			yyrr3554 = yyrl3554
+	if yyv3562 == nil {
+		if yyrl3562, yyrt3562 = z.DecInferLen(yyl3562, z.DecBasicHandle().MaxInitLen, 504); yyrt3562 {
+			yyrr3562 = yyrl3562
 		}
-		yyv3554 = make([]Pod, yyrl3554)
-		yyc3554 = true
+		yyv3562 = make([]Pod, yyrl3562)
+		yyc3562 = true
 	}
 
-	if yyl3554 == 0 {
-		if len(yyv3554) != 0 {
-			yyv3554 = yyv3554[:0]
-			yyc3554 = true
+	if yyl3562 == 0 {
+		if len(yyv3562) != 0 {
+			yyv3562 = yyv3562[:0]
+			yyc3562 = true
 		}
-	} else if yyl3554 > 0 {
+	} else if yyl3562 > 0 {
 
-		if yyl3554 > cap(yyv3554) {
-			yyrl3554, yyrt3554 = z.DecInferLen(yyl3554, z.DecBasicHandle().MaxInitLen, 520)
-			yyv3554 = make([]Pod, yyrl3554)
-			yyc3554 = true
+		if yyl3562 > cap(yyv3562) {
+			yyrl3562, yyrt3562 = z.DecInferLen(yyl3562, z.DecBasicHandle().MaxInitLen, 504)
+			yyv3562 = make([]Pod, yyrl3562)
+			yyc3562 = true
 
-			yyrr3554 = len(yyv3554)
-		} else if yyl3554 != len(yyv3554) {
-			yyv3554 = yyv3554[:yyl3554]
-			yyc3554 = true
+			yyrr3562 = len(yyv3562)
+		} else if yyl3562 != len(yyv3562) {
+			yyv3562 = yyv3562[:yyl3562]
+			yyc3562 = true
 		}
-		yyj3554 := 0
-		for ; yyj3554 < yyrr3554; yyj3554++ {
+		yyj3562 := 0
+		for ; yyj3562 < yyrr3562; yyj3562++ {
 			if r.TryDecodeAsNil() {
-				yyv3554[yyj3554] = Pod{}
+				yyv3562[yyj3562] = Pod{}
 			} else {
-				yyv3555 := &yyv3554[yyj3554]
-				yyv3555.CodecDecodeSelf(d)
+				yyv3563 := &yyv3562[yyj3562]
+				yyv3563.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3554 {
-			for ; yyj3554 < yyl3554; yyj3554++ {
-				yyv3554 = append(yyv3554, Pod{})
+		if yyrt3562 {
+			for ; yyj3562 < yyl3562; yyj3562++ {
+				yyv3562 = append(yyv3562, Pod{})
 				if r.TryDecodeAsNil() {
-					yyv3554[yyj3554] = Pod{}
+					yyv3562[yyj3562] = Pod{}
 				} else {
-					yyv3556 := &yyv3554[yyj3554]
-					yyv3556.CodecDecodeSelf(d)
+					yyv3564 := &yyv3562[yyj3562]
+					yyv3564.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3554 := 0; !r.CheckBreak(); yyj3554++ {
-			if yyj3554 >= len(yyv3554) {
-				yyv3554 = append(yyv3554, Pod{}) // var yyz3554 Pod
-				yyc3554 = true
+		for yyj3562 := 0; !r.CheckBreak(); yyj3562++ {
+			if yyj3562 >= len(yyv3562) {
+				yyv3562 = append(yyv3562, Pod{}) // var yyz3562 Pod
+				yyc3562 = true
 			}
 
-			if yyj3554 < len(yyv3554) {
+			if yyj3562 < len(yyv3562) {
 				if r.TryDecodeAsNil() {
-					yyv3554[yyj3554] = Pod{}
+					yyv3562[yyj3562] = Pod{}
 				} else {
-					yyv3557 := &yyv3554[yyj3554]
-					yyv3557.CodecDecodeSelf(d)
+					yyv3565 := &yyv3562[yyj3562]
+					yyv3565.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41474,10 +41534,10 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3554.End()
+		yyh3562.End()
 	}
-	if yyc3554 {
-		*v = yyv3554
+	if yyc3562 {
+		*v = yyv3562
 	}
 
 }
@@ -41487,9 +41547,9 @@ func (x codecSelfer1234) encSlicePodTemplate(v []PodTemplate, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3558 := range v {
-		yy3559 := &yyv3558
-		yy3559.CodecEncodeSelf(e)
+	for _, yyv3566 := range v {
+		yy3567 := &yyv3566
+		yy3567.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41499,75 +41559,75 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3560 := *v
-	yyh3560, yyl3560 := z.DecSliceHelperStart()
+	yyv3568 := *v
+	yyh3568, yyl3568 := z.DecSliceHelperStart()
 
-	var yyrr3560, yyrl3560 int
-	var yyc3560, yyrt3560 bool
-	_, _, _ = yyc3560, yyrt3560, yyrl3560
-	yyrr3560 = yyl3560
+	var yyrr3568, yyrl3568 int
+	var yyc3568, yyrt3568 bool
+	_, _, _ = yyc3568, yyrt3568, yyrl3568
+	yyrr3568 = yyl3568
 
-	if yyv3560 == nil {
-		if yyrl3560, yyrt3560 = z.DecInferLen(yyl3560, z.DecBasicHandle().MaxInitLen, 544); yyrt3560 {
-			yyrr3560 = yyrl3560
+	if yyv3568 == nil {
+		if yyrl3568, yyrt3568 = z.DecInferLen(yyl3568, z.DecBasicHandle().MaxInitLen, 528); yyrt3568 {
+			yyrr3568 = yyrl3568
 		}
-		yyv3560 = make([]PodTemplate, yyrl3560)
-		yyc3560 = true
+		yyv3568 = make([]PodTemplate, yyrl3568)
+		yyc3568 = true
 	}
 
-	if yyl3560 == 0 {
-		if len(yyv3560) != 0 {
-			yyv3560 = yyv3560[:0]
-			yyc3560 = true
+	if yyl3568 == 0 {
+		if len(yyv3568) != 0 {
+			yyv3568 = yyv3568[:0]
+			yyc3568 = true
 		}
-	} else if yyl3560 > 0 {
+	} else if yyl3568 > 0 {
 
-		if yyl3560 > cap(yyv3560) {
-			yyrl3560, yyrt3560 = z.DecInferLen(yyl3560, z.DecBasicHandle().MaxInitLen, 544)
-			yyv3560 = make([]PodTemplate, yyrl3560)
-			yyc3560 = true
+		if yyl3568 > cap(yyv3568) {
+			yyrl3568, yyrt3568 = z.DecInferLen(yyl3568, z.DecBasicHandle().MaxInitLen, 528)
+			yyv3568 = make([]PodTemplate, yyrl3568)
+			yyc3568 = true
 
-			yyrr3560 = len(yyv3560)
-		} else if yyl3560 != len(yyv3560) {
-			yyv3560 = yyv3560[:yyl3560]
-			yyc3560 = true
+			yyrr3568 = len(yyv3568)
+		} else if yyl3568 != len(yyv3568) {
+			yyv3568 = yyv3568[:yyl3568]
+			yyc3568 = true
 		}
-		yyj3560 := 0
-		for ; yyj3560 < yyrr3560; yyj3560++ {
+		yyj3568 := 0
+		for ; yyj3568 < yyrr3568; yyj3568++ {
 			if r.TryDecodeAsNil() {
-				yyv3560[yyj3560] = PodTemplate{}
+				yyv3568[yyj3568] = PodTemplate{}
 			} else {
-				yyv3561 := &yyv3560[yyj3560]
-				yyv3561.CodecDecodeSelf(d)
+				yyv3569 := &yyv3568[yyj3568]
+				yyv3569.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3560 {
-			for ; yyj3560 < yyl3560; yyj3560++ {
-				yyv3560 = append(yyv3560, PodTemplate{})
+		if yyrt3568 {
+			for ; yyj3568 < yyl3568; yyj3568++ {
+				yyv3568 = append(yyv3568, PodTemplate{})
 				if r.TryDecodeAsNil() {
-					yyv3560[yyj3560] = PodTemplate{}
+					yyv3568[yyj3568] = PodTemplate{}
 				} else {
-					yyv3562 := &yyv3560[yyj3560]
-					yyv3562.CodecDecodeSelf(d)
+					yyv3570 := &yyv3568[yyj3568]
+					yyv3570.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3560 := 0; !r.CheckBreak(); yyj3560++ {
-			if yyj3560 >= len(yyv3560) {
-				yyv3560 = append(yyv3560, PodTemplate{}) // var yyz3560 PodTemplate
-				yyc3560 = true
+		for yyj3568 := 0; !r.CheckBreak(); yyj3568++ {
+			if yyj3568 >= len(yyv3568) {
+				yyv3568 = append(yyv3568, PodTemplate{}) // var yyz3568 PodTemplate
+				yyc3568 = true
 			}
 
-			if yyj3560 < len(yyv3560) {
+			if yyj3568 < len(yyv3568) {
 				if r.TryDecodeAsNil() {
-					yyv3560[yyj3560] = PodTemplate{}
+					yyv3568[yyj3568] = PodTemplate{}
 				} else {
-					yyv3563 := &yyv3560[yyj3560]
-					yyv3563.CodecDecodeSelf(d)
+					yyv3571 := &yyv3568[yyj3568]
+					yyv3571.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41575,10 +41635,10 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 			}
 
 		}
-		yyh3560.End()
+		yyh3568.End()
 	}
-	if yyc3560 {
-		*v = yyv3560
+	if yyc3568 {
+		*v = yyv3568
 	}
 
 }
@@ -41588,9 +41648,9 @@ func (x codecSelfer1234) encSliceReplicationController(v []ReplicationController
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3564 := range v {
-		yy3565 := &yyv3564
-		yy3565.CodecEncodeSelf(e)
+	for _, yyv3572 := range v {
+		yy3573 := &yyv3572
+		yy3573.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41600,75 +41660,75 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3566 := *v
-	yyh3566, yyl3566 := z.DecSliceHelperStart()
+	yyv3574 := *v
+	yyh3574, yyl3574 := z.DecSliceHelperStart()
 
-	var yyrr3566, yyrl3566 int
-	var yyc3566, yyrt3566 bool
-	_, _, _ = yyc3566, yyrt3566, yyrl3566
-	yyrr3566 = yyl3566
+	var yyrr3574, yyrl3574 int
+	var yyc3574, yyrt3574 bool
+	_, _, _ = yyc3574, yyrt3574, yyrl3574
+	yyrr3574 = yyl3574
 
-	if yyv3566 == nil {
-		if yyrl3566, yyrt3566 = z.DecInferLen(yyl3566, z.DecBasicHandle().MaxInitLen, 232); yyrt3566 {
-			yyrr3566 = yyrl3566
+	if yyv3574 == nil {
+		if yyrl3574, yyrt3574 = z.DecInferLen(yyl3574, z.DecBasicHandle().MaxInitLen, 232); yyrt3574 {
+			yyrr3574 = yyrl3574
 		}
-		yyv3566 = make([]ReplicationController, yyrl3566)
-		yyc3566 = true
+		yyv3574 = make([]ReplicationController, yyrl3574)
+		yyc3574 = true
 	}
 
-	if yyl3566 == 0 {
-		if len(yyv3566) != 0 {
-			yyv3566 = yyv3566[:0]
-			yyc3566 = true
+	if yyl3574 == 0 {
+		if len(yyv3574) != 0 {
+			yyv3574 = yyv3574[:0]
+			yyc3574 = true
 		}
-	} else if yyl3566 > 0 {
+	} else if yyl3574 > 0 {
 
-		if yyl3566 > cap(yyv3566) {
-			yyrl3566, yyrt3566 = z.DecInferLen(yyl3566, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3566 = make([]ReplicationController, yyrl3566)
-			yyc3566 = true
+		if yyl3574 > cap(yyv3574) {
+			yyrl3574, yyrt3574 = z.DecInferLen(yyl3574, z.DecBasicHandle().MaxInitLen, 232)
+			yyv3574 = make([]ReplicationController, yyrl3574)
+			yyc3574 = true
 
-			yyrr3566 = len(yyv3566)
-		} else if yyl3566 != len(yyv3566) {
-			yyv3566 = yyv3566[:yyl3566]
-			yyc3566 = true
+			yyrr3574 = len(yyv3574)
+		} else if yyl3574 != len(yyv3574) {
+			yyv3574 = yyv3574[:yyl3574]
+			yyc3574 = true
 		}
-		yyj3566 := 0
-		for ; yyj3566 < yyrr3566; yyj3566++ {
+		yyj3574 := 0
+		for ; yyj3574 < yyrr3574; yyj3574++ {
 			if r.TryDecodeAsNil() {
-				yyv3566[yyj3566] = ReplicationController{}
+				yyv3574[yyj3574] = ReplicationController{}
 			} else {
-				yyv3567 := &yyv3566[yyj3566]
-				yyv3567.CodecDecodeSelf(d)
+				yyv3575 := &yyv3574[yyj3574]
+				yyv3575.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3566 {
-			for ; yyj3566 < yyl3566; yyj3566++ {
-				yyv3566 = append(yyv3566, ReplicationController{})
+		if yyrt3574 {
+			for ; yyj3574 < yyl3574; yyj3574++ {
+				yyv3574 = append(yyv3574, ReplicationController{})
 				if r.TryDecodeAsNil() {
-					yyv3566[yyj3566] = ReplicationController{}
+					yyv3574[yyj3574] = ReplicationController{}
 				} else {
-					yyv3568 := &yyv3566[yyj3566]
-					yyv3568.CodecDecodeSelf(d)
+					yyv3576 := &yyv3574[yyj3574]
+					yyv3576.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3566 := 0; !r.CheckBreak(); yyj3566++ {
-			if yyj3566 >= len(yyv3566) {
-				yyv3566 = append(yyv3566, ReplicationController{}) // var yyz3566 ReplicationController
-				yyc3566 = true
+		for yyj3574 := 0; !r.CheckBreak(); yyj3574++ {
+			if yyj3574 >= len(yyv3574) {
+				yyv3574 = append(yyv3574, ReplicationController{}) // var yyz3574 ReplicationController
+				yyc3574 = true
 			}
 
-			if yyj3566 < len(yyv3566) {
+			if yyj3574 < len(yyv3574) {
 				if r.TryDecodeAsNil() {
-					yyv3566[yyj3566] = ReplicationController{}
+					yyv3574[yyj3574] = ReplicationController{}
 				} else {
-					yyv3569 := &yyv3566[yyj3566]
-					yyv3569.CodecDecodeSelf(d)
+					yyv3577 := &yyv3574[yyj3574]
+					yyv3577.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41676,10 +41736,10 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 			}
 
 		}
-		yyh3566.End()
+		yyh3574.End()
 	}
-	if yyc3566 {
-		*v = yyv3566
+	if yyc3574 {
+		*v = yyv3574
 	}
 
 }
@@ -41689,9 +41749,9 @@ func (x codecSelfer1234) encSliceLoadBalancerIngress(v []LoadBalancerIngress, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3570 := range v {
-		yy3571 := &yyv3570
-		yy3571.CodecEncodeSelf(e)
+	for _, yyv3578 := range v {
+		yy3579 := &yyv3578
+		yy3579.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41701,75 +41761,75 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3572 := *v
-	yyh3572, yyl3572 := z.DecSliceHelperStart()
+	yyv3580 := *v
+	yyh3580, yyl3580 := z.DecSliceHelperStart()
 
-	var yyrr3572, yyrl3572 int
-	var yyc3572, yyrt3572 bool
-	_, _, _ = yyc3572, yyrt3572, yyrl3572
-	yyrr3572 = yyl3572
+	var yyrr3580, yyrl3580 int
+	var yyc3580, yyrt3580 bool
+	_, _, _ = yyc3580, yyrt3580, yyrl3580
+	yyrr3580 = yyl3580
 
-	if yyv3572 == nil {
-		if yyrl3572, yyrt3572 = z.DecInferLen(yyl3572, z.DecBasicHandle().MaxInitLen, 32); yyrt3572 {
-			yyrr3572 = yyrl3572
+	if yyv3580 == nil {
+		if yyrl3580, yyrt3580 = z.DecInferLen(yyl3580, z.DecBasicHandle().MaxInitLen, 32); yyrt3580 {
+			yyrr3580 = yyrl3580
 		}
-		yyv3572 = make([]LoadBalancerIngress, yyrl3572)
-		yyc3572 = true
+		yyv3580 = make([]LoadBalancerIngress, yyrl3580)
+		yyc3580 = true
 	}
 
-	if yyl3572 == 0 {
-		if len(yyv3572) != 0 {
-			yyv3572 = yyv3572[:0]
-			yyc3572 = true
+	if yyl3580 == 0 {
+		if len(yyv3580) != 0 {
+			yyv3580 = yyv3580[:0]
+			yyc3580 = true
 		}
-	} else if yyl3572 > 0 {
+	} else if yyl3580 > 0 {
 
-		if yyl3572 > cap(yyv3572) {
-			yyrl3572, yyrt3572 = z.DecInferLen(yyl3572, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3572 = make([]LoadBalancerIngress, yyrl3572)
-			yyc3572 = true
+		if yyl3580 > cap(yyv3580) {
+			yyrl3580, yyrt3580 = z.DecInferLen(yyl3580, z.DecBasicHandle().MaxInitLen, 32)
+			yyv3580 = make([]LoadBalancerIngress, yyrl3580)
+			yyc3580 = true
 
-			yyrr3572 = len(yyv3572)
-		} else if yyl3572 != len(yyv3572) {
-			yyv3572 = yyv3572[:yyl3572]
-			yyc3572 = true
+			yyrr3580 = len(yyv3580)
+		} else if yyl3580 != len(yyv3580) {
+			yyv3580 = yyv3580[:yyl3580]
+			yyc3580 = true
 		}
-		yyj3572 := 0
-		for ; yyj3572 < yyrr3572; yyj3572++ {
+		yyj3580 := 0
+		for ; yyj3580 < yyrr3580; yyj3580++ {
 			if r.TryDecodeAsNil() {
-				yyv3572[yyj3572] = LoadBalancerIngress{}
+				yyv3580[yyj3580] = LoadBalancerIngress{}
 			} else {
-				yyv3573 := &yyv3572[yyj3572]
-				yyv3573.CodecDecodeSelf(d)
+				yyv3581 := &yyv3580[yyj3580]
+				yyv3581.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3572 {
-			for ; yyj3572 < yyl3572; yyj3572++ {
-				yyv3572 = append(yyv3572, LoadBalancerIngress{})
+		if yyrt3580 {
+			for ; yyj3580 < yyl3580; yyj3580++ {
+				yyv3580 = append(yyv3580, LoadBalancerIngress{})
 				if r.TryDecodeAsNil() {
-					yyv3572[yyj3572] = LoadBalancerIngress{}
+					yyv3580[yyj3580] = LoadBalancerIngress{}
 				} else {
-					yyv3574 := &yyv3572[yyj3572]
-					yyv3574.CodecDecodeSelf(d)
+					yyv3582 := &yyv3580[yyj3580]
+					yyv3582.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3572 := 0; !r.CheckBreak(); yyj3572++ {
-			if yyj3572 >= len(yyv3572) {
-				yyv3572 = append(yyv3572, LoadBalancerIngress{}) // var yyz3572 LoadBalancerIngress
-				yyc3572 = true
+		for yyj3580 := 0; !r.CheckBreak(); yyj3580++ {
+			if yyj3580 >= len(yyv3580) {
+				yyv3580 = append(yyv3580, LoadBalancerIngress{}) // var yyz3580 LoadBalancerIngress
+				yyc3580 = true
 			}
 
-			if yyj3572 < len(yyv3572) {
+			if yyj3580 < len(yyv3580) {
 				if r.TryDecodeAsNil() {
-					yyv3572[yyj3572] = LoadBalancerIngress{}
+					yyv3580[yyj3580] = LoadBalancerIngress{}
 				} else {
-					yyv3575 := &yyv3572[yyj3572]
-					yyv3575.CodecDecodeSelf(d)
+					yyv3583 := &yyv3580[yyj3580]
+					yyv3583.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41777,10 +41837,10 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 			}
 
 		}
-		yyh3572.End()
+		yyh3580.End()
 	}
-	if yyc3572 {
-		*v = yyv3572
+	if yyc3580 {
+		*v = yyv3580
 	}
 
 }
@@ -41790,9 +41850,9 @@ func (x codecSelfer1234) encSliceServicePort(v []ServicePort, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3576 := range v {
-		yy3577 := &yyv3576
-		yy3577.CodecEncodeSelf(e)
+	for _, yyv3584 := range v {
+		yy3585 := &yyv3584
+		yy3585.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41802,75 +41862,75 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3578 := *v
-	yyh3578, yyl3578 := z.DecSliceHelperStart()
+	yyv3586 := *v
+	yyh3586, yyl3586 := z.DecSliceHelperStart()
 
-	var yyrr3578, yyrl3578 int
-	var yyc3578, yyrt3578 bool
-	_, _, _ = yyc3578, yyrt3578, yyrl3578
-	yyrr3578 = yyl3578
+	var yyrr3586, yyrl3586 int
+	var yyc3586, yyrt3586 bool
+	_, _, _ = yyc3586, yyrt3586, yyrl3586
+	yyrr3586 = yyl3586
 
-	if yyv3578 == nil {
-		if yyrl3578, yyrt3578 = z.DecInferLen(yyl3578, z.DecBasicHandle().MaxInitLen, 80); yyrt3578 {
-			yyrr3578 = yyrl3578
+	if yyv3586 == nil {
+		if yyrl3586, yyrt3586 = z.DecInferLen(yyl3586, z.DecBasicHandle().MaxInitLen, 80); yyrt3586 {
+			yyrr3586 = yyrl3586
 		}
-		yyv3578 = make([]ServicePort, yyrl3578)
-		yyc3578 = true
+		yyv3586 = make([]ServicePort, yyrl3586)
+		yyc3586 = true
 	}
 
-	if yyl3578 == 0 {
-		if len(yyv3578) != 0 {
-			yyv3578 = yyv3578[:0]
-			yyc3578 = true
+	if yyl3586 == 0 {
+		if len(yyv3586) != 0 {
+			yyv3586 = yyv3586[:0]
+			yyc3586 = true
 		}
-	} else if yyl3578 > 0 {
+	} else if yyl3586 > 0 {
 
-		if yyl3578 > cap(yyv3578) {
-			yyrl3578, yyrt3578 = z.DecInferLen(yyl3578, z.DecBasicHandle().MaxInitLen, 80)
-			yyv3578 = make([]ServicePort, yyrl3578)
-			yyc3578 = true
+		if yyl3586 > cap(yyv3586) {
+			yyrl3586, yyrt3586 = z.DecInferLen(yyl3586, z.DecBasicHandle().MaxInitLen, 80)
+			yyv3586 = make([]ServicePort, yyrl3586)
+			yyc3586 = true
 
-			yyrr3578 = len(yyv3578)
-		} else if yyl3578 != len(yyv3578) {
-			yyv3578 = yyv3578[:yyl3578]
-			yyc3578 = true
+			yyrr3586 = len(yyv3586)
+		} else if yyl3586 != len(yyv3586) {
+			yyv3586 = yyv3586[:yyl3586]
+			yyc3586 = true
 		}
-		yyj3578 := 0
-		for ; yyj3578 < yyrr3578; yyj3578++ {
+		yyj3586 := 0
+		for ; yyj3586 < yyrr3586; yyj3586++ {
 			if r.TryDecodeAsNil() {
-				yyv3578[yyj3578] = ServicePort{}
+				yyv3586[yyj3586] = ServicePort{}
 			} else {
-				yyv3579 := &yyv3578[yyj3578]
-				yyv3579.CodecDecodeSelf(d)
+				yyv3587 := &yyv3586[yyj3586]
+				yyv3587.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3578 {
-			for ; yyj3578 < yyl3578; yyj3578++ {
-				yyv3578 = append(yyv3578, ServicePort{})
+		if yyrt3586 {
+			for ; yyj3586 < yyl3586; yyj3586++ {
+				yyv3586 = append(yyv3586, ServicePort{})
 				if r.TryDecodeAsNil() {
-					yyv3578[yyj3578] = ServicePort{}
+					yyv3586[yyj3586] = ServicePort{}
 				} else {
-					yyv3580 := &yyv3578[yyj3578]
-					yyv3580.CodecDecodeSelf(d)
+					yyv3588 := &yyv3586[yyj3586]
+					yyv3588.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3578 := 0; !r.CheckBreak(); yyj3578++ {
-			if yyj3578 >= len(yyv3578) {
-				yyv3578 = append(yyv3578, ServicePort{}) // var yyz3578 ServicePort
-				yyc3578 = true
+		for yyj3586 := 0; !r.CheckBreak(); yyj3586++ {
+			if yyj3586 >= len(yyv3586) {
+				yyv3586 = append(yyv3586, ServicePort{}) // var yyz3586 ServicePort
+				yyc3586 = true
 			}
 
-			if yyj3578 < len(yyv3578) {
+			if yyj3586 < len(yyv3586) {
 				if r.TryDecodeAsNil() {
-					yyv3578[yyj3578] = ServicePort{}
+					yyv3586[yyj3586] = ServicePort{}
 				} else {
-					yyv3581 := &yyv3578[yyj3578]
-					yyv3581.CodecDecodeSelf(d)
+					yyv3589 := &yyv3586[yyj3586]
+					yyv3589.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41878,10 +41938,10 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 			}
 
 		}
-		yyh3578.End()
+		yyh3586.End()
 	}
-	if yyc3578 {
-		*v = yyv3578
+	if yyc3586 {
+		*v = yyv3586
 	}
 
 }
@@ -41891,9 +41951,9 @@ func (x codecSelfer1234) encSliceService(v []Service, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3582 := range v {
-		yy3583 := &yyv3582
-		yy3583.CodecEncodeSelf(e)
+	for _, yyv3590 := range v {
+		yy3591 := &yyv3590
+		yy3591.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41903,75 +41963,75 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3584 := *v
-	yyh3584, yyl3584 := z.DecSliceHelperStart()
+	yyv3592 := *v
+	yyh3592, yyl3592 := z.DecSliceHelperStart()
 
-	var yyrr3584, yyrl3584 int
-	var yyc3584, yyrt3584 bool
-	_, _, _ = yyc3584, yyrt3584, yyrl3584
-	yyrr3584 = yyl3584
+	var yyrr3592, yyrl3592 int
+	var yyc3592, yyrt3592 bool
+	_, _, _ = yyc3592, yyrt3592, yyrl3592
+	yyrr3592 = yyl3592
 
-	if yyv3584 == nil {
-		if yyrl3584, yyrt3584 = z.DecInferLen(yyl3584, z.DecBasicHandle().MaxInitLen, 360); yyrt3584 {
-			yyrr3584 = yyrl3584
+	if yyv3592 == nil {
+		if yyrl3592, yyrt3592 = z.DecInferLen(yyl3592, z.DecBasicHandle().MaxInitLen, 360); yyrt3592 {
+			yyrr3592 = yyrl3592
 		}
-		yyv3584 = make([]Service, yyrl3584)
-		yyc3584 = true
+		yyv3592 = make([]Service, yyrl3592)
+		yyc3592 = true
 	}
 
-	if yyl3584 == 0 {
-		if len(yyv3584) != 0 {
-			yyv3584 = yyv3584[:0]
-			yyc3584 = true
+	if yyl3592 == 0 {
+		if len(yyv3592) != 0 {
+			yyv3592 = yyv3592[:0]
+			yyc3592 = true
 		}
-	} else if yyl3584 > 0 {
+	} else if yyl3592 > 0 {
 
-		if yyl3584 > cap(yyv3584) {
-			yyrl3584, yyrt3584 = z.DecInferLen(yyl3584, z.DecBasicHandle().MaxInitLen, 360)
-			yyv3584 = make([]Service, yyrl3584)
-			yyc3584 = true
+		if yyl3592 > cap(yyv3592) {
+			yyrl3592, yyrt3592 = z.DecInferLen(yyl3592, z.DecBasicHandle().MaxInitLen, 360)
+			yyv3592 = make([]Service, yyrl3592)
+			yyc3592 = true
 
-			yyrr3584 = len(yyv3584)
-		} else if yyl3584 != len(yyv3584) {
-			yyv3584 = yyv3584[:yyl3584]
-			yyc3584 = true
+			yyrr3592 = len(yyv3592)
+		} else if yyl3592 != len(yyv3592) {
+			yyv3592 = yyv3592[:yyl3592]
+			yyc3592 = true
 		}
-		yyj3584 := 0
-		for ; yyj3584 < yyrr3584; yyj3584++ {
+		yyj3592 := 0
+		for ; yyj3592 < yyrr3592; yyj3592++ {
 			if r.TryDecodeAsNil() {
-				yyv3584[yyj3584] = Service{}
+				yyv3592[yyj3592] = Service{}
 			} else {
-				yyv3585 := &yyv3584[yyj3584]
-				yyv3585.CodecDecodeSelf(d)
+				yyv3593 := &yyv3592[yyj3592]
+				yyv3593.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3584 {
-			for ; yyj3584 < yyl3584; yyj3584++ {
-				yyv3584 = append(yyv3584, Service{})
+		if yyrt3592 {
+			for ; yyj3592 < yyl3592; yyj3592++ {
+				yyv3592 = append(yyv3592, Service{})
 				if r.TryDecodeAsNil() {
-					yyv3584[yyj3584] = Service{}
+					yyv3592[yyj3592] = Service{}
 				} else {
-					yyv3586 := &yyv3584[yyj3584]
-					yyv3586.CodecDecodeSelf(d)
+					yyv3594 := &yyv3592[yyj3592]
+					yyv3594.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3584 := 0; !r.CheckBreak(); yyj3584++ {
-			if yyj3584 >= len(yyv3584) {
-				yyv3584 = append(yyv3584, Service{}) // var yyz3584 Service
-				yyc3584 = true
+		for yyj3592 := 0; !r.CheckBreak(); yyj3592++ {
+			if yyj3592 >= len(yyv3592) {
+				yyv3592 = append(yyv3592, Service{}) // var yyz3592 Service
+				yyc3592 = true
 			}
 
-			if yyj3584 < len(yyv3584) {
+			if yyj3592 < len(yyv3592) {
 				if r.TryDecodeAsNil() {
-					yyv3584[yyj3584] = Service{}
+					yyv3592[yyj3592] = Service{}
 				} else {
-					yyv3587 := &yyv3584[yyj3584]
-					yyv3587.CodecDecodeSelf(d)
+					yyv3595 := &yyv3592[yyj3592]
+					yyv3595.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41979,10 +42039,10 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3584.End()
+		yyh3592.End()
 	}
-	if yyc3584 {
-		*v = yyv3584
+	if yyc3592 {
+		*v = yyv3592
 	}
 
 }
@@ -41992,9 +42052,9 @@ func (x codecSelfer1234) encSliceObjectReference(v []ObjectReference, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3588 := range v {
-		yy3589 := &yyv3588
-		yy3589.CodecEncodeSelf(e)
+	for _, yyv3596 := range v {
+		yy3597 := &yyv3596
+		yy3597.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42004,75 +42064,75 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3590 := *v
-	yyh3590, yyl3590 := z.DecSliceHelperStart()
+	yyv3598 := *v
+	yyh3598, yyl3598 := z.DecSliceHelperStart()
 
-	var yyrr3590, yyrl3590 int
-	var yyc3590, yyrt3590 bool
-	_, _, _ = yyc3590, yyrt3590, yyrl3590
-	yyrr3590 = yyl3590
+	var yyrr3598, yyrl3598 int
+	var yyc3598, yyrt3598 bool
+	_, _, _ = yyc3598, yyrt3598, yyrl3598
+	yyrr3598 = yyl3598
 
-	if yyv3590 == nil {
-		if yyrl3590, yyrt3590 = z.DecInferLen(yyl3590, z.DecBasicHandle().MaxInitLen, 112); yyrt3590 {
-			yyrr3590 = yyrl3590
+	if yyv3598 == nil {
+		if yyrl3598, yyrt3598 = z.DecInferLen(yyl3598, z.DecBasicHandle().MaxInitLen, 112); yyrt3598 {
+			yyrr3598 = yyrl3598
 		}
-		yyv3590 = make([]ObjectReference, yyrl3590)
-		yyc3590 = true
+		yyv3598 = make([]ObjectReference, yyrl3598)
+		yyc3598 = true
 	}
 
-	if yyl3590 == 0 {
-		if len(yyv3590) != 0 {
-			yyv3590 = yyv3590[:0]
-			yyc3590 = true
+	if yyl3598 == 0 {
+		if len(yyv3598) != 0 {
+			yyv3598 = yyv3598[:0]
+			yyc3598 = true
 		}
-	} else if yyl3590 > 0 {
+	} else if yyl3598 > 0 {
 
-		if yyl3590 > cap(yyv3590) {
-			yyrl3590, yyrt3590 = z.DecInferLen(yyl3590, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3590 = make([]ObjectReference, yyrl3590)
-			yyc3590 = true
+		if yyl3598 > cap(yyv3598) {
+			yyrl3598, yyrt3598 = z.DecInferLen(yyl3598, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3598 = make([]ObjectReference, yyrl3598)
+			yyc3598 = true
 
-			yyrr3590 = len(yyv3590)
-		} else if yyl3590 != len(yyv3590) {
-			yyv3590 = yyv3590[:yyl3590]
-			yyc3590 = true
+			yyrr3598 = len(yyv3598)
+		} else if yyl3598 != len(yyv3598) {
+			yyv3598 = yyv3598[:yyl3598]
+			yyc3598 = true
 		}
-		yyj3590 := 0
-		for ; yyj3590 < yyrr3590; yyj3590++ {
+		yyj3598 := 0
+		for ; yyj3598 < yyrr3598; yyj3598++ {
 			if r.TryDecodeAsNil() {
-				yyv3590[yyj3590] = ObjectReference{}
+				yyv3598[yyj3598] = ObjectReference{}
 			} else {
-				yyv3591 := &yyv3590[yyj3590]
-				yyv3591.CodecDecodeSelf(d)
+				yyv3599 := &yyv3598[yyj3598]
+				yyv3599.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3590 {
-			for ; yyj3590 < yyl3590; yyj3590++ {
-				yyv3590 = append(yyv3590, ObjectReference{})
+		if yyrt3598 {
+			for ; yyj3598 < yyl3598; yyj3598++ {
+				yyv3598 = append(yyv3598, ObjectReference{})
 				if r.TryDecodeAsNil() {
-					yyv3590[yyj3590] = ObjectReference{}
+					yyv3598[yyj3598] = ObjectReference{}
 				} else {
-					yyv3592 := &yyv3590[yyj3590]
-					yyv3592.CodecDecodeSelf(d)
+					yyv3600 := &yyv3598[yyj3598]
+					yyv3600.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3590 := 0; !r.CheckBreak(); yyj3590++ {
-			if yyj3590 >= len(yyv3590) {
-				yyv3590 = append(yyv3590, ObjectReference{}) // var yyz3590 ObjectReference
-				yyc3590 = true
+		for yyj3598 := 0; !r.CheckBreak(); yyj3598++ {
+			if yyj3598 >= len(yyv3598) {
+				yyv3598 = append(yyv3598, ObjectReference{}) // var yyz3598 ObjectReference
+				yyc3598 = true
 			}
 
-			if yyj3590 < len(yyv3590) {
+			if yyj3598 < len(yyv3598) {
 				if r.TryDecodeAsNil() {
-					yyv3590[yyj3590] = ObjectReference{}
+					yyv3598[yyj3598] = ObjectReference{}
 				} else {
-					yyv3593 := &yyv3590[yyj3590]
-					yyv3593.CodecDecodeSelf(d)
+					yyv3601 := &yyv3598[yyj3598]
+					yyv3601.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42080,10 +42140,10 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 			}
 
 		}
-		yyh3590.End()
+		yyh3598.End()
 	}
-	if yyc3590 {
-		*v = yyv3590
+	if yyc3598 {
+		*v = yyv3598
 	}
 
 }
@@ -42093,9 +42153,9 @@ func (x codecSelfer1234) encSliceServiceAccount(v []ServiceAccount, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3594 := range v {
-		yy3595 := &yyv3594
-		yy3595.CodecEncodeSelf(e)
+	for _, yyv3602 := range v {
+		yy3603 := &yyv3602
+		yy3603.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42105,75 +42165,75 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3596 := *v
-	yyh3596, yyl3596 := z.DecSliceHelperStart()
+	yyv3604 := *v
+	yyh3604, yyl3604 := z.DecSliceHelperStart()
 
-	var yyrr3596, yyrl3596 int
-	var yyc3596, yyrt3596 bool
-	_, _, _ = yyc3596, yyrt3596, yyrl3596
-	yyrr3596 = yyl3596
+	var yyrr3604, yyrl3604 int
+	var yyc3604, yyrt3604 bool
+	_, _, _ = yyc3604, yyrt3604, yyrl3604
+	yyrr3604 = yyl3604
 
-	if yyv3596 == nil {
-		if yyrl3596, yyrt3596 = z.DecInferLen(yyl3596, z.DecBasicHandle().MaxInitLen, 240); yyrt3596 {
-			yyrr3596 = yyrl3596
+	if yyv3604 == nil {
+		if yyrl3604, yyrt3604 = z.DecInferLen(yyl3604, z.DecBasicHandle().MaxInitLen, 240); yyrt3604 {
+			yyrr3604 = yyrl3604
 		}
-		yyv3596 = make([]ServiceAccount, yyrl3596)
-		yyc3596 = true
+		yyv3604 = make([]ServiceAccount, yyrl3604)
+		yyc3604 = true
 	}
 
-	if yyl3596 == 0 {
-		if len(yyv3596) != 0 {
-			yyv3596 = yyv3596[:0]
-			yyc3596 = true
+	if yyl3604 == 0 {
+		if len(yyv3604) != 0 {
+			yyv3604 = yyv3604[:0]
+			yyc3604 = true
 		}
-	} else if yyl3596 > 0 {
+	} else if yyl3604 > 0 {
 
-		if yyl3596 > cap(yyv3596) {
-			yyrl3596, yyrt3596 = z.DecInferLen(yyl3596, z.DecBasicHandle().MaxInitLen, 240)
-			yyv3596 = make([]ServiceAccount, yyrl3596)
-			yyc3596 = true
+		if yyl3604 > cap(yyv3604) {
+			yyrl3604, yyrt3604 = z.DecInferLen(yyl3604, z.DecBasicHandle().MaxInitLen, 240)
+			yyv3604 = make([]ServiceAccount, yyrl3604)
+			yyc3604 = true
 
-			yyrr3596 = len(yyv3596)
-		} else if yyl3596 != len(yyv3596) {
-			yyv3596 = yyv3596[:yyl3596]
-			yyc3596 = true
+			yyrr3604 = len(yyv3604)
+		} else if yyl3604 != len(yyv3604) {
+			yyv3604 = yyv3604[:yyl3604]
+			yyc3604 = true
 		}
-		yyj3596 := 0
-		for ; yyj3596 < yyrr3596; yyj3596++ {
+		yyj3604 := 0
+		for ; yyj3604 < yyrr3604; yyj3604++ {
 			if r.TryDecodeAsNil() {
-				yyv3596[yyj3596] = ServiceAccount{}
+				yyv3604[yyj3604] = ServiceAccount{}
 			} else {
-				yyv3597 := &yyv3596[yyj3596]
-				yyv3597.CodecDecodeSelf(d)
+				yyv3605 := &yyv3604[yyj3604]
+				yyv3605.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3596 {
-			for ; yyj3596 < yyl3596; yyj3596++ {
-				yyv3596 = append(yyv3596, ServiceAccount{})
+		if yyrt3604 {
+			for ; yyj3604 < yyl3604; yyj3604++ {
+				yyv3604 = append(yyv3604, ServiceAccount{})
 				if r.TryDecodeAsNil() {
-					yyv3596[yyj3596] = ServiceAccount{}
+					yyv3604[yyj3604] = ServiceAccount{}
 				} else {
-					yyv3598 := &yyv3596[yyj3596]
-					yyv3598.CodecDecodeSelf(d)
+					yyv3606 := &yyv3604[yyj3604]
+					yyv3606.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3596 := 0; !r.CheckBreak(); yyj3596++ {
-			if yyj3596 >= len(yyv3596) {
-				yyv3596 = append(yyv3596, ServiceAccount{}) // var yyz3596 ServiceAccount
-				yyc3596 = true
+		for yyj3604 := 0; !r.CheckBreak(); yyj3604++ {
+			if yyj3604 >= len(yyv3604) {
+				yyv3604 = append(yyv3604, ServiceAccount{}) // var yyz3604 ServiceAccount
+				yyc3604 = true
 			}
 
-			if yyj3596 < len(yyv3596) {
+			if yyj3604 < len(yyv3604) {
 				if r.TryDecodeAsNil() {
-					yyv3596[yyj3596] = ServiceAccount{}
+					yyv3604[yyj3604] = ServiceAccount{}
 				} else {
-					yyv3599 := &yyv3596[yyj3596]
-					yyv3599.CodecDecodeSelf(d)
+					yyv3607 := &yyv3604[yyj3604]
+					yyv3607.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42181,10 +42241,10 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 			}
 
 		}
-		yyh3596.End()
+		yyh3604.End()
 	}
-	if yyc3596 {
-		*v = yyv3596
+	if yyc3604 {
+		*v = yyv3604
 	}
 
 }
@@ -42194,9 +42254,9 @@ func (x codecSelfer1234) encSliceEndpointSubset(v []EndpointSubset, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3600 := range v {
-		yy3601 := &yyv3600
-		yy3601.CodecEncodeSelf(e)
+	for _, yyv3608 := range v {
+		yy3609 := &yyv3608
+		yy3609.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42206,75 +42266,75 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3602 := *v
-	yyh3602, yyl3602 := z.DecSliceHelperStart()
+	yyv3610 := *v
+	yyh3610, yyl3610 := z.DecSliceHelperStart()
 
-	var yyrr3602, yyrl3602 int
-	var yyc3602, yyrt3602 bool
-	_, _, _ = yyc3602, yyrt3602, yyrl3602
-	yyrr3602 = yyl3602
+	var yyrr3610, yyrl3610 int
+	var yyc3610, yyrt3610 bool
+	_, _, _ = yyc3610, yyrt3610, yyrl3610
+	yyrr3610 = yyl3610
 
-	if yyv3602 == nil {
-		if yyrl3602, yyrt3602 = z.DecInferLen(yyl3602, z.DecBasicHandle().MaxInitLen, 72); yyrt3602 {
-			yyrr3602 = yyrl3602
+	if yyv3610 == nil {
+		if yyrl3610, yyrt3610 = z.DecInferLen(yyl3610, z.DecBasicHandle().MaxInitLen, 72); yyrt3610 {
+			yyrr3610 = yyrl3610
 		}
-		yyv3602 = make([]EndpointSubset, yyrl3602)
-		yyc3602 = true
+		yyv3610 = make([]EndpointSubset, yyrl3610)
+		yyc3610 = true
 	}
 
-	if yyl3602 == 0 {
-		if len(yyv3602) != 0 {
-			yyv3602 = yyv3602[:0]
-			yyc3602 = true
+	if yyl3610 == 0 {
+		if len(yyv3610) != 0 {
+			yyv3610 = yyv3610[:0]
+			yyc3610 = true
 		}
-	} else if yyl3602 > 0 {
+	} else if yyl3610 > 0 {
 
-		if yyl3602 > cap(yyv3602) {
-			yyrl3602, yyrt3602 = z.DecInferLen(yyl3602, z.DecBasicHandle().MaxInitLen, 72)
-			yyv3602 = make([]EndpointSubset, yyrl3602)
-			yyc3602 = true
+		if yyl3610 > cap(yyv3610) {
+			yyrl3610, yyrt3610 = z.DecInferLen(yyl3610, z.DecBasicHandle().MaxInitLen, 72)
+			yyv3610 = make([]EndpointSubset, yyrl3610)
+			yyc3610 = true
 
-			yyrr3602 = len(yyv3602)
-		} else if yyl3602 != len(yyv3602) {
-			yyv3602 = yyv3602[:yyl3602]
-			yyc3602 = true
+			yyrr3610 = len(yyv3610)
+		} else if yyl3610 != len(yyv3610) {
+			yyv3610 = yyv3610[:yyl3610]
+			yyc3610 = true
 		}
-		yyj3602 := 0
-		for ; yyj3602 < yyrr3602; yyj3602++ {
+		yyj3610 := 0
+		for ; yyj3610 < yyrr3610; yyj3610++ {
 			if r.TryDecodeAsNil() {
-				yyv3602[yyj3602] = EndpointSubset{}
+				yyv3610[yyj3610] = EndpointSubset{}
 			} else {
-				yyv3603 := &yyv3602[yyj3602]
-				yyv3603.CodecDecodeSelf(d)
+				yyv3611 := &yyv3610[yyj3610]
+				yyv3611.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3602 {
-			for ; yyj3602 < yyl3602; yyj3602++ {
-				yyv3602 = append(yyv3602, EndpointSubset{})
+		if yyrt3610 {
+			for ; yyj3610 < yyl3610; yyj3610++ {
+				yyv3610 = append(yyv3610, EndpointSubset{})
 				if r.TryDecodeAsNil() {
-					yyv3602[yyj3602] = EndpointSubset{}
+					yyv3610[yyj3610] = EndpointSubset{}
 				} else {
-					yyv3604 := &yyv3602[yyj3602]
-					yyv3604.CodecDecodeSelf(d)
+					yyv3612 := &yyv3610[yyj3610]
+					yyv3612.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3602 := 0; !r.CheckBreak(); yyj3602++ {
-			if yyj3602 >= len(yyv3602) {
-				yyv3602 = append(yyv3602, EndpointSubset{}) // var yyz3602 EndpointSubset
-				yyc3602 = true
+		for yyj3610 := 0; !r.CheckBreak(); yyj3610++ {
+			if yyj3610 >= len(yyv3610) {
+				yyv3610 = append(yyv3610, EndpointSubset{}) // var yyz3610 EndpointSubset
+				yyc3610 = true
 			}
 
-			if yyj3602 < len(yyv3602) {
+			if yyj3610 < len(yyv3610) {
 				if r.TryDecodeAsNil() {
-					yyv3602[yyj3602] = EndpointSubset{}
+					yyv3610[yyj3610] = EndpointSubset{}
 				} else {
-					yyv3605 := &yyv3602[yyj3602]
-					yyv3605.CodecDecodeSelf(d)
+					yyv3613 := &yyv3610[yyj3610]
+					yyv3613.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42282,10 +42342,10 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 			}
 
 		}
-		yyh3602.End()
+		yyh3610.End()
 	}
-	if yyc3602 {
-		*v = yyv3602
+	if yyc3610 {
+		*v = yyv3610
 	}
 
 }
@@ -42295,9 +42355,9 @@ func (x codecSelfer1234) encSliceEndpointAddress(v []EndpointAddress, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3606 := range v {
-		yy3607 := &yyv3606
-		yy3607.CodecEncodeSelf(e)
+	for _, yyv3614 := range v {
+		yy3615 := &yyv3614
+		yy3615.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42307,75 +42367,75 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3608 := *v
-	yyh3608, yyl3608 := z.DecSliceHelperStart()
+	yyv3616 := *v
+	yyh3616, yyl3616 := z.DecSliceHelperStart()
 
-	var yyrr3608, yyrl3608 int
-	var yyc3608, yyrt3608 bool
-	_, _, _ = yyc3608, yyrt3608, yyrl3608
-	yyrr3608 = yyl3608
+	var yyrr3616, yyrl3616 int
+	var yyc3616, yyrt3616 bool
+	_, _, _ = yyc3616, yyrt3616, yyrl3616
+	yyrr3616 = yyl3616
 
-	if yyv3608 == nil {
-		if yyrl3608, yyrt3608 = z.DecInferLen(yyl3608, z.DecBasicHandle().MaxInitLen, 24); yyrt3608 {
-			yyrr3608 = yyrl3608
+	if yyv3616 == nil {
+		if yyrl3616, yyrt3616 = z.DecInferLen(yyl3616, z.DecBasicHandle().MaxInitLen, 24); yyrt3616 {
+			yyrr3616 = yyrl3616
 		}
-		yyv3608 = make([]EndpointAddress, yyrl3608)
-		yyc3608 = true
+		yyv3616 = make([]EndpointAddress, yyrl3616)
+		yyc3616 = true
 	}
 
-	if yyl3608 == 0 {
-		if len(yyv3608) != 0 {
-			yyv3608 = yyv3608[:0]
-			yyc3608 = true
+	if yyl3616 == 0 {
+		if len(yyv3616) != 0 {
+			yyv3616 = yyv3616[:0]
+			yyc3616 = true
 		}
-	} else if yyl3608 > 0 {
+	} else if yyl3616 > 0 {
 
-		if yyl3608 > cap(yyv3608) {
-			yyrl3608, yyrt3608 = z.DecInferLen(yyl3608, z.DecBasicHandle().MaxInitLen, 24)
-			yyv3608 = make([]EndpointAddress, yyrl3608)
-			yyc3608 = true
+		if yyl3616 > cap(yyv3616) {
+			yyrl3616, yyrt3616 = z.DecInferLen(yyl3616, z.DecBasicHandle().MaxInitLen, 24)
+			yyv3616 = make([]EndpointAddress, yyrl3616)
+			yyc3616 = true
 
-			yyrr3608 = len(yyv3608)
-		} else if yyl3608 != len(yyv3608) {
-			yyv3608 = yyv3608[:yyl3608]
-			yyc3608 = true
+			yyrr3616 = len(yyv3616)
+		} else if yyl3616 != len(yyv3616) {
+			yyv3616 = yyv3616[:yyl3616]
+			yyc3616 = true
 		}
-		yyj3608 := 0
-		for ; yyj3608 < yyrr3608; yyj3608++ {
+		yyj3616 := 0
+		for ; yyj3616 < yyrr3616; yyj3616++ {
 			if r.TryDecodeAsNil() {
-				yyv3608[yyj3608] = EndpointAddress{}
+				yyv3616[yyj3616] = EndpointAddress{}
 			} else {
-				yyv3609 := &yyv3608[yyj3608]
-				yyv3609.CodecDecodeSelf(d)
+				yyv3617 := &yyv3616[yyj3616]
+				yyv3617.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3608 {
-			for ; yyj3608 < yyl3608; yyj3608++ {
-				yyv3608 = append(yyv3608, EndpointAddress{})
+		if yyrt3616 {
+			for ; yyj3616 < yyl3616; yyj3616++ {
+				yyv3616 = append(yyv3616, EndpointAddress{})
 				if r.TryDecodeAsNil() {
-					yyv3608[yyj3608] = EndpointAddress{}
+					yyv3616[yyj3616] = EndpointAddress{}
 				} else {
-					yyv3610 := &yyv3608[yyj3608]
-					yyv3610.CodecDecodeSelf(d)
+					yyv3618 := &yyv3616[yyj3616]
+					yyv3618.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3608 := 0; !r.CheckBreak(); yyj3608++ {
-			if yyj3608 >= len(yyv3608) {
-				yyv3608 = append(yyv3608, EndpointAddress{}) // var yyz3608 EndpointAddress
-				yyc3608 = true
+		for yyj3616 := 0; !r.CheckBreak(); yyj3616++ {
+			if yyj3616 >= len(yyv3616) {
+				yyv3616 = append(yyv3616, EndpointAddress{}) // var yyz3616 EndpointAddress
+				yyc3616 = true
 			}
 
-			if yyj3608 < len(yyv3608) {
+			if yyj3616 < len(yyv3616) {
 				if r.TryDecodeAsNil() {
-					yyv3608[yyj3608] = EndpointAddress{}
+					yyv3616[yyj3616] = EndpointAddress{}
 				} else {
-					yyv3611 := &yyv3608[yyj3608]
-					yyv3611.CodecDecodeSelf(d)
+					yyv3619 := &yyv3616[yyj3616]
+					yyv3619.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42383,10 +42443,10 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 			}
 
 		}
-		yyh3608.End()
+		yyh3616.End()
 	}
-	if yyc3608 {
-		*v = yyv3608
+	if yyc3616 {
+		*v = yyv3616
 	}
 
 }
@@ -42396,9 +42456,9 @@ func (x codecSelfer1234) encSliceEndpointPort(v []EndpointPort, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3612 := range v {
-		yy3613 := &yyv3612
-		yy3613.CodecEncodeSelf(e)
+	for _, yyv3620 := range v {
+		yy3621 := &yyv3620
+		yy3621.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42408,75 +42468,75 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3614 := *v
-	yyh3614, yyl3614 := z.DecSliceHelperStart()
+	yyv3622 := *v
+	yyh3622, yyl3622 := z.DecSliceHelperStart()
 
-	var yyrr3614, yyrl3614 int
-	var yyc3614, yyrt3614 bool
-	_, _, _ = yyc3614, yyrt3614, yyrl3614
-	yyrr3614 = yyl3614
+	var yyrr3622, yyrl3622 int
+	var yyc3622, yyrt3622 bool
+	_, _, _ = yyc3622, yyrt3622, yyrl3622
+	yyrr3622 = yyl3622
 
-	if yyv3614 == nil {
-		if yyrl3614, yyrt3614 = z.DecInferLen(yyl3614, z.DecBasicHandle().MaxInitLen, 40); yyrt3614 {
-			yyrr3614 = yyrl3614
+	if yyv3622 == nil {
+		if yyrl3622, yyrt3622 = z.DecInferLen(yyl3622, z.DecBasicHandle().MaxInitLen, 40); yyrt3622 {
+			yyrr3622 = yyrl3622
 		}
-		yyv3614 = make([]EndpointPort, yyrl3614)
-		yyc3614 = true
+		yyv3622 = make([]EndpointPort, yyrl3622)
+		yyc3622 = true
 	}
 
-	if yyl3614 == 0 {
-		if len(yyv3614) != 0 {
-			yyv3614 = yyv3614[:0]
-			yyc3614 = true
+	if yyl3622 == 0 {
+		if len(yyv3622) != 0 {
+			yyv3622 = yyv3622[:0]
+			yyc3622 = true
 		}
-	} else if yyl3614 > 0 {
+	} else if yyl3622 > 0 {
 
-		if yyl3614 > cap(yyv3614) {
-			yyrl3614, yyrt3614 = z.DecInferLen(yyl3614, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3614 = make([]EndpointPort, yyrl3614)
-			yyc3614 = true
+		if yyl3622 > cap(yyv3622) {
+			yyrl3622, yyrt3622 = z.DecInferLen(yyl3622, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3622 = make([]EndpointPort, yyrl3622)
+			yyc3622 = true
 
-			yyrr3614 = len(yyv3614)
-		} else if yyl3614 != len(yyv3614) {
-			yyv3614 = yyv3614[:yyl3614]
-			yyc3614 = true
+			yyrr3622 = len(yyv3622)
+		} else if yyl3622 != len(yyv3622) {
+			yyv3622 = yyv3622[:yyl3622]
+			yyc3622 = true
 		}
-		yyj3614 := 0
-		for ; yyj3614 < yyrr3614; yyj3614++ {
+		yyj3622 := 0
+		for ; yyj3622 < yyrr3622; yyj3622++ {
 			if r.TryDecodeAsNil() {
-				yyv3614[yyj3614] = EndpointPort{}
+				yyv3622[yyj3622] = EndpointPort{}
 			} else {
-				yyv3615 := &yyv3614[yyj3614]
-				yyv3615.CodecDecodeSelf(d)
+				yyv3623 := &yyv3622[yyj3622]
+				yyv3623.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3614 {
-			for ; yyj3614 < yyl3614; yyj3614++ {
-				yyv3614 = append(yyv3614, EndpointPort{})
+		if yyrt3622 {
+			for ; yyj3622 < yyl3622; yyj3622++ {
+				yyv3622 = append(yyv3622, EndpointPort{})
 				if r.TryDecodeAsNil() {
-					yyv3614[yyj3614] = EndpointPort{}
+					yyv3622[yyj3622] = EndpointPort{}
 				} else {
-					yyv3616 := &yyv3614[yyj3614]
-					yyv3616.CodecDecodeSelf(d)
+					yyv3624 := &yyv3622[yyj3622]
+					yyv3624.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3614 := 0; !r.CheckBreak(); yyj3614++ {
-			if yyj3614 >= len(yyv3614) {
-				yyv3614 = append(yyv3614, EndpointPort{}) // var yyz3614 EndpointPort
-				yyc3614 = true
+		for yyj3622 := 0; !r.CheckBreak(); yyj3622++ {
+			if yyj3622 >= len(yyv3622) {
+				yyv3622 = append(yyv3622, EndpointPort{}) // var yyz3622 EndpointPort
+				yyc3622 = true
 			}
 
-			if yyj3614 < len(yyv3614) {
+			if yyj3622 < len(yyv3622) {
 				if r.TryDecodeAsNil() {
-					yyv3614[yyj3614] = EndpointPort{}
+					yyv3622[yyj3622] = EndpointPort{}
 				} else {
-					yyv3617 := &yyv3614[yyj3614]
-					yyv3617.CodecDecodeSelf(d)
+					yyv3625 := &yyv3622[yyj3622]
+					yyv3625.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42484,10 +42544,10 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 			}
 
 		}
-		yyh3614.End()
+		yyh3622.End()
 	}
-	if yyc3614 {
-		*v = yyv3614
+	if yyc3622 {
+		*v = yyv3622
 	}
 
 }
@@ -42497,9 +42557,9 @@ func (x codecSelfer1234) encSliceEndpoints(v []Endpoints, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3618 := range v {
-		yy3619 := &yyv3618
-		yy3619.CodecEncodeSelf(e)
+	for _, yyv3626 := range v {
+		yy3627 := &yyv3626
+		yy3627.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42509,75 +42569,75 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3620 := *v
-	yyh3620, yyl3620 := z.DecSliceHelperStart()
+	yyv3628 := *v
+	yyh3628, yyl3628 := z.DecSliceHelperStart()
 
-	var yyrr3620, yyrl3620 int
-	var yyc3620, yyrt3620 bool
-	_, _, _ = yyc3620, yyrt3620, yyrl3620
-	yyrr3620 = yyl3620
+	var yyrr3628, yyrl3628 int
+	var yyc3628, yyrt3628 bool
+	_, _, _ = yyc3628, yyrt3628, yyrl3628
+	yyrr3628 = yyl3628
 
-	if yyv3620 == nil {
-		if yyrl3620, yyrt3620 = z.DecInferLen(yyl3620, z.DecBasicHandle().MaxInitLen, 216); yyrt3620 {
-			yyrr3620 = yyrl3620
+	if yyv3628 == nil {
+		if yyrl3628, yyrt3628 = z.DecInferLen(yyl3628, z.DecBasicHandle().MaxInitLen, 216); yyrt3628 {
+			yyrr3628 = yyrl3628
 		}
-		yyv3620 = make([]Endpoints, yyrl3620)
-		yyc3620 = true
+		yyv3628 = make([]Endpoints, yyrl3628)
+		yyc3628 = true
 	}
 
-	if yyl3620 == 0 {
-		if len(yyv3620) != 0 {
-			yyv3620 = yyv3620[:0]
-			yyc3620 = true
+	if yyl3628 == 0 {
+		if len(yyv3628) != 0 {
+			yyv3628 = yyv3628[:0]
+			yyc3628 = true
 		}
-	} else if yyl3620 > 0 {
+	} else if yyl3628 > 0 {
 
-		if yyl3620 > cap(yyv3620) {
-			yyrl3620, yyrt3620 = z.DecInferLen(yyl3620, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3620 = make([]Endpoints, yyrl3620)
-			yyc3620 = true
+		if yyl3628 > cap(yyv3628) {
+			yyrl3628, yyrt3628 = z.DecInferLen(yyl3628, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3628 = make([]Endpoints, yyrl3628)
+			yyc3628 = true
 
-			yyrr3620 = len(yyv3620)
-		} else if yyl3620 != len(yyv3620) {
-			yyv3620 = yyv3620[:yyl3620]
-			yyc3620 = true
+			yyrr3628 = len(yyv3628)
+		} else if yyl3628 != len(yyv3628) {
+			yyv3628 = yyv3628[:yyl3628]
+			yyc3628 = true
 		}
-		yyj3620 := 0
-		for ; yyj3620 < yyrr3620; yyj3620++ {
+		yyj3628 := 0
+		for ; yyj3628 < yyrr3628; yyj3628++ {
 			if r.TryDecodeAsNil() {
-				yyv3620[yyj3620] = Endpoints{}
+				yyv3628[yyj3628] = Endpoints{}
 			} else {
-				yyv3621 := &yyv3620[yyj3620]
-				yyv3621.CodecDecodeSelf(d)
+				yyv3629 := &yyv3628[yyj3628]
+				yyv3629.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3620 {
-			for ; yyj3620 < yyl3620; yyj3620++ {
-				yyv3620 = append(yyv3620, Endpoints{})
+		if yyrt3628 {
+			for ; yyj3628 < yyl3628; yyj3628++ {
+				yyv3628 = append(yyv3628, Endpoints{})
 				if r.TryDecodeAsNil() {
-					yyv3620[yyj3620] = Endpoints{}
+					yyv3628[yyj3628] = Endpoints{}
 				} else {
-					yyv3622 := &yyv3620[yyj3620]
-					yyv3622.CodecDecodeSelf(d)
+					yyv3630 := &yyv3628[yyj3628]
+					yyv3630.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3620 := 0; !r.CheckBreak(); yyj3620++ {
-			if yyj3620 >= len(yyv3620) {
-				yyv3620 = append(yyv3620, Endpoints{}) // var yyz3620 Endpoints
-				yyc3620 = true
+		for yyj3628 := 0; !r.CheckBreak(); yyj3628++ {
+			if yyj3628 >= len(yyv3628) {
+				yyv3628 = append(yyv3628, Endpoints{}) // var yyz3628 Endpoints
+				yyc3628 = true
 			}
 
-			if yyj3620 < len(yyv3620) {
+			if yyj3628 < len(yyv3628) {
 				if r.TryDecodeAsNil() {
-					yyv3620[yyj3620] = Endpoints{}
+					yyv3628[yyj3628] = Endpoints{}
 				} else {
-					yyv3623 := &yyv3620[yyj3620]
-					yyv3623.CodecDecodeSelf(d)
+					yyv3631 := &yyv3628[yyj3628]
+					yyv3631.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42585,10 +42645,10 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3620.End()
+		yyh3628.End()
 	}
-	if yyc3620 {
-		*v = yyv3620
+	if yyc3628 {
+		*v = yyv3628
 	}
 
 }
@@ -42598,9 +42658,9 @@ func (x codecSelfer1234) encSliceNodeCondition(v []NodeCondition, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3624 := range v {
-		yy3625 := &yyv3624
-		yy3625.CodecEncodeSelf(e)
+	for _, yyv3632 := range v {
+		yy3633 := &yyv3632
+		yy3633.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42610,75 +42670,75 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3626 := *v
-	yyh3626, yyl3626 := z.DecSliceHelperStart()
+	yyv3634 := *v
+	yyh3634, yyl3634 := z.DecSliceHelperStart()
 
-	var yyrr3626, yyrl3626 int
-	var yyc3626, yyrt3626 bool
-	_, _, _ = yyc3626, yyrt3626, yyrl3626
-	yyrr3626 = yyl3626
+	var yyrr3634, yyrl3634 int
+	var yyc3634, yyrt3634 bool
+	_, _, _ = yyc3634, yyrt3634, yyrl3634
+	yyrr3634 = yyl3634
 
-	if yyv3626 == nil {
-		if yyrl3626, yyrt3626 = z.DecInferLen(yyl3626, z.DecBasicHandle().MaxInitLen, 112); yyrt3626 {
-			yyrr3626 = yyrl3626
+	if yyv3634 == nil {
+		if yyrl3634, yyrt3634 = z.DecInferLen(yyl3634, z.DecBasicHandle().MaxInitLen, 112); yyrt3634 {
+			yyrr3634 = yyrl3634
 		}
-		yyv3626 = make([]NodeCondition, yyrl3626)
-		yyc3626 = true
+		yyv3634 = make([]NodeCondition, yyrl3634)
+		yyc3634 = true
 	}
 
-	if yyl3626 == 0 {
-		if len(yyv3626) != 0 {
-			yyv3626 = yyv3626[:0]
-			yyc3626 = true
+	if yyl3634 == 0 {
+		if len(yyv3634) != 0 {
+			yyv3634 = yyv3634[:0]
+			yyc3634 = true
 		}
-	} else if yyl3626 > 0 {
+	} else if yyl3634 > 0 {
 
-		if yyl3626 > cap(yyv3626) {
-			yyrl3626, yyrt3626 = z.DecInferLen(yyl3626, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3626 = make([]NodeCondition, yyrl3626)
-			yyc3626 = true
+		if yyl3634 > cap(yyv3634) {
+			yyrl3634, yyrt3634 = z.DecInferLen(yyl3634, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3634 = make([]NodeCondition, yyrl3634)
+			yyc3634 = true
 
-			yyrr3626 = len(yyv3626)
-		} else if yyl3626 != len(yyv3626) {
-			yyv3626 = yyv3626[:yyl3626]
-			yyc3626 = true
+			yyrr3634 = len(yyv3634)
+		} else if yyl3634 != len(yyv3634) {
+			yyv3634 = yyv3634[:yyl3634]
+			yyc3634 = true
 		}
-		yyj3626 := 0
-		for ; yyj3626 < yyrr3626; yyj3626++ {
+		yyj3634 := 0
+		for ; yyj3634 < yyrr3634; yyj3634++ {
 			if r.TryDecodeAsNil() {
-				yyv3626[yyj3626] = NodeCondition{}
+				yyv3634[yyj3634] = NodeCondition{}
 			} else {
-				yyv3627 := &yyv3626[yyj3626]
-				yyv3627.CodecDecodeSelf(d)
+				yyv3635 := &yyv3634[yyj3634]
+				yyv3635.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3626 {
-			for ; yyj3626 < yyl3626; yyj3626++ {
-				yyv3626 = append(yyv3626, NodeCondition{})
+		if yyrt3634 {
+			for ; yyj3634 < yyl3634; yyj3634++ {
+				yyv3634 = append(yyv3634, NodeCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3626[yyj3626] = NodeCondition{}
+					yyv3634[yyj3634] = NodeCondition{}
 				} else {
-					yyv3628 := &yyv3626[yyj3626]
-					yyv3628.CodecDecodeSelf(d)
+					yyv3636 := &yyv3634[yyj3634]
+					yyv3636.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3626 := 0; !r.CheckBreak(); yyj3626++ {
-			if yyj3626 >= len(yyv3626) {
-				yyv3626 = append(yyv3626, NodeCondition{}) // var yyz3626 NodeCondition
-				yyc3626 = true
+		for yyj3634 := 0; !r.CheckBreak(); yyj3634++ {
+			if yyj3634 >= len(yyv3634) {
+				yyv3634 = append(yyv3634, NodeCondition{}) // var yyz3634 NodeCondition
+				yyc3634 = true
 			}
 
-			if yyj3626 < len(yyv3626) {
+			if yyj3634 < len(yyv3634) {
 				if r.TryDecodeAsNil() {
-					yyv3626[yyj3626] = NodeCondition{}
+					yyv3634[yyj3634] = NodeCondition{}
 				} else {
-					yyv3629 := &yyv3626[yyj3626]
-					yyv3629.CodecDecodeSelf(d)
+					yyv3637 := &yyv3634[yyj3634]
+					yyv3637.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42686,10 +42746,10 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 			}
 
 		}
-		yyh3626.End()
+		yyh3634.End()
 	}
-	if yyc3626 {
-		*v = yyv3626
+	if yyc3634 {
+		*v = yyv3634
 	}
 
 }
@@ -42699,9 +42759,9 @@ func (x codecSelfer1234) encSliceNodeAddress(v []NodeAddress, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3630 := range v {
-		yy3631 := &yyv3630
-		yy3631.CodecEncodeSelf(e)
+	for _, yyv3638 := range v {
+		yy3639 := &yyv3638
+		yy3639.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42711,75 +42771,75 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3632 := *v
-	yyh3632, yyl3632 := z.DecSliceHelperStart()
+	yyv3640 := *v
+	yyh3640, yyl3640 := z.DecSliceHelperStart()
 
-	var yyrr3632, yyrl3632 int
-	var yyc3632, yyrt3632 bool
-	_, _, _ = yyc3632, yyrt3632, yyrl3632
-	yyrr3632 = yyl3632
+	var yyrr3640, yyrl3640 int
+	var yyc3640, yyrt3640 bool
+	_, _, _ = yyc3640, yyrt3640, yyrl3640
+	yyrr3640 = yyl3640
 
-	if yyv3632 == nil {
-		if yyrl3632, yyrt3632 = z.DecInferLen(yyl3632, z.DecBasicHandle().MaxInitLen, 32); yyrt3632 {
-			yyrr3632 = yyrl3632
+	if yyv3640 == nil {
+		if yyrl3640, yyrt3640 = z.DecInferLen(yyl3640, z.DecBasicHandle().MaxInitLen, 32); yyrt3640 {
+			yyrr3640 = yyrl3640
 		}
-		yyv3632 = make([]NodeAddress, yyrl3632)
-		yyc3632 = true
+		yyv3640 = make([]NodeAddress, yyrl3640)
+		yyc3640 = true
 	}
 
-	if yyl3632 == 0 {
-		if len(yyv3632) != 0 {
-			yyv3632 = yyv3632[:0]
-			yyc3632 = true
+	if yyl3640 == 0 {
+		if len(yyv3640) != 0 {
+			yyv3640 = yyv3640[:0]
+			yyc3640 = true
 		}
-	} else if yyl3632 > 0 {
+	} else if yyl3640 > 0 {
 
-		if yyl3632 > cap(yyv3632) {
-			yyrl3632, yyrt3632 = z.DecInferLen(yyl3632, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3632 = make([]NodeAddress, yyrl3632)
-			yyc3632 = true
+		if yyl3640 > cap(yyv3640) {
+			yyrl3640, yyrt3640 = z.DecInferLen(yyl3640, z.DecBasicHandle().MaxInitLen, 32)
+			yyv3640 = make([]NodeAddress, yyrl3640)
+			yyc3640 = true
 
-			yyrr3632 = len(yyv3632)
-		} else if yyl3632 != len(yyv3632) {
-			yyv3632 = yyv3632[:yyl3632]
-			yyc3632 = true
+			yyrr3640 = len(yyv3640)
+		} else if yyl3640 != len(yyv3640) {
+			yyv3640 = yyv3640[:yyl3640]
+			yyc3640 = true
 		}
-		yyj3632 := 0
-		for ; yyj3632 < yyrr3632; yyj3632++ {
+		yyj3640 := 0
+		for ; yyj3640 < yyrr3640; yyj3640++ {
 			if r.TryDecodeAsNil() {
-				yyv3632[yyj3632] = NodeAddress{}
+				yyv3640[yyj3640] = NodeAddress{}
 			} else {
-				yyv3633 := &yyv3632[yyj3632]
-				yyv3633.CodecDecodeSelf(d)
+				yyv3641 := &yyv3640[yyj3640]
+				yyv3641.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3632 {
-			for ; yyj3632 < yyl3632; yyj3632++ {
-				yyv3632 = append(yyv3632, NodeAddress{})
+		if yyrt3640 {
+			for ; yyj3640 < yyl3640; yyj3640++ {
+				yyv3640 = append(yyv3640, NodeAddress{})
 				if r.TryDecodeAsNil() {
-					yyv3632[yyj3632] = NodeAddress{}
+					yyv3640[yyj3640] = NodeAddress{}
 				} else {
-					yyv3634 := &yyv3632[yyj3632]
-					yyv3634.CodecDecodeSelf(d)
+					yyv3642 := &yyv3640[yyj3640]
+					yyv3642.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3632 := 0; !r.CheckBreak(); yyj3632++ {
-			if yyj3632 >= len(yyv3632) {
-				yyv3632 = append(yyv3632, NodeAddress{}) // var yyz3632 NodeAddress
-				yyc3632 = true
+		for yyj3640 := 0; !r.CheckBreak(); yyj3640++ {
+			if yyj3640 >= len(yyv3640) {
+				yyv3640 = append(yyv3640, NodeAddress{}) // var yyz3640 NodeAddress
+				yyc3640 = true
 			}
 
-			if yyj3632 < len(yyv3632) {
+			if yyj3640 < len(yyv3640) {
 				if r.TryDecodeAsNil() {
-					yyv3632[yyj3632] = NodeAddress{}
+					yyv3640[yyj3640] = NodeAddress{}
 				} else {
-					yyv3635 := &yyv3632[yyj3632]
-					yyv3635.CodecDecodeSelf(d)
+					yyv3643 := &yyv3640[yyj3640]
+					yyv3643.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42787,10 +42847,10 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 			}
 
 		}
-		yyh3632.End()
+		yyh3640.End()
 	}
-	if yyc3632 {
-		*v = yyv3632
+	if yyc3640 {
+		*v = yyv3640
 	}
 
 }
@@ -42800,17 +42860,17 @@ func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk3636, yyv3636 := range v {
-		yyk3636.CodecEncodeSelf(e)
-		yy3637 := &yyv3636
-		yym3638 := z.EncBinary()
-		_ = yym3638
+	for yyk3644, yyv3644 := range v {
+		yyk3644.CodecEncodeSelf(e)
+		yy3645 := &yyv3644
+		yym3646 := z.EncBinary()
+		_ = yym3646
 		if false {
-		} else if z.HasExtensions() && z.EncExt(yy3637) {
-		} else if !yym3638 && z.IsJSONHandle() {
-			z.EncJSONMarshal(yy3637)
+		} else if z.HasExtensions() && z.EncExt(yy3645) {
+		} else if !yym3646 && z.IsJSONHandle() {
+			z.EncJSONMarshal(yy3645)
 		} else {
-			z.EncFallback(yy3637)
+			z.EncFallback(yy3645)
 		}
 	}
 	r.EncodeEnd()
@@ -42821,82 +42881,82 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3639 := *v
-	yyl3639 := r.ReadMapStart()
-	yybh3639 := z.DecBasicHandle()
-	if yyv3639 == nil {
-		yyrl3639, _ := z.DecInferLen(yyl3639, yybh3639.MaxInitLen, 40)
-		yyv3639 = make(map[ResourceName]pkg3_resource.Quantity, yyrl3639)
-		*v = yyv3639
+	yyv3647 := *v
+	yyl3647 := r.ReadMapStart()
+	yybh3647 := z.DecBasicHandle()
+	if yyv3647 == nil {
+		yyrl3647, _ := z.DecInferLen(yyl3647, yybh3647.MaxInitLen, 40)
+		yyv3647 = make(map[ResourceName]pkg3_resource.Quantity, yyrl3647)
+		*v = yyv3647
 	}
-	var yymk3639 ResourceName
-	var yymv3639 pkg3_resource.Quantity
-	var yymg3639 bool
-	if yybh3639.MapValueReset {
-		yymg3639 = true
+	var yymk3647 ResourceName
+	var yymv3647 pkg3_resource.Quantity
+	var yymg3647 bool
+	if yybh3647.MapValueReset {
+		yymg3647 = true
 	}
-	if yyl3639 > 0 {
-		for yyj3639 := 0; yyj3639 < yyl3639; yyj3639++ {
+	if yyl3647 > 0 {
+		for yyj3647 := 0; yyj3647 < yyl3647; yyj3647++ {
 			if r.TryDecodeAsNil() {
-				yymk3639 = ""
+				yymk3647 = ""
 			} else {
-				yymk3639 = ResourceName(r.DecodeString())
+				yymk3647 = ResourceName(r.DecodeString())
 			}
 
-			if yymg3639 {
-				yymv3639 = yyv3639[yymk3639]
+			if yymg3647 {
+				yymv3647 = yyv3647[yymk3647]
 			} else {
-				yymv3639 = pkg3_resource.Quantity{}
+				yymv3647 = pkg3_resource.Quantity{}
 			}
 			if r.TryDecodeAsNil() {
-				yymv3639 = pkg3_resource.Quantity{}
+				yymv3647 = pkg3_resource.Quantity{}
 			} else {
-				yyv3641 := &yymv3639
-				yym3642 := z.DecBinary()
-				_ = yym3642
+				yyv3649 := &yymv3647
+				yym3650 := z.DecBinary()
+				_ = yym3650
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3641) {
-				} else if !yym3642 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3641)
+				} else if z.HasExtensions() && z.DecExt(yyv3649) {
+				} else if !yym3650 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3649)
 				} else {
-					z.DecFallback(yyv3641, false)
+					z.DecFallback(yyv3649, false)
 				}
 			}
 
-			if yyv3639 != nil {
-				yyv3639[yymk3639] = yymv3639
+			if yyv3647 != nil {
+				yyv3647[yymk3647] = yymv3647
 			}
 		}
-	} else if yyl3639 < 0 {
-		for yyj3639 := 0; !r.CheckBreak(); yyj3639++ {
+	} else if yyl3647 < 0 {
+		for yyj3647 := 0; !r.CheckBreak(); yyj3647++ {
 			if r.TryDecodeAsNil() {
-				yymk3639 = ""
+				yymk3647 = ""
 			} else {
-				yymk3639 = ResourceName(r.DecodeString())
+				yymk3647 = ResourceName(r.DecodeString())
 			}
 
-			if yymg3639 {
-				yymv3639 = yyv3639[yymk3639]
+			if yymg3647 {
+				yymv3647 = yyv3647[yymk3647]
 			} else {
-				yymv3639 = pkg3_resource.Quantity{}
+				yymv3647 = pkg3_resource.Quantity{}
 			}
 			if r.TryDecodeAsNil() {
-				yymv3639 = pkg3_resource.Quantity{}
+				yymv3647 = pkg3_resource.Quantity{}
 			} else {
-				yyv3644 := &yymv3639
-				yym3645 := z.DecBinary()
-				_ = yym3645
+				yyv3652 := &yymv3647
+				yym3653 := z.DecBinary()
+				_ = yym3653
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3644) {
-				} else if !yym3645 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3644)
+				} else if z.HasExtensions() && z.DecExt(yyv3652) {
+				} else if !yym3653 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3652)
 				} else {
-					z.DecFallback(yyv3644, false)
+					z.DecFallback(yyv3652, false)
 				}
 			}
 
-			if yyv3639 != nil {
-				yyv3639[yymk3639] = yymv3639
+			if yyv3647 != nil {
+				yyv3647[yymk3647] = yymv3647
 			}
 		}
 		r.ReadEnd()
@@ -42908,9 +42968,9 @@ func (x codecSelfer1234) encSliceNode(v []Node, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3646 := range v {
-		yy3647 := &yyv3646
-		yy3647.CodecEncodeSelf(e)
+	for _, yyv3654 := range v {
+		yy3655 := &yyv3654
+		yy3655.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42920,75 +42980,75 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3648 := *v
-	yyh3648, yyl3648 := z.DecSliceHelperStart()
+	yyv3656 := *v
+	yyh3656, yyl3656 := z.DecSliceHelperStart()
 
-	var yyrr3648, yyrl3648 int
-	var yyc3648, yyrt3648 bool
-	_, _, _ = yyc3648, yyrt3648, yyrl3648
-	yyrr3648 = yyl3648
+	var yyrr3656, yyrl3656 int
+	var yyc3656, yyrt3656 bool
+	_, _, _ = yyc3656, yyrt3656, yyrl3656
+	yyrr3656 = yyl3656
 
-	if yyv3648 == nil {
-		if yyrl3648, yyrt3648 = z.DecInferLen(yyl3648, z.DecBasicHandle().MaxInitLen, 456); yyrt3648 {
-			yyrr3648 = yyrl3648
+	if yyv3656 == nil {
+		if yyrl3656, yyrt3656 = z.DecInferLen(yyl3656, z.DecBasicHandle().MaxInitLen, 456); yyrt3656 {
+			yyrr3656 = yyrl3656
 		}
-		yyv3648 = make([]Node, yyrl3648)
-		yyc3648 = true
+		yyv3656 = make([]Node, yyrl3656)
+		yyc3656 = true
 	}
 
-	if yyl3648 == 0 {
-		if len(yyv3648) != 0 {
-			yyv3648 = yyv3648[:0]
-			yyc3648 = true
+	if yyl3656 == 0 {
+		if len(yyv3656) != 0 {
+			yyv3656 = yyv3656[:0]
+			yyc3656 = true
 		}
-	} else if yyl3648 > 0 {
+	} else if yyl3656 > 0 {
 
-		if yyl3648 > cap(yyv3648) {
-			yyrl3648, yyrt3648 = z.DecInferLen(yyl3648, z.DecBasicHandle().MaxInitLen, 456)
-			yyv3648 = make([]Node, yyrl3648)
-			yyc3648 = true
+		if yyl3656 > cap(yyv3656) {
+			yyrl3656, yyrt3656 = z.DecInferLen(yyl3656, z.DecBasicHandle().MaxInitLen, 456)
+			yyv3656 = make([]Node, yyrl3656)
+			yyc3656 = true
 
-			yyrr3648 = len(yyv3648)
-		} else if yyl3648 != len(yyv3648) {
-			yyv3648 = yyv3648[:yyl3648]
-			yyc3648 = true
+			yyrr3656 = len(yyv3656)
+		} else if yyl3656 != len(yyv3656) {
+			yyv3656 = yyv3656[:yyl3656]
+			yyc3656 = true
 		}
-		yyj3648 := 0
-		for ; yyj3648 < yyrr3648; yyj3648++ {
+		yyj3656 := 0
+		for ; yyj3656 < yyrr3656; yyj3656++ {
 			if r.TryDecodeAsNil() {
-				yyv3648[yyj3648] = Node{}
+				yyv3656[yyj3656] = Node{}
 			} else {
-				yyv3649 := &yyv3648[yyj3648]
-				yyv3649.CodecDecodeSelf(d)
+				yyv3657 := &yyv3656[yyj3656]
+				yyv3657.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3648 {
-			for ; yyj3648 < yyl3648; yyj3648++ {
-				yyv3648 = append(yyv3648, Node{})
+		if yyrt3656 {
+			for ; yyj3656 < yyl3656; yyj3656++ {
+				yyv3656 = append(yyv3656, Node{})
 				if r.TryDecodeAsNil() {
-					yyv3648[yyj3648] = Node{}
+					yyv3656[yyj3656] = Node{}
 				} else {
-					yyv3650 := &yyv3648[yyj3648]
-					yyv3650.CodecDecodeSelf(d)
+					yyv3658 := &yyv3656[yyj3656]
+					yyv3658.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3648 := 0; !r.CheckBreak(); yyj3648++ {
-			if yyj3648 >= len(yyv3648) {
-				yyv3648 = append(yyv3648, Node{}) // var yyz3648 Node
-				yyc3648 = true
+		for yyj3656 := 0; !r.CheckBreak(); yyj3656++ {
+			if yyj3656 >= len(yyv3656) {
+				yyv3656 = append(yyv3656, Node{}) // var yyz3656 Node
+				yyc3656 = true
 			}
 
-			if yyj3648 < len(yyv3648) {
+			if yyj3656 < len(yyv3656) {
 				if r.TryDecodeAsNil() {
-					yyv3648[yyj3648] = Node{}
+					yyv3656[yyj3656] = Node{}
 				} else {
-					yyv3651 := &yyv3648[yyj3648]
-					yyv3651.CodecDecodeSelf(d)
+					yyv3659 := &yyv3656[yyj3656]
+					yyv3659.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42996,10 +43056,10 @@ func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3648.End()
+		yyh3656.End()
 	}
-	if yyc3648 {
-		*v = yyv3648
+	if yyc3656 {
+		*v = yyv3656
 	}
 
 }
@@ -43009,8 +43069,8 @@ func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3652 := range v {
-		yyv3652.CodecEncodeSelf(e)
+	for _, yyv3660 := range v {
+		yyv3660.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43020,77 +43080,77 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3653 := *v
-	yyh3653, yyl3653 := z.DecSliceHelperStart()
+	yyv3661 := *v
+	yyh3661, yyl3661 := z.DecSliceHelperStart()
 
-	var yyrr3653, yyrl3653 int
-	var yyc3653, yyrt3653 bool
-	_, _, _ = yyc3653, yyrt3653, yyrl3653
-	yyrr3653 = yyl3653
+	var yyrr3661, yyrl3661 int
+	var yyc3661, yyrt3661 bool
+	_, _, _ = yyc3661, yyrt3661, yyrl3661
+	yyrr3661 = yyl3661
 
-	if yyv3653 == nil {
-		if yyrl3653, yyrt3653 = z.DecInferLen(yyl3653, z.DecBasicHandle().MaxInitLen, 16); yyrt3653 {
-			yyrr3653 = yyrl3653
+	if yyv3661 == nil {
+		if yyrl3661, yyrt3661 = z.DecInferLen(yyl3661, z.DecBasicHandle().MaxInitLen, 16); yyrt3661 {
+			yyrr3661 = yyrl3661
 		}
-		yyv3653 = make([]FinalizerName, yyrl3653)
-		yyc3653 = true
+		yyv3661 = make([]FinalizerName, yyrl3661)
+		yyc3661 = true
 	}
 
-	if yyl3653 == 0 {
-		if len(yyv3653) != 0 {
-			yyv3653 = yyv3653[:0]
-			yyc3653 = true
+	if yyl3661 == 0 {
+		if len(yyv3661) != 0 {
+			yyv3661 = yyv3661[:0]
+			yyc3661 = true
 		}
-	} else if yyl3653 > 0 {
+	} else if yyl3661 > 0 {
 
-		if yyl3653 > cap(yyv3653) {
-			yyrl3653, yyrt3653 = z.DecInferLen(yyl3653, z.DecBasicHandle().MaxInitLen, 16)
+		if yyl3661 > cap(yyv3661) {
+			yyrl3661, yyrt3661 = z.DecInferLen(yyl3661, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23653 := yyv3653
-			yyv3653 = make([]FinalizerName, yyrl3653)
-			if len(yyv3653) > 0 {
-				copy(yyv3653, yyv23653[:cap(yyv23653)])
+			yyv23661 := yyv3661
+			yyv3661 = make([]FinalizerName, yyrl3661)
+			if len(yyv3661) > 0 {
+				copy(yyv3661, yyv23661[:cap(yyv23661)])
 			}
-			yyc3653 = true
+			yyc3661 = true
 
-			yyrr3653 = len(yyv3653)
-		} else if yyl3653 != len(yyv3653) {
-			yyv3653 = yyv3653[:yyl3653]
-			yyc3653 = true
+			yyrr3661 = len(yyv3661)
+		} else if yyl3661 != len(yyv3661) {
+			yyv3661 = yyv3661[:yyl3661]
+			yyc3661 = true
 		}
-		yyj3653 := 0
-		for ; yyj3653 < yyrr3653; yyj3653++ {
+		yyj3661 := 0
+		for ; yyj3661 < yyrr3661; yyj3661++ {
 			if r.TryDecodeAsNil() {
-				yyv3653[yyj3653] = ""
+				yyv3661[yyj3661] = ""
 			} else {
-				yyv3653[yyj3653] = FinalizerName(r.DecodeString())
+				yyv3661[yyj3661] = FinalizerName(r.DecodeString())
 			}
 
 		}
-		if yyrt3653 {
-			for ; yyj3653 < yyl3653; yyj3653++ {
-				yyv3653 = append(yyv3653, "")
+		if yyrt3661 {
+			for ; yyj3661 < yyl3661; yyj3661++ {
+				yyv3661 = append(yyv3661, "")
 				if r.TryDecodeAsNil() {
-					yyv3653[yyj3653] = ""
+					yyv3661[yyj3661] = ""
 				} else {
-					yyv3653[yyj3653] = FinalizerName(r.DecodeString())
+					yyv3661[yyj3661] = FinalizerName(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3653 := 0; !r.CheckBreak(); yyj3653++ {
-			if yyj3653 >= len(yyv3653) {
-				yyv3653 = append(yyv3653, "") // var yyz3653 FinalizerName
-				yyc3653 = true
+		for yyj3661 := 0; !r.CheckBreak(); yyj3661++ {
+			if yyj3661 >= len(yyv3661) {
+				yyv3661 = append(yyv3661, "") // var yyz3661 FinalizerName
+				yyc3661 = true
 			}
 
-			if yyj3653 < len(yyv3653) {
+			if yyj3661 < len(yyv3661) {
 				if r.TryDecodeAsNil() {
-					yyv3653[yyj3653] = ""
+					yyv3661[yyj3661] = ""
 				} else {
-					yyv3653[yyj3653] = FinalizerName(r.DecodeString())
+					yyv3661[yyj3661] = FinalizerName(r.DecodeString())
 				}
 
 			} else {
@@ -43098,10 +43158,10 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 			}
 
 		}
-		yyh3653.End()
+		yyh3661.End()
 	}
-	if yyc3653 {
-		*v = yyv3653
+	if yyc3661 {
+		*v = yyv3661
 	}
 
 }
@@ -43111,9 +43171,9 @@ func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3657 := range v {
-		yy3658 := &yyv3657
-		yy3658.CodecEncodeSelf(e)
+	for _, yyv3665 := range v {
+		yy3666 := &yyv3665
+		yy3666.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43123,75 +43183,75 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3659 := *v
-	yyh3659, yyl3659 := z.DecSliceHelperStart()
+	yyv3667 := *v
+	yyh3667, yyl3667 := z.DecSliceHelperStart()
 
-	var yyrr3659, yyrl3659 int
-	var yyc3659, yyrt3659 bool
-	_, _, _ = yyc3659, yyrt3659, yyrl3659
-	yyrr3659 = yyl3659
+	var yyrr3667, yyrl3667 int
+	var yyc3667, yyrt3667 bool
+	_, _, _ = yyc3667, yyrt3667, yyrl3667
+	yyrr3667 = yyl3667
 
-	if yyv3659 == nil {
-		if yyrl3659, yyrt3659 = z.DecInferLen(yyl3659, z.DecBasicHandle().MaxInitLen, 232); yyrt3659 {
-			yyrr3659 = yyrl3659
+	if yyv3667 == nil {
+		if yyrl3667, yyrt3667 = z.DecInferLen(yyl3667, z.DecBasicHandle().MaxInitLen, 232); yyrt3667 {
+			yyrr3667 = yyrl3667
 		}
-		yyv3659 = make([]Namespace, yyrl3659)
-		yyc3659 = true
+		yyv3667 = make([]Namespace, yyrl3667)
+		yyc3667 = true
 	}
 
-	if yyl3659 == 0 {
-		if len(yyv3659) != 0 {
-			yyv3659 = yyv3659[:0]
-			yyc3659 = true
+	if yyl3667 == 0 {
+		if len(yyv3667) != 0 {
+			yyv3667 = yyv3667[:0]
+			yyc3667 = true
 		}
-	} else if yyl3659 > 0 {
+	} else if yyl3667 > 0 {
 
-		if yyl3659 > cap(yyv3659) {
-			yyrl3659, yyrt3659 = z.DecInferLen(yyl3659, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3659 = make([]Namespace, yyrl3659)
-			yyc3659 = true
+		if yyl3667 > cap(yyv3667) {
+			yyrl3667, yyrt3667 = z.DecInferLen(yyl3667, z.DecBasicHandle().MaxInitLen, 232)
+			yyv3667 = make([]Namespace, yyrl3667)
+			yyc3667 = true
 
-			yyrr3659 = len(yyv3659)
-		} else if yyl3659 != len(yyv3659) {
-			yyv3659 = yyv3659[:yyl3659]
-			yyc3659 = true
+			yyrr3667 = len(yyv3667)
+		} else if yyl3667 != len(yyv3667) {
+			yyv3667 = yyv3667[:yyl3667]
+			yyc3667 = true
 		}
-		yyj3659 := 0
-		for ; yyj3659 < yyrr3659; yyj3659++ {
+		yyj3667 := 0
+		for ; yyj3667 < yyrr3667; yyj3667++ {
 			if r.TryDecodeAsNil() {
-				yyv3659[yyj3659] = Namespace{}
+				yyv3667[yyj3667] = Namespace{}
 			} else {
-				yyv3660 := &yyv3659[yyj3659]
-				yyv3660.CodecDecodeSelf(d)
+				yyv3668 := &yyv3667[yyj3667]
+				yyv3668.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3659 {
-			for ; yyj3659 < yyl3659; yyj3659++ {
-				yyv3659 = append(yyv3659, Namespace{})
+		if yyrt3667 {
+			for ; yyj3667 < yyl3667; yyj3667++ {
+				yyv3667 = append(yyv3667, Namespace{})
 				if r.TryDecodeAsNil() {
-					yyv3659[yyj3659] = Namespace{}
+					yyv3667[yyj3667] = Namespace{}
 				} else {
-					yyv3661 := &yyv3659[yyj3659]
-					yyv3661.CodecDecodeSelf(d)
+					yyv3669 := &yyv3667[yyj3667]
+					yyv3669.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3659 := 0; !r.CheckBreak(); yyj3659++ {
-			if yyj3659 >= len(yyv3659) {
-				yyv3659 = append(yyv3659, Namespace{}) // var yyz3659 Namespace
-				yyc3659 = true
+		for yyj3667 := 0; !r.CheckBreak(); yyj3667++ {
+			if yyj3667 >= len(yyv3667) {
+				yyv3667 = append(yyv3667, Namespace{}) // var yyz3667 Namespace
+				yyc3667 = true
 			}
 
-			if yyj3659 < len(yyv3659) {
+			if yyj3667 < len(yyv3667) {
 				if r.TryDecodeAsNil() {
-					yyv3659[yyj3659] = Namespace{}
+					yyv3667[yyj3667] = Namespace{}
 				} else {
-					yyv3662 := &yyv3659[yyj3659]
-					yyv3662.CodecDecodeSelf(d)
+					yyv3670 := &yyv3667[yyj3667]
+					yyv3670.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43199,10 +43259,10 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3659.End()
+		yyh3667.End()
 	}
-	if yyc3659 {
-		*v = yyv3659
+	if yyc3667 {
+		*v = yyv3667
 	}
 
 }
@@ -43212,9 +43272,9 @@ func (x codecSelfer1234) encSliceEvent(v []Event, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3663 := range v {
-		yy3664 := &yyv3663
-		yy3664.CodecEncodeSelf(e)
+	for _, yyv3671 := range v {
+		yy3672 := &yyv3671
+		yy3672.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43224,75 +43284,75 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3665 := *v
-	yyh3665, yyl3665 := z.DecSliceHelperStart()
+	yyv3673 := *v
+	yyh3673, yyl3673 := z.DecSliceHelperStart()
 
-	var yyrr3665, yyrl3665 int
-	var yyc3665, yyrt3665 bool
-	_, _, _ = yyc3665, yyrt3665, yyrl3665
-	yyrr3665 = yyl3665
+	var yyrr3673, yyrl3673 int
+	var yyc3673, yyrt3673 bool
+	_, _, _ = yyc3673, yyrt3673, yyrl3673
+	yyrr3673 = yyl3673
 
-	if yyv3665 == nil {
-		if yyrl3665, yyrt3665 = z.DecInferLen(yyl3665, z.DecBasicHandle().MaxInitLen, 424); yyrt3665 {
-			yyrr3665 = yyrl3665
+	if yyv3673 == nil {
+		if yyrl3673, yyrt3673 = z.DecInferLen(yyl3673, z.DecBasicHandle().MaxInitLen, 424); yyrt3673 {
+			yyrr3673 = yyrl3673
 		}
-		yyv3665 = make([]Event, yyrl3665)
-		yyc3665 = true
+		yyv3673 = make([]Event, yyrl3673)
+		yyc3673 = true
 	}
 
-	if yyl3665 == 0 {
-		if len(yyv3665) != 0 {
-			yyv3665 = yyv3665[:0]
-			yyc3665 = true
+	if yyl3673 == 0 {
+		if len(yyv3673) != 0 {
+			yyv3673 = yyv3673[:0]
+			yyc3673 = true
 		}
-	} else if yyl3665 > 0 {
+	} else if yyl3673 > 0 {
 
-		if yyl3665 > cap(yyv3665) {
-			yyrl3665, yyrt3665 = z.DecInferLen(yyl3665, z.DecBasicHandle().MaxInitLen, 424)
-			yyv3665 = make([]Event, yyrl3665)
-			yyc3665 = true
+		if yyl3673 > cap(yyv3673) {
+			yyrl3673, yyrt3673 = z.DecInferLen(yyl3673, z.DecBasicHandle().MaxInitLen, 424)
+			yyv3673 = make([]Event, yyrl3673)
+			yyc3673 = true
 
-			yyrr3665 = len(yyv3665)
-		} else if yyl3665 != len(yyv3665) {
-			yyv3665 = yyv3665[:yyl3665]
-			yyc3665 = true
+			yyrr3673 = len(yyv3673)
+		} else if yyl3673 != len(yyv3673) {
+			yyv3673 = yyv3673[:yyl3673]
+			yyc3673 = true
 		}
-		yyj3665 := 0
-		for ; yyj3665 < yyrr3665; yyj3665++ {
+		yyj3673 := 0
+		for ; yyj3673 < yyrr3673; yyj3673++ {
 			if r.TryDecodeAsNil() {
-				yyv3665[yyj3665] = Event{}
+				yyv3673[yyj3673] = Event{}
 			} else {
-				yyv3666 := &yyv3665[yyj3665]
-				yyv3666.CodecDecodeSelf(d)
+				yyv3674 := &yyv3673[yyj3673]
+				yyv3674.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3665 {
-			for ; yyj3665 < yyl3665; yyj3665++ {
-				yyv3665 = append(yyv3665, Event{})
+		if yyrt3673 {
+			for ; yyj3673 < yyl3673; yyj3673++ {
+				yyv3673 = append(yyv3673, Event{})
 				if r.TryDecodeAsNil() {
-					yyv3665[yyj3665] = Event{}
+					yyv3673[yyj3673] = Event{}
 				} else {
-					yyv3667 := &yyv3665[yyj3665]
-					yyv3667.CodecDecodeSelf(d)
+					yyv3675 := &yyv3673[yyj3673]
+					yyv3675.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3665 := 0; !r.CheckBreak(); yyj3665++ {
-			if yyj3665 >= len(yyv3665) {
-				yyv3665 = append(yyv3665, Event{}) // var yyz3665 Event
-				yyc3665 = true
+		for yyj3673 := 0; !r.CheckBreak(); yyj3673++ {
+			if yyj3673 >= len(yyv3673) {
+				yyv3673 = append(yyv3673, Event{}) // var yyz3673 Event
+				yyc3673 = true
 			}
 
-			if yyj3665 < len(yyv3665) {
+			if yyj3673 < len(yyv3673) {
 				if r.TryDecodeAsNil() {
-					yyv3665[yyj3665] = Event{}
+					yyv3673[yyj3673] = Event{}
 				} else {
-					yyv3668 := &yyv3665[yyj3665]
-					yyv3668.CodecDecodeSelf(d)
+					yyv3676 := &yyv3673[yyj3673]
+					yyv3676.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43300,10 +43360,10 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3665.End()
+		yyh3673.End()
 	}
-	if yyc3665 {
-		*v = yyv3665
+	if yyc3673 {
+		*v = yyv3673
 	}
 
 }
@@ -43313,16 +43373,16 @@ func (x codecSelfer1234) encSliceruntime_RawExtension(v []pkg6_runtime.RawExtens
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3669 := range v {
-		yy3670 := &yyv3669
-		yym3671 := z.EncBinary()
-		_ = yym3671
+	for _, yyv3677 := range v {
+		yy3678 := &yyv3677
+		yym3679 := z.EncBinary()
+		_ = yym3679
 		if false {
-		} else if z.HasExtensions() && z.EncExt(yy3670) {
-		} else if !yym3671 && z.IsJSONHandle() {
-			z.EncJSONMarshal(yy3670)
+		} else if z.HasExtensions() && z.EncExt(yy3678) {
+		} else if !yym3679 && z.IsJSONHandle() {
+			z.EncJSONMarshal(yy3678)
 		} else {
-			z.EncFallback(yy3670)
+			z.EncFallback(yy3678)
 		}
 	}
 	r.EncodeEnd()
@@ -43333,72 +43393,72 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3672 := *v
-	yyh3672, yyl3672 := z.DecSliceHelperStart()
+	yyv3680 := *v
+	yyh3680, yyl3680 := z.DecSliceHelperStart()
 
-	var yyrr3672, yyrl3672 int
-	var yyc3672, yyrt3672 bool
-	_, _, _ = yyc3672, yyrt3672, yyrl3672
-	yyrr3672 = yyl3672
+	var yyrr3680, yyrl3680 int
+	var yyc3680, yyrt3680 bool
+	_, _, _ = yyc3680, yyrt3680, yyrl3680
+	yyrr3680 = yyl3680
 
-	if yyv3672 == nil {
-		if yyrl3672, yyrt3672 = z.DecInferLen(yyl3672, z.DecBasicHandle().MaxInitLen, 24); yyrt3672 {
-			yyrr3672 = yyrl3672
+	if yyv3680 == nil {
+		if yyrl3680, yyrt3680 = z.DecInferLen(yyl3680, z.DecBasicHandle().MaxInitLen, 24); yyrt3680 {
+			yyrr3680 = yyrl3680
 		}
-		yyv3672 = make([]pkg6_runtime.RawExtension, yyrl3672)
-		yyc3672 = true
+		yyv3680 = make([]pkg6_runtime.RawExtension, yyrl3680)
+		yyc3680 = true
 	}
 
-	if yyl3672 == 0 {
-		if len(yyv3672) != 0 {
-			yyv3672 = yyv3672[:0]
-			yyc3672 = true
+	if yyl3680 == 0 {
+		if len(yyv3680) != 0 {
+			yyv3680 = yyv3680[:0]
+			yyc3680 = true
 		}
-	} else if yyl3672 > 0 {
+	} else if yyl3680 > 0 {
 
-		if yyl3672 > cap(yyv3672) {
-			yyrl3672, yyrt3672 = z.DecInferLen(yyl3672, z.DecBasicHandle().MaxInitLen, 24)
-			yyv3672 = make([]pkg6_runtime.RawExtension, yyrl3672)
-			yyc3672 = true
+		if yyl3680 > cap(yyv3680) {
+			yyrl3680, yyrt3680 = z.DecInferLen(yyl3680, z.DecBasicHandle().MaxInitLen, 24)
+			yyv3680 = make([]pkg6_runtime.RawExtension, yyrl3680)
+			yyc3680 = true
 
-			yyrr3672 = len(yyv3672)
-		} else if yyl3672 != len(yyv3672) {
-			yyv3672 = yyv3672[:yyl3672]
-			yyc3672 = true
+			yyrr3680 = len(yyv3680)
+		} else if yyl3680 != len(yyv3680) {
+			yyv3680 = yyv3680[:yyl3680]
+			yyc3680 = true
 		}
-		yyj3672 := 0
-		for ; yyj3672 < yyrr3672; yyj3672++ {
+		yyj3680 := 0
+		for ; yyj3680 < yyrr3680; yyj3680++ {
 			if r.TryDecodeAsNil() {
-				yyv3672[yyj3672] = pkg6_runtime.RawExtension{}
+				yyv3680[yyj3680] = pkg6_runtime.RawExtension{}
 			} else {
-				yyv3673 := &yyv3672[yyj3672]
-				yym3674 := z.DecBinary()
-				_ = yym3674
+				yyv3681 := &yyv3680[yyj3680]
+				yym3682 := z.DecBinary()
+				_ = yym3682
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3673) {
-				} else if !yym3674 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3673)
+				} else if z.HasExtensions() && z.DecExt(yyv3681) {
+				} else if !yym3682 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3681)
 				} else {
-					z.DecFallback(yyv3673, false)
+					z.DecFallback(yyv3681, false)
 				}
 			}
 
 		}
-		if yyrt3672 {
-			for ; yyj3672 < yyl3672; yyj3672++ {
-				yyv3672 = append(yyv3672, pkg6_runtime.RawExtension{})
+		if yyrt3680 {
+			for ; yyj3680 < yyl3680; yyj3680++ {
+				yyv3680 = append(yyv3680, pkg6_runtime.RawExtension{})
 				if r.TryDecodeAsNil() {
-					yyv3672[yyj3672] = pkg6_runtime.RawExtension{}
+					yyv3680[yyj3680] = pkg6_runtime.RawExtension{}
 				} else {
-					yyv3675 := &yyv3672[yyj3672]
-					yym3676 := z.DecBinary()
-					_ = yym3676
+					yyv3683 := &yyv3680[yyj3680]
+					yym3684 := z.DecBinary()
+					_ = yym3684
 					if false {
-					} else if z.HasExtensions() && z.DecExt(yyv3675) {
-					} else if !yym3676 && z.IsJSONHandle() {
-						z.DecJSONUnmarshal(yyv3675)
+					} else if z.HasExtensions() && z.DecExt(yyv3683) {
+					} else if !yym3684 && z.IsJSONHandle() {
+						z.DecJSONUnmarshal(yyv3683)
 					} else {
-						z.DecFallback(yyv3675, false)
+						z.DecFallback(yyv3683, false)
 					}
 				}
 
@@ -43406,25 +43466,25 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 		}
 
 	} else {
-		for yyj3672 := 0; !r.CheckBreak(); yyj3672++ {
-			if yyj3672 >= len(yyv3672) {
-				yyv3672 = append(yyv3672, pkg6_runtime.RawExtension{}) // var yyz3672 pkg6_runtime.RawExtension
-				yyc3672 = true
+		for yyj3680 := 0; !r.CheckBreak(); yyj3680++ {
+			if yyj3680 >= len(yyv3680) {
+				yyv3680 = append(yyv3680, pkg6_runtime.RawExtension{}) // var yyz3680 pkg6_runtime.RawExtension
+				yyc3680 = true
 			}
 
-			if yyj3672 < len(yyv3672) {
+			if yyj3680 < len(yyv3680) {
 				if r.TryDecodeAsNil() {
-					yyv3672[yyj3672] = pkg6_runtime.RawExtension{}
+					yyv3680[yyj3680] = pkg6_runtime.RawExtension{}
 				} else {
-					yyv3677 := &yyv3672[yyj3672]
-					yym3678 := z.DecBinary()
-					_ = yym3678
+					yyv3685 := &yyv3680[yyj3680]
+					yym3686 := z.DecBinary()
+					_ = yym3686
 					if false {
-					} else if z.HasExtensions() && z.DecExt(yyv3677) {
-					} else if !yym3678 && z.IsJSONHandle() {
-						z.DecJSONUnmarshal(yyv3677)
+					} else if z.HasExtensions() && z.DecExt(yyv3685) {
+					} else if !yym3686 && z.IsJSONHandle() {
+						z.DecJSONUnmarshal(yyv3685)
 					} else {
-						z.DecFallback(yyv3677, false)
+						z.DecFallback(yyv3685, false)
 					}
 				}
 
@@ -43433,10 +43493,10 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 			}
 
 		}
-		yyh3672.End()
+		yyh3680.End()
 	}
-	if yyc3672 {
-		*v = yyv3672
+	if yyc3680 {
+		*v = yyv3680
 	}
 
 }
@@ -43446,9 +43506,9 @@ func (x codecSelfer1234) encSliceLimitRangeItem(v []LimitRangeItem, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3679 := range v {
-		yy3680 := &yyv3679
-		yy3680.CodecEncodeSelf(e)
+	for _, yyv3687 := range v {
+		yy3688 := &yyv3687
+		yy3688.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43458,75 +43518,75 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3681 := *v
-	yyh3681, yyl3681 := z.DecSliceHelperStart()
+	yyv3689 := *v
+	yyh3689, yyl3689 := z.DecSliceHelperStart()
 
-	var yyrr3681, yyrl3681 int
-	var yyc3681, yyrt3681 bool
-	_, _, _ = yyc3681, yyrt3681, yyrl3681
-	yyrr3681 = yyl3681
+	var yyrr3689, yyrl3689 int
+	var yyc3689, yyrt3689 bool
+	_, _, _ = yyc3689, yyrt3689, yyrl3689
+	yyrr3689 = yyl3689
 
-	if yyv3681 == nil {
-		if yyrl3681, yyrt3681 = z.DecInferLen(yyl3681, z.DecBasicHandle().MaxInitLen, 56); yyrt3681 {
-			yyrr3681 = yyrl3681
+	if yyv3689 == nil {
+		if yyrl3689, yyrt3689 = z.DecInferLen(yyl3689, z.DecBasicHandle().MaxInitLen, 56); yyrt3689 {
+			yyrr3689 = yyrl3689
 		}
-		yyv3681 = make([]LimitRangeItem, yyrl3681)
-		yyc3681 = true
+		yyv3689 = make([]LimitRangeItem, yyrl3689)
+		yyc3689 = true
 	}
 
-	if yyl3681 == 0 {
-		if len(yyv3681) != 0 {
-			yyv3681 = yyv3681[:0]
-			yyc3681 = true
+	if yyl3689 == 0 {
+		if len(yyv3689) != 0 {
+			yyv3689 = yyv3689[:0]
+			yyc3689 = true
 		}
-	} else if yyl3681 > 0 {
+	} else if yyl3689 > 0 {
 
-		if yyl3681 > cap(yyv3681) {
-			yyrl3681, yyrt3681 = z.DecInferLen(yyl3681, z.DecBasicHandle().MaxInitLen, 56)
-			yyv3681 = make([]LimitRangeItem, yyrl3681)
-			yyc3681 = true
+		if yyl3689 > cap(yyv3689) {
+			yyrl3689, yyrt3689 = z.DecInferLen(yyl3689, z.DecBasicHandle().MaxInitLen, 56)
+			yyv3689 = make([]LimitRangeItem, yyrl3689)
+			yyc3689 = true
 
-			yyrr3681 = len(yyv3681)
-		} else if yyl3681 != len(yyv3681) {
-			yyv3681 = yyv3681[:yyl3681]
-			yyc3681 = true
+			yyrr3689 = len(yyv3689)
+		} else if yyl3689 != len(yyv3689) {
+			yyv3689 = yyv3689[:yyl3689]
+			yyc3689 = true
 		}
-		yyj3681 := 0
-		for ; yyj3681 < yyrr3681; yyj3681++ {
+		yyj3689 := 0
+		for ; yyj3689 < yyrr3689; yyj3689++ {
 			if r.TryDecodeAsNil() {
-				yyv3681[yyj3681] = LimitRangeItem{}
+				yyv3689[yyj3689] = LimitRangeItem{}
 			} else {
-				yyv3682 := &yyv3681[yyj3681]
-				yyv3682.CodecDecodeSelf(d)
+				yyv3690 := &yyv3689[yyj3689]
+				yyv3690.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3681 {
-			for ; yyj3681 < yyl3681; yyj3681++ {
-				yyv3681 = append(yyv3681, LimitRangeItem{})
+		if yyrt3689 {
+			for ; yyj3689 < yyl3689; yyj3689++ {
+				yyv3689 = append(yyv3689, LimitRangeItem{})
 				if r.TryDecodeAsNil() {
-					yyv3681[yyj3681] = LimitRangeItem{}
+					yyv3689[yyj3689] = LimitRangeItem{}
 				} else {
-					yyv3683 := &yyv3681[yyj3681]
-					yyv3683.CodecDecodeSelf(d)
+					yyv3691 := &yyv3689[yyj3689]
+					yyv3691.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3681 := 0; !r.CheckBreak(); yyj3681++ {
-			if yyj3681 >= len(yyv3681) {
-				yyv3681 = append(yyv3681, LimitRangeItem{}) // var yyz3681 LimitRangeItem
-				yyc3681 = true
+		for yyj3689 := 0; !r.CheckBreak(); yyj3689++ {
+			if yyj3689 >= len(yyv3689) {
+				yyv3689 = append(yyv3689, LimitRangeItem{}) // var yyz3689 LimitRangeItem
+				yyc3689 = true
 			}
 
-			if yyj3681 < len(yyv3681) {
+			if yyj3689 < len(yyv3689) {
 				if r.TryDecodeAsNil() {
-					yyv3681[yyj3681] = LimitRangeItem{}
+					yyv3689[yyj3689] = LimitRangeItem{}
 				} else {
-					yyv3684 := &yyv3681[yyj3681]
-					yyv3684.CodecDecodeSelf(d)
+					yyv3692 := &yyv3689[yyj3689]
+					yyv3692.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43534,10 +43594,10 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 			}
 
 		}
-		yyh3681.End()
+		yyh3689.End()
 	}
-	if yyc3681 {
-		*v = yyv3681
+	if yyc3689 {
+		*v = yyv3689
 	}
 
 }
@@ -43547,9 +43607,9 @@ func (x codecSelfer1234) encSliceLimitRange(v []LimitRange, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3685 := range v {
-		yy3686 := &yyv3685
-		yy3686.CodecEncodeSelf(e)
+	for _, yyv3693 := range v {
+		yy3694 := &yyv3693
+		yy3694.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43559,75 +43619,75 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3687 := *v
-	yyh3687, yyl3687 := z.DecSliceHelperStart()
+	yyv3695 := *v
+	yyh3695, yyl3695 := z.DecSliceHelperStart()
 
-	var yyrr3687, yyrl3687 int
-	var yyc3687, yyrt3687 bool
-	_, _, _ = yyc3687, yyrt3687, yyrl3687
-	yyrr3687 = yyl3687
+	var yyrr3695, yyrl3695 int
+	var yyc3695, yyrt3695 bool
+	_, _, _ = yyc3695, yyrt3695, yyrl3695
+	yyrr3695 = yyl3695
 
-	if yyv3687 == nil {
-		if yyrl3687, yyrt3687 = z.DecInferLen(yyl3687, z.DecBasicHandle().MaxInitLen, 216); yyrt3687 {
-			yyrr3687 = yyrl3687
+	if yyv3695 == nil {
+		if yyrl3695, yyrt3695 = z.DecInferLen(yyl3695, z.DecBasicHandle().MaxInitLen, 216); yyrt3695 {
+			yyrr3695 = yyrl3695
 		}
-		yyv3687 = make([]LimitRange, yyrl3687)
-		yyc3687 = true
+		yyv3695 = make([]LimitRange, yyrl3695)
+		yyc3695 = true
 	}
 
-	if yyl3687 == 0 {
-		if len(yyv3687) != 0 {
-			yyv3687 = yyv3687[:0]
-			yyc3687 = true
+	if yyl3695 == 0 {
+		if len(yyv3695) != 0 {
+			yyv3695 = yyv3695[:0]
+			yyc3695 = true
 		}
-	} else if yyl3687 > 0 {
+	} else if yyl3695 > 0 {
 
-		if yyl3687 > cap(yyv3687) {
-			yyrl3687, yyrt3687 = z.DecInferLen(yyl3687, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3687 = make([]LimitRange, yyrl3687)
-			yyc3687 = true
+		if yyl3695 > cap(yyv3695) {
+			yyrl3695, yyrt3695 = z.DecInferLen(yyl3695, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3695 = make([]LimitRange, yyrl3695)
+			yyc3695 = true
 
-			yyrr3687 = len(yyv3687)
-		} else if yyl3687 != len(yyv3687) {
-			yyv3687 = yyv3687[:yyl3687]
-			yyc3687 = true
+			yyrr3695 = len(yyv3695)
+		} else if yyl3695 != len(yyv3695) {
+			yyv3695 = yyv3695[:yyl3695]
+			yyc3695 = true
 		}
-		yyj3687 := 0
-		for ; yyj3687 < yyrr3687; yyj3687++ {
+		yyj3695 := 0
+		for ; yyj3695 < yyrr3695; yyj3695++ {
 			if r.TryDecodeAsNil() {
-				yyv3687[yyj3687] = LimitRange{}
+				yyv3695[yyj3695] = LimitRange{}
 			} else {
-				yyv3688 := &yyv3687[yyj3687]
-				yyv3688.CodecDecodeSelf(d)
+				yyv3696 := &yyv3695[yyj3695]
+				yyv3696.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3687 {
-			for ; yyj3687 < yyl3687; yyj3687++ {
-				yyv3687 = append(yyv3687, LimitRange{})
+		if yyrt3695 {
+			for ; yyj3695 < yyl3695; yyj3695++ {
+				yyv3695 = append(yyv3695, LimitRange{})
 				if r.TryDecodeAsNil() {
-					yyv3687[yyj3687] = LimitRange{}
+					yyv3695[yyj3695] = LimitRange{}
 				} else {
-					yyv3689 := &yyv3687[yyj3687]
-					yyv3689.CodecDecodeSelf(d)
+					yyv3697 := &yyv3695[yyj3695]
+					yyv3697.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3687 := 0; !r.CheckBreak(); yyj3687++ {
-			if yyj3687 >= len(yyv3687) {
-				yyv3687 = append(yyv3687, LimitRange{}) // var yyz3687 LimitRange
-				yyc3687 = true
+		for yyj3695 := 0; !r.CheckBreak(); yyj3695++ {
+			if yyj3695 >= len(yyv3695) {
+				yyv3695 = append(yyv3695, LimitRange{}) // var yyz3695 LimitRange
+				yyc3695 = true
 			}
 
-			if yyj3687 < len(yyv3687) {
+			if yyj3695 < len(yyv3695) {
 				if r.TryDecodeAsNil() {
-					yyv3687[yyj3687] = LimitRange{}
+					yyv3695[yyj3695] = LimitRange{}
 				} else {
-					yyv3690 := &yyv3687[yyj3687]
-					yyv3690.CodecDecodeSelf(d)
+					yyv3698 := &yyv3695[yyj3695]
+					yyv3698.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43635,10 +43695,10 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 			}
 
 		}
-		yyh3687.End()
+		yyh3695.End()
 	}
-	if yyc3687 {
-		*v = yyv3687
+	if yyc3695 {
+		*v = yyv3695
 	}
 
 }
@@ -43648,9 +43708,9 @@ func (x codecSelfer1234) encSliceResourceQuota(v []ResourceQuota, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3691 := range v {
-		yy3692 := &yyv3691
-		yy3692.CodecEncodeSelf(e)
+	for _, yyv3699 := range v {
+		yy3700 := &yyv3699
+		yy3700.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43660,75 +43720,75 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3693 := *v
-	yyh3693, yyl3693 := z.DecSliceHelperStart()
+	yyv3701 := *v
+	yyh3701, yyl3701 := z.DecSliceHelperStart()
 
-	var yyrr3693, yyrl3693 int
-	var yyc3693, yyrt3693 bool
-	_, _, _ = yyc3693, yyrt3693, yyrl3693
-	yyrr3693 = yyl3693
+	var yyrr3701, yyrl3701 int
+	var yyc3701, yyrt3701 bool
+	_, _, _ = yyc3701, yyrt3701, yyrl3701
+	yyrr3701 = yyl3701
 
-	if yyv3693 == nil {
-		if yyrl3693, yyrt3693 = z.DecInferLen(yyl3693, z.DecBasicHandle().MaxInitLen, 216); yyrt3693 {
-			yyrr3693 = yyrl3693
+	if yyv3701 == nil {
+		if yyrl3701, yyrt3701 = z.DecInferLen(yyl3701, z.DecBasicHandle().MaxInitLen, 216); yyrt3701 {
+			yyrr3701 = yyrl3701
 		}
-		yyv3693 = make([]ResourceQuota, yyrl3693)
-		yyc3693 = true
+		yyv3701 = make([]ResourceQuota, yyrl3701)
+		yyc3701 = true
 	}
 
-	if yyl3693 == 0 {
-		if len(yyv3693) != 0 {
-			yyv3693 = yyv3693[:0]
-			yyc3693 = true
+	if yyl3701 == 0 {
+		if len(yyv3701) != 0 {
+			yyv3701 = yyv3701[:0]
+			yyc3701 = true
 		}
-	} else if yyl3693 > 0 {
+	} else if yyl3701 > 0 {
 
-		if yyl3693 > cap(yyv3693) {
-			yyrl3693, yyrt3693 = z.DecInferLen(yyl3693, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3693 = make([]ResourceQuota, yyrl3693)
-			yyc3693 = true
+		if yyl3701 > cap(yyv3701) {
+			yyrl3701, yyrt3701 = z.DecInferLen(yyl3701, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3701 = make([]ResourceQuota, yyrl3701)
+			yyc3701 = true
 
-			yyrr3693 = len(yyv3693)
-		} else if yyl3693 != len(yyv3693) {
-			yyv3693 = yyv3693[:yyl3693]
-			yyc3693 = true
+			yyrr3701 = len(yyv3701)
+		} else if yyl3701 != len(yyv3701) {
+			yyv3701 = yyv3701[:yyl3701]
+			yyc3701 = true
 		}
-		yyj3693 := 0
-		for ; yyj3693 < yyrr3693; yyj3693++ {
+		yyj3701 := 0
+		for ; yyj3701 < yyrr3701; yyj3701++ {
 			if r.TryDecodeAsNil() {
-				yyv3693[yyj3693] = ResourceQuota{}
+				yyv3701[yyj3701] = ResourceQuota{}
 			} else {
-				yyv3694 := &yyv3693[yyj3693]
-				yyv3694.CodecDecodeSelf(d)
+				yyv3702 := &yyv3701[yyj3701]
+				yyv3702.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3693 {
-			for ; yyj3693 < yyl3693; yyj3693++ {
-				yyv3693 = append(yyv3693, ResourceQuota{})
+		if yyrt3701 {
+			for ; yyj3701 < yyl3701; yyj3701++ {
+				yyv3701 = append(yyv3701, ResourceQuota{})
 				if r.TryDecodeAsNil() {
-					yyv3693[yyj3693] = ResourceQuota{}
+					yyv3701[yyj3701] = ResourceQuota{}
 				} else {
-					yyv3695 := &yyv3693[yyj3693]
-					yyv3695.CodecDecodeSelf(d)
+					yyv3703 := &yyv3701[yyj3701]
+					yyv3703.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3693 := 0; !r.CheckBreak(); yyj3693++ {
-			if yyj3693 >= len(yyv3693) {
-				yyv3693 = append(yyv3693, ResourceQuota{}) // var yyz3693 ResourceQuota
-				yyc3693 = true
+		for yyj3701 := 0; !r.CheckBreak(); yyj3701++ {
+			if yyj3701 >= len(yyv3701) {
+				yyv3701 = append(yyv3701, ResourceQuota{}) // var yyz3701 ResourceQuota
+				yyc3701 = true
 			}
 
-			if yyj3693 < len(yyv3693) {
+			if yyj3701 < len(yyv3701) {
 				if r.TryDecodeAsNil() {
-					yyv3693[yyj3693] = ResourceQuota{}
+					yyv3701[yyj3701] = ResourceQuota{}
 				} else {
-					yyv3696 := &yyv3693[yyj3693]
-					yyv3696.CodecDecodeSelf(d)
+					yyv3704 := &yyv3701[yyj3701]
+					yyv3704.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43736,10 +43796,10 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 			}
 
 		}
-		yyh3693.End()
+		yyh3701.End()
 	}
-	if yyc3693 {
-		*v = yyv3693
+	if yyc3701 {
+		*v = yyv3701
 	}
 
 }
@@ -43749,21 +43809,21 @@ func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk3697, yyv3697 := range v {
-		yym3698 := z.EncBinary()
-		_ = yym3698
+	for yyk3705, yyv3705 := range v {
+		yym3706 := z.EncBinary()
+		_ = yym3706
 		if false {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyk3697))
+			r.EncodeString(codecSelferC_UTF81234, string(yyk3705))
 		}
-		if yyv3697 == nil {
+		if yyv3705 == nil {
 			r.EncodeNil()
 		} else {
-			yym3699 := z.EncBinary()
-			_ = yym3699
+			yym3707 := z.EncBinary()
+			_ = yym3707
 			if false {
 			} else {
-				r.EncodeStringBytes(codecSelferC_RAW1234, []byte(yyv3697))
+				r.EncodeStringBytes(codecSelferC_RAW1234, []byte(yyv3705))
 			}
 		}
 	}
@@ -43775,76 +43835,76 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3700 := *v
-	yyl3700 := r.ReadMapStart()
-	yybh3700 := z.DecBasicHandle()
-	if yyv3700 == nil {
-		yyrl3700, _ := z.DecInferLen(yyl3700, yybh3700.MaxInitLen, 40)
-		yyv3700 = make(map[string][]uint8, yyrl3700)
-		*v = yyv3700
+	yyv3708 := *v
+	yyl3708 := r.ReadMapStart()
+	yybh3708 := z.DecBasicHandle()
+	if yyv3708 == nil {
+		yyrl3708, _ := z.DecInferLen(yyl3708, yybh3708.MaxInitLen, 40)
+		yyv3708 = make(map[string][]uint8, yyrl3708)
+		*v = yyv3708
 	}
-	var yymk3700 string
-	var yymv3700 []uint8
-	var yymg3700 bool
-	if yybh3700.MapValueReset {
-		yymg3700 = true
+	var yymk3708 string
+	var yymv3708 []uint8
+	var yymg3708 bool
+	if yybh3708.MapValueReset {
+		yymg3708 = true
 	}
-	if yyl3700 > 0 {
-		for yyj3700 := 0; yyj3700 < yyl3700; yyj3700++ {
+	if yyl3708 > 0 {
+		for yyj3708 := 0; yyj3708 < yyl3708; yyj3708++ {
 			if r.TryDecodeAsNil() {
-				yymk3700 = ""
+				yymk3708 = ""
 			} else {
-				yymk3700 = string(r.DecodeString())
+				yymk3708 = string(r.DecodeString())
 			}
 
-			if yymg3700 {
-				yymv3700 = yyv3700[yymk3700]
+			if yymg3708 {
+				yymv3708 = yyv3708[yymk3708]
 			} else {
-				yymv3700 = nil
+				yymv3708 = nil
 			}
 			if r.TryDecodeAsNil() {
-				yymv3700 = nil
+				yymv3708 = nil
 			} else {
-				yyv3702 := &yymv3700
-				yym3703 := z.DecBinary()
-				_ = yym3703
+				yyv3710 := &yymv3708
+				yym3711 := z.DecBinary()
+				_ = yym3711
 				if false {
 				} else {
-					*yyv3702 = r.DecodeBytes(*(*[]byte)(yyv3702), false, false)
+					*yyv3710 = r.DecodeBytes(*(*[]byte)(yyv3710), false, false)
 				}
 			}
 
-			if yyv3700 != nil {
-				yyv3700[yymk3700] = yymv3700
+			if yyv3708 != nil {
+				yyv3708[yymk3708] = yymv3708
 			}
 		}
-	} else if yyl3700 < 0 {
-		for yyj3700 := 0; !r.CheckBreak(); yyj3700++ {
+	} else if yyl3708 < 0 {
+		for yyj3708 := 0; !r.CheckBreak(); yyj3708++ {
 			if r.TryDecodeAsNil() {
-				yymk3700 = ""
+				yymk3708 = ""
 			} else {
-				yymk3700 = string(r.DecodeString())
+				yymk3708 = string(r.DecodeString())
 			}
 
-			if yymg3700 {
-				yymv3700 = yyv3700[yymk3700]
+			if yymg3708 {
+				yymv3708 = yyv3708[yymk3708]
 			} else {
-				yymv3700 = nil
+				yymv3708 = nil
 			}
 			if r.TryDecodeAsNil() {
-				yymv3700 = nil
+				yymv3708 = nil
 			} else {
-				yyv3705 := &yymv3700
-				yym3706 := z.DecBinary()
-				_ = yym3706
+				yyv3713 := &yymv3708
+				yym3714 := z.DecBinary()
+				_ = yym3714
 				if false {
 				} else {
-					*yyv3705 = r.DecodeBytes(*(*[]byte)(yyv3705), false, false)
+					*yyv3713 = r.DecodeBytes(*(*[]byte)(yyv3713), false, false)
 				}
 			}
 
-			if yyv3700 != nil {
-				yyv3700[yymk3700] = yymv3700
+			if yyv3708 != nil {
+				yyv3708[yymk3708] = yymv3708
 			}
 		}
 		r.ReadEnd()
@@ -43856,9 +43916,9 @@ func (x codecSelfer1234) encSliceSecret(v []Secret, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3707 := range v {
-		yy3708 := &yyv3707
-		yy3708.CodecEncodeSelf(e)
+	for _, yyv3715 := range v {
+		yy3716 := &yyv3715
+		yy3716.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43868,75 +43928,75 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3709 := *v
-	yyh3709, yyl3709 := z.DecSliceHelperStart()
+	yyv3717 := *v
+	yyh3717, yyl3717 := z.DecSliceHelperStart()
 
-	var yyrr3709, yyrl3709 int
-	var yyc3709, yyrt3709 bool
-	_, _, _ = yyc3709, yyrt3709, yyrl3709
-	yyrr3709 = yyl3709
+	var yyrr3717, yyrl3717 int
+	var yyc3717, yyrt3717 bool
+	_, _, _ = yyc3717, yyrt3717, yyrl3717
+	yyrr3717 = yyl3717
 
-	if yyv3709 == nil {
-		if yyrl3709, yyrt3709 = z.DecInferLen(yyl3709, z.DecBasicHandle().MaxInitLen, 216); yyrt3709 {
-			yyrr3709 = yyrl3709
+	if yyv3717 == nil {
+		if yyrl3717, yyrt3717 = z.DecInferLen(yyl3717, z.DecBasicHandle().MaxInitLen, 216); yyrt3717 {
+			yyrr3717 = yyrl3717
 		}
-		yyv3709 = make([]Secret, yyrl3709)
-		yyc3709 = true
+		yyv3717 = make([]Secret, yyrl3717)
+		yyc3717 = true
 	}
 
-	if yyl3709 == 0 {
-		if len(yyv3709) != 0 {
-			yyv3709 = yyv3709[:0]
-			yyc3709 = true
+	if yyl3717 == 0 {
+		if len(yyv3717) != 0 {
+			yyv3717 = yyv3717[:0]
+			yyc3717 = true
 		}
-	} else if yyl3709 > 0 {
+	} else if yyl3717 > 0 {
 
-		if yyl3709 > cap(yyv3709) {
-			yyrl3709, yyrt3709 = z.DecInferLen(yyl3709, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3709 = make([]Secret, yyrl3709)
-			yyc3709 = true
+		if yyl3717 > cap(yyv3717) {
+			yyrl3717, yyrt3717 = z.DecInferLen(yyl3717, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3717 = make([]Secret, yyrl3717)
+			yyc3717 = true
 
-			yyrr3709 = len(yyv3709)
-		} else if yyl3709 != len(yyv3709) {
-			yyv3709 = yyv3709[:yyl3709]
-			yyc3709 = true
+			yyrr3717 = len(yyv3717)
+		} else if yyl3717 != len(yyv3717) {
+			yyv3717 = yyv3717[:yyl3717]
+			yyc3717 = true
 		}
-		yyj3709 := 0
-		for ; yyj3709 < yyrr3709; yyj3709++ {
+		yyj3717 := 0
+		for ; yyj3717 < yyrr3717; yyj3717++ {
 			if r.TryDecodeAsNil() {
-				yyv3709[yyj3709] = Secret{}
+				yyv3717[yyj3717] = Secret{}
 			} else {
-				yyv3710 := &yyv3709[yyj3709]
-				yyv3710.CodecDecodeSelf(d)
+				yyv3718 := &yyv3717[yyj3717]
+				yyv3718.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3709 {
-			for ; yyj3709 < yyl3709; yyj3709++ {
-				yyv3709 = append(yyv3709, Secret{})
+		if yyrt3717 {
+			for ; yyj3717 < yyl3717; yyj3717++ {
+				yyv3717 = append(yyv3717, Secret{})
 				if r.TryDecodeAsNil() {
-					yyv3709[yyj3709] = Secret{}
+					yyv3717[yyj3717] = Secret{}
 				} else {
-					yyv3711 := &yyv3709[yyj3709]
-					yyv3711.CodecDecodeSelf(d)
+					yyv3719 := &yyv3717[yyj3717]
+					yyv3719.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3709 := 0; !r.CheckBreak(); yyj3709++ {
-			if yyj3709 >= len(yyv3709) {
-				yyv3709 = append(yyv3709, Secret{}) // var yyz3709 Secret
-				yyc3709 = true
+		for yyj3717 := 0; !r.CheckBreak(); yyj3717++ {
+			if yyj3717 >= len(yyv3717) {
+				yyv3717 = append(yyv3717, Secret{}) // var yyz3717 Secret
+				yyc3717 = true
 			}
 
-			if yyj3709 < len(yyv3709) {
+			if yyj3717 < len(yyv3717) {
 				if r.TryDecodeAsNil() {
-					yyv3709[yyj3709] = Secret{}
+					yyv3717[yyj3717] = Secret{}
 				} else {
-					yyv3712 := &yyv3709[yyj3709]
-					yyv3712.CodecDecodeSelf(d)
+					yyv3720 := &yyv3717[yyj3717]
+					yyv3720.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43944,10 +44004,10 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3709.End()
+		yyh3717.End()
 	}
-	if yyc3709 {
-		*v = yyv3709
+	if yyc3717 {
+		*v = yyv3717
 	}
 
 }
@@ -43957,9 +44017,9 @@ func (x codecSelfer1234) encSliceComponentCondition(v []ComponentCondition, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3713 := range v {
-		yy3714 := &yyv3713
-		yy3714.CodecEncodeSelf(e)
+	for _, yyv3721 := range v {
+		yy3722 := &yyv3721
+		yy3722.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43969,75 +44029,75 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3715 := *v
-	yyh3715, yyl3715 := z.DecSliceHelperStart()
+	yyv3723 := *v
+	yyh3723, yyl3723 := z.DecSliceHelperStart()
 
-	var yyrr3715, yyrl3715 int
-	var yyc3715, yyrt3715 bool
-	_, _, _ = yyc3715, yyrt3715, yyrl3715
-	yyrr3715 = yyl3715
+	var yyrr3723, yyrl3723 int
+	var yyc3723, yyrt3723 bool
+	_, _, _ = yyc3723, yyrt3723, yyrl3723
+	yyrr3723 = yyl3723
 
-	if yyv3715 == nil {
-		if yyrl3715, yyrt3715 = z.DecInferLen(yyl3715, z.DecBasicHandle().MaxInitLen, 64); yyrt3715 {
-			yyrr3715 = yyrl3715
+	if yyv3723 == nil {
+		if yyrl3723, yyrt3723 = z.DecInferLen(yyl3723, z.DecBasicHandle().MaxInitLen, 64); yyrt3723 {
+			yyrr3723 = yyrl3723
 		}
-		yyv3715 = make([]ComponentCondition, yyrl3715)
-		yyc3715 = true
+		yyv3723 = make([]ComponentCondition, yyrl3723)
+		yyc3723 = true
 	}
 
-	if yyl3715 == 0 {
-		if len(yyv3715) != 0 {
-			yyv3715 = yyv3715[:0]
-			yyc3715 = true
+	if yyl3723 == 0 {
+		if len(yyv3723) != 0 {
+			yyv3723 = yyv3723[:0]
+			yyc3723 = true
 		}
-	} else if yyl3715 > 0 {
+	} else if yyl3723 > 0 {
 
-		if yyl3715 > cap(yyv3715) {
-			yyrl3715, yyrt3715 = z.DecInferLen(yyl3715, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3715 = make([]ComponentCondition, yyrl3715)
-			yyc3715 = true
+		if yyl3723 > cap(yyv3723) {
+			yyrl3723, yyrt3723 = z.DecInferLen(yyl3723, z.DecBasicHandle().MaxInitLen, 64)
+			yyv3723 = make([]ComponentCondition, yyrl3723)
+			yyc3723 = true
 
-			yyrr3715 = len(yyv3715)
-		} else if yyl3715 != len(yyv3715) {
-			yyv3715 = yyv3715[:yyl3715]
-			yyc3715 = true
+			yyrr3723 = len(yyv3723)
+		} else if yyl3723 != len(yyv3723) {
+			yyv3723 = yyv3723[:yyl3723]
+			yyc3723 = true
 		}
-		yyj3715 := 0
-		for ; yyj3715 < yyrr3715; yyj3715++ {
+		yyj3723 := 0
+		for ; yyj3723 < yyrr3723; yyj3723++ {
 			if r.TryDecodeAsNil() {
-				yyv3715[yyj3715] = ComponentCondition{}
+				yyv3723[yyj3723] = ComponentCondition{}
 			} else {
-				yyv3716 := &yyv3715[yyj3715]
-				yyv3716.CodecDecodeSelf(d)
+				yyv3724 := &yyv3723[yyj3723]
+				yyv3724.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3715 {
-			for ; yyj3715 < yyl3715; yyj3715++ {
-				yyv3715 = append(yyv3715, ComponentCondition{})
+		if yyrt3723 {
+			for ; yyj3723 < yyl3723; yyj3723++ {
+				yyv3723 = append(yyv3723, ComponentCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3715[yyj3715] = ComponentCondition{}
+					yyv3723[yyj3723] = ComponentCondition{}
 				} else {
-					yyv3717 := &yyv3715[yyj3715]
-					yyv3717.CodecDecodeSelf(d)
+					yyv3725 := &yyv3723[yyj3723]
+					yyv3725.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3715 := 0; !r.CheckBreak(); yyj3715++ {
-			if yyj3715 >= len(yyv3715) {
-				yyv3715 = append(yyv3715, ComponentCondition{}) // var yyz3715 ComponentCondition
-				yyc3715 = true
+		for yyj3723 := 0; !r.CheckBreak(); yyj3723++ {
+			if yyj3723 >= len(yyv3723) {
+				yyv3723 = append(yyv3723, ComponentCondition{}) // var yyz3723 ComponentCondition
+				yyc3723 = true
 			}
 
-			if yyj3715 < len(yyv3715) {
+			if yyj3723 < len(yyv3723) {
 				if r.TryDecodeAsNil() {
-					yyv3715[yyj3715] = ComponentCondition{}
+					yyv3723[yyj3723] = ComponentCondition{}
 				} else {
-					yyv3718 := &yyv3715[yyj3715]
-					yyv3718.CodecDecodeSelf(d)
+					yyv3726 := &yyv3723[yyj3723]
+					yyv3726.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -44045,10 +44105,10 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 			}
 
 		}
-		yyh3715.End()
+		yyh3723.End()
 	}
-	if yyc3715 {
-		*v = yyv3715
+	if yyc3723 {
+		*v = yyv3723
 	}
 
 }
@@ -44058,9 +44118,9 @@ func (x codecSelfer1234) encSliceComponentStatus(v []ComponentStatus, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3719 := range v {
-		yy3720 := &yyv3719
-		yy3720.CodecEncodeSelf(e)
+	for _, yyv3727 := range v {
+		yy3728 := &yyv3727
+		yy3728.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -44070,75 +44130,75 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3721 := *v
-	yyh3721, yyl3721 := z.DecSliceHelperStart()
+	yyv3729 := *v
+	yyh3729, yyl3729 := z.DecSliceHelperStart()
 
-	var yyrr3721, yyrl3721 int
-	var yyc3721, yyrt3721 bool
-	_, _, _ = yyc3721, yyrt3721, yyrl3721
-	yyrr3721 = yyl3721
+	var yyrr3729, yyrl3729 int
+	var yyc3729, yyrt3729 bool
+	_, _, _ = yyc3729, yyrt3729, yyrl3729
+	yyrr3729 = yyl3729
 
-	if yyv3721 == nil {
-		if yyrl3721, yyrt3721 = z.DecInferLen(yyl3721, z.DecBasicHandle().MaxInitLen, 216); yyrt3721 {
-			yyrr3721 = yyrl3721
+	if yyv3729 == nil {
+		if yyrl3729, yyrt3729 = z.DecInferLen(yyl3729, z.DecBasicHandle().MaxInitLen, 216); yyrt3729 {
+			yyrr3729 = yyrl3729
 		}
-		yyv3721 = make([]ComponentStatus, yyrl3721)
-		yyc3721 = true
+		yyv3729 = make([]ComponentStatus, yyrl3729)
+		yyc3729 = true
 	}
 
-	if yyl3721 == 0 {
-		if len(yyv3721) != 0 {
-			yyv3721 = yyv3721[:0]
-			yyc3721 = true
+	if yyl3729 == 0 {
+		if len(yyv3729) != 0 {
+			yyv3729 = yyv3729[:0]
+			yyc3729 = true
 		}
-	} else if yyl3721 > 0 {
+	} else if yyl3729 > 0 {
 
-		if yyl3721 > cap(yyv3721) {
-			yyrl3721, yyrt3721 = z.DecInferLen(yyl3721, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3721 = make([]ComponentStatus, yyrl3721)
-			yyc3721 = true
+		if yyl3729 > cap(yyv3729) {
+			yyrl3729, yyrt3729 = z.DecInferLen(yyl3729, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3729 = make([]ComponentStatus, yyrl3729)
+			yyc3729 = true
 
-			yyrr3721 = len(yyv3721)
-		} else if yyl3721 != len(yyv3721) {
-			yyv3721 = yyv3721[:yyl3721]
-			yyc3721 = true
+			yyrr3729 = len(yyv3729)
+		} else if yyl3729 != len(yyv3729) {
+			yyv3729 = yyv3729[:yyl3729]
+			yyc3729 = true
 		}
-		yyj3721 := 0
-		for ; yyj3721 < yyrr3721; yyj3721++ {
+		yyj3729 := 0
+		for ; yyj3729 < yyrr3729; yyj3729++ {
 			if r.TryDecodeAsNil() {
-				yyv3721[yyj3721] = ComponentStatus{}
+				yyv3729[yyj3729] = ComponentStatus{}
 			} else {
-				yyv3722 := &yyv3721[yyj3721]
-				yyv3722.CodecDecodeSelf(d)
+				yyv3730 := &yyv3729[yyj3729]
+				yyv3730.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3721 {
-			for ; yyj3721 < yyl3721; yyj3721++ {
-				yyv3721 = append(yyv3721, ComponentStatus{})
+		if yyrt3729 {
+			for ; yyj3729 < yyl3729; yyj3729++ {
+				yyv3729 = append(yyv3729, ComponentStatus{})
 				if r.TryDecodeAsNil() {
-					yyv3721[yyj3721] = ComponentStatus{}
+					yyv3729[yyj3729] = ComponentStatus{}
 				} else {
-					yyv3723 := &yyv3721[yyj3721]
-					yyv3723.CodecDecodeSelf(d)
+					yyv3731 := &yyv3729[yyj3729]
+					yyv3731.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3721 := 0; !r.CheckBreak(); yyj3721++ {
-			if yyj3721 >= len(yyv3721) {
-				yyv3721 = append(yyv3721, ComponentStatus{}) // var yyz3721 ComponentStatus
-				yyc3721 = true
+		for yyj3729 := 0; !r.CheckBreak(); yyj3729++ {
+			if yyj3729 >= len(yyv3729) {
+				yyv3729 = append(yyv3729, ComponentStatus{}) // var yyz3729 ComponentStatus
+				yyc3729 = true
 			}
 
-			if yyj3721 < len(yyv3721) {
+			if yyj3729 < len(yyv3729) {
 				if r.TryDecodeAsNil() {
-					yyv3721[yyj3721] = ComponentStatus{}
+					yyv3729[yyj3729] = ComponentStatus{}
 				} else {
-					yyv3724 := &yyv3721[yyj3721]
-					yyv3724.CodecDecodeSelf(d)
+					yyv3732 := &yyv3729[yyj3729]
+					yyv3732.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -44146,10 +44206,10 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 			}
 
 		}
-		yyh3721.End()
+		yyh3729.End()
 	}
-	if yyc3721 {
-		*v = yyv3721
+	if yyc3729 {
+		*v = yyv3729
 	}
 
 }
@@ -44159,9 +44219,9 @@ func (x codecSelfer1234) encSliceDownwardAPIVolumeFile(v []DownwardAPIVolumeFile
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3725 := range v {
-		yy3726 := &yyv3725
-		yy3726.CodecEncodeSelf(e)
+	for _, yyv3733 := range v {
+		yy3734 := &yyv3733
+		yy3734.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -44171,75 +44231,75 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3727 := *v
-	yyh3727, yyl3727 := z.DecSliceHelperStart()
+	yyv3735 := *v
+	yyh3735, yyl3735 := z.DecSliceHelperStart()
 
-	var yyrr3727, yyrl3727 int
-	var yyc3727, yyrt3727 bool
-	_, _, _ = yyc3727, yyrt3727, yyrl3727
-	yyrr3727 = yyl3727
+	var yyrr3735, yyrl3735 int
+	var yyc3735, yyrt3735 bool
+	_, _, _ = yyc3735, yyrt3735, yyrl3735
+	yyrr3735 = yyl3735
 
-	if yyv3727 == nil {
-		if yyrl3727, yyrt3727 = z.DecInferLen(yyl3727, z.DecBasicHandle().MaxInitLen, 48); yyrt3727 {
-			yyrr3727 = yyrl3727
+	if yyv3735 == nil {
+		if yyrl3735, yyrt3735 = z.DecInferLen(yyl3735, z.DecBasicHandle().MaxInitLen, 48); yyrt3735 {
+			yyrr3735 = yyrl3735
 		}
-		yyv3727 = make([]DownwardAPIVolumeFile, yyrl3727)
-		yyc3727 = true
+		yyv3735 = make([]DownwardAPIVolumeFile, yyrl3735)
+		yyc3735 = true
 	}
 
-	if yyl3727 == 0 {
-		if len(yyv3727) != 0 {
-			yyv3727 = yyv3727[:0]
-			yyc3727 = true
+	if yyl3735 == 0 {
+		if len(yyv3735) != 0 {
+			yyv3735 = yyv3735[:0]
+			yyc3735 = true
 		}
-	} else if yyl3727 > 0 {
+	} else if yyl3735 > 0 {
 
-		if yyl3727 > cap(yyv3727) {
-			yyrl3727, yyrt3727 = z.DecInferLen(yyl3727, z.DecBasicHandle().MaxInitLen, 48)
-			yyv3727 = make([]DownwardAPIVolumeFile, yyrl3727)
-			yyc3727 = true
+		if yyl3735 > cap(yyv3735) {
+			yyrl3735, yyrt3735 = z.DecInferLen(yyl3735, z.DecBasicHandle().MaxInitLen, 48)
+			yyv3735 = make([]DownwardAPIVolumeFile, yyrl3735)
+			yyc3735 = true
 
-			yyrr3727 = len(yyv3727)
-		} else if yyl3727 != len(yyv3727) {
-			yyv3727 = yyv3727[:yyl3727]
-			yyc3727 = true
+			yyrr3735 = len(yyv3735)
+		} else if yyl3735 != len(yyv3735) {
+			yyv3735 = yyv3735[:yyl3735]
+			yyc3735 = true
 		}
-		yyj3727 := 0
-		for ; yyj3727 < yyrr3727; yyj3727++ {
+		yyj3735 := 0
+		for ; yyj3735 < yyrr3735; yyj3735++ {
 			if r.TryDecodeAsNil() {
-				yyv3727[yyj3727] = DownwardAPIVolumeFile{}
+				yyv3735[yyj3735] = DownwardAPIVolumeFile{}
 			} else {
-				yyv3728 := &yyv3727[yyj3727]
-				yyv3728.CodecDecodeSelf(d)
+				yyv3736 := &yyv3735[yyj3735]
+				yyv3736.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3727 {
-			for ; yyj3727 < yyl3727; yyj3727++ {
-				yyv3727 = append(yyv3727, DownwardAPIVolumeFile{})
+		if yyrt3735 {
+			for ; yyj3735 < yyl3735; yyj3735++ {
+				yyv3735 = append(yyv3735, DownwardAPIVolumeFile{})
 				if r.TryDecodeAsNil() {
-					yyv3727[yyj3727] = DownwardAPIVolumeFile{}
+					yyv3735[yyj3735] = DownwardAPIVolumeFile{}
 				} else {
-					yyv3729 := &yyv3727[yyj3727]
-					yyv3729.CodecDecodeSelf(d)
+					yyv3737 := &yyv3735[yyj3735]
+					yyv3737.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3727 := 0; !r.CheckBreak(); yyj3727++ {
-			if yyj3727 >= len(yyv3727) {
-				yyv3727 = append(yyv3727, DownwardAPIVolumeFile{}) // var yyz3727 DownwardAPIVolumeFile
-				yyc3727 = true
+		for yyj3735 := 0; !r.CheckBreak(); yyj3735++ {
+			if yyj3735 >= len(yyv3735) {
+				yyv3735 = append(yyv3735, DownwardAPIVolumeFile{}) // var yyz3735 DownwardAPIVolumeFile
+				yyc3735 = true
 			}
 
-			if yyj3727 < len(yyv3727) {
+			if yyj3735 < len(yyv3735) {
 				if r.TryDecodeAsNil() {
-					yyv3727[yyj3727] = DownwardAPIVolumeFile{}
+					yyv3735[yyj3735] = DownwardAPIVolumeFile{}
 				} else {
-					yyv3730 := &yyv3727[yyj3727]
-					yyv3730.CodecDecodeSelf(d)
+					yyv3738 := &yyv3735[yyj3735]
+					yyv3738.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -44247,10 +44307,10 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 			}
 
 		}
-		yyh3727.End()
+		yyh3735.End()
 	}
-	if yyc3727 {
-		*v = yyv3727
+	if yyc3735 {
+		*v = yyv3735
 	}
 
 }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1238,10 +1238,10 @@ type PodSpec struct {
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod.
 	// More info: http://releases.k8s.io/HEAD/docs/design/service_accounts.md
-	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
 	// DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
 	// Deprecated: Use serviceAccountName instead.
-	DeprecatedServiceAccount string `json:"serviceAccount,omitempty"`
+	DeprecatedServiceAccount *string `json:"serviceAccount,omitempty"`
 
 	// NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
 	// the scheduler simply schedules this pod onto that node, assuming that it fits resource

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1130,9 +1130,11 @@ func ValidatePodSpec(spec *api.PodSpec) errs.ValidationErrorList {
 	allErrs = append(allErrs, ValidateLabels(spec.NodeSelector, "nodeSelector")...)
 	allErrs = append(allErrs, ValidatePodSecurityContext(spec.SecurityContext, spec).Prefix("securityContext")...)
 	allErrs = append(allErrs, validateImagePullSecrets(spec.ImagePullSecrets).Prefix("imagePullSecrets")...)
-	if len(spec.ServiceAccountName) > 0 {
-		if ok, msg := ValidateServiceAccountName(spec.ServiceAccountName, false); !ok {
-			allErrs = append(allErrs, errs.NewFieldInvalid("serviceAccountName", spec.ServiceAccountName, msg))
+	if spec.ServiceAccountName != nil {
+		if len(*spec.ServiceAccountName) > 0 {
+			if ok, msg := ValidateServiceAccountName(*spec.ServiceAccountName, false); !ok {
+				allErrs = append(allErrs, errs.NewFieldInvalid("serviceAccountName", *spec.ServiceAccountName, msg))
+			}
 		}
 	}
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1237,6 +1237,7 @@ func TestValidateDNSPolicy(t *testing.T) {
 
 func TestValidatePodSpec(t *testing.T) {
 	activeDeadlineSeconds := int64(30)
+	validServiceAcctName := "acct"
 	successCases := []api.PodSpec{
 		{ // Populate basic fields, leave defaults for most.
 			Volumes:       []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}},
@@ -1256,7 +1257,7 @@ func TestValidatePodSpec(t *testing.T) {
 			NodeName:              "foobar",
 			DNSPolicy:             api.DNSClusterFirst,
 			ActiveDeadlineSeconds: &activeDeadlineSeconds,
-			ServiceAccountName:    "acct",
+			ServiceAccountName:    &validServiceAcctName,
 		},
 		{ // Populate HostNetwork.
 			Containers: []api.Container{
@@ -1294,7 +1295,7 @@ func TestValidatePodSpec(t *testing.T) {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
-
+	invalidServiceAccountName := "invalidName"
 	activeDeadlineSeconds = int64(0)
 	failureCases := map[string]api.PodSpec{
 		"bad volume": {
@@ -1321,7 +1322,7 @@ func TestValidatePodSpec(t *testing.T) {
 			Containers:         []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
 			RestartPolicy:      api.RestartPolicyAlways,
 			DNSPolicy:          api.DNSClusterFirst,
-			ServiceAccountName: "invalidName",
+			ServiceAccountName: &invalidServiceAccountName,
 		},
 		"bad restart policy": {
 			RestartPolicy: "UnknowPolicy",

--- a/pkg/apis/extensions/deep_copy_generated.go
+++ b/pkg/apis/extensions/deep_copy_generated.go
@@ -544,7 +544,12 @@ func deepCopy_api_PodSpec(in api.PodSpec, out *api.PodSpec, c *conversion.Cloner
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+	}
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(api.PodSecurityContext)

--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -12892,7 +12892,7 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	yyrr1141 = yyl1141
 
 	if yyv1141 == nil {
-		if yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592); yyrt1141 {
+		if yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 584); yyrt1141 {
 			yyrr1141 = yyrl1141
 		}
 		yyv1141 = make([]Deployment, yyrl1141)
@@ -12907,7 +12907,7 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	} else if yyl1141 > 0 {
 
 		if yyl1141 > cap(yyv1141) {
-			yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592)
+			yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 584)
 			yyv1141 = make([]Deployment, yyrl1141)
 			yyc1141 = true
 
@@ -13195,7 +13195,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	yyrr1159 = yyl1159
 
 	if yyv1159 == nil {
-		if yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608); yyrt1159 {
+		if yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 600); yyrt1159 {
 			yyrr1159 = yyrl1159
 		}
 		yyv1159 = make([]Job, yyrl1159)
@@ -13210,7 +13210,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	} else if yyl1159 > 0 {
 
 		if yyl1159 > cap(yyv1159) {
-			yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608)
+			yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 600)
 			yyv1159 = make([]Job, yyrl1159)
 			yyc1159 = true
 

--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -93,9 +93,16 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conve
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
-	// DeprecatedServiceAccount is an alias for ServiceAccountName.
-	out.DeprecatedServiceAccount = in.ServiceAccountName
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+		// DeprecatedServiceAccount is an alias for ServiceAccountName.
+		out.DeprecatedServiceAccount = new(string)
+		*out.DeprecatedServiceAccount = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+		out.DeprecatedServiceAccount = nil
+	}
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(v1.PodSecurityContext)
@@ -167,10 +174,15 @@ func convert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conve
 		out.NodeSelector = nil
 	}
 	// We support DeprecatedServiceAccount as an alias for ServiceAccountName.
-	// If both are specified, ServiceAccountName (the new field) wins.
-	out.ServiceAccountName = in.ServiceAccountName
-	if in.ServiceAccountName == "" {
-		out.ServiceAccountName = in.DeprecatedServiceAccount
+	// If ServiceAccountName is unspecified, then use the old field.
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		if in.DeprecatedServiceAccount != nil {
+			out.ServiceAccountName = new(string)
+			*out.ServiceAccountName = *in.DeprecatedServiceAccount
+		}
 	}
 	out.NodeName = in.NodeName
 

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -707,7 +707,12 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s c
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+	}
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
 		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
@@ -1766,7 +1771,12 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s c
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+	}
 	// in.DeprecatedServiceAccount has no peer in out
 	out.NodeName = in.NodeName
 	// in.HostNetwork has no peer in out

--- a/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -577,8 +577,18 @@ func deepCopy_v1_PodSpec(in v1.PodSpec, out *v1.PodSpec, c *conversion.Cloner) e
 	} else {
 		out.NodeSelector = nil
 	}
-	out.ServiceAccountName = in.ServiceAccountName
-	out.DeprecatedServiceAccount = in.DeprecatedServiceAccount
+	if in.ServiceAccountName != nil {
+		out.ServiceAccountName = new(string)
+		*out.ServiceAccountName = *in.ServiceAccountName
+	} else {
+		out.ServiceAccountName = nil
+	}
+	if in.DeprecatedServiceAccount != nil {
+		out.DeprecatedServiceAccount = new(string)
+		*out.DeprecatedServiceAccount = *in.DeprecatedServiceAccount
+	} else {
+		out.DeprecatedServiceAccount = nil
+	}
 	out.NodeName = in.NodeName
 	out.HostNetwork = in.HostNetwork
 	out.HostPID = in.HostPID

--- a/pkg/apis/extensions/v1beta1/types.generated.go
+++ b/pkg/apis/extensions/v1beta1/types.generated.go
@@ -12980,7 +12980,7 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	yyrr1145 = yyl1145
 
 	if yyv1145 == nil {
-		if yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 608); yyrt1145 {
+		if yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 592); yyrt1145 {
 			yyrr1145 = yyrl1145
 		}
 		yyv1145 = make([]Deployment, yyrl1145)
@@ -12995,7 +12995,7 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	} else if yyl1145 > 0 {
 
 		if yyl1145 > cap(yyv1145) {
-			yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 608)
+			yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 592)
 			yyv1145 = make([]Deployment, yyrl1145)
 			yyc1145 = true
 
@@ -13283,7 +13283,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	yyrr1163 = yyl1163
 
 	if yyv1163 == nil {
-		if yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 632); yyrt1163 {
+		if yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 616); yyrt1163 {
 			yyrr1163 = yyrl1163
 		}
 		yyv1163 = make([]Job, yyrl1163)
@@ -13298,7 +13298,7 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	} else if yyl1163 > 0 {
 
 		if yyl1163 > cap(yyv1163) {
-			yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 632)
+			yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 616)
 			yyv1163 = make([]Job, yyrl1163)
 			yyc1163 = true
 

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -168,12 +168,16 @@ func (s *serviceAccount) Admit(a admission.Attributes) (err error) {
 		return nil
 	}
 
-	// Set the default service account if needed
+	// Set the default service account if unspecified.
 	if pod.Spec.ServiceAccountName == nil {
 		pod.Spec.ServiceAccountName = new(string)
-	}
-	if len(*pod.Spec.ServiceAccountName) == 0 {
 		*pod.Spec.ServiceAccountName = DefaultServiceAccountName
+	} else {
+		// If an empty string ServiceAccountName is explicitly provided,
+		// the user does not want a service account for the Pod.
+		if len(*pod.Spec.ServiceAccountName) == 0 {
+			return nil
+		}
 	}
 
 	// Ensure the referenced service account exists

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -86,6 +86,7 @@ func TestIgnoresMirrorPod(t *testing.T) {
 }
 
 func TestRejectsMirrorPodWithServiceAccount(t *testing.T) {
+	defaultStr := "default"
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Annotations: map[string]string{
@@ -93,7 +94,7 @@ func TestRejectsMirrorPodWithServiceAccount(t *testing.T) {
 			},
 		},
 		Spec: api.PodSpec{
-			ServiceAccountName: "default",
+			ServiceAccountName: &defaultStr,
 		},
 	}
 	attrs := admission.NewAttributesRecord(pod, "Pod", "myns", "myname", string(api.ResourcePods), "", admission.Create, nil)
@@ -144,8 +145,11 @@ func TestAssignsDefaultServiceAccountAndToleratesMissingAPIToken(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if pod.Spec.ServiceAccountName != DefaultServiceAccountName {
-		t.Errorf("Expected service account %s assigned, got %s", DefaultServiceAccountName, pod.Spec.ServiceAccountName)
+	if pod.Spec.ServiceAccountName == nil {
+		t.Errorf("Expected service account non-nil, got nil")
+	}
+	if *pod.Spec.ServiceAccountName != DefaultServiceAccountName {
+		t.Errorf("Expected service account %s assigned, got %s", DefaultServiceAccountName, *pod.Spec.ServiceAccountName)
 	}
 }
 
@@ -192,8 +196,11 @@ func TestFetchesUncachedServiceAccount(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if pod.Spec.ServiceAccountName != DefaultServiceAccountName {
-		t.Errorf("Expected service account %s assigned, got %s", DefaultServiceAccountName, pod.Spec.ServiceAccountName)
+	if pod.Spec.ServiceAccountName == nil {
+		t.Errorf("Expected service account non-nil, got nil")
+	}
+	if *pod.Spec.ServiceAccountName != DefaultServiceAccountName {
+		t.Errorf("Expected service account %s assigned, got %s", DefaultServiceAccountName, *pod.Spec.ServiceAccountName)
 	}
 }
 
@@ -274,8 +281,11 @@ func TestAutomountsAPIToken(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if pod.Spec.ServiceAccountName != DefaultServiceAccountName {
-		t.Errorf("Expected service account %s assigned, got %s", DefaultServiceAccountName, pod.Spec.ServiceAccountName)
+	if pod.Spec.ServiceAccountName == nil {
+		t.Errorf("Expected service account non-nil, got nil")
+	}
+	if *pod.Spec.ServiceAccountName != DefaultServiceAccountName {
+		t.Errorf("Expected service account %s assigned, got %s", DefaultServiceAccountName, *pod.Spec.ServiceAccountName)
 	}
 	if len(pod.Spec.Volumes) != 1 {
 		t.Fatalf("Expected 1 volume, got %d", len(pod.Spec.Volumes))
@@ -353,8 +363,11 @@ func TestRespectsExistingMount(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if pod.Spec.ServiceAccountName != DefaultServiceAccountName {
-		t.Errorf("Expected service account %s assigned, got %s", DefaultServiceAccountName, pod.Spec.ServiceAccountName)
+	if pod.Spec.ServiceAccountName == nil {
+		t.Errorf("Expected service account non-nil, got nil")
+	}
+	if *pod.Spec.ServiceAccountName != DefaultServiceAccountName {
+		t.Errorf("Expected service account %s assigned, got %s", DefaultServiceAccountName, *pod.Spec.ServiceAccountName)
 	}
 	if len(pod.Spec.Volumes) != 0 {
 		t.Fatalf("Expected 0 volumes (shouldn't create a volume for a secret we don't need), got %d", len(pod.Spec.Volumes))


### PR DESCRIPTION
## Summary
- Make Pod.Spec.ServiceAccountName a *string
- Empty string ServiceAccountName means do nothing.
- nil ServiceAccountName means use default service account.
## Rationale

This allows a user to disable addition of API tokens to their pod.

This could have been accomplished in other ways, but this way
allows the user to explicitly specify that a pod should not have
any service account, thus making it behave the same on all systems,
regardless of whether or not each system has the service account
plugin running or not.
## On Compatibility

 This should be a non-breaking change for API clients, for practical purposes.
-   Any old wire format proto should convert to the new internal format:
  either has the field missing in JSON, which will convert fine, or
  have the field present string, which will also convert fine to the
  new internal go struct.
-   Any new internal representation will marshall to the same space
  of possible values as before:  if the pointer is nil, it will be
  omitted due to omitEmpty.  If the pointer is non-nil, then it will
  do the same thing as the old internal representation would.
  In theory, some rogue marshaller could decide to emit
  JSON like `... serviceAccountName = null, ...` but our code
  should not do that because of omitEmpty.
-   This is a change in behavior, in that people who previously created
  a pod with explicit `serviceAccount = ""` would have previously
  gotten an API token, and now will not. This is very unlikely.  It would require that:
  - They would have to explicitly type their pod description that way, which is silly.
  - Their client has to be of their own writing, and has to ignore omitEmpty
  - They cannot be using a pod template (RC, Job, etc), since Controller-created
    pods would have the pod template passed through a go client
    which should omitEmpty an empty string `serviceAccount`.
  - This would only affect newly POSTed pods: existing ones would keep working.
  - The pod needs to actually care that it got the default service account.
## Release Notes
- You can now disable use of a service account by a pod (no api access token,
  and pod cannot pull images using an imagePullSecret attached to default service
  account), by explicitly setting `serviceAccountName = ""` in your pods and pod templates.
- If you have a go client that processes the serviceAccountName of Pods, you should recompile because the internal representation changed.

**Unlikely but possible breaking change**: If you meet **ALL** the following, very unlikely, set of conditions, you may experience a backward incompatible change:
    - You have explicitly typed `serviceAccountName = ""` in your client-side JSON files, or the equivalent in YAML (this is distinct from not having the `serviceAccountName` key at all).
    - You do not use kubectl or our Go client, but instead use a client of your own writing, which does not respect the `omitEmpty` struct tags.
    - You create this pod directly, not using an RC, etc.
    - Your pod depends on the default service account for API access or imagePullSecrets.

If you meet these requirements, when you re-create such a pod from the client-side JSON files, then it will not be able to access the API or pull images using imagePullSecrets.
