### PR TITLE
Release procedure changes

### DIFF
--- a/docs/devel/releasing.md
+++ b/docs/devel/releasing.md
@@ -148,8 +148,17 @@ Then, run
 ```
 
 This will do a dry run of the release.  It will give you instructions at the
-end for `pushd`ing into the dry-run directory and having a look around.  If
-you're satisfied with the result, run
+end for `pushd`ing into the dry-run directory and having a look around.
+`pushd` into the directory and make sure everythig looks as you expect:
+
+```console
+git log "${VER}"  # do you see the commit you expect?
+make release
+./cluster/kubectl.sh version -c
+```
+
+If you're satisfied with the result of the script, go back to `upstream/master`
+run
 
 ```console
 ./release/cut-official-release.sh "${VER}" "${GITHASH}" --no-dry-run

--- a/release/build-official-release.sh
+++ b/release/build-official-release.sh
@@ -98,18 +98,13 @@ instructions elsewhere):
 
   1) pushd ${KUBE_BUILD_DIR}; build/push-official-release.sh ${KUBE_RELEASE_VERSION}
 
-  2) Go to https://github.com/GoogleCloudPlatform/kubernetes/releases
-     and create a new release with the ${KUBE_RELEASE_VERSION} tag.
+  2) Release notes draft, to be published when the release is announced:
 
-     a) Mark it as a pre-release (someone on the GKE team will mark it as an
-     official release when it's being rolled out, but should not be considered
-     stable prior to that).
-
-     b) Title it:
+     a) Title:
 
        Release ${KUBE_RELEASE_VERSION}
 
-     c) Use this template for the description:
+     b) Template for the description:
 
 ## [Documentation](http://releases.k8s.io/${RELEASE_BRANCH}/docs/README.md)
 ## [Examples](http://releases.k8s.io/${RELEASE_BRANCH}/examples)
@@ -124,10 +119,9 @@ binary | hash alg | hash
 
      We'll fill in the release notes in the next stage.
 
-  3) Upload the ${KUBE_BUILD_DIR}/kubernetes.tar.gz to GitHub
+  4) Ensure all the binaries are in place on GCS before cleaning, (you might
+  want to wait until the release is announced and published on GitHub, too).
 
-  4) Ensure all the binaries are in place on GitHub and GCS before cleaning.
-
-  5) (make clean; popd; rm -rf ${KUBE_BUILD_DIR})
+  5) make clean; popd; rm -rf ${KUBE_BUILD_DIR}
 
 EOM

--- a/release/cut-official-release.sh
+++ b/release/cut-official-release.sh
@@ -215,15 +215,9 @@ function alpha-release() {
   git-push "${alpha_version}"
 
   cat >> "${INSTRUCTIONS}" <<- EOM
-- Finish the ${alpha_version} release build:
-  - From this directory (clone of upstream/master),
-      ./release/build-official-release.sh ${alpha_version}
-  - Prep release notes:
-    - Figure out what the PR numbers for this release and last release are, and
-      get an api-token from GitHub (https://github.com/settings/tokens).  From a
-      clone of kubernetes/contrib at upstream/master,
-        go run release-notes/release-notes.go --last-release-pr=<number> --current-release-pr=<number> --api-token=<token>
-      Feel free to prune.
+- Finish the ${alpha_version} release build: from this directory (clone of
+  upstream/master),
+    ./release/build-official-release.sh ${alpha_version}
 EOM
 }
 
@@ -238,12 +232,10 @@ function beta-release() {
   git tag -a -m "Kubernetes pre-release ${beta_version}" "${beta_version}"
   git-push "${beta_version}"
 
-  # NOTE: We currently don't publish beta release notes, since they'll go out
-  # with the official release, so we don't prompt for compiling them here.
   cat >> "${INSTRUCTIONS}" <<- EOM
-- Finish the ${beta_version} release build:
-  - From this directory (clone of upstream/master),
-      ./release/build-official-release.sh ${beta_version}
+- Finish the ${beta_version} release build: from this directory (clone of
+  upstream/master),
+    ./release/build-official-release.sh ${beta_version}
 EOM
 }
 
@@ -259,18 +251,9 @@ function official-release() {
   git-push "${official_version}"
 
   cat >> "${INSTRUCTIONS}" <<- EOM
-- Finish the ${official_version} release build:
-  - From this directory (clone of upstream/master),
-      ./release/build-official-release.sh ${official_version}
-  - Prep release notes:
-    - From this directory (clone of upstream/master), run
-        ./hack/cherry_pick_list.sh ${official_version}
-      to get the release notes for the patch release you just created. Feel
-      free to prune anything internal, but typically for patch releases we tend
-      to include everything in the release notes.
-    - If this is a first official release (vX.Y.0), scan through the release
-      notes for all of the alpha releases since the last cycle, and include
-      anything important in release notes.
+- Finish the ${official_version} release build: from this directory (clone of
+  upstream/master),
+    ./release/build-official-release.sh ${official_version}
 EOM
 }
 

--- a/release/cut-official-release.sh
+++ b/release/cut-official-release.sh
@@ -93,7 +93,7 @@ function main() {
   local -r release_umask=${release_umask:-022}
   umask "${release_umask}"
 
-  local -r github="git@github.com:kubernetes/kubernetes.git"
+  local -r github="https://github.com/kubernetes/kubernetes.git"
   declare -r DIR=$(mktemp -d "/tmp/kubernetes-${release_type}-release-${new_version}-XXXXXXX")
 
   # Start a tmp file that will hold instructions for the user.
@@ -148,8 +148,8 @@ EOM
     git-push ${release_branch}
   elif [[ "${release_type}" == 'official' ]]; then
     local -r release_branch="release-${version_major}.${version_minor}"
-    local -r beta_version="v${version_major}.${version_minor}.$((${version_patch}+1))-beta"
-    local -r ancestor="${new_version}-beta"
+    local -r beta_version="v${version_major}.${version_minor}.$((${version_patch}+1))-beta.0"
+    local -r ancestor="${new_version}-beta.0"
 
     git checkout "${release_branch}"
     verify-at-git-commit "${git_commit}"
@@ -162,7 +162,7 @@ EOM
   else # [[ "${release_type}" == 'series' ]]
     local -r release_branch="release-${version_major}.${version_minor}"
     local -r alpha_version="v${version_major}.$((${version_minor}+1)).0-alpha.0"
-    local -r beta_version="v${version_major}.${version_minor}.0-beta"
+    local -r beta_version="v${version_major}.${version_minor}.0-beta.0"
     # NOTE: We check the second alpha version, ...-alpha.1, because ...-alpha.0
     # is the branch point for the previous release cycle, so could provide a
     # false positive if we accidentally try to release off of the old release


### PR DESCRIPTION
This PR:
1. defers release notes publication until announcement of a release, allowing us to cut, build, and begin testing a release before we publish/announce it publicly;
2. removes the instructions to mark a release as a pre-release (and defer that mark to the GKE team) instead preferring to defer the whole publication until we're ready to mark it as stable; and
3. moves instructions for building release notes into docs and out of scripts, since they're a bit convoluted due to #17444.

These are changes that we're making to release procedures; design doc forthcoming, (sorry about the delay).
