### PR TITLE
Replace readlink in update-codecgen for OSX

### DIFF
--- a/hack/update-codecgen.sh
+++ b/hack/update-codecgen.sh
@@ -53,7 +53,8 @@ result=""
 function depends {
   file=${generated_files[$1]//\.generated\.go/.go}
   deps=$(go list -f "{{.Deps}}" ${file} | tr "[" " " | tr "]" " ")
-  fullpath=$(readlink -f ${generated_files[$2]//\.generated\.go/.go})
+  inputfile=${generated_files[$2]//\.generated\.go/.go}
+  fullpath=$(cd "$(dirname "${inputfile}")" && pwd -P)
   candidate=$(dirname "${fullpath}")
   result=false
   for dep in ${deps}; do


### PR DESCRIPTION
OS X does not have `readlink -f` so the script will not run without this fix.
