### PR TITLE
MESOS: added proxy-mode flag to scheduler and minion

### DIFF
--- a/contrib/mesos/pkg/minion/server.go
+++ b/contrib/mesos/pkg/minion/server.go
@@ -69,6 +69,7 @@ type MinionServer struct {
 	runProxy     bool
 	proxyLogV    int
 	proxyBindall bool
+	proxyMode    string
 }
 
 // NewMinionServer creates the MinionServer struct with default values to be used by hyperkube
@@ -82,6 +83,7 @@ func NewMinionServer() *MinionServer {
 		logMaxBackups:         config.DefaultLogMaxBackups,
 		logMaxAgeInDays:       config.DefaultLogMaxAgeInDays,
 		runProxy:              true,
+		proxyMode:             "userspace", // upstream default is "iptables" post-v1.1
 	}
 
 	// cache this for later use
@@ -136,6 +138,7 @@ func (ms *MinionServer) launchProxyServer() {
 		fmt.Sprintf("--v=%d", ms.proxyLogV),
 		"--logtostderr=true",
 		"--resource-container=" + path.Join("/", ms.mesosCgroup, "kube-proxy"),
+		"--proxy-mode=" + ms.proxyMode,
 	}
 
 	if ms.clientConfig.Host != "" {
@@ -342,4 +345,5 @@ func (ms *MinionServer) AddMinionFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&ms.runProxy, "run-proxy", ms.runProxy, "Maintain a running kube-proxy instance as a child proc of this kubelet-executor.")
 	fs.IntVar(&ms.proxyLogV, "proxy-logv", ms.proxyLogV, "Log verbosity of the child kube-proxy.")
 	fs.BoolVar(&ms.proxyBindall, "proxy-bindall", ms.proxyBindall, "When true will cause kube-proxy to bind to 0.0.0.0.")
+	fs.StringVar(&ms.proxyMode, "proxy-mode", ms.proxyMode, "Which proxy mode to use: 'userspace' (older) or 'iptables' (faster). If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.")
 }


### PR DESCRIPTION
Allow k8sm users to control the `--proxy-mode` of kube-proxy via framework configuration.
xref https://github.com/mesosphere/kubernetes-mesos/issues/593
