### PR TITLE
(reopened) Modify request.go to use exponential backoff. 

### DIFF
--- a/pkg/client/unversioned/fake/fake.go
+++ b/pkg/client/unversioned/fake/fake.go
@@ -50,23 +50,23 @@ type RESTClient struct {
 }
 
 func (c *RESTClient) Get() *unversioned.Request {
-	return unversioned.NewRequest(c, "GET", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec)
+	return unversioned.NewRequest(c, "GET", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec, nil)
 }
 
 func (c *RESTClient) Put() *unversioned.Request {
-	return unversioned.NewRequest(c, "PUT", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec)
+	return unversioned.NewRequest(c, "PUT", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec, nil)
 }
 
 func (c *RESTClient) Patch(_ api.PatchType) *unversioned.Request {
-	return unversioned.NewRequest(c, "PATCH", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec)
+	return unversioned.NewRequest(c, "PATCH", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec, nil)
 }
 
 func (c *RESTClient) Post() *unversioned.Request {
-	return unversioned.NewRequest(c, "POST", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec)
+	return unversioned.NewRequest(c, "POST", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec, nil)
 }
 
 func (c *RESTClient) Delete() *unversioned.Request {
-	return unversioned.NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec)
+	return unversioned.NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, *testapi.Default.GroupVersion(), c.Codec, nil)
 }
 
 func (c *RESTClient) Do(req *http.Request) (*http.Response, error) {

--- a/pkg/client/unversioned/restclient_test.go
+++ b/pkg/client/unversioned/restclient_test.go
@@ -19,8 +19,11 @@ package unversioned
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -138,4 +141,40 @@ func TestDoRequestCreated(t *testing.T) {
 		t.Errorf("Unexpected mis-match. Expected %#v.  Saw %#v", status, statusOut)
 	}
 	fakeHandler.ValidateRequest(t, "/"+testapi.Default.Version()+"/test", "GET", nil)
+}
+
+func TestCreateBackoffManager(t *testing.T) {
+
+	theUrl, _ := url.Parse("http://localhost")
+
+	// 1 second base backoff + duration of 2 seconds -> exponential backoff for requests.
+	os.Setenv(envBackoffBase, "1")
+	os.Setenv(envBackoffDuration, "2")
+	backoff := readExpBackoffConfig()
+	backoff.UpdateBackoff(theUrl, nil, 500)
+	backoff.UpdateBackoff(theUrl, nil, 500)
+	if backoff.CalculateBackoff(theUrl)/time.Second != 2 {
+		t.Errorf("Backoff env not working.")
+	}
+
+	// 0 duration -> no backoff.
+	os.Setenv(envBackoffBase, "1")
+	os.Setenv(envBackoffDuration, "0")
+	backoff.UpdateBackoff(theUrl, nil, 500)
+	backoff.UpdateBackoff(theUrl, nil, 500)
+	backoff = readExpBackoffConfig()
+	if backoff.CalculateBackoff(theUrl)/time.Second != 0 {
+		t.Errorf("Zero backoff duration, but backoff still occuring.")
+	}
+
+	// No env -> No backoff.
+	os.Setenv(envBackoffBase, "")
+	os.Setenv(envBackoffDuration, "")
+	backoff = readExpBackoffConfig()
+	backoff.UpdateBackoff(theUrl, nil, 500)
+	backoff.UpdateBackoff(theUrl, nil, 500)
+	if backoff.CalculateBackoff(theUrl)/time.Second != 0 {
+		t.Errorf("Backoff should have been 0.")
+	}
+
 }

--- a/pkg/client/unversioned/urlbackoff.go
+++ b/pkg/client/unversioned/urlbackoff.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// Set of resp. Codes that we backoff for.
+// In general these should be errors that indicate a server is overloaded.
+// These shouldn't be configured by any user, we set them based on conventions
+// described in
+var serverIsOverloadedSet = sets.NewInt(429)
+var maxResponseCode = 499
+
+type BackoffManager interface {
+	UpdateBackoff(actualUrl *url.URL, err error, responseCode int)
+	CalculateBackoff(actualUrl *url.URL) time.Duration
+}
+
+// URLBackoff struct implements the semantics on top of Backoff which
+// we need for URL specific exponential backoff.
+type URLBackoff struct {
+	// Uses backoff as underlying implementation.
+	Backoff *util.Backoff
+}
+
+// NoBackoff is a stub implementation, can be used for mocking or else as a default.
+type NoBackoff struct {
+}
+
+func (n *NoBackoff) UpdateBackoff(actualUrl *url.URL, err error, responseCode int) {
+	// do nothing.
+}
+func (n *NoBackoff) CalculateBackoff(actualUrl *url.URL) time.Duration {
+	return 0 * time.Second
+}
+
+// Disable makes the backoff trivial, i.e., sets it to zero.  This might be used
+// by tests which want to run 1000s of mock requests without slowing down.
+func (b *URLBackoff) Disable() {
+	glog.V(4).Infof("Disabling backoff strategy")
+	b.Backoff = util.NewBackOff(0*time.Second, 0*time.Second)
+}
+
+// baseUrlKey returns the key which urls will be mapped to.
+// For example, 127.0.0.1:8080/api/v2/abcde -> 127.0.0.1:8080.
+func (b *URLBackoff) baseUrlKey(rawurl *url.URL) string {
+	// Simple implementation for now, just the host.
+	// We may backoff specific paths (i.e. "pods") differentially
+	// in the future.
+	host, err := url.Parse(rawurl.String())
+	if err != nil {
+		glog.V(4).Infof("Error extracting url: %v", rawurl)
+		panic("bad url!")
+	}
+	return host.Host
+}
+
+// UpdateBackoff updates backoff metadata
+func (b *URLBackoff) UpdateBackoff(actualUrl *url.URL, err error, responseCode int) {
+	// range for retry counts that we store is [0,13]
+	if responseCode > maxResponseCode || serverIsOverloadedSet.Has(responseCode) {
+		b.Backoff.Next(b.baseUrlKey(actualUrl), time.Now())
+		return
+	} else if responseCode >= 300 || err != nil {
+		glog.V(4).Infof("Client is returning errors: code %v, error %v", responseCode, err)
+	}
+
+	//If we got this far, there is no backoff required for this URL anymore.
+	b.Backoff.Reset(b.baseUrlKey(actualUrl))
+}
+
+// CalculateBackoff takes a url and back's off exponentially,
+// based on its knowledge of existing failures.
+func (b *URLBackoff) CalculateBackoff(actualUrl *url.URL) time.Duration {
+	return b.Backoff.Get(b.baseUrlKey(actualUrl))
+}

--- a/pkg/client/unversioned/urlbackoff_test.go
+++ b/pkg/client/unversioned/urlbackoff_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/util"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func parse(raw string) *url.URL {
+	theUrl, _ := url.Parse(raw)
+	return theUrl
+}
+
+func TestURLBackoffFunctionalityCollisions(t *testing.T) {
+	myBackoff := &URLBackoff{
+		Backoff: util.NewBackOff(1*time.Second, 60*time.Second),
+	}
+
+	// Add some noise and make sure backoff for a clean URL is zero.
+	myBackoff.UpdateBackoff(parse("http://100.200.300.400:8080"), nil, 500)
+
+	myBackoff.UpdateBackoff(parse("http://1.2.3.4:8080"), nil, 500)
+
+	if myBackoff.CalculateBackoff(parse("http://1.2.3.4:100")) > 0 {
+		t.Errorf("URLs are colliding in the backoff map!")
+	}
+}
+
+// TestURLBackoffFunctionality generally tests the URLBackoff wrapper.  We avoid duplicating tests from backoff and request.
+func TestURLBackoffFunctionality(t *testing.T) {
+	myBackoff := &URLBackoff{
+		Backoff: util.NewBackOff(1*time.Second, 60*time.Second),
+	}
+
+	// Now test that backoff increases, then recovers.
+	// 200 and 300 should both result in clearing the backoff.
+	// all others like 429 should result in increased backoff.
+	seconds := []int{0,
+		1, 2, 4, 8, 0,
+		1, 2}
+	returnCodes := []int{
+		429, 500, 501, 502, 300,
+		500, 501, 502,
+	}
+
+	if len(seconds) != len(returnCodes) {
+		t.Fatalf("responseCode to backoff arrays should be the same length... sanity check failed.")
+	}
+
+	for i, sec := range seconds {
+		backoffSec := myBackoff.CalculateBackoff(parse("http://1.2.3.4:100"))
+		if backoffSec < time.Duration(sec)*time.Second || backoffSec > time.Duration(sec+5)*time.Second {
+			t.Errorf("Backoff out of range %v: %v %v", i, sec, backoffSec)
+		}
+		myBackoff.UpdateBackoff(parse("http://1.2.3.4:100/responseCodeForFuncTest"), nil, returnCodes[i])
+	}
+
+	if myBackoff.CalculateBackoff(parse("http://1.2.3.4:100")) == 0 {
+		t.Errorf("The final return code %v should have resulted in a backoff ! ", returnCodes[7])
+	}
+}


### PR DESCRIPTION
I've reissued a new PR, for original PR #16811 (turns out in github, you cant close+reopen an issue after force pushing).

The summary of feedback resulted in a conclusion that, rather than globally backoff, use request scoped backoffs, and later we can move the backoff into the client.
