### PR TITLE
Removing a deployment test from flaky tests list

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -171,7 +171,6 @@ GCE_FLAKY_TESTS=(
     "Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon"
     "Resource\susage\sof\ssystem\scontainers"
     "allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster" # file: resize_nodes.go, issue: #13258
-    "deployment.*\sin\sthe\sright\sorder" # issue: #15369
     )
 
 # The following tests are known to be slow running (> 2 min), and are


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/15622

The test has been passing for a long time now.
Removing it from the list of flaky tests

cc @wojtek-t @janetkuo 
