### PR TITLE
Return response StatusCode when http probe fail

### DIFF
--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -18,6 +18,7 @@ package http
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -72,5 +73,5 @@ func DoHTTPProbe(url *url.URL, client HTTPGetInterface) (probe.Result, string, e
 		return probe.Success, body, nil
 	}
 	glog.V(4).Infof("Probe failed for %s, Response: %v", url.String(), *res)
-	return probe.Failure, body, nil
+	return probe.Failure, fmt.Sprintf("HTTP probe failed with statuscode: %d", res.StatusCode), nil
 }

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package http
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -28,6 +29,8 @@ import (
 
 	"k8s.io/kubernetes/pkg/probe"
 )
+
+const FailureCode int = -1
 
 func containsAny(s string, substrs []string) bool {
 	for _, substr := range substrs {
@@ -61,9 +64,9 @@ func TestHTTPProbeChecker(t *testing.T) {
 			[]string{"ok body"},
 		},
 		{
-			handleReq(-1, "fail body"),
+			handleReq(FailureCode, "fail body"),
 			probe.Failure,
-			[]string{"fail body"},
+			[]string{fmt.Sprintf("HTTP probe failed with statuscode: %d", FailureCode)},
 		},
 		{
 			func(w http.ResponseWriter) {


### PR DESCRIPTION
Fixed #17487

Probe failure is caused by StatusCode of response. User will be more interested of StatusCode.
