### PR TITLE
handle the HEAD verb correctly for authorization

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -502,7 +502,7 @@ func (r *RequestInfoResolver) GetRequestInfo(req *http.Request) (RequestInfo, er
 		switch req.Method {
 		case "POST":
 			requestInfo.Verb = "create"
-		case "GET":
+		case "GET", "HEAD":
 			requestInfo.Verb = "get"
 		case "PUT":
 			requestInfo.Verb = "update"

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -222,7 +222,9 @@ func TestGetAPIRequestInfo(t *testing.T) {
 
 		{"GET", "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
+		{"HEAD", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1/pods", "list", "api", "", "v1", api.NamespaceAll, "pods", "", "", []string{"pods"}},
+		{"HEAD", "/api/v1/pods", "list", "api", "", "v1", api.NamespaceAll, "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 


### PR DESCRIPTION
`HEAD` is supposed to be equivalent to `GET`.  It doesn't really make sense to interpret those differently than we treat `GET` for authorization requests.  This allows `HEAD` to be interpreted as either `get` or `list`, just how the HTTP `GET` is handled.

@kubernetes/kube-iam 
