### PR TITLE
Use 10s period for image pulling backoff

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -335,7 +335,7 @@ func NewMainKubelet(
 	}
 
 	procFs := procfs.NewProcFS()
-	imageBackOff := util.NewBackOff(resyncInterval, MaxContainerBackOff)
+	imageBackOff := util.NewBackOff(backOffPeriod, MaxContainerBackOff)
 
 	klet.livenessManager = proberesults.NewManager()
 


### PR DESCRIPTION
This is consistent with the container restart backoff period.

This fixes #17523
