### PR TITLE
Add missing kube_flags to kubectl scale in hack/test-cmd.sh

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -848,7 +848,7 @@ __EOF__
   kubectl create -f examples/guestbook/redis-master-controller.yaml "${kube_flags[@]}"
   kubectl create -f examples/guestbook/redis-slave-controller.yaml "${kube_flags[@]}"
   # Command
-  kubectl scale rc/redis-master rc/redis-slave --replicas=4
+  kubectl scale rc/redis-master rc/redis-slave --replicas=4 "${kube_flags[@]}"
   # Post-condition: 4 replicas each
   kube::test::get_object_assert 'rc redis-master' "{{$rc_replicas_field}}" '4'
   kube::test::get_object_assert 'rc redis-slave' "{{$rc_replicas_field}}" '4'


### PR DESCRIPTION
cc @kubernetes/rh-cluster-infra @liggitt 

FYI @ingvagabund you'll need to add this as a patch to your copr and remove https://github.com/ingvagabund/kubernetes-copr/blob/master/do-not-unset-default-cluster.patch
