### PR TITLE
Disabled HPA tests for deployment because they are flaky

### DIFF
--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -42,10 +42,10 @@ var _ = Describe("Horizontal pod autoscaling", func() {
 	titleDown := "%s should scale from 5 pods to 3 pods and from 3 to 1 (via %s, with scale resource: CPU)"
 
 	// CPU tests via deployments
-	It(fmt.Sprintf(titleUp, "[Autoscaling Suite]", kindDeployment), func() {
+	It(fmt.Sprintf(titleUp, "[Skipped]", kindDeployment), func() {
 		scaleUp("deployment", kindDeployment, rc, f)
 	})
-	It(fmt.Sprintf(titleDown, "[Autoscaling Suite]", kindDeployment), func() {
+	It(fmt.Sprintf(titleDown, "[Skipped]", kindDeployment), func() {
 		scaleDown("deployment", kindDeployment, rc, f)
 	})
 


### PR DESCRIPTION
The test are not critical as for now and as I wrote in #16425 the problem might be with the way how metrics are collected. I'll take a look into Resource Consumer on Monday whether it's flaky.
ref #17584
