### PR TITLE
Use correct home directory on Windows

### DIFF
--- a/pkg/util/homedir/homedir.go
+++ b/pkg/util/homedir/homedir.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package homedir
+
+import (
+	"os"
+	"runtime"
+)
+
+// HomeDir returns the home directory for the current user
+func HomeDir() string {
+	if runtime.GOOS == "windows" {
+		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
+			homeDir := homeDrive + homePath
+			if _, err := os.Stat(homeDir); err == nil {
+				return homeDir
+			}
+		}
+		if userProfile := os.Getenv("USERPROFILE"); len(userProfile) > 0 {
+			if _, err := os.Stat(userProfile); err == nil {
+				return userProfile
+			}
+		}
+	}
+	return os.Getenv("HOME")
+}


### PR DESCRIPTION
As of now the `kubectl` config mechanism that saves/loads `~/.kube/config` is broken on Windows, saving the config file in the _current_ directory instead of the user's _home_ dir. This happens because most Windows don't respect the `HOME` environment variable. 

This PR changes the config file loading mechanism to use the recommended way to detect the user home on Windows (`HOMEDRIVE`+`HOMEPATH` or `USERPROFILE`), and adds a migration for users that might be currently relying on existing config files.
