### PR TITLE
Diff GCP resource usage in soak tests too

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -487,6 +487,7 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX:="gce-soak-weekly-1-1"}
     : ${KUBE_GCS_STAGING_PATH_SUFFIX:="soak-1.1"}
     : ${PROJECT:="kubernetes-jenkins"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     ;;
 
   # Runs tests on GCE soak cluster for latest 1.1 ci release.
@@ -1667,9 +1668,11 @@ fi
 ### Set up ###
 if [[ "${E2E_UP,,}" == "true" ]]; then
     go run ./hack/e2e.go ${E2E_OPT} -v --down
-    if [[ "${gcp_list_resources}" == "true" ]]; then
-      ${gcp_list_resources_script} > "${gcp_resources_before}"
-    fi
+fi
+if [[ "${gcp_list_resources}" == "true" ]]; then
+  ${gcp_list_resources_script} > "${gcp_resources_before}"
+fi
+if [[ "${E2E_UP,,}" == "true" ]]; then
     go run ./hack/e2e.go ${E2E_OPT} -v --up
     go run ./hack/e2e.go -v --ctl="version --match-server-version=false"
     if [[ "${gcp_list_resources}" == "true" ]]; then
@@ -1717,12 +1720,15 @@ if [[ "${E2E_DOWN,,}" == "true" ]]; then
     # for the wait between attempts.
     sleep 30
     go run ./hack/e2e.go ${E2E_OPT} -v --down
-    if [[ "${gcp_list_resources}" == "true" ]]; then
-      ${gcp_list_resources_script} > "${gcp_resources_after}"
-    fi
+fi
+if [[ "${gcp_list_resources}" == "true" ]]; then
+  ${gcp_list_resources_script} > "${gcp_resources_after}"
 fi
 
-if [[ -f "${gcp_resources_before}" && -f "${gcp_resources_after}" ]]; then
+# Compare resources if either the cluster was
+# * started and destroyed (normal e2e)
+# * neither started nor destroyed (soak test)
+if [[ "${E2E_UP:-}" == "${E2E_DOWN:-}" && -f "${gcp_resources_before}" && -f "${gcp_resources_after}" ]]; then
   if ! diff -sw -U0 -F'^\[.*\]$' "${gcp_resources_before}" "${gcp_resources_after}" && [[ "${FAIL_ON_GCP_RESOURCE_LEAK:-}" == "true" ]]; then
     echo "!!! FAIL: Google Cloud Platform resources leaked while running tests!"
     exit 1


### PR DESCRIPTION
Currently we only check for leaked GCP resources if the cluster is both started and destroyed in a given test run. With this PR, we'll also check for leaked resources if the cluster is neither started nor destroyed (e.g. soak tests).

Note that only the 1.1 soak test will fail on leaked resources, since the other soak tests run in the shared kubernetes-jenkins project.

@kubernetes/goog-testing 
