### PR TITLE
Ubuntu provider - can't set docker opts or complete install

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -71,3 +71,5 @@ ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 # Add envitonment variable separated with blank space like "http_proxy=http://10.x.x.x:8080 https_proxy=https://10.x.x.x:8443"
 PROXY_SETTING=${PROXY_SETTING:-""}
 
+DEBUG=${DEBUG:-"false"}
+

--- a/cluster/ubuntu/reconfDocker.sh
+++ b/cluster/ubuntu/reconfDocker.sh
@@ -46,7 +46,9 @@ function config_etcd {
 }
 
 function restart_docker {
-  
+
+  source ~/kube/config-default.sh
+
   attempt=0
   while [[ ! -f /run/flannel/subnet.env ]]; do 
     if (( attempt > 200 )); then

--- a/cluster/ubuntu/reconfDocker.sh
+++ b/cluster/ubuntu/reconfDocker.sh
@@ -16,6 +16,8 @@
 
 # reconfigure docker network setting
 
+source ~/kube/config-default.sh
+
 if [ "$(id -u)" != "0" ]; then
   echo >&2 "Please run as root"
   exit 1
@@ -23,9 +25,6 @@ fi
 
 
 function config_etcd {
-
-  source ~/kube/config-default.sh
-
   attempt=0
   while true; do
     /opt/bin/etcdctl get /coreos.com/network/config
@@ -46,9 +45,6 @@ function config_etcd {
 }
 
 function restart_docker {
-
-  source ~/kube/config-default.sh
-
   attempt=0
   while [[ ! -f /run/flannel/subnet.env ]]; do 
     if (( attempt > 200 )); then

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -373,8 +373,15 @@ function provision-master() {
 
   EXTRA_SANS=$(echo "${EXTRA_SANS[@]}" | tr ' ' ,)
 
+  BASH_DEBUG_FLAGS=""
+  if [[ "$DEBUG" == "true" ]] ; then
+    BASH_DEBUG_FLAGS="set -x"
+  fi
+
   # remote login to MASTER and configue k8s master
   ssh $SSH_OPTS -t "${MASTER}" "
+    set +e
+    ${BASH_DEBUG_FLAGS}
     source ~/kube/util.sh
 
     setClusterInfo
@@ -386,7 +393,9 @@ function provision-master() {
     create-kube-controller-manager-opts '${NODE_IPS}'
     create-kube-scheduler-opts
     create-flanneld-opts '127.0.0.1' '${MASTER_IP}'
-    sudo -E -p '[sudo] password to start master: ' -- /bin/bash -c '
+    sudo -E -p '[sudo] password to start master: ' -- /bin/bash -ce '
+      ${BASH_DEBUG_FLAGS}
+
       cp ~/kube/default/* /etc/default/
       cp ~/kube/init_conf/* /etc/init/
       cp ~/kube/init_scripts/* /etc/init.d/
@@ -418,8 +427,15 @@ function provision-node() {
     ubuntu/binaries/minion \
     "${1}:~/kube"
 
+  BASH_DEBUG_FLAGS=""
+  if [[ "$DEBUG" == "true" ]] ; then
+    BASH_DEBUG_FLAGS="set -x"
+  fi
+
   # remote login to node and configue k8s node
   ssh $SSH_OPTS -t "$1" "
+    set +e
+    ${BASH_DEBUG_FLAGS}
     source ~/kube/util.sh
 
     setClusterInfo
@@ -433,7 +449,8 @@ function provision-node() {
       '${MASTER_IP}' 
     create-flanneld-opts '${MASTER_IP}' '${1#*@}'
 
-    sudo -E -p '[sudo] password to start node: ' -- /bin/bash -c '
+    sudo -E -p '[sudo] password to start node: ' -- /bin/bash -ce '    
+      ${BASH_DEBUG_FLAGS}
       cp ~/kube/default/* /etc/default/
       cp ~/kube/init_conf/* /etc/init/
       cp ~/kube/init_scripts/* /etc/init.d/
@@ -477,8 +494,15 @@ function provision-masterandnode() {
 
   EXTRA_SANS=$(echo "${EXTRA_SANS[@]}" | tr ' ' ,)
 
+  BASH_DEBUG_FLAGS=""
+  if [[ "$DEBUG" == "true" ]] ; then
+    BASH_DEBUG_FLAGS="set -x"
+  fi
+
   # remote login to the master/node and configue k8s
   ssh $SSH_OPTS -t "$MASTER" "
+    set +e
+    ${BASH_DEBUG_FLAGS}
     source ~/kube/util.sh
 
     setClusterInfo
@@ -499,7 +523,8 @@ function provision-masterandnode() {
       '${MASTER_IP}'
     create-flanneld-opts '127.0.0.1' '${MASTER_IP}'
 
-    sudo -E -p '[sudo] password to start master: ' -- /bin/bash -c '
+    sudo -E -p '[sudo] password to start master: ' -- /bin/bash -ce ' 
+      ${BASH_DEBUG_FLAGS}
       cp ~/kube/default/* /etc/default/
       cp ~/kube/init_conf/* /etc/init/
       cp ~/kube/init_scripts/* /etc/init.d/


### PR DESCRIPTION
Setting custom DOCKER_OPTS so that you can use a private registry isn't working - the config-default.sh file needs to be sourced so it's visible when the /etc/default/docker file is written.

Additionally, the recent change to add quoting to PROXY_SETTING is not allowing the certificates to be created, which breaks cluster creation. The apiserver never starts because it's missing its certificates.
