### PR TITLE
Create constants for resource names in client/unversioned pkg

### DIFF
--- a/pkg/client/unversioned/componentstatuses.go
+++ b/pkg/client/unversioned/componentstatuses.go
@@ -20,6 +20,10 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
+const (
+	componentStatusResourceName string = "componentStatuses"
+)
+
 type ComponentStatusesInterface interface {
 	ComponentStatuses() ComponentStatusInterface
 }
@@ -45,7 +49,7 @@ func newComponentStatuses(c *Client) *componentStatuses {
 func (c *componentStatuses) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
 	result = &api.ComponentStatusList{}
 	err = c.client.Get().
-		Resource("componentStatuses").
+		Resource(componentStatusResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -55,6 +59,6 @@ func (c *componentStatuses) List(opts api.ListOptions) (result *api.ComponentSta
 
 func (c *componentStatuses) Get(name string) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
-	err = c.client.Get().Resource("componentStatuses").Name(name).Do().Into(result)
+	err = c.client.Get().Resource(componentStatusResourceName).Name(name).Do().Into(result)
 	return
 }

--- a/pkg/client/unversioned/daemon_sets.go
+++ b/pkg/client/unversioned/daemon_sets.go
@@ -22,6 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	daemonSetResourceName string = "daemonsets"
+)
+
 // DaemonsSetsNamespacer has methods to work with DaemonSet resources in a namespace
 type DaemonSetsNamespacer interface {
 	DaemonSets(namespace string) DaemonSetInterface
@@ -52,41 +56,41 @@ var _ DaemonSetInterface = &daemonSets{}
 
 func (c *daemonSets) List(opts api.ListOptions) (result *extensions.DaemonSetList, err error) {
 	result = &extensions.DaemonSetList{}
-	err = c.r.Get().Namespace(c.ns).Resource("daemonsets").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(daemonSetResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get returns information about a particular daemon set.
 func (c *daemonSets) Get(name string) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}
-	err = c.r.Get().Namespace(c.ns).Resource("daemonsets").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(daemonSetResourceName).Name(name).Do().Into(result)
 	return
 }
 
 // Create creates a new daemon set.
 func (c *daemonSets) Create(daemon *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}
-	err = c.r.Post().Namespace(c.ns).Resource("daemonsets").Body(daemon).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource(daemonSetResourceName).Body(daemon).Do().Into(result)
 	return
 }
 
 // Update updates an existing daemon set.
 func (c *daemonSets) Update(daemon *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}
-	err = c.r.Put().Namespace(c.ns).Resource("daemonsets").Name(daemon.Name).Body(daemon).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(daemonSetResourceName).Name(daemon.Name).Body(daemon).Do().Into(result)
 	return
 }
 
 // UpdateStatus updates an existing daemon set status
 func (c *daemonSets) UpdateStatus(daemon *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}
-	err = c.r.Put().Namespace(c.ns).Resource("daemonsets").Name(daemon.Name).SubResource("status").Body(daemon).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(daemonSetResourceName).Name(daemon.Name).SubResource("status").Body(daemon).Do().Into(result)
 	return
 }
 
 // Delete deletes an existing daemon set.
 func (c *daemonSets) Delete(name string) error {
-	return c.r.Delete().Namespace(c.ns).Resource("daemonsets").Name(name).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(daemonSetResourceName).Name(name).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested daemon sets.
@@ -94,7 +98,7 @@ func (c *daemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("daemonsets").
+		Resource(daemonSetResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/daemon_sets_test.go
+++ b/pkg/client/unversioned/daemon_sets_test.go
@@ -29,16 +29,16 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
-func getDSResourceName() string {
-	return "daemonsets"
-}
+const (
+	daemonSetResourceName string = "daemonsets"
+)
 
 func TestListDaemonSets(t *testing.T) {
 	ns := api.NamespaceAll
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getDSResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(daemonSetResourceName, ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &extensions.DaemonSetList{
@@ -67,7 +67,7 @@ func TestListDaemonSets(t *testing.T) {
 func TestGetDaemonSet(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(daemonSetResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.DaemonSet{
@@ -105,7 +105,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(daemonSetResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.DaemonSet{
@@ -132,7 +132,7 @@ func TestUpdateDaemonSetUpdateStatus(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(daemonSetResourceName, ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.DaemonSet{
@@ -157,7 +157,7 @@ func TestUpdateDaemonSetUpdateStatus(t *testing.T) {
 func TestDeleteDaemon(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(daemonSetResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Extensions().DaemonSets(ns).Delete("foo")
@@ -170,7 +170,7 @@ func TestCreateDaemonSet(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, ""), Body: requestDaemonSet, Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(daemonSetResourceName, ns, ""), Body: requestDaemonSet, Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.DaemonSet{

--- a/pkg/client/unversioned/deployment.go
+++ b/pkg/client/unversioned/deployment.go
@@ -22,6 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	deploymentResourceName string = "deployments"
+)
+
 // DeploymentsNamespacer has methods to work with Deployment resources in a namespace
 type DeploymentsNamespacer interface {
 	Deployments(namespace string) DeploymentInterface
@@ -55,46 +59,46 @@ func newDeployments(c *ExtensionsClient, namespace string) *deployments {
 // List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *deployments) List(opts api.ListOptions) (result *extensions.DeploymentList, err error) {
 	result = &extensions.DeploymentList{}
-	err = c.client.Get().Namespace(c.ns).Resource("deployments").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.client.Get().Namespace(c.ns).Resource(deploymentResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
 func (c *deployments) Get(name string) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
-	err = c.client.Get().Namespace(c.ns).Resource("deployments").Name(name).Do().Into(result)
+	err = c.client.Get().Namespace(c.ns).Resource(deploymentResourceName).Name(name).Do().Into(result)
 	return
 }
 
 // Delete takes name of the deployment and deletes it. Returns an error if one occurs.
 func (c *deployments) Delete(name string, options *api.DeleteOptions) error {
 	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Do().Error()
+		return c.client.Delete().Namespace(c.ns).Resource(deploymentResourceName).Name(name).Do().Error()
 	}
 	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
 	if err != nil {
 		return err
 	}
-	return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Body(body).Do().Error()
+	return c.client.Delete().Namespace(c.ns).Resource(deploymentResourceName).Name(name).Body(body).Do().Error()
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
-	err = c.client.Post().Namespace(c.ns).Resource("deployments").Body(deployment).Do().Into(result)
+	err = c.client.Post().Namespace(c.ns).Resource(deploymentResourceName).Body(deployment).Do().Into(result)
 	return
 }
 
 // Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Update(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
-	err = c.client.Put().Namespace(c.ns).Resource("deployments").Name(deployment.Name).Body(deployment).Do().Into(result)
+	err = c.client.Put().Namespace(c.ns).Resource(deploymentResourceName).Name(deployment.Name).Body(deployment).Do().Into(result)
 	return
 }
 
 func (c *deployments) UpdateStatus(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
-	err = c.client.Put().Namespace(c.ns).Resource("deployments").Name(deployment.Name).SubResource("status").Body(deployment).Do().Into(result)
+	err = c.client.Put().Namespace(c.ns).Resource(deploymentResourceName).Name(deployment.Name).SubResource("status").Body(deployment).Do().Into(result)
 	return
 }
 
@@ -103,7 +107,7 @@ func (c *deployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("deployments").
+		Resource(deploymentResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/deployment_test.go
+++ b/pkg/client/unversioned/deployment_test.go
@@ -33,9 +33,9 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-func getDeploymentsResoureName() string {
-	return "deployments"
-}
+const (
+	deploymentResourceName string = "deployments"
+)
 
 func TestDeploymentCreate(t *testing.T) {
 	ns := api.NamespaceDefault
@@ -48,7 +48,7 @@ func TestDeploymentCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(deploymentResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   &deployment,
 		},
@@ -73,7 +73,7 @@ func TestDeploymentGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, "abc"),
+			Path:   testapi.Extensions.ResourcePath(deploymentResourceName, ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -99,7 +99,7 @@ func TestDeploymentList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(deploymentResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -121,7 +121,7 @@ func TestDeploymentUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, "abc"),
+			Path:   testapi.Extensions.ResourcePath(deploymentResourceName, ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{StatusCode: 200, Body: deployment},
@@ -142,7 +142,7 @@ func TestDeploymentUpdateStatus(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, "abc") + "/status",
+			Path:   testapi.Extensions.ResourcePath(deploymentResourceName, ns, "abc") + "/status",
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{StatusCode: 200, Body: deployment},
@@ -156,7 +156,7 @@ func TestDeploymentDelete(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(deploymentResourceName, ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{StatusCode: 200},
@@ -169,7 +169,7 @@ func TestDeploymentWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePathWithPrefix("watch", getDeploymentsResoureName(), "", ""),
+			Path:   testapi.Extensions.ResourcePathWithPrefix("watch", deploymentResourceName, "", ""),
 			Query:  url.Values{"resourceVersion": []string{}},
 		},
 		Response: simple.Response{StatusCode: 200},

--- a/pkg/client/unversioned/endpoints.go
+++ b/pkg/client/unversioned/endpoints.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	endpointResourceName string = "endpoints"
+)
+
 // EndpointsNamespacer has methods to work with Endpoints resources in a namespace
 type EndpointsNamespacer interface {
 	Endpoints(namespace string) EndpointsInterface
@@ -52,7 +56,7 @@ func newEndpoints(c *Client, namespace string) *endpoints {
 // Create creates a new endpoint.
 func (c *endpoints) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
 	result := &api.Endpoints{}
-	err := c.r.Post().Namespace(c.ns).Resource("endpoints").Body(endpoints).Do().Into(result)
+	err := c.r.Post().Namespace(c.ns).Resource(endpointResourceName).Body(endpoints).Do().Into(result)
 	return result, err
 }
 
@@ -61,7 +65,7 @@ func (c *endpoints) List(opts api.ListOptions) (result *api.EndpointsList, err e
 	result = &api.EndpointsList{}
 	err = c.r.Get().
 		Namespace(c.ns).
-		Resource("endpoints").
+		Resource(endpointResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -71,13 +75,13 @@ func (c *endpoints) List(opts api.ListOptions) (result *api.EndpointsList, err e
 // Get returns information about the endpoints for a particular service.
 func (c *endpoints) Get(name string) (result *api.Endpoints, err error) {
 	result = &api.Endpoints{}
-	err = c.r.Get().Namespace(c.ns).Resource("endpoints").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(endpointResourceName).Name(name).Do().Into(result)
 	return
 }
 
 // Delete takes the name of the endpoint, and returns an error if one occurs
 func (c *endpoints) Delete(name string) error {
-	return c.r.Delete().Namespace(c.ns).Resource("endpoints").Name(name).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(endpointResourceName).Name(name).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested endpoints for a service.
@@ -85,7 +89,7 @@ func (c *endpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("endpoints").
+		Resource(endpointResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }
@@ -97,7 +101,7 @@ func (c *endpoints) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {
 	}
 	err := c.r.Put().
 		Namespace(c.ns).
-		Resource("endpoints").
+		Resource(endpointResourceName).
 		Name(endpoints.Name).
 		Body(endpoints).
 		Do().

--- a/pkg/client/unversioned/endpoints_test.go
+++ b/pkg/client/unversioned/endpoints_test.go
@@ -28,10 +28,14 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
+const (
+	endpointResourceName string = "endpoints"
+)
+
 func TestListEndpoints(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, ""), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(endpointResourceName, ns, ""), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200,
 			Body: &api.EndpointsList{
 				Items: []api.Endpoints{
@@ -53,7 +57,7 @@ func TestListEndpoints(t *testing.T) {
 func TestGetEndpoints(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, "endpoint-1"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(endpointResourceName, ns, "endpoint-1"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: &api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "endpoint-1"}}},
 	}
 	response, err := c.Setup(t).Endpoints(ns).Get("endpoint-1")

--- a/pkg/client/unversioned/events.go
+++ b/pkg/client/unversioned/events.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	eventResourceName string = "events"
+)
+
 // EventNamespacer can return an EventInterface for the given namespace.
 type EventNamespacer interface {
 	Events(namespace string) EventInterface
@@ -73,7 +77,7 @@ func (e *events) Create(event *api.Event) (*api.Event, error) {
 	result := &api.Event{}
 	err := e.client.Post().
 		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
-		Resource("events").
+		Resource(eventResourceName).
 		Body(event).
 		Do().
 		Into(result)
@@ -92,7 +96,7 @@ func (e *events) Update(event *api.Event) (*api.Event, error) {
 	result := &api.Event{}
 	err := e.client.Put().
 		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
-		Resource("events").
+		Resource(eventResourceName).
 		Name(event.Name).
 		Body(event).
 		Do().
@@ -108,7 +112,7 @@ func (e *events) Patch(incompleteEvent *api.Event, data []byte) (*api.Event, err
 	result := &api.Event{}
 	err := e.client.Patch(api.StrategicMergePatchType).
 		NamespaceIfScoped(incompleteEvent.Namespace, len(incompleteEvent.Namespace) > 0).
-		Resource("events").
+		Resource(eventResourceName).
 		Name(incompleteEvent.Name).
 		Body(data).
 		Do().
@@ -121,7 +125,7 @@ func (e *events) List(opts api.ListOptions) (*api.EventList, error) {
 	result := &api.EventList{}
 	err := e.client.Get().
 		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
-		Resource("events").
+		Resource(eventResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -133,7 +137,7 @@ func (e *events) Get(name string) (*api.Event, error) {
 	result := &api.Event{}
 	err := e.client.Get().
 		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
-		Resource("events").
+		Resource(eventResourceName).
 		Name(name).
 		Do().
 		Into(result)
@@ -145,7 +149,7 @@ func (e *events) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return e.client.Get().
 		Prefix("watch").
 		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
-		Resource("events").
+		Resource(eventResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }
@@ -179,7 +183,7 @@ func (e *events) Search(objOrRef runtime.Object) (*api.EventList, error) {
 func (e *events) Delete(name string) error {
 	return e.client.Delete().
 		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
-		Resource("events").
+		Resource(eventResourceName).
 		Name(name).
 		Do().
 		Error()

--- a/pkg/client/unversioned/events_test.go
+++ b/pkg/client/unversioned/events_test.go
@@ -31,11 +31,15 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
+const (
+	eventResourceName string = "events"
+)
+
 func TestEventSearch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("events", "baz", ""),
+			Path:   testapi.Default.ResourcePath(eventResourceName, "baz", ""),
 			Query: url.Values{
 				unversioned.FieldSelectorQueryParam(testapi.Default.GroupVersion().String()): []string{
 					GetInvolvedObjectNameFieldLabel(testapi.Default.GroupVersion().String()) + "=foo,",
@@ -82,7 +86,7 @@ func TestEventCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath("events", api.NamespaceDefault, ""),
+			Path:   testapi.Default.ResourcePath(eventResourceName, api.NamespaceDefault, ""),
 			Body:   event,
 		},
 		Response: simple.Response{StatusCode: 200, Body: event},
@@ -122,7 +126,7 @@ func TestEventGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("events", "other", "1"),
+			Path:   testapi.Default.ResourcePath(eventResourceName, "other", "1"),
 			Body:   nil,
 		},
 		Response: simple.Response{StatusCode: 200, Body: event},
@@ -164,7 +168,7 @@ func TestEventList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("events", ns, ""),
+			Path:   testapi.Default.ResourcePath(eventResourceName, ns, ""),
 			Body:   nil,
 		},
 		Response: simple.Response{StatusCode: 200, Body: eventList},
@@ -191,7 +195,7 @@ func TestEventDelete(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Default.ResourcePath("events", ns, "foo"),
+			Path:   testapi.Default.ResourcePath(eventResourceName, ns, "foo"),
 		},
 		Response: simple.Response{StatusCode: 200},
 	}

--- a/pkg/client/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/unversioned/horizontalpodautoscaler.go
@@ -22,6 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	horizontalPodAutoscalerResourceName string = "horizontalPodAutoscalers"
+)
+
 // HorizontalPodAutoscalersNamespacer has methods to work with HorizontalPodAutoscaler resources in a namespace
 type HorizontalPodAutoscalersNamespacer interface {
 	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface
@@ -55,14 +59,14 @@ func newHorizontalPodAutoscalers(c *ExtensionsClient, namespace string) *horizon
 // List takes label and field selectors, and returns the list of horizontalPodAutoscalers that match those selectors.
 func (c *horizontalPodAutoscalers) List(opts api.ListOptions) (result *extensions.HorizontalPodAutoscalerList, err error) {
 	result = &extensions.HorizontalPodAutoscalerList{}
-	err = c.client.Get().Namespace(c.ns).Resource("horizontalPodAutoscalers").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.client.Get().Namespace(c.ns).Resource(horizontalPodAutoscalerResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get takes the name of the horizontalPodAutoscaler, and returns the corresponding HorizontalPodAutoscaler object, and an error if it occurs
 func (c *horizontalPodAutoscalers) Get(name string) (result *extensions.HorizontalPodAutoscaler, err error) {
 	result = &extensions.HorizontalPodAutoscaler{}
-	err = c.client.Get().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Do().Into(result)
+	err = c.client.Get().Namespace(c.ns).Resource(horizontalPodAutoscalerResourceName).Name(name).Do().Into(result)
 	return
 }
 
@@ -70,33 +74,33 @@ func (c *horizontalPodAutoscalers) Get(name string) (result *extensions.Horizont
 func (c *horizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
 	// TODO: to make this reusable in other client libraries
 	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Do().Error()
+		return c.client.Delete().Namespace(c.ns).Resource(horizontalPodAutoscalerResourceName).Name(name).Do().Error()
 	}
 	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
 	if err != nil {
 		return err
 	}
-	return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Body(body).Do().Error()
+	return c.client.Delete().Namespace(c.ns).Resource(horizontalPodAutoscalerResourceName).Name(name).Body(body).Do().Error()
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if it occurs.
 func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
 	result = &extensions.HorizontalPodAutoscaler{}
-	err = c.client.Post().Namespace(c.ns).Resource("horizontalPodAutoscalers").Body(horizontalPodAutoscaler).Do().Into(result)
+	err = c.client.Post().Namespace(c.ns).Resource(horizontalPodAutoscalerResourceName).Body(horizontalPodAutoscaler).Do().Into(result)
 	return
 }
 
 // Update takes the representation of a horizontalPodAutoscaler and updates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if it occurs.
 func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
 	result = &extensions.HorizontalPodAutoscaler{}
-	err = c.client.Put().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(horizontalPodAutoscaler.Name).Body(horizontalPodAutoscaler).Do().Into(result)
+	err = c.client.Put().Namespace(c.ns).Resource(horizontalPodAutoscalerResourceName).Name(horizontalPodAutoscaler.Name).Body(horizontalPodAutoscaler).Do().Into(result)
 	return
 }
 
 // UpdateStatus takes the representation of a horizontalPodAutoscaler and updates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if it occurs.
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
 	result = &extensions.HorizontalPodAutoscaler{}
-	err = c.client.Put().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(horizontalPodAutoscaler.Name).SubResource("status").Body(horizontalPodAutoscaler).Do().Into(result)
+	err = c.client.Put().Namespace(c.ns).Resource(horizontalPodAutoscalerResourceName).Name(horizontalPodAutoscaler.Name).SubResource("status").Body(horizontalPodAutoscaler).Do().Into(result)
 	return
 }
 
@@ -105,7 +109,7 @@ func (c *horizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface,
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("horizontalPodAutoscalers").
+		Resource(horizontalPodAutoscalerResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/horizontalpodautoscaler_test.go
+++ b/pkg/client/unversioned/horizontalpodautoscaler_test.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
-func getHorizontalPodAutoscalersResoureName() string {
-	return "horizontalpodautoscalers"
-}
+const (
+	horizontalPodAutoscalerResourceName string = "horizontalPodAutoscalers"
+)
 
 func TestHorizontalPodAutoscalerCreate(t *testing.T) {
 	ns := api.NamespaceDefault
@@ -45,7 +45,7 @@ func TestHorizontalPodAutoscalerCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Extensions.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(horizontalPodAutoscalerResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   &horizontalPodAutoscaler,
 		},
@@ -70,7 +70,7 @@ func TestHorizontalPodAutoscalerGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc"),
+			Path:   testapi.Extensions.ResourcePath(horizontalPodAutoscalerResourceName, ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -96,7 +96,7 @@ func TestHorizontalPodAutoscalerList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(horizontalPodAutoscalerResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -116,7 +116,7 @@ func TestHorizontalPodAutoscalerUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(horizontalPodAutoscalerResourceName, ns, "abc"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: horizontalPodAutoscaler},
 	}
 	response, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).Update(horizontalPodAutoscaler)
@@ -133,7 +133,7 @@ func TestHorizontalPodAutoscalerUpdateStatus(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc") + "/status", Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(horizontalPodAutoscalerResourceName, ns, "abc") + "/status", Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: horizontalPodAutoscaler},
 	}
 	response, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).UpdateStatus(horizontalPodAutoscaler)
@@ -143,7 +143,7 @@ func TestHorizontalPodAutoscalerUpdateStatus(t *testing.T) {
 func TestHorizontalPodAutoscalerDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(horizontalPodAutoscalerResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).Delete("foo", nil)
@@ -154,7 +154,7 @@ func TestHorizontalPodAutoscalerWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePathWithPrefix("watch", getHorizontalPodAutoscalersResoureName(), "", ""),
+			Path:   testapi.Extensions.ResourcePathWithPrefix("watch", horizontalPodAutoscalerResourceName, "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: simple.Response{StatusCode: 200},
 	}

--- a/pkg/client/unversioned/ingress.go
+++ b/pkg/client/unversioned/ingress.go
@@ -22,6 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	ingressResourceName string = "ingresses"
+)
+
 // IngressNamespacer has methods to work with Ingress resources in a namespace
 type IngressNamespacer interface {
 	Ingress(namespace string) IngressInterface
@@ -52,42 +56,42 @@ func newIngress(c *ExtensionsClient, namespace string) *ingress {
 // List returns a list of ingress that match the label and field selectors.
 func (c *ingress) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
 	result = &extensions.IngressList{}
-	err = c.r.Get().Namespace(c.ns).Resource("ingresses").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(ingressResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get returns information about a particular ingress.
 func (c *ingress) Get(name string) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
-	err = c.r.Get().Namespace(c.ns).Resource("ingresses").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(ingressResourceName).Name(name).Do().Into(result)
 	return
 }
 
 // Create creates a new ingress.
 func (c *ingress) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
-	err = c.r.Post().Namespace(c.ns).Resource("ingresses").Body(ingress).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource(ingressResourceName).Body(ingress).Do().Into(result)
 	return
 }
 
 // Update updates an existing ingress.
 func (c *ingress) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
-	err = c.r.Put().Namespace(c.ns).Resource("ingresses").Name(ingress.Name).Body(ingress).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(ingressResourceName).Name(ingress.Name).Body(ingress).Do().Into(result)
 	return
 }
 
 // Delete deletes a ingress, returns error if one occurs.
 func (c *ingress) Delete(name string, options *api.DeleteOptions) (err error) {
 	if options == nil {
-		return c.r.Delete().Namespace(c.ns).Resource("ingresses").Name(name).Do().Error()
+		return c.r.Delete().Namespace(c.ns).Resource(ingressResourceName).Name(name).Do().Error()
 	}
 
 	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion().String())
 	if err != nil {
 		return err
 	}
-	return c.r.Delete().Namespace(c.ns).Resource("ingresses").Name(name).Body(body).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(ingressResourceName).Name(name).Body(body).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested ingress.
@@ -95,7 +99,7 @@ func (c *ingress) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("ingresses").
+		Resource(ingressResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }
@@ -103,6 +107,6 @@ func (c *ingress) Watch(opts api.ListOptions) (watch.Interface, error) {
 // UpdateStatus takes the name of the ingress and the new status.  Returns the server's representation of the ingress, and an error, if it occurs.
 func (c *ingress) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
-	err = c.r.Put().Namespace(c.ns).Resource("ingresses").Name(ingress.Name).SubResource("status").Body(ingress).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(ingressResourceName).Name(ingress.Name).SubResource("status").Body(ingress).Do().Into(result)
 	return
 }

--- a/pkg/client/unversioned/ingress_test.go
+++ b/pkg/client/unversioned/ingress_test.go
@@ -29,16 +29,16 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
-func getIngressResourceName() string {
-	return "ingresses"
-}
+const (
+	ingressResourceName string = "ingresses"
+)
 
 func TestListIngress(t *testing.T) {
 	ns := api.NamespaceAll
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(ingressResourceName, ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &extensions.IngressList{
@@ -68,7 +68,7 @@ func TestGetIngress(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(ingressResourceName, ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -114,7 +114,7 @@ func TestUpdateIngress(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(ingressResourceName, ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -157,7 +157,7 @@ func TestUpdateIngressStatus(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, "foo") + "/status",
+			Path:   testapi.Extensions.ResourcePath(ingressResourceName, ns, "foo") + "/status",
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -188,7 +188,7 @@ func TestDeleteIngress(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(ingressResourceName, ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{StatusCode: 200},
@@ -208,7 +208,7 @@ func TestCreateIngress(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(ingressResourceName, ns, ""),
 			Body:   requestIngress,
 			Query:  simple.BuildQueryValues(nil),
 		},

--- a/pkg/client/unversioned/jobs.go
+++ b/pkg/client/unversioned/jobs.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	jobResourceName string = "jobs"
+)
+
 // JobsNamespacer has methods to work with Job resources in a namespace
 type JobsNamespacer interface {
 	Jobs(namespace string) JobInterface
@@ -56,42 +60,42 @@ var _ JobInterface = &jobs{}
 // List returns a list of jobs that match the label and field selectors.
 func (c *jobs) List(opts api.ListOptions) (result *extensions.JobList, err error) {
 	result = &extensions.JobList{}
-	err = c.r.Get().Namespace(c.ns).Resource("jobs").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(jobResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get returns information about a particular job.
 func (c *jobs) Get(name string) (result *extensions.Job, err error) {
 	result = &extensions.Job{}
-	err = c.r.Get().Namespace(c.ns).Resource("jobs").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(jobResourceName).Name(name).Do().Into(result)
 	return
 }
 
 // Create creates a new job.
 func (c *jobs) Create(job *extensions.Job) (result *extensions.Job, err error) {
 	result = &extensions.Job{}
-	err = c.r.Post().Namespace(c.ns).Resource("jobs").Body(job).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource(jobResourceName).Body(job).Do().Into(result)
 	return
 }
 
 // Update updates an existing job.
 func (c *jobs) Update(job *extensions.Job) (result *extensions.Job, err error) {
 	result = &extensions.Job{}
-	err = c.r.Put().Namespace(c.ns).Resource("jobs").Name(job.Name).Body(job).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(jobResourceName).Name(job.Name).Body(job).Do().Into(result)
 	return
 }
 
 // Delete deletes a job, returns error if one occurs.
 func (c *jobs) Delete(name string, options *api.DeleteOptions) (err error) {
 	if options == nil {
-		return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Do().Error()
+		return c.r.Delete().Namespace(c.ns).Resource(jobResourceName).Name(name).Do().Error()
 	}
 
 	body, err := api.Scheme.EncodeToVersion(options, latest.GroupOrDie("").GroupVersion.String())
 	if err != nil {
 		return err
 	}
-	return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Body(body).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(jobResourceName).Name(name).Body(body).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested jobs.
@@ -99,7 +103,7 @@ func (c *jobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("jobs").
+		Resource(jobResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }
@@ -107,6 +111,6 @@ func (c *jobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 // UpdateStatus takes the name of the job and the new status.  Returns the server's representation of the job, and an error, if it occurs.
 func (c *jobs) UpdateStatus(job *extensions.Job) (result *extensions.Job, err error) {
 	result = &extensions.Job{}
-	err = c.r.Put().Namespace(c.ns).Resource("jobs").Name(job.Name).SubResource("status").Body(job).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(jobResourceName).Name(job.Name).SubResource("status").Body(job).Do().Into(result)
 	return
 }

--- a/pkg/client/unversioned/jobs_test.go
+++ b/pkg/client/unversioned/jobs_test.go
@@ -29,16 +29,16 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
-func getJobResourceName() string {
-	return "jobs"
-}
+const (
+	jobResourceName string = "jobs"
+)
 
 func TestListJobs(t *testing.T) {
 	ns := api.NamespaceAll
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getJobResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(jobResourceName, ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &extensions.JobList{
@@ -68,7 +68,7 @@ func TestGetJob(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getJobResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(jobResourceName, ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -114,7 +114,7 @@ func TestUpdateJob(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getJobResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(jobResourceName, ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -149,7 +149,7 @@ func TestUpdateJobStatus(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getJobResourceName(), ns, "foo") + "/status",
+			Path:   testapi.Extensions.ResourcePath(jobResourceName, ns, "foo") + "/status",
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -180,7 +180,7 @@ func TestDeleteJob(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Extensions.ResourcePath(getJobResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(jobResourceName, ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{StatusCode: 200},
@@ -200,7 +200,7 @@ func TestCreateJob(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Extensions.ResourcePath(getJobResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(jobResourceName, ns, ""),
 			Body:   requestJob,
 			Query:  simple.BuildQueryValues(nil),
 		},

--- a/pkg/client/unversioned/limit_ranges.go
+++ b/pkg/client/unversioned/limit_ranges.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	limitRangeResourceName string = "limitRanges"
+)
+
 // LimitRangesNamespacer has methods to work with LimitRange resources in a namespace
 type LimitRangesNamespacer interface {
 	LimitRanges(namespace string) LimitRangeInterface
@@ -55,26 +59,26 @@ func newLimitRanges(c *Client, namespace string) *limitRanges {
 // List takes a selector, and returns the list of limitRanges that match that selector.
 func (c *limitRanges) List(opts api.ListOptions) (result *api.LimitRangeList, err error) {
 	result = &api.LimitRangeList{}
-	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(limitRangeResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get takes the name of the limitRange, and returns the corresponding Pod object, and an error if it occurs
 func (c *limitRanges) Get(name string) (result *api.LimitRange, err error) {
 	result = &api.LimitRange{}
-	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(limitRangeResourceName).Name(name).Do().Into(result)
 	return
 }
 
 // Delete takes the name of the limitRange, and returns an error if one occurs
 func (c *limitRanges) Delete(name string) error {
-	return c.r.Delete().Namespace(c.ns).Resource("limitRanges").Name(name).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(limitRangeResourceName).Name(name).Do().Error()
 }
 
 // Create takes the representation of a limitRange.  Returns the server's representation of the limitRange, and an error, if it occurs.
 func (c *limitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
 	result = &api.LimitRange{}
-	err = c.r.Post().Namespace(c.ns).Resource("limitRanges").Body(limitRange).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource(limitRangeResourceName).Body(limitRange).Do().Into(result)
 	return
 }
 
@@ -85,7 +89,7 @@ func (c *limitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange
 		err = fmt.Errorf("invalid update object, missing resource version: %v", limitRange)
 		return
 	}
-	err = c.r.Put().Namespace(c.ns).Resource("limitRanges").Name(limitRange.Name).Body(limitRange).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(limitRangeResourceName).Name(limitRange.Name).Body(limitRange).Do().Into(result)
 	return
 }
 
@@ -94,7 +98,7 @@ func (c *limitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("limitRanges").
+		Resource(limitRangeResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/limit_ranges_test.go
+++ b/pkg/client/unversioned/limit_ranges_test.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
-func getLimitRangesResourceName() string {
-	return "limitranges"
-}
+const (
+	limitRangeResourceName string = "limitRanges"
+)
 
 func TestLimitRangeCreate(t *testing.T) {
 	ns := api.NamespaceDefault
@@ -59,7 +59,7 @@ func TestLimitRangeCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(limitRangeResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   limitRange,
 		},
@@ -95,7 +95,7 @@ func TestLimitRangeGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"),
+			Path:   testapi.Default.ResourcePath(limitRangeResourceName, ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -119,7 +119,7 @@ func TestLimitRangeList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(limitRangeResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -153,7 +153,7 @@ func TestLimitRangeUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(limitRangeResourceName, ns, "abc"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: limitRange},
 	}
 	response, err := c.Setup(t).LimitRanges(ns).Update(limitRange)
@@ -183,7 +183,7 @@ func TestInvalidLimitRangeUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(limitRangeResourceName, ns, "abc"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: limitRange},
 	}
 	_, err := c.Setup(t).LimitRanges(ns).Update(limitRange)
@@ -195,7 +195,7 @@ func TestInvalidLimitRangeUpdate(t *testing.T) {
 func TestLimitRangeDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(limitRangeResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).LimitRanges(ns).Delete("foo")
@@ -206,7 +206,7 @@ func TestLimitRangeWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getLimitRangesResourceName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", limitRangeResourceName, "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: simple.Response{StatusCode: 200},
 	}

--- a/pkg/client/unversioned/namespaces.go
+++ b/pkg/client/unversioned/namespaces.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	namespaceResourceName string = "namespaces"
+)
+
 type NamespacesInterface interface {
 	Namespaces() NamespaceInterface
 }
@@ -51,7 +55,7 @@ func newNamespaces(c *Client) *namespaces {
 // Create creates a new namespace.
 func (c *namespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
 	result := &api.Namespace{}
-	err := c.r.Post().Resource("namespaces").Body(namespace).Do().Into(result)
+	err := c.r.Post().Resource(namespaceResourceName).Body(namespace).Do().Into(result)
 	return result, err
 }
 
@@ -59,7 +63,7 @@ func (c *namespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
 func (c *namespaces) List(opts api.ListOptions) (*api.NamespaceList, error) {
 	result := &api.NamespaceList{}
 	err := c.r.Get().
-		Resource("namespaces").
+		Resource(namespaceResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Do().Into(result)
 	return result, err
@@ -72,7 +76,7 @@ func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, er
 		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
 		return
 	}
-	err = c.r.Put().Resource("namespaces").Name(namespace.Name).Body(namespace).Do().Into(result)
+	err = c.r.Put().Resource(namespaceResourceName).Name(namespace.Name).Body(namespace).Do().Into(result)
 	return
 }
 
@@ -83,7 +87,7 @@ func (c *namespaces) Finalize(namespace *api.Namespace) (result *api.Namespace, 
 		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
 		return
 	}
-	err = c.r.Put().Resource("namespaces").Name(namespace.Name).SubResource("finalize").Body(namespace).Do().Into(result)
+	err = c.r.Put().Resource(namespaceResourceName).Name(namespace.Name).SubResource("finalize").Body(namespace).Do().Into(result)
 	return
 }
 
@@ -94,27 +98,27 @@ func (c *namespaces) Status(namespace *api.Namespace) (result *api.Namespace, er
 		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
 		return
 	}
-	err = c.r.Put().Resource("namespaces").Name(namespace.Name).SubResource("status").Body(namespace).Do().Into(result)
+	err = c.r.Put().Resource(namespaceResourceName).Name(namespace.Name).SubResource("status").Body(namespace).Do().Into(result)
 	return
 }
 
 // Get gets an existing namespace
 func (c *namespaces) Get(name string) (*api.Namespace, error) {
 	result := &api.Namespace{}
-	err := c.r.Get().Resource("namespaces").Name(name).Do().Into(result)
+	err := c.r.Get().Resource(namespaceResourceName).Name(name).Do().Into(result)
 	return result, err
 }
 
 // Delete deletes an existing namespace.
 func (c *namespaces) Delete(name string) error {
-	return c.r.Delete().Resource("namespaces").Name(name).Do().Error()
+	return c.r.Delete().Resource(namespaceResourceName).Name(name).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested namespaces.
 func (c *namespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
-		Resource("namespaces").
+		Resource(namespaceResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/namespaces_test.go
+++ b/pkg/client/unversioned/namespaces_test.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
+const (
+	namespaceResourceName string = "namespaces"
+)
+
 func TestNamespaceCreate(t *testing.T) {
 	// we create a namespace relative to another namespace
 	namespace := &api.Namespace{
@@ -37,7 +41,7 @@ func TestNamespaceCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath("namespaces", "", ""),
+			Path:   testapi.Default.ResourcePath(namespaceResourceName, "", ""),
 			Body:   namespace,
 		},
 		Response: simple.Response{StatusCode: 200, Body: namespace},
@@ -62,7 +66,7 @@ func TestNamespaceGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("namespaces", "", "foo"),
+			Path:   testapi.Default.ResourcePath(namespaceResourceName, "", "foo"),
 			Body:   nil,
 		},
 		Response: simple.Response{StatusCode: 200, Body: namespace},
@@ -90,7 +94,7 @@ func TestNamespaceList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("namespaces", "", ""),
+			Path:   testapi.Default.ResourcePath(namespaceResourceName, "", ""),
 			Body:   nil,
 		},
 		Response: simple.Response{StatusCode: 200, Body: namespaceList},
@@ -128,7 +132,7 @@ func TestNamespaceUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath("namespaces", "", "foo")},
+			Path:   testapi.Default.ResourcePath(namespaceResourceName, "", "foo")},
 		Response: simple.Response{StatusCode: 200, Body: requestNamespace},
 	}
 	receivedNamespace, err := c.Setup(t).Namespaces().Update(requestNamespace)
@@ -152,7 +156,7 @@ func TestNamespaceFinalize(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath("namespaces", "", "foo") + "/finalize",
+			Path:   testapi.Default.ResourcePath(namespaceResourceName, "", "foo") + "/finalize",
 		},
 		Response: simple.Response{StatusCode: 200, Body: requestNamespace},
 	}
@@ -162,7 +166,7 @@ func TestNamespaceFinalize(t *testing.T) {
 
 func TestNamespaceDelete(t *testing.T) {
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath("namespaces", "", "foo")},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(namespaceResourceName, "", "foo")},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Namespaces().Delete("foo")
@@ -173,7 +177,7 @@ func TestNamespaceWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", "namespaces", "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", namespaceResourceName, "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: simple.Response{StatusCode: 200},
 	}

--- a/pkg/client/unversioned/nodes.go
+++ b/pkg/client/unversioned/nodes.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	nodeResourceName string = "nodes"
+)
+
 type NodesInterface interface {
 	Nodes() NodeInterface
 }
@@ -47,35 +51,30 @@ func newNodes(c *Client) *nodes {
 	return &nodes{c}
 }
 
-// resourceName returns node's URL resource name.
-func (c *nodes) resourceName() string {
-	return "nodes"
-}
-
 // Create creates a new node.
 func (c *nodes) Create(node *api.Node) (*api.Node, error) {
 	result := &api.Node{}
-	err := c.r.Post().Resource(c.resourceName()).Body(node).Do().Into(result)
+	err := c.r.Post().Resource(nodeResourceName).Body(node).Do().Into(result)
 	return result, err
 }
 
 // List takes a selector, and returns the list of nodes that match that selector in the cluster.
 func (c *nodes) List(opts api.ListOptions) (*api.NodeList, error) {
 	result := &api.NodeList{}
-	err := c.r.Get().Resource(c.resourceName()).VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err := c.r.Get().Resource(nodeResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return result, err
 }
 
 // Get gets an existing node.
 func (c *nodes) Get(name string) (*api.Node, error) {
 	result := &api.Node{}
-	err := c.r.Get().Resource(c.resourceName()).Name(name).Do().Into(result)
+	err := c.r.Get().Resource(nodeResourceName).Name(name).Do().Into(result)
 	return result, err
 }
 
 // Delete deletes an existing node.
 func (c *nodes) Delete(name string) error {
-	return c.r.Delete().Resource(c.resourceName()).Name(name).Do().Error()
+	return c.r.Delete().Resource(nodeResourceName).Name(name).Do().Error()
 }
 
 // Update updates an existing node.
@@ -85,7 +84,7 @@ func (c *nodes) Update(node *api.Node) (*api.Node, error) {
 		err := fmt.Errorf("invalid update object, missing resource version: %v", node)
 		return nil, err
 	}
-	err := c.r.Put().Resource(c.resourceName()).Name(node.Name).Body(node).Do().Into(result)
+	err := c.r.Put().Resource(nodeResourceName).Name(node.Name).Body(node).Do().Into(result)
 	return result, err
 }
 
@@ -95,7 +94,7 @@ func (c *nodes) UpdateStatus(node *api.Node) (*api.Node, error) {
 		err := fmt.Errorf("invalid update object, missing resource version: %v", node)
 		return nil, err
 	}
-	err := c.r.Put().Resource(c.resourceName()).Name(node.Name).SubResource("status").Body(node).Do().Into(result)
+	err := c.r.Put().Resource(nodeResourceName).Name(node.Name).SubResource("status").Body(node).Do().Into(result)
 	return result, err
 }
 
@@ -104,7 +103,7 @@ func (c *nodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(api.NamespaceAll).
-		Resource(c.resourceName()).
+		Resource(nodeResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/nodes_test.go
+++ b/pkg/client/unversioned/nodes_test.go
@@ -32,15 +32,15 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-func getNodesResourceName() string {
-	return "nodes"
-}
+const (
+	nodeResourceName string = "nodes"
+)
 
 func TestListNodes(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Path:   testapi.Default.ResourcePath(nodeResourceName, "", ""),
 		},
 		Response: simple.Response{StatusCode: 200, Body: &api.NodeList{ListMeta: unversioned.ListMeta{ResourceVersion: "1"}}},
 	}
@@ -53,7 +53,7 @@ func TestListNodesLabels(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Path:   testapi.Default.ResourcePath(nodeResourceName, "", ""),
 			Query:  simple.BuildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
 		Response: simple.Response{
 			StatusCode: 200,
@@ -83,7 +83,7 @@ func TestGetNode(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "1"),
+			Path:   testapi.Default.ResourcePath(nodeResourceName, "", "1"),
 		},
 		Response: simple.Response{StatusCode: 200, Body: &api.Node{ObjectMeta: api.ObjectMeta{Name: "node-1"}}},
 	}
@@ -119,7 +119,7 @@ func TestCreateNode(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Path:   testapi.Default.ResourcePath(nodeResourceName, "", ""),
 			Body:   requestNode},
 		Response: simple.Response{
 			StatusCode: 200,
@@ -134,7 +134,7 @@ func TestDeleteNode(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "foo"),
+			Path:   testapi.Default.ResourcePath(nodeResourceName, "", "foo"),
 		},
 		Response: simple.Response{StatusCode: 200},
 	}
@@ -161,7 +161,7 @@ func TestUpdateNode(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "foo"),
+			Path:   testapi.Default.ResourcePath(nodeResourceName, "", "foo"),
 		},
 		Response: simple.Response{StatusCode: 200, Body: requestNode},
 	}

--- a/pkg/client/unversioned/persistentvolume_test.go
+++ b/pkg/client/unversioned/persistentvolume_test.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
-func getPersistentVolumesResoureName() string {
-	return "persistentvolumes"
-}
+const (
+	persistentVolumeResourceName string = "persistentVolumes"
+)
 
 func TestPersistentVolumeCreate(t *testing.T) {
 	pv := &api.PersistentVolume{
@@ -52,7 +52,7 @@ func TestPersistentVolumeCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePath(persistentVolumeResourceName, "", ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   pv,
 		},
@@ -81,7 +81,7 @@ func TestPersistentVolumeGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc"),
+			Path:   testapi.Default.ResourcePath(persistentVolumeResourceName, "", "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -103,7 +103,7 @@ func TestPersistentVolumeList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePath(persistentVolumeResourceName, "", ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -129,7 +129,7 @@ func TestPersistentVolumeUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(persistentVolumeResourceName, "", "abc"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: persistentVolume},
 	}
 	response, err := c.Setup(t).PersistentVolumes().Update(persistentVolume)
@@ -158,7 +158,7 @@ func TestPersistentVolumeStatusUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc") + "/status",
+			Path:   testapi.Default.ResourcePath(persistentVolumeResourceName, "", "abc") + "/status",
 			Query:  simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: persistentVolume},
 	}
@@ -168,7 +168,7 @@ func TestPersistentVolumeStatusUpdate(t *testing.T) {
 
 func TestPersistentVolumeDelete(t *testing.T) {
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(persistentVolumeResourceName, "", "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).PersistentVolumes().Delete("foo")
@@ -179,7 +179,7 @@ func TestPersistentVolumeWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumesResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", persistentVolumeResourceName, "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: simple.Response{StatusCode: 200},
 	}

--- a/pkg/client/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/unversioned/persistentvolumeclaim.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	persistentVolumeClaimResourceName string = "persistentVolumeClaims"
+)
+
 // PersistentVolumeClaimsNamespacer has methods to work with PersistentVolumeClaim resources in a namespace
 type PersistentVolumeClaimsNamespacer interface {
 	PersistentVolumeClaims(namespace string) PersistentVolumeClaimInterface
@@ -55,7 +59,7 @@ func (c *persistentVolumeClaims) List(opts api.ListOptions) (result *api.Persist
 
 	err = c.client.Get().
 		Namespace(c.namespace).
-		Resource("persistentVolumeClaims").
+		Resource(persistentVolumeClaimResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -65,13 +69,13 @@ func (c *persistentVolumeClaims) List(opts api.ListOptions) (result *api.Persist
 
 func (c *persistentVolumeClaims) Get(name string) (result *api.PersistentVolumeClaim, err error) {
 	result = &api.PersistentVolumeClaim{}
-	err = c.client.Get().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(name).Do().Into(result)
+	err = c.client.Get().Namespace(c.namespace).Resource(persistentVolumeClaimResourceName).Name(name).Do().Into(result)
 	return
 }
 
 func (c *persistentVolumeClaims) Create(claim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
 	result = &api.PersistentVolumeClaim{}
-	err = c.client.Post().Namespace(c.namespace).Resource("persistentVolumeClaims").Body(claim).Do().Into(result)
+	err = c.client.Post().Namespace(c.namespace).Resource(persistentVolumeClaimResourceName).Body(claim).Do().Into(result)
 	return
 }
 
@@ -81,25 +85,25 @@ func (c *persistentVolumeClaims) Update(claim *api.PersistentVolumeClaim) (resul
 		err = fmt.Errorf("invalid update object, missing resource version: %v", claim)
 		return
 	}
-	err = c.client.Put().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(claim.Name).Body(claim).Do().Into(result)
+	err = c.client.Put().Namespace(c.namespace).Resource(persistentVolumeClaimResourceName).Name(claim.Name).Body(claim).Do().Into(result)
 	return
 }
 
 func (c *persistentVolumeClaims) UpdateStatus(claim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
 	result = &api.PersistentVolumeClaim{}
-	err = c.client.Put().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(claim.Name).SubResource("status").Body(claim).Do().Into(result)
+	err = c.client.Put().Namespace(c.namespace).Resource(persistentVolumeClaimResourceName).Name(claim.Name).SubResource("status").Body(claim).Do().Into(result)
 	return
 }
 
 func (c *persistentVolumeClaims) Delete(name string) error {
-	return c.client.Delete().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(name).Do().Error()
+	return c.client.Delete().Namespace(c.namespace).Resource(persistentVolumeClaimResourceName).Name(name).Do().Error()
 }
 
 func (c *persistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.namespace).
-		Resource("persistentVolumeClaims").
+		Resource(persistentVolumeClaimResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/persistentvolumeclaim_test.go
+++ b/pkg/client/unversioned/persistentvolumeclaim_test.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
-func getPersistentVolumeClaimsResoureName() string {
-	return "persistentvolumeclaims"
-}
+const (
+	persistentVolumeClaimResourceName string = "persistentVolumeClaims"
+)
 
 func TestPersistentVolumeClaimCreate(t *testing.T) {
 	ns := api.NamespaceDefault
@@ -56,7 +56,7 @@ func TestPersistentVolumeClaimCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(persistentVolumeClaimResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   pv,
 		},
@@ -89,7 +89,7 @@ func TestPersistentVolumeClaimGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc"),
+			Path:   testapi.Default.ResourcePath(persistentVolumeClaimResourceName, ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -112,7 +112,7 @@ func TestPersistentVolumeClaimList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(persistentVolumeClaimResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -142,7 +142,7 @@ func TestPersistentVolumeClaimUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(persistentVolumeClaimResourceName, ns, "abc"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
 	}
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).Update(persistentVolumeClaim)
@@ -174,7 +174,7 @@ func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc") + "/status",
+			Path:   testapi.Default.ResourcePath(persistentVolumeClaimResourceName, ns, "abc") + "/status",
 			Query:  simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
 	}
@@ -185,7 +185,7 @@ func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
 func TestPersistentVolumeClaimDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(persistentVolumeClaimResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).PersistentVolumeClaims(ns).Delete("foo")
@@ -196,7 +196,7 @@ func TestPersistentVolumeClaimWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumeClaimsResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", persistentVolumeClaimResourceName, "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: simple.Response{StatusCode: 200},
 	}

--- a/pkg/client/unversioned/persistentvolumes.go
+++ b/pkg/client/unversioned/persistentvolumes.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	persistentVolumeResourceName string = "persistentVolumes"
+)
+
 type PersistentVolumesInterface interface {
 	PersistentVolumes() PersistentVolumeInterface
 }
@@ -50,7 +54,7 @@ func newPersistentVolumes(c *Client) *persistentVolumes {
 func (c *persistentVolumes) List(opts api.ListOptions) (result *api.PersistentVolumeList, err error) {
 	result = &api.PersistentVolumeList{}
 	err = c.client.Get().
-		Resource("persistentVolumes").
+		Resource(persistentVolumeResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -60,13 +64,13 @@ func (c *persistentVolumes) List(opts api.ListOptions) (result *api.PersistentVo
 
 func (c *persistentVolumes) Get(name string) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
-	err = c.client.Get().Resource("persistentVolumes").Name(name).Do().Into(result)
+	err = c.client.Get().Resource(persistentVolumeResourceName).Name(name).Do().Into(result)
 	return
 }
 
 func (c *persistentVolumes) Create(volume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
-	err = c.client.Post().Resource("persistentVolumes").Body(volume).Do().Into(result)
+	err = c.client.Post().Resource(persistentVolumeResourceName).Body(volume).Do().Into(result)
 	return
 }
 
@@ -76,24 +80,24 @@ func (c *persistentVolumes) Update(volume *api.PersistentVolume) (result *api.Pe
 		err = fmt.Errorf("invalid update object, missing resource version: %v", volume)
 		return
 	}
-	err = c.client.Put().Resource("persistentVolumes").Name(volume.Name).Body(volume).Do().Into(result)
+	err = c.client.Put().Resource(persistentVolumeResourceName).Name(volume.Name).Body(volume).Do().Into(result)
 	return
 }
 
 func (c *persistentVolumes) UpdateStatus(volume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
-	err = c.client.Put().Resource("persistentVolumes").Name(volume.Name).SubResource("status").Body(volume).Do().Into(result)
+	err = c.client.Put().Resource(persistentVolumeResourceName).Name(volume.Name).SubResource("status").Body(volume).Do().Into(result)
 	return
 }
 
 func (c *persistentVolumes) Delete(name string) error {
-	return c.client.Delete().Resource("persistentVolumes").Name(name).Do().Error()
+	return c.client.Delete().Resource(persistentVolumeResourceName).Name(name).Do().Error()
 }
 
 func (c *persistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Resource("persistentVolumes").
+		Resource(persistentVolumeResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/pod_templates.go
+++ b/pkg/client/unversioned/pod_templates.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	podTemplateResourceName string = "podTemplates"
+)
+
 // PodTemplatesNamespacer has methods to work with PodTemplate resources in a namespace
 type PodTemplatesNamespacer interface {
 	PodTemplates(namespace string) PodTemplateInterface
@@ -53,14 +57,14 @@ func newPodTemplates(c *Client, namespace string) *podTemplates {
 // List takes label and field selectors, and returns the list of podTemplates that match those selectors.
 func (c *podTemplates) List(opts api.ListOptions) (result *api.PodTemplateList, err error) {
 	result = &api.PodTemplateList{}
-	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(podTemplateResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get takes the name of the podTemplate, and returns the corresponding PodTemplate object, and an error if it occurs
 func (c *podTemplates) Get(name string) (result *api.PodTemplate, err error) {
 	result = &api.PodTemplate{}
-	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(podTemplateResourceName).Name(name).Do().Into(result)
 	return
 }
 
@@ -68,26 +72,26 @@ func (c *podTemplates) Get(name string) (result *api.PodTemplate, err error) {
 func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
 	// TODO: to make this reusable in other client libraries
 	if options == nil {
-		return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Error()
+		return c.r.Delete().Namespace(c.ns).Resource(podTemplateResourceName).Name(name).Do().Error()
 	}
 	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion().String())
 	if err != nil {
 		return err
 	}
-	return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Body(body).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(podTemplateResourceName).Name(name).Body(body).Do().Error()
 }
 
 // Create takes the representation of a podTemplate.  Returns the server's representation of the podTemplate, and an error, if it occurs.
 func (c *podTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
 	result = &api.PodTemplate{}
-	err = c.r.Post().Namespace(c.ns).Resource("podTemplates").Body(podTemplate).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource(podTemplateResourceName).Body(podTemplate).Do().Into(result)
 	return
 }
 
 // Update takes the representation of a podTemplate to update.  Returns the server's representation of the podTemplate, and an error, if it occurs.
 func (c *podTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
 	result = &api.PodTemplate{}
-	err = c.r.Put().Namespace(c.ns).Resource("podTemplates").Name(podTemplate.Name).Body(podTemplate).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(podTemplateResourceName).Name(podTemplate.Name).Body(podTemplate).Do().Into(result)
 	return
 }
 
@@ -96,7 +100,7 @@ func (c *podTemplates) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("podTemplates").
+		Resource(podTemplateResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/pod_templates_test.go
+++ b/pkg/client/unversioned/pod_templates_test.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
-func getPodTemplatesResoureName() string {
-	return "podtemplates"
-}
+const (
+	podTemplateResourceName string = "podTemplates"
+)
 
 func TestPodTemplateCreate(t *testing.T) {
 	ns := api.NamespaceDefault
@@ -45,7 +45,7 @@ func TestPodTemplateCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(podTemplateResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   &podTemplate,
 		},
@@ -68,7 +68,7 @@ func TestPodTemplateGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "abc"),
+			Path:   testapi.Default.ResourcePath(podTemplateResourceName, ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -94,7 +94,7 @@ func TestPodTemplateList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(podTemplateResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -115,7 +115,7 @@ func TestPodTemplateUpdate(t *testing.T) {
 		Template: api.PodTemplateSpec{},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(podTemplateResourceName, ns, "abc"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: podTemplate},
 	}
 	response, err := c.Setup(t).PodTemplates(ns).Update(podTemplate)
@@ -125,7 +125,7 @@ func TestPodTemplateUpdate(t *testing.T) {
 func TestPodTemplateDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(podTemplateResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).PodTemplates(ns).Delete("foo", nil)
@@ -136,7 +136,7 @@ func TestPodTemplateWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPodTemplatesResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", podTemplateResourceName, "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: simple.Response{StatusCode: 200},
 	}

--- a/pkg/client/unversioned/pods.go
+++ b/pkg/client/unversioned/pods.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	podResourceName string = "pods"
+)
+
 // PodsNamespacer has methods to work with Pod resources in a namespace
 type PodsNamespacer interface {
 	Pods(namespace string) PodInterface
@@ -56,14 +60,14 @@ func newPods(c *Client, namespace string) *pods {
 // List takes label and field selectors, and returns the list of pods that match those selectors.
 func (c *pods) List(opts api.ListOptions) (result *api.PodList, err error) {
 	result = &api.PodList{}
-	err = c.r.Get().Namespace(c.ns).Resource("pods").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(podResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get takes the name of the pod, and returns the corresponding Pod object, and an error if it occurs
 func (c *pods) Get(name string) (result *api.Pod, err error) {
 	result = &api.Pod{}
-	err = c.r.Get().Namespace(c.ns).Resource("pods").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(podResourceName).Name(name).Do().Into(result)
 	return
 }
 
@@ -71,26 +75,26 @@ func (c *pods) Get(name string) (result *api.Pod, err error) {
 func (c *pods) Delete(name string, options *api.DeleteOptions) error {
 	// TODO: to make this reusable in other client libraries
 	if options == nil {
-		return c.r.Delete().Namespace(c.ns).Resource("pods").Name(name).Do().Error()
+		return c.r.Delete().Namespace(c.ns).Resource(podResourceName).Name(name).Do().Error()
 	}
 	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion().String())
 	if err != nil {
 		return err
 	}
-	return c.r.Delete().Namespace(c.ns).Resource("pods").Name(name).Body(body).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(podResourceName).Name(name).Body(body).Do().Error()
 }
 
 // Create takes the representation of a pod.  Returns the server's representation of the pod, and an error, if it occurs.
 func (c *pods) Create(pod *api.Pod) (result *api.Pod, err error) {
 	result = &api.Pod{}
-	err = c.r.Post().Namespace(c.ns).Resource("pods").Body(pod).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource(podResourceName).Body(pod).Do().Into(result)
 	return
 }
 
 // Update takes the representation of a pod to update.  Returns the server's representation of the pod, and an error, if it occurs.
 func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
 	result = &api.Pod{}
-	err = c.r.Put().Namespace(c.ns).Resource("pods").Name(pod.Name).Body(pod).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(podResourceName).Name(pod.Name).Body(pod).Do().Into(result)
 	return
 }
 
@@ -99,24 +103,24 @@ func (c *pods) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("pods").
+		Resource(podResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }
 
 // Bind applies the provided binding to the named pod in the current namespace (binding.Namespace is ignored).
 func (c *pods) Bind(binding *api.Binding) error {
-	return c.r.Post().Namespace(c.ns).Resource("pods").Name(binding.Name).SubResource("binding").Body(binding).Do().Error()
+	return c.r.Post().Namespace(c.ns).Resource(podResourceName).Name(binding.Name).SubResource("binding").Body(binding).Do().Error()
 }
 
 // UpdateStatus takes the name of the pod and the new status.  Returns the server's representation of the pod, and an error, if it occurs.
 func (c *pods) UpdateStatus(pod *api.Pod) (result *api.Pod, err error) {
 	result = &api.Pod{}
-	err = c.r.Put().Namespace(c.ns).Resource("pods").Name(pod.Name).SubResource("status").Body(pod).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(podResourceName).Name(pod.Name).SubResource("status").Body(pod).Do().Into(result)
 	return
 }
 
 // Get constructs a request for getting the logs for a pod
 func (c *pods) GetLogs(name string, opts *api.PodLogOptions) *Request {
-	return c.r.Get().Namespace(c.ns).Name(name).Resource("pods").SubResource("log").VersionedParams(opts, api.Scheme)
+	return c.r.Get().Namespace(c.ns).Name(name).Resource(podResourceName).SubResource("log").VersionedParams(opts, api.Scheme)
 }

--- a/pkg/client/unversioned/pods_test.go
+++ b/pkg/client/unversioned/pods_test.go
@@ -30,10 +30,14 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
+const (
+	podResourceName string = "pods"
+)
+
 func TestListEmptyPods(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(podResourceName, ns, ""), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: http.StatusOK, Body: &api.PodList{}},
 	}
 	podList, err := c.Setup(t).Pods(ns).List(api.ListOptions{})
@@ -43,7 +47,7 @@ func TestListEmptyPods(t *testing.T) {
 func TestListPods(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(podResourceName, ns, ""), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: http.StatusOK,
 			Body: &api.PodList{
 				Items: []api.Pod{
@@ -72,7 +76,7 @@ func TestListPodsLabels(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("pods", ns, ""),
+			Path:   testapi.Default.ResourcePath(podResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
 		Response: simple.Response{
 			StatusCode: http.StatusOK,
@@ -104,7 +108,7 @@ func TestListPodsLabels(t *testing.T) {
 func TestGetPod(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(podResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: http.StatusOK,
 			Body: &api.Pod{
@@ -138,7 +142,7 @@ func TestGetPodWithNoName(t *testing.T) {
 func TestDeletePod(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(podResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: http.StatusOK},
 	}
 	err := c.Setup(t).Pods(ns).Delete("foo", nil)
@@ -159,7 +163,7 @@ func TestCreatePod(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "POST", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: simple.BuildQueryValues(nil), Body: requestPod},
+		Request: simple.Request{Method: "POST", Path: testapi.Default.ResourcePath(podResourceName, ns, ""), Query: simple.BuildQueryValues(nil), Body: requestPod},
 		Response: simple.Response{
 			StatusCode: http.StatusOK,
 			Body:       requestPod,
@@ -185,7 +189,7 @@ func TestUpdatePod(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(podResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: http.StatusOK, Body: requestPod},
 	}
 	receivedPod, err := c.Setup(t).Pods(ns).Update(requestPod)
@@ -201,7 +205,7 @@ func TestPodGetLogs(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("pods", ns, "podName") + "/log",
+			Path:   testapi.Default.ResourcePath(podResourceName, ns, "podName") + "/log",
 			Query: url.Values{
 				"follow":     []string{"true"},
 				"timestamps": []string{"true"},

--- a/pkg/client/unversioned/replication_controllers.go
+++ b/pkg/client/unversioned/replication_controllers.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	replicationControllerResourceName string = "replicationControllers"
+)
+
 // ReplicationControllersNamespacer has methods to work with ReplicationController resources in a namespace
 type ReplicationControllersNamespacer interface {
 	ReplicationControllers(namespace string) ReplicationControllerInterface
@@ -51,41 +55,41 @@ func newReplicationControllers(c *Client, namespace string) *replicationControll
 // List takes a selector, and returns the list of replication controllers that match that selector.
 func (c *replicationControllers) List(opts api.ListOptions) (result *api.ReplicationControllerList, err error) {
 	result = &api.ReplicationControllerList{}
-	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(replicationControllerResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get returns information about a particular replication controller.
 func (c *replicationControllers) Get(name string) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
-	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(replicationControllerResourceName).Name(name).Do().Into(result)
 	return
 }
 
 // Create creates a new replication controller.
 func (c *replicationControllers) Create(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
-	err = c.r.Post().Namespace(c.ns).Resource("replicationControllers").Body(controller).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource(replicationControllerResourceName).Body(controller).Do().Into(result)
 	return
 }
 
 // Update updates an existing replication controller.
 func (c *replicationControllers) Update(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
-	err = c.r.Put().Namespace(c.ns).Resource("replicationControllers").Name(controller.Name).Body(controller).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(replicationControllerResourceName).Name(controller.Name).Body(controller).Do().Into(result)
 	return
 }
 
 // UpdateStatus updates an existing replication controller status
 func (c *replicationControllers) UpdateStatus(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
-	err = c.r.Put().Namespace(c.ns).Resource("replicationControllers").Name(controller.Name).SubResource("status").Body(controller).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(replicationControllerResourceName).Name(controller.Name).SubResource("status").Body(controller).Do().Into(result)
 	return
 }
 
 // Delete deletes an existing replication controller.
 func (c *replicationControllers) Delete(name string) error {
-	return c.r.Delete().Namespace(c.ns).Resource("replicationControllers").Name(name).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(replicationControllerResourceName).Name(name).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested controllers.
@@ -93,7 +97,7 @@ func (c *replicationControllers) Watch(opts api.ListOptions) (watch.Interface, e
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("replicationControllers").
+		Resource(replicationControllerResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/replication_controllers_test.go
+++ b/pkg/client/unversioned/replication_controllers_test.go
@@ -28,16 +28,16 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
-func getRCResourceName() string {
-	return "replicationcontrollers"
-}
+const (
+	replicationControllerResourceName string = "replicationControllers"
+)
 
 func TestListControllers(t *testing.T) {
 	ns := api.NamespaceAll
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getRCResourceName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(replicationControllerResourceName, ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &api.ReplicationControllerList{
@@ -67,7 +67,7 @@ func TestListControllers(t *testing.T) {
 func TestGetController(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(replicationControllerResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &api.ReplicationController{
@@ -106,7 +106,7 @@ func TestUpdateController(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(replicationControllerResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &api.ReplicationController{
@@ -134,7 +134,7 @@ func TestUpdateStatusController(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(replicationControllerResourceName, ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &api.ReplicationController{
@@ -161,7 +161,7 @@ func TestUpdateStatusController(t *testing.T) {
 func TestDeleteController(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(replicationControllerResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).ReplicationControllers(ns).Delete("foo")
@@ -174,7 +174,7 @@ func TestCreateController(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "POST", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, ""), Body: requestController, Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "POST", Path: testapi.Default.ResourcePath(replicationControllerResourceName, ns, ""), Body: requestController, Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &api.ReplicationController{

--- a/pkg/client/unversioned/resource_quotas.go
+++ b/pkg/client/unversioned/resource_quotas.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	resourceQuotaResourceName string = "resourceQuotas"
+)
+
 // ResourceQuotasNamespacer has methods to work with ResourceQuota resources in a namespace
 type ResourceQuotasNamespacer interface {
 	ResourceQuotas(namespace string) ResourceQuotaInterface
@@ -54,40 +58,40 @@ func newResourceQuotas(c *Client, namespace string) *resourceQuotas {
 // List takes a selector, and returns the list of resourceQuotas that match that selector.
 func (c *resourceQuotas) List(opts api.ListOptions) (result *api.ResourceQuotaList, err error) {
 	result = &api.ResourceQuotaList{}
-	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").VersionedParams(&opts, api.Scheme).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(resourceQuotaResourceName).VersionedParams(&opts, api.Scheme).Do().Into(result)
 	return
 }
 
 // Get takes the name of the resourceQuota, and returns the corresponding ResourceQuota object, and an error if it occurs
 func (c *resourceQuotas) Get(name string) (result *api.ResourceQuota, err error) {
 	result = &api.ResourceQuota{}
-	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(resourceQuotaResourceName).Name(name).Do().Into(result)
 	return
 }
 
 // Delete takes the name of the resourceQuota, and returns an error if one occurs
 func (c *resourceQuotas) Delete(name string) error {
-	return c.r.Delete().Namespace(c.ns).Resource("resourceQuotas").Name(name).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(resourceQuotaResourceName).Name(name).Do().Error()
 }
 
 // Create takes the representation of a resourceQuota.  Returns the server's representation of the resourceQuota, and an error, if it occurs.
 func (c *resourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
 	result = &api.ResourceQuota{}
-	err = c.r.Post().Namespace(c.ns).Resource("resourceQuotas").Body(resourceQuota).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource(resourceQuotaResourceName).Body(resourceQuota).Do().Into(result)
 	return
 }
 
 // Update takes the representation of a resourceQuota to update spec.  Returns the server's representation of the resourceQuota, and an error, if it occurs.
 func (c *resourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
 	result = &api.ResourceQuota{}
-	err = c.r.Put().Namespace(c.ns).Resource("resourceQuotas").Name(resourceQuota.Name).Body(resourceQuota).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(resourceQuotaResourceName).Name(resourceQuota.Name).Body(resourceQuota).Do().Into(result)
 	return
 }
 
 // Status takes the representation of a resourceQuota to update status.  Returns the server's representation of the resourceQuota, and an error, if it occurs.
 func (c *resourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
 	result = &api.ResourceQuota{}
-	err = c.r.Put().Namespace(c.ns).Resource("resourceQuotas").Name(resourceQuota.Name).SubResource("status").Body(resourceQuota).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(resourceQuotaResourceName).Name(resourceQuota.Name).SubResource("status").Body(resourceQuota).Do().Into(result)
 	return
 }
 
@@ -96,7 +100,7 @@ func (c *resourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("resourceQuotas").
+		Resource(resourceQuotaResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/unversioned/resource_quotas_test.go
+++ b/pkg/client/unversioned/resource_quotas_test.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
-func getResourceQuotasResoureName() string {
-	return "resourcequotas"
-}
+const (
+	resourceQuotaResourceName string = "resourceQuotas"
+)
 
 func TestResourceQuotaCreate(t *testing.T) {
 	ns := api.NamespaceDefault
@@ -55,7 +55,7 @@ func TestResourceQuotaCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(resourceQuotaResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   resourceQuota,
 		},
@@ -87,7 +87,7 @@ func TestResourceQuotaGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc"),
+			Path:   testapi.Default.ResourcePath(resourceQuotaResourceName, ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -111,7 +111,7 @@ func TestResourceQuotaList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(resourceQuotaResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -141,7 +141,7 @@ func TestResourceQuotaUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(resourceQuotaResourceName, ns, "abc"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: resourceQuota},
 	}
 	response, err := c.Setup(t).ResourceQuotas(ns).Update(resourceQuota)
@@ -170,7 +170,7 @@ func TestResourceQuotaStatusUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc") + "/status",
+			Path:   testapi.Default.ResourcePath(resourceQuotaResourceName, ns, "abc") + "/status",
 			Query:  simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: resourceQuota},
 	}
@@ -181,7 +181,7 @@ func TestResourceQuotaStatusUpdate(t *testing.T) {
 func TestResourceQuotaDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(resourceQuotaResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).ResourceQuotas(ns).Delete("foo")
@@ -192,7 +192,7 @@ func TestResourceQuotaWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getResourceQuotasResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", resourceQuotaResourceName, "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: simple.Response{StatusCode: 200},
 	}

--- a/pkg/client/unversioned/scale.go
+++ b/pkg/client/unversioned/scale.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
+const (
+	scaleSubResourceName string = "scale"
+)
+
 type ScaleNamespacer interface {
 	Scales(namespace string) ScaleInterface
 }
@@ -49,7 +53,7 @@ func newScales(c *ExtensionsClient, namespace string) *scales {
 func (c *scales) Get(kind string, name string) (result *extensions.Scale, err error) {
 	result = &extensions.Scale{}
 	resource, _ := meta.KindToResource(kind, false)
-	err = c.client.Get().Namespace(c.ns).Resource(resource).Name(name).SubResource("scale").Do().Into(result)
+	err = c.client.Get().Namespace(c.ns).Resource(resource).Name(name).SubResource(scaleSubResourceName).Do().Into(result)
 	return
 }
 
@@ -60,7 +64,7 @@ func (c *scales) Update(kind string, scale *extensions.Scale) (result *extension
 		Namespace(scale.Namespace).
 		Resource(resource).
 		Name(scale.Name).
-		SubResource("scale").
+		SubResource(scaleSubResourceName).
 		Body(scale).
 		Do().
 		Into(result)

--- a/pkg/client/unversioned/secrets.go
+++ b/pkg/client/unversioned/secrets.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	secretResourceName string = "secrets"
+)
+
 type SecretsNamespacer interface {
 	Secrets(namespace string) SecretsInterface
 }
@@ -52,7 +56,7 @@ func (s *secrets) Create(secret *api.Secret) (*api.Secret, error) {
 	result := &api.Secret{}
 	err := s.client.Post().
 		Namespace(s.namespace).
-		Resource("secrets").
+		Resource(secretResourceName).
 		Body(secret).
 		Do().
 		Into(result)
@@ -66,7 +70,7 @@ func (s *secrets) List(opts api.ListOptions) (*api.SecretList, error) {
 
 	err := s.client.Get().
 		Namespace(s.namespace).
-		Resource("secrets").
+		Resource(secretResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -79,7 +83,7 @@ func (s *secrets) Get(name string) (*api.Secret, error) {
 	result := &api.Secret{}
 	err := s.client.Get().
 		Namespace(s.namespace).
-		Resource("secrets").
+		Resource(secretResourceName).
 		Name(name).
 		Do().
 		Into(result)
@@ -92,7 +96,7 @@ func (s *secrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return s.client.Get().
 		Prefix("watch").
 		Namespace(s.namespace).
-		Resource("secrets").
+		Resource(secretResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }
@@ -100,7 +104,7 @@ func (s *secrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 func (s *secrets) Delete(name string) error {
 	return s.client.Delete().
 		Namespace(s.namespace).
-		Resource("secrets").
+		Resource(secretResourceName).
 		Name(name).
 		Do().
 		Error()
@@ -110,7 +114,7 @@ func (s *secrets) Update(secret *api.Secret) (result *api.Secret, err error) {
 	result = &api.Secret{}
 	err = s.client.Put().
 		Namespace(s.namespace).
-		Resource("secrets").
+		Resource(secretResourceName).
 		Name(secret.Name).
 		Body(secret).
 		Do().

--- a/pkg/client/unversioned/service_accounts.go
+++ b/pkg/client/unversioned/service_accounts.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	serviceAccountResourceName string = "serviceaccounts"
+)
+
 type ServiceAccountsNamespacer interface {
 	ServiceAccounts(namespace string) ServiceAccountsInterface
 }
@@ -52,7 +56,7 @@ func (s *serviceAccounts) Create(serviceAccount *api.ServiceAccount) (*api.Servi
 	result := &api.ServiceAccount{}
 	err := s.client.Post().
 		Namespace(s.namespace).
-		Resource("serviceAccounts").
+		Resource(serviceAccountResourceName).
 		Body(serviceAccount).
 		Do().
 		Into(result)
@@ -66,7 +70,7 @@ func (s *serviceAccounts) List(opts api.ListOptions) (*api.ServiceAccountList, e
 
 	err := s.client.Get().
 		Namespace(s.namespace).
-		Resource("serviceAccounts").
+		Resource(serviceAccountResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -79,7 +83,7 @@ func (s *serviceAccounts) Get(name string) (*api.ServiceAccount, error) {
 	result := &api.ServiceAccount{}
 	err := s.client.Get().
 		Namespace(s.namespace).
-		Resource("serviceAccounts").
+		Resource(serviceAccountResourceName).
 		Name(name).
 		Do().
 		Into(result)
@@ -92,7 +96,7 @@ func (s *serviceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return s.client.Get().
 		Prefix("watch").
 		Namespace(s.namespace).
-		Resource("serviceAccounts").
+		Resource(serviceAccountResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }
@@ -100,7 +104,7 @@ func (s *serviceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
 func (s *serviceAccounts) Delete(name string) error {
 	return s.client.Delete().
 		Namespace(s.namespace).
-		Resource("serviceAccounts").
+		Resource(serviceAccountResourceName).
 		Name(name).
 		Do().
 		Error()
@@ -110,7 +114,7 @@ func (s *serviceAccounts) Update(serviceAccount *api.ServiceAccount) (result *ap
 	result = &api.ServiceAccount{}
 	err = s.client.Put().
 		Namespace(s.namespace).
-		Resource("serviceAccounts").
+		Resource(serviceAccountResourceName).
 		Name(serviceAccount.Name).
 		Body(serviceAccount).
 		Do().

--- a/pkg/client/unversioned/services.go
+++ b/pkg/client/unversioned/services.go
@@ -22,6 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	serviceResourceName string = "services"
+)
+
 // ServicesNamespacer has methods to work with Service resources in a namespace
 type ServicesNamespacer interface {
 	Services(namespace string) ServiceInterface
@@ -54,7 +58,7 @@ func (c *services) List(opts api.ListOptions) (result *api.ServiceList, err erro
 	result = &api.ServiceList{}
 	err = c.r.Get().
 		Namespace(c.ns).
-		Resource("services").
+		Resource(serviceResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -64,27 +68,27 @@ func (c *services) List(opts api.ListOptions) (result *api.ServiceList, err erro
 // Get returns information about a particular service.
 func (c *services) Get(name string) (result *api.Service, err error) {
 	result = &api.Service{}
-	err = c.r.Get().Namespace(c.ns).Resource("services").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource(serviceResourceName).Name(name).Do().Into(result)
 	return
 }
 
 // Create creates a new service.
 func (c *services) Create(svc *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}
-	err = c.r.Post().Namespace(c.ns).Resource("services").Body(svc).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource(serviceResourceName).Body(svc).Do().Into(result)
 	return
 }
 
 // Update updates an existing service.
 func (c *services) Update(svc *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}
-	err = c.r.Put().Namespace(c.ns).Resource("services").Name(svc.Name).Body(svc).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource(serviceResourceName).Name(svc.Name).Body(svc).Do().Into(result)
 	return
 }
 
 // Delete deletes an existing service.
 func (c *services) Delete(name string) error {
-	return c.r.Delete().Namespace(c.ns).Resource("services").Name(name).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource(serviceResourceName).Name(name).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested services.
@@ -92,7 +96,7 @@ func (c *services) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("services").
+		Resource(serviceResourceName).
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }
@@ -102,7 +106,7 @@ func (c *services) ProxyGet(scheme, name, port, path string, params map[string]s
 	request := c.r.Get().
 		Prefix("proxy").
 		Namespace(c.ns).
-		Resource("services").
+		Resource(serviceResourceName).
 		Name(util.JoinSchemeNamePort(scheme, name, port)).
 		Suffix(path)
 	for k, v := range params {

--- a/pkg/client/unversioned/services_test.go
+++ b/pkg/client/unversioned/services_test.go
@@ -31,12 +31,16 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
+const (
+	serviceResourceName string = "services"
+)
+
 func TestListServices(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Path:   testapi.Default.ResourcePath(serviceResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200,
 			Body: &api.ServiceList{
@@ -70,7 +74,7 @@ func TestListServicesLabels(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Path:   testapi.Default.ResourcePath(serviceResourceName, ns, ""),
 			Query:  simple.BuildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
 		Response: simple.Response{StatusCode: 200,
 			Body: &api.ServiceList{
@@ -106,7 +110,7 @@ func TestGetService(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("services", ns, "1"),
+			Path:   testapi.Default.ResourcePath(serviceResourceName, ns, "1"),
 			Query:  simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
 	}
@@ -130,7 +134,7 @@ func TestCreateService(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Path:   testapi.Default.ResourcePath(serviceResourceName, ns, ""),
 			Body:   &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}},
 			Query:  simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
@@ -143,7 +147,7 @@ func TestUpdateService(t *testing.T) {
 	ns := api.NamespaceDefault
 	svc := &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1", ResourceVersion: "1"}}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath("services", ns, "service-1"), Body: svc, Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(serviceResourceName, ns, "service-1"), Body: svc, Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200, Body: svc},
 	}
 	response, err := c.Setup(t).Services(ns).Update(svc)
@@ -153,7 +157,7 @@ func TestUpdateService(t *testing.T) {
 func TestDeleteService(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath("services", ns, "1"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(serviceResourceName, ns, "1"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Services(ns).Delete("1")
@@ -166,7 +170,7 @@ func TestServiceProxyGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("proxy", "services", ns, "service-1") + "/foo",
+			Path:   testapi.Default.ResourcePathWithPrefix("proxy", serviceResourceName, ns, "service-1") + "/foo",
 			Query:  simple.BuildQueryValues(url.Values{"param-name": []string{"param-value"}}),
 		},
 		Response: simple.Response{StatusCode: 200, RawBody: &body},
@@ -178,7 +182,7 @@ func TestServiceProxyGet(t *testing.T) {
 	c = &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("proxy", "services", ns, "https:service-1:my-port") + "/foo",
+			Path:   testapi.Default.ResourcePathWithPrefix("proxy", serviceResourceName, ns, "https:service-1:my-port") + "/foo",
 			Query:  simple.BuildQueryValues(url.Values{"param-name": []string{"param-value"}}),
 		},
 		Response: simple.Response{StatusCode: 200, RawBody: &body},

--- a/pkg/client/unversioned/testclient/fake_componentstatuses.go
+++ b/pkg/client/unversioned/testclient/fake_componentstatuses.go
@@ -20,13 +20,17 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
+const (
+	componentStatusResourceName string = "componentStatuses"
+)
+
 // Fake implements ComponentStatusInterface.
 type FakeComponentStatuses struct {
 	Fake *Fake
 }
 
 func (c *FakeComponentStatuses) Get(name string) (*api.ComponentStatus, error) {
-	obj, err := c.Fake.Invokes(NewRootGetAction("componentstatuses", name), &api.ComponentStatus{})
+	obj, err := c.Fake.Invokes(NewRootGetAction(componentStatusResourceName, name), &api.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}
@@ -35,7 +39,7 @@ func (c *FakeComponentStatuses) Get(name string) (*api.ComponentStatus, error) {
 }
 
 func (c *FakeComponentStatuses) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
-	obj, err := c.Fake.Invokes(NewRootListAction("componentstatuses", opts), &api.ComponentStatusList{})
+	obj, err := c.Fake.Invokes(NewRootListAction(componentStatusResourceName, opts), &api.ComponentStatusList{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/unversioned/testclient/fake_daemon_sets.go
+++ b/pkg/client/unversioned/testclient/fake_daemon_sets.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	daemonSetResourceName string = "daemonsets"
+)
+
 // FakeDaemonSet implements DaemonInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeDaemonSets struct {
@@ -34,7 +38,7 @@ type FakeDaemonSets struct {
 var _ kclientlib.DaemonSetInterface = &FakeDaemonSets{}
 
 func (c *FakeDaemonSets) Get(name string) (*extensions.DaemonSet, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("daemonsets", c.Namespace, name), &extensions.DaemonSet{})
+	obj, err := c.Fake.Invokes(NewGetAction(daemonSetResourceName, c.Namespace, name), &extensions.DaemonSet{})
 	if obj == nil {
 		return nil, err
 	}
@@ -42,7 +46,7 @@ func (c *FakeDaemonSets) Get(name string) (*extensions.DaemonSet, error) {
 }
 
 func (c *FakeDaemonSets) List(opts api.ListOptions) (*extensions.DaemonSetList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("daemonsets", c.Namespace, opts), &extensions.DaemonSetList{})
+	obj, err := c.Fake.Invokes(NewListAction(daemonSetResourceName, c.Namespace, opts), &extensions.DaemonSetList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -50,7 +54,7 @@ func (c *FakeDaemonSets) List(opts api.ListOptions) (*extensions.DaemonSetList, 
 }
 
 func (c *FakeDaemonSets) Create(daemon *extensions.DaemonSet) (*extensions.DaemonSet, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("daemonsets", c.Namespace, daemon), &extensions.DaemonSet{})
+	obj, err := c.Fake.Invokes(NewCreateAction(daemonSetResourceName, c.Namespace, daemon), &extensions.DaemonSet{})
 	if obj == nil {
 		return nil, err
 	}
@@ -58,7 +62,7 @@ func (c *FakeDaemonSets) Create(daemon *extensions.DaemonSet) (*extensions.Daemo
 }
 
 func (c *FakeDaemonSets) Update(daemon *extensions.DaemonSet) (*extensions.DaemonSet, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("daemonsets", c.Namespace, daemon), &extensions.DaemonSet{})
+	obj, err := c.Fake.Invokes(NewUpdateAction(daemonSetResourceName, c.Namespace, daemon), &extensions.DaemonSet{})
 	if obj == nil {
 		return nil, err
 	}
@@ -66,7 +70,7 @@ func (c *FakeDaemonSets) Update(daemon *extensions.DaemonSet) (*extensions.Daemo
 }
 
 func (c *FakeDaemonSets) UpdateStatus(daemon *extensions.DaemonSet) (*extensions.DaemonSet, error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("daemonsets", "status", c.Namespace, daemon), &extensions.DaemonSet{})
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction(daemonSetResourceName, "status", c.Namespace, daemon), &extensions.DaemonSet{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,10 +78,10 @@ func (c *FakeDaemonSets) UpdateStatus(daemon *extensions.DaemonSet) (*extensions
 }
 
 func (c *FakeDaemonSets) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("daemonsets", c.Namespace, name), &extensions.DaemonSet{})
+	_, err := c.Fake.Invokes(NewDeleteAction(daemonSetResourceName, c.Namespace, name), &extensions.DaemonSet{})
 	return err
 }
 
 func (c *FakeDaemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("daemonsets", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(daemonSetResourceName, c.Namespace, opts))
 }

--- a/pkg/client/unversioned/testclient/fake_deployments.go
+++ b/pkg/client/unversioned/testclient/fake_deployments.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	deploymentResourceName string = "deployments"
+)
+
 // FakeDeployments implements DeploymentsInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the methods you want to test easier.
 type FakeDeployments struct {
@@ -31,7 +35,7 @@ type FakeDeployments struct {
 }
 
 func (c *FakeDeployments) Get(name string) (*extensions.Deployment, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("deployments", c.Namespace, name), &extensions.Deployment{})
+	obj, err := c.Fake.Invokes(NewGetAction(deploymentResourceName, c.Namespace, name), &extensions.Deployment{})
 	if obj == nil {
 		return nil, err
 	}
@@ -40,7 +44,7 @@ func (c *FakeDeployments) Get(name string) (*extensions.Deployment, error) {
 }
 
 func (c *FakeDeployments) List(opts api.ListOptions) (*extensions.DeploymentList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("deployments", c.Namespace, opts), &extensions.DeploymentList{})
+	obj, err := c.Fake.Invokes(NewListAction(deploymentResourceName, c.Namespace, opts), &extensions.DeploymentList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -58,7 +62,7 @@ func (c *FakeDeployments) List(opts api.ListOptions) (*extensions.DeploymentList
 }
 
 func (c *FakeDeployments) Create(deployment *extensions.Deployment) (*extensions.Deployment, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("deployments", c.Namespace, deployment), deployment)
+	obj, err := c.Fake.Invokes(NewCreateAction(deploymentResourceName, c.Namespace, deployment), deployment)
 	if obj == nil {
 		return nil, err
 	}
@@ -67,7 +71,7 @@ func (c *FakeDeployments) Create(deployment *extensions.Deployment) (*extensions
 }
 
 func (c *FakeDeployments) Update(deployment *extensions.Deployment) (*extensions.Deployment, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("deployments", c.Namespace, deployment), deployment)
+	obj, err := c.Fake.Invokes(NewUpdateAction(deploymentResourceName, c.Namespace, deployment), deployment)
 	if obj == nil {
 		return nil, err
 	}
@@ -76,7 +80,7 @@ func (c *FakeDeployments) Update(deployment *extensions.Deployment) (*extensions
 }
 
 func (c *FakeDeployments) UpdateStatus(deployment *extensions.Deployment) (*extensions.Deployment, error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("deployments", "status", c.Namespace, deployment), deployment)
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction(deploymentResourceName, "status", c.Namespace, deployment), deployment)
 	if obj == nil {
 		return nil, err
 	}
@@ -85,10 +89,10 @@ func (c *FakeDeployments) UpdateStatus(deployment *extensions.Deployment) (*exte
 }
 
 func (c *FakeDeployments) Delete(name string, options *api.DeleteOptions) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("deployments", c.Namespace, name), &extensions.Deployment{})
+	_, err := c.Fake.Invokes(NewDeleteAction(deploymentResourceName, c.Namespace, name), &extensions.Deployment{})
 	return err
 }
 
 func (c *FakeDeployments) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("deployments", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(deploymentResourceName, c.Namespace, opts))
 }

--- a/pkg/client/unversioned/testclient/fake_endpoints.go
+++ b/pkg/client/unversioned/testclient/fake_endpoints.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	endpointResourceName string = "endpoints"
+)
+
 // FakeEndpoints implements EndpointInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeEndpoints struct {
@@ -29,7 +33,7 @@ type FakeEndpoints struct {
 }
 
 func (c *FakeEndpoints) Get(name string) (*api.Endpoints, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("endpoints", c.Namespace, name), &api.Endpoints{})
+	obj, err := c.Fake.Invokes(NewGetAction(endpointResourceName, c.Namespace, name), &api.Endpoints{})
 	if obj == nil {
 		return nil, err
 	}
@@ -38,7 +42,7 @@ func (c *FakeEndpoints) Get(name string) (*api.Endpoints, error) {
 }
 
 func (c *FakeEndpoints) List(opts api.ListOptions) (*api.EndpointsList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("endpoints", c.Namespace, opts), &api.EndpointsList{})
+	obj, err := c.Fake.Invokes(NewListAction(endpointResourceName, c.Namespace, opts), &api.EndpointsList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -47,7 +51,7 @@ func (c *FakeEndpoints) List(opts api.ListOptions) (*api.EndpointsList, error) {
 }
 
 func (c *FakeEndpoints) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("endpoints", c.Namespace, endpoints), endpoints)
+	obj, err := c.Fake.Invokes(NewCreateAction(endpointResourceName, c.Namespace, endpoints), endpoints)
 	if obj == nil {
 		return nil, err
 	}
@@ -56,7 +60,7 @@ func (c *FakeEndpoints) Create(endpoints *api.Endpoints) (*api.Endpoints, error)
 }
 
 func (c *FakeEndpoints) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("endpoints", c.Namespace, endpoints), endpoints)
+	obj, err := c.Fake.Invokes(NewUpdateAction(endpointResourceName, c.Namespace, endpoints), endpoints)
 	if obj == nil {
 		return nil, err
 	}
@@ -65,10 +69,10 @@ func (c *FakeEndpoints) Update(endpoints *api.Endpoints) (*api.Endpoints, error)
 }
 
 func (c *FakeEndpoints) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("endpoints", c.Namespace, name), &api.Endpoints{})
+	_, err := c.Fake.Invokes(NewDeleteAction(endpointResourceName, c.Namespace, name), &api.Endpoints{})
 	return err
 }
 
 func (c *FakeEndpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("endpoints", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(endpointResourceName, c.Namespace, opts))
 }

--- a/pkg/client/unversioned/testclient/fake_events.go
+++ b/pkg/client/unversioned/testclient/fake_events.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	eventResourceName string = "events"
+)
+
 // FakeEvents implements EventInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeEvents struct {
@@ -32,9 +36,9 @@ type FakeEvents struct {
 
 // Get returns the given event, or an error.
 func (c *FakeEvents) Get(name string) (*api.Event, error) {
-	action := NewRootGetAction("events", name)
+	action := NewRootGetAction(eventResourceName, name)
 	if c.Namespace != "" {
-		action = NewGetAction("events", c.Namespace, name)
+		action = NewGetAction(eventResourceName, c.Namespace, name)
 	}
 	obj, err := c.Fake.Invokes(action, &api.Event{})
 	if obj == nil {
@@ -46,9 +50,9 @@ func (c *FakeEvents) Get(name string) (*api.Event, error) {
 
 // List returns a list of events matching the selectors.
 func (c *FakeEvents) List(opts api.ListOptions) (*api.EventList, error) {
-	action := NewRootListAction("events", opts)
+	action := NewRootListAction(eventResourceName, opts)
 	if c.Namespace != "" {
-		action = NewListAction("events", c.Namespace, opts)
+		action = NewListAction(eventResourceName, c.Namespace, opts)
 	}
 	obj, err := c.Fake.Invokes(action, &api.EventList{})
 	if obj == nil {
@@ -60,9 +64,9 @@ func (c *FakeEvents) List(opts api.ListOptions) (*api.EventList, error) {
 
 // Create makes a new event. Returns the copy of the event the server returns, or an error.
 func (c *FakeEvents) Create(event *api.Event) (*api.Event, error) {
-	action := NewRootCreateAction("events", event)
+	action := NewRootCreateAction(eventResourceName, event)
 	if c.Namespace != "" {
-		action = NewCreateAction("events", c.Namespace, event)
+		action = NewCreateAction(eventResourceName, c.Namespace, event)
 	}
 	obj, err := c.Fake.Invokes(action, event)
 	if obj == nil {
@@ -74,9 +78,9 @@ func (c *FakeEvents) Create(event *api.Event) (*api.Event, error) {
 
 // Update replaces an existing event. Returns the copy of the event the server returns, or an error.
 func (c *FakeEvents) Update(event *api.Event) (*api.Event, error) {
-	action := NewRootUpdateAction("events", event)
+	action := NewRootUpdateAction(eventResourceName, event)
 	if c.Namespace != "" {
-		action = NewUpdateAction("events", c.Namespace, event)
+		action = NewUpdateAction(eventResourceName, c.Namespace, event)
 	}
 	obj, err := c.Fake.Invokes(action, event)
 	if obj == nil {
@@ -88,9 +92,9 @@ func (c *FakeEvents) Update(event *api.Event) (*api.Event, error) {
 
 // Patch patches an existing event. Returns the copy of the event the server returns, or an error.
 func (c *FakeEvents) Patch(event *api.Event, data []byte) (*api.Event, error) {
-	action := NewRootPatchAction("events", event)
+	action := NewRootPatchAction(eventResourceName, event)
 	if c.Namespace != "" {
-		action = NewPatchAction("events", c.Namespace, event)
+		action = NewPatchAction(eventResourceName, c.Namespace, event)
 	}
 	obj, err := c.Fake.Invokes(action, event)
 	if obj == nil {
@@ -101,9 +105,9 @@ func (c *FakeEvents) Patch(event *api.Event, data []byte) (*api.Event, error) {
 }
 
 func (c *FakeEvents) Delete(name string) error {
-	action := NewRootDeleteAction("events", name)
+	action := NewRootDeleteAction(eventResourceName, name)
 	if c.Namespace != "" {
-		action = NewDeleteAction("events", c.Namespace, name)
+		action = NewDeleteAction(eventResourceName, c.Namespace, name)
 	}
 	_, err := c.Fake.Invokes(action, &api.Event{})
 	return err
@@ -120,16 +124,16 @@ func (c *FakeEvents) DeleteCollection(options *api.DeleteOptions, listOptions ap
 
 // Watch starts watching for events matching the given selectors.
 func (c *FakeEvents) Watch(opts api.ListOptions) (watch.Interface, error) {
-	action := NewRootWatchAction("events", opts)
+	action := NewRootWatchAction(eventResourceName, opts)
 	if c.Namespace != "" {
-		action = NewWatchAction("events", c.Namespace, opts)
+		action = NewWatchAction(eventResourceName, c.Namespace, opts)
 	}
 	return c.Fake.InvokesWatch(action)
 }
 
 // Search returns a list of events matching the specified object.
 func (c *FakeEvents) Search(objOrRef runtime.Object) (*api.EventList, error) {
-	action := NewRootListAction("events", api.ListOptions{})
+	action := NewRootListAction(eventResourceName, api.ListOptions{})
 	if c.Namespace != "" {
 		action = NewListAction("events", c.Namespace, api.ListOptions{})
 	}
@@ -144,7 +148,7 @@ func (c *FakeEvents) Search(objOrRef runtime.Object) (*api.EventList, error) {
 func (c *FakeEvents) GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector {
 	action := GenericActionImpl{}
 	action.Verb = "get-field-selector"
-	action.Resource = "events"
+	action.Resource = eventResourceName
 
 	c.Fake.Invokes(action, nil)
 	return fields.Everything()

--- a/pkg/client/unversioned/testclient/fake_horizontal_pod_autoscalers.go
+++ b/pkg/client/unversioned/testclient/fake_horizontal_pod_autoscalers.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	horizontalPodAutoscalerResourceName string = "horizontalPodAutoscalers"
+)
+
 // FakeHorizontalPodAutoscalers implements HorizontalPodAutoscalerInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the methods you want to test easier.
 type FakeHorizontalPodAutoscalers struct {
@@ -31,7 +35,7 @@ type FakeHorizontalPodAutoscalers struct {
 }
 
 func (c *FakeHorizontalPodAutoscalers) Get(name string) (*extensions.HorizontalPodAutoscaler, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("horizontalpodautoscalers", c.Namespace, name), &extensions.HorizontalPodAutoscaler{})
+	obj, err := c.Fake.Invokes(NewGetAction(horizontalPodAutoscalerResourceName, c.Namespace, name), &extensions.HorizontalPodAutoscaler{})
 	if obj == nil {
 		return nil, err
 	}
@@ -40,7 +44,7 @@ func (c *FakeHorizontalPodAutoscalers) Get(name string) (*extensions.HorizontalP
 }
 
 func (c *FakeHorizontalPodAutoscalers) List(opts api.ListOptions) (*extensions.HorizontalPodAutoscalerList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("horizontalpodautoscalers", c.Namespace, opts), &extensions.HorizontalPodAutoscalerList{})
+	obj, err := c.Fake.Invokes(NewListAction(horizontalPodAutoscalerResourceName, c.Namespace, opts), &extensions.HorizontalPodAutoscalerList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -58,7 +62,7 @@ func (c *FakeHorizontalPodAutoscalers) List(opts api.ListOptions) (*extensions.H
 }
 
 func (c *FakeHorizontalPodAutoscalers) Create(a *extensions.HorizontalPodAutoscaler) (*extensions.HorizontalPodAutoscaler, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("horizontalpodautoscalers", c.Namespace, a), a)
+	obj, err := c.Fake.Invokes(NewCreateAction(horizontalPodAutoscalerResourceName, c.Namespace, a), a)
 	if obj == nil {
 		return nil, err
 	}
@@ -67,7 +71,7 @@ func (c *FakeHorizontalPodAutoscalers) Create(a *extensions.HorizontalPodAutosca
 }
 
 func (c *FakeHorizontalPodAutoscalers) Update(a *extensions.HorizontalPodAutoscaler) (*extensions.HorizontalPodAutoscaler, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("horizontalpodautoscalers", c.Namespace, a), a)
+	obj, err := c.Fake.Invokes(NewUpdateAction(horizontalPodAutoscalerResourceName, c.Namespace, a), a)
 	if obj == nil {
 		return nil, err
 	}
@@ -76,7 +80,7 @@ func (c *FakeHorizontalPodAutoscalers) Update(a *extensions.HorizontalPodAutosca
 }
 
 func (c *FakeHorizontalPodAutoscalers) UpdateStatus(a *extensions.HorizontalPodAutoscaler) (*extensions.HorizontalPodAutoscaler, error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("horizontalpodautoscalers", "status", c.Namespace, a), &extensions.HorizontalPodAutoscaler{})
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction(horizontalPodAutoscalerResourceName, "status", c.Namespace, a), &extensions.HorizontalPodAutoscaler{})
 	if obj == nil {
 		return nil, err
 	}
@@ -84,10 +88,10 @@ func (c *FakeHorizontalPodAutoscalers) UpdateStatus(a *extensions.HorizontalPodA
 }
 
 func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("horizontalpodautoscalers", c.Namespace, name), &extensions.HorizontalPodAutoscaler{})
+	_, err := c.Fake.Invokes(NewDeleteAction(horizontalPodAutoscalerResourceName, c.Namespace, name), &extensions.HorizontalPodAutoscaler{})
 	return err
 }
 
 func (c *FakeHorizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("horizontalpodautoscalers", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(horizontalPodAutoscalerResourceName, c.Namespace, opts))
 }

--- a/pkg/client/unversioned/testclient/fake_ingress.go
+++ b/pkg/client/unversioned/testclient/fake_ingress.go
@@ -22,6 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	ingressResourceName string = "ingresses"
+)
+
 // FakeIngress implements IngressInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeIngress struct {
@@ -30,7 +34,7 @@ type FakeIngress struct {
 }
 
 func (c *FakeIngress) Get(name string) (*extensions.Ingress, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("ingresses", c.Namespace, name), &extensions.Ingress{})
+	obj, err := c.Fake.Invokes(NewGetAction(ingressResourceName, c.Namespace, name), &extensions.Ingress{})
 	if obj == nil {
 		return nil, err
 	}
@@ -39,7 +43,7 @@ func (c *FakeIngress) Get(name string) (*extensions.Ingress, error) {
 }
 
 func (c *FakeIngress) List(opts api.ListOptions) (*extensions.IngressList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("ingresses", c.Namespace, opts), &extensions.IngressList{})
+	obj, err := c.Fake.Invokes(NewListAction(ingressResourceName, c.Namespace, opts), &extensions.IngressList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -48,7 +52,7 @@ func (c *FakeIngress) List(opts api.ListOptions) (*extensions.IngressList, error
 }
 
 func (c *FakeIngress) Create(ingress *extensions.Ingress) (*extensions.Ingress, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("ingresses", c.Namespace, ingress), ingress)
+	obj, err := c.Fake.Invokes(NewCreateAction(ingressResourceName, c.Namespace, ingress), ingress)
 	if obj == nil {
 		return nil, err
 	}
@@ -57,7 +61,7 @@ func (c *FakeIngress) Create(ingress *extensions.Ingress) (*extensions.Ingress, 
 }
 
 func (c *FakeIngress) Update(ingress *extensions.Ingress) (*extensions.Ingress, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("ingresses", c.Namespace, ingress), ingress)
+	obj, err := c.Fake.Invokes(NewUpdateAction(ingressResourceName, c.Namespace, ingress), ingress)
 	if obj == nil {
 		return nil, err
 	}
@@ -66,16 +70,16 @@ func (c *FakeIngress) Update(ingress *extensions.Ingress) (*extensions.Ingress, 
 }
 
 func (c *FakeIngress) Delete(name string, options *api.DeleteOptions) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("ingresses", c.Namespace, name), &extensions.Ingress{})
+	_, err := c.Fake.Invokes(NewDeleteAction(ingressResourceName, c.Namespace, name), &extensions.Ingress{})
 	return err
 }
 
 func (c *FakeIngress) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("ingresses", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(ingressResourceName, c.Namespace, opts))
 }
 
 func (c *FakeIngress) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("ingresses", "status", c.Namespace, ingress), ingress)
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction(ingressResourceName, "status", c.Namespace, ingress), ingress)
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/unversioned/testclient/fake_jobs.go
+++ b/pkg/client/unversioned/testclient/fake_jobs.go
@@ -22,6 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	jobResourceName string = "jobs"
+)
+
 // FakeJobs implements JobInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeJobs struct {
@@ -30,7 +34,7 @@ type FakeJobs struct {
 }
 
 func (c *FakeJobs) Get(name string) (*extensions.Job, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("jobs", c.Namespace, name), &extensions.Job{})
+	obj, err := c.Fake.Invokes(NewGetAction(jobResourceName, c.Namespace, name), &extensions.Job{})
 	if obj == nil {
 		return nil, err
 	}
@@ -39,7 +43,7 @@ func (c *FakeJobs) Get(name string) (*extensions.Job, error) {
 }
 
 func (c *FakeJobs) List(opts api.ListOptions) (*extensions.JobList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("jobs", c.Namespace, opts), &extensions.JobList{})
+	obj, err := c.Fake.Invokes(NewListAction(jobResourceName, c.Namespace, opts), &extensions.JobList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -48,7 +52,7 @@ func (c *FakeJobs) List(opts api.ListOptions) (*extensions.JobList, error) {
 }
 
 func (c *FakeJobs) Create(job *extensions.Job) (*extensions.Job, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("jobs", c.Namespace, job), job)
+	obj, err := c.Fake.Invokes(NewCreateAction(jobResourceName, c.Namespace, job), job)
 	if obj == nil {
 		return nil, err
 	}
@@ -57,7 +61,7 @@ func (c *FakeJobs) Create(job *extensions.Job) (*extensions.Job, error) {
 }
 
 func (c *FakeJobs) Update(job *extensions.Job) (*extensions.Job, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("jobs", c.Namespace, job), job)
+	obj, err := c.Fake.Invokes(NewUpdateAction(jobResourceName, c.Namespace, job), job)
 	if obj == nil {
 		return nil, err
 	}
@@ -66,16 +70,16 @@ func (c *FakeJobs) Update(job *extensions.Job) (*extensions.Job, error) {
 }
 
 func (c *FakeJobs) Delete(name string, options *api.DeleteOptions) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("jobs", c.Namespace, name), &extensions.Job{})
+	_, err := c.Fake.Invokes(NewDeleteAction(jobResourceName, c.Namespace, name), &extensions.Job{})
 	return err
 }
 
 func (c *FakeJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("jobs", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(jobResourceName, c.Namespace, opts))
 }
 
 func (c *FakeJobs) UpdateStatus(job *extensions.Job) (result *extensions.Job, err error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("jobs", "status", c.Namespace, job), job)
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction(jobResourceName, "status", c.Namespace, job), job)
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/unversioned/testclient/fake_limit_ranges.go
+++ b/pkg/client/unversioned/testclient/fake_limit_ranges.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	limitRangeResourceName string = "limitRanges"
+)
+
 // FakeLimitRanges implements PodsInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the methods you want to test easier.
 type FakeLimitRanges struct {
@@ -29,7 +33,7 @@ type FakeLimitRanges struct {
 }
 
 func (c *FakeLimitRanges) Get(name string) (*api.LimitRange, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("limitranges", c.Namespace, name), &api.LimitRange{})
+	obj, err := c.Fake.Invokes(NewGetAction(limitRangeResourceName, c.Namespace, name), &api.LimitRange{})
 	if obj == nil {
 		return nil, err
 	}
@@ -38,7 +42,7 @@ func (c *FakeLimitRanges) Get(name string) (*api.LimitRange, error) {
 }
 
 func (c *FakeLimitRanges) List(opts api.ListOptions) (*api.LimitRangeList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("limitranges", c.Namespace, opts), &api.LimitRangeList{})
+	obj, err := c.Fake.Invokes(NewListAction(limitRangeResourceName, c.Namespace, opts), &api.LimitRangeList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -47,7 +51,7 @@ func (c *FakeLimitRanges) List(opts api.ListOptions) (*api.LimitRangeList, error
 }
 
 func (c *FakeLimitRanges) Create(limitRange *api.LimitRange) (*api.LimitRange, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("limitranges", c.Namespace, limitRange), limitRange)
+	obj, err := c.Fake.Invokes(NewCreateAction(limitRangeResourceName, c.Namespace, limitRange), limitRange)
 	if obj == nil {
 		return nil, err
 	}
@@ -56,7 +60,7 @@ func (c *FakeLimitRanges) Create(limitRange *api.LimitRange) (*api.LimitRange, e
 }
 
 func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (*api.LimitRange, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("limitranges", c.Namespace, limitRange), limitRange)
+	obj, err := c.Fake.Invokes(NewUpdateAction(limitRangeResourceName, c.Namespace, limitRange), limitRange)
 	if obj == nil {
 		return nil, err
 	}
@@ -65,10 +69,10 @@ func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (*api.LimitRange, e
 }
 
 func (c *FakeLimitRanges) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("limitranges", c.Namespace, name), &api.LimitRange{})
+	_, err := c.Fake.Invokes(NewDeleteAction(limitRangeResourceName, c.Namespace, name), &api.LimitRange{})
 	return err
 }
 
 func (c *FakeLimitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("limitranges", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(limitRangeResourceName, c.Namespace, opts))
 }

--- a/pkg/client/unversioned/testclient/fake_namespaces.go
+++ b/pkg/client/unversioned/testclient/fake_namespaces.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	namespaceResourceName string = "namespaces"
+)
+
 // FakeNamespaces implements NamespacesInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the methods you want to test easier.
 type FakeNamespaces struct {
@@ -28,7 +32,7 @@ type FakeNamespaces struct {
 }
 
 func (c *FakeNamespaces) Get(name string) (*api.Namespace, error) {
-	obj, err := c.Fake.Invokes(NewRootGetAction("namespaces", name), &api.Namespace{})
+	obj, err := c.Fake.Invokes(NewRootGetAction(namespaceResourceName, name), &api.Namespace{})
 	if obj == nil {
 		return nil, err
 	}
@@ -37,7 +41,7 @@ func (c *FakeNamespaces) Get(name string) (*api.Namespace, error) {
 }
 
 func (c *FakeNamespaces) List(opts api.ListOptions) (*api.NamespaceList, error) {
-	obj, err := c.Fake.Invokes(NewRootListAction("namespaces", opts), &api.NamespaceList{})
+	obj, err := c.Fake.Invokes(NewRootListAction(namespaceResourceName, opts), &api.NamespaceList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -46,7 +50,7 @@ func (c *FakeNamespaces) List(opts api.ListOptions) (*api.NamespaceList, error) 
 }
 
 func (c *FakeNamespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
-	obj, err := c.Fake.Invokes(NewRootCreateAction("namespaces", namespace), namespace)
+	obj, err := c.Fake.Invokes(NewRootCreateAction(namespaceResourceName, namespace), namespace)
 	if obj == nil {
 		return nil, err
 	}
@@ -55,7 +59,7 @@ func (c *FakeNamespaces) Create(namespace *api.Namespace) (*api.Namespace, error
 }
 
 func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error) {
-	obj, err := c.Fake.Invokes(NewRootUpdateAction("namespaces", namespace), namespace)
+	obj, err := c.Fake.Invokes(NewRootUpdateAction(namespaceResourceName, namespace), namespace)
 	if obj == nil {
 		return nil, err
 	}
@@ -64,18 +68,18 @@ func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error
 }
 
 func (c *FakeNamespaces) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewRootDeleteAction("namespaces", name), &api.Namespace{})
+	_, err := c.Fake.Invokes(NewRootDeleteAction(namespaceResourceName, name), &api.Namespace{})
 	return err
 }
 
 func (c *FakeNamespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewRootWatchAction("namespaces", opts))
+	return c.Fake.InvokesWatch(NewRootWatchAction(namespaceResourceName, opts))
 }
 
 func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, error) {
 	action := CreateActionImpl{}
 	action.Verb = "create"
-	action.Resource = "namespaces"
+	action.Resource = namespaceResourceName
 	action.Subresource = "finalize"
 	action.Object = namespace
 
@@ -90,7 +94,7 @@ func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, err
 func (c *FakeNamespaces) Status(namespace *api.Namespace) (*api.Namespace, error) {
 	action := CreateActionImpl{}
 	action.Verb = "create"
-	action.Resource = "namespaces"
+	action.Resource = namespaceResourceName
 	action.Subresource = "status"
 	action.Object = namespace
 

--- a/pkg/client/unversioned/testclient/fake_nodes.go
+++ b/pkg/client/unversioned/testclient/fake_nodes.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	nodeResourceName string = "nodes"
+)
+
 // FakeNodes implements NodeInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeNodes struct {
@@ -28,7 +32,7 @@ type FakeNodes struct {
 }
 
 func (c *FakeNodes) Get(name string) (*api.Node, error) {
-	obj, err := c.Fake.Invokes(NewRootGetAction("nodes", name), &api.Node{})
+	obj, err := c.Fake.Invokes(NewRootGetAction(nodeResourceName, name), &api.Node{})
 	if obj == nil {
 		return nil, err
 	}
@@ -37,7 +41,7 @@ func (c *FakeNodes) Get(name string) (*api.Node, error) {
 }
 
 func (c *FakeNodes) List(opts api.ListOptions) (*api.NodeList, error) {
-	obj, err := c.Fake.Invokes(NewRootListAction("nodes", opts), &api.NodeList{})
+	obj, err := c.Fake.Invokes(NewRootListAction(nodeResourceName, opts), &api.NodeList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -46,7 +50,7 @@ func (c *FakeNodes) List(opts api.ListOptions) (*api.NodeList, error) {
 }
 
 func (c *FakeNodes) Create(node *api.Node) (*api.Node, error) {
-	obj, err := c.Fake.Invokes(NewRootCreateAction("nodes", node), node)
+	obj, err := c.Fake.Invokes(NewRootCreateAction(nodeResourceName, node), node)
 	if obj == nil {
 		return nil, err
 	}
@@ -55,7 +59,7 @@ func (c *FakeNodes) Create(node *api.Node) (*api.Node, error) {
 }
 
 func (c *FakeNodes) Update(node *api.Node) (*api.Node, error) {
-	obj, err := c.Fake.Invokes(NewRootUpdateAction("nodes", node), node)
+	obj, err := c.Fake.Invokes(NewRootUpdateAction(nodeResourceName, node), node)
 	if obj == nil {
 		return nil, err
 	}
@@ -64,18 +68,18 @@ func (c *FakeNodes) Update(node *api.Node) (*api.Node, error) {
 }
 
 func (c *FakeNodes) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewRootDeleteAction("nodes", name), &api.Node{})
+	_, err := c.Fake.Invokes(NewRootDeleteAction(nodeResourceName, name), &api.Node{})
 	return err
 }
 
 func (c *FakeNodes) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewRootWatchAction("nodes", opts))
+	return c.Fake.InvokesWatch(NewRootWatchAction(nodeResourceName, opts))
 }
 
 func (c *FakeNodes) UpdateStatus(node *api.Node) (*api.Node, error) {
 	action := CreateActionImpl{}
 	action.Verb = "update"
-	action.Resource = "nodes"
+	action.Resource = nodeResourceName
 	action.Subresource = "status"
 	action.Object = node
 

--- a/pkg/client/unversioned/testclient/fake_persistent_volume_claims.go
+++ b/pkg/client/unversioned/testclient/fake_persistent_volume_claims.go
@@ -21,13 +21,17 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	persistentVolumeClaimResourceName string = "persistentVolumeClaims"
+)
+
 type FakePersistentVolumeClaims struct {
 	Fake      *Fake
 	Namespace string
 }
 
 func (c *FakePersistentVolumeClaims) Get(name string) (*api.PersistentVolumeClaim, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("persistentvolumeclaims", c.Namespace, name), &api.PersistentVolumeClaim{})
+	obj, err := c.Fake.Invokes(NewGetAction(persistentVolumeClaimResourceName, c.Namespace, name), &api.PersistentVolumeClaim{})
 	if obj == nil {
 		return nil, err
 	}
@@ -36,7 +40,7 @@ func (c *FakePersistentVolumeClaims) Get(name string) (*api.PersistentVolumeClai
 }
 
 func (c *FakePersistentVolumeClaims) List(opts api.ListOptions) (*api.PersistentVolumeClaimList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("persistentvolumeclaims", c.Namespace, opts), &api.PersistentVolumeClaimList{})
+	obj, err := c.Fake.Invokes(NewListAction(persistentVolumeClaimResourceName, c.Namespace, opts), &api.PersistentVolumeClaimList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -45,7 +49,7 @@ func (c *FakePersistentVolumeClaims) List(opts api.ListOptions) (*api.Persistent
 }
 
 func (c *FakePersistentVolumeClaims) Create(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("persistentvolumeclaims", c.Namespace, claim), claim)
+	obj, err := c.Fake.Invokes(NewCreateAction(persistentVolumeClaimResourceName, c.Namespace, claim), claim)
 	if obj == nil {
 		return nil, err
 	}
@@ -54,7 +58,7 @@ func (c *FakePersistentVolumeClaims) Create(claim *api.PersistentVolumeClaim) (*
 }
 
 func (c *FakePersistentVolumeClaims) Update(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("persistentvolumeclaims", c.Namespace, claim), claim)
+	obj, err := c.Fake.Invokes(NewUpdateAction(persistentVolumeClaimResourceName, c.Namespace, claim), claim)
 	if obj == nil {
 		return nil, err
 	}
@@ -63,16 +67,16 @@ func (c *FakePersistentVolumeClaims) Update(claim *api.PersistentVolumeClaim) (*
 }
 
 func (c *FakePersistentVolumeClaims) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("persistentvolumeclaims", c.Namespace, name), &api.PersistentVolumeClaim{})
+	_, err := c.Fake.Invokes(NewDeleteAction(persistentVolumeClaimResourceName, c.Namespace, name), &api.PersistentVolumeClaim{})
 	return err
 }
 
 func (c *FakePersistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("persistentvolumeclaims", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(persistentVolumeClaimResourceName, c.Namespace, opts))
 }
 
 func (c *FakePersistentVolumeClaims) UpdateStatus(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("persistentvolumeclaims", "status", c.Namespace, claim), claim)
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction(persistentVolumeClaimResourceName, "status", c.Namespace, claim), claim)
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/unversioned/testclient/fake_persistent_volumes.go
+++ b/pkg/client/unversioned/testclient/fake_persistent_volumes.go
@@ -21,12 +21,16 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	persistentVolumeResourceName string = "persistentVolumes"
+)
+
 type FakePersistentVolumes struct {
 	Fake *Fake
 }
 
 func (c *FakePersistentVolumes) Get(name string) (*api.PersistentVolume, error) {
-	obj, err := c.Fake.Invokes(NewRootGetAction("persistentvolumes", name), &api.PersistentVolume{})
+	obj, err := c.Fake.Invokes(NewRootGetAction(persistentVolumeResourceName, name), &api.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}
@@ -35,7 +39,7 @@ func (c *FakePersistentVolumes) Get(name string) (*api.PersistentVolume, error) 
 }
 
 func (c *FakePersistentVolumes) List(opts api.ListOptions) (*api.PersistentVolumeList, error) {
-	obj, err := c.Fake.Invokes(NewRootListAction("persistentvolumes", opts), &api.PersistentVolumeList{})
+	obj, err := c.Fake.Invokes(NewRootListAction(persistentVolumeResourceName, opts), &api.PersistentVolumeList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -44,7 +48,7 @@ func (c *FakePersistentVolumes) List(opts api.ListOptions) (*api.PersistentVolum
 }
 
 func (c *FakePersistentVolumes) Create(pv *api.PersistentVolume) (*api.PersistentVolume, error) {
-	obj, err := c.Fake.Invokes(NewRootCreateAction("persistentvolumes", pv), pv)
+	obj, err := c.Fake.Invokes(NewRootCreateAction(persistentVolumeResourceName, pv), pv)
 	if obj == nil {
 		return nil, err
 	}
@@ -53,7 +57,7 @@ func (c *FakePersistentVolumes) Create(pv *api.PersistentVolume) (*api.Persisten
 }
 
 func (c *FakePersistentVolumes) Update(pv *api.PersistentVolume) (*api.PersistentVolume, error) {
-	obj, err := c.Fake.Invokes(NewRootUpdateAction("persistentvolumes", pv), pv)
+	obj, err := c.Fake.Invokes(NewRootUpdateAction(persistentVolumeResourceName, pv), pv)
 	if obj == nil {
 		return nil, err
 	}
@@ -62,18 +66,18 @@ func (c *FakePersistentVolumes) Update(pv *api.PersistentVolume) (*api.Persisten
 }
 
 func (c *FakePersistentVolumes) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewRootDeleteAction("persistentvolumes", name), &api.PersistentVolume{})
+	_, err := c.Fake.Invokes(NewRootDeleteAction(persistentVolumeResourceName, name), &api.PersistentVolume{})
 	return err
 }
 
 func (c *FakePersistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewRootWatchAction("persistentvolumes", opts))
+	return c.Fake.InvokesWatch(NewRootWatchAction(persistentVolumeResourceName, opts))
 }
 
 func (c *FakePersistentVolumes) UpdateStatus(pv *api.PersistentVolume) (*api.PersistentVolume, error) {
 	action := UpdateActionImpl{}
 	action.Verb = "update"
-	action.Resource = "persistentvolumes"
+	action.Resource = persistentVolumeResourceName
 	action.Subresource = "status"
 	action.Object = pv
 

--- a/pkg/client/unversioned/testclient/fake_pod_templates.go
+++ b/pkg/client/unversioned/testclient/fake_pod_templates.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	podTemplateResourceName string = "podTemplates"
+)
+
 // FakePodTemplates implements PodTemplatesInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the methods you want to test easier.
 type FakePodTemplates struct {
@@ -29,7 +33,7 @@ type FakePodTemplates struct {
 }
 
 func (c *FakePodTemplates) Get(name string) (*api.PodTemplate, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("podtemplates", c.Namespace, name), &api.PodTemplate{})
+	obj, err := c.Fake.Invokes(NewGetAction(podTemplateResourceName, c.Namespace, name), &api.PodTemplate{})
 	if obj == nil {
 		return nil, err
 	}
@@ -38,7 +42,7 @@ func (c *FakePodTemplates) Get(name string) (*api.PodTemplate, error) {
 }
 
 func (c *FakePodTemplates) List(opts api.ListOptions) (*api.PodTemplateList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("podtemplates", c.Namespace, opts), &api.PodTemplateList{})
+	obj, err := c.Fake.Invokes(NewListAction(podTemplateResourceName, c.Namespace, opts), &api.PodTemplateList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -47,7 +51,7 @@ func (c *FakePodTemplates) List(opts api.ListOptions) (*api.PodTemplateList, err
 }
 
 func (c *FakePodTemplates) Create(pod *api.PodTemplate) (*api.PodTemplate, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("podtemplates", c.Namespace, pod), pod)
+	obj, err := c.Fake.Invokes(NewCreateAction(podTemplateResourceName, c.Namespace, pod), pod)
 	if obj == nil {
 		return nil, err
 	}
@@ -56,7 +60,7 @@ func (c *FakePodTemplates) Create(pod *api.PodTemplate) (*api.PodTemplate, error
 }
 
 func (c *FakePodTemplates) Update(pod *api.PodTemplate) (*api.PodTemplate, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("podtemplates", c.Namespace, pod), pod)
+	obj, err := c.Fake.Invokes(NewUpdateAction(podTemplateResourceName, c.Namespace, pod), pod)
 	if obj == nil {
 		return nil, err
 	}
@@ -65,10 +69,10 @@ func (c *FakePodTemplates) Update(pod *api.PodTemplate) (*api.PodTemplate, error
 }
 
 func (c *FakePodTemplates) Delete(name string, options *api.DeleteOptions) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("podtemplates", c.Namespace, name), &api.PodTemplate{})
+	_, err := c.Fake.Invokes(NewDeleteAction(podTemplateResourceName, c.Namespace, name), &api.PodTemplate{})
 	return err
 }
 
 func (c *FakePodTemplates) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("podtemplates", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(podTemplateResourceName, c.Namespace, opts))
 }

--- a/pkg/client/unversioned/testclient/fake_pods.go
+++ b/pkg/client/unversioned/testclient/fake_pods.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	podResourceName string = "pods"
+)
+
 // FakePods implements PodsInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the methods you want to test easier.
 type FakePods struct {
@@ -31,7 +35,7 @@ type FakePods struct {
 }
 
 func (c *FakePods) Get(name string) (*api.Pod, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("pods", c.Namespace, name), &api.Pod{})
+	obj, err := c.Fake.Invokes(NewGetAction(podResourceName, c.Namespace, name), &api.Pod{})
 	if obj == nil {
 		return nil, err
 	}
@@ -40,7 +44,7 @@ func (c *FakePods) Get(name string) (*api.Pod, error) {
 }
 
 func (c *FakePods) List(opts api.ListOptions) (*api.PodList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("pods", c.Namespace, opts), &api.PodList{})
+	obj, err := c.Fake.Invokes(NewListAction(podResourceName, c.Namespace, opts), &api.PodList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -58,7 +62,7 @@ func (c *FakePods) List(opts api.ListOptions) (*api.PodList, error) {
 }
 
 func (c *FakePods) Create(pod *api.Pod) (*api.Pod, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("pods", c.Namespace, pod), pod)
+	obj, err := c.Fake.Invokes(NewCreateAction(podResourceName, c.Namespace, pod), pod)
 	if obj == nil {
 		return nil, err
 	}
@@ -67,7 +71,7 @@ func (c *FakePods) Create(pod *api.Pod) (*api.Pod, error) {
 }
 
 func (c *FakePods) Update(pod *api.Pod) (*api.Pod, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("pods", c.Namespace, pod), pod)
+	obj, err := c.Fake.Invokes(NewUpdateAction(podResourceName, c.Namespace, pod), pod)
 	if obj == nil {
 		return nil, err
 	}
@@ -76,18 +80,18 @@ func (c *FakePods) Update(pod *api.Pod) (*api.Pod, error) {
 }
 
 func (c *FakePods) Delete(name string, options *api.DeleteOptions) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("pods", c.Namespace, name), &api.Pod{})
+	_, err := c.Fake.Invokes(NewDeleteAction(podResourceName, c.Namespace, name), &api.Pod{})
 	return err
 }
 
 func (c *FakePods) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("pods", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(podResourceName, c.Namespace, opts))
 }
 
 func (c *FakePods) Bind(binding *api.Binding) error {
 	action := CreateActionImpl{}
 	action.Verb = "create"
-	action.Resource = "pods"
+	action.Resource = podResourceName
 	action.Subresource = "bindings"
 	action.Object = binding
 
@@ -96,7 +100,7 @@ func (c *FakePods) Bind(binding *api.Binding) error {
 }
 
 func (c *FakePods) UpdateStatus(pod *api.Pod) (*api.Pod, error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("pods", "status", c.Namespace, pod), pod)
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction(podResourceName, "status", c.Namespace, pod), pod)
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/unversioned/testclient/fake_replication_controllers.go
+++ b/pkg/client/unversioned/testclient/fake_replication_controllers.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	replicationControllerResourceName string = "replicationControllers"
+)
+
 // FakeReplicationControllers implements ReplicationControllerInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeReplicationControllers struct {
@@ -29,7 +33,7 @@ type FakeReplicationControllers struct {
 }
 
 func (c *FakeReplicationControllers) Get(name string) (*api.ReplicationController, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("replicationcontrollers", c.Namespace, name), &api.ReplicationController{})
+	obj, err := c.Fake.Invokes(NewGetAction(replicationControllerResourceName, c.Namespace, name), &api.ReplicationController{})
 	if obj == nil {
 		return nil, err
 	}
@@ -38,7 +42,7 @@ func (c *FakeReplicationControllers) Get(name string) (*api.ReplicationControlle
 }
 
 func (c *FakeReplicationControllers) List(opts api.ListOptions) (*api.ReplicationControllerList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("replicationcontrollers", c.Namespace, opts), &api.ReplicationControllerList{})
+	obj, err := c.Fake.Invokes(NewListAction(replicationControllerResourceName, c.Namespace, opts), &api.ReplicationControllerList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -47,7 +51,7 @@ func (c *FakeReplicationControllers) List(opts api.ListOptions) (*api.Replicatio
 }
 
 func (c *FakeReplicationControllers) Create(controller *api.ReplicationController) (*api.ReplicationController, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("replicationcontrollers", c.Namespace, controller), controller)
+	obj, err := c.Fake.Invokes(NewCreateAction(replicationControllerResourceName, c.Namespace, controller), controller)
 	if obj == nil {
 		return nil, err
 	}
@@ -56,7 +60,7 @@ func (c *FakeReplicationControllers) Create(controller *api.ReplicationControlle
 }
 
 func (c *FakeReplicationControllers) Update(controller *api.ReplicationController) (*api.ReplicationController, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("replicationcontrollers", c.Namespace, controller), controller)
+	obj, err := c.Fake.Invokes(NewUpdateAction(replicationControllerResourceName, c.Namespace, controller), controller)
 	if obj == nil {
 		return nil, err
 	}
@@ -65,7 +69,7 @@ func (c *FakeReplicationControllers) Update(controller *api.ReplicationControlle
 }
 
 func (c *FakeReplicationControllers) UpdateStatus(controller *api.ReplicationController) (*api.ReplicationController, error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("replicationcontrollers", "status", c.Namespace, controller), &api.ReplicationController{})
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction(replicationControllerResourceName, "status", c.Namespace, controller), &api.ReplicationController{})
 	if obj == nil {
 		return nil, err
 	}
@@ -73,10 +77,10 @@ func (c *FakeReplicationControllers) UpdateStatus(controller *api.ReplicationCon
 }
 
 func (c *FakeReplicationControllers) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("replicationcontrollers", c.Namespace, name), &api.ReplicationController{})
+	_, err := c.Fake.Invokes(NewDeleteAction(replicationControllerResourceName, c.Namespace, name), &api.ReplicationController{})
 	return err
 }
 
 func (c *FakeReplicationControllers) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("replicationcontrollers", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(replicationControllerResourceName, c.Namespace, opts))
 }

--- a/pkg/client/unversioned/testclient/fake_resource_quotas.go
+++ b/pkg/client/unversioned/testclient/fake_resource_quotas.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	resourceQuotaResourceName string = "resourceQuotas"
+)
+
 // FakeResourceQuotas implements ResourceQuotaInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the methods you want to test easier.
 type FakeResourceQuotas struct {
@@ -29,7 +33,7 @@ type FakeResourceQuotas struct {
 }
 
 func (c *FakeResourceQuotas) Get(name string) (*api.ResourceQuota, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("resourcequotas", c.Namespace, name), &api.ResourceQuota{})
+	obj, err := c.Fake.Invokes(NewGetAction(resourceQuotaResourceName, c.Namespace, name), &api.ResourceQuota{})
 	if obj == nil {
 		return nil, err
 	}
@@ -38,7 +42,7 @@ func (c *FakeResourceQuotas) Get(name string) (*api.ResourceQuota, error) {
 }
 
 func (c *FakeResourceQuotas) List(opts api.ListOptions) (*api.ResourceQuotaList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("resourcequotas", c.Namespace, opts), &api.ResourceQuotaList{})
+	obj, err := c.Fake.Invokes(NewListAction(resourceQuotaResourceName, c.Namespace, opts), &api.ResourceQuotaList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -47,7 +51,7 @@ func (c *FakeResourceQuotas) List(opts api.ListOptions) (*api.ResourceQuotaList,
 }
 
 func (c *FakeResourceQuotas) Create(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("resourcequotas", c.Namespace, resourceQuota), resourceQuota)
+	obj, err := c.Fake.Invokes(NewCreateAction(resourceQuotaResourceName, c.Namespace, resourceQuota), resourceQuota)
 	if obj == nil {
 		return nil, err
 	}
@@ -56,7 +60,7 @@ func (c *FakeResourceQuotas) Create(resourceQuota *api.ResourceQuota) (*api.Reso
 }
 
 func (c *FakeResourceQuotas) Update(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("resourcequotas", c.Namespace, resourceQuota), resourceQuota)
+	obj, err := c.Fake.Invokes(NewUpdateAction(resourceQuotaResourceName, c.Namespace, resourceQuota), resourceQuota)
 	if obj == nil {
 		return nil, err
 	}
@@ -65,16 +69,16 @@ func (c *FakeResourceQuotas) Update(resourceQuota *api.ResourceQuota) (*api.Reso
 }
 
 func (c *FakeResourceQuotas) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("resourcequotas", c.Namespace, name), &api.ResourceQuota{})
+	_, err := c.Fake.Invokes(NewDeleteAction(resourceQuotaResourceName, c.Namespace, name), &api.ResourceQuota{})
 	return err
 }
 
 func (c *FakeResourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("resourcequotas", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(resourceQuotaResourceName, c.Namespace, opts))
 }
 
 func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("resourcequotas", "status", c.Namespace, resourceQuota), resourceQuota)
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction(resourceQuotaResourceName, "status", c.Namespace, resourceQuota), resourceQuota)
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/unversioned/testclient/fake_scales.go
+++ b/pkg/client/unversioned/testclient/fake_scales.go
@@ -20,6 +20,10 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
+const (
+	scaleSubResourceName string = "scale"
+)
+
 // FakeScales implements ScaleInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the methods you want to test easier.
 type FakeScales struct {
@@ -32,7 +36,7 @@ func (c *FakeScales) Get(kind string, name string) (result *extensions.Scale, er
 	action.Verb = "get"
 	action.Namespace = c.Namespace
 	action.Resource = kind
-	action.Subresource = "scale"
+	action.Subresource = scaleSubResourceName
 	action.Name = name
 	obj, err := c.Fake.Invokes(action, &extensions.Scale{})
 	result = obj.(*extensions.Scale)
@@ -44,7 +48,7 @@ func (c *FakeScales) Update(kind string, scale *extensions.Scale) (result *exten
 	action.Verb = "update"
 	action.Namespace = c.Namespace
 	action.Resource = kind
-	action.Subresource = "scale"
+	action.Subresource = scaleSubResourceName
 	action.Object = scale
 	obj, err := c.Fake.Invokes(action, scale)
 	result = obj.(*extensions.Scale)

--- a/pkg/client/unversioned/testclient/fake_secrets.go
+++ b/pkg/client/unversioned/testclient/fake_secrets.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	secretResourceName string = "secrets"
+)
+
 // Fake implements SecretInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeSecrets struct {
@@ -29,7 +33,7 @@ type FakeSecrets struct {
 }
 
 func (c *FakeSecrets) Get(name string) (*api.Secret, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("secrets", c.Namespace, name), &api.Secret{})
+	obj, err := c.Fake.Invokes(NewGetAction(secretResourceName, c.Namespace, name), &api.Secret{})
 	if obj == nil {
 		return nil, err
 	}
@@ -38,7 +42,7 @@ func (c *FakeSecrets) Get(name string) (*api.Secret, error) {
 }
 
 func (c *FakeSecrets) List(opts api.ListOptions) (*api.SecretList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("secrets", c.Namespace, opts), &api.SecretList{})
+	obj, err := c.Fake.Invokes(NewListAction(secretResourceName, c.Namespace, opts), &api.SecretList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -47,7 +51,7 @@ func (c *FakeSecrets) List(opts api.ListOptions) (*api.SecretList, error) {
 }
 
 func (c *FakeSecrets) Create(secret *api.Secret) (*api.Secret, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("secrets", c.Namespace, secret), secret)
+	obj, err := c.Fake.Invokes(NewCreateAction(secretResourceName, c.Namespace, secret), secret)
 	if obj == nil {
 		return nil, err
 	}
@@ -56,7 +60,7 @@ func (c *FakeSecrets) Create(secret *api.Secret) (*api.Secret, error) {
 }
 
 func (c *FakeSecrets) Update(secret *api.Secret) (*api.Secret, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("secrets", c.Namespace, secret), secret)
+	obj, err := c.Fake.Invokes(NewUpdateAction(secretResourceName, c.Namespace, secret), secret)
 	if obj == nil {
 		return nil, err
 	}
@@ -65,10 +69,10 @@ func (c *FakeSecrets) Update(secret *api.Secret) (*api.Secret, error) {
 }
 
 func (c *FakeSecrets) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("secrets", c.Namespace, name), &api.Secret{})
+	_, err := c.Fake.Invokes(NewDeleteAction(secretResourceName, c.Namespace, name), &api.Secret{})
 	return err
 }
 
 func (c *FakeSecrets) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("secrets", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(secretResourceName, c.Namespace, opts))
 }

--- a/pkg/client/unversioned/testclient/fake_service_accounts.go
+++ b/pkg/client/unversioned/testclient/fake_service_accounts.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	serviceAccountResourceName string = "serviceaccounts"
+)
+
 // FakeServiceAccounts implements ServiceAccountsInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeServiceAccounts struct {
@@ -29,7 +33,7 @@ type FakeServiceAccounts struct {
 }
 
 func (c *FakeServiceAccounts) Get(name string) (*api.ServiceAccount, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("serviceaccounts", c.Namespace, name), &api.ServiceAccount{})
+	obj, err := c.Fake.Invokes(NewGetAction(serviceAccountResourceName, c.Namespace, name), &api.ServiceAccount{})
 	if obj == nil {
 		return nil, err
 	}
@@ -38,7 +42,7 @@ func (c *FakeServiceAccounts) Get(name string) (*api.ServiceAccount, error) {
 }
 
 func (c *FakeServiceAccounts) List(opts api.ListOptions) (*api.ServiceAccountList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("serviceaccounts", c.Namespace, opts), &api.ServiceAccountList{})
+	obj, err := c.Fake.Invokes(NewListAction(serviceAccountResourceName, c.Namespace, opts), &api.ServiceAccountList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -47,7 +51,7 @@ func (c *FakeServiceAccounts) List(opts api.ListOptions) (*api.ServiceAccountLis
 }
 
 func (c *FakeServiceAccounts) Create(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("serviceaccounts", c.Namespace, serviceAccount), serviceAccount)
+	obj, err := c.Fake.Invokes(NewCreateAction(serviceAccountResourceName, c.Namespace, serviceAccount), serviceAccount)
 	if obj == nil {
 		return nil, err
 	}
@@ -56,7 +60,7 @@ func (c *FakeServiceAccounts) Create(serviceAccount *api.ServiceAccount) (*api.S
 }
 
 func (c *FakeServiceAccounts) Update(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("serviceaccounts", c.Namespace, serviceAccount), serviceAccount)
+	obj, err := c.Fake.Invokes(NewUpdateAction(serviceAccountResourceName, c.Namespace, serviceAccount), serviceAccount)
 	if obj == nil {
 		return nil, err
 	}
@@ -65,10 +69,10 @@ func (c *FakeServiceAccounts) Update(serviceAccount *api.ServiceAccount) (*api.S
 }
 
 func (c *FakeServiceAccounts) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("serviceaccounts", c.Namespace, name), &api.ServiceAccount{})
+	_, err := c.Fake.Invokes(NewDeleteAction(serviceAccountResourceName, c.Namespace, name), &api.ServiceAccount{})
 	return err
 }
 
 func (c *FakeServiceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("serviceaccounts", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(serviceAccountResourceName, c.Namespace, opts))
 }

--- a/pkg/client/unversioned/testclient/fake_services.go
+++ b/pkg/client/unversioned/testclient/fake_services.go
@@ -22,6 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	serviceResourceName string = "services"
+)
+
 // Fake implements ServiceInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the method you want to test easier.
 type FakeServices struct {
@@ -30,7 +34,7 @@ type FakeServices struct {
 }
 
 func (c *FakeServices) Get(name string) (*api.Service, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("services", c.Namespace, name), &api.Service{})
+	obj, err := c.Fake.Invokes(NewGetAction(serviceResourceName, c.Namespace, name), &api.Service{})
 	if obj == nil {
 		return nil, err
 	}
@@ -39,7 +43,7 @@ func (c *FakeServices) Get(name string) (*api.Service, error) {
 }
 
 func (c *FakeServices) List(opts api.ListOptions) (*api.ServiceList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("services", c.Namespace, opts), &api.ServiceList{})
+	obj, err := c.Fake.Invokes(NewListAction(serviceResourceName, c.Namespace, opts), &api.ServiceList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -48,7 +52,7 @@ func (c *FakeServices) List(opts api.ListOptions) (*api.ServiceList, error) {
 }
 
 func (c *FakeServices) Create(service *api.Service) (*api.Service, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("services", c.Namespace, service), service)
+	obj, err := c.Fake.Invokes(NewCreateAction(serviceResourceName, c.Namespace, service), service)
 	if obj == nil {
 		return nil, err
 	}
@@ -57,7 +61,7 @@ func (c *FakeServices) Create(service *api.Service) (*api.Service, error) {
 }
 
 func (c *FakeServices) Update(service *api.Service) (*api.Service, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("services", c.Namespace, service), service)
+	obj, err := c.Fake.Invokes(NewUpdateAction(serviceResourceName, c.Namespace, service), service)
 	if obj == nil {
 		return nil, err
 	}
@@ -66,14 +70,14 @@ func (c *FakeServices) Update(service *api.Service) (*api.Service, error) {
 }
 
 func (c *FakeServices) Delete(name string) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("services", c.Namespace, name), &api.Service{})
+	_, err := c.Fake.Invokes(NewDeleteAction(serviceResourceName, c.Namespace, name), &api.Service{})
 	return err
 }
 
 func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("services", c.Namespace, opts))
+	return c.Fake.InvokesWatch(NewWatchAction(serviceResourceName, c.Namespace, opts))
 }
 
 func (c *FakeServices) ProxyGet(scheme, name, port, path string, params map[string]string) client.ResponseWrapper {
-	return c.Fake.InvokesProxy(NewProxyGetAction("services", c.Namespace, scheme, name, port, path, params))
+	return c.Fake.InvokesProxy(NewProxyGetAction(serviceResourceName, c.Namespace, scheme, name, port, path, params))
 }

--- a/pkg/client/unversioned/thirdpartyresources_test.go
+++ b/pkg/client/unversioned/thirdpartyresources_test.go
@@ -26,16 +26,16 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getThirdPartyResourceName() string {
-	return "thirdpartyresources"
-}
+const (
+	thirdPartyResourceName = "thirdpartyresources"
+)
 
 func TestListThirdPartyResources(t *testing.T) {
 	ns := api.NamespaceAll
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getThirdPartyResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(thirdPartyResourceName, ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &extensions.ThirdPartyResourceList{
@@ -62,7 +62,7 @@ func TestListThirdPartyResources(t *testing.T) {
 func TestGetThirdPartyResource(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(thirdPartyResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ThirdPartyResource{
@@ -98,7 +98,7 @@ func TestUpdateThirdPartyResource(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(thirdPartyResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ThirdPartyResource{
@@ -123,7 +123,7 @@ func TestUpdateThirdPartyResourceUpdateStatus(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(thirdPartyResourceName, ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ThirdPartyResource{
@@ -145,7 +145,7 @@ func TestUpdateThirdPartyResourceUpdateStatus(t *testing.T) {
 func TestDeleteThirdPartyResource(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(thirdPartyResourceName, ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Extensions().ThirdPartyResources(ns).Delete("foo")
@@ -158,7 +158,7 @@ func TestCreateThirdPartyResource(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), ns, ""), Body: requestThirdPartyResource, Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(thirdPartyResourceName, ns, ""), Body: requestThirdPartyResource, Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ThirdPartyResource{

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -203,7 +203,7 @@ func deleteAllContent(kubeClient client.Interface, versions *unversioned.APIVers
 		if err != nil {
 			return estimate, err
 		}
-		if containsResource(resources, "horizontalpodautoscalers") {
+		if containsResource(resources, "horizontalPodAutoscalers") {
 			err = deleteHorizontalPodAutoscalers(kubeClient.Extensions(), namespace)
 			if err != nil {
 				return estimate, err

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -103,15 +103,15 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *unversioned.APIV
 	// TODO: Reuse the constants for all these strings from testclient
 	pendingActionSet := sets.NewString(
 		strings.Join([]string{"get", "namespaces", ""}, "-"),
-		strings.Join([]string{"list", "replicationcontrollers", ""}, "-"),
+		strings.Join([]string{"list", "replicationControllers", ""}, "-"),
 		strings.Join([]string{"list", "services", ""}, "-"),
 		strings.Join([]string{"list", "pods", ""}, "-"),
-		strings.Join([]string{"list", "resourcequotas", ""}, "-"),
+		strings.Join([]string{"list", "resourceQuotas", ""}, "-"),
 		strings.Join([]string{"list", "secrets", ""}, "-"),
-		strings.Join([]string{"list", "limitranges", ""}, "-"),
+		strings.Join([]string{"list", "limitRanges", ""}, "-"),
 		strings.Join([]string{"delete-collection", "events", ""}, "-"),
 		strings.Join([]string{"list", "serviceaccounts", ""}, "-"),
-		strings.Join([]string{"list", "persistentvolumeclaims", ""}, "-"),
+		strings.Join([]string{"list", "persistentVolumeClaims", ""}, "-"),
 		strings.Join([]string{"create", "namespaces", "finalize"}, "-"),
 	)
 
@@ -120,7 +120,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *unversioned.APIV
 			strings.Join([]string{"list", "daemonsets", ""}, "-"),
 			strings.Join([]string{"list", "deployments", ""}, "-"),
 			strings.Join([]string{"list", "jobs", ""}, "-"),
-			strings.Join([]string{"list", "horizontalpodautoscalers", ""}, "-"),
+			strings.Join([]string{"list", "horizontalPodAutoscalers", ""}, "-"),
 			strings.Join([]string{"list", "ingresses", ""}, "-"),
 			strings.Join([]string{"get", "resource", ""}, "-"),
 		)
@@ -147,7 +147,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *unversioned.APIV
 		mockClient := testclient.NewSimpleFake(testInput.testNamespace)
 		if containsVersion(versions, "extensions/v1beta1") {
 			resources := []unversioned.APIResource{}
-			for _, resource := range []string{"daemonsets", "deployments", "jobs", "horizontalpodautoscalers", "ingresses"} {
+			for _, resource := range []string{"daemonsets", "deployments", "jobs", "horizontalPodAutoscalers", "ingresses"} {
 				resources = append(resources, unversioned.APIResource{Name: resource})
 			}
 			mockClient.Resources = map[string]*unversioned.APIResourceList{

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -77,7 +77,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) *testclient.Fake {
 	tc.eventCreated = false
 
 	fakeClient := &testclient.Fake{}
-	fakeClient.AddReactor("list", "horizontalpodautoscalers", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
+	fakeClient.AddReactor("list", "horizontalPodAutoscalers", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
 		obj := &extensions.HorizontalPodAutoscalerList{
 			Items: []extensions.HorizontalPodAutoscaler{
 				{
@@ -175,7 +175,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) *testclient.Fake {
 		return true, obj, nil
 	})
 
-	fakeClient.AddReactor("update", "horizontalpodautoscalers", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
+	fakeClient.AddReactor("update", "horizontalPodAutoscalers", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
 		obj := action.(testclient.UpdateAction).GetObject().(*extensions.HorizontalPodAutoscaler)
 		assert.Equal(t, namespace, obj.Namespace)
 		assert.Equal(t, hpaName, obj.Name)

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -120,7 +120,7 @@ func validateSyncReplication(t *testing.T, fakePodControl *controller.FakePodCon
 }
 
 func replicationControllerResourceName() string {
-	return "replicationcontrollers"
+	return "replicationControllers"
 }
 
 type serverResponse struct {
@@ -592,7 +592,7 @@ func TestControllerUpdateRequeue(t *testing.T) {
 func TestControllerUpdateStatusWithFailure(t *testing.T) {
 	rc := newReplicationController(1)
 	fakeClient := &testclient.Fake{}
-	fakeClient.AddReactor("get", "replicationcontrollers", func(action testclient.Action) (bool, runtime.Object, error) {
+	fakeClient.AddReactor("get", "replicationControllers", func(action testclient.Action) (bool, runtime.Object, error) {
 		return true, rc, nil
 	})
 	fakeClient.AddReactor("*", "*", func(action testclient.Action) (bool, runtime.Object, error) {
@@ -603,7 +603,7 @@ func TestControllerUpdateStatusWithFailure(t *testing.T) {
 	updateReplicaCount(fakeRCClient, *rc, numReplicas)
 	updates, gets := 0, 0
 	for _, a := range fakeClient.Actions() {
-		if a.GetResource() != "replicationcontrollers" {
+		if a.GetResource() != "replicationControllers" {
 			t.Errorf("Unexpected action %+v", a)
 			continue
 		}

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -186,9 +186,9 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewCreateAction("secrets", api.NamespaceDefault, createdTokenSecret()),
-				testclient.NewUpdateAction("serviceaccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(emptySecretReferences()))),
+				testclient.NewUpdateAction("serviceAccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(emptySecretReferences()))),
 			},
 		},
 		"new serviceaccount with no secrets with unsynced secret store": {
@@ -198,9 +198,9 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewCreateAction("secrets", api.NamespaceDefault, createdTokenSecret()),
-				testclient.NewUpdateAction("serviceaccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(emptySecretReferences()))),
+				testclient.NewUpdateAction("serviceAccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(emptySecretReferences()))),
 			},
 		},
 		"new serviceaccount with missing secrets": {
@@ -208,9 +208,9 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedServiceAccount: serviceAccount(missingSecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewCreateAction("secrets", api.NamespaceDefault, createdTokenSecret()),
-				testclient.NewUpdateAction("serviceaccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(missingSecretReferences()))),
+				testclient.NewUpdateAction("serviceAccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(missingSecretReferences()))),
 			},
 		},
 		"new serviceaccount with missing secrets with unsynced secret store": {
@@ -226,9 +226,9 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedServiceAccount: serviceAccount(regularSecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewCreateAction("secrets", api.NamespaceDefault, createdTokenSecret()),
-				testclient.NewUpdateAction("serviceaccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(regularSecretReferences()))),
+				testclient.NewUpdateAction("serviceAccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(regularSecretReferences()))),
 			},
 		},
 		"new serviceaccount with token secrets": {
@@ -243,7 +243,7 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 			},
 		},
 
@@ -252,9 +252,9 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewCreateAction("secrets", api.NamespaceDefault, createdTokenSecret()),
-				testclient.NewUpdateAction("serviceaccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(emptySecretReferences()))),
+				testclient.NewUpdateAction("serviceAccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(emptySecretReferences()))),
 			},
 		},
 		"updated serviceaccount with no secrets with unsynced secret store": {
@@ -264,9 +264,9 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewCreateAction("secrets", api.NamespaceDefault, createdTokenSecret()),
-				testclient.NewUpdateAction("serviceaccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(emptySecretReferences()))),
+				testclient.NewUpdateAction("serviceAccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(emptySecretReferences()))),
 			},
 		},
 		"updated serviceaccount with missing secrets": {
@@ -274,9 +274,9 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedServiceAccount: serviceAccount(missingSecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewCreateAction("secrets", api.NamespaceDefault, createdTokenSecret()),
-				testclient.NewUpdateAction("serviceaccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(missingSecretReferences()))),
+				testclient.NewUpdateAction("serviceAccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(missingSecretReferences()))),
 			},
 		},
 		"updated serviceaccount with missing secrets with unsynced secret store": {
@@ -292,9 +292,9 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedServiceAccount: serviceAccount(regularSecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewCreateAction("secrets", api.NamespaceDefault, createdTokenSecret()),
-				testclient.NewUpdateAction("serviceaccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(regularSecretReferences()))),
+				testclient.NewUpdateAction("serviceAccounts", api.NamespaceDefault, serviceAccount(addTokenSecretReference(regularSecretReferences()))),
 			},
 		},
 		"updated serviceaccount with token secrets": {
@@ -308,7 +308,7 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 			},
 		},
 
@@ -341,7 +341,7 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedSecret: serviceAccountTokenSecret(),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewDeleteAction("secrets", api.NamespaceDefault, "token-secret-1"),
 			},
 		},
@@ -384,7 +384,7 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedSecret: serviceAccountTokenSecret(),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
 				testclient.NewDeleteAction("secrets", api.NamespaceDefault, "token-secret-1"),
 			},
 		},
@@ -432,8 +432,8 @@ func TestTokenCreation(t *testing.T) {
 
 			DeletedSecret: serviceAccountTokenSecret(),
 			ExpectedActions: []testclient.Action{
-				testclient.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
-				testclient.NewUpdateAction("serviceaccounts", api.NamespaceDefault, serviceAccount(emptySecretReferences())),
+				testclient.NewGetAction("serviceAccounts", api.NamespaceDefault, "default"),
+				testclient.NewUpdateAction("serviceAccounts", api.NamespaceDefault, serviceAccount(emptySecretReferences())),
 			},
 		},
 		"deleted secret with serviceaccount without reference": {

--- a/pkg/kubectl/scale_test.go
+++ b/pkg/kubectl/scale_test.go
@@ -103,10 +103,10 @@ func TestReplicationControllerScale(t *testing.T) {
 	if len(actions) != 2 {
 		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", actions)
 	}
-	if action, ok := actions[0].(testclient.GetAction); !ok || action.GetResource() != "replicationcontrollers" || action.GetName() != name {
+	if action, ok := actions[0].(testclient.GetAction); !ok || action.GetResource() != "replicationControllers" || action.GetName() != name {
 		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
 	}
-	if action, ok := actions[1].(testclient.UpdateAction); !ok || action.GetResource() != "replicationcontrollers" || action.GetObject().(*api.ReplicationController).Spec.Replicas != int(count) {
+	if action, ok := actions[1].(testclient.UpdateAction); !ok || action.GetResource() != "replicationControllers" || action.GetObject().(*api.ReplicationController).Spec.Replicas != int(count) {
 		t.Errorf("unexpected action %v, expected update-replicationController with replicas = %d", actions[1], count)
 	}
 }
@@ -127,7 +127,7 @@ func TestReplicationControllerScaleFailsPreconditions(t *testing.T) {
 	if len(actions) != 1 {
 		t.Errorf("unexpected actions: %v, expected 1 action (get)", actions)
 	}
-	if action, ok := actions[0].(testclient.GetAction); !ok || action.GetResource() != "replicationcontrollers" || action.GetName() != name {
+	if action, ok := actions[0].(testclient.GetAction); !ok || action.GetResource() != "replicationControllers" || action.GetName() != name {
 		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
 	}
 }

--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -254,7 +254,7 @@ func TestReplicationControllerStop(t *testing.T) {
 			continue
 		}
 		for i, verb := range test.ExpectedActions {
-			if actions[i].GetResource() != "replicationcontrollers" {
+			if actions[i].GetResource() != "replicationControllers" {
 				t.Errorf("%s unexpected action: %+v, expected %s-replicationController", test.Name, actions[i], verb)
 			}
 			if actions[i].GetVerb() != verb {


### PR DESCRIPTION
To reduce code duplication and inconsistent methods, every resource name in client/unversioned is a constant now.
