### PR TITLE
fix ./master.sh: line 125: --data-dir=/var/etcd/data: No such file or directory

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -121,7 +121,7 @@ start_k8s(){
     gcr.io/google_containers/etcd:2.2.1 \
     /usr/local/bin/etcd \
     --listen-client-urls=http://127.0.0.1:4001,http://${MASTER_IP}:4001 \
-    --advertise-client-urls=http://${MASTER_IP}:4001
+    --advertise-client-urls=http://${MASTER_IP}:4001 \
     --data-dir=/var/etcd/data
 
     sleep 5


### PR DESCRIPTION
when run the getting-started-guides/docker-multinode/master.sh
There seems like miss a '\' at line 124

fix ./master.sh: line 125: --data-dir=/var/etcd/data: No such file or directory
