### PR TITLE
Fix #11543 - use private ip instead of local hostname for AWS 

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1067,12 +1067,12 @@ func (s *AWSCloud) getSelfAWSInstance() (*awsInstance, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error fetching instance-id from ec2 metadata service: %v", err)
 		}
-		privateDnsName, err := s.metadata.GetMetadata("local-hostname")
+		privateIpAddress, err := s.metadata.GetMetadata("local-ipv4")
 		if err != nil {
-			return nil, fmt.Errorf("error fetching local-hostname from ec2 metadata service: %v", err)
+			return nil, fmt.Errorf("error fetching local-ipv4 from ec2 metadata service: %v", err)
 		}
 
-		i = newAWSInstance(s.ec2, instanceId, privateDnsName)
+		i = newAWSInstance(s.ec2, instanceId, privateIpAddress)
 		s.selfAWSInstance = i
 	}
 
@@ -2071,7 +2071,7 @@ func (a *AWSCloud) getInstancesByNodeNames(nodeNames []string) ([]*ec2.Instance,
 // Returns nil if it does not exist
 func (a *AWSCloud) findInstanceByNodeName(nodeName string) (*ec2.Instance, error) {
 	filters := []*ec2.Filter{
-		newEc2Filter("private-dns-name", nodeName),
+		newEc2Filter("private-ip-address", nodeName),
 	}
 	filters = a.addFilters(filters)
 	request := &ec2.DescribeInstancesInput{

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -266,11 +266,11 @@ func contains(haystack []*string, needle string) bool {
 
 func instanceMatchesFilter(instance *ec2.Instance, filter *ec2.Filter) bool {
 	name := *filter.Name
-	if name == "private-dns-name" {
-		if instance.PrivateDnsName == nil {
+	if name == "private-ip-address" {
+		if instance.PrivateIpAddress == nil {
 			return false
 		}
-		return contains(filter.Values, *instance.PrivateDnsName)
+		return contains(filter.Values, *instance.PrivateIpAddress)
 	}
 	panic("Unknown filter name: " + name)
 }
@@ -602,7 +602,7 @@ func TestNodeAddresses(t *testing.T) {
 	//1
 	instance1.InstanceId = aws.String("instance-same")
 	instance1.PrivateDnsName = aws.String("instance-same.ec2.internal")
-	instance1.PrivateIpAddress = aws.String("192.168.0.2")
+	instance1.PrivateIpAddress = aws.String("192.168.0.1")
 	instance1.InstanceType = aws.String("c3.large")
 	state1 := ec2.InstanceState{
 		Name: aws.String("running"),
@@ -612,19 +612,19 @@ func TestNodeAddresses(t *testing.T) {
 	instances := []*ec2.Instance{&instance0, &instance1}
 
 	aws1, _ := mockInstancesResp([]*ec2.Instance{})
-	_, err1 := aws1.NodeAddresses("instance-mismatch.ec2.internal")
+	_, err1 := aws1.NodeAddresses("192.168.0.12")
 	if err1 == nil {
 		t.Errorf("Should error when no instance found")
 	}
 
 	aws2, _ := mockInstancesResp(instances)
-	_, err2 := aws2.NodeAddresses("instance-same.ec2.internal")
+	_, err2 := aws2.NodeAddresses("192.168.0.1")
 	if err2 == nil {
 		t.Errorf("Should error when multiple instances found")
 	}
 
 	aws3, _ := mockInstancesResp(instances[0:1])
-	addrs3, err3 := aws3.NodeAddresses("instance-same.ec2.internal")
+	addrs3, err3 := aws3.NodeAddresses("192.168.0.1")
 	if err3 != nil {
 		t.Errorf("Should not error when instance found")
 	}


### PR DESCRIPTION
When using [private hosted zones](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html), the `local-hostname` returned by the instance metadata includes the private hosted zone e.g. `ip-x-x-x-x.my-domain.io` but when kubernetes filter `DescribeInstances` with `private-dns-name` using this value, AWS returns no result as it uses `ip-x-x-x-x.ec2.internal` through the API (different behaviour between instance metadata and AWS API). 

This patch fixes the problem by using the instance id instead of the local hostname which can be used without issue to filter the call to `DescribeInstances` as suggested in #11543. Note that it should be possible to use the private ip address (`local-ipv4`) if preferable for the same result.

**Caveat**: this will change the name when nodes are registered from something like `ip-x-x-x-x.ec2.internal` to something like `i-abc123` which may surprise existing users. Using the private ip address may be closer to today's behaviour. 
