### PR TITLE
Fix #17647 - AWS add tag to SG only if existing tag

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1552,12 +1552,14 @@ func (s *AWSCloud) ensureSecurityGroup(name string, description string, vpcID st
 		tags = append(tags, tag)
 	}
 
-	tagRequest := &ec2.CreateTagsInput{}
-	tagRequest.Resources = []*string{&groupID}
-	tagRequest.Tags = tags
-	if _, err := s.createTags(tagRequest); err != nil {
-		// Not clear how to recover fully from this; we're OK because we don't match on tags, but that is a little odd
-		return "", fmt.Errorf("error tagging security group: %v", err)
+	if len(tags) > 0 {
+		tagRequest := &ec2.CreateTagsInput{}
+		tagRequest.Resources = []*string{&groupID}
+		tagRequest.Tags = tags
+		if _, err := s.createTags(tagRequest); err != nil {
+			// Not clear how to recover fully from this; we're OK because we don't match on tags, but that is a little odd
+			return "", fmt.Errorf("error tagging security group: %v", err)
+		}
 	}
 	return groupID, nil
 }


### PR DESCRIPTION
Check if tags exist before trying to tag the security group on ELB creation otherwise ELB creation fails when vpc/nodes haven't be tagged.

The message on cloud provider initialisation seems to indicate that it should be a supported use case: https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/aws.go#L579.
