### PR TITLE
remove TODO: move restmapper to pkg/api/rest

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
-	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/rest/restmapper"
 	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/apiserver"
@@ -279,9 +279,9 @@ func (s *APIServer) verifyClusterIPFlags() {
 	}
 }
 
-type newEtcdFunc func(string, []string, meta.VersionInterfacesFunc, string, string) (storage.Interface, error)
+type newEtcdFunc func(string, []string, restmapper.VersionInterfacesFunc, string, string) (storage.Interface, error)
 
-func newEtcd(etcdConfigFile string, etcdServerList []string, interfacesFunc meta.VersionInterfacesFunc, storageVersion, pathPrefix string) (etcdStorage storage.Interface, err error) {
+func newEtcd(etcdConfigFile string, etcdServerList []string, interfacesFunc restmapper.VersionInterfacesFunc, storageVersion, pathPrefix string) (etcdStorage storage.Interface, err error) {
 	if storageVersion == "" {
 		return etcdStorage, fmt.Errorf("storageVersion is required to create a etcd storage")
 	}

--- a/cmd/kube-apiserver/app/server_test.go
+++ b/cmd/kube-apiserver/app/server_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/rest/restmapper"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/storage"
 )
@@ -130,7 +130,7 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		newEtcd := func(_ string, serverList []string, _ meta.VersionInterfacesFunc, _, _ string) (storage.Interface, error) {
+		newEtcd := func(_ string, serverList []string, _ restmapper.VersionInterfacesFunc, _, _ string) (storage.Interface, error) {
 			if !reflect.DeepEqual(test.servers, serverList) {
 				t.Errorf("unexpected server list, expected: %#v, got: %#v", test.servers, serverList)
 			}

--- a/pkg/api/mapper.go
+++ b/pkg/api/mapper.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/rest/restmapper"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
@@ -28,17 +29,17 @@ import (
 var RESTMapper meta.RESTMapper
 
 func init() {
-	RESTMapper = meta.MultiRESTMapper{}
+	RESTMapper = restmapper.MultiRESTMapper{}
 }
 
 func RegisterRESTMapper(m meta.RESTMapper) {
-	RESTMapper = append(RESTMapper.(meta.MultiRESTMapper), m)
+	RESTMapper = append(RESTMapper.(restmapper.MultiRESTMapper), m)
 }
 
-func NewDefaultRESTMapper(group string, groupVersionStrings []string, interfacesFunc meta.VersionInterfacesFunc,
-	importPathPrefix string, ignoredKinds, rootScoped sets.String) *meta.DefaultRESTMapper {
+func NewDefaultRESTMapper(group string, groupVersionStrings []string, interfacesFunc restmapper.VersionInterfacesFunc,
+	importPathPrefix string, ignoredKinds, rootScoped sets.String) *restmapper.DefaultRESTMapper {
 
-	mapper := meta.NewDefaultRESTMapper(group, groupVersionStrings, interfacesFunc)
+	mapper := restmapper.NewDefaultRESTMapper(group, groupVersionStrings, interfacesFunc)
 	// enumerate all supported versions, get the kinds, and register with the mapper how to address
 	// our resources.
 	for _, gvString := range groupVersionStrings {
@@ -58,9 +59,9 @@ func NewDefaultRESTMapper(group string, groupVersionStrings []string, interfaces
 			if !strings.HasPrefix(oType.PkgPath(), importPathPrefix) || ignoredKinds.Has(kind) {
 				continue
 			}
-			scope := meta.RESTScopeNamespace
+			scope := restmapper.RESTScopeNamespace
 			if rootScoped.Has(kind) {
-				scope = meta.RESTScopeRoot
+				scope = restmapper.RESTScopeRoot
 			}
 			mapper.Add(scope, kind, gv.String(), false)
 		}

--- a/pkg/api/rest/restmapper/restmapper_test.go
+++ b/pkg/api/rest/restmapper/restmapper_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package meta
+package restmapper
 
 import (
 	"errors"
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -71,16 +72,16 @@ func (fakeConvertor) ConvertFieldLabel(version, kind, label, value string) (stri
 }
 
 var validCodec = fakeCodec{}
-var validAccessor = resourceAccessor{}
+var validAccessor = meta.NewAccessor()
 var validConvertor = fakeConvertor{}
 
-func fakeInterfaces(version string) (*VersionInterfaces, error) {
-	return &VersionInterfaces{Codec: validCodec, ObjectConvertor: validConvertor, MetadataAccessor: validAccessor}, nil
+func fakeInterfaces(version string) (*meta.VersionInterfaces, error) {
+	return &meta.VersionInterfaces{Codec: validCodec, ObjectConvertor: validConvertor, MetadataAccessor: validAccessor}, nil
 }
 
 var unmatchedErr = errors.New("no version")
 
-func unmatchedVersionInterfaces(version string) (*VersionInterfaces, error) {
+func unmatchedVersionInterfaces(version string) (*meta.VersionInterfaces, error) {
 	return nil, unmatchedErr
 }
 

--- a/pkg/client/unversioned/scale.go
+++ b/pkg/client/unversioned/scale.go
@@ -17,7 +17,7 @@ limitations under the License.
 package unversioned
 
 import (
-	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/rest/restmapper"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
@@ -48,14 +48,14 @@ func newScales(c *ExtensionsClient, namespace string) *scales {
 // Get takes the reference to scale subresource and returns the subresource or error, if one occurs.
 func (c *scales) Get(kind string, name string) (result *extensions.Scale, err error) {
 	result = &extensions.Scale{}
-	resource, _ := meta.KindToResource(kind, false)
+	resource, _ := restmapper.KindToResource(kind, false)
 	err = c.client.Get().Namespace(c.ns).Resource(resource).Name(name).SubResource("scale").Do().Into(result)
 	return
 }
 
 func (c *scales) Update(kind string, scale *extensions.Scale) (result *extensions.Scale, err error) {
 	result = &extensions.Scale{}
-	resource, _ := meta.KindToResource(kind, false)
+	resource, _ := restmapper.KindToResource(kind, false)
 	err = c.client.Put().
 		Namespace(scale.Namespace).
 		Resource(resource).

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
-	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/rest/restmapper"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/kubectl"
@@ -362,7 +362,7 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 	if err != nil {
 		return err
 	}
-	_, res := meta.KindToResource(kind, false)
+	_, res := restmapper.KindToResource(kind, false)
 	cmdutil.PrintSuccess(mapper, false, out, res, oldName, message)
 	return nil
 }

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
+	"k8s.io/kubernetes/pkg/api/rest/restmapper"
 	"k8s.io/kubernetes/pkg/api/validation"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
@@ -476,7 +477,7 @@ func (c *clientSwaggerSchema) ValidateBytes(data []byte) error {
 	if ok := registered.IsRegisteredAPIVersion(version); !ok {
 		return fmt.Errorf("API version %q isn't supported, only supports API versions %q", version, registered.RegisteredVersions)
 	}
-	resource, _ := meta.KindToResource(kind, false)
+	resource, _ := restmapper.KindToResource(kind, false)
 	group, err := c.mapper.GroupForResource(resource)
 	if err != nil {
 		return fmt.Errorf("could not find api group for %s: %v", kind, err)

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -34,7 +34,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/rest/restmapper"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -237,7 +237,7 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		if !name.IsValid() {
 			name = reflect.ValueOf("<unknown>")
 		}
-		_, resource := meta.KindToResource(kind.String(), false)
+		_, resource := restmapper.KindToResource(kind.String(), false)
 
 		fmt.Fprintf(w, "%s/%s\n", resource, name)
 	}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
-	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/api/rest/restmapper"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -350,7 +350,7 @@ type Master struct {
 
 // NewEtcdStorage returns a storage.Interface for the provided arguments or an error if the version
 // is incorrect.
-func NewEtcdStorage(client tools.EtcdClient, interfacesFunc meta.VersionInterfacesFunc, version, prefix string) (etcdStorage storage.Interface, err error) {
+func NewEtcdStorage(client tools.EtcdClient, interfacesFunc restmapper.VersionInterfacesFunc, version, prefix string) (etcdStorage storage.Interface, err error) {
 	versionInterfaces, err := interfacesFunc(version)
 	if err != nil {
 		return etcdStorage, err


### PR DESCRIPTION
This PR helps to removeTODO: move restmapper to pkg/api/rest
