### PR TITLE
In pkg/kubectl/describe.go function Matches support unordered types matches #17667

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -1732,13 +1732,18 @@ type typeFunc struct {
 }
 
 // Matches returns true when the passed types exactly match the Extra list.
-// TODO: allow unordered types to be matched and reorderd.
 func (fn typeFunc) Matches(types []reflect.Type) bool {
 	if len(fn.Extra) != len(types) {
 		return false
 	}
+	// reorder the items in array types and fn.Extra
+	// convert the type into string and sort them, check if they are matched
+	varMap := make(map[reflect.Type]bool)
+	for i := range fn.Extra {
+		varMap[fn.Extra[i]] = true
+	}
 	for i := range types {
-		if fn.Extra[i] != types[i] {
+		if _, found := varMap[types[i]]; !found {
 			return false
 		}
 	}


### PR DESCRIPTION
The argument of function need to be matched. However, it did not support unorder matches in original codes. This is a TODO and I fix it.(line 1763 in pkg/kubectl/describe.go). I use a map to solve it which could compare two types array's difference.

Fix issue #17667
