### PR TITLE
Scheduler metrics: binding rate limiter saturation rate

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -549,7 +549,7 @@
 		},
 		{
 			"ImportPath": "github.com/juju/ratelimit",
-			"Rev": "772f5c38e468398c4511514f4f6aa9a4185bc0a0"
+			"Rev": "77ed1c8a01217656d2080ad51981f6e99adaa177"
 		},
 		{
 			"ImportPath": "github.com/kardianos/osext",

--- a/pkg/util/throttle.go
+++ b/pkg/util/throttle.go
@@ -28,7 +28,7 @@ type RateLimiter interface {
 	Stop()
 }
 
-type tickRateLimiter struct {
+type tokenBucketRateLimiter struct {
 	limiter *ratelimit.Bucket
 }
 
@@ -39,7 +39,7 @@ type tickRateLimiter struct {
 // The maximum number of tokens in the bucket is capped at 'burst'.
 func NewTokenBucketRateLimiter(qps float32, burst int) RateLimiter {
 	limiter := ratelimit.NewBucketWithRate(float64(qps), int64(burst))
-	return &tickRateLimiter{limiter}
+	return &tokenBucketRateLimiter{limiter}
 }
 
 type fakeRateLimiter struct{}
@@ -48,16 +48,16 @@ func NewFakeRateLimiter() RateLimiter {
 	return &fakeRateLimiter{}
 }
 
-func (t *tickRateLimiter) TryAccept() bool {
+func (t *tokenBucketRateLimiter) TryAccept() bool {
 	return t.limiter.TakeAvailable(1) == 1
 }
 
 // Accept will block until a token becomes available
-func (t *tickRateLimiter) Accept() {
+func (t *tokenBucketRateLimiter) Accept() {
 	t.limiter.Wait(1)
 }
 
-func (t *tickRateLimiter) Stop() {
+func (t *tokenBucketRateLimiter) Stop() {
 }
 
 func (t *fakeRateLimiter) TryAccept() bool {

--- a/plugin/pkg/scheduler/metrics/metrics.go
+++ b/plugin/pkg/scheduler/metrics/metrics.go
@@ -25,6 +25,8 @@ import (
 
 const schedulerSubsystem = "scheduler"
 
+var BindingSaturationReportInterval = 1 * time.Second
+
 var (
 	E2eSchedulingLatency = prometheus.NewSummary(
 		prometheus.SummaryOpts{
@@ -50,6 +52,13 @@ var (
 			MaxAge:    time.Hour,
 		},
 	)
+	BindingRateLimiterSaturation = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: schedulerSubsystem,
+			Name:      "binding_ratelimiter_saturation",
+			Help:      "Binding rateLimiter's saturation rate in percentage",
+		},
+	)
 )
 
 var registerMetrics sync.Once
@@ -61,6 +70,7 @@ func Register() {
 		prometheus.MustRegister(E2eSchedulingLatency)
 		prometheus.MustRegister(SchedulingAlgorithmLatency)
 		prometheus.MustRegister(BindingLatency)
+		prometheus.MustRegister(BindingRateLimiterSaturation)
 	})
 }
 

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -77,6 +77,7 @@ type Config struct {
 	Binder     Binder
 
 	// Rate at which we can create pods
+	// If this field is nil, we don't have any rate limit.
 	BindPodsRateLimiter util.RateLimiter
 
 	// NextPod should be a function that blocks until the next pod
@@ -107,6 +108,12 @@ func New(c *Config) *Scheduler {
 
 // Run begins watching and scheduling. It starts a goroutine and returns immediately.
 func (s *Scheduler) Run() {
+	if s.config.BindPodsRateLimiter != nil {
+		go util.Forever(func() {
+			sat := s.config.BindPodsRateLimiter.Saturation()
+			metrics.BindingRateLimiterSaturation.Set(sat)
+		}, metrics.BindingSaturationReportInterval)
+	}
 	go util.Until(s.scheduleOne, 0, s.config.StopEverything)
 }
 

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -307,6 +307,10 @@ func (fr *FakeRateLimiter) TryAccept() bool {
 	return true
 }
 
+func (fr *FakeRateLimiter) Saturation() float64 {
+	return 0
+}
+
 func (fr *FakeRateLimiter) Stop() {}
 
 func (fr *FakeRateLimiter) Accept() {


### PR DESCRIPTION
This PR exposes the pod binding rate. We are exposing it because there is a rate limiter. We want to measure and see how long before it becomes a bottleneck.
