### PR TITLE
RateLimiter: change CanAccept() to TryAccept()

### DIFF
--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -35,7 +35,7 @@ import (
 type fakeRL bool
 
 func (fakeRL) Stop()             {}
-func (f fakeRL) CanAccept() bool { return bool(f) }
+func (f fakeRL) TryAccept() bool { return bool(f) }
 func (f fakeRL) Accept()         {}
 
 func expectHTTP(url string, code int, t *testing.T) {

--- a/pkg/controller/node/rate_limited_queue.go
+++ b/pkg/controller/node/rate_limited_queue.go
@@ -163,7 +163,7 @@ func (q *RateLimitedTimedQueue) Try(fn ActionFunc) {
 	val, ok := q.queue.Head()
 	for ok {
 		// rate limit the queue checking
-		if !q.limiter.CanAccept() {
+		if !q.limiter.TryAccept() {
 			glog.V(10).Info("Try rate limitted...")
 			// Try again later
 			break

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -197,7 +197,7 @@ func (p dockerPuller) Pull(image string, secrets []api.Secret) error {
 }
 
 func (p throttledDockerPuller) Pull(image string, secrets []api.Secret) error {
-	if p.limiter.CanAccept() {
+	if p.limiter.TryAccept() {
 		return p.puller.Pull(image, secrets)
 	}
 	return fmt.Errorf("pull QPS exceeded.")

--- a/pkg/util/throttle.go
+++ b/pkg/util/throttle.go
@@ -19,8 +19,9 @@ package util
 import "github.com/juju/ratelimit"
 
 type RateLimiter interface {
-	// CanAccept returns true if the rate is below the limit, false otherwise
-	CanAccept() bool
+	// TryAccept returns true if a token is taken immediately. Otherwise,
+	// it returns false.
+	TryAccept() bool
 	// Accept returns once a token becomes available.
 	Accept()
 	// Stop stops the rate limiter, subsequent calls to CanAccept will return false
@@ -47,7 +48,7 @@ func NewFakeRateLimiter() RateLimiter {
 	return &fakeRateLimiter{}
 }
 
-func (t *tickRateLimiter) CanAccept() bool {
+func (t *tickRateLimiter) TryAccept() bool {
 	return t.limiter.TakeAvailable(1) == 1
 }
 
@@ -59,7 +60,7 @@ func (t *tickRateLimiter) Accept() {
 func (t *tickRateLimiter) Stop() {
 }
 
-func (t *fakeRateLimiter) CanAccept() bool {
+func (t *fakeRateLimiter) TryAccept() bool {
 	return true
 }
 

--- a/pkg/util/throttle_test.go
+++ b/pkg/util/throttle_test.go
@@ -24,28 +24,28 @@ import (
 func TestBasicThrottle(t *testing.T) {
 	r := NewTokenBucketRateLimiter(1, 3)
 	for i := 0; i < 3; i++ {
-		if !r.CanAccept() {
+		if !r.TryAccept() {
 			t.Error("unexpected false accept")
 		}
 	}
-	if r.CanAccept() {
+	if r.TryAccept() {
 		t.Error("unexpected true accept")
 	}
 }
 
 func TestIncrementThrottle(t *testing.T) {
 	r := NewTokenBucketRateLimiter(1, 1)
-	if !r.CanAccept() {
+	if !r.TryAccept() {
 		t.Error("unexpected false accept")
 	}
-	if r.CanAccept() {
+	if r.TryAccept() {
 		t.Error("unexpected true accept")
 	}
 
 	// Allow to refill
 	time.Sleep(2 * time.Second)
 
-	if !r.CanAccept() {
+	if !r.TryAccept() {
 		t.Error("unexpected false accept")
 	}
 }

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -302,14 +302,14 @@ type FakeRateLimiter struct {
 	acceptValues []bool
 }
 
-func (fr *FakeRateLimiter) CanAccept() bool {
+func (fr *FakeRateLimiter) TryAccept() bool {
 	return true
 }
 
 func (fr *FakeRateLimiter) Stop() {}
 
 func (fr *FakeRateLimiter) Accept() {
-	fr.acceptValues = append(fr.acceptValues, fr.r.CanAccept())
+	fr.acceptValues = append(fr.acceptValues, fr.r.TryAccept())
 }
 
 func TestSchedulerRateLimitsBinding(t *testing.T) {


### PR DESCRIPTION
The `CanAccept` interface description is not accurate. The actual behavior is taking a token instead of just testing without side-effect. And all the users of the interface relies on the taking behavior, not testing.

This commit gives it a better name and also a more accurate description.

/cc @brendandburns @liggitt 
