### PR TITLE
Fill in kubelet raw metrics API

### DIFF
--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -524,43 +524,55 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr31 || yy2arr31 {
 				if yyq31[2] {
 					yy39 := &x.ObjectMeta
-					yy39.CodecEncodeSelf(e)
+					yym40 := z.EncBinary()
+					_ = yym40
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy39) {
+					} else {
+						z.EncFallback(yy39)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq31[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy40 := &x.ObjectMeta
-					yy40.CodecEncodeSelf(e)
+					yy41 := &x.ObjectMeta
+					yym42 := z.EncBinary()
+					_ = yym42
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy41) {
+					} else {
+						z.EncFallback(yy41)
+					}
 				}
 			}
 			if yyr31 || yy2arr31 {
 				if yyq31[3] {
-					yy42 := &x.Spec
-					yy42.CodecEncodeSelf(e)
+					yy44 := &x.Spec
+					yy44.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq31[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy43 := &x.Spec
-					yy43.CodecEncodeSelf(e)
+					yy45 := &x.Spec
+					yy45.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				if yyq31[4] {
-					yy45 := &x.Status
-					yy45.CodecEncodeSelf(e)
+					yy47 := &x.Status
+					yy47.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq31[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy46 := &x.Status
-					yy46.CodecEncodeSelf(e)
+					yy48 := &x.Status
+					yy48.CodecEncodeSelf(e)
 				}
 			}
 			if yysep31 {
@@ -574,24 +586,24 @@ func (x *Scale) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym47 := z.DecBinary()
-	_ = yym47
+	yym49 := z.DecBinary()
+	_ = yym49
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl48 := r.ReadMapStart()
-			if yyl48 == 0 {
+			yyl50 := r.ReadMapStart()
+			if yyl50 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl48, d)
+				x.codecDecodeSelfFromMap(yyl50, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl48 := r.ReadArrayStart()
-			if yyl48 == 0 {
+			yyl50 := r.ReadArrayStart()
+			if yyl50 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl48, d)
+				x.codecDecodeSelfFromArray(yyl50, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -603,12 +615,12 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys49Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys49Slc
-	var yyhl49 bool = l >= 0
-	for yyj49 := 0; ; yyj49++ {
-		if yyhl49 {
-			if yyj49 >= l {
+	var yys51Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys51Slc
+	var yyhl51 bool = l >= 0
+	for yyj51 := 0; ; yyj51++ {
+		if yyhl51 {
+			if yyj51 >= l {
 				break
 			}
 		} else {
@@ -616,9 +628,9 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys49Slc = r.DecodeBytes(yys49Slc, true, true)
-		yys49 := string(yys49Slc)
-		switch yys49 {
+		yys51Slc = r.DecodeBytes(yys51Slc, true, true)
+		yys51 := string(yys51Slc)
+		switch yys51 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -635,28 +647,34 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv52 := &x.ObjectMeta
-				yyv52.CodecDecodeSelf(d)
+				yyv54 := &x.ObjectMeta
+				yym55 := z.DecBinary()
+				_ = yym55
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv54) {
+				} else {
+					z.DecFallback(yyv54, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ScaleSpec{}
 			} else {
-				yyv53 := &x.Spec
-				yyv53.CodecDecodeSelf(d)
+				yyv56 := &x.Spec
+				yyv56.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ScaleStatus{}
 			} else {
-				yyv54 := &x.Status
-				yyv54.CodecDecodeSelf(d)
+				yyv57 := &x.Status
+				yyv57.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys49)
-		} // end switch yys49
-	} // end for yyj49
-	if !yyhl49 {
+			z.DecStructFieldNotFound(-1, yys51)
+		} // end switch yys51
+	} // end for yyj51
+	if !yyhl51 {
 		r.ReadEnd()
 	}
 }
@@ -665,16 +683,16 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj55 int
-	var yyb55 bool
-	var yyhl55 bool = l >= 0
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	var yyj58 int
+	var yyb58 bool
+	var yyhl58 bool = l >= 0
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
@@ -683,13 +701,13 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
@@ -698,65 +716,71 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv58 := &x.ObjectMeta
-		yyv58.CodecDecodeSelf(d)
+		yyv61 := &x.ObjectMeta
+		yym62 := z.DecBinary()
+		_ = yym62
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv61) {
+		} else {
+			z.DecFallback(yyv61, false)
+		}
 	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ScaleSpec{}
 	} else {
-		yyv59 := &x.Spec
-		yyv59.CodecDecodeSelf(d)
+		yyv63 := &x.Spec
+		yyv63.CodecDecodeSelf(d)
 	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ScaleStatus{}
 	} else {
-		yyv60 := &x.Status
-		yyv60.CodecDecodeSelf(d)
+		yyv64 := &x.Status
+		yyv64.CodecDecodeSelf(d)
 	}
 	for {
-		yyj55++
-		if yyhl55 {
-			yyb55 = yyj55 > l
+		yyj58++
+		if yyhl58 {
+			yyb58 = yyj58 > l
 		} else {
-			yyb55 = r.CheckBreak()
+			yyb58 = r.CheckBreak()
 		}
-		if yyb55 {
+		if yyb58 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj55-1, "")
+		z.DecStructFieldNotFound(yyj58-1, "")
 	}
 	r.ReadEnd()
 }
@@ -768,74 +792,74 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym61 := z.EncBinary()
-		_ = yym61
+		yym65 := z.EncBinary()
+		_ = yym65
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep62 := !z.EncBinary()
-			yy2arr62 := z.EncBasicHandle().StructToArray
-			var yyq62 [2]bool
-			_, _, _ = yysep62, yyq62, yy2arr62
-			const yyr62 bool = false
-			yyq62[0] = x.Kind != ""
-			yyq62[1] = x.APIVersion != ""
-			if yyr62 || yy2arr62 {
+			yysep66 := !z.EncBinary()
+			yy2arr66 := z.EncBasicHandle().StructToArray
+			var yyq66 [2]bool
+			_, _, _ = yysep66, yyq66, yy2arr66
+			const yyr66 bool = false
+			yyq66[0] = x.Kind != ""
+			yyq66[1] = x.APIVersion != ""
+			if yyr66 || yy2arr66 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn62 int = 0
-				for _, b := range yyq62 {
+				var yynn66 int = 0
+				for _, b := range yyq66 {
 					if b {
-						yynn62++
+						yynn66++
 					}
 				}
-				r.EncodeMapStart(yynn62)
+				r.EncodeMapStart(yynn66)
 			}
-			if yyr62 || yy2arr62 {
-				if yyq62[0] {
-					yym64 := z.EncBinary()
-					_ = yym64
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq62[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym65 := z.EncBinary()
-					_ = yym65
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr62 || yy2arr62 {
-				if yyq62[1] {
-					yym67 := z.EncBinary()
-					_ = yym67
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq62[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr66 || yy2arr66 {
+				if yyq66[0] {
 					yym68 := z.EncBinary()
 					_ = yym68
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq66[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym69 := z.EncBinary()
+					_ = yym69
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr66 || yy2arr66 {
+				if yyq66[1] {
+					yym71 := z.EncBinary()
+					_ = yym71
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq66[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym72 := z.EncBinary()
+					_ = yym72
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yysep62 {
+			if yysep66 {
 				r.EncodeEnd()
 			}
 		}
@@ -846,24 +870,24 @@ func (x *ReplicationControllerDummy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym69 := z.DecBinary()
-	_ = yym69
+	yym73 := z.DecBinary()
+	_ = yym73
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl70 := r.ReadMapStart()
-			if yyl70 == 0 {
+			yyl74 := r.ReadMapStart()
+			if yyl74 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl70, d)
+				x.codecDecodeSelfFromMap(yyl74, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl70 := r.ReadArrayStart()
-			if yyl70 == 0 {
+			yyl74 := r.ReadArrayStart()
+			if yyl74 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl70, d)
+				x.codecDecodeSelfFromArray(yyl74, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -875,12 +899,12 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys71Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys71Slc
-	var yyhl71 bool = l >= 0
-	for yyj71 := 0; ; yyj71++ {
-		if yyhl71 {
-			if yyj71 >= l {
+	var yys75Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys75Slc
+	var yyhl75 bool = l >= 0
+	for yyj75 := 0; ; yyj75++ {
+		if yyhl75 {
+			if yyj75 >= l {
 				break
 			}
 		} else {
@@ -888,9 +912,9 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
-		yys71Slc = r.DecodeBytes(yys71Slc, true, true)
-		yys71 := string(yys71Slc)
-		switch yys71 {
+		yys75Slc = r.DecodeBytes(yys75Slc, true, true)
+		yys75 := string(yys75Slc)
+		switch yys75 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -904,10 +928,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys71)
-		} // end switch yys71
-	} // end for yyj71
-	if !yyhl71 {
+			z.DecStructFieldNotFound(-1, yys75)
+		} // end switch yys75
+	} // end for yyj75
+	if !yyhl75 {
 		r.ReadEnd()
 	}
 }
@@ -916,16 +940,16 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj74 int
-	var yyb74 bool
-	var yyhl74 bool = l >= 0
-	yyj74++
-	if yyhl74 {
-		yyb74 = yyj74 > l
+	var yyj78 int
+	var yyb78 bool
+	var yyhl78 bool = l >= 0
+	yyj78++
+	if yyhl78 {
+		yyb78 = yyj78 > l
 	} else {
-		yyb74 = r.CheckBreak()
+		yyb78 = r.CheckBreak()
 	}
-	if yyb74 {
+	if yyb78 {
 		r.ReadEnd()
 		return
 	}
@@ -934,13 +958,13 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj74++
-	if yyhl74 {
-		yyb74 = yyj74 > l
+	yyj78++
+	if yyhl78 {
+		yyb78 = yyj78 > l
 	} else {
-		yyb74 = r.CheckBreak()
+		yyb78 = r.CheckBreak()
 	}
-	if yyb74 {
+	if yyb78 {
 		r.ReadEnd()
 		return
 	}
@@ -950,16 +974,16 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj74++
-		if yyhl74 {
-			yyb74 = yyj74 > l
+		yyj78++
+		if yyhl78 {
+			yyb78 = yyj78 > l
 		} else {
-			yyb74 = r.CheckBreak()
+			yyb78 = r.CheckBreak()
 		}
-		if yyb74 {
+		if yyb78 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj74-1, "")
+		z.DecStructFieldNotFound(yyj78-1, "")
 	}
 	r.ReadEnd()
 }
@@ -971,101 +995,101 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym77 := z.EncBinary()
-		_ = yym77
+		yym81 := z.EncBinary()
+		_ = yym81
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep78 := !z.EncBinary()
-			yy2arr78 := z.EncBasicHandle().StructToArray
-			var yyq78 [4]bool
-			_, _, _ = yysep78, yyq78, yy2arr78
-			const yyr78 bool = false
-			yyq78[0] = x.Kind != ""
-			yyq78[1] = x.Name != ""
-			yyq78[2] = x.APIVersion != ""
-			yyq78[3] = x.Subresource != ""
-			if yyr78 || yy2arr78 {
+			yysep82 := !z.EncBinary()
+			yy2arr82 := z.EncBasicHandle().StructToArray
+			var yyq82 [4]bool
+			_, _, _ = yysep82, yyq82, yy2arr82
+			const yyr82 bool = false
+			yyq82[0] = x.Kind != ""
+			yyq82[1] = x.Name != ""
+			yyq82[2] = x.APIVersion != ""
+			yyq82[3] = x.Subresource != ""
+			if yyr82 || yy2arr82 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn78 int = 0
-				for _, b := range yyq78 {
+				var yynn82 int = 0
+				for _, b := range yyq82 {
 					if b {
-						yynn78++
+						yynn82++
 					}
 				}
-				r.EncodeMapStart(yynn78)
+				r.EncodeMapStart(yynn82)
 			}
-			if yyr78 || yy2arr78 {
-				if yyq78[0] {
-					yym80 := z.EncBinary()
-					_ = yym80
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq78[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym81 := z.EncBinary()
-					_ = yym81
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr78 || yy2arr78 {
-				if yyq78[1] {
-					yym83 := z.EncBinary()
-					_ = yym83
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq78[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
+			if yyr82 || yy2arr82 {
+				if yyq82[0] {
 					yym84 := z.EncBinary()
 					_ = yym84
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				}
-			}
-			if yyr78 || yy2arr78 {
-				if yyq78[2] {
-					yym86 := z.EncBinary()
-					_ = yym86
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq78[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+				if yyq82[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym85 := z.EncBinary()
+					_ = yym85
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr82 || yy2arr82 {
+				if yyq82[1] {
 					yym87 := z.EncBinary()
 					_ = yym87
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq82[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					yym88 := z.EncBinary()
+					_ = yym88
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				}
+			}
+			if yyr82 || yy2arr82 {
+				if yyq82[2] {
+					yym90 := z.EncBinary()
+					_ = yym90
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq82[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym91 := z.EncBinary()
+					_ = yym91
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr78 || yy2arr78 {
-				if yyq78[3] {
-					yym89 := z.EncBinary()
-					_ = yym89
+			if yyr82 || yy2arr82 {
+				if yyq82[3] {
+					yym93 := z.EncBinary()
+					_ = yym93
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
@@ -1074,17 +1098,17 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq78[3] {
+				if yyq82[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("subresource"))
-					yym90 := z.EncBinary()
-					_ = yym90
+					yym94 := z.EncBinary()
+					_ = yym94
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
 					}
 				}
 			}
-			if yysep78 {
+			if yysep82 {
 				r.EncodeEnd()
 			}
 		}
@@ -1095,24 +1119,24 @@ func (x *SubresourceReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym91 := z.DecBinary()
-	_ = yym91
+	yym95 := z.DecBinary()
+	_ = yym95
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl92 := r.ReadMapStart()
-			if yyl92 == 0 {
+			yyl96 := r.ReadMapStart()
+			if yyl96 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl92, d)
+				x.codecDecodeSelfFromMap(yyl96, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl92 := r.ReadArrayStart()
-			if yyl92 == 0 {
+			yyl96 := r.ReadArrayStart()
+			if yyl96 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl92, d)
+				x.codecDecodeSelfFromArray(yyl96, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1124,12 +1148,12 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys93Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys93Slc
-	var yyhl93 bool = l >= 0
-	for yyj93 := 0; ; yyj93++ {
-		if yyhl93 {
-			if yyj93 >= l {
+	var yys97Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys97Slc
+	var yyhl97 bool = l >= 0
+	for yyj97 := 0; ; yyj97++ {
+		if yyhl97 {
+			if yyj97 >= l {
 				break
 			}
 		} else {
@@ -1137,9 +1161,9 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys93Slc = r.DecodeBytes(yys93Slc, true, true)
-		yys93 := string(yys93Slc)
-		switch yys93 {
+		yys97Slc = r.DecodeBytes(yys97Slc, true, true)
+		yys97 := string(yys97Slc)
+		switch yys97 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -1165,10 +1189,10 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.Subresource = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys93)
-		} // end switch yys93
-	} // end for yyj93
-	if !yyhl93 {
+			z.DecStructFieldNotFound(-1, yys97)
+		} // end switch yys97
+	} // end for yyj97
+	if !yyhl97 {
 		r.ReadEnd()
 	}
 }
@@ -1177,16 +1201,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj98 int
-	var yyb98 bool
-	var yyhl98 bool = l >= 0
-	yyj98++
-	if yyhl98 {
-		yyb98 = yyj98 > l
+	var yyj102 int
+	var yyb102 bool
+	var yyhl102 bool = l >= 0
+	yyj102++
+	if yyhl102 {
+		yyb102 = yyj102 > l
 	} else {
-		yyb98 = r.CheckBreak()
+		yyb102 = r.CheckBreak()
 	}
-	if yyb98 {
+	if yyb102 {
 		r.ReadEnd()
 		return
 	}
@@ -1195,13 +1219,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj98++
-	if yyhl98 {
-		yyb98 = yyj98 > l
+	yyj102++
+	if yyhl102 {
+		yyb102 = yyj102 > l
 	} else {
-		yyb98 = r.CheckBreak()
+		yyb102 = r.CheckBreak()
 	}
-	if yyb98 {
+	if yyb102 {
 		r.ReadEnd()
 		return
 	}
@@ -1210,13 +1234,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj98++
-	if yyhl98 {
-		yyb98 = yyj98 > l
+	yyj102++
+	if yyhl102 {
+		yyb102 = yyj102 > l
 	} else {
-		yyb98 = r.CheckBreak()
+		yyb102 = r.CheckBreak()
 	}
-	if yyb98 {
+	if yyb102 {
 		r.ReadEnd()
 		return
 	}
@@ -1225,13 +1249,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj98++
-	if yyhl98 {
-		yyb98 = yyj98 > l
+	yyj102++
+	if yyhl102 {
+		yyb102 = yyj102 > l
 	} else {
-		yyb98 = r.CheckBreak()
+		yyb102 = r.CheckBreak()
 	}
-	if yyb98 {
+	if yyb102 {
 		r.ReadEnd()
 		return
 	}
@@ -1241,16 +1265,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.Subresource = string(r.DecodeString())
 	}
 	for {
-		yyj98++
-		if yyhl98 {
-			yyb98 = yyj98 > l
+		yyj102++
+		if yyhl102 {
+			yyb102 = yyj102 > l
 		} else {
-			yyb98 = r.CheckBreak()
+			yyb102 = r.CheckBreak()
 		}
-		if yyb98 {
+		if yyb102 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj98-1, "")
+		z.DecStructFieldNotFound(yyj102-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1262,44 +1286,44 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym103 := z.EncBinary()
-		_ = yym103
+		yym107 := z.EncBinary()
+		_ = yym107
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep104 := !z.EncBinary()
-			yy2arr104 := z.EncBasicHandle().StructToArray
-			var yyq104 [1]bool
-			_, _, _ = yysep104, yyq104, yy2arr104
-			const yyr104 bool = false
-			if yyr104 || yy2arr104 {
+			yysep108 := !z.EncBinary()
+			yy2arr108 := z.EncBasicHandle().StructToArray
+			var yyq108 [1]bool
+			_, _, _ = yysep108, yyq108, yy2arr108
+			const yyr108 bool = false
+			if yyr108 || yy2arr108 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn104 int = 1
-				for _, b := range yyq104 {
+				var yynn108 int = 1
+				for _, b := range yyq108 {
 					if b {
-						yynn104++
+						yynn108++
 					}
 				}
-				r.EncodeMapStart(yynn104)
+				r.EncodeMapStart(yynn108)
 			}
-			if yyr104 || yy2arr104 {
-				yym106 := z.EncBinary()
-				_ = yym106
+			if yyr108 || yy2arr108 {
+				yym110 := z.EncBinary()
+				_ = yym110
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("targetPercentage"))
-				yym107 := z.EncBinary()
-				_ = yym107
+				yym111 := z.EncBinary()
+				_ = yym111
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			}
-			if yysep104 {
+			if yysep108 {
 				r.EncodeEnd()
 			}
 		}
@@ -1310,24 +1334,24 @@ func (x *CPUTargetUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym108 := z.DecBinary()
-	_ = yym108
+	yym112 := z.DecBinary()
+	_ = yym112
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl109 := r.ReadMapStart()
-			if yyl109 == 0 {
+			yyl113 := r.ReadMapStart()
+			if yyl113 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl109, d)
+				x.codecDecodeSelfFromMap(yyl113, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl109 := r.ReadArrayStart()
-			if yyl109 == 0 {
+			yyl113 := r.ReadArrayStart()
+			if yyl113 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl109, d)
+				x.codecDecodeSelfFromArray(yyl113, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1339,12 +1363,12 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys110Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys110Slc
-	var yyhl110 bool = l >= 0
-	for yyj110 := 0; ; yyj110++ {
-		if yyhl110 {
-			if yyj110 >= l {
+	var yys114Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys114Slc
+	var yyhl114 bool = l >= 0
+	for yyj114 := 0; ; yyj114++ {
+		if yyhl114 {
+			if yyj114 >= l {
 				break
 			}
 		} else {
@@ -1352,9 +1376,9 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys110Slc = r.DecodeBytes(yys110Slc, true, true)
-		yys110 := string(yys110Slc)
-		switch yys110 {
+		yys114Slc = r.DecodeBytes(yys114Slc, true, true)
+		yys114 := string(yys114Slc)
+		switch yys114 {
 		case "targetPercentage":
 			if r.TryDecodeAsNil() {
 				x.TargetPercentage = 0
@@ -1362,10 +1386,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys110)
-		} // end switch yys110
-	} // end for yyj110
-	if !yyhl110 {
+			z.DecStructFieldNotFound(-1, yys114)
+		} // end switch yys114
+	} // end for yyj114
+	if !yyhl114 {
 		r.ReadEnd()
 	}
 }
@@ -1374,16 +1398,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj112 int
-	var yyb112 bool
-	var yyhl112 bool = l >= 0
-	yyj112++
-	if yyhl112 {
-		yyb112 = yyj112 > l
+	var yyj116 int
+	var yyb116 bool
+	var yyhl116 bool = l >= 0
+	yyj116++
+	if yyhl116 {
+		yyb116 = yyj116 > l
 	} else {
-		yyb112 = r.CheckBreak()
+		yyb116 = r.CheckBreak()
 	}
-	if yyb112 {
+	if yyb116 {
 		r.ReadEnd()
 		return
 	}
@@ -1393,16 +1417,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj112++
-		if yyhl112 {
-			yyb112 = yyj112 > l
+		yyj116++
+		if yyhl116 {
+			yyb116 = yyj116 > l
 		} else {
-			yyb112 = r.CheckBreak()
+			yyb116 = r.CheckBreak()
 		}
-		if yyb112 {
+		if yyb116 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj112-1, "")
+		z.DecStructFieldNotFound(yyj116-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1414,87 +1438,87 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym114 := z.EncBinary()
-		_ = yym114
+		yym118 := z.EncBinary()
+		_ = yym118
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep115 := !z.EncBinary()
-			yy2arr115 := z.EncBasicHandle().StructToArray
-			var yyq115 [4]bool
-			_, _, _ = yysep115, yyq115, yy2arr115
-			const yyr115 bool = false
-			yyq115[1] = x.MinReplicas != nil
-			yyq115[3] = x.CPUUtilization != nil
-			if yyr115 || yy2arr115 {
+			yysep119 := !z.EncBinary()
+			yy2arr119 := z.EncBasicHandle().StructToArray
+			var yyq119 [4]bool
+			_, _, _ = yysep119, yyq119, yy2arr119
+			const yyr119 bool = false
+			yyq119[1] = x.MinReplicas != nil
+			yyq119[3] = x.CPUUtilization != nil
+			if yyr119 || yy2arr119 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn115 int = 2
-				for _, b := range yyq115 {
+				var yynn119 int = 2
+				for _, b := range yyq119 {
 					if b {
-						yynn115++
+						yynn119++
 					}
 				}
-				r.EncodeMapStart(yynn115)
+				r.EncodeMapStart(yynn119)
 			}
-			if yyr115 || yy2arr115 {
-				yy117 := &x.ScaleRef
-				yy117.CodecEncodeSelf(e)
+			if yyr119 || yy2arr119 {
+				yy121 := &x.ScaleRef
+				yy121.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("scaleRef"))
-				yy118 := &x.ScaleRef
-				yy118.CodecEncodeSelf(e)
+				yy122 := &x.ScaleRef
+				yy122.CodecEncodeSelf(e)
 			}
-			if yyr115 || yy2arr115 {
-				if yyq115[1] {
+			if yyr119 || yy2arr119 {
+				if yyq119[1] {
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy120 := *x.MinReplicas
-						yym121 := z.EncBinary()
-						_ = yym121
+						yy124 := *x.MinReplicas
+						yym125 := z.EncBinary()
+						_ = yym125
 						if false {
 						} else {
-							r.EncodeInt(int64(yy120))
+							r.EncodeInt(int64(yy124))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq115[1] {
+				if yyq119[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReplicas"))
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy122 := *x.MinReplicas
-						yym123 := z.EncBinary()
-						_ = yym123
+						yy126 := *x.MinReplicas
+						yym127 := z.EncBinary()
+						_ = yym127
 						if false {
 						} else {
-							r.EncodeInt(int64(yy122))
+							r.EncodeInt(int64(yy126))
 						}
 					}
 				}
 			}
-			if yyr115 || yy2arr115 {
-				yym125 := z.EncBinary()
-				_ = yym125
+			if yyr119 || yy2arr119 {
+				yym129 := z.EncBinary()
+				_ = yym129
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxReplicas"))
-				yym126 := z.EncBinary()
-				_ = yym126
+				yym130 := z.EncBinary()
+				_ = yym130
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			}
-			if yyr115 || yy2arr115 {
-				if yyq115[3] {
+			if yyr119 || yy2arr119 {
+				if yyq119[3] {
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
 					} else {
@@ -1504,7 +1528,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq115[3] {
+				if yyq119[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpuUtilization"))
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
@@ -1513,7 +1537,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep115 {
+			if yysep119 {
 				r.EncodeEnd()
 			}
 		}
@@ -1524,24 +1548,24 @@ func (x *HorizontalPodAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym128 := z.DecBinary()
-	_ = yym128
+	yym132 := z.DecBinary()
+	_ = yym132
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl129 := r.ReadMapStart()
-			if yyl129 == 0 {
+			yyl133 := r.ReadMapStart()
+			if yyl133 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl129, d)
+				x.codecDecodeSelfFromMap(yyl133, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl129 := r.ReadArrayStart()
-			if yyl129 == 0 {
+			yyl133 := r.ReadArrayStart()
+			if yyl133 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl129, d)
+				x.codecDecodeSelfFromArray(yyl133, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1553,12 +1577,12 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys130Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys130Slc
-	var yyhl130 bool = l >= 0
-	for yyj130 := 0; ; yyj130++ {
-		if yyhl130 {
-			if yyj130 >= l {
+	var yys134Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys134Slc
+	var yyhl134 bool = l >= 0
+	for yyj134 := 0; ; yyj134++ {
+		if yyhl134 {
+			if yyj134 >= l {
 				break
 			}
 		} else {
@@ -1566,15 +1590,15 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys130Slc = r.DecodeBytes(yys130Slc, true, true)
-		yys130 := string(yys130Slc)
-		switch yys130 {
+		yys134Slc = r.DecodeBytes(yys134Slc, true, true)
+		yys134 := string(yys134Slc)
+		switch yys134 {
 		case "scaleRef":
 			if r.TryDecodeAsNil() {
 				x.ScaleRef = SubresourceReference{}
 			} else {
-				yyv131 := &x.ScaleRef
-				yyv131.CodecDecodeSelf(d)
+				yyv135 := &x.ScaleRef
+				yyv135.CodecDecodeSelf(d)
 			}
 		case "minReplicas":
 			if r.TryDecodeAsNil() {
@@ -1585,8 +1609,8 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				if x.MinReplicas == nil {
 					x.MinReplicas = new(int)
 				}
-				yym133 := z.DecBinary()
-				_ = yym133
+				yym137 := z.DecBinary()
+				_ = yym137
 				if false {
 				} else {
 					*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -1610,10 +1634,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				x.CPUUtilization.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys130)
-		} // end switch yys130
-	} // end for yyj130
-	if !yyhl130 {
+			z.DecStructFieldNotFound(-1, yys134)
+		} // end switch yys134
+	} // end for yyj134
+	if !yyhl134 {
 		r.ReadEnd()
 	}
 }
@@ -1622,32 +1646,32 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj136 int
-	var yyb136 bool
-	var yyhl136 bool = l >= 0
-	yyj136++
-	if yyhl136 {
-		yyb136 = yyj136 > l
+	var yyj140 int
+	var yyb140 bool
+	var yyhl140 bool = l >= 0
+	yyj140++
+	if yyhl140 {
+		yyb140 = yyj140 > l
 	} else {
-		yyb136 = r.CheckBreak()
+		yyb140 = r.CheckBreak()
 	}
-	if yyb136 {
+	if yyb140 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ScaleRef = SubresourceReference{}
 	} else {
-		yyv137 := &x.ScaleRef
-		yyv137.CodecDecodeSelf(d)
+		yyv141 := &x.ScaleRef
+		yyv141.CodecDecodeSelf(d)
 	}
-	yyj136++
-	if yyhl136 {
-		yyb136 = yyj136 > l
+	yyj140++
+	if yyhl140 {
+		yyb140 = yyj140 > l
 	} else {
-		yyb136 = r.CheckBreak()
+		yyb140 = r.CheckBreak()
 	}
-	if yyb136 {
+	if yyb140 {
 		r.ReadEnd()
 		return
 	}
@@ -1659,20 +1683,20 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		if x.MinReplicas == nil {
 			x.MinReplicas = new(int)
 		}
-		yym139 := z.DecBinary()
-		_ = yym139
+		yym143 := z.DecBinary()
+		_ = yym143
 		if false {
 		} else {
 			*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj136++
-	if yyhl136 {
-		yyb136 = yyj136 > l
+	yyj140++
+	if yyhl140 {
+		yyb140 = yyj140 > l
 	} else {
-		yyb136 = r.CheckBreak()
+		yyb140 = r.CheckBreak()
 	}
-	if yyb136 {
+	if yyb140 {
 		r.ReadEnd()
 		return
 	}
@@ -1681,13 +1705,13 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.MaxReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj136++
-	if yyhl136 {
-		yyb136 = yyj136 > l
+	yyj140++
+	if yyhl140 {
+		yyb140 = yyj140 > l
 	} else {
-		yyb136 = r.CheckBreak()
+		yyb140 = r.CheckBreak()
 	}
-	if yyb136 {
+	if yyb140 {
 		r.ReadEnd()
 		return
 	}
@@ -1702,16 +1726,16 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		x.CPUUtilization.CodecDecodeSelf(d)
 	}
 	for {
-		yyj136++
-		if yyhl136 {
-			yyb136 = yyj136 > l
+		yyj140++
+		if yyhl140 {
+			yyb140 = yyj140 > l
 		} else {
-			yyb136 = r.CheckBreak()
+			yyb140 = r.CheckBreak()
 		}
-		if yyb136 {
+		if yyb140 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj136-1, "")
+		z.DecStructFieldNotFound(yyj140-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1723,74 +1747,74 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym142 := z.EncBinary()
-		_ = yym142
+		yym146 := z.EncBinary()
+		_ = yym146
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep143 := !z.EncBinary()
-			yy2arr143 := z.EncBasicHandle().StructToArray
-			var yyq143 [5]bool
-			_, _, _ = yysep143, yyq143, yy2arr143
-			const yyr143 bool = false
-			yyq143[0] = x.ObservedGeneration != nil
-			yyq143[1] = x.LastScaleTime != nil
-			yyq143[4] = x.CurrentCPUUtilizationPercentage != nil
-			if yyr143 || yy2arr143 {
+			yysep147 := !z.EncBinary()
+			yy2arr147 := z.EncBasicHandle().StructToArray
+			var yyq147 [5]bool
+			_, _, _ = yysep147, yyq147, yy2arr147
+			const yyr147 bool = false
+			yyq147[0] = x.ObservedGeneration != nil
+			yyq147[1] = x.LastScaleTime != nil
+			yyq147[4] = x.CurrentCPUUtilizationPercentage != nil
+			if yyr147 || yy2arr147 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn143 int = 2
-				for _, b := range yyq143 {
+				var yynn147 int = 2
+				for _, b := range yyq147 {
 					if b {
-						yynn143++
+						yynn147++
 					}
 				}
-				r.EncodeMapStart(yynn143)
+				r.EncodeMapStart(yynn147)
 			}
-			if yyr143 || yy2arr143 {
-				if yyq143[0] {
+			if yyr147 || yy2arr147 {
+				if yyq147[0] {
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy145 := *x.ObservedGeneration
-						yym146 := z.EncBinary()
-						_ = yym146
+						yy149 := *x.ObservedGeneration
+						yym150 := z.EncBinary()
+						_ = yym150
 						if false {
 						} else {
-							r.EncodeInt(int64(yy145))
+							r.EncodeInt(int64(yy149))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq143[0] {
+				if yyq147[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy147 := *x.ObservedGeneration
-						yym148 := z.EncBinary()
-						_ = yym148
+						yy151 := *x.ObservedGeneration
+						yym152 := z.EncBinary()
+						_ = yym152
 						if false {
 						} else {
-							r.EncodeInt(int64(yy147))
+							r.EncodeInt(int64(yy151))
 						}
 					}
 				}
 			}
-			if yyr143 || yy2arr143 {
-				if yyq143[1] {
+			if yyr147 || yy2arr147 {
+				if yyq147[1] {
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym150 := z.EncBinary()
-						_ = yym150
+						yym154 := z.EncBinary()
+						_ = yym154
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym150 {
+						} else if yym154 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym150 && z.IsJSONHandle() {
+						} else if !yym154 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1800,18 +1824,18 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq143[1] {
+				if yyq147[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastScaleTime"))
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym151 := z.EncBinary()
-						_ = yym151
+						yym155 := z.EncBinary()
+						_ = yym155
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym151 {
+						} else if yym155 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym151 && z.IsJSONHandle() {
+						} else if !yym155 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1819,71 +1843,71 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr143 || yy2arr143 {
-				yym153 := z.EncBinary()
-				_ = yym153
+			if yyr147 || yy2arr147 {
+				yym157 := z.EncBinary()
+				_ = yym157
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentReplicas"))
-				yym154 := z.EncBinary()
-				_ = yym154
+				yym158 := z.EncBinary()
+				_ = yym158
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			}
-			if yyr143 || yy2arr143 {
-				yym156 := z.EncBinary()
-				_ = yym156
+			if yyr147 || yy2arr147 {
+				yym160 := z.EncBinary()
+				_ = yym160
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredReplicas"))
-				yym157 := z.EncBinary()
-				_ = yym157
+				yym161 := z.EncBinary()
+				_ = yym161
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			}
-			if yyr143 || yy2arr143 {
-				if yyq143[4] {
+			if yyr147 || yy2arr147 {
+				if yyq147[4] {
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy159 := *x.CurrentCPUUtilizationPercentage
-						yym160 := z.EncBinary()
-						_ = yym160
+						yy163 := *x.CurrentCPUUtilizationPercentage
+						yym164 := z.EncBinary()
+						_ = yym164
 						if false {
 						} else {
-							r.EncodeInt(int64(yy159))
+							r.EncodeInt(int64(yy163))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq143[4] {
+				if yyq147[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("currentCPUUtilizationPercentage"))
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy161 := *x.CurrentCPUUtilizationPercentage
-						yym162 := z.EncBinary()
-						_ = yym162
+						yy165 := *x.CurrentCPUUtilizationPercentage
+						yym166 := z.EncBinary()
+						_ = yym166
 						if false {
 						} else {
-							r.EncodeInt(int64(yy161))
+							r.EncodeInt(int64(yy165))
 						}
 					}
 				}
 			}
-			if yysep143 {
+			if yysep147 {
 				r.EncodeEnd()
 			}
 		}
@@ -1894,24 +1918,24 @@ func (x *HorizontalPodAutoscalerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym163 := z.DecBinary()
-	_ = yym163
+	yym167 := z.DecBinary()
+	_ = yym167
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl164 := r.ReadMapStart()
-			if yyl164 == 0 {
+			yyl168 := r.ReadMapStart()
+			if yyl168 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl164, d)
+				x.codecDecodeSelfFromMap(yyl168, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl164 := r.ReadArrayStart()
-			if yyl164 == 0 {
+			yyl168 := r.ReadArrayStart()
+			if yyl168 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl164, d)
+				x.codecDecodeSelfFromArray(yyl168, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1923,12 +1947,12 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys165Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys165Slc
-	var yyhl165 bool = l >= 0
-	for yyj165 := 0; ; yyj165++ {
-		if yyhl165 {
-			if yyj165 >= l {
+	var yys169Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys169Slc
+	var yyhl169 bool = l >= 0
+	for yyj169 := 0; ; yyj169++ {
+		if yyhl169 {
+			if yyj169 >= l {
 				break
 			}
 		} else {
@@ -1936,9 +1960,9 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				break
 			}
 		}
-		yys165Slc = r.DecodeBytes(yys165Slc, true, true)
-		yys165 := string(yys165Slc)
-		switch yys165 {
+		yys169Slc = r.DecodeBytes(yys169Slc, true, true)
+		yys169 := string(yys169Slc)
+		switch yys169 {
 		case "observedGeneration":
 			if r.TryDecodeAsNil() {
 				if x.ObservedGeneration != nil {
@@ -1948,8 +1972,8 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.ObservedGeneration == nil {
 					x.ObservedGeneration = new(int64)
 				}
-				yym167 := z.DecBinary()
-				_ = yym167
+				yym171 := z.DecBinary()
+				_ = yym171
 				if false {
 				} else {
 					*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
@@ -1964,13 +1988,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.LastScaleTime == nil {
 					x.LastScaleTime = new(pkg1_unversioned.Time)
 				}
-				yym169 := z.DecBinary()
-				_ = yym169
+				yym173 := z.DecBinary()
+				_ = yym173
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-				} else if yym169 {
+				} else if yym173 {
 					z.DecBinaryUnmarshal(x.LastScaleTime)
-				} else if !yym169 && z.IsJSONHandle() {
+				} else if !yym173 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LastScaleTime)
 				} else {
 					z.DecFallback(x.LastScaleTime, false)
@@ -1997,18 +2021,18 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.CurrentCPUUtilizationPercentage == nil {
 					x.CurrentCPUUtilizationPercentage = new(int)
 				}
-				yym173 := z.DecBinary()
-				_ = yym173
+				yym177 := z.DecBinary()
+				_ = yym177
 				if false {
 				} else {
 					*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys165)
-		} // end switch yys165
-	} // end for yyj165
-	if !yyhl165 {
+			z.DecStructFieldNotFound(-1, yys169)
+		} // end switch yys169
+	} // end for yyj169
+	if !yyhl169 {
 		r.ReadEnd()
 	}
 }
@@ -2017,16 +2041,16 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj174 int
-	var yyb174 bool
-	var yyhl174 bool = l >= 0
-	yyj174++
-	if yyhl174 {
-		yyb174 = yyj174 > l
+	var yyj178 int
+	var yyb178 bool
+	var yyhl178 bool = l >= 0
+	yyj178++
+	if yyhl178 {
+		yyb178 = yyj178 > l
 	} else {
-		yyb174 = r.CheckBreak()
+		yyb178 = r.CheckBreak()
 	}
-	if yyb174 {
+	if yyb178 {
 		r.ReadEnd()
 		return
 	}
@@ -2038,20 +2062,20 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.ObservedGeneration == nil {
 			x.ObservedGeneration = new(int64)
 		}
-		yym176 := z.DecBinary()
-		_ = yym176
+		yym180 := z.DecBinary()
+		_ = yym180
 		if false {
 		} else {
 			*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj174++
-	if yyhl174 {
-		yyb174 = yyj174 > l
+	yyj178++
+	if yyhl178 {
+		yyb178 = yyj178 > l
 	} else {
-		yyb174 = r.CheckBreak()
+		yyb178 = r.CheckBreak()
 	}
-	if yyb174 {
+	if yyb178 {
 		r.ReadEnd()
 		return
 	}
@@ -2063,25 +2087,25 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.LastScaleTime == nil {
 			x.LastScaleTime = new(pkg1_unversioned.Time)
 		}
-		yym178 := z.DecBinary()
-		_ = yym178
+		yym182 := z.DecBinary()
+		_ = yym182
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-		} else if yym178 {
+		} else if yym182 {
 			z.DecBinaryUnmarshal(x.LastScaleTime)
-		} else if !yym178 && z.IsJSONHandle() {
+		} else if !yym182 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LastScaleTime)
 		} else {
 			z.DecFallback(x.LastScaleTime, false)
 		}
 	}
-	yyj174++
-	if yyhl174 {
-		yyb174 = yyj174 > l
+	yyj178++
+	if yyhl178 {
+		yyb178 = yyj178 > l
 	} else {
-		yyb174 = r.CheckBreak()
+		yyb178 = r.CheckBreak()
 	}
-	if yyb174 {
+	if yyb178 {
 		r.ReadEnd()
 		return
 	}
@@ -2090,13 +2114,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.CurrentReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj174++
-	if yyhl174 {
-		yyb174 = yyj174 > l
+	yyj178++
+	if yyhl178 {
+		yyb178 = yyj178 > l
 	} else {
-		yyb174 = r.CheckBreak()
+		yyb178 = r.CheckBreak()
 	}
-	if yyb174 {
+	if yyb178 {
 		r.ReadEnd()
 		return
 	}
@@ -2105,13 +2129,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.DesiredReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj174++
-	if yyhl174 {
-		yyb174 = yyj174 > l
+	yyj178++
+	if yyhl178 {
+		yyb178 = yyj178 > l
 	} else {
-		yyb174 = r.CheckBreak()
+		yyb178 = r.CheckBreak()
 	}
-	if yyb174 {
+	if yyb178 {
 		r.ReadEnd()
 		return
 	}
@@ -2123,24 +2147,24 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.CurrentCPUUtilizationPercentage == nil {
 			x.CurrentCPUUtilizationPercentage = new(int)
 		}
-		yym182 := z.DecBinary()
-		_ = yym182
+		yym186 := z.DecBinary()
+		_ = yym186
 		if false {
 		} else {
 			*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
 	for {
-		yyj174++
-		if yyhl174 {
-			yyb174 = yyj174 > l
+		yyj178++
+		if yyhl178 {
+			yyb178 = yyj178 > l
 		} else {
-			yyb174 = r.CheckBreak()
+			yyb178 = r.CheckBreak()
 		}
-		if yyb174 {
+		if yyb178 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj174-1, "")
+		z.DecStructFieldNotFound(yyj178-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2152,119 +2176,131 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym183 := z.EncBinary()
-		_ = yym183
+		yym187 := z.EncBinary()
+		_ = yym187
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep184 := !z.EncBinary()
-			yy2arr184 := z.EncBasicHandle().StructToArray
-			var yyq184 [5]bool
-			_, _, _ = yysep184, yyq184, yy2arr184
-			const yyr184 bool = false
-			yyq184[0] = x.Kind != ""
-			yyq184[1] = x.APIVersion != ""
-			yyq184[2] = true
-			yyq184[3] = true
-			yyq184[4] = true
-			if yyr184 || yy2arr184 {
+			yysep188 := !z.EncBinary()
+			yy2arr188 := z.EncBasicHandle().StructToArray
+			var yyq188 [5]bool
+			_, _, _ = yysep188, yyq188, yy2arr188
+			const yyr188 bool = false
+			yyq188[0] = x.Kind != ""
+			yyq188[1] = x.APIVersion != ""
+			yyq188[2] = true
+			yyq188[3] = true
+			yyq188[4] = true
+			if yyr188 || yy2arr188 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn184 int = 0
-				for _, b := range yyq184 {
+				var yynn188 int = 0
+				for _, b := range yyq188 {
 					if b {
-						yynn184++
+						yynn188++
 					}
 				}
-				r.EncodeMapStart(yynn184)
+				r.EncodeMapStart(yynn188)
 			}
-			if yyr184 || yy2arr184 {
-				if yyq184[0] {
-					yym186 := z.EncBinary()
-					_ = yym186
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq184[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym187 := z.EncBinary()
-					_ = yym187
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr184 || yy2arr184 {
-				if yyq184[1] {
-					yym189 := z.EncBinary()
-					_ = yym189
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq184[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr188 || yy2arr188 {
+				if yyq188[0] {
 					yym190 := z.EncBinary()
 					_ = yym190
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq188[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym191 := z.EncBinary()
+					_ = yym191
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr188 || yy2arr188 {
+				if yyq188[1] {
+					yym193 := z.EncBinary()
+					_ = yym193
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq188[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym194 := z.EncBinary()
+					_ = yym194
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr184 || yy2arr184 {
-				if yyq184[2] {
-					yy192 := &x.ObjectMeta
-					yy192.CodecEncodeSelf(e)
+			if yyr188 || yy2arr188 {
+				if yyq188[2] {
+					yy196 := &x.ObjectMeta
+					yym197 := z.EncBinary()
+					_ = yym197
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy196) {
+					} else {
+						z.EncFallback(yy196)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq184[2] {
+				if yyq188[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy193 := &x.ObjectMeta
-					yy193.CodecEncodeSelf(e)
+					yy198 := &x.ObjectMeta
+					yym199 := z.EncBinary()
+					_ = yym199
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy198) {
+					} else {
+						z.EncFallback(yy198)
+					}
 				}
 			}
-			if yyr184 || yy2arr184 {
-				if yyq184[3] {
-					yy195 := &x.Spec
-					yy195.CodecEncodeSelf(e)
+			if yyr188 || yy2arr188 {
+				if yyq188[3] {
+					yy201 := &x.Spec
+					yy201.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq184[3] {
+				if yyq188[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy196 := &x.Spec
-					yy196.CodecEncodeSelf(e)
+					yy202 := &x.Spec
+					yy202.CodecEncodeSelf(e)
 				}
 			}
-			if yyr184 || yy2arr184 {
-				if yyq184[4] {
-					yy198 := &x.Status
-					yy198.CodecEncodeSelf(e)
+			if yyr188 || yy2arr188 {
+				if yyq188[4] {
+					yy204 := &x.Status
+					yy204.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq184[4] {
+				if yyq188[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy199 := &x.Status
-					yy199.CodecEncodeSelf(e)
+					yy205 := &x.Status
+					yy205.CodecEncodeSelf(e)
 				}
 			}
-			if yysep184 {
+			if yysep188 {
 				r.EncodeEnd()
 			}
 		}
@@ -2275,24 +2311,24 @@ func (x *HorizontalPodAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym200 := z.DecBinary()
-	_ = yym200
+	yym206 := z.DecBinary()
+	_ = yym206
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl201 := r.ReadMapStart()
-			if yyl201 == 0 {
+			yyl207 := r.ReadMapStart()
+			if yyl207 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl201, d)
+				x.codecDecodeSelfFromMap(yyl207, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl201 := r.ReadArrayStart()
-			if yyl201 == 0 {
+			yyl207 := r.ReadArrayStart()
+			if yyl207 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl201, d)
+				x.codecDecodeSelfFromArray(yyl207, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2304,12 +2340,12 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys202Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys202Slc
-	var yyhl202 bool = l >= 0
-	for yyj202 := 0; ; yyj202++ {
-		if yyhl202 {
-			if yyj202 >= l {
+	var yys208Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys208Slc
+	var yyhl208 bool = l >= 0
+	for yyj208 := 0; ; yyj208++ {
+		if yyhl208 {
+			if yyj208 >= l {
 				break
 			}
 		} else {
@@ -2317,9 +2353,9 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys202Slc = r.DecodeBytes(yys202Slc, true, true)
-		yys202 := string(yys202Slc)
-		switch yys202 {
+		yys208Slc = r.DecodeBytes(yys208Slc, true, true)
+		yys208 := string(yys208Slc)
+		switch yys208 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2336,28 +2372,34 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv205 := &x.ObjectMeta
-				yyv205.CodecDecodeSelf(d)
+				yyv211 := &x.ObjectMeta
+				yym212 := z.DecBinary()
+				_ = yym212
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv211) {
+				} else {
+					z.DecFallback(yyv211, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = HorizontalPodAutoscalerSpec{}
 			} else {
-				yyv206 := &x.Spec
-				yyv206.CodecDecodeSelf(d)
+				yyv213 := &x.Spec
+				yyv213.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = HorizontalPodAutoscalerStatus{}
 			} else {
-				yyv207 := &x.Status
-				yyv207.CodecDecodeSelf(d)
+				yyv214 := &x.Status
+				yyv214.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys202)
-		} // end switch yys202
-	} // end for yyj202
-	if !yyhl202 {
+			z.DecStructFieldNotFound(-1, yys208)
+		} // end switch yys208
+	} // end for yyj208
+	if !yyhl208 {
 		r.ReadEnd()
 	}
 }
@@ -2366,16 +2408,16 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj208 int
-	var yyb208 bool
-	var yyhl208 bool = l >= 0
-	yyj208++
-	if yyhl208 {
-		yyb208 = yyj208 > l
+	var yyj215 int
+	var yyb215 bool
+	var yyhl215 bool = l >= 0
+	yyj215++
+	if yyhl215 {
+		yyb215 = yyj215 > l
 	} else {
-		yyb208 = r.CheckBreak()
+		yyb215 = r.CheckBreak()
 	}
-	if yyb208 {
+	if yyb215 {
 		r.ReadEnd()
 		return
 	}
@@ -2384,13 +2426,13 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj208++
-	if yyhl208 {
-		yyb208 = yyj208 > l
+	yyj215++
+	if yyhl215 {
+		yyb215 = yyj215 > l
 	} else {
-		yyb208 = r.CheckBreak()
+		yyb215 = r.CheckBreak()
 	}
-	if yyb208 {
+	if yyb215 {
 		r.ReadEnd()
 		return
 	}
@@ -2399,65 +2441,71 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj208++
-	if yyhl208 {
-		yyb208 = yyj208 > l
+	yyj215++
+	if yyhl215 {
+		yyb215 = yyj215 > l
 	} else {
-		yyb208 = r.CheckBreak()
+		yyb215 = r.CheckBreak()
 	}
-	if yyb208 {
+	if yyb215 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv211 := &x.ObjectMeta
-		yyv211.CodecDecodeSelf(d)
+		yyv218 := &x.ObjectMeta
+		yym219 := z.DecBinary()
+		_ = yym219
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv218) {
+		} else {
+			z.DecFallback(yyv218, false)
+		}
 	}
-	yyj208++
-	if yyhl208 {
-		yyb208 = yyj208 > l
+	yyj215++
+	if yyhl215 {
+		yyb215 = yyj215 > l
 	} else {
-		yyb208 = r.CheckBreak()
+		yyb215 = r.CheckBreak()
 	}
-	if yyb208 {
+	if yyb215 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = HorizontalPodAutoscalerSpec{}
 	} else {
-		yyv212 := &x.Spec
-		yyv212.CodecDecodeSelf(d)
+		yyv220 := &x.Spec
+		yyv220.CodecDecodeSelf(d)
 	}
-	yyj208++
-	if yyhl208 {
-		yyb208 = yyj208 > l
+	yyj215++
+	if yyhl215 {
+		yyb215 = yyj215 > l
 	} else {
-		yyb208 = r.CheckBreak()
+		yyb215 = r.CheckBreak()
 	}
-	if yyb208 {
+	if yyb215 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = HorizontalPodAutoscalerStatus{}
 	} else {
-		yyv213 := &x.Status
-		yyv213.CodecDecodeSelf(d)
+		yyv221 := &x.Status
+		yyv221.CodecDecodeSelf(d)
 	}
 	for {
-		yyj208++
-		if yyhl208 {
-			yyb208 = yyj208 > l
+		yyj215++
+		if yyhl215 {
+			yyb215 = yyj215 > l
 		} else {
-			yyb208 = r.CheckBreak()
+			yyb215 = r.CheckBreak()
 		}
-		if yyb208 {
+		if yyb215 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj208-1, "")
+		z.DecStructFieldNotFound(yyj215-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2469,34 +2517,34 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym214 := z.EncBinary()
-		_ = yym214
+		yym222 := z.EncBinary()
+		_ = yym222
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep215 := !z.EncBinary()
-			yy2arr215 := z.EncBasicHandle().StructToArray
-			var yyq215 [4]bool
-			_, _, _ = yysep215, yyq215, yy2arr215
-			const yyr215 bool = false
-			yyq215[0] = x.Kind != ""
-			yyq215[1] = x.APIVersion != ""
-			yyq215[2] = true
-			if yyr215 || yy2arr215 {
+			yysep223 := !z.EncBinary()
+			yy2arr223 := z.EncBasicHandle().StructToArray
+			var yyq223 [4]bool
+			_, _, _ = yysep223, yyq223, yy2arr223
+			const yyr223 bool = false
+			yyq223[0] = x.Kind != ""
+			yyq223[1] = x.APIVersion != ""
+			yyq223[2] = true
+			if yyr223 || yy2arr223 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn215 int = 1
-				for _, b := range yyq215 {
+				var yynn223 int = 1
+				for _, b := range yyq223 {
 					if b {
-						yynn215++
+						yynn223++
 					}
 				}
-				r.EncodeMapStart(yynn215)
+				r.EncodeMapStart(yynn223)
 			}
-			if yyr215 || yy2arr215 {
-				if yyq215[0] {
-					yym217 := z.EncBinary()
-					_ = yym217
+			if yyr223 || yy2arr223 {
+				if yyq223[0] {
+					yym225 := z.EncBinary()
+					_ = yym225
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2505,70 +2553,70 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq215[0] {
+				if yyq223[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym218 := z.EncBinary()
-					_ = yym218
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr215 || yy2arr215 {
-				if yyq215[1] {
-					yym220 := z.EncBinary()
-					_ = yym220
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq215[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym221 := z.EncBinary()
-					_ = yym221
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr215 || yy2arr215 {
-				if yyq215[2] {
-					yy223 := &x.ListMeta
-					yym224 := z.EncBinary()
-					_ = yym224
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy223) {
-					} else {
-						z.EncFallback(yy223)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq215[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy225 := &x.ListMeta
 					yym226 := z.EncBinary()
 					_ = yym226
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy225) {
 					} else {
-						z.EncFallback(yy225)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr215 || yy2arr215 {
+			if yyr223 || yy2arr223 {
+				if yyq223[1] {
+					yym228 := z.EncBinary()
+					_ = yym228
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq223[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym229 := z.EncBinary()
+					_ = yym229
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr223 || yy2arr223 {
+				if yyq223[2] {
+					yy231 := &x.ListMeta
+					yym232 := z.EncBinary()
+					_ = yym232
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy231) {
+					} else {
+						z.EncFallback(yy231)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq223[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy233 := &x.ListMeta
+					yym234 := z.EncBinary()
+					_ = yym234
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy233) {
+					} else {
+						z.EncFallback(yy233)
+					}
+				}
+			}
+			if yyr223 || yy2arr223 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym228 := z.EncBinary()
-					_ = yym228
+					yym236 := z.EncBinary()
+					_ = yym236
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
@@ -2579,15 +2627,15 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym229 := z.EncBinary()
-					_ = yym229
+					yym237 := z.EncBinary()
+					_ = yym237
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep215 {
+			if yysep223 {
 				r.EncodeEnd()
 			}
 		}
@@ -2598,24 +2646,24 @@ func (x *HorizontalPodAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym230 := z.DecBinary()
-	_ = yym230
+	yym238 := z.DecBinary()
+	_ = yym238
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl231 := r.ReadMapStart()
-			if yyl231 == 0 {
+			yyl239 := r.ReadMapStart()
+			if yyl239 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl231, d)
+				x.codecDecodeSelfFromMap(yyl239, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl231 := r.ReadArrayStart()
-			if yyl231 == 0 {
+			yyl239 := r.ReadArrayStart()
+			if yyl239 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl231, d)
+				x.codecDecodeSelfFromArray(yyl239, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2627,12 +2675,12 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys232Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys232Slc
-	var yyhl232 bool = l >= 0
-	for yyj232 := 0; ; yyj232++ {
-		if yyhl232 {
-			if yyj232 >= l {
+	var yys240Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys240Slc
+	var yyhl240 bool = l >= 0
+	for yyj240 := 0; ; yyj240++ {
+		if yyhl240 {
+			if yyj240 >= l {
 				break
 			}
 		} else {
@@ -2640,9 +2688,9 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys232Slc = r.DecodeBytes(yys232Slc, true, true)
-		yys232 := string(yys232Slc)
-		switch yys232 {
+		yys240Slc = r.DecodeBytes(yys240Slc, true, true)
+		yys240 := string(yys240Slc)
+		switch yys240 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2659,32 +2707,32 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv235 := &x.ListMeta
-				yym236 := z.DecBinary()
-				_ = yym236
+				yyv243 := &x.ListMeta
+				yym244 := z.DecBinary()
+				_ = yym244
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv235) {
+				} else if z.HasExtensions() && z.DecExt(yyv243) {
 				} else {
-					z.DecFallback(yyv235, false)
+					z.DecFallback(yyv243, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv237 := &x.Items
-				yym238 := z.DecBinary()
-				_ = yym238
+				yyv245 := &x.Items
+				yym246 := z.DecBinary()
+				_ = yym246
 				if false {
 				} else {
-					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv237), d)
+					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv245), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys232)
-		} // end switch yys232
-	} // end for yyj232
-	if !yyhl232 {
+			z.DecStructFieldNotFound(-1, yys240)
+		} // end switch yys240
+	} // end for yyj240
+	if !yyhl240 {
 		r.ReadEnd()
 	}
 }
@@ -2693,16 +2741,16 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj239 int
-	var yyb239 bool
-	var yyhl239 bool = l >= 0
-	yyj239++
-	if yyhl239 {
-		yyb239 = yyj239 > l
+	var yyj247 int
+	var yyb247 bool
+	var yyhl247 bool = l >= 0
+	yyj247++
+	if yyhl247 {
+		yyb247 = yyj247 > l
 	} else {
-		yyb239 = r.CheckBreak()
+		yyb247 = r.CheckBreak()
 	}
-	if yyb239 {
+	if yyb247 {
 		r.ReadEnd()
 		return
 	}
@@ -2711,13 +2759,13 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj239++
-	if yyhl239 {
-		yyb239 = yyj239 > l
+	yyj247++
+	if yyhl247 {
+		yyb247 = yyj247 > l
 	} else {
-		yyb239 = r.CheckBreak()
+		yyb247 = r.CheckBreak()
 	}
-	if yyb239 {
+	if yyb247 {
 		r.ReadEnd()
 		return
 	}
@@ -2726,60 +2774,60 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj239++
-	if yyhl239 {
-		yyb239 = yyj239 > l
+	yyj247++
+	if yyhl247 {
+		yyb247 = yyj247 > l
 	} else {
-		yyb239 = r.CheckBreak()
+		yyb247 = r.CheckBreak()
 	}
-	if yyb239 {
+	if yyb247 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv242 := &x.ListMeta
-		yym243 := z.DecBinary()
-		_ = yym243
+		yyv250 := &x.ListMeta
+		yym251 := z.DecBinary()
+		_ = yym251
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv242) {
+		} else if z.HasExtensions() && z.DecExt(yyv250) {
 		} else {
-			z.DecFallback(yyv242, false)
+			z.DecFallback(yyv250, false)
 		}
 	}
-	yyj239++
-	if yyhl239 {
-		yyb239 = yyj239 > l
+	yyj247++
+	if yyhl247 {
+		yyb247 = yyj247 > l
 	} else {
-		yyb239 = r.CheckBreak()
+		yyb247 = r.CheckBreak()
 	}
-	if yyb239 {
+	if yyb247 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv244 := &x.Items
-		yym245 := z.DecBinary()
-		_ = yym245
+		yyv252 := &x.Items
+		yym253 := z.DecBinary()
+		_ = yym253
 		if false {
 		} else {
-			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv244), d)
+			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv252), d)
 		}
 	}
 	for {
-		yyj239++
-		if yyhl239 {
-			yyb239 = yyj239 > l
+		yyj247++
+		if yyhl247 {
+			yyb247 = yyj247 > l
 		} else {
-			yyb239 = r.CheckBreak()
+			yyb247 = r.CheckBreak()
 		}
-		if yyb239 {
+		if yyb247 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj239-1, "")
+		z.DecStructFieldNotFound(yyj247-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2791,36 +2839,36 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym246 := z.EncBinary()
-		_ = yym246
+		yym254 := z.EncBinary()
+		_ = yym254
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep247 := !z.EncBinary()
-			yy2arr247 := z.EncBasicHandle().StructToArray
-			var yyq247 [5]bool
-			_, _, _ = yysep247, yyq247, yy2arr247
-			const yyr247 bool = false
-			yyq247[0] = x.Kind != ""
-			yyq247[1] = x.APIVersion != ""
-			yyq247[2] = true
-			yyq247[3] = x.Description != ""
-			yyq247[4] = len(x.Versions) != 0
-			if yyr247 || yy2arr247 {
+			yysep255 := !z.EncBinary()
+			yy2arr255 := z.EncBasicHandle().StructToArray
+			var yyq255 [5]bool
+			_, _, _ = yysep255, yyq255, yy2arr255
+			const yyr255 bool = false
+			yyq255[0] = x.Kind != ""
+			yyq255[1] = x.APIVersion != ""
+			yyq255[2] = true
+			yyq255[3] = x.Description != ""
+			yyq255[4] = len(x.Versions) != 0
+			if yyr255 || yy2arr255 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn247 int = 0
-				for _, b := range yyq247 {
+				var yynn255 int = 0
+				for _, b := range yyq255 {
 					if b {
-						yynn247++
+						yynn255++
 					}
 				}
-				r.EncodeMapStart(yynn247)
+				r.EncodeMapStart(yynn255)
 			}
-			if yyr247 || yy2arr247 {
-				if yyq247[0] {
-					yym249 := z.EncBinary()
-					_ = yym249
+			if yyr255 || yy2arr255 {
+				if yyq255[0] {
+					yym257 := z.EncBinary()
+					_ = yym257
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2829,81 +2877,93 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq247[0] {
+				if yyq255[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym250 := z.EncBinary()
-					_ = yym250
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr247 || yy2arr247 {
-				if yyq247[1] {
-					yym252 := z.EncBinary()
-					_ = yym252
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq247[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym253 := z.EncBinary()
-					_ = yym253
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr247 || yy2arr247 {
-				if yyq247[2] {
-					yy255 := &x.ObjectMeta
-					yy255.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq247[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy256 := &x.ObjectMeta
-					yy256.CodecEncodeSelf(e)
-				}
-			}
-			if yyr247 || yy2arr247 {
-				if yyq247[3] {
 					yym258 := z.EncBinary()
 					_ = yym258
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr255 || yy2arr255 {
+				if yyq255[1] {
+					yym260 := z.EncBinary()
+					_ = yym260
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq255[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym261 := z.EncBinary()
+					_ = yym261
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr255 || yy2arr255 {
+				if yyq255[2] {
+					yy263 := &x.ObjectMeta
+					yym264 := z.EncBinary()
+					_ = yym264
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy263) {
+					} else {
+						z.EncFallback(yy263)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq255[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy265 := &x.ObjectMeta
+					yym266 := z.EncBinary()
+					_ = yym266
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy265) {
+					} else {
+						z.EncFallback(yy265)
+					}
+				}
+			}
+			if yyr255 || yy2arr255 {
+				if yyq255[3] {
+					yym268 := z.EncBinary()
+					_ = yym268
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq247[3] {
+				if yyq255[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("description"))
-					yym259 := z.EncBinary()
-					_ = yym259
+					yym269 := z.EncBinary()
+					_ = yym269
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				}
 			}
-			if yyr247 || yy2arr247 {
-				if yyq247[4] {
+			if yyr255 || yy2arr255 {
+				if yyq255[4] {
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym261 := z.EncBinary()
-						_ = yym261
+						yym271 := z.EncBinary()
+						_ = yym271
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2913,13 +2973,13 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq247[4] {
+				if yyq255[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("versions"))
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym262 := z.EncBinary()
-						_ = yym262
+						yym272 := z.EncBinary()
+						_ = yym272
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2927,7 +2987,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep247 {
+			if yysep255 {
 				r.EncodeEnd()
 			}
 		}
@@ -2938,24 +2998,24 @@ func (x *ThirdPartyResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym263 := z.DecBinary()
-	_ = yym263
+	yym273 := z.DecBinary()
+	_ = yym273
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl264 := r.ReadMapStart()
-			if yyl264 == 0 {
+			yyl274 := r.ReadMapStart()
+			if yyl274 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl264, d)
+				x.codecDecodeSelfFromMap(yyl274, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl264 := r.ReadArrayStart()
-			if yyl264 == 0 {
+			yyl274 := r.ReadArrayStart()
+			if yyl274 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl264, d)
+				x.codecDecodeSelfFromArray(yyl274, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2967,12 +3027,12 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys265Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys265Slc
-	var yyhl265 bool = l >= 0
-	for yyj265 := 0; ; yyj265++ {
-		if yyhl265 {
-			if yyj265 >= l {
+	var yys275Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys275Slc
+	var yyhl275 bool = l >= 0
+	for yyj275 := 0; ; yyj275++ {
+		if yyhl275 {
+			if yyj275 >= l {
 				break
 			}
 		} else {
@@ -2980,9 +3040,9 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys265Slc = r.DecodeBytes(yys265Slc, true, true)
-		yys265 := string(yys265Slc)
-		switch yys265 {
+		yys275Slc = r.DecodeBytes(yys275Slc, true, true)
+		yys275 := string(yys275Slc)
+		switch yys275 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2999,8 +3059,14 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv268 := &x.ObjectMeta
-				yyv268.CodecDecodeSelf(d)
+				yyv278 := &x.ObjectMeta
+				yym279 := z.DecBinary()
+				_ = yym279
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv278) {
+				} else {
+					z.DecFallback(yyv278, false)
+				}
 			}
 		case "description":
 			if r.TryDecodeAsNil() {
@@ -3012,19 +3078,19 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Versions = nil
 			} else {
-				yyv270 := &x.Versions
-				yym271 := z.DecBinary()
-				_ = yym271
+				yyv281 := &x.Versions
+				yym282 := z.DecBinary()
+				_ = yym282
 				if false {
 				} else {
-					h.decSliceAPIVersion((*[]APIVersion)(yyv270), d)
+					h.decSliceAPIVersion((*[]APIVersion)(yyv281), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys265)
-		} // end switch yys265
-	} // end for yyj265
-	if !yyhl265 {
+			z.DecStructFieldNotFound(-1, yys275)
+		} // end switch yys275
+	} // end for yyj275
+	if !yyhl275 {
 		r.ReadEnd()
 	}
 }
@@ -3033,16 +3099,16 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj272 int
-	var yyb272 bool
-	var yyhl272 bool = l >= 0
-	yyj272++
-	if yyhl272 {
-		yyb272 = yyj272 > l
+	var yyj283 int
+	var yyb283 bool
+	var yyhl283 bool = l >= 0
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
 	} else {
-		yyb272 = r.CheckBreak()
+		yyb283 = r.CheckBreak()
 	}
-	if yyb272 {
+	if yyb283 {
 		r.ReadEnd()
 		return
 	}
@@ -3051,13 +3117,13 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj272++
-	if yyhl272 {
-		yyb272 = yyj272 > l
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
 	} else {
-		yyb272 = r.CheckBreak()
+		yyb283 = r.CheckBreak()
 	}
-	if yyb272 {
+	if yyb283 {
 		r.ReadEnd()
 		return
 	}
@@ -3066,29 +3132,35 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj272++
-	if yyhl272 {
-		yyb272 = yyj272 > l
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
 	} else {
-		yyb272 = r.CheckBreak()
+		yyb283 = r.CheckBreak()
 	}
-	if yyb272 {
+	if yyb283 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv275 := &x.ObjectMeta
-		yyv275.CodecDecodeSelf(d)
+		yyv286 := &x.ObjectMeta
+		yym287 := z.DecBinary()
+		_ = yym287
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv286) {
+		} else {
+			z.DecFallback(yyv286, false)
+		}
 	}
-	yyj272++
-	if yyhl272 {
-		yyb272 = yyj272 > l
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
 	} else {
-		yyb272 = r.CheckBreak()
+		yyb283 = r.CheckBreak()
 	}
-	if yyb272 {
+	if yyb283 {
 		r.ReadEnd()
 		return
 	}
@@ -3097,38 +3169,38 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Description = string(r.DecodeString())
 	}
-	yyj272++
-	if yyhl272 {
-		yyb272 = yyj272 > l
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
 	} else {
-		yyb272 = r.CheckBreak()
+		yyb283 = r.CheckBreak()
 	}
-	if yyb272 {
+	if yyb283 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Versions = nil
 	} else {
-		yyv277 := &x.Versions
-		yym278 := z.DecBinary()
-		_ = yym278
+		yyv289 := &x.Versions
+		yym290 := z.DecBinary()
+		_ = yym290
 		if false {
 		} else {
-			h.decSliceAPIVersion((*[]APIVersion)(yyv277), d)
+			h.decSliceAPIVersion((*[]APIVersion)(yyv289), d)
 		}
 	}
 	for {
-		yyj272++
-		if yyhl272 {
-			yyb272 = yyj272 > l
+		yyj283++
+		if yyhl283 {
+			yyb283 = yyj283 > l
 		} else {
-			yyb272 = r.CheckBreak()
+			yyb283 = r.CheckBreak()
 		}
-		if yyb272 {
+		if yyb283 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj272-1, "")
+		z.DecStructFieldNotFound(yyj283-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3140,34 +3212,34 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym279 := z.EncBinary()
-		_ = yym279
+		yym291 := z.EncBinary()
+		_ = yym291
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep280 := !z.EncBinary()
-			yy2arr280 := z.EncBasicHandle().StructToArray
-			var yyq280 [4]bool
-			_, _, _ = yysep280, yyq280, yy2arr280
-			const yyr280 bool = false
-			yyq280[0] = x.Kind != ""
-			yyq280[1] = x.APIVersion != ""
-			yyq280[2] = true
-			if yyr280 || yy2arr280 {
+			yysep292 := !z.EncBinary()
+			yy2arr292 := z.EncBasicHandle().StructToArray
+			var yyq292 [4]bool
+			_, _, _ = yysep292, yyq292, yy2arr292
+			const yyr292 bool = false
+			yyq292[0] = x.Kind != ""
+			yyq292[1] = x.APIVersion != ""
+			yyq292[2] = true
+			if yyr292 || yy2arr292 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn280 int = 1
-				for _, b := range yyq280 {
+				var yynn292 int = 1
+				for _, b := range yyq292 {
 					if b {
-						yynn280++
+						yynn292++
 					}
 				}
-				r.EncodeMapStart(yynn280)
+				r.EncodeMapStart(yynn292)
 			}
-			if yyr280 || yy2arr280 {
-				if yyq280[0] {
-					yym282 := z.EncBinary()
-					_ = yym282
+			if yyr292 || yy2arr292 {
+				if yyq292[0] {
+					yym294 := z.EncBinary()
+					_ = yym294
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3176,20 +3248,20 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq280[0] {
+				if yyq292[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym283 := z.EncBinary()
-					_ = yym283
+					yym295 := z.EncBinary()
+					_ = yym295
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr280 || yy2arr280 {
-				if yyq280[1] {
-					yym285 := z.EncBinary()
-					_ = yym285
+			if yyr292 || yy2arr292 {
+				if yyq292[1] {
+					yym297 := z.EncBinary()
+					_ = yym297
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3198,48 +3270,48 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq280[1] {
+				if yyq292[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym286 := z.EncBinary()
-					_ = yym286
+					yym298 := z.EncBinary()
+					_ = yym298
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr280 || yy2arr280 {
-				if yyq280[2] {
-					yy288 := &x.ListMeta
-					yym289 := z.EncBinary()
-					_ = yym289
+			if yyr292 || yy2arr292 {
+				if yyq292[2] {
+					yy300 := &x.ListMeta
+					yym301 := z.EncBinary()
+					_ = yym301
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy288) {
+					} else if z.HasExtensions() && z.EncExt(yy300) {
 					} else {
-						z.EncFallback(yy288)
+						z.EncFallback(yy300)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq280[2] {
+				if yyq292[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy290 := &x.ListMeta
-					yym291 := z.EncBinary()
-					_ = yym291
+					yy302 := &x.ListMeta
+					yym303 := z.EncBinary()
+					_ = yym303
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy290) {
+					} else if z.HasExtensions() && z.EncExt(yy302) {
 					} else {
-						z.EncFallback(yy290)
+						z.EncFallback(yy302)
 					}
 				}
 			}
-			if yyr280 || yy2arr280 {
+			if yyr292 || yy2arr292 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym293 := z.EncBinary()
-					_ = yym293
+					yym305 := z.EncBinary()
+					_ = yym305
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
@@ -3250,15 +3322,15 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym294 := z.EncBinary()
-					_ = yym294
+					yym306 := z.EncBinary()
+					_ = yym306
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
 					}
 				}
 			}
-			if yysep280 {
+			if yysep292 {
 				r.EncodeEnd()
 			}
 		}
@@ -3269,24 +3341,24 @@ func (x *ThirdPartyResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym295 := z.DecBinary()
-	_ = yym295
+	yym307 := z.DecBinary()
+	_ = yym307
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl296 := r.ReadMapStart()
-			if yyl296 == 0 {
+			yyl308 := r.ReadMapStart()
+			if yyl308 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl296, d)
+				x.codecDecodeSelfFromMap(yyl308, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl296 := r.ReadArrayStart()
-			if yyl296 == 0 {
+			yyl308 := r.ReadArrayStart()
+			if yyl308 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl296, d)
+				x.codecDecodeSelfFromArray(yyl308, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3298,12 +3370,12 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys297Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys297Slc
-	var yyhl297 bool = l >= 0
-	for yyj297 := 0; ; yyj297++ {
-		if yyhl297 {
-			if yyj297 >= l {
+	var yys309Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys309Slc
+	var yyhl309 bool = l >= 0
+	for yyj309 := 0; ; yyj309++ {
+		if yyhl309 {
+			if yyj309 >= l {
 				break
 			}
 		} else {
@@ -3311,9 +3383,9 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys297Slc = r.DecodeBytes(yys297Slc, true, true)
-		yys297 := string(yys297Slc)
-		switch yys297 {
+		yys309Slc = r.DecodeBytes(yys309Slc, true, true)
+		yys309 := string(yys309Slc)
+		switch yys309 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3330,32 +3402,32 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv300 := &x.ListMeta
-				yym301 := z.DecBinary()
-				_ = yym301
+				yyv312 := &x.ListMeta
+				yym313 := z.DecBinary()
+				_ = yym313
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv300) {
+				} else if z.HasExtensions() && z.DecExt(yyv312) {
 				} else {
-					z.DecFallback(yyv300, false)
+					z.DecFallback(yyv312, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv302 := &x.Items
-				yym303 := z.DecBinary()
-				_ = yym303
+				yyv314 := &x.Items
+				yym315 := z.DecBinary()
+				_ = yym315
 				if false {
 				} else {
-					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv302), d)
+					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv314), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys297)
-		} // end switch yys297
-	} // end for yyj297
-	if !yyhl297 {
+			z.DecStructFieldNotFound(-1, yys309)
+		} // end switch yys309
+	} // end for yyj309
+	if !yyhl309 {
 		r.ReadEnd()
 	}
 }
@@ -3364,16 +3436,16 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj304 int
-	var yyb304 bool
-	var yyhl304 bool = l >= 0
-	yyj304++
-	if yyhl304 {
-		yyb304 = yyj304 > l
+	var yyj316 int
+	var yyb316 bool
+	var yyhl316 bool = l >= 0
+	yyj316++
+	if yyhl316 {
+		yyb316 = yyj316 > l
 	} else {
-		yyb304 = r.CheckBreak()
+		yyb316 = r.CheckBreak()
 	}
-	if yyb304 {
+	if yyb316 {
 		r.ReadEnd()
 		return
 	}
@@ -3382,13 +3454,13 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj304++
-	if yyhl304 {
-		yyb304 = yyj304 > l
+	yyj316++
+	if yyhl316 {
+		yyb316 = yyj316 > l
 	} else {
-		yyb304 = r.CheckBreak()
+		yyb316 = r.CheckBreak()
 	}
-	if yyb304 {
+	if yyb316 {
 		r.ReadEnd()
 		return
 	}
@@ -3397,60 +3469,60 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj304++
-	if yyhl304 {
-		yyb304 = yyj304 > l
+	yyj316++
+	if yyhl316 {
+		yyb316 = yyj316 > l
 	} else {
-		yyb304 = r.CheckBreak()
+		yyb316 = r.CheckBreak()
 	}
-	if yyb304 {
+	if yyb316 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv307 := &x.ListMeta
-		yym308 := z.DecBinary()
-		_ = yym308
+		yyv319 := &x.ListMeta
+		yym320 := z.DecBinary()
+		_ = yym320
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv307) {
+		} else if z.HasExtensions() && z.DecExt(yyv319) {
 		} else {
-			z.DecFallback(yyv307, false)
+			z.DecFallback(yyv319, false)
 		}
 	}
-	yyj304++
-	if yyhl304 {
-		yyb304 = yyj304 > l
+	yyj316++
+	if yyhl316 {
+		yyb316 = yyj316 > l
 	} else {
-		yyb304 = r.CheckBreak()
+		yyb316 = r.CheckBreak()
 	}
-	if yyb304 {
+	if yyb316 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv309 := &x.Items
-		yym310 := z.DecBinary()
-		_ = yym310
+		yyv321 := &x.Items
+		yym322 := z.DecBinary()
+		_ = yym322
 		if false {
 		} else {
-			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv309), d)
+			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv321), d)
 		}
 	}
 	for {
-		yyj304++
-		if yyhl304 {
-			yyb304 = yyj304 > l
+		yyj316++
+		if yyhl316 {
+			yyb316 = yyj316 > l
 		} else {
-			yyb304 = r.CheckBreak()
+			yyb316 = r.CheckBreak()
 		}
-		if yyb304 {
+		if yyb316 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj304-1, "")
+		z.DecStructFieldNotFound(yyj316-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3462,33 +3534,33 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym311 := z.EncBinary()
-		_ = yym311
+		yym323 := z.EncBinary()
+		_ = yym323
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep312 := !z.EncBinary()
-			yy2arr312 := z.EncBasicHandle().StructToArray
-			var yyq312 [2]bool
-			_, _, _ = yysep312, yyq312, yy2arr312
-			const yyr312 bool = false
-			yyq312[0] = x.Name != ""
-			yyq312[1] = x.APIGroup != ""
-			if yyr312 || yy2arr312 {
+			yysep324 := !z.EncBinary()
+			yy2arr324 := z.EncBasicHandle().StructToArray
+			var yyq324 [2]bool
+			_, _, _ = yysep324, yyq324, yy2arr324
+			const yyr324 bool = false
+			yyq324[0] = x.Name != ""
+			yyq324[1] = x.APIGroup != ""
+			if yyr324 || yy2arr324 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn312 int = 0
-				for _, b := range yyq312 {
+				var yynn324 int = 0
+				for _, b := range yyq324 {
 					if b {
-						yynn312++
+						yynn324++
 					}
 				}
-				r.EncodeMapStart(yynn312)
+				r.EncodeMapStart(yynn324)
 			}
-			if yyr312 || yy2arr312 {
-				if yyq312[0] {
-					yym314 := z.EncBinary()
-					_ = yym314
+			if yyr324 || yy2arr324 {
+				if yyq324[0] {
+					yym326 := z.EncBinary()
+					_ = yym326
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -3497,20 +3569,20 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq312[0] {
+				if yyq324[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym315 := z.EncBinary()
-					_ = yym315
+					yym327 := z.EncBinary()
+					_ = yym327
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yyr312 || yy2arr312 {
-				if yyq312[1] {
-					yym317 := z.EncBinary()
-					_ = yym317
+			if yyr324 || yy2arr324 {
+				if yyq324[1] {
+					yym329 := z.EncBinary()
+					_ = yym329
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
@@ -3519,17 +3591,17 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq312[1] {
+				if yyq324[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiGroup"))
-					yym318 := z.EncBinary()
-					_ = yym318
+					yym330 := z.EncBinary()
+					_ = yym330
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
 					}
 				}
 			}
-			if yysep312 {
+			if yysep324 {
 				r.EncodeEnd()
 			}
 		}
@@ -3540,24 +3612,24 @@ func (x *APIVersion) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym319 := z.DecBinary()
-	_ = yym319
+	yym331 := z.DecBinary()
+	_ = yym331
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl320 := r.ReadMapStart()
-			if yyl320 == 0 {
+			yyl332 := r.ReadMapStart()
+			if yyl332 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl320, d)
+				x.codecDecodeSelfFromMap(yyl332, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl320 := r.ReadArrayStart()
-			if yyl320 == 0 {
+			yyl332 := r.ReadArrayStart()
+			if yyl332 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl320, d)
+				x.codecDecodeSelfFromArray(yyl332, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3569,12 +3641,12 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys321Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys321Slc
-	var yyhl321 bool = l >= 0
-	for yyj321 := 0; ; yyj321++ {
-		if yyhl321 {
-			if yyj321 >= l {
+	var yys333Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys333Slc
+	var yyhl333 bool = l >= 0
+	for yyj333 := 0; ; yyj333++ {
+		if yyhl333 {
+			if yyj333 >= l {
 				break
 			}
 		} else {
@@ -3582,9 +3654,9 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys321Slc = r.DecodeBytes(yys321Slc, true, true)
-		yys321 := string(yys321Slc)
-		switch yys321 {
+		yys333Slc = r.DecodeBytes(yys333Slc, true, true)
+		yys333 := string(yys333Slc)
+		switch yys333 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -3598,10 +3670,10 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIGroup = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys321)
-		} // end switch yys321
-	} // end for yyj321
-	if !yyhl321 {
+			z.DecStructFieldNotFound(-1, yys333)
+		} // end switch yys333
+	} // end for yyj333
+	if !yyhl333 {
 		r.ReadEnd()
 	}
 }
@@ -3610,16 +3682,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj324 int
-	var yyb324 bool
-	var yyhl324 bool = l >= 0
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	var yyj336 int
+	var yyb336 bool
+	var yyhl336 bool = l >= 0
+	yyj336++
+	if yyhl336 {
+		yyb336 = yyj336 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb336 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb336 {
 		r.ReadEnd()
 		return
 	}
@@ -3628,13 +3700,13 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	yyj336++
+	if yyhl336 {
+		yyb336 = yyj336 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb336 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb336 {
 		r.ReadEnd()
 		return
 	}
@@ -3644,16 +3716,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIGroup = string(r.DecodeString())
 	}
 	for {
-		yyj324++
-		if yyhl324 {
-			yyb324 = yyj324 > l
+		yyj336++
+		if yyhl336 {
+			yyb336 = yyj336 > l
 		} else {
-			yyb324 = r.CheckBreak()
+			yyb336 = r.CheckBreak()
 		}
-		if yyb324 {
+		if yyb336 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj324-1, "")
+		z.DecStructFieldNotFound(yyj336-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3665,35 +3737,35 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym327 := z.EncBinary()
-		_ = yym327
+		yym339 := z.EncBinary()
+		_ = yym339
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep328 := !z.EncBinary()
-			yy2arr328 := z.EncBasicHandle().StructToArray
-			var yyq328 [4]bool
-			_, _, _ = yysep328, yyq328, yy2arr328
-			const yyr328 bool = false
-			yyq328[0] = x.Kind != ""
-			yyq328[1] = x.APIVersion != ""
-			yyq328[2] = true
-			yyq328[3] = len(x.Data) != 0
-			if yyr328 || yy2arr328 {
+			yysep340 := !z.EncBinary()
+			yy2arr340 := z.EncBasicHandle().StructToArray
+			var yyq340 [4]bool
+			_, _, _ = yysep340, yyq340, yy2arr340
+			const yyr340 bool = false
+			yyq340[0] = x.Kind != ""
+			yyq340[1] = x.APIVersion != ""
+			yyq340[2] = true
+			yyq340[3] = len(x.Data) != 0
+			if yyr340 || yy2arr340 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn328 int = 0
-				for _, b := range yyq328 {
+				var yynn340 int = 0
+				for _, b := range yyq340 {
 					if b {
-						yynn328++
+						yynn340++
 					}
 				}
-				r.EncodeMapStart(yynn328)
+				r.EncodeMapStart(yynn340)
 			}
-			if yyr328 || yy2arr328 {
-				if yyq328[0] {
-					yym330 := z.EncBinary()
-					_ = yym330
+			if yyr340 || yy2arr340 {
+				if yyq340[0] {
+					yym342 := z.EncBinary()
+					_ = yym342
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3702,20 +3774,20 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq328[0] {
+				if yyq340[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym331 := z.EncBinary()
-					_ = yym331
+					yym343 := z.EncBinary()
+					_ = yym343
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr328 || yy2arr328 {
-				if yyq328[1] {
-					yym333 := z.EncBinary()
-					_ = yym333
+			if yyr340 || yy2arr340 {
+				if yyq340[1] {
+					yym345 := z.EncBinary()
+					_ = yym345
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3724,37 +3796,49 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq328[1] {
+				if yyq340[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym334 := z.EncBinary()
-					_ = yym334
+					yym346 := z.EncBinary()
+					_ = yym346
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr328 || yy2arr328 {
-				if yyq328[2] {
-					yy336 := &x.ObjectMeta
-					yy336.CodecEncodeSelf(e)
+			if yyr340 || yy2arr340 {
+				if yyq340[2] {
+					yy348 := &x.ObjectMeta
+					yym349 := z.EncBinary()
+					_ = yym349
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy348) {
+					} else {
+						z.EncFallback(yy348)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq328[2] {
+				if yyq340[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy337 := &x.ObjectMeta
-					yy337.CodecEncodeSelf(e)
+					yy350 := &x.ObjectMeta
+					yym351 := z.EncBinary()
+					_ = yym351
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy350) {
+					} else {
+						z.EncFallback(yy350)
+					}
 				}
 			}
-			if yyr328 || yy2arr328 {
-				if yyq328[3] {
+			if yyr340 || yy2arr340 {
+				if yyq340[3] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym339 := z.EncBinary()
-						_ = yym339
+						yym353 := z.EncBinary()
+						_ = yym353
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3764,13 +3848,13 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq328[3] {
+				if yyq340[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym340 := z.EncBinary()
-						_ = yym340
+						yym354 := z.EncBinary()
+						_ = yym354
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3778,7 +3862,7 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep328 {
+			if yysep340 {
 				r.EncodeEnd()
 			}
 		}
@@ -3789,24 +3873,24 @@ func (x *ThirdPartyResourceData) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym341 := z.DecBinary()
-	_ = yym341
+	yym355 := z.DecBinary()
+	_ = yym355
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl342 := r.ReadMapStart()
-			if yyl342 == 0 {
+			yyl356 := r.ReadMapStart()
+			if yyl356 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl342, d)
+				x.codecDecodeSelfFromMap(yyl356, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl342 := r.ReadArrayStart()
-			if yyl342 == 0 {
+			yyl356 := r.ReadArrayStart()
+			if yyl356 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl342, d)
+				x.codecDecodeSelfFromArray(yyl356, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3818,12 +3902,12 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys343Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys343Slc
-	var yyhl343 bool = l >= 0
-	for yyj343 := 0; ; yyj343++ {
-		if yyhl343 {
-			if yyj343 >= l {
+	var yys357Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys357Slc
+	var yyhl357 bool = l >= 0
+	for yyj357 := 0; ; yyj357++ {
+		if yyhl357 {
+			if yyj357 >= l {
 				break
 			}
 		} else {
@@ -3831,9 +3915,9 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
-		yys343 := string(yys343Slc)
-		switch yys343 {
+		yys357Slc = r.DecodeBytes(yys357Slc, true, true)
+		yys357 := string(yys357Slc)
+		switch yys357 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3850,26 +3934,32 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv346 := &x.ObjectMeta
-				yyv346.CodecDecodeSelf(d)
+				yyv360 := &x.ObjectMeta
+				yym361 := z.DecBinary()
+				_ = yym361
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv360) {
+				} else {
+					z.DecFallback(yyv360, false)
+				}
 			}
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv347 := &x.Data
-				yym348 := z.DecBinary()
-				_ = yym348
+				yyv362 := &x.Data
+				yym363 := z.DecBinary()
+				_ = yym363
 				if false {
 				} else {
-					*yyv347 = r.DecodeBytes(*(*[]byte)(yyv347), false, false)
+					*yyv362 = r.DecodeBytes(*(*[]byte)(yyv362), false, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys343)
-		} // end switch yys343
-	} // end for yyj343
-	if !yyhl343 {
+			z.DecStructFieldNotFound(-1, yys357)
+		} // end switch yys357
+	} // end for yyj357
+	if !yyhl357 {
 		r.ReadEnd()
 	}
 }
@@ -3878,16 +3968,16 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj349 int
-	var yyb349 bool
-	var yyhl349 bool = l >= 0
-	yyj349++
-	if yyhl349 {
-		yyb349 = yyj349 > l
+	var yyj364 int
+	var yyb364 bool
+	var yyhl364 bool = l >= 0
+	yyj364++
+	if yyhl364 {
+		yyb364 = yyj364 > l
 	} else {
-		yyb349 = r.CheckBreak()
+		yyb364 = r.CheckBreak()
 	}
-	if yyb349 {
+	if yyb364 {
 		r.ReadEnd()
 		return
 	}
@@ -3896,13 +3986,13 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj349++
-	if yyhl349 {
-		yyb349 = yyj349 > l
+	yyj364++
+	if yyhl364 {
+		yyb364 = yyj364 > l
 	} else {
-		yyb349 = r.CheckBreak()
+		yyb364 = r.CheckBreak()
 	}
-	if yyb349 {
+	if yyb364 {
 		r.ReadEnd()
 		return
 	}
@@ -3911,54 +4001,60 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj349++
-	if yyhl349 {
-		yyb349 = yyj349 > l
+	yyj364++
+	if yyhl364 {
+		yyb364 = yyj364 > l
 	} else {
-		yyb349 = r.CheckBreak()
+		yyb364 = r.CheckBreak()
 	}
-	if yyb349 {
+	if yyb364 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv352 := &x.ObjectMeta
-		yyv352.CodecDecodeSelf(d)
+		yyv367 := &x.ObjectMeta
+		yym368 := z.DecBinary()
+		_ = yym368
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv367) {
+		} else {
+			z.DecFallback(yyv367, false)
+		}
 	}
-	yyj349++
-	if yyhl349 {
-		yyb349 = yyj349 > l
+	yyj364++
+	if yyhl364 {
+		yyb364 = yyj364 > l
 	} else {
-		yyb349 = r.CheckBreak()
+		yyb364 = r.CheckBreak()
 	}
-	if yyb349 {
+	if yyb364 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv353 := &x.Data
-		yym354 := z.DecBinary()
-		_ = yym354
+		yyv369 := &x.Data
+		yym370 := z.DecBinary()
+		_ = yym370
 		if false {
 		} else {
-			*yyv353 = r.DecodeBytes(*(*[]byte)(yyv353), false, false)
+			*yyv369 = r.DecodeBytes(*(*[]byte)(yyv369), false, false)
 		}
 	}
 	for {
-		yyj349++
-		if yyhl349 {
-			yyb349 = yyj349 > l
+		yyj364++
+		if yyhl364 {
+			yyb364 = yyj364 > l
 		} else {
-			yyb349 = r.CheckBreak()
+			yyb364 = r.CheckBreak()
 		}
-		if yyb349 {
+		if yyb364 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj349-1, "")
+		z.DecStructFieldNotFound(yyj364-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3970,36 +4066,36 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym355 := z.EncBinary()
-		_ = yym355
+		yym371 := z.EncBinary()
+		_ = yym371
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep356 := !z.EncBinary()
-			yy2arr356 := z.EncBasicHandle().StructToArray
-			var yyq356 [5]bool
-			_, _, _ = yysep356, yyq356, yy2arr356
-			const yyr356 bool = false
-			yyq356[0] = x.Kind != ""
-			yyq356[1] = x.APIVersion != ""
-			yyq356[2] = true
-			yyq356[3] = true
-			yyq356[4] = true
-			if yyr356 || yy2arr356 {
+			yysep372 := !z.EncBinary()
+			yy2arr372 := z.EncBasicHandle().StructToArray
+			var yyq372 [5]bool
+			_, _, _ = yysep372, yyq372, yy2arr372
+			const yyr372 bool = false
+			yyq372[0] = x.Kind != ""
+			yyq372[1] = x.APIVersion != ""
+			yyq372[2] = true
+			yyq372[3] = true
+			yyq372[4] = true
+			if yyr372 || yy2arr372 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn356 int = 0
-				for _, b := range yyq356 {
+				var yynn372 int = 0
+				for _, b := range yyq372 {
 					if b {
-						yynn356++
+						yynn372++
 					}
 				}
-				r.EncodeMapStart(yynn356)
+				r.EncodeMapStart(yynn372)
 			}
-			if yyr356 || yy2arr356 {
-				if yyq356[0] {
-					yym358 := z.EncBinary()
-					_ = yym358
+			if yyr372 || yy2arr372 {
+				if yyq372[0] {
+					yym374 := z.EncBinary()
+					_ = yym374
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -4008,20 +4104,20 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq356[0] {
+				if yyq372[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym359 := z.EncBinary()
-					_ = yym359
+					yym375 := z.EncBinary()
+					_ = yym375
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr356 || yy2arr356 {
-				if yyq356[1] {
-					yym361 := z.EncBinary()
-					_ = yym361
+			if yyr372 || yy2arr372 {
+				if yyq372[1] {
+					yym377 := z.EncBinary()
+					_ = yym377
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -4030,59 +4126,71 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq356[1] {
+				if yyq372[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym362 := z.EncBinary()
-					_ = yym362
+					yym378 := z.EncBinary()
+					_ = yym378
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr356 || yy2arr356 {
-				if yyq356[2] {
-					yy364 := &x.ObjectMeta
-					yy364.CodecEncodeSelf(e)
+			if yyr372 || yy2arr372 {
+				if yyq372[2] {
+					yy380 := &x.ObjectMeta
+					yym381 := z.EncBinary()
+					_ = yym381
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy380) {
+					} else {
+						z.EncFallback(yy380)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq356[2] {
+				if yyq372[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy365 := &x.ObjectMeta
-					yy365.CodecEncodeSelf(e)
+					yy382 := &x.ObjectMeta
+					yym383 := z.EncBinary()
+					_ = yym383
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy382) {
+					} else {
+						z.EncFallback(yy382)
+					}
 				}
 			}
-			if yyr356 || yy2arr356 {
-				if yyq356[3] {
-					yy367 := &x.Spec
-					yy367.CodecEncodeSelf(e)
+			if yyr372 || yy2arr372 {
+				if yyq372[3] {
+					yy385 := &x.Spec
+					yy385.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq356[3] {
+				if yyq372[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy368 := &x.Spec
-					yy368.CodecEncodeSelf(e)
+					yy386 := &x.Spec
+					yy386.CodecEncodeSelf(e)
 				}
 			}
-			if yyr356 || yy2arr356 {
-				if yyq356[4] {
-					yy370 := &x.Status
-					yy370.CodecEncodeSelf(e)
+			if yyr372 || yy2arr372 {
+				if yyq372[4] {
+					yy388 := &x.Status
+					yy388.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq356[4] {
+				if yyq372[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy371 := &x.Status
-					yy371.CodecEncodeSelf(e)
+					yy389 := &x.Status
+					yy389.CodecEncodeSelf(e)
 				}
 			}
-			if yysep356 {
+			if yysep372 {
 				r.EncodeEnd()
 			}
 		}
@@ -4093,24 +4201,24 @@ func (x *Deployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym372 := z.DecBinary()
-	_ = yym372
+	yym390 := z.DecBinary()
+	_ = yym390
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl373 := r.ReadMapStart()
-			if yyl373 == 0 {
+			yyl391 := r.ReadMapStart()
+			if yyl391 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl373, d)
+				x.codecDecodeSelfFromMap(yyl391, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl373 := r.ReadArrayStart()
-			if yyl373 == 0 {
+			yyl391 := r.ReadArrayStart()
+			if yyl391 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl373, d)
+				x.codecDecodeSelfFromArray(yyl391, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4122,12 +4230,12 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys374Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys374Slc
-	var yyhl374 bool = l >= 0
-	for yyj374 := 0; ; yyj374++ {
-		if yyhl374 {
-			if yyj374 >= l {
+	var yys392Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys392Slc
+	var yyhl392 bool = l >= 0
+	for yyj392 := 0; ; yyj392++ {
+		if yyhl392 {
+			if yyj392 >= l {
 				break
 			}
 		} else {
@@ -4135,9 +4243,9 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys374Slc = r.DecodeBytes(yys374Slc, true, true)
-		yys374 := string(yys374Slc)
-		switch yys374 {
+		yys392Slc = r.DecodeBytes(yys392Slc, true, true)
+		yys392 := string(yys392Slc)
+		switch yys392 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4154,28 +4262,34 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv377 := &x.ObjectMeta
-				yyv377.CodecDecodeSelf(d)
+				yyv395 := &x.ObjectMeta
+				yym396 := z.DecBinary()
+				_ = yym396
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv395) {
+				} else {
+					z.DecFallback(yyv395, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DeploymentSpec{}
 			} else {
-				yyv378 := &x.Spec
-				yyv378.CodecDecodeSelf(d)
+				yyv397 := &x.Spec
+				yyv397.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DeploymentStatus{}
 			} else {
-				yyv379 := &x.Status
-				yyv379.CodecDecodeSelf(d)
+				yyv398 := &x.Status
+				yyv398.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys374)
-		} // end switch yys374
-	} // end for yyj374
-	if !yyhl374 {
+			z.DecStructFieldNotFound(-1, yys392)
+		} // end switch yys392
+	} // end for yyj392
+	if !yyhl392 {
 		r.ReadEnd()
 	}
 }
@@ -4184,16 +4298,16 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj380 int
-	var yyb380 bool
-	var yyhl380 bool = l >= 0
-	yyj380++
-	if yyhl380 {
-		yyb380 = yyj380 > l
+	var yyj399 int
+	var yyb399 bool
+	var yyhl399 bool = l >= 0
+	yyj399++
+	if yyhl399 {
+		yyb399 = yyj399 > l
 	} else {
-		yyb380 = r.CheckBreak()
+		yyb399 = r.CheckBreak()
 	}
-	if yyb380 {
+	if yyb399 {
 		r.ReadEnd()
 		return
 	}
@@ -4202,13 +4316,13 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj380++
-	if yyhl380 {
-		yyb380 = yyj380 > l
+	yyj399++
+	if yyhl399 {
+		yyb399 = yyj399 > l
 	} else {
-		yyb380 = r.CheckBreak()
+		yyb399 = r.CheckBreak()
 	}
-	if yyb380 {
+	if yyb399 {
 		r.ReadEnd()
 		return
 	}
@@ -4217,65 +4331,71 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj380++
-	if yyhl380 {
-		yyb380 = yyj380 > l
+	yyj399++
+	if yyhl399 {
+		yyb399 = yyj399 > l
 	} else {
-		yyb380 = r.CheckBreak()
+		yyb399 = r.CheckBreak()
 	}
-	if yyb380 {
+	if yyb399 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv383 := &x.ObjectMeta
-		yyv383.CodecDecodeSelf(d)
+		yyv402 := &x.ObjectMeta
+		yym403 := z.DecBinary()
+		_ = yym403
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv402) {
+		} else {
+			z.DecFallback(yyv402, false)
+		}
 	}
-	yyj380++
-	if yyhl380 {
-		yyb380 = yyj380 > l
+	yyj399++
+	if yyhl399 {
+		yyb399 = yyj399 > l
 	} else {
-		yyb380 = r.CheckBreak()
+		yyb399 = r.CheckBreak()
 	}
-	if yyb380 {
+	if yyb399 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = DeploymentSpec{}
 	} else {
-		yyv384 := &x.Spec
-		yyv384.CodecDecodeSelf(d)
+		yyv404 := &x.Spec
+		yyv404.CodecDecodeSelf(d)
 	}
-	yyj380++
-	if yyhl380 {
-		yyb380 = yyj380 > l
+	yyj399++
+	if yyhl399 {
+		yyb399 = yyj399 > l
 	} else {
-		yyb380 = r.CheckBreak()
+		yyb399 = r.CheckBreak()
 	}
-	if yyb380 {
+	if yyb399 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = DeploymentStatus{}
 	} else {
-		yyv385 := &x.Status
-		yyv385.CodecDecodeSelf(d)
+		yyv405 := &x.Status
+		yyv405.CodecDecodeSelf(d)
 	}
 	for {
-		yyj380++
-		if yyhl380 {
-			yyb380 = yyj380 > l
+		yyj399++
+		if yyhl399 {
+			yyb399 = yyj399 > l
 		} else {
-			yyb380 = r.CheckBreak()
+			yyb399 = r.CheckBreak()
 		}
-		if yyb380 {
+		if yyb399 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj380-1, "")
+		z.DecStructFieldNotFound(yyj399-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4287,35 +4407,35 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym386 := z.EncBinary()
-		_ = yym386
+		yym406 := z.EncBinary()
+		_ = yym406
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep387 := !z.EncBinary()
-			yy2arr387 := z.EncBasicHandle().StructToArray
-			var yyq387 [5]bool
-			_, _, _ = yysep387, yyq387, yy2arr387
-			const yyr387 bool = false
-			yyq387[0] = x.Replicas != 0
-			yyq387[1] = len(x.Selector) != 0
-			yyq387[3] = true
-			yyq387[4] = x.UniqueLabelKey != ""
-			if yyr387 || yy2arr387 {
+			yysep407 := !z.EncBinary()
+			yy2arr407 := z.EncBasicHandle().StructToArray
+			var yyq407 [5]bool
+			_, _, _ = yysep407, yyq407, yy2arr407
+			const yyr407 bool = false
+			yyq407[0] = x.Replicas != 0
+			yyq407[1] = len(x.Selector) != 0
+			yyq407[3] = true
+			yyq407[4] = x.UniqueLabelKey != ""
+			if yyr407 || yy2arr407 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn387 int = 1
-				for _, b := range yyq387 {
+				var yynn407 int = 1
+				for _, b := range yyq407 {
 					if b {
-						yynn387++
+						yynn407++
 					}
 				}
-				r.EncodeMapStart(yynn387)
+				r.EncodeMapStart(yynn407)
 			}
-			if yyr387 || yy2arr387 {
-				if yyq387[0] {
-					yym389 := z.EncBinary()
-					_ = yym389
+			if yyr407 || yy2arr407 {
+				if yyq407[0] {
+					yym409 := z.EncBinary()
+					_ = yym409
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -4324,23 +4444,23 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq387[0] {
+				if yyq407[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-					yym390 := z.EncBinary()
-					_ = yym390
+					yym410 := z.EncBinary()
+					_ = yym410
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr387 || yy2arr387 {
-				if yyq387[1] {
+			if yyr407 || yy2arr407 {
+				if yyq407[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym392 := z.EncBinary()
-						_ = yym392
+						yym412 := z.EncBinary()
+						_ = yym412
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4350,13 +4470,13 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq387[1] {
+				if yyq407[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym393 := z.EncBinary()
-						_ = yym393
+						yym413 := z.EncBinary()
+						_ = yym413
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4364,32 +4484,44 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr387 || yy2arr387 {
-				yy395 := &x.Template
-				yy395.CodecEncodeSelf(e)
+			if yyr407 || yy2arr407 {
+				yy415 := &x.Template
+				yym416 := z.EncBinary()
+				_ = yym416
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy415) {
+				} else {
+					z.EncFallback(yy415)
+				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
-				yy396 := &x.Template
-				yy396.CodecEncodeSelf(e)
+				yy417 := &x.Template
+				yym418 := z.EncBinary()
+				_ = yym418
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy417) {
+				} else {
+					z.EncFallback(yy417)
+				}
 			}
-			if yyr387 || yy2arr387 {
-				if yyq387[3] {
-					yy398 := &x.Strategy
-					yy398.CodecEncodeSelf(e)
+			if yyr407 || yy2arr407 {
+				if yyq407[3] {
+					yy420 := &x.Strategy
+					yy420.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq387[3] {
+				if yyq407[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("strategy"))
-					yy399 := &x.Strategy
-					yy399.CodecEncodeSelf(e)
+					yy421 := &x.Strategy
+					yy421.CodecEncodeSelf(e)
 				}
 			}
-			if yyr387 || yy2arr387 {
-				if yyq387[4] {
-					yym401 := z.EncBinary()
-					_ = yym401
+			if yyr407 || yy2arr407 {
+				if yyq407[4] {
+					yym423 := z.EncBinary()
+					_ = yym423
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
@@ -4398,17 +4530,17 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq387[4] {
+				if yyq407[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
-					yym402 := z.EncBinary()
-					_ = yym402
+					yym424 := z.EncBinary()
+					_ = yym424
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
 					}
 				}
 			}
-			if yysep387 {
+			if yysep407 {
 				r.EncodeEnd()
 			}
 		}
@@ -4419,24 +4551,24 @@ func (x *DeploymentSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym403 := z.DecBinary()
-	_ = yym403
+	yym425 := z.DecBinary()
+	_ = yym425
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl404 := r.ReadMapStart()
-			if yyl404 == 0 {
+			yyl426 := r.ReadMapStart()
+			if yyl426 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl404, d)
+				x.codecDecodeSelfFromMap(yyl426, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl404 := r.ReadArrayStart()
-			if yyl404 == 0 {
+			yyl426 := r.ReadArrayStart()
+			if yyl426 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl404, d)
+				x.codecDecodeSelfFromArray(yyl426, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4448,12 +4580,12 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys405Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys405Slc
-	var yyhl405 bool = l >= 0
-	for yyj405 := 0; ; yyj405++ {
-		if yyhl405 {
-			if yyj405 >= l {
+	var yys427Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys427Slc
+	var yyhl427 bool = l >= 0
+	for yyj427 := 0; ; yyj427++ {
+		if yyhl427 {
+			if yyj427 >= l {
 				break
 			}
 		} else {
@@ -4461,9 +4593,9 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys405Slc = r.DecodeBytes(yys405Slc, true, true)
-		yys405 := string(yys405Slc)
-		switch yys405 {
+		yys427Slc = r.DecodeBytes(yys427Slc, true, true)
+		yys427 := string(yys427Slc)
+		switch yys427 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -4474,27 +4606,33 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv407 := &x.Selector
-				yym408 := z.DecBinary()
-				_ = yym408
+				yyv429 := &x.Selector
+				yym430 := z.DecBinary()
+				_ = yym430
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv407, false, d)
+					z.F.DecMapStringStringX(yyv429, false, d)
 				}
 			}
 		case "template":
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv409 := &x.Template
-				yyv409.CodecDecodeSelf(d)
+				yyv431 := &x.Template
+				yym432 := z.DecBinary()
+				_ = yym432
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv431) {
+				} else {
+					z.DecFallback(yyv431, false)
+				}
 			}
 		case "strategy":
 			if r.TryDecodeAsNil() {
 				x.Strategy = DeploymentStrategy{}
 			} else {
-				yyv410 := &x.Strategy
-				yyv410.CodecDecodeSelf(d)
+				yyv433 := &x.Strategy
+				yyv433.CodecDecodeSelf(d)
 			}
 		case "uniqueLabelKey":
 			if r.TryDecodeAsNil() {
@@ -4503,10 +4641,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.UniqueLabelKey = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys405)
-		} // end switch yys405
-	} // end for yyj405
-	if !yyhl405 {
+			z.DecStructFieldNotFound(-1, yys427)
+		} // end switch yys427
+	} // end for yyj427
+	if !yyhl427 {
 		r.ReadEnd()
 	}
 }
@@ -4515,16 +4653,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj412 int
-	var yyb412 bool
-	var yyhl412 bool = l >= 0
-	yyj412++
-	if yyhl412 {
-		yyb412 = yyj412 > l
+	var yyj435 int
+	var yyb435 bool
+	var yyhl435 bool = l >= 0
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb412 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb412 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
@@ -4533,66 +4671,72 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj412++
-	if yyhl412 {
-		yyb412 = yyj412 > l
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb412 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb412 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv414 := &x.Selector
-		yym415 := z.DecBinary()
-		_ = yym415
+		yyv437 := &x.Selector
+		yym438 := z.DecBinary()
+		_ = yym438
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv414, false, d)
+			z.F.DecMapStringStringX(yyv437, false, d)
 		}
 	}
-	yyj412++
-	if yyhl412 {
-		yyb412 = yyj412 > l
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb412 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb412 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv416 := &x.Template
-		yyv416.CodecDecodeSelf(d)
+		yyv439 := &x.Template
+		yym440 := z.DecBinary()
+		_ = yym440
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv439) {
+		} else {
+			z.DecFallback(yyv439, false)
+		}
 	}
-	yyj412++
-	if yyhl412 {
-		yyb412 = yyj412 > l
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb412 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb412 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Strategy = DeploymentStrategy{}
 	} else {
-		yyv417 := &x.Strategy
-		yyv417.CodecDecodeSelf(d)
+		yyv441 := &x.Strategy
+		yyv441.CodecDecodeSelf(d)
 	}
-	yyj412++
-	if yyhl412 {
-		yyb412 = yyj412 > l
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb412 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb412 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
@@ -4602,16 +4746,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.UniqueLabelKey = string(r.DecodeString())
 	}
 	for {
-		yyj412++
-		if yyhl412 {
-			yyb412 = yyj412 > l
+		yyj435++
+		if yyhl435 {
+			yyb435 = yyj435 > l
 		} else {
-			yyb412 = r.CheckBreak()
+			yyb435 = r.CheckBreak()
 		}
-		if yyb412 {
+		if yyb435 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj412-1, "")
+		z.DecStructFieldNotFound(yyj435-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4623,43 +4767,43 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym419 := z.EncBinary()
-		_ = yym419
+		yym443 := z.EncBinary()
+		_ = yym443
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep420 := !z.EncBinary()
-			yy2arr420 := z.EncBasicHandle().StructToArray
-			var yyq420 [2]bool
-			_, _, _ = yysep420, yyq420, yy2arr420
-			const yyr420 bool = false
-			yyq420[0] = x.Type != ""
-			yyq420[1] = x.RollingUpdate != nil
-			if yyr420 || yy2arr420 {
+			yysep444 := !z.EncBinary()
+			yy2arr444 := z.EncBasicHandle().StructToArray
+			var yyq444 [2]bool
+			_, _, _ = yysep444, yyq444, yy2arr444
+			const yyr444 bool = false
+			yyq444[0] = x.Type != ""
+			yyq444[1] = x.RollingUpdate != nil
+			if yyr444 || yy2arr444 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn420 int = 0
-				for _, b := range yyq420 {
+				var yynn444 int = 0
+				for _, b := range yyq444 {
 					if b {
-						yynn420++
+						yynn444++
 					}
 				}
-				r.EncodeMapStart(yynn420)
+				r.EncodeMapStart(yynn444)
 			}
-			if yyr420 || yy2arr420 {
-				if yyq420[0] {
+			if yyr444 || yy2arr444 {
+				if yyq444[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq420[0] {
+				if yyq444[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr420 || yy2arr420 {
-				if yyq420[1] {
+			if yyr444 || yy2arr444 {
+				if yyq444[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -4669,7 +4813,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq420[1] {
+				if yyq444[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
@@ -4678,7 +4822,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep420 {
+			if yysep444 {
 				r.EncodeEnd()
 			}
 		}
@@ -4689,24 +4833,24 @@ func (x *DeploymentStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym423 := z.DecBinary()
-	_ = yym423
+	yym447 := z.DecBinary()
+	_ = yym447
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl424 := r.ReadMapStart()
-			if yyl424 == 0 {
+			yyl448 := r.ReadMapStart()
+			if yyl448 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl424, d)
+				x.codecDecodeSelfFromMap(yyl448, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl424 := r.ReadArrayStart()
-			if yyl424 == 0 {
+			yyl448 := r.ReadArrayStart()
+			if yyl448 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl424, d)
+				x.codecDecodeSelfFromArray(yyl448, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4718,12 +4862,12 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys425Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys425Slc
-	var yyhl425 bool = l >= 0
-	for yyj425 := 0; ; yyj425++ {
-		if yyhl425 {
-			if yyj425 >= l {
+	var yys449Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys449Slc
+	var yyhl449 bool = l >= 0
+	for yyj449 := 0; ; yyj449++ {
+		if yyhl449 {
+			if yyj449 >= l {
 				break
 			}
 		} else {
@@ -4731,9 +4875,9 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys425Slc = r.DecodeBytes(yys425Slc, true, true)
-		yys425 := string(yys425Slc)
-		switch yys425 {
+		yys449Slc = r.DecodeBytes(yys449Slc, true, true)
+		yys449 := string(yys449Slc)
+		switch yys449 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -4752,10 +4896,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.RollingUpdate.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys425)
-		} // end switch yys425
-	} // end for yyj425
-	if !yyhl425 {
+			z.DecStructFieldNotFound(-1, yys449)
+		} // end switch yys449
+	} // end for yyj449
+	if !yyhl449 {
 		r.ReadEnd()
 	}
 }
@@ -4764,16 +4908,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj428 int
-	var yyb428 bool
-	var yyhl428 bool = l >= 0
-	yyj428++
-	if yyhl428 {
-		yyb428 = yyj428 > l
+	var yyj452 int
+	var yyb452 bool
+	var yyhl452 bool = l >= 0
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb428 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb428 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
@@ -4782,13 +4926,13 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = DeploymentStrategyType(r.DecodeString())
 	}
-	yyj428++
-	if yyhl428 {
-		yyb428 = yyj428 > l
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb428 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb428 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
@@ -4803,16 +4947,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.RollingUpdate.CodecDecodeSelf(d)
 	}
 	for {
-		yyj428++
-		if yyhl428 {
-			yyb428 = yyj428 > l
+		yyj452++
+		if yyhl452 {
+			yyb452 = yyj452 > l
 		} else {
-			yyb428 = r.CheckBreak()
+			yyb452 = r.CheckBreak()
 		}
-		if yyb428 {
+		if yyb452 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj428-1, "")
+		z.DecStructFieldNotFound(yyj452-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4821,8 +4965,8 @@ func (x DeploymentStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym431 := z.EncBinary()
-	_ = yym431
+	yym455 := z.EncBinary()
+	_ = yym455
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -4834,8 +4978,8 @@ func (x *DeploymentStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym432 := z.DecBinary()
-	_ = yym432
+	yym456 := z.DecBinary()
+	_ = yym456
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -4850,94 +4994,94 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym433 := z.EncBinary()
-		_ = yym433
+		yym457 := z.EncBinary()
+		_ = yym457
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep434 := !z.EncBinary()
-			yy2arr434 := z.EncBasicHandle().StructToArray
-			var yyq434 [3]bool
-			_, _, _ = yysep434, yyq434, yy2arr434
-			const yyr434 bool = false
-			yyq434[0] = true
-			yyq434[1] = true
-			yyq434[2] = x.MinReadySeconds != 0
-			if yyr434 || yy2arr434 {
+			yysep458 := !z.EncBinary()
+			yy2arr458 := z.EncBasicHandle().StructToArray
+			var yyq458 [3]bool
+			_, _, _ = yysep458, yyq458, yy2arr458
+			const yyr458 bool = false
+			yyq458[0] = true
+			yyq458[1] = true
+			yyq458[2] = x.MinReadySeconds != 0
+			if yyr458 || yy2arr458 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn434 int = 0
-				for _, b := range yyq434 {
+				var yynn458 int = 0
+				for _, b := range yyq458 {
 					if b {
-						yynn434++
+						yynn458++
 					}
 				}
-				r.EncodeMapStart(yynn434)
+				r.EncodeMapStart(yynn458)
 			}
-			if yyr434 || yy2arr434 {
-				if yyq434[0] {
-					yy436 := &x.MaxUnavailable
-					yym437 := z.EncBinary()
-					_ = yym437
+			if yyr458 || yy2arr458 {
+				if yyq458[0] {
+					yy460 := &x.MaxUnavailable
+					yym461 := z.EncBinary()
+					_ = yym461
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy436) {
-					} else if !yym437 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy436)
+					} else if z.HasExtensions() && z.EncExt(yy460) {
+					} else if !yym461 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy460)
 					} else {
-						z.EncFallback(yy436)
+						z.EncFallback(yy460)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq434[0] {
+				if yyq458[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
-					yy438 := &x.MaxUnavailable
-					yym439 := z.EncBinary()
-					_ = yym439
+					yy462 := &x.MaxUnavailable
+					yym463 := z.EncBinary()
+					_ = yym463
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy438) {
-					} else if !yym439 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy438)
+					} else if z.HasExtensions() && z.EncExt(yy462) {
+					} else if !yym463 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy462)
 					} else {
-						z.EncFallback(yy438)
+						z.EncFallback(yy462)
 					}
 				}
 			}
-			if yyr434 || yy2arr434 {
-				if yyq434[1] {
-					yy441 := &x.MaxSurge
-					yym442 := z.EncBinary()
-					_ = yym442
+			if yyr458 || yy2arr458 {
+				if yyq458[1] {
+					yy465 := &x.MaxSurge
+					yym466 := z.EncBinary()
+					_ = yym466
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy441) {
-					} else if !yym442 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy441)
+					} else if z.HasExtensions() && z.EncExt(yy465) {
+					} else if !yym466 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy465)
 					} else {
-						z.EncFallback(yy441)
+						z.EncFallback(yy465)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq434[1] {
+				if yyq458[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
-					yy443 := &x.MaxSurge
-					yym444 := z.EncBinary()
-					_ = yym444
+					yy467 := &x.MaxSurge
+					yym468 := z.EncBinary()
+					_ = yym468
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy443) {
-					} else if !yym444 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy443)
+					} else if z.HasExtensions() && z.EncExt(yy467) {
+					} else if !yym468 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy467)
 					} else {
-						z.EncFallback(yy443)
+						z.EncFallback(yy467)
 					}
 				}
 			}
-			if yyr434 || yy2arr434 {
-				if yyq434[2] {
-					yym446 := z.EncBinary()
-					_ = yym446
+			if yyr458 || yy2arr458 {
+				if yyq458[2] {
+					yym470 := z.EncBinary()
+					_ = yym470
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
@@ -4946,17 +5090,17 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq434[2] {
+				if yyq458[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
-					yym447 := z.EncBinary()
-					_ = yym447
+					yym471 := z.EncBinary()
+					_ = yym471
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
 					}
 				}
 			}
-			if yysep434 {
+			if yysep458 {
 				r.EncodeEnd()
 			}
 		}
@@ -4967,24 +5111,24 @@ func (x *RollingUpdateDeployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym448 := z.DecBinary()
-	_ = yym448
+	yym472 := z.DecBinary()
+	_ = yym472
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl449 := r.ReadMapStart()
-			if yyl449 == 0 {
+			yyl473 := r.ReadMapStart()
+			if yyl473 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl449, d)
+				x.codecDecodeSelfFromMap(yyl473, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl449 := r.ReadArrayStart()
-			if yyl449 == 0 {
+			yyl473 := r.ReadArrayStart()
+			if yyl473 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl449, d)
+				x.codecDecodeSelfFromArray(yyl473, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4996,12 +5140,12 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys450Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys450Slc
-	var yyhl450 bool = l >= 0
-	for yyj450 := 0; ; yyj450++ {
-		if yyhl450 {
-			if yyj450 >= l {
+	var yys474Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys474Slc
+	var yyhl474 bool = l >= 0
+	for yyj474 := 0; ; yyj474++ {
+		if yyhl474 {
+			if yyj474 >= l {
 				break
 			}
 		} else {
@@ -5009,37 +5153,37 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys450Slc = r.DecodeBytes(yys450Slc, true, true)
-		yys450 := string(yys450Slc)
-		switch yys450 {
+		yys474Slc = r.DecodeBytes(yys474Slc, true, true)
+		yys474 := string(yys474Slc)
+		switch yys474 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
 				x.MaxUnavailable = pkg6_intstr.IntOrString{}
 			} else {
-				yyv451 := &x.MaxUnavailable
-				yym452 := z.DecBinary()
-				_ = yym452
+				yyv475 := &x.MaxUnavailable
+				yym476 := z.DecBinary()
+				_ = yym476
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv451) {
-				} else if !yym452 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv451)
+				} else if z.HasExtensions() && z.DecExt(yyv475) {
+				} else if !yym476 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv475)
 				} else {
-					z.DecFallback(yyv451, false)
+					z.DecFallback(yyv475, false)
 				}
 			}
 		case "maxSurge":
 			if r.TryDecodeAsNil() {
 				x.MaxSurge = pkg6_intstr.IntOrString{}
 			} else {
-				yyv453 := &x.MaxSurge
-				yym454 := z.DecBinary()
-				_ = yym454
+				yyv477 := &x.MaxSurge
+				yym478 := z.DecBinary()
+				_ = yym478
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv453) {
-				} else if !yym454 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv453)
+				} else if z.HasExtensions() && z.DecExt(yyv477) {
+				} else if !yym478 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv477)
 				} else {
-					z.DecFallback(yyv453, false)
+					z.DecFallback(yyv477, false)
 				}
 			}
 		case "minReadySeconds":
@@ -5049,10 +5193,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys450)
-		} // end switch yys450
-	} // end for yyj450
-	if !yyhl450 {
+			z.DecStructFieldNotFound(-1, yys474)
+		} // end switch yys474
+	} // end for yyj474
+	if !yyhl474 {
 		r.ReadEnd()
 	}
 }
@@ -5061,64 +5205,64 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj456 int
-	var yyb456 bool
-	var yyhl456 bool = l >= 0
-	yyj456++
-	if yyhl456 {
-		yyb456 = yyj456 > l
+	var yyj480 int
+	var yyb480 bool
+	var yyhl480 bool = l >= 0
+	yyj480++
+	if yyhl480 {
+		yyb480 = yyj480 > l
 	} else {
-		yyb456 = r.CheckBreak()
+		yyb480 = r.CheckBreak()
 	}
-	if yyb456 {
+	if yyb480 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxUnavailable = pkg6_intstr.IntOrString{}
 	} else {
-		yyv457 := &x.MaxUnavailable
-		yym458 := z.DecBinary()
-		_ = yym458
+		yyv481 := &x.MaxUnavailable
+		yym482 := z.DecBinary()
+		_ = yym482
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv457) {
-		} else if !yym458 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv457)
+		} else if z.HasExtensions() && z.DecExt(yyv481) {
+		} else if !yym482 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv481)
 		} else {
-			z.DecFallback(yyv457, false)
+			z.DecFallback(yyv481, false)
 		}
 	}
-	yyj456++
-	if yyhl456 {
-		yyb456 = yyj456 > l
+	yyj480++
+	if yyhl480 {
+		yyb480 = yyj480 > l
 	} else {
-		yyb456 = r.CheckBreak()
+		yyb480 = r.CheckBreak()
 	}
-	if yyb456 {
+	if yyb480 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxSurge = pkg6_intstr.IntOrString{}
 	} else {
-		yyv459 := &x.MaxSurge
-		yym460 := z.DecBinary()
-		_ = yym460
+		yyv483 := &x.MaxSurge
+		yym484 := z.DecBinary()
+		_ = yym484
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv459) {
-		} else if !yym460 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv459)
+		} else if z.HasExtensions() && z.DecExt(yyv483) {
+		} else if !yym484 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv483)
 		} else {
-			z.DecFallback(yyv459, false)
+			z.DecFallback(yyv483, false)
 		}
 	}
-	yyj456++
-	if yyhl456 {
-		yyb456 = yyj456 > l
+	yyj480++
+	if yyhl480 {
+		yyb480 = yyj480 > l
 	} else {
-		yyb456 = r.CheckBreak()
+		yyb480 = r.CheckBreak()
 	}
-	if yyb456 {
+	if yyb480 {
 		r.ReadEnd()
 		return
 	}
@@ -5128,16 +5272,16 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj456++
-		if yyhl456 {
-			yyb456 = yyj456 > l
+		yyj480++
+		if yyhl480 {
+			yyb480 = yyj480 > l
 		} else {
-			yyb456 = r.CheckBreak()
+			yyb480 = r.CheckBreak()
 		}
-		if yyb456 {
+		if yyb480 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj456-1, "")
+		z.DecStructFieldNotFound(yyj480-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5149,33 +5293,33 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym462 := z.EncBinary()
-		_ = yym462
+		yym486 := z.EncBinary()
+		_ = yym486
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep463 := !z.EncBinary()
-			yy2arr463 := z.EncBasicHandle().StructToArray
-			var yyq463 [2]bool
-			_, _, _ = yysep463, yyq463, yy2arr463
-			const yyr463 bool = false
-			yyq463[0] = x.Replicas != 0
-			yyq463[1] = x.UpdatedReplicas != 0
-			if yyr463 || yy2arr463 {
+			yysep487 := !z.EncBinary()
+			yy2arr487 := z.EncBasicHandle().StructToArray
+			var yyq487 [2]bool
+			_, _, _ = yysep487, yyq487, yy2arr487
+			const yyr487 bool = false
+			yyq487[0] = x.Replicas != 0
+			yyq487[1] = x.UpdatedReplicas != 0
+			if yyr487 || yy2arr487 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn463 int = 0
-				for _, b := range yyq463 {
+				var yynn487 int = 0
+				for _, b := range yyq487 {
 					if b {
-						yynn463++
+						yynn487++
 					}
 				}
-				r.EncodeMapStart(yynn463)
+				r.EncodeMapStart(yynn487)
 			}
-			if yyr463 || yy2arr463 {
-				if yyq463[0] {
-					yym465 := z.EncBinary()
-					_ = yym465
+			if yyr487 || yy2arr487 {
+				if yyq487[0] {
+					yym489 := z.EncBinary()
+					_ = yym489
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -5184,20 +5328,20 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq463[0] {
+				if yyq487[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-					yym466 := z.EncBinary()
-					_ = yym466
+					yym490 := z.EncBinary()
+					_ = yym490
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr463 || yy2arr463 {
-				if yyq463[1] {
-					yym468 := z.EncBinary()
-					_ = yym468
+			if yyr487 || yy2arr487 {
+				if yyq487[1] {
+					yym492 := z.EncBinary()
+					_ = yym492
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
@@ -5206,17 +5350,17 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq463[1] {
+				if yyq487[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("updatedReplicas"))
-					yym469 := z.EncBinary()
-					_ = yym469
+					yym493 := z.EncBinary()
+					_ = yym493
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
 					}
 				}
 			}
-			if yysep463 {
+			if yysep487 {
 				r.EncodeEnd()
 			}
 		}
@@ -5224,260 +5368,6 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym470 := z.DecBinary()
-	_ = yym470
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl471 := r.ReadMapStart()
-			if yyl471 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl471, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl471 := r.ReadArrayStart()
-			if yyl471 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl471, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys472Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys472Slc
-	var yyhl472 bool = l >= 0
-	for yyj472 := 0; ; yyj472++ {
-		if yyhl472 {
-			if yyj472 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys472Slc = r.DecodeBytes(yys472Slc, true, true)
-		yys472 := string(yys472Slc)
-		switch yys472 {
-		case "replicas":
-			if r.TryDecodeAsNil() {
-				x.Replicas = 0
-			} else {
-				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		case "updatedReplicas":
-			if r.TryDecodeAsNil() {
-				x.UpdatedReplicas = 0
-			} else {
-				x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys472)
-		} // end switch yys472
-	} // end for yyj472
-	if !yyhl472 {
-		r.ReadEnd()
-	}
-}
-
-func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj475 int
-	var yyb475 bool
-	var yyhl475 bool = l >= 0
-	yyj475++
-	if yyhl475 {
-		yyb475 = yyj475 > l
-	} else {
-		yyb475 = r.CheckBreak()
-	}
-	if yyb475 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Replicas = 0
-	} else {
-		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
-	}
-	yyj475++
-	if yyhl475 {
-		yyb475 = yyj475 > l
-	} else {
-		yyb475 = r.CheckBreak()
-	}
-	if yyb475 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.UpdatedReplicas = 0
-	} else {
-		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
-	}
-	for {
-		yyj475++
-		if yyhl475 {
-			yyb475 = yyj475 > l
-		} else {
-			yyb475 = r.CheckBreak()
-		}
-		if yyb475 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj475-1, "")
-	}
-	r.ReadEnd()
-}
-
-func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym478 := z.EncBinary()
-		_ = yym478
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep479 := !z.EncBinary()
-			yy2arr479 := z.EncBasicHandle().StructToArray
-			var yyq479 [4]bool
-			_, _, _ = yysep479, yyq479, yy2arr479
-			const yyr479 bool = false
-			yyq479[0] = x.Kind != ""
-			yyq479[1] = x.APIVersion != ""
-			yyq479[2] = true
-			if yyr479 || yy2arr479 {
-				r.EncodeArrayStart(4)
-			} else {
-				var yynn479 int = 1
-				for _, b := range yyq479 {
-					if b {
-						yynn479++
-					}
-				}
-				r.EncodeMapStart(yynn479)
-			}
-			if yyr479 || yy2arr479 {
-				if yyq479[0] {
-					yym481 := z.EncBinary()
-					_ = yym481
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq479[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym482 := z.EncBinary()
-					_ = yym482
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr479 || yy2arr479 {
-				if yyq479[1] {
-					yym484 := z.EncBinary()
-					_ = yym484
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq479[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym485 := z.EncBinary()
-					_ = yym485
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr479 || yy2arr479 {
-				if yyq479[2] {
-					yy487 := &x.ListMeta
-					yym488 := z.EncBinary()
-					_ = yym488
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy487) {
-					} else {
-						z.EncFallback(yy487)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq479[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy489 := &x.ListMeta
-					yym490 := z.EncBinary()
-					_ = yym490
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy489) {
-					} else {
-						z.EncFallback(yy489)
-					}
-				}
-			}
-			if yyr479 || yy2arr479 {
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym492 := z.EncBinary()
-					_ = yym492
-					if false {
-					} else {
-						h.encSliceDeployment(([]Deployment)(x.Items), e)
-					}
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("items"))
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym493 := z.EncBinary()
-					_ = yym493
-					if false {
-					} else {
-						h.encSliceDeployment(([]Deployment)(x.Items), e)
-					}
-				}
-			}
-			if yysep479 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -5506,7 +5396,7 @@ func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -5526,6 +5416,260 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys496Slc = r.DecodeBytes(yys496Slc, true, true)
 		yys496 := string(yys496Slc)
 		switch yys496 {
+		case "replicas":
+			if r.TryDecodeAsNil() {
+				x.Replicas = 0
+			} else {
+				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		case "updatedReplicas":
+			if r.TryDecodeAsNil() {
+				x.UpdatedReplicas = 0
+			} else {
+				x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys496)
+		} // end switch yys496
+	} // end for yyj496
+	if !yyhl496 {
+		r.ReadEnd()
+	}
+}
+
+func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj499 int
+	var yyb499 bool
+	var yyhl499 bool = l >= 0
+	yyj499++
+	if yyhl499 {
+		yyb499 = yyj499 > l
+	} else {
+		yyb499 = r.CheckBreak()
+	}
+	if yyb499 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Replicas = 0
+	} else {
+		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+	}
+	yyj499++
+	if yyhl499 {
+		yyb499 = yyj499 > l
+	} else {
+		yyb499 = r.CheckBreak()
+	}
+	if yyb499 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.UpdatedReplicas = 0
+	} else {
+		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+	}
+	for {
+		yyj499++
+		if yyhl499 {
+			yyb499 = yyj499 > l
+		} else {
+			yyb499 = r.CheckBreak()
+		}
+		if yyb499 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj499-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym502 := z.EncBinary()
+		_ = yym502
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep503 := !z.EncBinary()
+			yy2arr503 := z.EncBasicHandle().StructToArray
+			var yyq503 [4]bool
+			_, _, _ = yysep503, yyq503, yy2arr503
+			const yyr503 bool = false
+			yyq503[0] = x.Kind != ""
+			yyq503[1] = x.APIVersion != ""
+			yyq503[2] = true
+			if yyr503 || yy2arr503 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn503 int = 1
+				for _, b := range yyq503 {
+					if b {
+						yynn503++
+					}
+				}
+				r.EncodeMapStart(yynn503)
+			}
+			if yyr503 || yy2arr503 {
+				if yyq503[0] {
+					yym505 := z.EncBinary()
+					_ = yym505
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq503[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym506 := z.EncBinary()
+					_ = yym506
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr503 || yy2arr503 {
+				if yyq503[1] {
+					yym508 := z.EncBinary()
+					_ = yym508
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq503[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym509 := z.EncBinary()
+					_ = yym509
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr503 || yy2arr503 {
+				if yyq503[2] {
+					yy511 := &x.ListMeta
+					yym512 := z.EncBinary()
+					_ = yym512
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy511) {
+					} else {
+						z.EncFallback(yy511)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq503[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy513 := &x.ListMeta
+					yym514 := z.EncBinary()
+					_ = yym514
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy513) {
+					} else {
+						z.EncFallback(yy513)
+					}
+				}
+			}
+			if yyr503 || yy2arr503 {
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym516 := z.EncBinary()
+					_ = yym516
+					if false {
+					} else {
+						h.encSliceDeployment(([]Deployment)(x.Items), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym517 := z.EncBinary()
+					_ = yym517
+					if false {
+					} else {
+						h.encSliceDeployment(([]Deployment)(x.Items), e)
+					}
+				}
+			}
+			if yysep503 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym518 := z.DecBinary()
+	_ = yym518
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl519 := r.ReadMapStart()
+			if yyl519 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl519, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl519 := r.ReadArrayStart()
+			if yyl519 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl519, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys520Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys520Slc
+	var yyhl520 bool = l >= 0
+	for yyj520 := 0; ; yyj520++ {
+		if yyhl520 {
+			if yyj520 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys520Slc = r.DecodeBytes(yys520Slc, true, true)
+		yys520 := string(yys520Slc)
+		switch yys520 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -5542,32 +5686,32 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv499 := &x.ListMeta
-				yym500 := z.DecBinary()
-				_ = yym500
+				yyv523 := &x.ListMeta
+				yym524 := z.DecBinary()
+				_ = yym524
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv499) {
+				} else if z.HasExtensions() && z.DecExt(yyv523) {
 				} else {
-					z.DecFallback(yyv499, false)
+					z.DecFallback(yyv523, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv501 := &x.Items
-				yym502 := z.DecBinary()
-				_ = yym502
+				yyv525 := &x.Items
+				yym526 := z.DecBinary()
+				_ = yym526
 				if false {
 				} else {
-					h.decSliceDeployment((*[]Deployment)(yyv501), d)
+					h.decSliceDeployment((*[]Deployment)(yyv525), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys496)
-		} // end switch yys496
-	} // end for yyj496
-	if !yyhl496 {
+			z.DecStructFieldNotFound(-1, yys520)
+		} // end switch yys520
+	} // end for yyj520
+	if !yyhl520 {
 		r.ReadEnd()
 	}
 }
@@ -5576,16 +5720,16 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj503 int
-	var yyb503 bool
-	var yyhl503 bool = l >= 0
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	var yyj527 int
+	var yyb527 bool
+	var yyhl527 bool = l >= 0
+	yyj527++
+	if yyhl527 {
+		yyb527 = yyj527 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb527 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb527 {
 		r.ReadEnd()
 		return
 	}
@@ -5594,13 +5738,13 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	yyj527++
+	if yyhl527 {
+		yyb527 = yyj527 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb527 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb527 {
 		r.ReadEnd()
 		return
 	}
@@ -5609,60 +5753,60 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	yyj527++
+	if yyhl527 {
+		yyb527 = yyj527 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb527 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb527 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv506 := &x.ListMeta
-		yym507 := z.DecBinary()
-		_ = yym507
+		yyv530 := &x.ListMeta
+		yym531 := z.DecBinary()
+		_ = yym531
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv506) {
+		} else if z.HasExtensions() && z.DecExt(yyv530) {
 		} else {
-			z.DecFallback(yyv506, false)
+			z.DecFallback(yyv530, false)
 		}
 	}
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	yyj527++
+	if yyhl527 {
+		yyb527 = yyj527 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb527 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb527 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv508 := &x.Items
-		yym509 := z.DecBinary()
-		_ = yym509
+		yyv532 := &x.Items
+		yym533 := z.DecBinary()
+		_ = yym533
 		if false {
 		} else {
-			h.decSliceDeployment((*[]Deployment)(yyv508), d)
+			h.decSliceDeployment((*[]Deployment)(yyv532), d)
 		}
 	}
 	for {
-		yyj503++
-		if yyhl503 {
-			yyb503 = yyj503 > l
+		yyj527++
+		if yyhl527 {
+			yyb527 = yyj527 > l
 		} else {
-			yyb503 = r.CheckBreak()
+			yyb527 = r.CheckBreak()
 		}
-		if yyb503 {
+		if yyb527 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj503-1, "")
+		z.DecStructFieldNotFound(yyj527-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5674,31 +5818,31 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym510 := z.EncBinary()
-		_ = yym510
+		yym534 := z.EncBinary()
+		_ = yym534
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep511 := !z.EncBinary()
-			yy2arr511 := z.EncBasicHandle().StructToArray
-			var yyq511 [2]bool
-			_, _, _ = yysep511, yyq511, yy2arr511
-			const yyr511 bool = false
-			yyq511[0] = x.Selector != nil
-			yyq511[1] = x.Template != nil
-			if yyr511 || yy2arr511 {
+			yysep535 := !z.EncBinary()
+			yy2arr535 := z.EncBasicHandle().StructToArray
+			var yyq535 [2]bool
+			_, _, _ = yysep535, yyq535, yy2arr535
+			const yyr535 bool = false
+			yyq535[0] = x.Selector != nil
+			yyq535[1] = x.Template != nil
+			if yyr535 || yy2arr535 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn511 int = 0
-				for _, b := range yyq511 {
+				var yynn535 int = 0
+				for _, b := range yyq535 {
 					if b {
-						yynn511++
+						yynn535++
 					}
 				}
-				r.EncodeMapStart(yynn511)
+				r.EncodeMapStart(yynn535)
 			}
-			if yyr511 || yy2arr511 {
-				if yyq511[0] {
+			if yyr535 || yy2arr535 {
+				if yyq535[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -5708,7 +5852,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq511[0] {
+				if yyq535[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -5717,27 +5861,39 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr511 || yy2arr511 {
-				if yyq511[1] {
+			if yyr535 || yy2arr535 {
+				if yyq535[1] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
-						x.Template.CodecEncodeSelf(e)
+						yym538 := z.EncBinary()
+						_ = yym538
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.Template) {
+						} else {
+							z.EncFallback(x.Template)
+						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq511[1] {
+				if yyq535[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
-						x.Template.CodecEncodeSelf(e)
+						yym539 := z.EncBinary()
+						_ = yym539
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.Template) {
+						} else {
+							z.EncFallback(x.Template)
+						}
 					}
 				}
 			}
-			if yysep511 {
+			if yysep535 {
 				r.EncodeEnd()
 			}
 		}
@@ -5748,24 +5904,24 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym514 := z.DecBinary()
-	_ = yym514
+	yym540 := z.DecBinary()
+	_ = yym540
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl515 := r.ReadMapStart()
-			if yyl515 == 0 {
+			yyl541 := r.ReadMapStart()
+			if yyl541 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl515, d)
+				x.codecDecodeSelfFromMap(yyl541, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl515 := r.ReadArrayStart()
-			if yyl515 == 0 {
+			yyl541 := r.ReadArrayStart()
+			if yyl541 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl515, d)
+				x.codecDecodeSelfFromArray(yyl541, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5777,12 +5933,12 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys516Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys516Slc
-	var yyhl516 bool = l >= 0
-	for yyj516 := 0; ; yyj516++ {
-		if yyhl516 {
-			if yyj516 >= l {
+	var yys542Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys542Slc
+	var yyhl542 bool = l >= 0
+	for yyj542 := 0; ; yyj542++ {
+		if yyhl542 {
+			if yyj542 >= l {
 				break
 			}
 		} else {
@@ -5790,9 +5946,9 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys516Slc = r.DecodeBytes(yys516Slc, true, true)
-		yys516 := string(yys516Slc)
-		switch yys516 {
+		yys542Slc = r.DecodeBytes(yys542Slc, true, true)
+		yys542 := string(yys542Slc)
+		switch yys542 {
 		case "selector":
 			if r.TryDecodeAsNil() {
 				if x.Selector != nil {
@@ -5813,13 +5969,19 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Template == nil {
 					x.Template = new(pkg2_api.PodTemplateSpec)
 				}
-				x.Template.CodecDecodeSelf(d)
+				yym545 := z.DecBinary()
+				_ = yym545
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.Template) {
+				} else {
+					z.DecFallback(x.Template, false)
+				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys516)
-		} // end switch yys516
-	} // end for yyj516
-	if !yyhl516 {
+			z.DecStructFieldNotFound(-1, yys542)
+		} // end switch yys542
+	} // end for yyj542
+	if !yyhl542 {
 		r.ReadEnd()
 	}
 }
@@ -5828,16 +5990,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj519 int
-	var yyb519 bool
-	var yyhl519 bool = l >= 0
-	yyj519++
-	if yyhl519 {
-		yyb519 = yyj519 > l
+	var yyj546 int
+	var yyb546 bool
+	var yyhl546 bool = l >= 0
+	yyj546++
+	if yyhl546 {
+		yyb546 = yyj546 > l
 	} else {
-		yyb519 = r.CheckBreak()
+		yyb546 = r.CheckBreak()
 	}
-	if yyb519 {
+	if yyb546 {
 		r.ReadEnd()
 		return
 	}
@@ -5851,13 +6013,13 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj519++
-	if yyhl519 {
-		yyb519 = yyj519 > l
+	yyj546++
+	if yyhl546 {
+		yyb546 = yyj546 > l
 	} else {
-		yyb519 = r.CheckBreak()
+		yyb546 = r.CheckBreak()
 	}
-	if yyb519 {
+	if yyb546 {
 		r.ReadEnd()
 		return
 	}
@@ -5869,19 +6031,25 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Template == nil {
 			x.Template = new(pkg2_api.PodTemplateSpec)
 		}
-		x.Template.CodecDecodeSelf(d)
+		yym549 := z.DecBinary()
+		_ = yym549
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.Template) {
+		} else {
+			z.DecFallback(x.Template, false)
+		}
 	}
 	for {
-		yyj519++
-		if yyhl519 {
-			yyb519 = yyj519 > l
+		yyj546++
+		if yyhl546 {
+			yyb546 = yyj546 > l
 		} else {
-			yyb519 = r.CheckBreak()
+			yyb546 = r.CheckBreak()
 		}
-		if yyb519 {
+		if yyb546 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj519-1, "")
+		z.DecStructFieldNotFound(yyj546-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5893,76 +6061,76 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym522 := z.EncBinary()
-		_ = yym522
+		yym550 := z.EncBinary()
+		_ = yym550
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep523 := !z.EncBinary()
-			yy2arr523 := z.EncBasicHandle().StructToArray
-			var yyq523 [3]bool
-			_, _, _ = yysep523, yyq523, yy2arr523
-			const yyr523 bool = false
-			if yyr523 || yy2arr523 {
+			yysep551 := !z.EncBinary()
+			yy2arr551 := z.EncBasicHandle().StructToArray
+			var yyq551 [3]bool
+			_, _, _ = yysep551, yyq551, yy2arr551
+			const yyr551 bool = false
+			if yyr551 || yy2arr551 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn523 int = 3
-				for _, b := range yyq523 {
+				var yynn551 int = 3
+				for _, b := range yyq551 {
 					if b {
-						yynn523++
+						yynn551++
 					}
 				}
-				r.EncodeMapStart(yynn523)
+				r.EncodeMapStart(yynn551)
 			}
-			if yyr523 || yy2arr523 {
-				yym525 := z.EncBinary()
-				_ = yym525
+			if yyr551 || yy2arr551 {
+				yym553 := z.EncBinary()
+				_ = yym553
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
-				yym526 := z.EncBinary()
-				_ = yym526
+				yym554 := z.EncBinary()
+				_ = yym554
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			}
-			if yyr523 || yy2arr523 {
-				yym528 := z.EncBinary()
-				_ = yym528
+			if yyr551 || yy2arr551 {
+				yym556 := z.EncBinary()
+				_ = yym556
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
-				yym529 := z.EncBinary()
-				_ = yym529
+				yym557 := z.EncBinary()
+				_ = yym557
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			}
-			if yyr523 || yy2arr523 {
-				yym531 := z.EncBinary()
-				_ = yym531
+			if yyr551 || yy2arr551 {
+				yym559 := z.EncBinary()
+				_ = yym559
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
-				yym532 := z.EncBinary()
-				_ = yym532
+				yym560 := z.EncBinary()
+				_ = yym560
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yysep523 {
+			if yysep551 {
 				r.EncodeEnd()
 			}
 		}
@@ -5973,24 +6141,24 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym533 := z.DecBinary()
-	_ = yym533
+	yym561 := z.DecBinary()
+	_ = yym561
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl534 := r.ReadMapStart()
-			if yyl534 == 0 {
+			yyl562 := r.ReadMapStart()
+			if yyl562 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl534, d)
+				x.codecDecodeSelfFromMap(yyl562, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl534 := r.ReadArrayStart()
-			if yyl534 == 0 {
+			yyl562 := r.ReadArrayStart()
+			if yyl562 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl534, d)
+				x.codecDecodeSelfFromArray(yyl562, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6002,12 +6170,12 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys535Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys535Slc
-	var yyhl535 bool = l >= 0
-	for yyj535 := 0; ; yyj535++ {
-		if yyhl535 {
-			if yyj535 >= l {
+	var yys563Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys563Slc
+	var yyhl563 bool = l >= 0
+	for yyj563 := 0; ; yyj563++ {
+		if yyhl563 {
+			if yyj563 >= l {
 				break
 			}
 		} else {
@@ -6015,9 +6183,9 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys535Slc = r.DecodeBytes(yys535Slc, true, true)
-		yys535 := string(yys535Slc)
-		switch yys535 {
+		yys563Slc = r.DecodeBytes(yys563Slc, true, true)
+		yys563 := string(yys563Slc)
+		switch yys563 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
@@ -6037,10 +6205,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys535)
-		} // end switch yys535
-	} // end for yyj535
-	if !yyhl535 {
+			z.DecStructFieldNotFound(-1, yys563)
+		} // end switch yys563
+	} // end for yyj563
+	if !yyhl563 {
 		r.ReadEnd()
 	}
 }
@@ -6049,16 +6217,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj539 int
-	var yyb539 bool
-	var yyhl539 bool = l >= 0
-	yyj539++
-	if yyhl539 {
-		yyb539 = yyj539 > l
+	var yyj567 int
+	var yyb567 bool
+	var yyhl567 bool = l >= 0
+	yyj567++
+	if yyhl567 {
+		yyb567 = yyj567 > l
 	} else {
-		yyb539 = r.CheckBreak()
+		yyb567 = r.CheckBreak()
 	}
-	if yyb539 {
+	if yyb567 {
 		r.ReadEnd()
 		return
 	}
@@ -6067,13 +6235,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.CurrentNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj539++
-	if yyhl539 {
-		yyb539 = yyj539 > l
+	yyj567++
+	if yyhl567 {
+		yyb567 = yyj567 > l
 	} else {
-		yyb539 = r.CheckBreak()
+		yyb567 = r.CheckBreak()
 	}
-	if yyb539 {
+	if yyb567 {
 		r.ReadEnd()
 		return
 	}
@@ -6082,13 +6250,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.NumberMisscheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj539++
-	if yyhl539 {
-		yyb539 = yyj539 > l
+	yyj567++
+	if yyhl567 {
+		yyb567 = yyj567 > l
 	} else {
-		yyb539 = r.CheckBreak()
+		yyb567 = r.CheckBreak()
 	}
-	if yyb539 {
+	if yyb567 {
 		r.ReadEnd()
 		return
 	}
@@ -6098,16 +6266,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj539++
-		if yyhl539 {
-			yyb539 = yyj539 > l
+		yyj567++
+		if yyhl567 {
+			yyb567 = yyj567 > l
 		} else {
-			yyb539 = r.CheckBreak()
+			yyb567 = r.CheckBreak()
 		}
-		if yyb539 {
+		if yyb567 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj539-1, "")
+		z.DecStructFieldNotFound(yyj567-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6119,36 +6287,36 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym543 := z.EncBinary()
-		_ = yym543
+		yym571 := z.EncBinary()
+		_ = yym571
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep544 := !z.EncBinary()
-			yy2arr544 := z.EncBasicHandle().StructToArray
-			var yyq544 [5]bool
-			_, _, _ = yysep544, yyq544, yy2arr544
-			const yyr544 bool = false
-			yyq544[0] = x.Kind != ""
-			yyq544[1] = x.APIVersion != ""
-			yyq544[2] = true
-			yyq544[3] = true
-			yyq544[4] = true
-			if yyr544 || yy2arr544 {
+			yysep572 := !z.EncBinary()
+			yy2arr572 := z.EncBasicHandle().StructToArray
+			var yyq572 [5]bool
+			_, _, _ = yysep572, yyq572, yy2arr572
+			const yyr572 bool = false
+			yyq572[0] = x.Kind != ""
+			yyq572[1] = x.APIVersion != ""
+			yyq572[2] = true
+			yyq572[3] = true
+			yyq572[4] = true
+			if yyr572 || yy2arr572 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn544 int = 0
-				for _, b := range yyq544 {
+				var yynn572 int = 0
+				for _, b := range yyq572 {
 					if b {
-						yynn544++
+						yynn572++
 					}
 				}
-				r.EncodeMapStart(yynn544)
+				r.EncodeMapStart(yynn572)
 			}
-			if yyr544 || yy2arr544 {
-				if yyq544[0] {
-					yym546 := z.EncBinary()
-					_ = yym546
+			if yyr572 || yy2arr572 {
+				if yyq572[0] {
+					yym574 := z.EncBinary()
+					_ = yym574
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6157,20 +6325,20 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq544[0] {
+				if yyq572[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym547 := z.EncBinary()
-					_ = yym547
+					yym575 := z.EncBinary()
+					_ = yym575
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr544 || yy2arr544 {
-				if yyq544[1] {
-					yym549 := z.EncBinary()
-					_ = yym549
+			if yyr572 || yy2arr572 {
+				if yyq572[1] {
+					yym577 := z.EncBinary()
+					_ = yym577
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6179,59 +6347,71 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq544[1] {
+				if yyq572[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym550 := z.EncBinary()
-					_ = yym550
+					yym578 := z.EncBinary()
+					_ = yym578
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr544 || yy2arr544 {
-				if yyq544[2] {
-					yy552 := &x.ObjectMeta
-					yy552.CodecEncodeSelf(e)
+			if yyr572 || yy2arr572 {
+				if yyq572[2] {
+					yy580 := &x.ObjectMeta
+					yym581 := z.EncBinary()
+					_ = yym581
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy580) {
+					} else {
+						z.EncFallback(yy580)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq544[2] {
+				if yyq572[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy553 := &x.ObjectMeta
-					yy553.CodecEncodeSelf(e)
+					yy582 := &x.ObjectMeta
+					yym583 := z.EncBinary()
+					_ = yym583
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy582) {
+					} else {
+						z.EncFallback(yy582)
+					}
 				}
 			}
-			if yyr544 || yy2arr544 {
-				if yyq544[3] {
-					yy555 := &x.Spec
-					yy555.CodecEncodeSelf(e)
+			if yyr572 || yy2arr572 {
+				if yyq572[3] {
+					yy585 := &x.Spec
+					yy585.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq544[3] {
+				if yyq572[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy556 := &x.Spec
-					yy556.CodecEncodeSelf(e)
+					yy586 := &x.Spec
+					yy586.CodecEncodeSelf(e)
 				}
 			}
-			if yyr544 || yy2arr544 {
-				if yyq544[4] {
-					yy558 := &x.Status
-					yy558.CodecEncodeSelf(e)
+			if yyr572 || yy2arr572 {
+				if yyq572[4] {
+					yy588 := &x.Status
+					yy588.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq544[4] {
+				if yyq572[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy559 := &x.Status
-					yy559.CodecEncodeSelf(e)
+					yy589 := &x.Status
+					yy589.CodecEncodeSelf(e)
 				}
 			}
-			if yysep544 {
+			if yysep572 {
 				r.EncodeEnd()
 			}
 		}
@@ -6239,329 +6419,6 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym560 := z.DecBinary()
-	_ = yym560
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl561 := r.ReadMapStart()
-			if yyl561 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl561, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl561 := r.ReadArrayStart()
-			if yyl561 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl561, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys562Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys562Slc
-	var yyhl562 bool = l >= 0
-	for yyj562 := 0; ; yyj562++ {
-		if yyhl562 {
-			if yyj562 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys562Slc = r.DecodeBytes(yys562Slc, true, true)
-		yys562 := string(yys562Slc)
-		switch yys562 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv565 := &x.ObjectMeta
-				yyv565.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = DaemonSetSpec{}
-			} else {
-				yyv566 := &x.Spec
-				yyv566.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = DaemonSetStatus{}
-			} else {
-				yyv567 := &x.Status
-				yyv567.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys562)
-		} // end switch yys562
-	} // end for yyj562
-	if !yyhl562 {
-		r.ReadEnd()
-	}
-}
-
-func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj568 int
-	var yyb568 bool
-	var yyhl568 bool = l >= 0
-	yyj568++
-	if yyhl568 {
-		yyb568 = yyj568 > l
-	} else {
-		yyb568 = r.CheckBreak()
-	}
-	if yyb568 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj568++
-	if yyhl568 {
-		yyb568 = yyj568 > l
-	} else {
-		yyb568 = r.CheckBreak()
-	}
-	if yyb568 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj568++
-	if yyhl568 {
-		yyb568 = yyj568 > l
-	} else {
-		yyb568 = r.CheckBreak()
-	}
-	if yyb568 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv571 := &x.ObjectMeta
-		yyv571.CodecDecodeSelf(d)
-	}
-	yyj568++
-	if yyhl568 {
-		yyb568 = yyj568 > l
-	} else {
-		yyb568 = r.CheckBreak()
-	}
-	if yyb568 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Spec = DaemonSetSpec{}
-	} else {
-		yyv572 := &x.Spec
-		yyv572.CodecDecodeSelf(d)
-	}
-	yyj568++
-	if yyhl568 {
-		yyb568 = yyj568 > l
-	} else {
-		yyb568 = r.CheckBreak()
-	}
-	if yyb568 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Status = DaemonSetStatus{}
-	} else {
-		yyv573 := &x.Status
-		yyv573.CodecDecodeSelf(d)
-	}
-	for {
-		yyj568++
-		if yyhl568 {
-			yyb568 = yyj568 > l
-		} else {
-			yyb568 = r.CheckBreak()
-		}
-		if yyb568 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj568-1, "")
-	}
-	r.ReadEnd()
-}
-
-func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym574 := z.EncBinary()
-		_ = yym574
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep575 := !z.EncBinary()
-			yy2arr575 := z.EncBasicHandle().StructToArray
-			var yyq575 [4]bool
-			_, _, _ = yysep575, yyq575, yy2arr575
-			const yyr575 bool = false
-			yyq575[0] = x.Kind != ""
-			yyq575[1] = x.APIVersion != ""
-			yyq575[2] = true
-			if yyr575 || yy2arr575 {
-				r.EncodeArrayStart(4)
-			} else {
-				var yynn575 int = 1
-				for _, b := range yyq575 {
-					if b {
-						yynn575++
-					}
-				}
-				r.EncodeMapStart(yynn575)
-			}
-			if yyr575 || yy2arr575 {
-				if yyq575[0] {
-					yym577 := z.EncBinary()
-					_ = yym577
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq575[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym578 := z.EncBinary()
-					_ = yym578
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr575 || yy2arr575 {
-				if yyq575[1] {
-					yym580 := z.EncBinary()
-					_ = yym580
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq575[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym581 := z.EncBinary()
-					_ = yym581
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr575 || yy2arr575 {
-				if yyq575[2] {
-					yy583 := &x.ListMeta
-					yym584 := z.EncBinary()
-					_ = yym584
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy583) {
-					} else {
-						z.EncFallback(yy583)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq575[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy585 := &x.ListMeta
-					yym586 := z.EncBinary()
-					_ = yym586
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy585) {
-					} else {
-						z.EncFallback(yy585)
-					}
-				}
-			}
-			if yyr575 || yy2arr575 {
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym588 := z.EncBinary()
-					_ = yym588
-					if false {
-					} else {
-						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
-					}
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("items"))
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym589 := z.EncBinary()
-					_ = yym589
-					if false {
-					} else {
-						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
-					}
-				}
-			}
-			if yysep575 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6590,7 +6447,7 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6624,9 +6481,9 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv595 := &x.ListMeta
+				yyv595 := &x.ObjectMeta
 				yym596 := z.DecBinary()
 				_ = yym596
 				if false {
@@ -6635,17 +6492,19 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.DecFallback(yyv595, false)
 				}
 			}
-		case "items":
+		case "spec":
 			if r.TryDecodeAsNil() {
-				x.Items = nil
+				x.Spec = DaemonSetSpec{}
 			} else {
-				yyv597 := &x.Items
-				yym598 := z.DecBinary()
-				_ = yym598
-				if false {
-				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv597), d)
-				}
+				yyv597 := &x.Spec
+				yyv597.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = DaemonSetStatus{}
+			} else {
+				yyv598 := &x.Status
+				yyv598.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys592)
@@ -6656,7 +6515,7 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	}
 }
 
-func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6704,9 +6563,9 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv602 := &x.ListMeta
+		yyv602 := &x.ObjectMeta
 		yym603 := z.DecBinary()
 		_ = yym603
 		if false {
@@ -6726,15 +6585,26 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.Items = nil
+		x.Spec = DaemonSetSpec{}
 	} else {
-		yyv604 := &x.Items
-		yym605 := z.DecBinary()
-		_ = yym605
-		if false {
-		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv604), d)
-		}
+		yyv604 := &x.Spec
+		yyv604.CodecDecodeSelf(d)
+	}
+	yyj599++
+	if yyhl599 {
+		yyb599 = yyj599 > l
+	} else {
+		yyb599 = r.CheckBreak()
+	}
+	if yyb599 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Status = DaemonSetStatus{}
+	} else {
+		yyv605 := &x.Status
+		yyv605.CodecDecodeSelf(d)
 	}
 	for {
 		yyj599++
@@ -6751,7 +6621,7 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	r.ReadEnd()
 }
 
-func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -6860,7 +6730,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym620
 					if false {
 					} else {
-						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			} else {
@@ -6872,7 +6742,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym621
 					if false {
 					} else {
-						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			}
@@ -6883,7 +6753,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6912,7 +6782,7 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6966,7 +6836,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				_ = yym630
 				if false {
 				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv629), d)
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv629), d)
 				}
 			}
 		default:
@@ -6978,7 +6848,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 	}
 }
 
-func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -7055,7 +6925,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		_ = yym637
 		if false {
 		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv636), d)
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv636), d)
 		}
 	}
 	for {
@@ -7073,7 +6943,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	r.ReadEnd()
 }
 
-func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -7087,18 +6957,16 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep639 := !z.EncBinary()
 			yy2arr639 := z.EncBasicHandle().StructToArray
-			var yyq639 [5]bool
+			var yyq639 [4]bool
 			_, _, _ = yysep639, yyq639, yy2arr639
 			const yyr639 bool = false
 			yyq639[0] = x.Kind != ""
 			yyq639[1] = x.APIVersion != ""
 			yyq639[2] = true
-			yyq639[3] = true
-			yyq639[4] = true
 			if yyr639 || yy2arr639 {
-				r.EncodeArrayStart(5)
+				r.EncodeArrayStart(4)
 			} else {
-				var yynn639 int = 0
+				var yynn639 int = 1
 				for _, b := range yyq639 {
 					if b {
 						yynn639++
@@ -7152,44 +7020,52 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr639 || yy2arr639 {
 				if yyq639[2] {
-					yy647 := &x.ObjectMeta
-					yy647.CodecEncodeSelf(e)
+					yy647 := &x.ListMeta
+					yym648 := z.EncBinary()
+					_ = yym648
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy647) {
+					} else {
+						z.EncFallback(yy647)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq639[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy648 := &x.ObjectMeta
-					yy648.CodecEncodeSelf(e)
+					yy649 := &x.ListMeta
+					yym650 := z.EncBinary()
+					_ = yym650
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy649) {
+					} else {
+						z.EncFallback(yy649)
+					}
 				}
 			}
 			if yyr639 || yy2arr639 {
-				if yyq639[3] {
-					yy650 := &x.Spec
-					yy650.CodecEncodeSelf(e)
-				} else {
+				if x.Items == nil {
 					r.EncodeNil()
+				} else {
+					yym652 := z.EncBinary()
+					_ = yym652
+					if false {
+					} else {
+						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+					}
 				}
 			} else {
-				if yyq639[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy651 := &x.Spec
-					yy651.CodecEncodeSelf(e)
-				}
-			}
-			if yyr639 || yy2arr639 {
-				if yyq639[4] {
-					yy653 := &x.Status
-					yy653.CodecEncodeSelf(e)
-				} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
 					r.EncodeNil()
-				}
-			} else {
-				if yyq639[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy654 := &x.Status
-					yy654.CodecEncodeSelf(e)
+				} else {
+					yym653 := z.EncBinary()
+					_ = yym653
+					if false {
+					} else {
+						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+					}
 				}
 			}
 			if yysep639 {
@@ -7199,28 +7075,28 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym655 := z.DecBinary()
-	_ = yym655
+	yym654 := z.DecBinary()
+	_ = yym654
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl656 := r.ReadMapStart()
-			if yyl656 == 0 {
+			yyl655 := r.ReadMapStart()
+			if yyl655 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl656, d)
+				x.codecDecodeSelfFromMap(yyl655, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl656 := r.ReadArrayStart()
-			if yyl656 == 0 {
+			yyl655 := r.ReadArrayStart()
+			if yyl655 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl656, d)
+				x.codecDecodeSelfFromArray(yyl655, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7228,16 +7104,16 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys657Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys657Slc
-	var yyhl657 bool = l >= 0
-	for yyj657 := 0; ; yyj657++ {
-		if yyhl657 {
-			if yyj657 >= l {
+	var yys656Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys656Slc
+	var yyhl656 bool = l >= 0
+	for yyj656 := 0; ; yyj656++ {
+		if yyhl656 {
+			if yyj656 >= l {
 				break
 			}
 		} else {
@@ -7245,9 +7121,9 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys657Slc = r.DecodeBytes(yys657Slc, true, true)
-		yys657 := string(yys657Slc)
-		switch yys657 {
+		yys656Slc = r.DecodeBytes(yys656Slc, true, true)
+		yys656 := string(yys656Slc)
+		switch yys656 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7262,35 +7138,39 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
+				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv660 := &x.ObjectMeta
-				yyv660.CodecDecodeSelf(d)
+				yyv659 := &x.ListMeta
+				yym660 := z.DecBinary()
+				_ = yym660
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv659) {
+				} else {
+					z.DecFallback(yyv659, false)
+				}
 			}
-		case "spec":
+		case "items":
 			if r.TryDecodeAsNil() {
-				x.Spec = JobSpec{}
+				x.Items = nil
 			} else {
-				yyv661 := &x.Spec
-				yyv661.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = JobStatus{}
-			} else {
-				yyv662 := &x.Status
-				yyv662.CodecDecodeSelf(d)
+				yyv661 := &x.Items
+				yym662 := z.DecBinary()
+				_ = yym662
+				if false {
+				} else {
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv661), d)
+				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys657)
-		} // end switch yys657
-	} // end for yyj657
-	if !yyhl657 {
+			z.DecStructFieldNotFound(-1, yys656)
+		} // end switch yys656
+	} // end for yyj656
+	if !yyhl656 {
 		r.ReadEnd()
 	}
 }
 
-func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -7338,10 +7218,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
+		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv666 := &x.ObjectMeta
-		yyv666.CodecDecodeSelf(d)
+		yyv666 := &x.ListMeta
+		yym667 := z.DecBinary()
+		_ = yym667
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv666) {
+		} else {
+			z.DecFallback(yyv666, false)
+		}
 	}
 	yyj663++
 	if yyhl663 {
@@ -7354,26 +7240,15 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.Spec = JobSpec{}
+		x.Items = nil
 	} else {
-		yyv667 := &x.Spec
-		yyv667.CodecDecodeSelf(d)
-	}
-	yyj663++
-	if yyhl663 {
-		yyb663 = yyj663 > l
-	} else {
-		yyb663 = r.CheckBreak()
-	}
-	if yyb663 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Status = JobStatus{}
-	} else {
-		yyv668 := &x.Status
-		yyv668.CodecDecodeSelf(d)
+		yyv668 := &x.Items
+		yym669 := z.DecBinary()
+		_ = yym669
+		if false {
+		} else {
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv668), d)
+		}
 	}
 	for {
 		yyj663++
@@ -7390,6 +7265,347 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	r.ReadEnd()
 }
 
+func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym670 := z.EncBinary()
+		_ = yym670
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep671 := !z.EncBinary()
+			yy2arr671 := z.EncBasicHandle().StructToArray
+			var yyq671 [5]bool
+			_, _, _ = yysep671, yyq671, yy2arr671
+			const yyr671 bool = false
+			yyq671[0] = x.Kind != ""
+			yyq671[1] = x.APIVersion != ""
+			yyq671[2] = true
+			yyq671[3] = true
+			yyq671[4] = true
+			if yyr671 || yy2arr671 {
+				r.EncodeArrayStart(5)
+			} else {
+				var yynn671 int = 0
+				for _, b := range yyq671 {
+					if b {
+						yynn671++
+					}
+				}
+				r.EncodeMapStart(yynn671)
+			}
+			if yyr671 || yy2arr671 {
+				if yyq671[0] {
+					yym673 := z.EncBinary()
+					_ = yym673
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq671[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym674 := z.EncBinary()
+					_ = yym674
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr671 || yy2arr671 {
+				if yyq671[1] {
+					yym676 := z.EncBinary()
+					_ = yym676
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq671[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym677 := z.EncBinary()
+					_ = yym677
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr671 || yy2arr671 {
+				if yyq671[2] {
+					yy679 := &x.ObjectMeta
+					yym680 := z.EncBinary()
+					_ = yym680
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy679) {
+					} else {
+						z.EncFallback(yy679)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq671[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy681 := &x.ObjectMeta
+					yym682 := z.EncBinary()
+					_ = yym682
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy681) {
+					} else {
+						z.EncFallback(yy681)
+					}
+				}
+			}
+			if yyr671 || yy2arr671 {
+				if yyq671[3] {
+					yy684 := &x.Spec
+					yy684.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq671[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy685 := &x.Spec
+					yy685.CodecEncodeSelf(e)
+				}
+			}
+			if yyr671 || yy2arr671 {
+				if yyq671[4] {
+					yy687 := &x.Status
+					yy687.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq671[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy688 := &x.Status
+					yy688.CodecEncodeSelf(e)
+				}
+			}
+			if yysep671 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym689 := z.DecBinary()
+	_ = yym689
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl690 := r.ReadMapStart()
+			if yyl690 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl690, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl690 := r.ReadArrayStart()
+			if yyl690 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl690, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys691Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys691Slc
+	var yyhl691 bool = l >= 0
+	for yyj691 := 0; ; yyj691++ {
+		if yyhl691 {
+			if yyj691 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys691Slc = r.DecodeBytes(yys691Slc, true, true)
+		yys691 := string(yys691Slc)
+		switch yys691 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv694 := &x.ObjectMeta
+				yym695 := z.DecBinary()
+				_ = yym695
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv694) {
+				} else {
+					z.DecFallback(yyv694, false)
+				}
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = JobSpec{}
+			} else {
+				yyv696 := &x.Spec
+				yyv696.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = JobStatus{}
+			} else {
+				yyv697 := &x.Status
+				yyv697.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys691)
+		} // end switch yys691
+	} // end for yyj691
+	if !yyhl691 {
+		r.ReadEnd()
+	}
+}
+
+func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj698 int
+	var yyb698 bool
+	var yyhl698 bool = l >= 0
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
+	} else {
+		yyb698 = r.CheckBreak()
+	}
+	if yyb698 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
+	} else {
+		yyb698 = r.CheckBreak()
+	}
+	if yyb698 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
+	} else {
+		yyb698 = r.CheckBreak()
+	}
+	if yyb698 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv701 := &x.ObjectMeta
+		yym702 := z.DecBinary()
+		_ = yym702
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv701) {
+		} else {
+			z.DecFallback(yyv701, false)
+		}
+	}
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
+	} else {
+		yyb698 = r.CheckBreak()
+	}
+	if yyb698 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Spec = JobSpec{}
+	} else {
+		yyv703 := &x.Spec
+		yyv703.CodecDecodeSelf(d)
+	}
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
+	} else {
+		yyb698 = r.CheckBreak()
+	}
+	if yyb698 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Status = JobStatus{}
+	} else {
+		yyv704 := &x.Status
+		yyv704.CodecDecodeSelf(d)
+	}
+	for {
+		yyj698++
+		if yyhl698 {
+			yyb698 = yyj698 > l
+		} else {
+			yyb698 = r.CheckBreak()
+		}
+		if yyb698 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj698-1, "")
+	}
+	r.ReadEnd()
+}
+
 func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
@@ -7397,34 +7613,34 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym669 := z.EncBinary()
-		_ = yym669
+		yym705 := z.EncBinary()
+		_ = yym705
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep670 := !z.EncBinary()
-			yy2arr670 := z.EncBasicHandle().StructToArray
-			var yyq670 [4]bool
-			_, _, _ = yysep670, yyq670, yy2arr670
-			const yyr670 bool = false
-			yyq670[0] = x.Kind != ""
-			yyq670[1] = x.APIVersion != ""
-			yyq670[2] = true
-			if yyr670 || yy2arr670 {
+			yysep706 := !z.EncBinary()
+			yy2arr706 := z.EncBasicHandle().StructToArray
+			var yyq706 [4]bool
+			_, _, _ = yysep706, yyq706, yy2arr706
+			const yyr706 bool = false
+			yyq706[0] = x.Kind != ""
+			yyq706[1] = x.APIVersion != ""
+			yyq706[2] = true
+			if yyr706 || yy2arr706 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn670 int = 1
-				for _, b := range yyq670 {
+				var yynn706 int = 1
+				for _, b := range yyq706 {
 					if b {
-						yynn670++
+						yynn706++
 					}
 				}
-				r.EncodeMapStart(yynn670)
+				r.EncodeMapStart(yynn706)
 			}
-			if yyr670 || yy2arr670 {
-				if yyq670[0] {
-					yym672 := z.EncBinary()
-					_ = yym672
+			if yyr706 || yy2arr706 {
+				if yyq706[0] {
+					yym708 := z.EncBinary()
+					_ = yym708
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7433,20 +7649,20 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq670[0] {
+				if yyq706[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym673 := z.EncBinary()
-					_ = yym673
+					yym709 := z.EncBinary()
+					_ = yym709
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr670 || yy2arr670 {
-				if yyq670[1] {
-					yym675 := z.EncBinary()
-					_ = yym675
+			if yyr706 || yy2arr706 {
+				if yyq706[1] {
+					yym711 := z.EncBinary()
+					_ = yym711
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7455,48 +7671,48 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq670[1] {
+				if yyq706[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym676 := z.EncBinary()
-					_ = yym676
+					yym712 := z.EncBinary()
+					_ = yym712
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr670 || yy2arr670 {
-				if yyq670[2] {
-					yy678 := &x.ListMeta
-					yym679 := z.EncBinary()
-					_ = yym679
+			if yyr706 || yy2arr706 {
+				if yyq706[2] {
+					yy714 := &x.ListMeta
+					yym715 := z.EncBinary()
+					_ = yym715
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy678) {
+					} else if z.HasExtensions() && z.EncExt(yy714) {
 					} else {
-						z.EncFallback(yy678)
+						z.EncFallback(yy714)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq670[2] {
+				if yyq706[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy680 := &x.ListMeta
-					yym681 := z.EncBinary()
-					_ = yym681
+					yy716 := &x.ListMeta
+					yym717 := z.EncBinary()
+					_ = yym717
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy680) {
+					} else if z.HasExtensions() && z.EncExt(yy716) {
 					} else {
-						z.EncFallback(yy680)
+						z.EncFallback(yy716)
 					}
 				}
 			}
-			if yyr670 || yy2arr670 {
+			if yyr706 || yy2arr706 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym683 := z.EncBinary()
-					_ = yym683
+					yym719 := z.EncBinary()
+					_ = yym719
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -7507,15 +7723,15 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym684 := z.EncBinary()
-					_ = yym684
+					yym720 := z.EncBinary()
+					_ = yym720
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
 					}
 				}
 			}
-			if yysep670 {
+			if yysep706 {
 				r.EncodeEnd()
 			}
 		}
@@ -7526,24 +7742,24 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym685 := z.DecBinary()
-	_ = yym685
+	yym721 := z.DecBinary()
+	_ = yym721
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl686 := r.ReadMapStart()
-			if yyl686 == 0 {
+			yyl722 := r.ReadMapStart()
+			if yyl722 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl686, d)
+				x.codecDecodeSelfFromMap(yyl722, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl686 := r.ReadArrayStart()
-			if yyl686 == 0 {
+			yyl722 := r.ReadArrayStart()
+			if yyl722 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl686, d)
+				x.codecDecodeSelfFromArray(yyl722, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7555,12 +7771,12 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys687Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys687Slc
-	var yyhl687 bool = l >= 0
-	for yyj687 := 0; ; yyj687++ {
-		if yyhl687 {
-			if yyj687 >= l {
+	var yys723Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys723Slc
+	var yyhl723 bool = l >= 0
+	for yyj723 := 0; ; yyj723++ {
+		if yyhl723 {
+			if yyj723 >= l {
 				break
 			}
 		} else {
@@ -7568,9 +7784,9 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys687Slc = r.DecodeBytes(yys687Slc, true, true)
-		yys687 := string(yys687Slc)
-		switch yys687 {
+		yys723Slc = r.DecodeBytes(yys723Slc, true, true)
+		yys723 := string(yys723Slc)
+		switch yys723 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7587,32 +7803,32 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv690 := &x.ListMeta
-				yym691 := z.DecBinary()
-				_ = yym691
+				yyv726 := &x.ListMeta
+				yym727 := z.DecBinary()
+				_ = yym727
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv690) {
+				} else if z.HasExtensions() && z.DecExt(yyv726) {
 				} else {
-					z.DecFallback(yyv690, false)
+					z.DecFallback(yyv726, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv692 := &x.Items
-				yym693 := z.DecBinary()
-				_ = yym693
+				yyv728 := &x.Items
+				yym729 := z.DecBinary()
+				_ = yym729
 				if false {
 				} else {
-					h.decSliceJob((*[]Job)(yyv692), d)
+					h.decSliceJob((*[]Job)(yyv728), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys687)
-		} // end switch yys687
-	} // end for yyj687
-	if !yyhl687 {
+			z.DecStructFieldNotFound(-1, yys723)
+		} // end switch yys723
+	} // end for yyj723
+	if !yyhl723 {
 		r.ReadEnd()
 	}
 }
@@ -7621,16 +7837,16 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj694 int
-	var yyb694 bool
-	var yyhl694 bool = l >= 0
-	yyj694++
-	if yyhl694 {
-		yyb694 = yyj694 > l
+	var yyj730 int
+	var yyb730 bool
+	var yyhl730 bool = l >= 0
+	yyj730++
+	if yyhl730 {
+		yyb730 = yyj730 > l
 	} else {
-		yyb694 = r.CheckBreak()
+		yyb730 = r.CheckBreak()
 	}
-	if yyb694 {
+	if yyb730 {
 		r.ReadEnd()
 		return
 	}
@@ -7639,13 +7855,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj694++
-	if yyhl694 {
-		yyb694 = yyj694 > l
+	yyj730++
+	if yyhl730 {
+		yyb730 = yyj730 > l
 	} else {
-		yyb694 = r.CheckBreak()
+		yyb730 = r.CheckBreak()
 	}
-	if yyb694 {
+	if yyb730 {
 		r.ReadEnd()
 		return
 	}
@@ -7654,60 +7870,60 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj694++
-	if yyhl694 {
-		yyb694 = yyj694 > l
+	yyj730++
+	if yyhl730 {
+		yyb730 = yyj730 > l
 	} else {
-		yyb694 = r.CheckBreak()
+		yyb730 = r.CheckBreak()
 	}
-	if yyb694 {
+	if yyb730 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv697 := &x.ListMeta
-		yym698 := z.DecBinary()
-		_ = yym698
+		yyv733 := &x.ListMeta
+		yym734 := z.DecBinary()
+		_ = yym734
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv697) {
+		} else if z.HasExtensions() && z.DecExt(yyv733) {
 		} else {
-			z.DecFallback(yyv697, false)
+			z.DecFallback(yyv733, false)
 		}
 	}
-	yyj694++
-	if yyhl694 {
-		yyb694 = yyj694 > l
+	yyj730++
+	if yyhl730 {
+		yyb730 = yyj730 > l
 	} else {
-		yyb694 = r.CheckBreak()
+		yyb730 = r.CheckBreak()
 	}
-	if yyb694 {
+	if yyb730 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv699 := &x.Items
-		yym700 := z.DecBinary()
-		_ = yym700
+		yyv735 := &x.Items
+		yym736 := z.DecBinary()
+		_ = yym736
 		if false {
 		} else {
-			h.decSliceJob((*[]Job)(yyv699), d)
+			h.decSliceJob((*[]Job)(yyv735), d)
 		}
 	}
 	for {
-		yyj694++
-		if yyhl694 {
-			yyb694 = yyj694 > l
+		yyj730++
+		if yyhl730 {
+			yyb730 = yyj730 > l
 		} else {
-			yyb694 = r.CheckBreak()
+			yyb730 = r.CheckBreak()
 		}
-		if yyb694 {
+		if yyb730 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj694-1, "")
+		z.DecStructFieldNotFound(yyj730-1, "")
 	}
 	r.ReadEnd()
 }
@@ -7719,96 +7935,96 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym701 := z.EncBinary()
-		_ = yym701
+		yym737 := z.EncBinary()
+		_ = yym737
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep702 := !z.EncBinary()
-			yy2arr702 := z.EncBasicHandle().StructToArray
-			var yyq702 [4]bool
-			_, _, _ = yysep702, yyq702, yy2arr702
-			const yyr702 bool = false
-			yyq702[0] = x.Parallelism != nil
-			yyq702[1] = x.Completions != nil
-			yyq702[2] = x.Selector != nil
-			if yyr702 || yy2arr702 {
+			yysep738 := !z.EncBinary()
+			yy2arr738 := z.EncBasicHandle().StructToArray
+			var yyq738 [4]bool
+			_, _, _ = yysep738, yyq738, yy2arr738
+			const yyr738 bool = false
+			yyq738[0] = x.Parallelism != nil
+			yyq738[1] = x.Completions != nil
+			yyq738[2] = x.Selector != nil
+			if yyr738 || yy2arr738 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn702 int = 1
-				for _, b := range yyq702 {
+				var yynn738 int = 1
+				for _, b := range yyq738 {
 					if b {
-						yynn702++
+						yynn738++
 					}
 				}
-				r.EncodeMapStart(yynn702)
+				r.EncodeMapStart(yynn738)
 			}
-			if yyr702 || yy2arr702 {
-				if yyq702[0] {
+			if yyr738 || yy2arr738 {
+				if yyq738[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy704 := *x.Parallelism
-						yym705 := z.EncBinary()
-						_ = yym705
+						yy740 := *x.Parallelism
+						yym741 := z.EncBinary()
+						_ = yym741
 						if false {
 						} else {
-							r.EncodeInt(int64(yy704))
+							r.EncodeInt(int64(yy740))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq702[0] {
+				if yyq738[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy706 := *x.Parallelism
-						yym707 := z.EncBinary()
-						_ = yym707
+						yy742 := *x.Parallelism
+						yym743 := z.EncBinary()
+						_ = yym743
 						if false {
 						} else {
-							r.EncodeInt(int64(yy706))
+							r.EncodeInt(int64(yy742))
 						}
 					}
 				}
 			}
-			if yyr702 || yy2arr702 {
-				if yyq702[1] {
+			if yyr738 || yy2arr738 {
+				if yyq738[1] {
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy709 := *x.Completions
-						yym710 := z.EncBinary()
-						_ = yym710
+						yy745 := *x.Completions
+						yym746 := z.EncBinary()
+						_ = yym746
 						if false {
 						} else {
-							r.EncodeInt(int64(yy709))
+							r.EncodeInt(int64(yy745))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq702[1] {
+				if yyq738[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("completions"))
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy711 := *x.Completions
-						yym712 := z.EncBinary()
-						_ = yym712
+						yy747 := *x.Completions
+						yym748 := z.EncBinary()
+						_ = yym748
 						if false {
 						} else {
-							r.EncodeInt(int64(yy711))
+							r.EncodeInt(int64(yy747))
 						}
 					}
 				}
 			}
-			if yyr702 || yy2arr702 {
-				if yyq702[2] {
+			if yyr738 || yy2arr738 {
+				if yyq738[2] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -7818,7 +8034,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq702[2] {
+				if yyq738[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -7827,15 +8043,27 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr702 || yy2arr702 {
-				yy715 := &x.Template
-				yy715.CodecEncodeSelf(e)
+			if yyr738 || yy2arr738 {
+				yy751 := &x.Template
+				yym752 := z.EncBinary()
+				_ = yym752
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy751) {
+				} else {
+					z.EncFallback(yy751)
+				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
-				yy716 := &x.Template
-				yy716.CodecEncodeSelf(e)
+				yy753 := &x.Template
+				yym754 := z.EncBinary()
+				_ = yym754
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy753) {
+				} else {
+					z.EncFallback(yy753)
+				}
 			}
-			if yysep702 {
+			if yysep738 {
 				r.EncodeEnd()
 			}
 		}
@@ -7846,24 +8074,24 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym717 := z.DecBinary()
-	_ = yym717
+	yym755 := z.DecBinary()
+	_ = yym755
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl718 := r.ReadMapStart()
-			if yyl718 == 0 {
+			yyl756 := r.ReadMapStart()
+			if yyl756 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl718, d)
+				x.codecDecodeSelfFromMap(yyl756, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl718 := r.ReadArrayStart()
-			if yyl718 == 0 {
+			yyl756 := r.ReadArrayStart()
+			if yyl756 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl718, d)
+				x.codecDecodeSelfFromArray(yyl756, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7875,12 +8103,12 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys719Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys719Slc
-	var yyhl719 bool = l >= 0
-	for yyj719 := 0; ; yyj719++ {
-		if yyhl719 {
-			if yyj719 >= l {
+	var yys757Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys757Slc
+	var yyhl757 bool = l >= 0
+	for yyj757 := 0; ; yyj757++ {
+		if yyhl757 {
+			if yyj757 >= l {
 				break
 			}
 		} else {
@@ -7888,9 +8116,9 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys719Slc = r.DecodeBytes(yys719Slc, true, true)
-		yys719 := string(yys719Slc)
-		switch yys719 {
+		yys757Slc = r.DecodeBytes(yys757Slc, true, true)
+		yys757 := string(yys757Slc)
+		switch yys757 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
 				if x.Parallelism != nil {
@@ -7900,8 +8128,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Parallelism == nil {
 					x.Parallelism = new(int)
 				}
-				yym721 := z.DecBinary()
-				_ = yym721
+				yym759 := z.DecBinary()
+				_ = yym759
 				if false {
 				} else {
 					*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -7916,8 +8144,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Completions == nil {
 					x.Completions = new(int)
 				}
-				yym723 := z.DecBinary()
-				_ = yym723
+				yym761 := z.DecBinary()
+				_ = yym761
 				if false {
 				} else {
 					*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -7938,14 +8166,20 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv725 := &x.Template
-				yyv725.CodecDecodeSelf(d)
+				yyv763 := &x.Template
+				yym764 := z.DecBinary()
+				_ = yym764
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv763) {
+				} else {
+					z.DecFallback(yyv763, false)
+				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys719)
-		} // end switch yys719
-	} // end for yyj719
-	if !yyhl719 {
+			z.DecStructFieldNotFound(-1, yys757)
+		} // end switch yys757
+	} // end for yyj757
+	if !yyhl757 {
 		r.ReadEnd()
 	}
 }
@@ -7954,16 +8188,16 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj726 int
-	var yyb726 bool
-	var yyhl726 bool = l >= 0
-	yyj726++
-	if yyhl726 {
-		yyb726 = yyj726 > l
+	var yyj765 int
+	var yyb765 bool
+	var yyhl765 bool = l >= 0
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb726 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb726 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
@@ -7975,20 +8209,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parallelism == nil {
 			x.Parallelism = new(int)
 		}
-		yym728 := z.DecBinary()
-		_ = yym728
+		yym767 := z.DecBinary()
+		_ = yym767
 		if false {
 		} else {
 			*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj726++
-	if yyhl726 {
-		yyb726 = yyj726 > l
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb726 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb726 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
@@ -8000,20 +8234,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Completions == nil {
 			x.Completions = new(int)
 		}
-		yym730 := z.DecBinary()
-		_ = yym730
+		yym769 := z.DecBinary()
+		_ = yym769
 		if false {
 		} else {
 			*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj726++
-	if yyhl726 {
-		yyb726 = yyj726 > l
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb726 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb726 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
@@ -8027,33 +8261,39 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj726++
-	if yyhl726 {
-		yyb726 = yyj726 > l
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb726 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb726 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv732 := &x.Template
-		yyv732.CodecDecodeSelf(d)
+		yyv771 := &x.Template
+		yym772 := z.DecBinary()
+		_ = yym772
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv771) {
+		} else {
+			z.DecFallback(yyv771, false)
+		}
 	}
 	for {
-		yyj726++
-		if yyhl726 {
-			yyb726 = yyj726 > l
+		yyj765++
+		if yyhl765 {
+			yyb765 = yyj765 > l
 		} else {
-			yyb726 = r.CheckBreak()
+			yyb765 = r.CheckBreak()
 		}
-		if yyb726 {
+		if yyb765 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj726-1, "")
+		z.DecStructFieldNotFound(yyj765-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8065,40 +8305,40 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym733 := z.EncBinary()
-		_ = yym733
+		yym773 := z.EncBinary()
+		_ = yym773
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep734 := !z.EncBinary()
-			yy2arr734 := z.EncBasicHandle().StructToArray
-			var yyq734 [6]bool
-			_, _, _ = yysep734, yyq734, yy2arr734
-			const yyr734 bool = false
-			yyq734[0] = len(x.Conditions) != 0
-			yyq734[1] = x.StartTime != nil
-			yyq734[2] = x.CompletionTime != nil
-			yyq734[3] = x.Active != 0
-			yyq734[4] = x.Succeeded != 0
-			yyq734[5] = x.Failed != 0
-			if yyr734 || yy2arr734 {
+			yysep774 := !z.EncBinary()
+			yy2arr774 := z.EncBasicHandle().StructToArray
+			var yyq774 [6]bool
+			_, _, _ = yysep774, yyq774, yy2arr774
+			const yyr774 bool = false
+			yyq774[0] = len(x.Conditions) != 0
+			yyq774[1] = x.StartTime != nil
+			yyq774[2] = x.CompletionTime != nil
+			yyq774[3] = x.Active != 0
+			yyq774[4] = x.Succeeded != 0
+			yyq774[5] = x.Failed != 0
+			if yyr774 || yy2arr774 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn734 int = 0
-				for _, b := range yyq734 {
+				var yynn774 int = 0
+				for _, b := range yyq774 {
 					if b {
-						yynn734++
+						yynn774++
 					}
 				}
-				r.EncodeMapStart(yynn734)
+				r.EncodeMapStart(yynn774)
 			}
-			if yyr734 || yy2arr734 {
-				if yyq734[0] {
+			if yyr774 || yy2arr774 {
+				if yyq774[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym736 := z.EncBinary()
-						_ = yym736
+						yym776 := z.EncBinary()
+						_ = yym776
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -8108,13 +8348,13 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq734[0] {
+				if yyq774[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym737 := z.EncBinary()
-						_ = yym737
+						yym777 := z.EncBinary()
+						_ = yym777
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -8122,18 +8362,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr734 || yy2arr734 {
-				if yyq734[1] {
+			if yyr774 || yy2arr774 {
+				if yyq774[1] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym739 := z.EncBinary()
-						_ = yym739
+						yym779 := z.EncBinary()
+						_ = yym779
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym739 {
+						} else if yym779 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym739 && z.IsJSONHandle() {
+						} else if !yym779 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -8143,18 +8383,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq734[1] {
+				if yyq774[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym740 := z.EncBinary()
-						_ = yym740
+						yym780 := z.EncBinary()
+						_ = yym780
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym740 {
+						} else if yym780 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym740 && z.IsJSONHandle() {
+						} else if !yym780 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -8162,18 +8402,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr734 || yy2arr734 {
-				if yyq734[2] {
+			if yyr774 || yy2arr774 {
+				if yyq774[2] {
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym742 := z.EncBinary()
-						_ = yym742
+						yym782 := z.EncBinary()
+						_ = yym782
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym742 {
+						} else if yym782 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym742 && z.IsJSONHandle() {
+						} else if !yym782 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8183,18 +8423,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq734[2] {
+				if yyq774[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym743 := z.EncBinary()
-						_ = yym743
+						yym783 := z.EncBinary()
+						_ = yym783
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym743 {
+						} else if yym783 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym743 && z.IsJSONHandle() {
+						} else if !yym783 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8202,10 +8442,10 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr734 || yy2arr734 {
-				if yyq734[3] {
-					yym745 := z.EncBinary()
-					_ = yym745
+			if yyr774 || yy2arr774 {
+				if yyq774[3] {
+					yym785 := z.EncBinary()
+					_ = yym785
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
@@ -8214,20 +8454,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq734[3] {
+				if yyq774[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
-					yym746 := z.EncBinary()
-					_ = yym746
+					yym786 := z.EncBinary()
+					_ = yym786
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
 					}
 				}
 			}
-			if yyr734 || yy2arr734 {
-				if yyq734[4] {
-					yym748 := z.EncBinary()
-					_ = yym748
+			if yyr774 || yy2arr774 {
+				if yyq774[4] {
+					yym788 := z.EncBinary()
+					_ = yym788
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
@@ -8236,20 +8476,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq734[4] {
+				if yyq774[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
-					yym749 := z.EncBinary()
-					_ = yym749
+					yym789 := z.EncBinary()
+					_ = yym789
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
 					}
 				}
 			}
-			if yyr734 || yy2arr734 {
-				if yyq734[5] {
-					yym751 := z.EncBinary()
-					_ = yym751
+			if yyr774 || yy2arr774 {
+				if yyq774[5] {
+					yym791 := z.EncBinary()
+					_ = yym791
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
@@ -8258,17 +8498,17 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq734[5] {
+				if yyq774[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
-					yym752 := z.EncBinary()
-					_ = yym752
+					yym792 := z.EncBinary()
+					_ = yym792
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				}
 			}
-			if yysep734 {
+			if yysep774 {
 				r.EncodeEnd()
 			}
 		}
@@ -8279,24 +8519,24 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym753 := z.DecBinary()
-	_ = yym753
+	yym793 := z.DecBinary()
+	_ = yym793
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl754 := r.ReadMapStart()
-			if yyl754 == 0 {
+			yyl794 := r.ReadMapStart()
+			if yyl794 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl754, d)
+				x.codecDecodeSelfFromMap(yyl794, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl754 := r.ReadArrayStart()
-			if yyl754 == 0 {
+			yyl794 := r.ReadArrayStart()
+			if yyl794 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl754, d)
+				x.codecDecodeSelfFromArray(yyl794, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8308,12 +8548,12 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys755Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys755Slc
-	var yyhl755 bool = l >= 0
-	for yyj755 := 0; ; yyj755++ {
-		if yyhl755 {
-			if yyj755 >= l {
+	var yys795Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys795Slc
+	var yyhl795 bool = l >= 0
+	for yyj795 := 0; ; yyj795++ {
+		if yyhl795 {
+			if yyj795 >= l {
 				break
 			}
 		} else {
@@ -8321,19 +8561,19 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys755Slc = r.DecodeBytes(yys755Slc, true, true)
-		yys755 := string(yys755Slc)
-		switch yys755 {
+		yys795Slc = r.DecodeBytes(yys795Slc, true, true)
+		yys795 := string(yys795Slc)
+		switch yys795 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv756 := &x.Conditions
-				yym757 := z.DecBinary()
-				_ = yym757
+				yyv796 := &x.Conditions
+				yym797 := z.DecBinary()
+				_ = yym797
 				if false {
 				} else {
-					h.decSliceJobCondition((*[]JobCondition)(yyv756), d)
+					h.decSliceJobCondition((*[]JobCondition)(yyv796), d)
 				}
 			}
 		case "startTime":
@@ -8345,13 +8585,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg1_unversioned.Time)
 				}
-				yym759 := z.DecBinary()
-				_ = yym759
+				yym799 := z.DecBinary()
+				_ = yym799
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym759 {
+				} else if yym799 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym759 && z.IsJSONHandle() {
+				} else if !yym799 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -8366,13 +8606,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.CompletionTime == nil {
 					x.CompletionTime = new(pkg1_unversioned.Time)
 				}
-				yym761 := z.DecBinary()
-				_ = yym761
+				yym801 := z.DecBinary()
+				_ = yym801
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-				} else if yym761 {
+				} else if yym801 {
 					z.DecBinaryUnmarshal(x.CompletionTime)
-				} else if !yym761 && z.IsJSONHandle() {
+				} else if !yym801 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.CompletionTime)
 				} else {
 					z.DecFallback(x.CompletionTime, false)
@@ -8397,10 +8637,10 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys755)
-		} // end switch yys755
-	} // end for yyj755
-	if !yyhl755 {
+			z.DecStructFieldNotFound(-1, yys795)
+		} // end switch yys795
+	} // end for yyj795
+	if !yyhl795 {
 		r.ReadEnd()
 	}
 }
@@ -8409,37 +8649,37 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj765 int
-	var yyb765 bool
-	var yyhl765 bool = l >= 0
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	var yyj805 int
+	var yyb805 bool
+	var yyhl805 bool = l >= 0
+	yyj805++
+	if yyhl805 {
+		yyb805 = yyj805 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb805 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb805 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv766 := &x.Conditions
-		yym767 := z.DecBinary()
-		_ = yym767
+		yyv806 := &x.Conditions
+		yym807 := z.DecBinary()
+		_ = yym807
 		if false {
 		} else {
-			h.decSliceJobCondition((*[]JobCondition)(yyv766), d)
+			h.decSliceJobCondition((*[]JobCondition)(yyv806), d)
 		}
 	}
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	yyj805++
+	if yyhl805 {
+		yyb805 = yyj805 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb805 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb805 {
 		r.ReadEnd()
 		return
 	}
@@ -8451,25 +8691,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg1_unversioned.Time)
 		}
-		yym769 := z.DecBinary()
-		_ = yym769
+		yym809 := z.DecBinary()
+		_ = yym809
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym769 {
+		} else if yym809 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym769 && z.IsJSONHandle() {
+		} else if !yym809 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	yyj805++
+	if yyhl805 {
+		yyb805 = yyj805 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb805 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb805 {
 		r.ReadEnd()
 		return
 	}
@@ -8481,25 +8721,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.CompletionTime == nil {
 			x.CompletionTime = new(pkg1_unversioned.Time)
 		}
-		yym771 := z.DecBinary()
-		_ = yym771
+		yym811 := z.DecBinary()
+		_ = yym811
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-		} else if yym771 {
+		} else if yym811 {
 			z.DecBinaryUnmarshal(x.CompletionTime)
-		} else if !yym771 && z.IsJSONHandle() {
+		} else if !yym811 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.CompletionTime)
 		} else {
 			z.DecFallback(x.CompletionTime, false)
 		}
 	}
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	yyj805++
+	if yyhl805 {
+		yyb805 = yyj805 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb805 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb805 {
 		r.ReadEnd()
 		return
 	}
@@ -8508,13 +8748,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Active = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	yyj805++
+	if yyhl805 {
+		yyb805 = yyj805 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb805 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb805 {
 		r.ReadEnd()
 		return
 	}
@@ -8523,13 +8763,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Succeeded = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	yyj805++
+	if yyhl805 {
+		yyb805 = yyj805 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb805 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb805 {
 		r.ReadEnd()
 		return
 	}
@@ -8539,16 +8779,16 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj765++
-		if yyhl765 {
-			yyb765 = yyj765 > l
+		yyj805++
+		if yyhl805 {
+			yyb805 = yyj805 > l
 		} else {
-			yyb765 = r.CheckBreak()
+			yyb805 = r.CheckBreak()
 		}
-		if yyb765 {
+		if yyb805 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj765-1, "")
+		z.DecStructFieldNotFound(yyj805-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8557,8 +8797,8 @@ func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym775 := z.EncBinary()
-	_ = yym775
+	yym815 := z.EncBinary()
+	_ = yym815
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -8570,8 +8810,8 @@ func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym776 := z.DecBinary()
-	_ = yym776
+	yym816 := z.DecBinary()
+	_ = yym816
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -8586,40 +8826,40 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym777 := z.EncBinary()
-		_ = yym777
+		yym817 := z.EncBinary()
+		_ = yym817
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep778 := !z.EncBinary()
-			yy2arr778 := z.EncBasicHandle().StructToArray
-			var yyq778 [6]bool
-			_, _, _ = yysep778, yyq778, yy2arr778
-			const yyr778 bool = false
-			yyq778[2] = true
-			yyq778[3] = true
-			yyq778[4] = x.Reason != ""
-			yyq778[5] = x.Message != ""
-			if yyr778 || yy2arr778 {
+			yysep818 := !z.EncBinary()
+			yy2arr818 := z.EncBasicHandle().StructToArray
+			var yyq818 [6]bool
+			_, _, _ = yysep818, yyq818, yy2arr818
+			const yyr818 bool = false
+			yyq818[2] = true
+			yyq818[3] = true
+			yyq818[4] = x.Reason != ""
+			yyq818[5] = x.Message != ""
+			if yyr818 || yy2arr818 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn778 int = 2
-				for _, b := range yyq778 {
+				var yynn818 int = 2
+				for _, b := range yyq818 {
 					if b {
-						yynn778++
+						yynn818++
 					}
 				}
-				r.EncodeMapStart(yynn778)
+				r.EncodeMapStart(yynn818)
 			}
-			if yyr778 || yy2arr778 {
+			if yyr818 || yy2arr818 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr778 || yy2arr778 {
-				yym781 := z.EncBinary()
-				_ = yym781
+			if yyr818 || yy2arr818 {
+				yym821 := z.EncBinary()
+				_ = yym821
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
@@ -8627,86 +8867,86 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
-				yym782 := z.EncBinary()
-				_ = yym782
+				yym822 := z.EncBinary()
+				_ = yym822
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			}
-			if yyr778 || yy2arr778 {
-				if yyq778[2] {
-					yy784 := &x.LastProbeTime
-					yym785 := z.EncBinary()
-					_ = yym785
+			if yyr818 || yy2arr818 {
+				if yyq818[2] {
+					yy824 := &x.LastProbeTime
+					yym825 := z.EncBinary()
+					_ = yym825
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy784) {
-					} else if yym785 {
-						z.EncBinaryMarshal(yy784)
-					} else if !yym785 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy784)
+					} else if z.HasExtensions() && z.EncExt(yy824) {
+					} else if yym825 {
+						z.EncBinaryMarshal(yy824)
+					} else if !yym825 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy824)
 					} else {
-						z.EncFallback(yy784)
+						z.EncFallback(yy824)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq778[2] {
+				if yyq818[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
-					yy786 := &x.LastProbeTime
-					yym787 := z.EncBinary()
-					_ = yym787
+					yy826 := &x.LastProbeTime
+					yym827 := z.EncBinary()
+					_ = yym827
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy786) {
-					} else if yym787 {
-						z.EncBinaryMarshal(yy786)
-					} else if !yym787 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy786)
+					} else if z.HasExtensions() && z.EncExt(yy826) {
+					} else if yym827 {
+						z.EncBinaryMarshal(yy826)
+					} else if !yym827 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy826)
 					} else {
-						z.EncFallback(yy786)
+						z.EncFallback(yy826)
 					}
 				}
 			}
-			if yyr778 || yy2arr778 {
-				if yyq778[3] {
-					yy789 := &x.LastTransitionTime
-					yym790 := z.EncBinary()
-					_ = yym790
+			if yyr818 || yy2arr818 {
+				if yyq818[3] {
+					yy829 := &x.LastTransitionTime
+					yym830 := z.EncBinary()
+					_ = yym830
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy789) {
-					} else if yym790 {
-						z.EncBinaryMarshal(yy789)
-					} else if !yym790 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy789)
+					} else if z.HasExtensions() && z.EncExt(yy829) {
+					} else if yym830 {
+						z.EncBinaryMarshal(yy829)
+					} else if !yym830 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy829)
 					} else {
-						z.EncFallback(yy789)
+						z.EncFallback(yy829)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq778[3] {
+				if yyq818[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
-					yy791 := &x.LastTransitionTime
-					yym792 := z.EncBinary()
-					_ = yym792
+					yy831 := &x.LastTransitionTime
+					yym832 := z.EncBinary()
+					_ = yym832
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy791) {
-					} else if yym792 {
-						z.EncBinaryMarshal(yy791)
-					} else if !yym792 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy791)
+					} else if z.HasExtensions() && z.EncExt(yy831) {
+					} else if yym832 {
+						z.EncBinaryMarshal(yy831)
+					} else if !yym832 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy831)
 					} else {
-						z.EncFallback(yy791)
+						z.EncFallback(yy831)
 					}
 				}
 			}
-			if yyr778 || yy2arr778 {
-				if yyq778[4] {
-					yym794 := z.EncBinary()
-					_ = yym794
+			if yyr818 || yy2arr818 {
+				if yyq818[4] {
+					yym834 := z.EncBinary()
+					_ = yym834
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -8715,20 +8955,20 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq778[4] {
+				if yyq818[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym795 := z.EncBinary()
-					_ = yym795
+					yym835 := z.EncBinary()
+					_ = yym835
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr778 || yy2arr778 {
-				if yyq778[5] {
-					yym797 := z.EncBinary()
-					_ = yym797
+			if yyr818 || yy2arr818 {
+				if yyq818[5] {
+					yym837 := z.EncBinary()
+					_ = yym837
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -8737,17 +8977,17 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq778[5] {
+				if yyq818[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym798 := z.EncBinary()
-					_ = yym798
+					yym838 := z.EncBinary()
+					_ = yym838
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yysep778 {
+			if yysep818 {
 				r.EncodeEnd()
 			}
 		}
@@ -8758,24 +8998,24 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym799 := z.DecBinary()
-	_ = yym799
+	yym839 := z.DecBinary()
+	_ = yym839
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl800 := r.ReadMapStart()
-			if yyl800 == 0 {
+			yyl840 := r.ReadMapStart()
+			if yyl840 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl800, d)
+				x.codecDecodeSelfFromMap(yyl840, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl800 := r.ReadArrayStart()
-			if yyl800 == 0 {
+			yyl840 := r.ReadArrayStart()
+			if yyl840 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl800, d)
+				x.codecDecodeSelfFromArray(yyl840, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8787,12 +9027,12 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys801Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys801Slc
-	var yyhl801 bool = l >= 0
-	for yyj801 := 0; ; yyj801++ {
-		if yyhl801 {
-			if yyj801 >= l {
+	var yys841Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys841Slc
+	var yyhl841 bool = l >= 0
+	for yyj841 := 0; ; yyj841++ {
+		if yyhl841 {
+			if yyj841 >= l {
 				break
 			}
 		} else {
@@ -8800,9 +9040,9 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys801Slc = r.DecodeBytes(yys801Slc, true, true)
-		yys801 := string(yys801Slc)
-		switch yys801 {
+		yys841Slc = r.DecodeBytes(yys841Slc, true, true)
+		yys841 := string(yys841Slc)
+		switch yys841 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -8819,34 +9059,34 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastProbeTime = pkg1_unversioned.Time{}
 			} else {
-				yyv804 := &x.LastProbeTime
-				yym805 := z.DecBinary()
-				_ = yym805
+				yyv844 := &x.LastProbeTime
+				yym845 := z.DecBinary()
+				_ = yym845
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv804) {
-				} else if yym805 {
-					z.DecBinaryUnmarshal(yyv804)
-				} else if !yym805 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv804)
+				} else if z.HasExtensions() && z.DecExt(yyv844) {
+				} else if yym845 {
+					z.DecBinaryUnmarshal(yyv844)
+				} else if !yym845 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv844)
 				} else {
-					z.DecFallback(yyv804, false)
+					z.DecFallback(yyv844, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg1_unversioned.Time{}
 			} else {
-				yyv806 := &x.LastTransitionTime
-				yym807 := z.DecBinary()
-				_ = yym807
+				yyv846 := &x.LastTransitionTime
+				yym847 := z.DecBinary()
+				_ = yym847
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv806) {
-				} else if yym807 {
-					z.DecBinaryUnmarshal(yyv806)
-				} else if !yym807 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv806)
+				} else if z.HasExtensions() && z.DecExt(yyv846) {
+				} else if yym847 {
+					z.DecBinaryUnmarshal(yyv846)
+				} else if !yym847 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv846)
 				} else {
-					z.DecFallback(yyv806, false)
+					z.DecFallback(yyv846, false)
 				}
 			}
 		case "reason":
@@ -8862,10 +9102,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys801)
-		} // end switch yys801
-	} // end for yyj801
-	if !yyhl801 {
+			z.DecStructFieldNotFound(-1, yys841)
+		} // end switch yys841
+	} // end for yyj841
+	if !yyhl841 {
 		r.ReadEnd()
 	}
 }
@@ -8874,16 +9114,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj810 int
-	var yyb810 bool
-	var yyhl810 bool = l >= 0
-	yyj810++
-	if yyhl810 {
-		yyb810 = yyj810 > l
+	var yyj850 int
+	var yyb850 bool
+	var yyhl850 bool = l >= 0
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb810 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb810 {
+	if yyb850 {
 		r.ReadEnd()
 		return
 	}
@@ -8892,13 +9132,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = JobConditionType(r.DecodeString())
 	}
-	yyj810++
-	if yyhl810 {
-		yyb810 = yyj810 > l
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb810 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb810 {
+	if yyb850 {
 		r.ReadEnd()
 		return
 	}
@@ -8907,65 +9147,65 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = pkg2_api.ConditionStatus(r.DecodeString())
 	}
-	yyj810++
-	if yyhl810 {
-		yyb810 = yyj810 > l
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb810 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb810 {
+	if yyb850 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
-		yyv813 := &x.LastProbeTime
-		yym814 := z.DecBinary()
-		_ = yym814
+		yyv853 := &x.LastProbeTime
+		yym854 := z.DecBinary()
+		_ = yym854
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv813) {
-		} else if yym814 {
-			z.DecBinaryUnmarshal(yyv813)
-		} else if !yym814 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv813)
+		} else if z.HasExtensions() && z.DecExt(yyv853) {
+		} else if yym854 {
+			z.DecBinaryUnmarshal(yyv853)
+		} else if !yym854 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv853)
 		} else {
-			z.DecFallback(yyv813, false)
+			z.DecFallback(yyv853, false)
 		}
 	}
-	yyj810++
-	if yyhl810 {
-		yyb810 = yyj810 > l
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb810 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb810 {
+	if yyb850 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
-		yyv815 := &x.LastTransitionTime
-		yym816 := z.DecBinary()
-		_ = yym816
+		yyv855 := &x.LastTransitionTime
+		yym856 := z.DecBinary()
+		_ = yym856
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv815) {
-		} else if yym816 {
-			z.DecBinaryUnmarshal(yyv815)
-		} else if !yym816 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv815)
+		} else if z.HasExtensions() && z.DecExt(yyv855) {
+		} else if yym856 {
+			z.DecBinaryUnmarshal(yyv855)
+		} else if !yym856 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv855)
 		} else {
-			z.DecFallback(yyv815, false)
+			z.DecFallback(yyv855, false)
 		}
 	}
-	yyj810++
-	if yyhl810 {
-		yyb810 = yyj810 > l
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb810 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb810 {
+	if yyb850 {
 		r.ReadEnd()
 		return
 	}
@@ -8974,13 +9214,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj810++
-	if yyhl810 {
-		yyb810 = yyj810 > l
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb810 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb810 {
+	if yyb850 {
 		r.ReadEnd()
 		return
 	}
@@ -8990,16 +9230,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj810++
-		if yyhl810 {
-			yyb810 = yyj810 > l
+		yyj850++
+		if yyhl850 {
+			yyb850 = yyj850 > l
 		} else {
-			yyb810 = r.CheckBreak()
+			yyb850 = r.CheckBreak()
 		}
-		if yyb810 {
+		if yyb850 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj810-1, "")
+		z.DecStructFieldNotFound(yyj850-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9011,36 +9251,36 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym819 := z.EncBinary()
-		_ = yym819
+		yym859 := z.EncBinary()
+		_ = yym859
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep820 := !z.EncBinary()
-			yy2arr820 := z.EncBasicHandle().StructToArray
-			var yyq820 [5]bool
-			_, _, _ = yysep820, yyq820, yy2arr820
-			const yyr820 bool = false
-			yyq820[0] = x.Kind != ""
-			yyq820[1] = x.APIVersion != ""
-			yyq820[2] = true
-			yyq820[3] = true
-			yyq820[4] = true
-			if yyr820 || yy2arr820 {
+			yysep860 := !z.EncBinary()
+			yy2arr860 := z.EncBasicHandle().StructToArray
+			var yyq860 [5]bool
+			_, _, _ = yysep860, yyq860, yy2arr860
+			const yyr860 bool = false
+			yyq860[0] = x.Kind != ""
+			yyq860[1] = x.APIVersion != ""
+			yyq860[2] = true
+			yyq860[3] = true
+			yyq860[4] = true
+			if yyr860 || yy2arr860 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn820 int = 0
-				for _, b := range yyq820 {
+				var yynn860 int = 0
+				for _, b := range yyq860 {
 					if b {
-						yynn820++
+						yynn860++
 					}
 				}
-				r.EncodeMapStart(yynn820)
+				r.EncodeMapStart(yynn860)
 			}
-			if yyr820 || yy2arr820 {
-				if yyq820[0] {
-					yym822 := z.EncBinary()
-					_ = yym822
+			if yyr860 || yy2arr860 {
+				if yyq860[0] {
+					yym862 := z.EncBinary()
+					_ = yym862
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9049,20 +9289,20 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq820[0] {
+				if yyq860[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym823 := z.EncBinary()
-					_ = yym823
+					yym863 := z.EncBinary()
+					_ = yym863
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr820 || yy2arr820 {
-				if yyq820[1] {
-					yym825 := z.EncBinary()
-					_ = yym825
+			if yyr860 || yy2arr860 {
+				if yyq860[1] {
+					yym865 := z.EncBinary()
+					_ = yym865
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9071,59 +9311,71 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq820[1] {
+				if yyq860[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym826 := z.EncBinary()
-					_ = yym826
+					yym866 := z.EncBinary()
+					_ = yym866
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr820 || yy2arr820 {
-				if yyq820[2] {
-					yy828 := &x.ObjectMeta
-					yy828.CodecEncodeSelf(e)
+			if yyr860 || yy2arr860 {
+				if yyq860[2] {
+					yy868 := &x.ObjectMeta
+					yym869 := z.EncBinary()
+					_ = yym869
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy868) {
+					} else {
+						z.EncFallback(yy868)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq820[2] {
+				if yyq860[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy829 := &x.ObjectMeta
-					yy829.CodecEncodeSelf(e)
+					yy870 := &x.ObjectMeta
+					yym871 := z.EncBinary()
+					_ = yym871
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy870) {
+					} else {
+						z.EncFallback(yy870)
+					}
 				}
 			}
-			if yyr820 || yy2arr820 {
-				if yyq820[3] {
-					yy831 := &x.Spec
-					yy831.CodecEncodeSelf(e)
+			if yyr860 || yy2arr860 {
+				if yyq860[3] {
+					yy873 := &x.Spec
+					yy873.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq820[3] {
+				if yyq860[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy832 := &x.Spec
-					yy832.CodecEncodeSelf(e)
+					yy874 := &x.Spec
+					yy874.CodecEncodeSelf(e)
 				}
 			}
-			if yyr820 || yy2arr820 {
-				if yyq820[4] {
-					yy834 := &x.Status
-					yy834.CodecEncodeSelf(e)
+			if yyr860 || yy2arr860 {
+				if yyq860[4] {
+					yy876 := &x.Status
+					yy876.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq820[4] {
+				if yyq860[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy835 := &x.Status
-					yy835.CodecEncodeSelf(e)
+					yy877 := &x.Status
+					yy877.CodecEncodeSelf(e)
 				}
 			}
-			if yysep820 {
+			if yysep860 {
 				r.EncodeEnd()
 			}
 		}
@@ -9134,24 +9386,24 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym836 := z.DecBinary()
-	_ = yym836
+	yym878 := z.DecBinary()
+	_ = yym878
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl837 := r.ReadMapStart()
-			if yyl837 == 0 {
+			yyl879 := r.ReadMapStart()
+			if yyl879 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl837, d)
+				x.codecDecodeSelfFromMap(yyl879, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl837 := r.ReadArrayStart()
-			if yyl837 == 0 {
+			yyl879 := r.ReadArrayStart()
+			if yyl879 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl837, d)
+				x.codecDecodeSelfFromArray(yyl879, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9163,12 +9415,12 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys838Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys838Slc
-	var yyhl838 bool = l >= 0
-	for yyj838 := 0; ; yyj838++ {
-		if yyhl838 {
-			if yyj838 >= l {
+	var yys880Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys880Slc
+	var yyhl880 bool = l >= 0
+	for yyj880 := 0; ; yyj880++ {
+		if yyhl880 {
+			if yyj880 >= l {
 				break
 			}
 		} else {
@@ -9176,9 +9428,9 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys838Slc = r.DecodeBytes(yys838Slc, true, true)
-		yys838 := string(yys838Slc)
-		switch yys838 {
+		yys880Slc = r.DecodeBytes(yys880Slc, true, true)
+		yys880 := string(yys880Slc)
+		switch yys880 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9195,28 +9447,34 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv841 := &x.ObjectMeta
-				yyv841.CodecDecodeSelf(d)
+				yyv883 := &x.ObjectMeta
+				yym884 := z.DecBinary()
+				_ = yym884
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv883) {
+				} else {
+					z.DecFallback(yyv883, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = IngressSpec{}
 			} else {
-				yyv842 := &x.Spec
-				yyv842.CodecDecodeSelf(d)
+				yyv885 := &x.Spec
+				yyv885.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = IngressStatus{}
 			} else {
-				yyv843 := &x.Status
-				yyv843.CodecDecodeSelf(d)
+				yyv886 := &x.Status
+				yyv886.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys838)
-		} // end switch yys838
-	} // end for yyj838
-	if !yyhl838 {
+			z.DecStructFieldNotFound(-1, yys880)
+		} // end switch yys880
+	} // end for yyj880
+	if !yyhl880 {
 		r.ReadEnd()
 	}
 }
@@ -9225,16 +9483,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj844 int
-	var yyb844 bool
-	var yyhl844 bool = l >= 0
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	var yyj887 int
+	var yyb887 bool
+	var yyhl887 bool = l >= 0
+	yyj887++
+	if yyhl887 {
+		yyb887 = yyj887 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb887 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb887 {
 		r.ReadEnd()
 		return
 	}
@@ -9243,13 +9501,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	yyj887++
+	if yyhl887 {
+		yyb887 = yyj887 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb887 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb887 {
 		r.ReadEnd()
 		return
 	}
@@ -9258,65 +9516,71 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	yyj887++
+	if yyhl887 {
+		yyb887 = yyj887 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb887 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb887 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv847 := &x.ObjectMeta
-		yyv847.CodecDecodeSelf(d)
+		yyv890 := &x.ObjectMeta
+		yym891 := z.DecBinary()
+		_ = yym891
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv890) {
+		} else {
+			z.DecFallback(yyv890, false)
+		}
 	}
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	yyj887++
+	if yyhl887 {
+		yyb887 = yyj887 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb887 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb887 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
-		yyv848 := &x.Spec
-		yyv848.CodecDecodeSelf(d)
+		yyv892 := &x.Spec
+		yyv892.CodecDecodeSelf(d)
 	}
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	yyj887++
+	if yyhl887 {
+		yyb887 = yyj887 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb887 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb887 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
-		yyv849 := &x.Status
-		yyv849.CodecDecodeSelf(d)
+		yyv893 := &x.Status
+		yyv893.CodecDecodeSelf(d)
 	}
 	for {
-		yyj844++
-		if yyhl844 {
-			yyb844 = yyj844 > l
+		yyj887++
+		if yyhl887 {
+			yyb887 = yyj887 > l
 		} else {
-			yyb844 = r.CheckBreak()
+			yyb887 = r.CheckBreak()
 		}
-		if yyb844 {
+		if yyb887 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj844-1, "")
+		z.DecStructFieldNotFound(yyj887-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9328,34 +9592,34 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym850 := z.EncBinary()
-		_ = yym850
+		yym894 := z.EncBinary()
+		_ = yym894
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep851 := !z.EncBinary()
-			yy2arr851 := z.EncBasicHandle().StructToArray
-			var yyq851 [4]bool
-			_, _, _ = yysep851, yyq851, yy2arr851
-			const yyr851 bool = false
-			yyq851[0] = x.Kind != ""
-			yyq851[1] = x.APIVersion != ""
-			yyq851[2] = true
-			if yyr851 || yy2arr851 {
+			yysep895 := !z.EncBinary()
+			yy2arr895 := z.EncBasicHandle().StructToArray
+			var yyq895 [4]bool
+			_, _, _ = yysep895, yyq895, yy2arr895
+			const yyr895 bool = false
+			yyq895[0] = x.Kind != ""
+			yyq895[1] = x.APIVersion != ""
+			yyq895[2] = true
+			if yyr895 || yy2arr895 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn851 int = 1
-				for _, b := range yyq851 {
+				var yynn895 int = 1
+				for _, b := range yyq895 {
 					if b {
-						yynn851++
+						yynn895++
 					}
 				}
-				r.EncodeMapStart(yynn851)
+				r.EncodeMapStart(yynn895)
 			}
-			if yyr851 || yy2arr851 {
-				if yyq851[0] {
-					yym853 := z.EncBinary()
-					_ = yym853
+			if yyr895 || yy2arr895 {
+				if yyq895[0] {
+					yym897 := z.EncBinary()
+					_ = yym897
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9364,20 +9628,20 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq851[0] {
+				if yyq895[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym854 := z.EncBinary()
-					_ = yym854
+					yym898 := z.EncBinary()
+					_ = yym898
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr851 || yy2arr851 {
-				if yyq851[1] {
-					yym856 := z.EncBinary()
-					_ = yym856
+			if yyr895 || yy2arr895 {
+				if yyq895[1] {
+					yym900 := z.EncBinary()
+					_ = yym900
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9386,48 +9650,48 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq851[1] {
+				if yyq895[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym857 := z.EncBinary()
-					_ = yym857
+					yym901 := z.EncBinary()
+					_ = yym901
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr851 || yy2arr851 {
-				if yyq851[2] {
-					yy859 := &x.ListMeta
-					yym860 := z.EncBinary()
-					_ = yym860
+			if yyr895 || yy2arr895 {
+				if yyq895[2] {
+					yy903 := &x.ListMeta
+					yym904 := z.EncBinary()
+					_ = yym904
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy859) {
+					} else if z.HasExtensions() && z.EncExt(yy903) {
 					} else {
-						z.EncFallback(yy859)
+						z.EncFallback(yy903)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq851[2] {
+				if yyq895[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy861 := &x.ListMeta
-					yym862 := z.EncBinary()
-					_ = yym862
+					yy905 := &x.ListMeta
+					yym906 := z.EncBinary()
+					_ = yym906
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy861) {
+					} else if z.HasExtensions() && z.EncExt(yy905) {
 					} else {
-						z.EncFallback(yy861)
+						z.EncFallback(yy905)
 					}
 				}
 			}
-			if yyr851 || yy2arr851 {
+			if yyr895 || yy2arr895 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym864 := z.EncBinary()
-					_ = yym864
+					yym908 := z.EncBinary()
+					_ = yym908
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -9438,15 +9702,15 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym865 := z.EncBinary()
-					_ = yym865
+					yym909 := z.EncBinary()
+					_ = yym909
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
 					}
 				}
 			}
-			if yysep851 {
+			if yysep895 {
 				r.EncodeEnd()
 			}
 		}
@@ -9457,24 +9721,24 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym866 := z.DecBinary()
-	_ = yym866
+	yym910 := z.DecBinary()
+	_ = yym910
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl867 := r.ReadMapStart()
-			if yyl867 == 0 {
+			yyl911 := r.ReadMapStart()
+			if yyl911 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl867, d)
+				x.codecDecodeSelfFromMap(yyl911, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl867 := r.ReadArrayStart()
-			if yyl867 == 0 {
+			yyl911 := r.ReadArrayStart()
+			if yyl911 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl867, d)
+				x.codecDecodeSelfFromArray(yyl911, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9486,12 +9750,12 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys868Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys868Slc
-	var yyhl868 bool = l >= 0
-	for yyj868 := 0; ; yyj868++ {
-		if yyhl868 {
-			if yyj868 >= l {
+	var yys912Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys912Slc
+	var yyhl912 bool = l >= 0
+	for yyj912 := 0; ; yyj912++ {
+		if yyhl912 {
+			if yyj912 >= l {
 				break
 			}
 		} else {
@@ -9499,9 +9763,9 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys868Slc = r.DecodeBytes(yys868Slc, true, true)
-		yys868 := string(yys868Slc)
-		switch yys868 {
+		yys912Slc = r.DecodeBytes(yys912Slc, true, true)
+		yys912 := string(yys912Slc)
+		switch yys912 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9518,32 +9782,32 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv871 := &x.ListMeta
-				yym872 := z.DecBinary()
-				_ = yym872
+				yyv915 := &x.ListMeta
+				yym916 := z.DecBinary()
+				_ = yym916
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv871) {
+				} else if z.HasExtensions() && z.DecExt(yyv915) {
 				} else {
-					z.DecFallback(yyv871, false)
+					z.DecFallback(yyv915, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv873 := &x.Items
-				yym874 := z.DecBinary()
-				_ = yym874
+				yyv917 := &x.Items
+				yym918 := z.DecBinary()
+				_ = yym918
 				if false {
 				} else {
-					h.decSliceIngress((*[]Ingress)(yyv873), d)
+					h.decSliceIngress((*[]Ingress)(yyv917), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys868)
-		} // end switch yys868
-	} // end for yyj868
-	if !yyhl868 {
+			z.DecStructFieldNotFound(-1, yys912)
+		} // end switch yys912
+	} // end for yyj912
+	if !yyhl912 {
 		r.ReadEnd()
 	}
 }
@@ -9552,16 +9816,16 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj875 int
-	var yyb875 bool
-	var yyhl875 bool = l >= 0
-	yyj875++
-	if yyhl875 {
-		yyb875 = yyj875 > l
+	var yyj919 int
+	var yyb919 bool
+	var yyhl919 bool = l >= 0
+	yyj919++
+	if yyhl919 {
+		yyb919 = yyj919 > l
 	} else {
-		yyb875 = r.CheckBreak()
+		yyb919 = r.CheckBreak()
 	}
-	if yyb875 {
+	if yyb919 {
 		r.ReadEnd()
 		return
 	}
@@ -9570,13 +9834,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj875++
-	if yyhl875 {
-		yyb875 = yyj875 > l
+	yyj919++
+	if yyhl919 {
+		yyb919 = yyj919 > l
 	} else {
-		yyb875 = r.CheckBreak()
+		yyb919 = r.CheckBreak()
 	}
-	if yyb875 {
+	if yyb919 {
 		r.ReadEnd()
 		return
 	}
@@ -9585,60 +9849,60 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj875++
-	if yyhl875 {
-		yyb875 = yyj875 > l
+	yyj919++
+	if yyhl919 {
+		yyb919 = yyj919 > l
 	} else {
-		yyb875 = r.CheckBreak()
+		yyb919 = r.CheckBreak()
 	}
-	if yyb875 {
+	if yyb919 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv878 := &x.ListMeta
-		yym879 := z.DecBinary()
-		_ = yym879
+		yyv922 := &x.ListMeta
+		yym923 := z.DecBinary()
+		_ = yym923
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv878) {
+		} else if z.HasExtensions() && z.DecExt(yyv922) {
 		} else {
-			z.DecFallback(yyv878, false)
+			z.DecFallback(yyv922, false)
 		}
 	}
-	yyj875++
-	if yyhl875 {
-		yyb875 = yyj875 > l
+	yyj919++
+	if yyhl919 {
+		yyb919 = yyj919 > l
 	} else {
-		yyb875 = r.CheckBreak()
+		yyb919 = r.CheckBreak()
 	}
-	if yyb875 {
+	if yyb919 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv880 := &x.Items
-		yym881 := z.DecBinary()
-		_ = yym881
+		yyv924 := &x.Items
+		yym925 := z.DecBinary()
+		_ = yym925
 		if false {
 		} else {
-			h.decSliceIngress((*[]Ingress)(yyv880), d)
+			h.decSliceIngress((*[]Ingress)(yyv924), d)
 		}
 	}
 	for {
-		yyj875++
-		if yyhl875 {
-			yyb875 = yyj875 > l
+		yyj919++
+		if yyhl919 {
+			yyb919 = yyj919 > l
 		} else {
-			yyb875 = r.CheckBreak()
+			yyb919 = r.CheckBreak()
 		}
-		if yyb875 {
+		if yyb919 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj875-1, "")
+		z.DecStructFieldNotFound(yyj919-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9650,31 +9914,31 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym882 := z.EncBinary()
-		_ = yym882
+		yym926 := z.EncBinary()
+		_ = yym926
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep883 := !z.EncBinary()
-			yy2arr883 := z.EncBasicHandle().StructToArray
-			var yyq883 [2]bool
-			_, _, _ = yysep883, yyq883, yy2arr883
-			const yyr883 bool = false
-			yyq883[0] = x.Backend != nil
-			yyq883[1] = len(x.Rules) != 0
-			if yyr883 || yy2arr883 {
+			yysep927 := !z.EncBinary()
+			yy2arr927 := z.EncBasicHandle().StructToArray
+			var yyq927 [2]bool
+			_, _, _ = yysep927, yyq927, yy2arr927
+			const yyr927 bool = false
+			yyq927[0] = x.Backend != nil
+			yyq927[1] = len(x.Rules) != 0
+			if yyr927 || yy2arr927 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn883 int = 0
-				for _, b := range yyq883 {
+				var yynn927 int = 0
+				for _, b := range yyq927 {
 					if b {
-						yynn883++
+						yynn927++
 					}
 				}
-				r.EncodeMapStart(yynn883)
+				r.EncodeMapStart(yynn927)
 			}
-			if yyr883 || yy2arr883 {
-				if yyq883[0] {
+			if yyr927 || yy2arr927 {
+				if yyq927[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -9684,7 +9948,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq883[0] {
+				if yyq927[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
 					if x.Backend == nil {
 						r.EncodeNil()
@@ -9693,13 +9957,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr883 || yy2arr883 {
-				if yyq883[1] {
+			if yyr927 || yy2arr927 {
+				if yyq927[1] {
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym886 := z.EncBinary()
-						_ = yym886
+						yym930 := z.EncBinary()
+						_ = yym930
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9709,13 +9973,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq883[1] {
+				if yyq927[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym887 := z.EncBinary()
-						_ = yym887
+						yym931 := z.EncBinary()
+						_ = yym931
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9723,7 +9987,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep883 {
+			if yysep927 {
 				r.EncodeEnd()
 			}
 		}
@@ -9734,24 +9998,24 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym888 := z.DecBinary()
-	_ = yym888
+	yym932 := z.DecBinary()
+	_ = yym932
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl889 := r.ReadMapStart()
-			if yyl889 == 0 {
+			yyl933 := r.ReadMapStart()
+			if yyl933 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl889, d)
+				x.codecDecodeSelfFromMap(yyl933, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl889 := r.ReadArrayStart()
-			if yyl889 == 0 {
+			yyl933 := r.ReadArrayStart()
+			if yyl933 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl889, d)
+				x.codecDecodeSelfFromArray(yyl933, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9763,12 +10027,12 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys890Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys890Slc
-	var yyhl890 bool = l >= 0
-	for yyj890 := 0; ; yyj890++ {
-		if yyhl890 {
-			if yyj890 >= l {
+	var yys934Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys934Slc
+	var yyhl934 bool = l >= 0
+	for yyj934 := 0; ; yyj934++ {
+		if yyhl934 {
+			if yyj934 >= l {
 				break
 			}
 		} else {
@@ -9776,9 +10040,9 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys890Slc = r.DecodeBytes(yys890Slc, true, true)
-		yys890 := string(yys890Slc)
-		switch yys890 {
+		yys934Slc = r.DecodeBytes(yys934Slc, true, true)
+		yys934 := string(yys934Slc)
+		switch yys934 {
 		case "backend":
 			if r.TryDecodeAsNil() {
 				if x.Backend != nil {
@@ -9794,19 +10058,19 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Rules = nil
 			} else {
-				yyv892 := &x.Rules
-				yym893 := z.DecBinary()
-				_ = yym893
+				yyv936 := &x.Rules
+				yym937 := z.DecBinary()
+				_ = yym937
 				if false {
 				} else {
-					h.decSliceIngressRule((*[]IngressRule)(yyv892), d)
+					h.decSliceIngressRule((*[]IngressRule)(yyv936), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys890)
-		} // end switch yys890
-	} // end for yyj890
-	if !yyhl890 {
+			z.DecStructFieldNotFound(-1, yys934)
+		} // end switch yys934
+	} // end for yyj934
+	if !yyhl934 {
 		r.ReadEnd()
 	}
 }
@@ -9815,16 +10079,16 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj894 int
-	var yyb894 bool
-	var yyhl894 bool = l >= 0
-	yyj894++
-	if yyhl894 {
-		yyb894 = yyj894 > l
+	var yyj938 int
+	var yyb938 bool
+	var yyhl938 bool = l >= 0
+	yyj938++
+	if yyhl938 {
+		yyb938 = yyj938 > l
 	} else {
-		yyb894 = r.CheckBreak()
+		yyb938 = r.CheckBreak()
 	}
-	if yyb894 {
+	if yyb938 {
 		r.ReadEnd()
 		return
 	}
@@ -9838,38 +10102,38 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Backend.CodecDecodeSelf(d)
 	}
-	yyj894++
-	if yyhl894 {
-		yyb894 = yyj894 > l
+	yyj938++
+	if yyhl938 {
+		yyb938 = yyj938 > l
 	} else {
-		yyb894 = r.CheckBreak()
+		yyb938 = r.CheckBreak()
 	}
-	if yyb894 {
+	if yyb938 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
-		yyv896 := &x.Rules
-		yym897 := z.DecBinary()
-		_ = yym897
+		yyv940 := &x.Rules
+		yym941 := z.DecBinary()
+		_ = yym941
 		if false {
 		} else {
-			h.decSliceIngressRule((*[]IngressRule)(yyv896), d)
+			h.decSliceIngressRule((*[]IngressRule)(yyv940), d)
 		}
 	}
 	for {
-		yyj894++
-		if yyhl894 {
-			yyb894 = yyj894 > l
+		yyj938++
+		if yyhl938 {
+			yyb938 = yyj938 > l
 		} else {
-			yyb894 = r.CheckBreak()
+			yyb938 = r.CheckBreak()
 		}
-		if yyb894 {
+		if yyb938 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj894-1, "")
+		z.DecStructFieldNotFound(yyj938-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9881,43 +10145,55 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym898 := z.EncBinary()
-		_ = yym898
+		yym942 := z.EncBinary()
+		_ = yym942
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep899 := !z.EncBinary()
-			yy2arr899 := z.EncBasicHandle().StructToArray
-			var yyq899 [1]bool
-			_, _, _ = yysep899, yyq899, yy2arr899
-			const yyr899 bool = false
-			yyq899[0] = true
-			if yyr899 || yy2arr899 {
+			yysep943 := !z.EncBinary()
+			yy2arr943 := z.EncBasicHandle().StructToArray
+			var yyq943 [1]bool
+			_, _, _ = yysep943, yyq943, yy2arr943
+			const yyr943 bool = false
+			yyq943[0] = true
+			if yyr943 || yy2arr943 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn899 int = 0
-				for _, b := range yyq899 {
+				var yynn943 int = 0
+				for _, b := range yyq943 {
 					if b {
-						yynn899++
+						yynn943++
 					}
 				}
-				r.EncodeMapStart(yynn899)
+				r.EncodeMapStart(yynn943)
 			}
-			if yyr899 || yy2arr899 {
-				if yyq899[0] {
-					yy901 := &x.LoadBalancer
-					yy901.CodecEncodeSelf(e)
+			if yyr943 || yy2arr943 {
+				if yyq943[0] {
+					yy945 := &x.LoadBalancer
+					yym946 := z.EncBinary()
+					_ = yym946
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy945) {
+					} else {
+						z.EncFallback(yy945)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq899[0] {
+				if yyq943[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
-					yy902 := &x.LoadBalancer
-					yy902.CodecEncodeSelf(e)
+					yy947 := &x.LoadBalancer
+					yym948 := z.EncBinary()
+					_ = yym948
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy947) {
+					} else {
+						z.EncFallback(yy947)
+					}
 				}
 			}
-			if yysep899 {
+			if yysep943 {
 				r.EncodeEnd()
 			}
 		}
@@ -9928,24 +10204,24 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym903 := z.DecBinary()
-	_ = yym903
+	yym949 := z.DecBinary()
+	_ = yym949
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl904 := r.ReadMapStart()
-			if yyl904 == 0 {
+			yyl950 := r.ReadMapStart()
+			if yyl950 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl904, d)
+				x.codecDecodeSelfFromMap(yyl950, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl904 := r.ReadArrayStart()
-			if yyl904 == 0 {
+			yyl950 := r.ReadArrayStart()
+			if yyl950 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl904, d)
+				x.codecDecodeSelfFromArray(yyl950, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9957,12 +10233,12 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys905Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys905Slc
-	var yyhl905 bool = l >= 0
-	for yyj905 := 0; ; yyj905++ {
-		if yyhl905 {
-			if yyj905 >= l {
+	var yys951Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys951Slc
+	var yyhl951 bool = l >= 0
+	for yyj951 := 0; ; yyj951++ {
+		if yyhl951 {
+			if yyj951 >= l {
 				break
 			}
 		} else {
@@ -9970,21 +10246,27 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys905Slc = r.DecodeBytes(yys905Slc, true, true)
-		yys905 := string(yys905Slc)
-		switch yys905 {
+		yys951Slc = r.DecodeBytes(yys951Slc, true, true)
+		yys951 := string(yys951Slc)
+		switch yys951 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 			} else {
-				yyv906 := &x.LoadBalancer
-				yyv906.CodecDecodeSelf(d)
+				yyv952 := &x.LoadBalancer
+				yym953 := z.DecBinary()
+				_ = yym953
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv952) {
+				} else {
+					z.DecFallback(yyv952, false)
+				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys905)
-		} // end switch yys905
-	} // end for yyj905
-	if !yyhl905 {
+			z.DecStructFieldNotFound(-1, yys951)
+		} // end switch yys951
+	} // end for yyj951
+	if !yyhl951 {
 		r.ReadEnd()
 	}
 }
@@ -9993,36 +10275,42 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj907 int
-	var yyb907 bool
-	var yyhl907 bool = l >= 0
-	yyj907++
-	if yyhl907 {
-		yyb907 = yyj907 > l
+	var yyj954 int
+	var yyb954 bool
+	var yyhl954 bool = l >= 0
+	yyj954++
+	if yyhl954 {
+		yyb954 = yyj954 > l
 	} else {
-		yyb907 = r.CheckBreak()
+		yyb954 = r.CheckBreak()
 	}
-	if yyb907 {
+	if yyb954 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 	} else {
-		yyv908 := &x.LoadBalancer
-		yyv908.CodecDecodeSelf(d)
+		yyv955 := &x.LoadBalancer
+		yym956 := z.DecBinary()
+		_ = yym956
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv955) {
+		} else {
+			z.DecFallback(yyv955, false)
+		}
 	}
 	for {
-		yyj907++
-		if yyhl907 {
-			yyb907 = yyj907 > l
+		yyj954++
+		if yyhl954 {
+			yyb954 = yyj954 > l
 		} else {
-			yyb907 = r.CheckBreak()
+			yyb954 = r.CheckBreak()
 		}
-		if yyb907 {
+		if yyb954 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj907-1, "")
+		z.DecStructFieldNotFound(yyj954-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10034,33 +10322,33 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym909 := z.EncBinary()
-		_ = yym909
+		yym957 := z.EncBinary()
+		_ = yym957
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep910 := !z.EncBinary()
-			yy2arr910 := z.EncBasicHandle().StructToArray
-			var yyq910 [2]bool
-			_, _, _ = yysep910, yyq910, yy2arr910
-			const yyr910 bool = false
-			yyq910[0] = x.Host != ""
-			yyq910[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
-			if yyr910 || yy2arr910 {
+			yysep958 := !z.EncBinary()
+			yy2arr958 := z.EncBasicHandle().StructToArray
+			var yyq958 [2]bool
+			_, _, _ = yysep958, yyq958, yy2arr958
+			const yyr958 bool = false
+			yyq958[0] = x.Host != ""
+			yyq958[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			if yyr958 || yy2arr958 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn910 int = 0
-				for _, b := range yyq910 {
+				var yynn958 int = 0
+				for _, b := range yyq958 {
 					if b {
-						yynn910++
+						yynn958++
 					}
 				}
-				r.EncodeMapStart(yynn910)
+				r.EncodeMapStart(yynn958)
 			}
-			if yyr910 || yy2arr910 {
-				if yyq910[0] {
-					yym912 := z.EncBinary()
-					_ = yym912
+			if yyr958 || yy2arr958 {
+				if yyq958[0] {
+					yym960 := z.EncBinary()
+					_ = yym960
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -10069,27 +10357,27 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq910[0] {
+				if yyq958[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
-					yym913 := z.EncBinary()
-					_ = yym913
+					yym961 := z.EncBinary()
+					_ = yym961
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			var yyn914 bool
+			var yyn962 bool
 			if x.IngressRuleValue.HTTP == nil {
-				yyn914 = true
-				goto LABEL914
+				yyn962 = true
+				goto LABEL962
 			}
-		LABEL914:
-			if yyr910 || yy2arr910 {
-				if yyn914 {
+		LABEL962:
+			if yyr958 || yy2arr958 {
+				if yyn962 {
 					r.EncodeNil()
 				} else {
-					if yyq910[1] {
+					if yyq958[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
 						} else {
@@ -10100,9 +10388,9 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				if yyq910[1] {
+				if yyq958[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
-					if yyn914 {
+					if yyn962 {
 						r.EncodeNil()
 					} else {
 						if x.HTTP == nil {
@@ -10113,7 +10401,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep910 {
+			if yysep958 {
 				r.EncodeEnd()
 			}
 		}
@@ -10124,24 +10412,24 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym915 := z.DecBinary()
-	_ = yym915
+	yym963 := z.DecBinary()
+	_ = yym963
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl916 := r.ReadMapStart()
-			if yyl916 == 0 {
+			yyl964 := r.ReadMapStart()
+			if yyl964 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl916, d)
+				x.codecDecodeSelfFromMap(yyl964, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl916 := r.ReadArrayStart()
-			if yyl916 == 0 {
+			yyl964 := r.ReadArrayStart()
+			if yyl964 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl916, d)
+				x.codecDecodeSelfFromArray(yyl964, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10153,12 +10441,12 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys917Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys917Slc
-	var yyhl917 bool = l >= 0
-	for yyj917 := 0; ; yyj917++ {
-		if yyhl917 {
-			if yyj917 >= l {
+	var yys965Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys965Slc
+	var yyhl965 bool = l >= 0
+	for yyj965 := 0; ; yyj965++ {
+		if yyhl965 {
+			if yyj965 >= l {
 				break
 			}
 		} else {
@@ -10166,9 +10454,9 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys917Slc = r.DecodeBytes(yys917Slc, true, true)
-		yys917 := string(yys917Slc)
-		switch yys917 {
+		yys965Slc = r.DecodeBytes(yys965Slc, true, true)
+		yys965 := string(yys965Slc)
+		switch yys965 {
 		case "host":
 			if r.TryDecodeAsNil() {
 				x.Host = ""
@@ -10190,10 +10478,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys917)
-		} // end switch yys917
-	} // end for yyj917
-	if !yyhl917 {
+			z.DecStructFieldNotFound(-1, yys965)
+		} // end switch yys965
+	} // end for yyj965
+	if !yyhl965 {
 		r.ReadEnd()
 	}
 }
@@ -10202,16 +10490,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj920 int
-	var yyb920 bool
-	var yyhl920 bool = l >= 0
-	yyj920++
-	if yyhl920 {
-		yyb920 = yyj920 > l
+	var yyj968 int
+	var yyb968 bool
+	var yyhl968 bool = l >= 0
+	yyj968++
+	if yyhl968 {
+		yyb968 = yyj968 > l
 	} else {
-		yyb920 = r.CheckBreak()
+		yyb968 = r.CheckBreak()
 	}
-	if yyb920 {
+	if yyb968 {
 		r.ReadEnd()
 		return
 	}
@@ -10220,13 +10508,13 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Host = string(r.DecodeString())
 	}
-	yyj920++
-	if yyhl920 {
-		yyb920 = yyj920 > l
+	yyj968++
+	if yyhl968 {
+		yyb968 = yyj968 > l
 	} else {
-		yyb920 = r.CheckBreak()
+		yyb968 = r.CheckBreak()
 	}
-	if yyb920 {
+	if yyb968 {
 		r.ReadEnd()
 		return
 	}
@@ -10241,16 +10529,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj920++
-		if yyhl920 {
-			yyb920 = yyj920 > l
+		yyj968++
+		if yyhl968 {
+			yyb968 = yyj968 > l
 		} else {
-			yyb920 = r.CheckBreak()
+			yyb968 = r.CheckBreak()
 		}
-		if yyb920 {
+		if yyb968 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj920-1, "")
+		z.DecStructFieldNotFound(yyj968-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10262,30 +10550,30 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym923 := z.EncBinary()
-		_ = yym923
+		yym971 := z.EncBinary()
+		_ = yym971
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep924 := !z.EncBinary()
-			yy2arr924 := z.EncBasicHandle().StructToArray
-			var yyq924 [1]bool
-			_, _, _ = yysep924, yyq924, yy2arr924
-			const yyr924 bool = false
-			yyq924[0] = x.HTTP != nil
-			if yyr924 || yy2arr924 {
+			yysep972 := !z.EncBinary()
+			yy2arr972 := z.EncBasicHandle().StructToArray
+			var yyq972 [1]bool
+			_, _, _ = yysep972, yyq972, yy2arr972
+			const yyr972 bool = false
+			yyq972[0] = x.HTTP != nil
+			if yyr972 || yy2arr972 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn924 int = 0
-				for _, b := range yyq924 {
+				var yynn972 int = 0
+				for _, b := range yyq972 {
 					if b {
-						yynn924++
+						yynn972++
 					}
 				}
-				r.EncodeMapStart(yynn924)
+				r.EncodeMapStart(yynn972)
 			}
-			if yyr924 || yy2arr924 {
-				if yyq924[0] {
+			if yyr972 || yy2arr972 {
+				if yyq972[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -10295,7 +10583,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq924[0] {
+				if yyq972[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					if x.HTTP == nil {
 						r.EncodeNil()
@@ -10304,7 +10592,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep924 {
+			if yysep972 {
 				r.EncodeEnd()
 			}
 		}
@@ -10315,24 +10603,24 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym926 := z.DecBinary()
-	_ = yym926
+	yym974 := z.DecBinary()
+	_ = yym974
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl927 := r.ReadMapStart()
-			if yyl927 == 0 {
+			yyl975 := r.ReadMapStart()
+			if yyl975 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl927, d)
+				x.codecDecodeSelfFromMap(yyl975, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl927 := r.ReadArrayStart()
-			if yyl927 == 0 {
+			yyl975 := r.ReadArrayStart()
+			if yyl975 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl927, d)
+				x.codecDecodeSelfFromArray(yyl975, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10344,12 +10632,12 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys928Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys928Slc
-	var yyhl928 bool = l >= 0
-	for yyj928 := 0; ; yyj928++ {
-		if yyhl928 {
-			if yyj928 >= l {
+	var yys976Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys976Slc
+	var yyhl976 bool = l >= 0
+	for yyj976 := 0; ; yyj976++ {
+		if yyhl976 {
+			if yyj976 >= l {
 				break
 			}
 		} else {
@@ -10357,9 +10645,9 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys928Slc = r.DecodeBytes(yys928Slc, true, true)
-		yys928 := string(yys928Slc)
-		switch yys928 {
+		yys976Slc = r.DecodeBytes(yys976Slc, true, true)
+		yys976 := string(yys976Slc)
+		switch yys976 {
 		case "http":
 			if r.TryDecodeAsNil() {
 				if x.HTTP != nil {
@@ -10372,10 +10660,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys928)
-		} // end switch yys928
-	} // end for yyj928
-	if !yyhl928 {
+			z.DecStructFieldNotFound(-1, yys976)
+		} // end switch yys976
+	} // end for yyj976
+	if !yyhl976 {
 		r.ReadEnd()
 	}
 }
@@ -10384,16 +10672,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj930 int
-	var yyb930 bool
-	var yyhl930 bool = l >= 0
-	yyj930++
-	if yyhl930 {
-		yyb930 = yyj930 > l
+	var yyj978 int
+	var yyb978 bool
+	var yyhl978 bool = l >= 0
+	yyj978++
+	if yyhl978 {
+		yyb978 = yyj978 > l
 	} else {
-		yyb930 = r.CheckBreak()
+		yyb978 = r.CheckBreak()
 	}
-	if yyb930 {
+	if yyb978 {
 		r.ReadEnd()
 		return
 	}
@@ -10408,16 +10696,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj930++
-		if yyhl930 {
-			yyb930 = yyj930 > l
+		yyj978++
+		if yyhl978 {
+			yyb978 = yyj978 > l
 		} else {
-			yyb930 = r.CheckBreak()
+			yyb978 = r.CheckBreak()
 		}
-		if yyb930 {
+		if yyb978 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj930-1, "")
+		z.DecStructFieldNotFound(yyj978-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10429,33 +10717,33 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym932 := z.EncBinary()
-		_ = yym932
+		yym980 := z.EncBinary()
+		_ = yym980
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep933 := !z.EncBinary()
-			yy2arr933 := z.EncBasicHandle().StructToArray
-			var yyq933 [1]bool
-			_, _, _ = yysep933, yyq933, yy2arr933
-			const yyr933 bool = false
-			if yyr933 || yy2arr933 {
+			yysep981 := !z.EncBinary()
+			yy2arr981 := z.EncBasicHandle().StructToArray
+			var yyq981 [1]bool
+			_, _, _ = yysep981, yyq981, yy2arr981
+			const yyr981 bool = false
+			if yyr981 || yy2arr981 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn933 int = 1
-				for _, b := range yyq933 {
+				var yynn981 int = 1
+				for _, b := range yyq981 {
 					if b {
-						yynn933++
+						yynn981++
 					}
 				}
-				r.EncodeMapStart(yynn933)
+				r.EncodeMapStart(yynn981)
 			}
-			if yyr933 || yy2arr933 {
+			if yyr981 || yy2arr981 {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym935 := z.EncBinary()
-					_ = yym935
+					yym983 := z.EncBinary()
+					_ = yym983
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
@@ -10466,15 +10754,15 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym936 := z.EncBinary()
-					_ = yym936
+					yym984 := z.EncBinary()
+					_ = yym984
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
 					}
 				}
 			}
-			if yysep933 {
+			if yysep981 {
 				r.EncodeEnd()
 			}
 		}
@@ -10485,24 +10773,24 @@ func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym937 := z.DecBinary()
-	_ = yym937
+	yym985 := z.DecBinary()
+	_ = yym985
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl938 := r.ReadMapStart()
-			if yyl938 == 0 {
+			yyl986 := r.ReadMapStart()
+			if yyl986 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl938, d)
+				x.codecDecodeSelfFromMap(yyl986, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl938 := r.ReadArrayStart()
-			if yyl938 == 0 {
+			yyl986 := r.ReadArrayStart()
+			if yyl986 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl938, d)
+				x.codecDecodeSelfFromArray(yyl986, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10514,12 +10802,12 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys939Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys939Slc
-	var yyhl939 bool = l >= 0
-	for yyj939 := 0; ; yyj939++ {
-		if yyhl939 {
-			if yyj939 >= l {
+	var yys987Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys987Slc
+	var yyhl987 bool = l >= 0
+	for yyj987 := 0; ; yyj987++ {
+		if yyhl987 {
+			if yyj987 >= l {
 				break
 			}
 		} else {
@@ -10527,26 +10815,26 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys939Slc = r.DecodeBytes(yys939Slc, true, true)
-		yys939 := string(yys939Slc)
-		switch yys939 {
+		yys987Slc = r.DecodeBytes(yys987Slc, true, true)
+		yys987 := string(yys987Slc)
+		switch yys987 {
 		case "paths":
 			if r.TryDecodeAsNil() {
 				x.Paths = nil
 			} else {
-				yyv940 := &x.Paths
-				yym941 := z.DecBinary()
-				_ = yym941
+				yyv988 := &x.Paths
+				yym989 := z.DecBinary()
+				_ = yym989
 				if false {
 				} else {
-					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv940), d)
+					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv988), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys939)
-		} // end switch yys939
-	} // end for yyj939
-	if !yyhl939 {
+			z.DecStructFieldNotFound(-1, yys987)
+		} // end switch yys987
+	} // end for yyj987
+	if !yyhl987 {
 		r.ReadEnd()
 	}
 }
@@ -10555,41 +10843,41 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj942 int
-	var yyb942 bool
-	var yyhl942 bool = l >= 0
-	yyj942++
-	if yyhl942 {
-		yyb942 = yyj942 > l
+	var yyj990 int
+	var yyb990 bool
+	var yyhl990 bool = l >= 0
+	yyj990++
+	if yyhl990 {
+		yyb990 = yyj990 > l
 	} else {
-		yyb942 = r.CheckBreak()
+		yyb990 = r.CheckBreak()
 	}
-	if yyb942 {
+	if yyb990 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Paths = nil
 	} else {
-		yyv943 := &x.Paths
-		yym944 := z.DecBinary()
-		_ = yym944
+		yyv991 := &x.Paths
+		yym992 := z.DecBinary()
+		_ = yym992
 		if false {
 		} else {
-			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv943), d)
+			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv991), d)
 		}
 	}
 	for {
-		yyj942++
-		if yyhl942 {
-			yyb942 = yyj942 > l
+		yyj990++
+		if yyhl990 {
+			yyb990 = yyj990 > l
 		} else {
-			yyb942 = r.CheckBreak()
+			yyb990 = r.CheckBreak()
 		}
-		if yyb942 {
+		if yyb990 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj942-1, "")
+		z.DecStructFieldNotFound(yyj990-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10601,32 +10889,32 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym945 := z.EncBinary()
-		_ = yym945
+		yym993 := z.EncBinary()
+		_ = yym993
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep946 := !z.EncBinary()
-			yy2arr946 := z.EncBasicHandle().StructToArray
-			var yyq946 [2]bool
-			_, _, _ = yysep946, yyq946, yy2arr946
-			const yyr946 bool = false
-			yyq946[0] = x.Path != ""
-			if yyr946 || yy2arr946 {
+			yysep994 := !z.EncBinary()
+			yy2arr994 := z.EncBasicHandle().StructToArray
+			var yyq994 [2]bool
+			_, _, _ = yysep994, yyq994, yy2arr994
+			const yyr994 bool = false
+			yyq994[0] = x.Path != ""
+			if yyr994 || yy2arr994 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn946 int = 1
-				for _, b := range yyq946 {
+				var yynn994 int = 1
+				for _, b := range yyq994 {
 					if b {
-						yynn946++
+						yynn994++
 					}
 				}
-				r.EncodeMapStart(yynn946)
+				r.EncodeMapStart(yynn994)
 			}
-			if yyr946 || yy2arr946 {
-				if yyq946[0] {
-					yym948 := z.EncBinary()
-					_ = yym948
+			if yyr994 || yy2arr994 {
+				if yyq994[0] {
+					yym996 := z.EncBinary()
+					_ = yym996
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
@@ -10635,25 +10923,25 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq946[0] {
+				if yyq994[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
-					yym949 := z.EncBinary()
-					_ = yym949
+					yym997 := z.EncBinary()
+					_ = yym997
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
-			if yyr946 || yy2arr946 {
-				yy951 := &x.Backend
-				yy951.CodecEncodeSelf(e)
+			if yyr994 || yy2arr994 {
+				yy999 := &x.Backend
+				yy999.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("backend"))
-				yy952 := &x.Backend
-				yy952.CodecEncodeSelf(e)
+				yy1000 := &x.Backend
+				yy1000.CodecEncodeSelf(e)
 			}
-			if yysep946 {
+			if yysep994 {
 				r.EncodeEnd()
 			}
 		}
@@ -10664,24 +10952,24 @@ func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym953 := z.DecBinary()
-	_ = yym953
+	yym1001 := z.DecBinary()
+	_ = yym1001
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl954 := r.ReadMapStart()
-			if yyl954 == 0 {
+			yyl1002 := r.ReadMapStart()
+			if yyl1002 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl954, d)
+				x.codecDecodeSelfFromMap(yyl1002, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl954 := r.ReadArrayStart()
-			if yyl954 == 0 {
+			yyl1002 := r.ReadArrayStart()
+			if yyl1002 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl954, d)
+				x.codecDecodeSelfFromArray(yyl1002, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10693,12 +10981,12 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys955Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys955Slc
-	var yyhl955 bool = l >= 0
-	for yyj955 := 0; ; yyj955++ {
-		if yyhl955 {
-			if yyj955 >= l {
+	var yys1003Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1003Slc
+	var yyhl1003 bool = l >= 0
+	for yyj1003 := 0; ; yyj1003++ {
+		if yyhl1003 {
+			if yyj1003 >= l {
 				break
 			}
 		} else {
@@ -10706,9 +10994,9 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys955Slc = r.DecodeBytes(yys955Slc, true, true)
-		yys955 := string(yys955Slc)
-		switch yys955 {
+		yys1003Slc = r.DecodeBytes(yys1003Slc, true, true)
+		yys1003 := string(yys1003Slc)
+		switch yys1003 {
 		case "path":
 			if r.TryDecodeAsNil() {
 				x.Path = ""
@@ -10719,14 +11007,14 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Backend = IngressBackend{}
 			} else {
-				yyv957 := &x.Backend
-				yyv957.CodecDecodeSelf(d)
+				yyv1005 := &x.Backend
+				yyv1005.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys955)
-		} // end switch yys955
-	} // end for yyj955
-	if !yyhl955 {
+			z.DecStructFieldNotFound(-1, yys1003)
+		} // end switch yys1003
+	} // end for yyj1003
+	if !yyhl1003 {
 		r.ReadEnd()
 	}
 }
@@ -10735,16 +11023,16 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj958 int
-	var yyb958 bool
-	var yyhl958 bool = l >= 0
-	yyj958++
-	if yyhl958 {
-		yyb958 = yyj958 > l
+	var yyj1006 int
+	var yyb1006 bool
+	var yyhl1006 bool = l >= 0
+	yyj1006++
+	if yyhl1006 {
+		yyb1006 = yyj1006 > l
 	} else {
-		yyb958 = r.CheckBreak()
+		yyb1006 = r.CheckBreak()
 	}
-	if yyb958 {
+	if yyb1006 {
 		r.ReadEnd()
 		return
 	}
@@ -10753,33 +11041,33 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Path = string(r.DecodeString())
 	}
-	yyj958++
-	if yyhl958 {
-		yyb958 = yyj958 > l
+	yyj1006++
+	if yyhl1006 {
+		yyb1006 = yyj1006 > l
 	} else {
-		yyb958 = r.CheckBreak()
+		yyb1006 = r.CheckBreak()
 	}
-	if yyb958 {
+	if yyb1006 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Backend = IngressBackend{}
 	} else {
-		yyv960 := &x.Backend
-		yyv960.CodecDecodeSelf(d)
+		yyv1008 := &x.Backend
+		yyv1008.CodecDecodeSelf(d)
 	}
 	for {
-		yyj958++
-		if yyhl958 {
-			yyb958 = yyj958 > l
+		yyj1006++
+		if yyhl1006 {
+			yyb1006 = yyj1006 > l
 		} else {
-			yyb958 = r.CheckBreak()
+			yyb1006 = r.CheckBreak()
 		}
-		if yyb958 {
+		if yyb1006 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj958-1, "")
+		z.DecStructFieldNotFound(yyj1006-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10791,68 +11079,68 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym961 := z.EncBinary()
-		_ = yym961
+		yym1009 := z.EncBinary()
+		_ = yym1009
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep962 := !z.EncBinary()
-			yy2arr962 := z.EncBasicHandle().StructToArray
-			var yyq962 [2]bool
-			_, _, _ = yysep962, yyq962, yy2arr962
-			const yyr962 bool = false
-			if yyr962 || yy2arr962 {
+			yysep1010 := !z.EncBinary()
+			yy2arr1010 := z.EncBasicHandle().StructToArray
+			var yyq1010 [2]bool
+			_, _, _ = yysep1010, yyq1010, yy2arr1010
+			const yyr1010 bool = false
+			if yyr1010 || yy2arr1010 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn962 int = 2
-				for _, b := range yyq962 {
+				var yynn1010 int = 2
+				for _, b := range yyq1010 {
 					if b {
-						yynn962++
+						yynn1010++
 					}
 				}
-				r.EncodeMapStart(yynn962)
+				r.EncodeMapStart(yynn1010)
 			}
-			if yyr962 || yy2arr962 {
-				yym964 := z.EncBinary()
-				_ = yym964
+			if yyr1010 || yy2arr1010 {
+				yym1012 := z.EncBinary()
+				_ = yym1012
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
-				yym965 := z.EncBinary()
-				_ = yym965
+				yym1013 := z.EncBinary()
+				_ = yym1013
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			}
-			if yyr962 || yy2arr962 {
-				yy967 := &x.ServicePort
-				yym968 := z.EncBinary()
-				_ = yym968
+			if yyr1010 || yy2arr1010 {
+				yy1015 := &x.ServicePort
+				yym1016 := z.EncBinary()
+				_ = yym1016
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy967) {
-				} else if !yym968 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy967)
+				} else if z.HasExtensions() && z.EncExt(yy1015) {
+				} else if !yym1016 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1015)
 				} else {
-					z.EncFallback(yy967)
+					z.EncFallback(yy1015)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
-				yy969 := &x.ServicePort
-				yym970 := z.EncBinary()
-				_ = yym970
+				yy1017 := &x.ServicePort
+				yym1018 := z.EncBinary()
+				_ = yym1018
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy969) {
-				} else if !yym970 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy969)
+				} else if z.HasExtensions() && z.EncExt(yy1017) {
+				} else if !yym1018 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1017)
 				} else {
-					z.EncFallback(yy969)
+					z.EncFallback(yy1017)
 				}
 			}
-			if yysep962 {
+			if yysep1010 {
 				r.EncodeEnd()
 			}
 		}
@@ -10863,24 +11151,24 @@ func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym971 := z.DecBinary()
-	_ = yym971
+	yym1019 := z.DecBinary()
+	_ = yym1019
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl972 := r.ReadMapStart()
-			if yyl972 == 0 {
+			yyl1020 := r.ReadMapStart()
+			if yyl1020 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl972, d)
+				x.codecDecodeSelfFromMap(yyl1020, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl972 := r.ReadArrayStart()
-			if yyl972 == 0 {
+			yyl1020 := r.ReadArrayStart()
+			if yyl1020 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl972, d)
+				x.codecDecodeSelfFromArray(yyl1020, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10892,12 +11180,12 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys973Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys973Slc
-	var yyhl973 bool = l >= 0
-	for yyj973 := 0; ; yyj973++ {
-		if yyhl973 {
-			if yyj973 >= l {
+	var yys1021Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1021Slc
+	var yyhl1021 bool = l >= 0
+	for yyj1021 := 0; ; yyj1021++ {
+		if yyhl1021 {
+			if yyj1021 >= l {
 				break
 			}
 		} else {
@@ -10905,9 +11193,9 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys973Slc = r.DecodeBytes(yys973Slc, true, true)
-		yys973 := string(yys973Slc)
-		switch yys973 {
+		yys1021Slc = r.DecodeBytes(yys1021Slc, true, true)
+		yys1021 := string(yys1021Slc)
+		switch yys1021 {
 		case "serviceName":
 			if r.TryDecodeAsNil() {
 				x.ServiceName = ""
@@ -10918,22 +11206,22 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ServicePort = pkg6_intstr.IntOrString{}
 			} else {
-				yyv975 := &x.ServicePort
-				yym976 := z.DecBinary()
-				_ = yym976
+				yyv1023 := &x.ServicePort
+				yym1024 := z.DecBinary()
+				_ = yym1024
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv975) {
-				} else if !yym976 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv975)
+				} else if z.HasExtensions() && z.DecExt(yyv1023) {
+				} else if !yym1024 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1023)
 				} else {
-					z.DecFallback(yyv975, false)
+					z.DecFallback(yyv1023, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys973)
-		} // end switch yys973
-	} // end for yyj973
-	if !yyhl973 {
+			z.DecStructFieldNotFound(-1, yys1021)
+		} // end switch yys1021
+	} // end for yyj1021
+	if !yyhl1021 {
 		r.ReadEnd()
 	}
 }
@@ -10942,16 +11230,16 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj977 int
-	var yyb977 bool
-	var yyhl977 bool = l >= 0
-	yyj977++
-	if yyhl977 {
-		yyb977 = yyj977 > l
+	var yyj1025 int
+	var yyb1025 bool
+	var yyhl1025 bool = l >= 0
+	yyj1025++
+	if yyhl1025 {
+		yyb1025 = yyj1025 > l
 	} else {
-		yyb977 = r.CheckBreak()
+		yyb1025 = r.CheckBreak()
 	}
-	if yyb977 {
+	if yyb1025 {
 		r.ReadEnd()
 		return
 	}
@@ -10960,41 +11248,41 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ServiceName = string(r.DecodeString())
 	}
-	yyj977++
-	if yyhl977 {
-		yyb977 = yyj977 > l
+	yyj1025++
+	if yyhl1025 {
+		yyb1025 = yyj1025 > l
 	} else {
-		yyb977 = r.CheckBreak()
+		yyb1025 = r.CheckBreak()
 	}
-	if yyb977 {
+	if yyb1025 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ServicePort = pkg6_intstr.IntOrString{}
 	} else {
-		yyv979 := &x.ServicePort
-		yym980 := z.DecBinary()
-		_ = yym980
+		yyv1027 := &x.ServicePort
+		yym1028 := z.DecBinary()
+		_ = yym1028
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv979) {
-		} else if !yym980 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv979)
+		} else if z.HasExtensions() && z.DecExt(yyv1027) {
+		} else if !yym1028 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1027)
 		} else {
-			z.DecFallback(yyv979, false)
+			z.DecFallback(yyv1027, false)
 		}
 	}
 	for {
-		yyj977++
-		if yyhl977 {
-			yyb977 = yyj977 > l
+		yyj1025++
+		if yyhl1025 {
+			yyb1025 = yyj1025 > l
 		} else {
-			yyb977 = r.CheckBreak()
+			yyb1025 = r.CheckBreak()
 		}
-		if yyb977 {
+		if yyb1025 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj977-1, "")
+		z.DecStructFieldNotFound(yyj1025-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11003,8 +11291,8 @@ func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym981 := z.EncBinary()
-	_ = yym981
+	yym1029 := z.EncBinary()
+	_ = yym1029
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -11016,8 +11304,8 @@ func (x *NodeResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym982 := z.DecBinary()
-	_ = yym982
+	yym1030 := z.DecBinary()
+	_ = yym1030
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -11032,50 +11320,50 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym983 := z.EncBinary()
-		_ = yym983
+		yym1031 := z.EncBinary()
+		_ = yym1031
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep984 := !z.EncBinary()
-			yy2arr984 := z.EncBasicHandle().StructToArray
-			var yyq984 [2]bool
-			_, _, _ = yysep984, yyq984, yy2arr984
-			const yyr984 bool = false
-			if yyr984 || yy2arr984 {
+			yysep1032 := !z.EncBinary()
+			yy2arr1032 := z.EncBasicHandle().StructToArray
+			var yyq1032 [2]bool
+			_, _, _ = yysep1032, yyq1032, yy2arr1032
+			const yyr1032 bool = false
+			if yyr1032 || yy2arr1032 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn984 int = 2
-				for _, b := range yyq984 {
+				var yynn1032 int = 2
+				for _, b := range yyq1032 {
 					if b {
-						yynn984++
+						yynn1032++
 					}
 				}
-				r.EncodeMapStart(yynn984)
+				r.EncodeMapStart(yynn1032)
 			}
-			if yyr984 || yy2arr984 {
+			if yyr1032 || yy2arr1032 {
 				x.Resource.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("resource"))
 				x.Resource.CodecEncodeSelf(e)
 			}
-			if yyr984 || yy2arr984 {
-				yym987 := z.EncBinary()
-				_ = yym987
+			if yyr1032 || yy2arr1032 {
+				yym1035 := z.EncBinary()
+				_ = yym1035
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yym988 := z.EncBinary()
-				_ = yym988
+				yym1036 := z.EncBinary()
+				_ = yym1036
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yysep984 {
+			if yysep1032 {
 				r.EncodeEnd()
 			}
 		}
@@ -11086,24 +11374,24 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym989 := z.DecBinary()
-	_ = yym989
+	yym1037 := z.DecBinary()
+	_ = yym1037
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl990 := r.ReadMapStart()
-			if yyl990 == 0 {
+			yyl1038 := r.ReadMapStart()
+			if yyl1038 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl990, d)
+				x.codecDecodeSelfFromMap(yyl1038, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl990 := r.ReadArrayStart()
-			if yyl990 == 0 {
+			yyl1038 := r.ReadArrayStart()
+			if yyl1038 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl990, d)
+				x.codecDecodeSelfFromArray(yyl1038, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11115,12 +11403,12 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys991Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys991Slc
-	var yyhl991 bool = l >= 0
-	for yyj991 := 0; ; yyj991++ {
-		if yyhl991 {
-			if yyj991 >= l {
+	var yys1039Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1039Slc
+	var yyhl1039 bool = l >= 0
+	for yyj1039 := 0; ; yyj1039++ {
+		if yyhl1039 {
+			if yyj1039 >= l {
 				break
 			}
 		} else {
@@ -11128,9 +11416,9 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys991Slc = r.DecodeBytes(yys991Slc, true, true)
-		yys991 := string(yys991Slc)
-		switch yys991 {
+		yys1039Slc = r.DecodeBytes(yys1039Slc, true, true)
+		yys1039 := string(yys1039Slc)
+		switch yys1039 {
 		case "resource":
 			if r.TryDecodeAsNil() {
 				x.Resource = ""
@@ -11144,10 +11432,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = float64(r.DecodeFloat(false))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys991)
-		} // end switch yys991
-	} // end for yyj991
-	if !yyhl991 {
+			z.DecStructFieldNotFound(-1, yys1039)
+		} // end switch yys1039
+	} // end for yyj1039
+	if !yyhl1039 {
 		r.ReadEnd()
 	}
 }
@@ -11156,16 +11444,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj994 int
-	var yyb994 bool
-	var yyhl994 bool = l >= 0
-	yyj994++
-	if yyhl994 {
-		yyb994 = yyj994 > l
+	var yyj1042 int
+	var yyb1042 bool
+	var yyhl1042 bool = l >= 0
+	yyj1042++
+	if yyhl1042 {
+		yyb1042 = yyj1042 > l
 	} else {
-		yyb994 = r.CheckBreak()
+		yyb1042 = r.CheckBreak()
 	}
-	if yyb994 {
+	if yyb1042 {
 		r.ReadEnd()
 		return
 	}
@@ -11174,13 +11462,13 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Resource = NodeResource(r.DecodeString())
 	}
-	yyj994++
-	if yyhl994 {
-		yyb994 = yyj994 > l
+	yyj1042++
+	if yyhl1042 {
+		yyb1042 = yyj1042 > l
 	} else {
-		yyb994 = r.CheckBreak()
+		yyb1042 = r.CheckBreak()
 	}
-	if yyb994 {
+	if yyb1042 {
 		r.ReadEnd()
 		return
 	}
@@ -11190,16 +11478,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Value = float64(r.DecodeFloat(false))
 	}
 	for {
-		yyj994++
-		if yyhl994 {
-			yyb994 = yyj994 > l
+		yyj1042++
+		if yyhl1042 {
+			yyb1042 = yyj1042 > l
 		} else {
-			yyb994 = r.CheckBreak()
+			yyb1042 = r.CheckBreak()
 		}
-		if yyb994 {
+		if yyb1042 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj994-1, "")
+		z.DecStructFieldNotFound(yyj1042-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11211,65 +11499,65 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym997 := z.EncBinary()
-		_ = yym997
+		yym1045 := z.EncBinary()
+		_ = yym1045
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep998 := !z.EncBinary()
-			yy2arr998 := z.EncBasicHandle().StructToArray
-			var yyq998 [3]bool
-			_, _, _ = yysep998, yyq998, yy2arr998
-			const yyr998 bool = false
-			if yyr998 || yy2arr998 {
+			yysep1046 := !z.EncBinary()
+			yy2arr1046 := z.EncBasicHandle().StructToArray
+			var yyq1046 [3]bool
+			_, _, _ = yysep1046, yyq1046, yy2arr1046
+			const yyr1046 bool = false
+			if yyr1046 || yy2arr1046 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn998 int = 3
-				for _, b := range yyq998 {
+				var yynn1046 int = 3
+				for _, b := range yyq1046 {
 					if b {
-						yynn998++
+						yynn1046++
 					}
 				}
-				r.EncodeMapStart(yynn998)
+				r.EncodeMapStart(yynn1046)
 			}
-			if yyr998 || yy2arr998 {
-				yym1000 := z.EncBinary()
-				_ = yym1000
+			if yyr1046 || yy2arr1046 {
+				yym1048 := z.EncBinary()
+				_ = yym1048
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
-				yym1001 := z.EncBinary()
-				_ = yym1001
+				yym1049 := z.EncBinary()
+				_ = yym1049
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			}
-			if yyr998 || yy2arr998 {
-				yym1003 := z.EncBinary()
-				_ = yym1003
+			if yyr1046 || yy2arr1046 {
+				yym1051 := z.EncBinary()
+				_ = yym1051
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
-				yym1004 := z.EncBinary()
-				_ = yym1004
+				yym1052 := z.EncBinary()
+				_ = yym1052
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			}
-			if yyr998 || yy2arr998 {
+			if yyr1046 || yy2arr1046 {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1006 := z.EncBinary()
-					_ = yym1006
+					yym1054 := z.EncBinary()
+					_ = yym1054
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
@@ -11280,15 +11568,15 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1007 := z.EncBinary()
-					_ = yym1007
+					yym1055 := z.EncBinary()
+					_ = yym1055
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
 					}
 				}
 			}
-			if yysep998 {
+			if yysep1046 {
 				r.EncodeEnd()
 			}
 		}
@@ -11299,24 +11587,24 @@ func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1008 := z.DecBinary()
-	_ = yym1008
+	yym1056 := z.DecBinary()
+	_ = yym1056
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1009 := r.ReadMapStart()
-			if yyl1009 == 0 {
+			yyl1057 := r.ReadMapStart()
+			if yyl1057 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1009, d)
+				x.codecDecodeSelfFromMap(yyl1057, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1009 := r.ReadArrayStart()
-			if yyl1009 == 0 {
+			yyl1057 := r.ReadArrayStart()
+			if yyl1057 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1009, d)
+				x.codecDecodeSelfFromArray(yyl1057, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11328,12 +11616,12 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1010Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1010Slc
-	var yyhl1010 bool = l >= 0
-	for yyj1010 := 0; ; yyj1010++ {
-		if yyhl1010 {
-			if yyj1010 >= l {
+	var yys1058Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1058Slc
+	var yyhl1058 bool = l >= 0
+	for yyj1058 := 0; ; yyj1058++ {
+		if yyhl1058 {
+			if yyj1058 >= l {
 				break
 			}
 		} else {
@@ -11341,9 +11629,9 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1010Slc = r.DecodeBytes(yys1010Slc, true, true)
-		yys1010 := string(yys1010Slc)
-		switch yys1010 {
+		yys1058Slc = r.DecodeBytes(yys1058Slc, true, true)
+		yys1058 := string(yys1058Slc)
+		switch yys1058 {
 		case "minNodes":
 			if r.TryDecodeAsNil() {
 				x.MinNodes = 0
@@ -11360,19 +11648,19 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.TargetUtilization = nil
 			} else {
-				yyv1013 := &x.TargetUtilization
-				yym1014 := z.DecBinary()
-				_ = yym1014
+				yyv1061 := &x.TargetUtilization
+				yym1062 := z.DecBinary()
+				_ = yym1062
 				if false {
 				} else {
-					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1013), d)
+					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1061), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1010)
-		} // end switch yys1010
-	} // end for yyj1010
-	if !yyhl1010 {
+			z.DecStructFieldNotFound(-1, yys1058)
+		} // end switch yys1058
+	} // end for yyj1058
+	if !yyhl1058 {
 		r.ReadEnd()
 	}
 }
@@ -11381,16 +11669,16 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1015 int
-	var yyb1015 bool
-	var yyhl1015 bool = l >= 0
-	yyj1015++
-	if yyhl1015 {
-		yyb1015 = yyj1015 > l
+	var yyj1063 int
+	var yyb1063 bool
+	var yyhl1063 bool = l >= 0
+	yyj1063++
+	if yyhl1063 {
+		yyb1063 = yyj1063 > l
 	} else {
-		yyb1015 = r.CheckBreak()
+		yyb1063 = r.CheckBreak()
 	}
-	if yyb1015 {
+	if yyb1063 {
 		r.ReadEnd()
 		return
 	}
@@ -11399,13 +11687,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1015++
-	if yyhl1015 {
-		yyb1015 = yyj1015 > l
+	yyj1063++
+	if yyhl1063 {
+		yyb1063 = yyj1063 > l
 	} else {
-		yyb1015 = r.CheckBreak()
+		yyb1063 = r.CheckBreak()
 	}
-	if yyb1015 {
+	if yyb1063 {
 		r.ReadEnd()
 		return
 	}
@@ -11414,38 +11702,38 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1015++
-	if yyhl1015 {
-		yyb1015 = yyj1015 > l
+	yyj1063++
+	if yyhl1063 {
+		yyb1063 = yyj1063 > l
 	} else {
-		yyb1015 = r.CheckBreak()
+		yyb1063 = r.CheckBreak()
 	}
-	if yyb1015 {
+	if yyb1063 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.TargetUtilization = nil
 	} else {
-		yyv1018 := &x.TargetUtilization
-		yym1019 := z.DecBinary()
-		_ = yym1019
+		yyv1066 := &x.TargetUtilization
+		yym1067 := z.DecBinary()
+		_ = yym1067
 		if false {
 		} else {
-			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1018), d)
+			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1066), d)
 		}
 	}
 	for {
-		yyj1015++
-		if yyhl1015 {
-			yyb1015 = yyj1015 > l
+		yyj1063++
+		if yyhl1063 {
+			yyb1063 = yyj1063 > l
 		} else {
-			yyb1015 = r.CheckBreak()
+			yyb1063 = r.CheckBreak()
 		}
-		if yyb1015 {
+		if yyb1063 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1015-1, "")
+		z.DecStructFieldNotFound(yyj1063-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11457,35 +11745,35 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1020 := z.EncBinary()
-		_ = yym1020
+		yym1068 := z.EncBinary()
+		_ = yym1068
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1021 := !z.EncBinary()
-			yy2arr1021 := z.EncBasicHandle().StructToArray
-			var yyq1021 [4]bool
-			_, _, _ = yysep1021, yyq1021, yy2arr1021
-			const yyr1021 bool = false
-			yyq1021[0] = x.Kind != ""
-			yyq1021[1] = x.APIVersion != ""
-			yyq1021[2] = true
-			yyq1021[3] = true
-			if yyr1021 || yy2arr1021 {
+			yysep1069 := !z.EncBinary()
+			yy2arr1069 := z.EncBasicHandle().StructToArray
+			var yyq1069 [4]bool
+			_, _, _ = yysep1069, yyq1069, yy2arr1069
+			const yyr1069 bool = false
+			yyq1069[0] = x.Kind != ""
+			yyq1069[1] = x.APIVersion != ""
+			yyq1069[2] = true
+			yyq1069[3] = true
+			if yyr1069 || yy2arr1069 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1021 int = 0
-				for _, b := range yyq1021 {
+				var yynn1069 int = 0
+				for _, b := range yyq1069 {
 					if b {
-						yynn1021++
+						yynn1069++
 					}
 				}
-				r.EncodeMapStart(yynn1021)
+				r.EncodeMapStart(yynn1069)
 			}
-			if yyr1021 || yy2arr1021 {
-				if yyq1021[0] {
-					yym1023 := z.EncBinary()
-					_ = yym1023
+			if yyr1069 || yy2arr1069 {
+				if yyq1069[0] {
+					yym1071 := z.EncBinary()
+					_ = yym1071
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11494,20 +11782,20 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1021[0] {
+				if yyq1069[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1024 := z.EncBinary()
-					_ = yym1024
+					yym1072 := z.EncBinary()
+					_ = yym1072
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1021 || yy2arr1021 {
-				if yyq1021[1] {
-					yym1026 := z.EncBinary()
-					_ = yym1026
+			if yyr1069 || yy2arr1069 {
+				if yyq1069[1] {
+					yym1074 := z.EncBinary()
+					_ = yym1074
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11516,45 +11804,57 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1021[1] {
+				if yyq1069[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1027 := z.EncBinary()
-					_ = yym1027
+					yym1075 := z.EncBinary()
+					_ = yym1075
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1021 || yy2arr1021 {
-				if yyq1021[2] {
-					yy1029 := &x.ObjectMeta
-					yy1029.CodecEncodeSelf(e)
+			if yyr1069 || yy2arr1069 {
+				if yyq1069[2] {
+					yy1077 := &x.ObjectMeta
+					yym1078 := z.EncBinary()
+					_ = yym1078
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1077) {
+					} else {
+						z.EncFallback(yy1077)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1021[2] {
+				if yyq1069[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1030 := &x.ObjectMeta
-					yy1030.CodecEncodeSelf(e)
+					yy1079 := &x.ObjectMeta
+					yym1080 := z.EncBinary()
+					_ = yym1080
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1079) {
+					} else {
+						z.EncFallback(yy1079)
+					}
 				}
 			}
-			if yyr1021 || yy2arr1021 {
-				if yyq1021[3] {
-					yy1032 := &x.Spec
-					yy1032.CodecEncodeSelf(e)
+			if yyr1069 || yy2arr1069 {
+				if yyq1069[3] {
+					yy1082 := &x.Spec
+					yy1082.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1021[3] {
+				if yyq1069[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1033 := &x.Spec
-					yy1033.CodecEncodeSelf(e)
+					yy1083 := &x.Spec
+					yy1083.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1021 {
+			if yysep1069 {
 				r.EncodeEnd()
 			}
 		}
@@ -11565,24 +11865,24 @@ func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1034 := z.DecBinary()
-	_ = yym1034
+	yym1084 := z.DecBinary()
+	_ = yym1084
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1035 := r.ReadMapStart()
-			if yyl1035 == 0 {
+			yyl1085 := r.ReadMapStart()
+			if yyl1085 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1035, d)
+				x.codecDecodeSelfFromMap(yyl1085, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1035 := r.ReadArrayStart()
-			if yyl1035 == 0 {
+			yyl1085 := r.ReadArrayStart()
+			if yyl1085 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1035, d)
+				x.codecDecodeSelfFromArray(yyl1085, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11594,12 +11894,12 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1036Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1036Slc
-	var yyhl1036 bool = l >= 0
-	for yyj1036 := 0; ; yyj1036++ {
-		if yyhl1036 {
-			if yyj1036 >= l {
+	var yys1086Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1086Slc
+	var yyhl1086 bool = l >= 0
+	for yyj1086 := 0; ; yyj1086++ {
+		if yyhl1086 {
+			if yyj1086 >= l {
 				break
 			}
 		} else {
@@ -11607,9 +11907,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys1036Slc = r.DecodeBytes(yys1036Slc, true, true)
-		yys1036 := string(yys1036Slc)
-		switch yys1036 {
+		yys1086Slc = r.DecodeBytes(yys1086Slc, true, true)
+		yys1086 := string(yys1086Slc)
+		switch yys1086 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -11626,21 +11926,27 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv1039 := &x.ObjectMeta
-				yyv1039.CodecDecodeSelf(d)
+				yyv1089 := &x.ObjectMeta
+				yym1090 := z.DecBinary()
+				_ = yym1090
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1089) {
+				} else {
+					z.DecFallback(yyv1089, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ClusterAutoscalerSpec{}
 			} else {
-				yyv1040 := &x.Spec
-				yyv1040.CodecDecodeSelf(d)
+				yyv1091 := &x.Spec
+				yyv1091.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1036)
-		} // end switch yys1036
-	} // end for yyj1036
-	if !yyhl1036 {
+			z.DecStructFieldNotFound(-1, yys1086)
+		} // end switch yys1086
+	} // end for yyj1086
+	if !yyhl1086 {
 		r.ReadEnd()
 	}
 }
@@ -11649,16 +11955,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1041 int
-	var yyb1041 bool
-	var yyhl1041 bool = l >= 0
-	yyj1041++
-	if yyhl1041 {
-		yyb1041 = yyj1041 > l
+	var yyj1092 int
+	var yyb1092 bool
+	var yyhl1092 bool = l >= 0
+	yyj1092++
+	if yyhl1092 {
+		yyb1092 = yyj1092 > l
 	} else {
-		yyb1041 = r.CheckBreak()
+		yyb1092 = r.CheckBreak()
 	}
-	if yyb1041 {
+	if yyb1092 {
 		r.ReadEnd()
 		return
 	}
@@ -11667,13 +11973,13 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1041++
-	if yyhl1041 {
-		yyb1041 = yyj1041 > l
+	yyj1092++
+	if yyhl1092 {
+		yyb1092 = yyj1092 > l
 	} else {
-		yyb1041 = r.CheckBreak()
+		yyb1092 = r.CheckBreak()
 	}
-	if yyb1041 {
+	if yyb1092 {
 		r.ReadEnd()
 		return
 	}
@@ -11682,49 +11988,55 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1041++
-	if yyhl1041 {
-		yyb1041 = yyj1041 > l
+	yyj1092++
+	if yyhl1092 {
+		yyb1092 = yyj1092 > l
 	} else {
-		yyb1041 = r.CheckBreak()
+		yyb1092 = r.CheckBreak()
 	}
-	if yyb1041 {
+	if yyb1092 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv1044 := &x.ObjectMeta
-		yyv1044.CodecDecodeSelf(d)
+		yyv1095 := &x.ObjectMeta
+		yym1096 := z.DecBinary()
+		_ = yym1096
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1095) {
+		} else {
+			z.DecFallback(yyv1095, false)
+		}
 	}
-	yyj1041++
-	if yyhl1041 {
-		yyb1041 = yyj1041 > l
+	yyj1092++
+	if yyhl1092 {
+		yyb1092 = yyj1092 > l
 	} else {
-		yyb1041 = r.CheckBreak()
+		yyb1092 = r.CheckBreak()
 	}
-	if yyb1041 {
+	if yyb1092 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ClusterAutoscalerSpec{}
 	} else {
-		yyv1045 := &x.Spec
-		yyv1045.CodecDecodeSelf(d)
+		yyv1097 := &x.Spec
+		yyv1097.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1041++
-		if yyhl1041 {
-			yyb1041 = yyj1041 > l
+		yyj1092++
+		if yyhl1092 {
+			yyb1092 = yyj1092 > l
 		} else {
-			yyb1041 = r.CheckBreak()
+			yyb1092 = r.CheckBreak()
 		}
-		if yyb1041 {
+		if yyb1092 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1041-1, "")
+		z.DecStructFieldNotFound(yyj1092-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11736,34 +12048,34 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1046 := z.EncBinary()
-		_ = yym1046
+		yym1098 := z.EncBinary()
+		_ = yym1098
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1047 := !z.EncBinary()
-			yy2arr1047 := z.EncBasicHandle().StructToArray
-			var yyq1047 [4]bool
-			_, _, _ = yysep1047, yyq1047, yy2arr1047
-			const yyr1047 bool = false
-			yyq1047[0] = x.Kind != ""
-			yyq1047[1] = x.APIVersion != ""
-			yyq1047[2] = true
-			if yyr1047 || yy2arr1047 {
+			yysep1099 := !z.EncBinary()
+			yy2arr1099 := z.EncBasicHandle().StructToArray
+			var yyq1099 [4]bool
+			_, _, _ = yysep1099, yyq1099, yy2arr1099
+			const yyr1099 bool = false
+			yyq1099[0] = x.Kind != ""
+			yyq1099[1] = x.APIVersion != ""
+			yyq1099[2] = true
+			if yyr1099 || yy2arr1099 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1047 int = 1
-				for _, b := range yyq1047 {
+				var yynn1099 int = 1
+				for _, b := range yyq1099 {
 					if b {
-						yynn1047++
+						yynn1099++
 					}
 				}
-				r.EncodeMapStart(yynn1047)
+				r.EncodeMapStart(yynn1099)
 			}
-			if yyr1047 || yy2arr1047 {
-				if yyq1047[0] {
-					yym1049 := z.EncBinary()
-					_ = yym1049
+			if yyr1099 || yy2arr1099 {
+				if yyq1099[0] {
+					yym1101 := z.EncBinary()
+					_ = yym1101
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11772,20 +12084,20 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1047[0] {
+				if yyq1099[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1050 := z.EncBinary()
-					_ = yym1050
+					yym1102 := z.EncBinary()
+					_ = yym1102
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1047 || yy2arr1047 {
-				if yyq1047[1] {
-					yym1052 := z.EncBinary()
-					_ = yym1052
+			if yyr1099 || yy2arr1099 {
+				if yyq1099[1] {
+					yym1104 := z.EncBinary()
+					_ = yym1104
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11794,48 +12106,48 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1047[1] {
+				if yyq1099[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1053 := z.EncBinary()
-					_ = yym1053
+					yym1105 := z.EncBinary()
+					_ = yym1105
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1047 || yy2arr1047 {
-				if yyq1047[2] {
-					yy1055 := &x.ListMeta
-					yym1056 := z.EncBinary()
-					_ = yym1056
+			if yyr1099 || yy2arr1099 {
+				if yyq1099[2] {
+					yy1107 := &x.ListMeta
+					yym1108 := z.EncBinary()
+					_ = yym1108
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1055) {
+					} else if z.HasExtensions() && z.EncExt(yy1107) {
 					} else {
-						z.EncFallback(yy1055)
+						z.EncFallback(yy1107)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1047[2] {
+				if yyq1099[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1057 := &x.ListMeta
-					yym1058 := z.EncBinary()
-					_ = yym1058
+					yy1109 := &x.ListMeta
+					yym1110 := z.EncBinary()
+					_ = yym1110
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1057) {
+					} else if z.HasExtensions() && z.EncExt(yy1109) {
 					} else {
-						z.EncFallback(yy1057)
+						z.EncFallback(yy1109)
 					}
 				}
 			}
-			if yyr1047 || yy2arr1047 {
+			if yyr1099 || yy2arr1099 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1060 := z.EncBinary()
-					_ = yym1060
+					yym1112 := z.EncBinary()
+					_ = yym1112
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -11846,15 +12158,15 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1061 := z.EncBinary()
-					_ = yym1061
+					yym1113 := z.EncBinary()
+					_ = yym1113
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep1047 {
+			if yysep1099 {
 				r.EncodeEnd()
 			}
 		}
@@ -11865,24 +12177,24 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1062 := z.DecBinary()
-	_ = yym1062
+	yym1114 := z.DecBinary()
+	_ = yym1114
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1063 := r.ReadMapStart()
-			if yyl1063 == 0 {
+			yyl1115 := r.ReadMapStart()
+			if yyl1115 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1063, d)
+				x.codecDecodeSelfFromMap(yyl1115, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1063 := r.ReadArrayStart()
-			if yyl1063 == 0 {
+			yyl1115 := r.ReadArrayStart()
+			if yyl1115 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1063, d)
+				x.codecDecodeSelfFromArray(yyl1115, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11894,12 +12206,12 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1064Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1064Slc
-	var yyhl1064 bool = l >= 0
-	for yyj1064 := 0; ; yyj1064++ {
-		if yyhl1064 {
-			if yyj1064 >= l {
+	var yys1116Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1116Slc
+	var yyhl1116 bool = l >= 0
+	for yyj1116 := 0; ; yyj1116++ {
+		if yyhl1116 {
+			if yyj1116 >= l {
 				break
 			}
 		} else {
@@ -11907,9 +12219,9 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1064Slc = r.DecodeBytes(yys1064Slc, true, true)
-		yys1064 := string(yys1064Slc)
-		switch yys1064 {
+		yys1116Slc = r.DecodeBytes(yys1116Slc, true, true)
+		yys1116 := string(yys1116Slc)
+		switch yys1116 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -11926,32 +12238,32 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1067 := &x.ListMeta
-				yym1068 := z.DecBinary()
-				_ = yym1068
+				yyv1119 := &x.ListMeta
+				yym1120 := z.DecBinary()
+				_ = yym1120
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1067) {
+				} else if z.HasExtensions() && z.DecExt(yyv1119) {
 				} else {
-					z.DecFallback(yyv1067, false)
+					z.DecFallback(yyv1119, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1069 := &x.Items
-				yym1070 := z.DecBinary()
-				_ = yym1070
+				yyv1121 := &x.Items
+				yym1122 := z.DecBinary()
+				_ = yym1122
 				if false {
 				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1069), d)
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1121), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1064)
-		} // end switch yys1064
-	} // end for yyj1064
-	if !yyhl1064 {
+			z.DecStructFieldNotFound(-1, yys1116)
+		} // end switch yys1116
+	} // end for yyj1116
+	if !yyhl1116 {
 		r.ReadEnd()
 	}
 }
@@ -11960,16 +12272,16 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1071 int
-	var yyb1071 bool
-	var yyhl1071 bool = l >= 0
-	yyj1071++
-	if yyhl1071 {
-		yyb1071 = yyj1071 > l
+	var yyj1123 int
+	var yyb1123 bool
+	var yyhl1123 bool = l >= 0
+	yyj1123++
+	if yyhl1123 {
+		yyb1123 = yyj1123 > l
 	} else {
-		yyb1071 = r.CheckBreak()
+		yyb1123 = r.CheckBreak()
 	}
-	if yyb1071 {
+	if yyb1123 {
 		r.ReadEnd()
 		return
 	}
@@ -11978,13 +12290,13 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1071++
-	if yyhl1071 {
-		yyb1071 = yyj1071 > l
+	yyj1123++
+	if yyhl1123 {
+		yyb1123 = yyj1123 > l
 	} else {
-		yyb1071 = r.CheckBreak()
+		yyb1123 = r.CheckBreak()
 	}
-	if yyb1071 {
+	if yyb1123 {
 		r.ReadEnd()
 		return
 	}
@@ -11993,60 +12305,60 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1071++
-	if yyhl1071 {
-		yyb1071 = yyj1071 > l
+	yyj1123++
+	if yyhl1123 {
+		yyb1123 = yyj1123 > l
 	} else {
-		yyb1071 = r.CheckBreak()
+		yyb1123 = r.CheckBreak()
 	}
-	if yyb1071 {
+	if yyb1123 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1074 := &x.ListMeta
-		yym1075 := z.DecBinary()
-		_ = yym1075
+		yyv1126 := &x.ListMeta
+		yym1127 := z.DecBinary()
+		_ = yym1127
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1074) {
+		} else if z.HasExtensions() && z.DecExt(yyv1126) {
 		} else {
-			z.DecFallback(yyv1074, false)
+			z.DecFallback(yyv1126, false)
 		}
 	}
-	yyj1071++
-	if yyhl1071 {
-		yyb1071 = yyj1071 > l
+	yyj1123++
+	if yyhl1123 {
+		yyb1123 = yyj1123 > l
 	} else {
-		yyb1071 = r.CheckBreak()
+		yyb1123 = r.CheckBreak()
 	}
-	if yyb1071 {
+	if yyb1123 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1076 := &x.Items
-		yym1077 := z.DecBinary()
-		_ = yym1077
+		yyv1128 := &x.Items
+		yym1129 := z.DecBinary()
+		_ = yym1129
 		if false {
 		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1076), d)
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1128), d)
 		}
 	}
 	for {
-		yyj1071++
-		if yyhl1071 {
-			yyb1071 = yyj1071 > l
+		yyj1123++
+		if yyhl1123 {
+			yyb1123 = yyj1123 > l
 		} else {
-			yyb1071 = r.CheckBreak()
+			yyb1123 = r.CheckBreak()
 		}
-		if yyb1071 {
+		if yyb1123 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1071-1, "")
+		z.DecStructFieldNotFound(yyj1123-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12058,36 +12370,36 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1078 := z.EncBinary()
-		_ = yym1078
+		yym1130 := z.EncBinary()
+		_ = yym1130
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1079 := !z.EncBinary()
-			yy2arr1079 := z.EncBasicHandle().StructToArray
-			var yyq1079 [2]bool
-			_, _, _ = yysep1079, yyq1079, yy2arr1079
-			const yyr1079 bool = false
-			yyq1079[0] = len(x.MatchLabels) != 0
-			yyq1079[1] = len(x.MatchExpressions) != 0
-			if yyr1079 || yy2arr1079 {
+			yysep1131 := !z.EncBinary()
+			yy2arr1131 := z.EncBasicHandle().StructToArray
+			var yyq1131 [2]bool
+			_, _, _ = yysep1131, yyq1131, yy2arr1131
+			const yyr1131 bool = false
+			yyq1131[0] = len(x.MatchLabels) != 0
+			yyq1131[1] = len(x.MatchExpressions) != 0
+			if yyr1131 || yy2arr1131 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1079 int = 0
-				for _, b := range yyq1079 {
+				var yynn1131 int = 0
+				for _, b := range yyq1131 {
 					if b {
-						yynn1079++
+						yynn1131++
 					}
 				}
-				r.EncodeMapStart(yynn1079)
+				r.EncodeMapStart(yynn1131)
 			}
-			if yyr1079 || yy2arr1079 {
-				if yyq1079[0] {
+			if yyr1131 || yy2arr1131 {
+				if yyq1131[0] {
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1081 := z.EncBinary()
-						_ = yym1081
+						yym1133 := z.EncBinary()
+						_ = yym1133
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12097,13 +12409,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1079[0] {
+				if yyq1131[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1082 := z.EncBinary()
-						_ = yym1082
+						yym1134 := z.EncBinary()
+						_ = yym1134
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12111,13 +12423,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1079 || yy2arr1079 {
-				if yyq1079[1] {
+			if yyr1131 || yy2arr1131 {
+				if yyq1131[1] {
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1084 := z.EncBinary()
-						_ = yym1084
+						yym1136 := z.EncBinary()
+						_ = yym1136
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12127,13 +12439,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1079[1] {
+				if yyq1131[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1085 := z.EncBinary()
-						_ = yym1085
+						yym1137 := z.EncBinary()
+						_ = yym1137
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12141,7 +12453,7 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1079 {
+			if yysep1131 {
 				r.EncodeEnd()
 			}
 		}
@@ -12152,24 +12464,24 @@ func (x *PodSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1086 := z.DecBinary()
-	_ = yym1086
+	yym1138 := z.DecBinary()
+	_ = yym1138
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1087 := r.ReadMapStart()
-			if yyl1087 == 0 {
+			yyl1139 := r.ReadMapStart()
+			if yyl1139 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1087, d)
+				x.codecDecodeSelfFromMap(yyl1139, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1087 := r.ReadArrayStart()
-			if yyl1087 == 0 {
+			yyl1139 := r.ReadArrayStart()
+			if yyl1139 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1087, d)
+				x.codecDecodeSelfFromArray(yyl1139, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12181,12 +12493,12 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1088Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1088Slc
-	var yyhl1088 bool = l >= 0
-	for yyj1088 := 0; ; yyj1088++ {
-		if yyhl1088 {
-			if yyj1088 >= l {
+	var yys1140Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1140Slc
+	var yyhl1140 bool = l >= 0
+	for yyj1140 := 0; ; yyj1140++ {
+		if yyhl1140 {
+			if yyj1140 >= l {
 				break
 			}
 		} else {
@@ -12194,38 +12506,38 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1088Slc = r.DecodeBytes(yys1088Slc, true, true)
-		yys1088 := string(yys1088Slc)
-		switch yys1088 {
+		yys1140Slc = r.DecodeBytes(yys1140Slc, true, true)
+		yys1140 := string(yys1140Slc)
+		switch yys1140 {
 		case "matchLabels":
 			if r.TryDecodeAsNil() {
 				x.MatchLabels = nil
 			} else {
-				yyv1089 := &x.MatchLabels
-				yym1090 := z.DecBinary()
-				_ = yym1090
+				yyv1141 := &x.MatchLabels
+				yym1142 := z.DecBinary()
+				_ = yym1142
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1089, false, d)
+					z.F.DecMapStringStringX(yyv1141, false, d)
 				}
 			}
 		case "matchExpressions":
 			if r.TryDecodeAsNil() {
 				x.MatchExpressions = nil
 			} else {
-				yyv1091 := &x.MatchExpressions
-				yym1092 := z.DecBinary()
-				_ = yym1092
+				yyv1143 := &x.MatchExpressions
+				yym1144 := z.DecBinary()
+				_ = yym1144
 				if false {
 				} else {
-					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1091), d)
+					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1143), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1088)
-		} // end switch yys1088
-	} // end for yyj1088
-	if !yyhl1088 {
+			z.DecStructFieldNotFound(-1, yys1140)
+		} // end switch yys1140
+	} // end for yyj1140
+	if !yyhl1140 {
 		r.ReadEnd()
 	}
 }
@@ -12234,62 +12546,62 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1093 int
-	var yyb1093 bool
-	var yyhl1093 bool = l >= 0
-	yyj1093++
-	if yyhl1093 {
-		yyb1093 = yyj1093 > l
+	var yyj1145 int
+	var yyb1145 bool
+	var yyhl1145 bool = l >= 0
+	yyj1145++
+	if yyhl1145 {
+		yyb1145 = yyj1145 > l
 	} else {
-		yyb1093 = r.CheckBreak()
+		yyb1145 = r.CheckBreak()
 	}
-	if yyb1093 {
+	if yyb1145 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchLabels = nil
 	} else {
-		yyv1094 := &x.MatchLabels
-		yym1095 := z.DecBinary()
-		_ = yym1095
+		yyv1146 := &x.MatchLabels
+		yym1147 := z.DecBinary()
+		_ = yym1147
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1094, false, d)
+			z.F.DecMapStringStringX(yyv1146, false, d)
 		}
 	}
-	yyj1093++
-	if yyhl1093 {
-		yyb1093 = yyj1093 > l
+	yyj1145++
+	if yyhl1145 {
+		yyb1145 = yyj1145 > l
 	} else {
-		yyb1093 = r.CheckBreak()
+		yyb1145 = r.CheckBreak()
 	}
-	if yyb1093 {
+	if yyb1145 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchExpressions = nil
 	} else {
-		yyv1096 := &x.MatchExpressions
-		yym1097 := z.DecBinary()
-		_ = yym1097
+		yyv1148 := &x.MatchExpressions
+		yym1149 := z.DecBinary()
+		_ = yym1149
 		if false {
 		} else {
-			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1096), d)
+			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1148), d)
 		}
 	}
 	for {
-		yyj1093++
-		if yyhl1093 {
-			yyb1093 = yyj1093 > l
+		yyj1145++
+		if yyhl1145 {
+			yyb1145 = yyj1145 > l
 		} else {
-			yyb1093 = r.CheckBreak()
+			yyb1145 = r.CheckBreak()
 		}
-		if yyb1093 {
+		if yyb1145 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1093-1, "")
+		z.DecStructFieldNotFound(yyj1145-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12301,57 +12613,57 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1098 := z.EncBinary()
-		_ = yym1098
+		yym1150 := z.EncBinary()
+		_ = yym1150
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1099 := !z.EncBinary()
-			yy2arr1099 := z.EncBasicHandle().StructToArray
-			var yyq1099 [3]bool
-			_, _, _ = yysep1099, yyq1099, yy2arr1099
-			const yyr1099 bool = false
-			yyq1099[2] = len(x.Values) != 0
-			if yyr1099 || yy2arr1099 {
+			yysep1151 := !z.EncBinary()
+			yy2arr1151 := z.EncBasicHandle().StructToArray
+			var yyq1151 [3]bool
+			_, _, _ = yysep1151, yyq1151, yy2arr1151
+			const yyr1151 bool = false
+			yyq1151[2] = len(x.Values) != 0
+			if yyr1151 || yy2arr1151 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1099 int = 2
-				for _, b := range yyq1099 {
+				var yynn1151 int = 2
+				for _, b := range yyq1151 {
 					if b {
-						yynn1099++
+						yynn1151++
 					}
 				}
-				r.EncodeMapStart(yynn1099)
+				r.EncodeMapStart(yynn1151)
 			}
-			if yyr1099 || yy2arr1099 {
-				yym1101 := z.EncBinary()
-				_ = yym1101
+			if yyr1151 || yy2arr1151 {
+				yym1153 := z.EncBinary()
+				_ = yym1153
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
-				yym1102 := z.EncBinary()
-				_ = yym1102
+				yym1154 := z.EncBinary()
+				_ = yym1154
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			}
-			if yyr1099 || yy2arr1099 {
+			if yyr1151 || yy2arr1151 {
 				x.Operator.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("operator"))
 				x.Operator.CodecEncodeSelf(e)
 			}
-			if yyr1099 || yy2arr1099 {
-				if yyq1099[2] {
+			if yyr1151 || yy2arr1151 {
+				if yyq1151[2] {
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1105 := z.EncBinary()
-						_ = yym1105
+						yym1157 := z.EncBinary()
+						_ = yym1157
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12361,13 +12673,13 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1099[2] {
+				if yyq1151[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("values"))
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1106 := z.EncBinary()
-						_ = yym1106
+						yym1158 := z.EncBinary()
+						_ = yym1158
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12375,7 +12687,7 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1099 {
+			if yysep1151 {
 				r.EncodeEnd()
 			}
 		}
@@ -12386,24 +12698,24 @@ func (x *PodSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1107 := z.DecBinary()
-	_ = yym1107
+	yym1159 := z.DecBinary()
+	_ = yym1159
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1108 := r.ReadMapStart()
-			if yyl1108 == 0 {
+			yyl1160 := r.ReadMapStart()
+			if yyl1160 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1108, d)
+				x.codecDecodeSelfFromMap(yyl1160, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1108 := r.ReadArrayStart()
-			if yyl1108 == 0 {
+			yyl1160 := r.ReadArrayStart()
+			if yyl1160 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1108, d)
+				x.codecDecodeSelfFromArray(yyl1160, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12415,12 +12727,12 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1109Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1109Slc
-	var yyhl1109 bool = l >= 0
-	for yyj1109 := 0; ; yyj1109++ {
-		if yyhl1109 {
-			if yyj1109 >= l {
+	var yys1161Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1161Slc
+	var yyhl1161 bool = l >= 0
+	for yyj1161 := 0; ; yyj1161++ {
+		if yyhl1161 {
+			if yyj1161 >= l {
 				break
 			}
 		} else {
@@ -12428,9 +12740,9 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys1109Slc = r.DecodeBytes(yys1109Slc, true, true)
-		yys1109 := string(yys1109Slc)
-		switch yys1109 {
+		yys1161Slc = r.DecodeBytes(yys1161Slc, true, true)
+		yys1161 := string(yys1161Slc)
+		switch yys1161 {
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
@@ -12447,19 +12759,19 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.Values = nil
 			} else {
-				yyv1112 := &x.Values
-				yym1113 := z.DecBinary()
-				_ = yym1113
+				yyv1164 := &x.Values
+				yym1165 := z.DecBinary()
+				_ = yym1165
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1112, false, d)
+					z.F.DecSliceStringX(yyv1164, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1109)
-		} // end switch yys1109
-	} // end for yyj1109
-	if !yyhl1109 {
+			z.DecStructFieldNotFound(-1, yys1161)
+		} // end switch yys1161
+	} // end for yyj1161
+	if !yyhl1161 {
 		r.ReadEnd()
 	}
 }
@@ -12468,16 +12780,16 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1114 int
-	var yyb1114 bool
-	var yyhl1114 bool = l >= 0
-	yyj1114++
-	if yyhl1114 {
-		yyb1114 = yyj1114 > l
+	var yyj1166 int
+	var yyb1166 bool
+	var yyhl1166 bool = l >= 0
+	yyj1166++
+	if yyhl1166 {
+		yyb1166 = yyj1166 > l
 	} else {
-		yyb1114 = r.CheckBreak()
+		yyb1166 = r.CheckBreak()
 	}
-	if yyb1114 {
+	if yyb1166 {
 		r.ReadEnd()
 		return
 	}
@@ -12486,13 +12798,13 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj1114++
-	if yyhl1114 {
-		yyb1114 = yyj1114 > l
+	yyj1166++
+	if yyhl1166 {
+		yyb1166 = yyj1166 > l
 	} else {
-		yyb1114 = r.CheckBreak()
+		yyb1166 = r.CheckBreak()
 	}
-	if yyb1114 {
+	if yyb1166 {
 		r.ReadEnd()
 		return
 	}
@@ -12501,38 +12813,38 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Operator = PodSelectorOperator(r.DecodeString())
 	}
-	yyj1114++
-	if yyhl1114 {
-		yyb1114 = yyj1114 > l
+	yyj1166++
+	if yyhl1166 {
+		yyb1166 = yyj1166 > l
 	} else {
-		yyb1114 = r.CheckBreak()
+		yyb1166 = r.CheckBreak()
 	}
-	if yyb1114 {
+	if yyb1166 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Values = nil
 	} else {
-		yyv1117 := &x.Values
-		yym1118 := z.DecBinary()
-		_ = yym1118
+		yyv1169 := &x.Values
+		yym1170 := z.DecBinary()
+		_ = yym1170
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1117, false, d)
+			z.F.DecSliceStringX(yyv1169, false, d)
 		}
 	}
 	for {
-		yyj1114++
-		if yyhl1114 {
-			yyb1114 = yyj1114 > l
+		yyj1166++
+		if yyhl1166 {
+			yyb1166 = yyj1166 > l
 		} else {
-			yyb1114 = r.CheckBreak()
+			yyb1166 = r.CheckBreak()
 		}
-		if yyb1114 {
+		if yyb1166 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1114-1, "")
+		z.DecStructFieldNotFound(yyj1166-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12541,8 +12853,8 @@ func (x PodSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1119 := z.EncBinary()
-	_ = yym1119
+	yym1171 := z.EncBinary()
+	_ = yym1171
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -12554,8 +12866,8 @@ func (x *PodSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1120 := z.DecBinary()
-	_ = yym1120
+	yym1172 := z.DecBinary()
+	_ = yym1172
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -12568,9 +12880,9 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1121 := range v {
-		yy1122 := &yyv1121
-		yy1122.CodecEncodeSelf(e)
+	for _, yyv1173 := range v {
+		yy1174 := &yyv1173
+		yy1174.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12580,75 +12892,75 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1123 := *v
-	yyh1123, yyl1123 := z.DecSliceHelperStart()
+	yyv1175 := *v
+	yyh1175, yyl1175 := z.DecSliceHelperStart()
 
-	var yyrr1123, yyrl1123 int
-	var yyc1123, yyrt1123 bool
-	_, _, _ = yyc1123, yyrt1123, yyrl1123
-	yyrr1123 = yyl1123
+	var yyrr1175, yyrl1175 int
+	var yyc1175, yyrt1175 bool
+	_, _, _ = yyc1175, yyrt1175, yyrl1175
+	yyrr1175 = yyl1175
 
-	if yyv1123 == nil {
-		if yyrl1123, yyrt1123 = z.DecInferLen(yyl1123, z.DecBasicHandle().MaxInitLen, 320); yyrt1123 {
-			yyrr1123 = yyrl1123
+	if yyv1175 == nil {
+		if yyrl1175, yyrt1175 = z.DecInferLen(yyl1175, z.DecBasicHandle().MaxInitLen, 320); yyrt1175 {
+			yyrr1175 = yyrl1175
 		}
-		yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
-		yyc1123 = true
+		yyv1175 = make([]HorizontalPodAutoscaler, yyrl1175)
+		yyc1175 = true
 	}
 
-	if yyl1123 == 0 {
-		if len(yyv1123) != 0 {
-			yyv1123 = yyv1123[:0]
-			yyc1123 = true
+	if yyl1175 == 0 {
+		if len(yyv1175) != 0 {
+			yyv1175 = yyv1175[:0]
+			yyc1175 = true
 		}
-	} else if yyl1123 > 0 {
+	} else if yyl1175 > 0 {
 
-		if yyl1123 > cap(yyv1123) {
-			yyrl1123, yyrt1123 = z.DecInferLen(yyl1123, z.DecBasicHandle().MaxInitLen, 320)
-			yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
-			yyc1123 = true
+		if yyl1175 > cap(yyv1175) {
+			yyrl1175, yyrt1175 = z.DecInferLen(yyl1175, z.DecBasicHandle().MaxInitLen, 320)
+			yyv1175 = make([]HorizontalPodAutoscaler, yyrl1175)
+			yyc1175 = true
 
-			yyrr1123 = len(yyv1123)
-		} else if yyl1123 != len(yyv1123) {
-			yyv1123 = yyv1123[:yyl1123]
-			yyc1123 = true
+			yyrr1175 = len(yyv1175)
+		} else if yyl1175 != len(yyv1175) {
+			yyv1175 = yyv1175[:yyl1175]
+			yyc1175 = true
 		}
-		yyj1123 := 0
-		for ; yyj1123 < yyrr1123; yyj1123++ {
+		yyj1175 := 0
+		for ; yyj1175 < yyrr1175; yyj1175++ {
 			if r.TryDecodeAsNil() {
-				yyv1123[yyj1123] = HorizontalPodAutoscaler{}
+				yyv1175[yyj1175] = HorizontalPodAutoscaler{}
 			} else {
-				yyv1124 := &yyv1123[yyj1123]
-				yyv1124.CodecDecodeSelf(d)
+				yyv1176 := &yyv1175[yyj1175]
+				yyv1176.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1123 {
-			for ; yyj1123 < yyl1123; yyj1123++ {
-				yyv1123 = append(yyv1123, HorizontalPodAutoscaler{})
+		if yyrt1175 {
+			for ; yyj1175 < yyl1175; yyj1175++ {
+				yyv1175 = append(yyv1175, HorizontalPodAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1123[yyj1123] = HorizontalPodAutoscaler{}
+					yyv1175[yyj1175] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1125 := &yyv1123[yyj1123]
-					yyv1125.CodecDecodeSelf(d)
+					yyv1177 := &yyv1175[yyj1175]
+					yyv1177.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1123 := 0; !r.CheckBreak(); yyj1123++ {
-			if yyj1123 >= len(yyv1123) {
-				yyv1123 = append(yyv1123, HorizontalPodAutoscaler{}) // var yyz1123 HorizontalPodAutoscaler
-				yyc1123 = true
+		for yyj1175 := 0; !r.CheckBreak(); yyj1175++ {
+			if yyj1175 >= len(yyv1175) {
+				yyv1175 = append(yyv1175, HorizontalPodAutoscaler{}) // var yyz1175 HorizontalPodAutoscaler
+				yyc1175 = true
 			}
 
-			if yyj1123 < len(yyv1123) {
+			if yyj1175 < len(yyv1175) {
 				if r.TryDecodeAsNil() {
-					yyv1123[yyj1123] = HorizontalPodAutoscaler{}
+					yyv1175[yyj1175] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1126 := &yyv1123[yyj1123]
-					yyv1126.CodecDecodeSelf(d)
+					yyv1178 := &yyv1175[yyj1175]
+					yyv1178.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12656,10 +12968,10 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		yyh1123.End()
+		yyh1175.End()
 	}
-	if yyc1123 {
-		*v = yyv1123
+	if yyc1175 {
+		*v = yyv1175
 	}
 
 }
@@ -12669,9 +12981,9 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1127 := range v {
-		yy1128 := &yyv1127
-		yy1128.CodecEncodeSelf(e)
+	for _, yyv1179 := range v {
+		yy1180 := &yyv1179
+		yy1180.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12681,75 +12993,75 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1129 := *v
-	yyh1129, yyl1129 := z.DecSliceHelperStart()
+	yyv1181 := *v
+	yyh1181, yyl1181 := z.DecSliceHelperStart()
 
-	var yyrr1129, yyrl1129 int
-	var yyc1129, yyrt1129 bool
-	_, _, _ = yyc1129, yyrt1129, yyrl1129
-	yyrr1129 = yyl1129
+	var yyrr1181, yyrl1181 int
+	var yyc1181, yyrt1181 bool
+	_, _, _ = yyc1181, yyrt1181, yyrl1181
+	yyrr1181 = yyl1181
 
-	if yyv1129 == nil {
-		if yyrl1129, yyrt1129 = z.DecInferLen(yyl1129, z.DecBasicHandle().MaxInitLen, 32); yyrt1129 {
-			yyrr1129 = yyrl1129
+	if yyv1181 == nil {
+		if yyrl1181, yyrt1181 = z.DecInferLen(yyl1181, z.DecBasicHandle().MaxInitLen, 32); yyrt1181 {
+			yyrr1181 = yyrl1181
 		}
-		yyv1129 = make([]APIVersion, yyrl1129)
-		yyc1129 = true
+		yyv1181 = make([]APIVersion, yyrl1181)
+		yyc1181 = true
 	}
 
-	if yyl1129 == 0 {
-		if len(yyv1129) != 0 {
-			yyv1129 = yyv1129[:0]
-			yyc1129 = true
+	if yyl1181 == 0 {
+		if len(yyv1181) != 0 {
+			yyv1181 = yyv1181[:0]
+			yyc1181 = true
 		}
-	} else if yyl1129 > 0 {
+	} else if yyl1181 > 0 {
 
-		if yyl1129 > cap(yyv1129) {
-			yyrl1129, yyrt1129 = z.DecInferLen(yyl1129, z.DecBasicHandle().MaxInitLen, 32)
-			yyv1129 = make([]APIVersion, yyrl1129)
-			yyc1129 = true
+		if yyl1181 > cap(yyv1181) {
+			yyrl1181, yyrt1181 = z.DecInferLen(yyl1181, z.DecBasicHandle().MaxInitLen, 32)
+			yyv1181 = make([]APIVersion, yyrl1181)
+			yyc1181 = true
 
-			yyrr1129 = len(yyv1129)
-		} else if yyl1129 != len(yyv1129) {
-			yyv1129 = yyv1129[:yyl1129]
-			yyc1129 = true
+			yyrr1181 = len(yyv1181)
+		} else if yyl1181 != len(yyv1181) {
+			yyv1181 = yyv1181[:yyl1181]
+			yyc1181 = true
 		}
-		yyj1129 := 0
-		for ; yyj1129 < yyrr1129; yyj1129++ {
+		yyj1181 := 0
+		for ; yyj1181 < yyrr1181; yyj1181++ {
 			if r.TryDecodeAsNil() {
-				yyv1129[yyj1129] = APIVersion{}
+				yyv1181[yyj1181] = APIVersion{}
 			} else {
-				yyv1130 := &yyv1129[yyj1129]
-				yyv1130.CodecDecodeSelf(d)
+				yyv1182 := &yyv1181[yyj1181]
+				yyv1182.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1129 {
-			for ; yyj1129 < yyl1129; yyj1129++ {
-				yyv1129 = append(yyv1129, APIVersion{})
+		if yyrt1181 {
+			for ; yyj1181 < yyl1181; yyj1181++ {
+				yyv1181 = append(yyv1181, APIVersion{})
 				if r.TryDecodeAsNil() {
-					yyv1129[yyj1129] = APIVersion{}
+					yyv1181[yyj1181] = APIVersion{}
 				} else {
-					yyv1131 := &yyv1129[yyj1129]
-					yyv1131.CodecDecodeSelf(d)
+					yyv1183 := &yyv1181[yyj1181]
+					yyv1183.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1129 := 0; !r.CheckBreak(); yyj1129++ {
-			if yyj1129 >= len(yyv1129) {
-				yyv1129 = append(yyv1129, APIVersion{}) // var yyz1129 APIVersion
-				yyc1129 = true
+		for yyj1181 := 0; !r.CheckBreak(); yyj1181++ {
+			if yyj1181 >= len(yyv1181) {
+				yyv1181 = append(yyv1181, APIVersion{}) // var yyz1181 APIVersion
+				yyc1181 = true
 			}
 
-			if yyj1129 < len(yyv1129) {
+			if yyj1181 < len(yyv1181) {
 				if r.TryDecodeAsNil() {
-					yyv1129[yyj1129] = APIVersion{}
+					yyv1181[yyj1181] = APIVersion{}
 				} else {
-					yyv1132 := &yyv1129[yyj1129]
-					yyv1132.CodecDecodeSelf(d)
+					yyv1184 := &yyv1181[yyj1181]
+					yyv1184.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12757,10 +13069,10 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		yyh1129.End()
+		yyh1181.End()
 	}
-	if yyc1129 {
-		*v = yyv1129
+	if yyc1181 {
+		*v = yyv1181
 	}
 
 }
@@ -12770,9 +13082,9 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1133 := range v {
-		yy1134 := &yyv1133
-		yy1134.CodecEncodeSelf(e)
+	for _, yyv1185 := range v {
+		yy1186 := &yyv1185
+		yy1186.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12782,75 +13094,75 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1135 := *v
-	yyh1135, yyl1135 := z.DecSliceHelperStart()
+	yyv1187 := *v
+	yyh1187, yyl1187 := z.DecSliceHelperStart()
 
-	var yyrr1135, yyrl1135 int
-	var yyc1135, yyrt1135 bool
-	_, _, _ = yyc1135, yyrt1135, yyrl1135
-	yyrr1135 = yyl1135
+	var yyrr1187, yyrl1187 int
+	var yyc1187, yyrt1187 bool
+	_, _, _ = yyc1187, yyrt1187, yyrl1187
+	yyrr1187 = yyl1187
 
-	if yyv1135 == nil {
-		if yyrl1135, yyrt1135 = z.DecInferLen(yyl1135, z.DecBasicHandle().MaxInitLen, 232); yyrt1135 {
-			yyrr1135 = yyrl1135
+	if yyv1187 == nil {
+		if yyrl1187, yyrt1187 = z.DecInferLen(yyl1187, z.DecBasicHandle().MaxInitLen, 232); yyrt1187 {
+			yyrr1187 = yyrl1187
 		}
-		yyv1135 = make([]ThirdPartyResource, yyrl1135)
-		yyc1135 = true
+		yyv1187 = make([]ThirdPartyResource, yyrl1187)
+		yyc1187 = true
 	}
 
-	if yyl1135 == 0 {
-		if len(yyv1135) != 0 {
-			yyv1135 = yyv1135[:0]
-			yyc1135 = true
+	if yyl1187 == 0 {
+		if len(yyv1187) != 0 {
+			yyv1187 = yyv1187[:0]
+			yyc1187 = true
 		}
-	} else if yyl1135 > 0 {
+	} else if yyl1187 > 0 {
 
-		if yyl1135 > cap(yyv1135) {
-			yyrl1135, yyrt1135 = z.DecInferLen(yyl1135, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1135 = make([]ThirdPartyResource, yyrl1135)
-			yyc1135 = true
+		if yyl1187 > cap(yyv1187) {
+			yyrl1187, yyrt1187 = z.DecInferLen(yyl1187, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1187 = make([]ThirdPartyResource, yyrl1187)
+			yyc1187 = true
 
-			yyrr1135 = len(yyv1135)
-		} else if yyl1135 != len(yyv1135) {
-			yyv1135 = yyv1135[:yyl1135]
-			yyc1135 = true
+			yyrr1187 = len(yyv1187)
+		} else if yyl1187 != len(yyv1187) {
+			yyv1187 = yyv1187[:yyl1187]
+			yyc1187 = true
 		}
-		yyj1135 := 0
-		for ; yyj1135 < yyrr1135; yyj1135++ {
+		yyj1187 := 0
+		for ; yyj1187 < yyrr1187; yyj1187++ {
 			if r.TryDecodeAsNil() {
-				yyv1135[yyj1135] = ThirdPartyResource{}
+				yyv1187[yyj1187] = ThirdPartyResource{}
 			} else {
-				yyv1136 := &yyv1135[yyj1135]
-				yyv1136.CodecDecodeSelf(d)
+				yyv1188 := &yyv1187[yyj1187]
+				yyv1188.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1135 {
-			for ; yyj1135 < yyl1135; yyj1135++ {
-				yyv1135 = append(yyv1135, ThirdPartyResource{})
+		if yyrt1187 {
+			for ; yyj1187 < yyl1187; yyj1187++ {
+				yyv1187 = append(yyv1187, ThirdPartyResource{})
 				if r.TryDecodeAsNil() {
-					yyv1135[yyj1135] = ThirdPartyResource{}
+					yyv1187[yyj1187] = ThirdPartyResource{}
 				} else {
-					yyv1137 := &yyv1135[yyj1135]
-					yyv1137.CodecDecodeSelf(d)
+					yyv1189 := &yyv1187[yyj1187]
+					yyv1189.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1135 := 0; !r.CheckBreak(); yyj1135++ {
-			if yyj1135 >= len(yyv1135) {
-				yyv1135 = append(yyv1135, ThirdPartyResource{}) // var yyz1135 ThirdPartyResource
-				yyc1135 = true
+		for yyj1187 := 0; !r.CheckBreak(); yyj1187++ {
+			if yyj1187 >= len(yyv1187) {
+				yyv1187 = append(yyv1187, ThirdPartyResource{}) // var yyz1187 ThirdPartyResource
+				yyc1187 = true
 			}
 
-			if yyj1135 < len(yyv1135) {
+			if yyj1187 < len(yyv1187) {
 				if r.TryDecodeAsNil() {
-					yyv1135[yyj1135] = ThirdPartyResource{}
+					yyv1187[yyj1187] = ThirdPartyResource{}
 				} else {
-					yyv1138 := &yyv1135[yyj1135]
-					yyv1138.CodecDecodeSelf(d)
+					yyv1190 := &yyv1187[yyj1187]
+					yyv1190.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12858,10 +13170,10 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		yyh1135.End()
+		yyh1187.End()
 	}
-	if yyc1135 {
-		*v = yyv1135
+	if yyc1187 {
+		*v = yyv1187
 	}
 
 }
@@ -12871,9 +13183,9 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1139 := range v {
-		yy1140 := &yyv1139
-		yy1140.CodecEncodeSelf(e)
+	for _, yyv1191 := range v {
+		yy1192 := &yyv1191
+		yy1192.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12883,75 +13195,75 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1141 := *v
-	yyh1141, yyl1141 := z.DecSliceHelperStart()
+	yyv1193 := *v
+	yyh1193, yyl1193 := z.DecSliceHelperStart()
 
-	var yyrr1141, yyrl1141 int
-	var yyc1141, yyrt1141 bool
-	_, _, _ = yyc1141, yyrt1141, yyrl1141
-	yyrr1141 = yyl1141
+	var yyrr1193, yyrl1193 int
+	var yyc1193, yyrt1193 bool
+	_, _, _ = yyc1193, yyrt1193, yyrl1193
+	yyrr1193 = yyl1193
 
-	if yyv1141 == nil {
-		if yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592); yyrt1141 {
-			yyrr1141 = yyrl1141
+	if yyv1193 == nil {
+		if yyrl1193, yyrt1193 = z.DecInferLen(yyl1193, z.DecBasicHandle().MaxInitLen, 592); yyrt1193 {
+			yyrr1193 = yyrl1193
 		}
-		yyv1141 = make([]Deployment, yyrl1141)
-		yyc1141 = true
+		yyv1193 = make([]Deployment, yyrl1193)
+		yyc1193 = true
 	}
 
-	if yyl1141 == 0 {
-		if len(yyv1141) != 0 {
-			yyv1141 = yyv1141[:0]
-			yyc1141 = true
+	if yyl1193 == 0 {
+		if len(yyv1193) != 0 {
+			yyv1193 = yyv1193[:0]
+			yyc1193 = true
 		}
-	} else if yyl1141 > 0 {
+	} else if yyl1193 > 0 {
 
-		if yyl1141 > cap(yyv1141) {
-			yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592)
-			yyv1141 = make([]Deployment, yyrl1141)
-			yyc1141 = true
+		if yyl1193 > cap(yyv1193) {
+			yyrl1193, yyrt1193 = z.DecInferLen(yyl1193, z.DecBasicHandle().MaxInitLen, 592)
+			yyv1193 = make([]Deployment, yyrl1193)
+			yyc1193 = true
 
-			yyrr1141 = len(yyv1141)
-		} else if yyl1141 != len(yyv1141) {
-			yyv1141 = yyv1141[:yyl1141]
-			yyc1141 = true
+			yyrr1193 = len(yyv1193)
+		} else if yyl1193 != len(yyv1193) {
+			yyv1193 = yyv1193[:yyl1193]
+			yyc1193 = true
 		}
-		yyj1141 := 0
-		for ; yyj1141 < yyrr1141; yyj1141++ {
+		yyj1193 := 0
+		for ; yyj1193 < yyrr1193; yyj1193++ {
 			if r.TryDecodeAsNil() {
-				yyv1141[yyj1141] = Deployment{}
+				yyv1193[yyj1193] = Deployment{}
 			} else {
-				yyv1142 := &yyv1141[yyj1141]
-				yyv1142.CodecDecodeSelf(d)
+				yyv1194 := &yyv1193[yyj1193]
+				yyv1194.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1141 {
-			for ; yyj1141 < yyl1141; yyj1141++ {
-				yyv1141 = append(yyv1141, Deployment{})
+		if yyrt1193 {
+			for ; yyj1193 < yyl1193; yyj1193++ {
+				yyv1193 = append(yyv1193, Deployment{})
 				if r.TryDecodeAsNil() {
-					yyv1141[yyj1141] = Deployment{}
+					yyv1193[yyj1193] = Deployment{}
 				} else {
-					yyv1143 := &yyv1141[yyj1141]
-					yyv1143.CodecDecodeSelf(d)
+					yyv1195 := &yyv1193[yyj1193]
+					yyv1195.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1141 := 0; !r.CheckBreak(); yyj1141++ {
-			if yyj1141 >= len(yyv1141) {
-				yyv1141 = append(yyv1141, Deployment{}) // var yyz1141 Deployment
-				yyc1141 = true
+		for yyj1193 := 0; !r.CheckBreak(); yyj1193++ {
+			if yyj1193 >= len(yyv1193) {
+				yyv1193 = append(yyv1193, Deployment{}) // var yyz1193 Deployment
+				yyc1193 = true
 			}
 
-			if yyj1141 < len(yyv1141) {
+			if yyj1193 < len(yyv1193) {
 				if r.TryDecodeAsNil() {
-					yyv1141[yyj1141] = Deployment{}
+					yyv1193[yyj1193] = Deployment{}
 				} else {
-					yyv1144 := &yyv1141[yyj1141]
-					yyv1144.CodecDecodeSelf(d)
+					yyv1196 := &yyv1193[yyj1193]
+					yyv1196.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12959,10 +13271,10 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		yyh1141.End()
+		yyh1193.End()
 	}
-	if yyc1141 {
-		*v = yyv1141
+	if yyc1193 {
+		*v = yyv1193
 	}
 
 }
@@ -12972,9 +13284,9 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1145 := range v {
-		yy1146 := &yyv1145
-		yy1146.CodecEncodeSelf(e)
+	for _, yyv1197 := range v {
+		yy1198 := &yyv1197
+		yy1198.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12984,75 +13296,75 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1147 := *v
-	yyh1147, yyl1147 := z.DecSliceHelperStart()
+	yyv1199 := *v
+	yyh1199, yyl1199 := z.DecSliceHelperStart()
 
-	var yyrr1147, yyrl1147 int
-	var yyc1147, yyrt1147 bool
-	_, _, _ = yyc1147, yyrt1147, yyrl1147
-	yyrr1147 = yyl1147
+	var yyrr1199, yyrl1199 int
+	var yyc1199, yyrt1199 bool
+	_, _, _ = yyc1199, yyrt1199, yyrl1199
+	yyrr1199 = yyl1199
 
-	if yyv1147 == nil {
-		if yyrl1147, yyrt1147 = z.DecInferLen(yyl1147, z.DecBasicHandle().MaxInitLen, 232); yyrt1147 {
-			yyrr1147 = yyrl1147
+	if yyv1199 == nil {
+		if yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232); yyrt1199 {
+			yyrr1199 = yyrl1199
 		}
-		yyv1147 = make([]DaemonSet, yyrl1147)
-		yyc1147 = true
+		yyv1199 = make([]DaemonSet, yyrl1199)
+		yyc1199 = true
 	}
 
-	if yyl1147 == 0 {
-		if len(yyv1147) != 0 {
-			yyv1147 = yyv1147[:0]
-			yyc1147 = true
+	if yyl1199 == 0 {
+		if len(yyv1199) != 0 {
+			yyv1199 = yyv1199[:0]
+			yyc1199 = true
 		}
-	} else if yyl1147 > 0 {
+	} else if yyl1199 > 0 {
 
-		if yyl1147 > cap(yyv1147) {
-			yyrl1147, yyrt1147 = z.DecInferLen(yyl1147, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1147 = make([]DaemonSet, yyrl1147)
-			yyc1147 = true
+		if yyl1199 > cap(yyv1199) {
+			yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1199 = make([]DaemonSet, yyrl1199)
+			yyc1199 = true
 
-			yyrr1147 = len(yyv1147)
-		} else if yyl1147 != len(yyv1147) {
-			yyv1147 = yyv1147[:yyl1147]
-			yyc1147 = true
+			yyrr1199 = len(yyv1199)
+		} else if yyl1199 != len(yyv1199) {
+			yyv1199 = yyv1199[:yyl1199]
+			yyc1199 = true
 		}
-		yyj1147 := 0
-		for ; yyj1147 < yyrr1147; yyj1147++ {
+		yyj1199 := 0
+		for ; yyj1199 < yyrr1199; yyj1199++ {
 			if r.TryDecodeAsNil() {
-				yyv1147[yyj1147] = DaemonSet{}
+				yyv1199[yyj1199] = DaemonSet{}
 			} else {
-				yyv1148 := &yyv1147[yyj1147]
-				yyv1148.CodecDecodeSelf(d)
+				yyv1200 := &yyv1199[yyj1199]
+				yyv1200.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1147 {
-			for ; yyj1147 < yyl1147; yyj1147++ {
-				yyv1147 = append(yyv1147, DaemonSet{})
+		if yyrt1199 {
+			for ; yyj1199 < yyl1199; yyj1199++ {
+				yyv1199 = append(yyv1199, DaemonSet{})
 				if r.TryDecodeAsNil() {
-					yyv1147[yyj1147] = DaemonSet{}
+					yyv1199[yyj1199] = DaemonSet{}
 				} else {
-					yyv1149 := &yyv1147[yyj1147]
-					yyv1149.CodecDecodeSelf(d)
+					yyv1201 := &yyv1199[yyj1199]
+					yyv1201.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1147 := 0; !r.CheckBreak(); yyj1147++ {
-			if yyj1147 >= len(yyv1147) {
-				yyv1147 = append(yyv1147, DaemonSet{}) // var yyz1147 DaemonSet
-				yyc1147 = true
+		for yyj1199 := 0; !r.CheckBreak(); yyj1199++ {
+			if yyj1199 >= len(yyv1199) {
+				yyv1199 = append(yyv1199, DaemonSet{}) // var yyz1199 DaemonSet
+				yyc1199 = true
 			}
 
-			if yyj1147 < len(yyv1147) {
+			if yyj1199 < len(yyv1199) {
 				if r.TryDecodeAsNil() {
-					yyv1147[yyj1147] = DaemonSet{}
+					yyv1199[yyj1199] = DaemonSet{}
 				} else {
-					yyv1150 := &yyv1147[yyj1147]
-					yyv1150.CodecDecodeSelf(d)
+					yyv1202 := &yyv1199[yyj1199]
+					yyv1202.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13060,10 +13372,10 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		yyh1147.End()
+		yyh1199.End()
 	}
-	if yyc1147 {
-		*v = yyv1147
+	if yyc1199 {
+		*v = yyv1199
 	}
 
 }
@@ -13073,9 +13385,9 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1151 := range v {
-		yy1152 := &yyv1151
-		yy1152.CodecEncodeSelf(e)
+	for _, yyv1203 := range v {
+		yy1204 := &yyv1203
+		yy1204.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13085,75 +13397,75 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1153 := *v
-	yyh1153, yyl1153 := z.DecSliceHelperStart()
+	yyv1205 := *v
+	yyh1205, yyl1205 := z.DecSliceHelperStart()
 
-	var yyrr1153, yyrl1153 int
-	var yyc1153, yyrt1153 bool
-	_, _, _ = yyc1153, yyrt1153, yyrl1153
-	yyrr1153 = yyl1153
+	var yyrr1205, yyrl1205 int
+	var yyc1205, yyrt1205 bool
+	_, _, _ = yyc1205, yyrt1205, yyrl1205
+	yyrr1205 = yyl1205
 
-	if yyv1153 == nil {
-		if yyrl1153, yyrt1153 = z.DecInferLen(yyl1153, z.DecBasicHandle().MaxInitLen, 216); yyrt1153 {
-			yyrr1153 = yyrl1153
+	if yyv1205 == nil {
+		if yyrl1205, yyrt1205 = z.DecInferLen(yyl1205, z.DecBasicHandle().MaxInitLen, 216); yyrt1205 {
+			yyrr1205 = yyrl1205
 		}
-		yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
-		yyc1153 = true
+		yyv1205 = make([]ThirdPartyResourceData, yyrl1205)
+		yyc1205 = true
 	}
 
-	if yyl1153 == 0 {
-		if len(yyv1153) != 0 {
-			yyv1153 = yyv1153[:0]
-			yyc1153 = true
+	if yyl1205 == 0 {
+		if len(yyv1205) != 0 {
+			yyv1205 = yyv1205[:0]
+			yyc1205 = true
 		}
-	} else if yyl1153 > 0 {
+	} else if yyl1205 > 0 {
 
-		if yyl1153 > cap(yyv1153) {
-			yyrl1153, yyrt1153 = z.DecInferLen(yyl1153, z.DecBasicHandle().MaxInitLen, 216)
-			yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
-			yyc1153 = true
+		if yyl1205 > cap(yyv1205) {
+			yyrl1205, yyrt1205 = z.DecInferLen(yyl1205, z.DecBasicHandle().MaxInitLen, 216)
+			yyv1205 = make([]ThirdPartyResourceData, yyrl1205)
+			yyc1205 = true
 
-			yyrr1153 = len(yyv1153)
-		} else if yyl1153 != len(yyv1153) {
-			yyv1153 = yyv1153[:yyl1153]
-			yyc1153 = true
+			yyrr1205 = len(yyv1205)
+		} else if yyl1205 != len(yyv1205) {
+			yyv1205 = yyv1205[:yyl1205]
+			yyc1205 = true
 		}
-		yyj1153 := 0
-		for ; yyj1153 < yyrr1153; yyj1153++ {
+		yyj1205 := 0
+		for ; yyj1205 < yyrr1205; yyj1205++ {
 			if r.TryDecodeAsNil() {
-				yyv1153[yyj1153] = ThirdPartyResourceData{}
+				yyv1205[yyj1205] = ThirdPartyResourceData{}
 			} else {
-				yyv1154 := &yyv1153[yyj1153]
-				yyv1154.CodecDecodeSelf(d)
+				yyv1206 := &yyv1205[yyj1205]
+				yyv1206.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1153 {
-			for ; yyj1153 < yyl1153; yyj1153++ {
-				yyv1153 = append(yyv1153, ThirdPartyResourceData{})
+		if yyrt1205 {
+			for ; yyj1205 < yyl1205; yyj1205++ {
+				yyv1205 = append(yyv1205, ThirdPartyResourceData{})
 				if r.TryDecodeAsNil() {
-					yyv1153[yyj1153] = ThirdPartyResourceData{}
+					yyv1205[yyj1205] = ThirdPartyResourceData{}
 				} else {
-					yyv1155 := &yyv1153[yyj1153]
-					yyv1155.CodecDecodeSelf(d)
+					yyv1207 := &yyv1205[yyj1205]
+					yyv1207.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1153 := 0; !r.CheckBreak(); yyj1153++ {
-			if yyj1153 >= len(yyv1153) {
-				yyv1153 = append(yyv1153, ThirdPartyResourceData{}) // var yyz1153 ThirdPartyResourceData
-				yyc1153 = true
+		for yyj1205 := 0; !r.CheckBreak(); yyj1205++ {
+			if yyj1205 >= len(yyv1205) {
+				yyv1205 = append(yyv1205, ThirdPartyResourceData{}) // var yyz1205 ThirdPartyResourceData
+				yyc1205 = true
 			}
 
-			if yyj1153 < len(yyv1153) {
+			if yyj1205 < len(yyv1205) {
 				if r.TryDecodeAsNil() {
-					yyv1153[yyj1153] = ThirdPartyResourceData{}
+					yyv1205[yyj1205] = ThirdPartyResourceData{}
 				} else {
-					yyv1156 := &yyv1153[yyj1153]
-					yyv1156.CodecDecodeSelf(d)
+					yyv1208 := &yyv1205[yyj1205]
+					yyv1208.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13161,10 +13473,10 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		yyh1153.End()
+		yyh1205.End()
 	}
-	if yyc1153 {
-		*v = yyv1153
+	if yyc1205 {
+		*v = yyv1205
 	}
 
 }
@@ -13174,9 +13486,9 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1157 := range v {
-		yy1158 := &yyv1157
-		yy1158.CodecEncodeSelf(e)
+	for _, yyv1209 := range v {
+		yy1210 := &yyv1209
+		yy1210.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13186,75 +13498,75 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1159 := *v
-	yyh1159, yyl1159 := z.DecSliceHelperStart()
+	yyv1211 := *v
+	yyh1211, yyl1211 := z.DecSliceHelperStart()
 
-	var yyrr1159, yyrl1159 int
-	var yyc1159, yyrt1159 bool
-	_, _, _ = yyc1159, yyrt1159, yyrl1159
-	yyrr1159 = yyl1159
+	var yyrr1211, yyrl1211 int
+	var yyc1211, yyrt1211 bool
+	_, _, _ = yyc1211, yyrt1211, yyrl1211
+	yyrr1211 = yyl1211
 
-	if yyv1159 == nil {
-		if yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608); yyrt1159 {
-			yyrr1159 = yyrl1159
+	if yyv1211 == nil {
+		if yyrl1211, yyrt1211 = z.DecInferLen(yyl1211, z.DecBasicHandle().MaxInitLen, 608); yyrt1211 {
+			yyrr1211 = yyrl1211
 		}
-		yyv1159 = make([]Job, yyrl1159)
-		yyc1159 = true
+		yyv1211 = make([]Job, yyrl1211)
+		yyc1211 = true
 	}
 
-	if yyl1159 == 0 {
-		if len(yyv1159) != 0 {
-			yyv1159 = yyv1159[:0]
-			yyc1159 = true
+	if yyl1211 == 0 {
+		if len(yyv1211) != 0 {
+			yyv1211 = yyv1211[:0]
+			yyc1211 = true
 		}
-	} else if yyl1159 > 0 {
+	} else if yyl1211 > 0 {
 
-		if yyl1159 > cap(yyv1159) {
-			yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608)
-			yyv1159 = make([]Job, yyrl1159)
-			yyc1159 = true
+		if yyl1211 > cap(yyv1211) {
+			yyrl1211, yyrt1211 = z.DecInferLen(yyl1211, z.DecBasicHandle().MaxInitLen, 608)
+			yyv1211 = make([]Job, yyrl1211)
+			yyc1211 = true
 
-			yyrr1159 = len(yyv1159)
-		} else if yyl1159 != len(yyv1159) {
-			yyv1159 = yyv1159[:yyl1159]
-			yyc1159 = true
+			yyrr1211 = len(yyv1211)
+		} else if yyl1211 != len(yyv1211) {
+			yyv1211 = yyv1211[:yyl1211]
+			yyc1211 = true
 		}
-		yyj1159 := 0
-		for ; yyj1159 < yyrr1159; yyj1159++ {
+		yyj1211 := 0
+		for ; yyj1211 < yyrr1211; yyj1211++ {
 			if r.TryDecodeAsNil() {
-				yyv1159[yyj1159] = Job{}
+				yyv1211[yyj1211] = Job{}
 			} else {
-				yyv1160 := &yyv1159[yyj1159]
-				yyv1160.CodecDecodeSelf(d)
+				yyv1212 := &yyv1211[yyj1211]
+				yyv1212.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1159 {
-			for ; yyj1159 < yyl1159; yyj1159++ {
-				yyv1159 = append(yyv1159, Job{})
+		if yyrt1211 {
+			for ; yyj1211 < yyl1211; yyj1211++ {
+				yyv1211 = append(yyv1211, Job{})
 				if r.TryDecodeAsNil() {
-					yyv1159[yyj1159] = Job{}
+					yyv1211[yyj1211] = Job{}
 				} else {
-					yyv1161 := &yyv1159[yyj1159]
-					yyv1161.CodecDecodeSelf(d)
+					yyv1213 := &yyv1211[yyj1211]
+					yyv1213.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1159 := 0; !r.CheckBreak(); yyj1159++ {
-			if yyj1159 >= len(yyv1159) {
-				yyv1159 = append(yyv1159, Job{}) // var yyz1159 Job
-				yyc1159 = true
+		for yyj1211 := 0; !r.CheckBreak(); yyj1211++ {
+			if yyj1211 >= len(yyv1211) {
+				yyv1211 = append(yyv1211, Job{}) // var yyz1211 Job
+				yyc1211 = true
 			}
 
-			if yyj1159 < len(yyv1159) {
+			if yyj1211 < len(yyv1211) {
 				if r.TryDecodeAsNil() {
-					yyv1159[yyj1159] = Job{}
+					yyv1211[yyj1211] = Job{}
 				} else {
-					yyv1162 := &yyv1159[yyj1159]
-					yyv1162.CodecDecodeSelf(d)
+					yyv1214 := &yyv1211[yyj1211]
+					yyv1214.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13262,10 +13574,10 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1159.End()
+		yyh1211.End()
 	}
-	if yyc1159 {
-		*v = yyv1159
+	if yyc1211 {
+		*v = yyv1211
 	}
 
 }
@@ -13275,9 +13587,9 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1163 := range v {
-		yy1164 := &yyv1163
-		yy1164.CodecEncodeSelf(e)
+	for _, yyv1215 := range v {
+		yy1216 := &yyv1215
+		yy1216.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13287,75 +13599,75 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1165 := *v
-	yyh1165, yyl1165 := z.DecSliceHelperStart()
+	yyv1217 := *v
+	yyh1217, yyl1217 := z.DecSliceHelperStart()
 
-	var yyrr1165, yyrl1165 int
-	var yyc1165, yyrt1165 bool
-	_, _, _ = yyc1165, yyrt1165, yyrl1165
-	yyrr1165 = yyl1165
+	var yyrr1217, yyrl1217 int
+	var yyc1217, yyrt1217 bool
+	_, _, _ = yyc1217, yyrt1217, yyrl1217
+	yyrr1217 = yyl1217
 
-	if yyv1165 == nil {
-		if yyrl1165, yyrt1165 = z.DecInferLen(yyl1165, z.DecBasicHandle().MaxInitLen, 112); yyrt1165 {
-			yyrr1165 = yyrl1165
+	if yyv1217 == nil {
+		if yyrl1217, yyrt1217 = z.DecInferLen(yyl1217, z.DecBasicHandle().MaxInitLen, 112); yyrt1217 {
+			yyrr1217 = yyrl1217
 		}
-		yyv1165 = make([]JobCondition, yyrl1165)
-		yyc1165 = true
+		yyv1217 = make([]JobCondition, yyrl1217)
+		yyc1217 = true
 	}
 
-	if yyl1165 == 0 {
-		if len(yyv1165) != 0 {
-			yyv1165 = yyv1165[:0]
-			yyc1165 = true
+	if yyl1217 == 0 {
+		if len(yyv1217) != 0 {
+			yyv1217 = yyv1217[:0]
+			yyc1217 = true
 		}
-	} else if yyl1165 > 0 {
+	} else if yyl1217 > 0 {
 
-		if yyl1165 > cap(yyv1165) {
-			yyrl1165, yyrt1165 = z.DecInferLen(yyl1165, z.DecBasicHandle().MaxInitLen, 112)
-			yyv1165 = make([]JobCondition, yyrl1165)
-			yyc1165 = true
+		if yyl1217 > cap(yyv1217) {
+			yyrl1217, yyrt1217 = z.DecInferLen(yyl1217, z.DecBasicHandle().MaxInitLen, 112)
+			yyv1217 = make([]JobCondition, yyrl1217)
+			yyc1217 = true
 
-			yyrr1165 = len(yyv1165)
-		} else if yyl1165 != len(yyv1165) {
-			yyv1165 = yyv1165[:yyl1165]
-			yyc1165 = true
+			yyrr1217 = len(yyv1217)
+		} else if yyl1217 != len(yyv1217) {
+			yyv1217 = yyv1217[:yyl1217]
+			yyc1217 = true
 		}
-		yyj1165 := 0
-		for ; yyj1165 < yyrr1165; yyj1165++ {
+		yyj1217 := 0
+		for ; yyj1217 < yyrr1217; yyj1217++ {
 			if r.TryDecodeAsNil() {
-				yyv1165[yyj1165] = JobCondition{}
+				yyv1217[yyj1217] = JobCondition{}
 			} else {
-				yyv1166 := &yyv1165[yyj1165]
-				yyv1166.CodecDecodeSelf(d)
+				yyv1218 := &yyv1217[yyj1217]
+				yyv1218.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1165 {
-			for ; yyj1165 < yyl1165; yyj1165++ {
-				yyv1165 = append(yyv1165, JobCondition{})
+		if yyrt1217 {
+			for ; yyj1217 < yyl1217; yyj1217++ {
+				yyv1217 = append(yyv1217, JobCondition{})
 				if r.TryDecodeAsNil() {
-					yyv1165[yyj1165] = JobCondition{}
+					yyv1217[yyj1217] = JobCondition{}
 				} else {
-					yyv1167 := &yyv1165[yyj1165]
-					yyv1167.CodecDecodeSelf(d)
+					yyv1219 := &yyv1217[yyj1217]
+					yyv1219.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1165 := 0; !r.CheckBreak(); yyj1165++ {
-			if yyj1165 >= len(yyv1165) {
-				yyv1165 = append(yyv1165, JobCondition{}) // var yyz1165 JobCondition
-				yyc1165 = true
+		for yyj1217 := 0; !r.CheckBreak(); yyj1217++ {
+			if yyj1217 >= len(yyv1217) {
+				yyv1217 = append(yyv1217, JobCondition{}) // var yyz1217 JobCondition
+				yyc1217 = true
 			}
 
-			if yyj1165 < len(yyv1165) {
+			if yyj1217 < len(yyv1217) {
 				if r.TryDecodeAsNil() {
-					yyv1165[yyj1165] = JobCondition{}
+					yyv1217[yyj1217] = JobCondition{}
 				} else {
-					yyv1168 := &yyv1165[yyj1165]
-					yyv1168.CodecDecodeSelf(d)
+					yyv1220 := &yyv1217[yyj1217]
+					yyv1220.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13363,10 +13675,10 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		yyh1165.End()
+		yyh1217.End()
 	}
-	if yyc1165 {
-		*v = yyv1165
+	if yyc1217 {
+		*v = yyv1217
 	}
 
 }
@@ -13376,9 +13688,9 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1169 := range v {
-		yy1170 := &yyv1169
-		yy1170.CodecEncodeSelf(e)
+	for _, yyv1221 := range v {
+		yy1222 := &yyv1221
+		yy1222.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13388,75 +13700,75 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1171 := *v
-	yyh1171, yyl1171 := z.DecSliceHelperStart()
+	yyv1223 := *v
+	yyh1223, yyl1223 := z.DecSliceHelperStart()
 
-	var yyrr1171, yyrl1171 int
-	var yyc1171, yyrt1171 bool
-	_, _, _ = yyc1171, yyrt1171, yyrl1171
-	yyrr1171 = yyl1171
+	var yyrr1223, yyrl1223 int
+	var yyc1223, yyrt1223 bool
+	_, _, _ = yyc1223, yyrt1223, yyrl1223
+	yyrr1223 = yyl1223
 
-	if yyv1171 == nil {
-		if yyrl1171, yyrt1171 = z.DecInferLen(yyl1171, z.DecBasicHandle().MaxInitLen, 248); yyrt1171 {
-			yyrr1171 = yyrl1171
+	if yyv1223 == nil {
+		if yyrl1223, yyrt1223 = z.DecInferLen(yyl1223, z.DecBasicHandle().MaxInitLen, 248); yyrt1223 {
+			yyrr1223 = yyrl1223
 		}
-		yyv1171 = make([]Ingress, yyrl1171)
-		yyc1171 = true
+		yyv1223 = make([]Ingress, yyrl1223)
+		yyc1223 = true
 	}
 
-	if yyl1171 == 0 {
-		if len(yyv1171) != 0 {
-			yyv1171 = yyv1171[:0]
-			yyc1171 = true
+	if yyl1223 == 0 {
+		if len(yyv1223) != 0 {
+			yyv1223 = yyv1223[:0]
+			yyc1223 = true
 		}
-	} else if yyl1171 > 0 {
+	} else if yyl1223 > 0 {
 
-		if yyl1171 > cap(yyv1171) {
-			yyrl1171, yyrt1171 = z.DecInferLen(yyl1171, z.DecBasicHandle().MaxInitLen, 248)
-			yyv1171 = make([]Ingress, yyrl1171)
-			yyc1171 = true
+		if yyl1223 > cap(yyv1223) {
+			yyrl1223, yyrt1223 = z.DecInferLen(yyl1223, z.DecBasicHandle().MaxInitLen, 248)
+			yyv1223 = make([]Ingress, yyrl1223)
+			yyc1223 = true
 
-			yyrr1171 = len(yyv1171)
-		} else if yyl1171 != len(yyv1171) {
-			yyv1171 = yyv1171[:yyl1171]
-			yyc1171 = true
+			yyrr1223 = len(yyv1223)
+		} else if yyl1223 != len(yyv1223) {
+			yyv1223 = yyv1223[:yyl1223]
+			yyc1223 = true
 		}
-		yyj1171 := 0
-		for ; yyj1171 < yyrr1171; yyj1171++ {
+		yyj1223 := 0
+		for ; yyj1223 < yyrr1223; yyj1223++ {
 			if r.TryDecodeAsNil() {
-				yyv1171[yyj1171] = Ingress{}
+				yyv1223[yyj1223] = Ingress{}
 			} else {
-				yyv1172 := &yyv1171[yyj1171]
-				yyv1172.CodecDecodeSelf(d)
+				yyv1224 := &yyv1223[yyj1223]
+				yyv1224.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1171 {
-			for ; yyj1171 < yyl1171; yyj1171++ {
-				yyv1171 = append(yyv1171, Ingress{})
+		if yyrt1223 {
+			for ; yyj1223 < yyl1223; yyj1223++ {
+				yyv1223 = append(yyv1223, Ingress{})
 				if r.TryDecodeAsNil() {
-					yyv1171[yyj1171] = Ingress{}
+					yyv1223[yyj1223] = Ingress{}
 				} else {
-					yyv1173 := &yyv1171[yyj1171]
-					yyv1173.CodecDecodeSelf(d)
+					yyv1225 := &yyv1223[yyj1223]
+					yyv1225.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1171 := 0; !r.CheckBreak(); yyj1171++ {
-			if yyj1171 >= len(yyv1171) {
-				yyv1171 = append(yyv1171, Ingress{}) // var yyz1171 Ingress
-				yyc1171 = true
+		for yyj1223 := 0; !r.CheckBreak(); yyj1223++ {
+			if yyj1223 >= len(yyv1223) {
+				yyv1223 = append(yyv1223, Ingress{}) // var yyz1223 Ingress
+				yyc1223 = true
 			}
 
-			if yyj1171 < len(yyv1171) {
+			if yyj1223 < len(yyv1223) {
 				if r.TryDecodeAsNil() {
-					yyv1171[yyj1171] = Ingress{}
+					yyv1223[yyj1223] = Ingress{}
 				} else {
-					yyv1174 := &yyv1171[yyj1171]
-					yyv1174.CodecDecodeSelf(d)
+					yyv1226 := &yyv1223[yyj1223]
+					yyv1226.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13464,10 +13776,10 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1171.End()
+		yyh1223.End()
 	}
-	if yyc1171 {
-		*v = yyv1171
+	if yyc1223 {
+		*v = yyv1223
 	}
 
 }
@@ -13477,9 +13789,9 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1175 := range v {
-		yy1176 := &yyv1175
-		yy1176.CodecEncodeSelf(e)
+	for _, yyv1227 := range v {
+		yy1228 := &yyv1227
+		yy1228.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13489,75 +13801,75 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1177 := *v
-	yyh1177, yyl1177 := z.DecSliceHelperStart()
+	yyv1229 := *v
+	yyh1229, yyl1229 := z.DecSliceHelperStart()
 
-	var yyrr1177, yyrl1177 int
-	var yyc1177, yyrt1177 bool
-	_, _, _ = yyc1177, yyrt1177, yyrl1177
-	yyrr1177 = yyl1177
+	var yyrr1229, yyrl1229 int
+	var yyc1229, yyrt1229 bool
+	_, _, _ = yyc1229, yyrt1229, yyrl1229
+	yyrr1229 = yyl1229
 
-	if yyv1177 == nil {
-		if yyrl1177, yyrt1177 = z.DecInferLen(yyl1177, z.DecBasicHandle().MaxInitLen, 24); yyrt1177 {
-			yyrr1177 = yyrl1177
+	if yyv1229 == nil {
+		if yyrl1229, yyrt1229 = z.DecInferLen(yyl1229, z.DecBasicHandle().MaxInitLen, 24); yyrt1229 {
+			yyrr1229 = yyrl1229
 		}
-		yyv1177 = make([]IngressRule, yyrl1177)
-		yyc1177 = true
+		yyv1229 = make([]IngressRule, yyrl1229)
+		yyc1229 = true
 	}
 
-	if yyl1177 == 0 {
-		if len(yyv1177) != 0 {
-			yyv1177 = yyv1177[:0]
-			yyc1177 = true
+	if yyl1229 == 0 {
+		if len(yyv1229) != 0 {
+			yyv1229 = yyv1229[:0]
+			yyc1229 = true
 		}
-	} else if yyl1177 > 0 {
+	} else if yyl1229 > 0 {
 
-		if yyl1177 > cap(yyv1177) {
-			yyrl1177, yyrt1177 = z.DecInferLen(yyl1177, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1177 = make([]IngressRule, yyrl1177)
-			yyc1177 = true
+		if yyl1229 > cap(yyv1229) {
+			yyrl1229, yyrt1229 = z.DecInferLen(yyl1229, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1229 = make([]IngressRule, yyrl1229)
+			yyc1229 = true
 
-			yyrr1177 = len(yyv1177)
-		} else if yyl1177 != len(yyv1177) {
-			yyv1177 = yyv1177[:yyl1177]
-			yyc1177 = true
+			yyrr1229 = len(yyv1229)
+		} else if yyl1229 != len(yyv1229) {
+			yyv1229 = yyv1229[:yyl1229]
+			yyc1229 = true
 		}
-		yyj1177 := 0
-		for ; yyj1177 < yyrr1177; yyj1177++ {
+		yyj1229 := 0
+		for ; yyj1229 < yyrr1229; yyj1229++ {
 			if r.TryDecodeAsNil() {
-				yyv1177[yyj1177] = IngressRule{}
+				yyv1229[yyj1229] = IngressRule{}
 			} else {
-				yyv1178 := &yyv1177[yyj1177]
-				yyv1178.CodecDecodeSelf(d)
+				yyv1230 := &yyv1229[yyj1229]
+				yyv1230.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1177 {
-			for ; yyj1177 < yyl1177; yyj1177++ {
-				yyv1177 = append(yyv1177, IngressRule{})
+		if yyrt1229 {
+			for ; yyj1229 < yyl1229; yyj1229++ {
+				yyv1229 = append(yyv1229, IngressRule{})
 				if r.TryDecodeAsNil() {
-					yyv1177[yyj1177] = IngressRule{}
+					yyv1229[yyj1229] = IngressRule{}
 				} else {
-					yyv1179 := &yyv1177[yyj1177]
-					yyv1179.CodecDecodeSelf(d)
+					yyv1231 := &yyv1229[yyj1229]
+					yyv1231.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1177 := 0; !r.CheckBreak(); yyj1177++ {
-			if yyj1177 >= len(yyv1177) {
-				yyv1177 = append(yyv1177, IngressRule{}) // var yyz1177 IngressRule
-				yyc1177 = true
+		for yyj1229 := 0; !r.CheckBreak(); yyj1229++ {
+			if yyj1229 >= len(yyv1229) {
+				yyv1229 = append(yyv1229, IngressRule{}) // var yyz1229 IngressRule
+				yyc1229 = true
 			}
 
-			if yyj1177 < len(yyv1177) {
+			if yyj1229 < len(yyv1229) {
 				if r.TryDecodeAsNil() {
-					yyv1177[yyj1177] = IngressRule{}
+					yyv1229[yyj1229] = IngressRule{}
 				} else {
-					yyv1180 := &yyv1177[yyj1177]
-					yyv1180.CodecDecodeSelf(d)
+					yyv1232 := &yyv1229[yyj1229]
+					yyv1232.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13565,10 +13877,10 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		yyh1177.End()
+		yyh1229.End()
 	}
-	if yyc1177 {
-		*v = yyv1177
+	if yyc1229 {
+		*v = yyv1229
 	}
 
 }
@@ -13578,9 +13890,9 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1181 := range v {
-		yy1182 := &yyv1181
-		yy1182.CodecEncodeSelf(e)
+	for _, yyv1233 := range v {
+		yy1234 := &yyv1233
+		yy1234.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13590,75 +13902,75 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1183 := *v
-	yyh1183, yyl1183 := z.DecSliceHelperStart()
+	yyv1235 := *v
+	yyh1235, yyl1235 := z.DecSliceHelperStart()
 
-	var yyrr1183, yyrl1183 int
-	var yyc1183, yyrt1183 bool
-	_, _, _ = yyc1183, yyrt1183, yyrl1183
-	yyrr1183 = yyl1183
+	var yyrr1235, yyrl1235 int
+	var yyc1235, yyrt1235 bool
+	_, _, _ = yyc1235, yyrt1235, yyrl1235
+	yyrr1235 = yyl1235
 
-	if yyv1183 == nil {
-		if yyrl1183, yyrt1183 = z.DecInferLen(yyl1183, z.DecBasicHandle().MaxInitLen, 64); yyrt1183 {
-			yyrr1183 = yyrl1183
+	if yyv1235 == nil {
+		if yyrl1235, yyrt1235 = z.DecInferLen(yyl1235, z.DecBasicHandle().MaxInitLen, 64); yyrt1235 {
+			yyrr1235 = yyrl1235
 		}
-		yyv1183 = make([]HTTPIngressPath, yyrl1183)
-		yyc1183 = true
+		yyv1235 = make([]HTTPIngressPath, yyrl1235)
+		yyc1235 = true
 	}
 
-	if yyl1183 == 0 {
-		if len(yyv1183) != 0 {
-			yyv1183 = yyv1183[:0]
-			yyc1183 = true
+	if yyl1235 == 0 {
+		if len(yyv1235) != 0 {
+			yyv1235 = yyv1235[:0]
+			yyc1235 = true
 		}
-	} else if yyl1183 > 0 {
+	} else if yyl1235 > 0 {
 
-		if yyl1183 > cap(yyv1183) {
-			yyrl1183, yyrt1183 = z.DecInferLen(yyl1183, z.DecBasicHandle().MaxInitLen, 64)
-			yyv1183 = make([]HTTPIngressPath, yyrl1183)
-			yyc1183 = true
+		if yyl1235 > cap(yyv1235) {
+			yyrl1235, yyrt1235 = z.DecInferLen(yyl1235, z.DecBasicHandle().MaxInitLen, 64)
+			yyv1235 = make([]HTTPIngressPath, yyrl1235)
+			yyc1235 = true
 
-			yyrr1183 = len(yyv1183)
-		} else if yyl1183 != len(yyv1183) {
-			yyv1183 = yyv1183[:yyl1183]
-			yyc1183 = true
+			yyrr1235 = len(yyv1235)
+		} else if yyl1235 != len(yyv1235) {
+			yyv1235 = yyv1235[:yyl1235]
+			yyc1235 = true
 		}
-		yyj1183 := 0
-		for ; yyj1183 < yyrr1183; yyj1183++ {
+		yyj1235 := 0
+		for ; yyj1235 < yyrr1235; yyj1235++ {
 			if r.TryDecodeAsNil() {
-				yyv1183[yyj1183] = HTTPIngressPath{}
+				yyv1235[yyj1235] = HTTPIngressPath{}
 			} else {
-				yyv1184 := &yyv1183[yyj1183]
-				yyv1184.CodecDecodeSelf(d)
+				yyv1236 := &yyv1235[yyj1235]
+				yyv1236.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1183 {
-			for ; yyj1183 < yyl1183; yyj1183++ {
-				yyv1183 = append(yyv1183, HTTPIngressPath{})
+		if yyrt1235 {
+			for ; yyj1235 < yyl1235; yyj1235++ {
+				yyv1235 = append(yyv1235, HTTPIngressPath{})
 				if r.TryDecodeAsNil() {
-					yyv1183[yyj1183] = HTTPIngressPath{}
+					yyv1235[yyj1235] = HTTPIngressPath{}
 				} else {
-					yyv1185 := &yyv1183[yyj1183]
-					yyv1185.CodecDecodeSelf(d)
+					yyv1237 := &yyv1235[yyj1235]
+					yyv1237.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1183 := 0; !r.CheckBreak(); yyj1183++ {
-			if yyj1183 >= len(yyv1183) {
-				yyv1183 = append(yyv1183, HTTPIngressPath{}) // var yyz1183 HTTPIngressPath
-				yyc1183 = true
+		for yyj1235 := 0; !r.CheckBreak(); yyj1235++ {
+			if yyj1235 >= len(yyv1235) {
+				yyv1235 = append(yyv1235, HTTPIngressPath{}) // var yyz1235 HTTPIngressPath
+				yyc1235 = true
 			}
 
-			if yyj1183 < len(yyv1183) {
+			if yyj1235 < len(yyv1235) {
 				if r.TryDecodeAsNil() {
-					yyv1183[yyj1183] = HTTPIngressPath{}
+					yyv1235[yyj1235] = HTTPIngressPath{}
 				} else {
-					yyv1186 := &yyv1183[yyj1183]
-					yyv1186.CodecDecodeSelf(d)
+					yyv1238 := &yyv1235[yyj1235]
+					yyv1238.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13666,10 +13978,10 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		yyh1183.End()
+		yyh1235.End()
 	}
-	if yyc1183 {
-		*v = yyv1183
+	if yyc1235 {
+		*v = yyv1235
 	}
 
 }
@@ -13679,9 +13991,9 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1187 := range v {
-		yy1188 := &yyv1187
-		yy1188.CodecEncodeSelf(e)
+	for _, yyv1239 := range v {
+		yy1240 := &yyv1239
+		yy1240.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13691,75 +14003,75 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1189 := *v
-	yyh1189, yyl1189 := z.DecSliceHelperStart()
+	yyv1241 := *v
+	yyh1241, yyl1241 := z.DecSliceHelperStart()
 
-	var yyrr1189, yyrl1189 int
-	var yyc1189, yyrt1189 bool
-	_, _, _ = yyc1189, yyrt1189, yyrl1189
-	yyrr1189 = yyl1189
+	var yyrr1241, yyrl1241 int
+	var yyc1241, yyrt1241 bool
+	_, _, _ = yyc1241, yyrt1241, yyrl1241
+	yyrr1241 = yyl1241
 
-	if yyv1189 == nil {
-		if yyrl1189, yyrt1189 = z.DecInferLen(yyl1189, z.DecBasicHandle().MaxInitLen, 24); yyrt1189 {
-			yyrr1189 = yyrl1189
+	if yyv1241 == nil {
+		if yyrl1241, yyrt1241 = z.DecInferLen(yyl1241, z.DecBasicHandle().MaxInitLen, 24); yyrt1241 {
+			yyrr1241 = yyrl1241
 		}
-		yyv1189 = make([]NodeUtilization, yyrl1189)
-		yyc1189 = true
+		yyv1241 = make([]NodeUtilization, yyrl1241)
+		yyc1241 = true
 	}
 
-	if yyl1189 == 0 {
-		if len(yyv1189) != 0 {
-			yyv1189 = yyv1189[:0]
-			yyc1189 = true
+	if yyl1241 == 0 {
+		if len(yyv1241) != 0 {
+			yyv1241 = yyv1241[:0]
+			yyc1241 = true
 		}
-	} else if yyl1189 > 0 {
+	} else if yyl1241 > 0 {
 
-		if yyl1189 > cap(yyv1189) {
-			yyrl1189, yyrt1189 = z.DecInferLen(yyl1189, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1189 = make([]NodeUtilization, yyrl1189)
-			yyc1189 = true
+		if yyl1241 > cap(yyv1241) {
+			yyrl1241, yyrt1241 = z.DecInferLen(yyl1241, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1241 = make([]NodeUtilization, yyrl1241)
+			yyc1241 = true
 
-			yyrr1189 = len(yyv1189)
-		} else if yyl1189 != len(yyv1189) {
-			yyv1189 = yyv1189[:yyl1189]
-			yyc1189 = true
+			yyrr1241 = len(yyv1241)
+		} else if yyl1241 != len(yyv1241) {
+			yyv1241 = yyv1241[:yyl1241]
+			yyc1241 = true
 		}
-		yyj1189 := 0
-		for ; yyj1189 < yyrr1189; yyj1189++ {
+		yyj1241 := 0
+		for ; yyj1241 < yyrr1241; yyj1241++ {
 			if r.TryDecodeAsNil() {
-				yyv1189[yyj1189] = NodeUtilization{}
+				yyv1241[yyj1241] = NodeUtilization{}
 			} else {
-				yyv1190 := &yyv1189[yyj1189]
-				yyv1190.CodecDecodeSelf(d)
+				yyv1242 := &yyv1241[yyj1241]
+				yyv1242.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1189 {
-			for ; yyj1189 < yyl1189; yyj1189++ {
-				yyv1189 = append(yyv1189, NodeUtilization{})
+		if yyrt1241 {
+			for ; yyj1241 < yyl1241; yyj1241++ {
+				yyv1241 = append(yyv1241, NodeUtilization{})
 				if r.TryDecodeAsNil() {
-					yyv1189[yyj1189] = NodeUtilization{}
+					yyv1241[yyj1241] = NodeUtilization{}
 				} else {
-					yyv1191 := &yyv1189[yyj1189]
-					yyv1191.CodecDecodeSelf(d)
+					yyv1243 := &yyv1241[yyj1241]
+					yyv1243.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1189 := 0; !r.CheckBreak(); yyj1189++ {
-			if yyj1189 >= len(yyv1189) {
-				yyv1189 = append(yyv1189, NodeUtilization{}) // var yyz1189 NodeUtilization
-				yyc1189 = true
+		for yyj1241 := 0; !r.CheckBreak(); yyj1241++ {
+			if yyj1241 >= len(yyv1241) {
+				yyv1241 = append(yyv1241, NodeUtilization{}) // var yyz1241 NodeUtilization
+				yyc1241 = true
 			}
 
-			if yyj1189 < len(yyv1189) {
+			if yyj1241 < len(yyv1241) {
 				if r.TryDecodeAsNil() {
-					yyv1189[yyj1189] = NodeUtilization{}
+					yyv1241[yyj1241] = NodeUtilization{}
 				} else {
-					yyv1192 := &yyv1189[yyj1189]
-					yyv1192.CodecDecodeSelf(d)
+					yyv1244 := &yyv1241[yyj1241]
+					yyv1244.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13767,10 +14079,10 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		yyh1189.End()
+		yyh1241.End()
 	}
-	if yyc1189 {
-		*v = yyv1189
+	if yyc1241 {
+		*v = yyv1241
 	}
 
 }
@@ -13780,9 +14092,9 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1193 := range v {
-		yy1194 := &yyv1193
-		yy1194.CodecEncodeSelf(e)
+	for _, yyv1245 := range v {
+		yy1246 := &yyv1245
+		yy1246.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13792,75 +14104,75 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1195 := *v
-	yyh1195, yyl1195 := z.DecSliceHelperStart()
+	yyv1247 := *v
+	yyh1247, yyl1247 := z.DecSliceHelperStart()
 
-	var yyrr1195, yyrl1195 int
-	var yyc1195, yyrt1195 bool
-	_, _, _ = yyc1195, yyrt1195, yyrl1195
-	yyrr1195 = yyl1195
+	var yyrr1247, yyrl1247 int
+	var yyc1247, yyrt1247 bool
+	_, _, _ = yyc1247, yyrt1247, yyrl1247
+	yyrr1247 = yyl1247
 
-	if yyv1195 == nil {
-		if yyrl1195, yyrt1195 = z.DecInferLen(yyl1195, z.DecBasicHandle().MaxInitLen, 232); yyrt1195 {
-			yyrr1195 = yyrl1195
+	if yyv1247 == nil {
+		if yyrl1247, yyrt1247 = z.DecInferLen(yyl1247, z.DecBasicHandle().MaxInitLen, 232); yyrt1247 {
+			yyrr1247 = yyrl1247
 		}
-		yyv1195 = make([]ClusterAutoscaler, yyrl1195)
-		yyc1195 = true
+		yyv1247 = make([]ClusterAutoscaler, yyrl1247)
+		yyc1247 = true
 	}
 
-	if yyl1195 == 0 {
-		if len(yyv1195) != 0 {
-			yyv1195 = yyv1195[:0]
-			yyc1195 = true
+	if yyl1247 == 0 {
+		if len(yyv1247) != 0 {
+			yyv1247 = yyv1247[:0]
+			yyc1247 = true
 		}
-	} else if yyl1195 > 0 {
+	} else if yyl1247 > 0 {
 
-		if yyl1195 > cap(yyv1195) {
-			yyrl1195, yyrt1195 = z.DecInferLen(yyl1195, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1195 = make([]ClusterAutoscaler, yyrl1195)
-			yyc1195 = true
+		if yyl1247 > cap(yyv1247) {
+			yyrl1247, yyrt1247 = z.DecInferLen(yyl1247, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1247 = make([]ClusterAutoscaler, yyrl1247)
+			yyc1247 = true
 
-			yyrr1195 = len(yyv1195)
-		} else if yyl1195 != len(yyv1195) {
-			yyv1195 = yyv1195[:yyl1195]
-			yyc1195 = true
+			yyrr1247 = len(yyv1247)
+		} else if yyl1247 != len(yyv1247) {
+			yyv1247 = yyv1247[:yyl1247]
+			yyc1247 = true
 		}
-		yyj1195 := 0
-		for ; yyj1195 < yyrr1195; yyj1195++ {
+		yyj1247 := 0
+		for ; yyj1247 < yyrr1247; yyj1247++ {
 			if r.TryDecodeAsNil() {
-				yyv1195[yyj1195] = ClusterAutoscaler{}
+				yyv1247[yyj1247] = ClusterAutoscaler{}
 			} else {
-				yyv1196 := &yyv1195[yyj1195]
-				yyv1196.CodecDecodeSelf(d)
+				yyv1248 := &yyv1247[yyj1247]
+				yyv1248.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1195 {
-			for ; yyj1195 < yyl1195; yyj1195++ {
-				yyv1195 = append(yyv1195, ClusterAutoscaler{})
+		if yyrt1247 {
+			for ; yyj1247 < yyl1247; yyj1247++ {
+				yyv1247 = append(yyv1247, ClusterAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1195[yyj1195] = ClusterAutoscaler{}
+					yyv1247[yyj1247] = ClusterAutoscaler{}
 				} else {
-					yyv1197 := &yyv1195[yyj1195]
-					yyv1197.CodecDecodeSelf(d)
+					yyv1249 := &yyv1247[yyj1247]
+					yyv1249.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1195 := 0; !r.CheckBreak(); yyj1195++ {
-			if yyj1195 >= len(yyv1195) {
-				yyv1195 = append(yyv1195, ClusterAutoscaler{}) // var yyz1195 ClusterAutoscaler
-				yyc1195 = true
+		for yyj1247 := 0; !r.CheckBreak(); yyj1247++ {
+			if yyj1247 >= len(yyv1247) {
+				yyv1247 = append(yyv1247, ClusterAutoscaler{}) // var yyz1247 ClusterAutoscaler
+				yyc1247 = true
 			}
 
-			if yyj1195 < len(yyv1195) {
+			if yyj1247 < len(yyv1247) {
 				if r.TryDecodeAsNil() {
-					yyv1195[yyj1195] = ClusterAutoscaler{}
+					yyv1247[yyj1247] = ClusterAutoscaler{}
 				} else {
-					yyv1198 := &yyv1195[yyj1195]
-					yyv1198.CodecDecodeSelf(d)
+					yyv1250 := &yyv1247[yyj1247]
+					yyv1250.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13868,10 +14180,10 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		yyh1195.End()
+		yyh1247.End()
 	}
-	if yyc1195 {
-		*v = yyv1195
+	if yyc1247 {
+		*v = yyv1247
 	}
 
 }
@@ -13881,9 +14193,9 @@ func (x codecSelfer1234) encSlicePodSelectorRequirement(v []PodSelectorRequireme
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1199 := range v {
-		yy1200 := &yyv1199
-		yy1200.CodecEncodeSelf(e)
+	for _, yyv1251 := range v {
+		yy1252 := &yyv1251
+		yy1252.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13893,75 +14205,75 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1201 := *v
-	yyh1201, yyl1201 := z.DecSliceHelperStart()
+	yyv1253 := *v
+	yyh1253, yyl1253 := z.DecSliceHelperStart()
 
-	var yyrr1201, yyrl1201 int
-	var yyc1201, yyrt1201 bool
-	_, _, _ = yyc1201, yyrt1201, yyrl1201
-	yyrr1201 = yyl1201
+	var yyrr1253, yyrl1253 int
+	var yyc1253, yyrt1253 bool
+	_, _, _ = yyc1253, yyrt1253, yyrl1253
+	yyrr1253 = yyl1253
 
-	if yyv1201 == nil {
-		if yyrl1201, yyrt1201 = z.DecInferLen(yyl1201, z.DecBasicHandle().MaxInitLen, 56); yyrt1201 {
-			yyrr1201 = yyrl1201
+	if yyv1253 == nil {
+		if yyrl1253, yyrt1253 = z.DecInferLen(yyl1253, z.DecBasicHandle().MaxInitLen, 56); yyrt1253 {
+			yyrr1253 = yyrl1253
 		}
-		yyv1201 = make([]PodSelectorRequirement, yyrl1201)
-		yyc1201 = true
+		yyv1253 = make([]PodSelectorRequirement, yyrl1253)
+		yyc1253 = true
 	}
 
-	if yyl1201 == 0 {
-		if len(yyv1201) != 0 {
-			yyv1201 = yyv1201[:0]
-			yyc1201 = true
+	if yyl1253 == 0 {
+		if len(yyv1253) != 0 {
+			yyv1253 = yyv1253[:0]
+			yyc1253 = true
 		}
-	} else if yyl1201 > 0 {
+	} else if yyl1253 > 0 {
 
-		if yyl1201 > cap(yyv1201) {
-			yyrl1201, yyrt1201 = z.DecInferLen(yyl1201, z.DecBasicHandle().MaxInitLen, 56)
-			yyv1201 = make([]PodSelectorRequirement, yyrl1201)
-			yyc1201 = true
+		if yyl1253 > cap(yyv1253) {
+			yyrl1253, yyrt1253 = z.DecInferLen(yyl1253, z.DecBasicHandle().MaxInitLen, 56)
+			yyv1253 = make([]PodSelectorRequirement, yyrl1253)
+			yyc1253 = true
 
-			yyrr1201 = len(yyv1201)
-		} else if yyl1201 != len(yyv1201) {
-			yyv1201 = yyv1201[:yyl1201]
-			yyc1201 = true
+			yyrr1253 = len(yyv1253)
+		} else if yyl1253 != len(yyv1253) {
+			yyv1253 = yyv1253[:yyl1253]
+			yyc1253 = true
 		}
-		yyj1201 := 0
-		for ; yyj1201 < yyrr1201; yyj1201++ {
+		yyj1253 := 0
+		for ; yyj1253 < yyrr1253; yyj1253++ {
 			if r.TryDecodeAsNil() {
-				yyv1201[yyj1201] = PodSelectorRequirement{}
+				yyv1253[yyj1253] = PodSelectorRequirement{}
 			} else {
-				yyv1202 := &yyv1201[yyj1201]
-				yyv1202.CodecDecodeSelf(d)
+				yyv1254 := &yyv1253[yyj1253]
+				yyv1254.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1201 {
-			for ; yyj1201 < yyl1201; yyj1201++ {
-				yyv1201 = append(yyv1201, PodSelectorRequirement{})
+		if yyrt1253 {
+			for ; yyj1253 < yyl1253; yyj1253++ {
+				yyv1253 = append(yyv1253, PodSelectorRequirement{})
 				if r.TryDecodeAsNil() {
-					yyv1201[yyj1201] = PodSelectorRequirement{}
+					yyv1253[yyj1253] = PodSelectorRequirement{}
 				} else {
-					yyv1203 := &yyv1201[yyj1201]
-					yyv1203.CodecDecodeSelf(d)
+					yyv1255 := &yyv1253[yyj1253]
+					yyv1255.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1201 := 0; !r.CheckBreak(); yyj1201++ {
-			if yyj1201 >= len(yyv1201) {
-				yyv1201 = append(yyv1201, PodSelectorRequirement{}) // var yyz1201 PodSelectorRequirement
-				yyc1201 = true
+		for yyj1253 := 0; !r.CheckBreak(); yyj1253++ {
+			if yyj1253 >= len(yyv1253) {
+				yyv1253 = append(yyv1253, PodSelectorRequirement{}) // var yyz1253 PodSelectorRequirement
+				yyc1253 = true
 			}
 
-			if yyj1201 < len(yyv1201) {
+			if yyj1253 < len(yyv1253) {
 				if r.TryDecodeAsNil() {
-					yyv1201[yyj1201] = PodSelectorRequirement{}
+					yyv1253[yyj1253] = PodSelectorRequirement{}
 				} else {
-					yyv1204 := &yyv1201[yyj1201]
-					yyv1204.CodecDecodeSelf(d)
+					yyv1256 := &yyv1253[yyj1253]
+					yyv1256.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13969,10 +14281,10 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 			}
 
 		}
-		yyh1201.End()
+		yyh1253.End()
 	}
-	if yyc1201 {
-		*v = yyv1201
+	if yyc1253 {
+		*v = yyv1253
 	}
 
 }

--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -524,55 +524,43 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr31 || yy2arr31 {
 				if yyq31[2] {
 					yy39 := &x.ObjectMeta
-					yym40 := z.EncBinary()
-					_ = yym40
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy39) {
-					} else {
-						z.EncFallback(yy39)
-					}
+					yy39.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq31[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy41 := &x.ObjectMeta
-					yym42 := z.EncBinary()
-					_ = yym42
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy41) {
-					} else {
-						z.EncFallback(yy41)
-					}
+					yy40 := &x.ObjectMeta
+					yy40.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				if yyq31[3] {
-					yy44 := &x.Spec
-					yy44.CodecEncodeSelf(e)
+					yy42 := &x.Spec
+					yy42.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq31[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy45 := &x.Spec
-					yy45.CodecEncodeSelf(e)
+					yy43 := &x.Spec
+					yy43.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				if yyq31[4] {
-					yy47 := &x.Status
-					yy47.CodecEncodeSelf(e)
+					yy45 := &x.Status
+					yy45.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq31[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy48 := &x.Status
-					yy48.CodecEncodeSelf(e)
+					yy46 := &x.Status
+					yy46.CodecEncodeSelf(e)
 				}
 			}
 			if yysep31 {
@@ -586,24 +574,24 @@ func (x *Scale) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym49 := z.DecBinary()
-	_ = yym49
+	yym47 := z.DecBinary()
+	_ = yym47
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl50 := r.ReadMapStart()
-			if yyl50 == 0 {
+			yyl48 := r.ReadMapStart()
+			if yyl48 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl50, d)
+				x.codecDecodeSelfFromMap(yyl48, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl50 := r.ReadArrayStart()
-			if yyl50 == 0 {
+			yyl48 := r.ReadArrayStart()
+			if yyl48 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl50, d)
+				x.codecDecodeSelfFromArray(yyl48, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -615,12 +603,12 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys51Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys51Slc
-	var yyhl51 bool = l >= 0
-	for yyj51 := 0; ; yyj51++ {
-		if yyhl51 {
-			if yyj51 >= l {
+	var yys49Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys49Slc
+	var yyhl49 bool = l >= 0
+	for yyj49 := 0; ; yyj49++ {
+		if yyhl49 {
+			if yyj49 >= l {
 				break
 			}
 		} else {
@@ -628,9 +616,9 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys51Slc = r.DecodeBytes(yys51Slc, true, true)
-		yys51 := string(yys51Slc)
-		switch yys51 {
+		yys49Slc = r.DecodeBytes(yys49Slc, true, true)
+		yys49 := string(yys49Slc)
+		switch yys49 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -647,34 +635,28 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv54 := &x.ObjectMeta
-				yym55 := z.DecBinary()
-				_ = yym55
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv54) {
-				} else {
-					z.DecFallback(yyv54, false)
-				}
+				yyv52 := &x.ObjectMeta
+				yyv52.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ScaleSpec{}
 			} else {
-				yyv56 := &x.Spec
-				yyv56.CodecDecodeSelf(d)
+				yyv53 := &x.Spec
+				yyv53.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ScaleStatus{}
 			} else {
-				yyv57 := &x.Status
-				yyv57.CodecDecodeSelf(d)
+				yyv54 := &x.Status
+				yyv54.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys51)
-		} // end switch yys51
-	} // end for yyj51
-	if !yyhl51 {
+			z.DecStructFieldNotFound(-1, yys49)
+		} // end switch yys49
+	} // end for yyj49
+	if !yyhl49 {
 		r.ReadEnd()
 	}
 }
@@ -683,16 +665,16 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj58 int
-	var yyb58 bool
-	var yyhl58 bool = l >= 0
-	yyj58++
-	if yyhl58 {
-		yyb58 = yyj58 > l
+	var yyj55 int
+	var yyb55 bool
+	var yyhl55 bool = l >= 0
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
 	} else {
-		yyb58 = r.CheckBreak()
+		yyb55 = r.CheckBreak()
 	}
-	if yyb58 {
+	if yyb55 {
 		r.ReadEnd()
 		return
 	}
@@ -701,13 +683,13 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj58++
-	if yyhl58 {
-		yyb58 = yyj58 > l
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
 	} else {
-		yyb58 = r.CheckBreak()
+		yyb55 = r.CheckBreak()
 	}
-	if yyb58 {
+	if yyb55 {
 		r.ReadEnd()
 		return
 	}
@@ -716,71 +698,65 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj58++
-	if yyhl58 {
-		yyb58 = yyj58 > l
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
 	} else {
-		yyb58 = r.CheckBreak()
+		yyb55 = r.CheckBreak()
 	}
-	if yyb58 {
+	if yyb55 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv61 := &x.ObjectMeta
-		yym62 := z.DecBinary()
-		_ = yym62
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv61) {
-		} else {
-			z.DecFallback(yyv61, false)
-		}
+		yyv58 := &x.ObjectMeta
+		yyv58.CodecDecodeSelf(d)
 	}
-	yyj58++
-	if yyhl58 {
-		yyb58 = yyj58 > l
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
 	} else {
-		yyb58 = r.CheckBreak()
+		yyb55 = r.CheckBreak()
 	}
-	if yyb58 {
+	if yyb55 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ScaleSpec{}
 	} else {
-		yyv63 := &x.Spec
-		yyv63.CodecDecodeSelf(d)
+		yyv59 := &x.Spec
+		yyv59.CodecDecodeSelf(d)
 	}
-	yyj58++
-	if yyhl58 {
-		yyb58 = yyj58 > l
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
 	} else {
-		yyb58 = r.CheckBreak()
+		yyb55 = r.CheckBreak()
 	}
-	if yyb58 {
+	if yyb55 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ScaleStatus{}
 	} else {
-		yyv64 := &x.Status
-		yyv64.CodecDecodeSelf(d)
+		yyv60 := &x.Status
+		yyv60.CodecDecodeSelf(d)
 	}
 	for {
-		yyj58++
-		if yyhl58 {
-			yyb58 = yyj58 > l
+		yyj55++
+		if yyhl55 {
+			yyb55 = yyj55 > l
 		} else {
-			yyb58 = r.CheckBreak()
+			yyb55 = r.CheckBreak()
 		}
-		if yyb58 {
+		if yyb55 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj58-1, "")
+		z.DecStructFieldNotFound(yyj55-1, "")
 	}
 	r.ReadEnd()
 }
@@ -792,74 +768,74 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym65 := z.EncBinary()
-		_ = yym65
+		yym61 := z.EncBinary()
+		_ = yym61
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep66 := !z.EncBinary()
-			yy2arr66 := z.EncBasicHandle().StructToArray
-			var yyq66 [2]bool
-			_, _, _ = yysep66, yyq66, yy2arr66
-			const yyr66 bool = false
-			yyq66[0] = x.Kind != ""
-			yyq66[1] = x.APIVersion != ""
-			if yyr66 || yy2arr66 {
+			yysep62 := !z.EncBinary()
+			yy2arr62 := z.EncBasicHandle().StructToArray
+			var yyq62 [2]bool
+			_, _, _ = yysep62, yyq62, yy2arr62
+			const yyr62 bool = false
+			yyq62[0] = x.Kind != ""
+			yyq62[1] = x.APIVersion != ""
+			if yyr62 || yy2arr62 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn66 int = 0
-				for _, b := range yyq66 {
+				var yynn62 int = 0
+				for _, b := range yyq62 {
 					if b {
-						yynn66++
+						yynn62++
 					}
 				}
-				r.EncodeMapStart(yynn66)
+				r.EncodeMapStart(yynn62)
 			}
-			if yyr66 || yy2arr66 {
-				if yyq66[0] {
+			if yyr62 || yy2arr62 {
+				if yyq62[0] {
+					yym64 := z.EncBinary()
+					_ = yym64
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq62[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym65 := z.EncBinary()
+					_ = yym65
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr62 || yy2arr62 {
+				if yyq62[1] {
+					yym67 := z.EncBinary()
+					_ = yym67
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq62[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym68 := z.EncBinary()
 					_ = yym68
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq66[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym69 := z.EncBinary()
-					_ = yym69
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr66 || yy2arr66 {
-				if yyq66[1] {
-					yym71 := z.EncBinary()
-					_ = yym71
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq66[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym72 := z.EncBinary()
-					_ = yym72
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yysep66 {
+			if yysep62 {
 				r.EncodeEnd()
 			}
 		}
@@ -870,24 +846,24 @@ func (x *ReplicationControllerDummy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym73 := z.DecBinary()
-	_ = yym73
+	yym69 := z.DecBinary()
+	_ = yym69
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl74 := r.ReadMapStart()
-			if yyl74 == 0 {
+			yyl70 := r.ReadMapStart()
+			if yyl70 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl74, d)
+				x.codecDecodeSelfFromMap(yyl70, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl74 := r.ReadArrayStart()
-			if yyl74 == 0 {
+			yyl70 := r.ReadArrayStart()
+			if yyl70 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl74, d)
+				x.codecDecodeSelfFromArray(yyl70, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -899,12 +875,12 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys75Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys75Slc
-	var yyhl75 bool = l >= 0
-	for yyj75 := 0; ; yyj75++ {
-		if yyhl75 {
-			if yyj75 >= l {
+	var yys71Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys71Slc
+	var yyhl71 bool = l >= 0
+	for yyj71 := 0; ; yyj71++ {
+		if yyhl71 {
+			if yyj71 >= l {
 				break
 			}
 		} else {
@@ -912,9 +888,9 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
-		yys75Slc = r.DecodeBytes(yys75Slc, true, true)
-		yys75 := string(yys75Slc)
-		switch yys75 {
+		yys71Slc = r.DecodeBytes(yys71Slc, true, true)
+		yys71 := string(yys71Slc)
+		switch yys71 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -928,10 +904,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys75)
-		} // end switch yys75
-	} // end for yyj75
-	if !yyhl75 {
+			z.DecStructFieldNotFound(-1, yys71)
+		} // end switch yys71
+	} // end for yyj71
+	if !yyhl71 {
 		r.ReadEnd()
 	}
 }
@@ -940,16 +916,16 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj78 int
-	var yyb78 bool
-	var yyhl78 bool = l >= 0
-	yyj78++
-	if yyhl78 {
-		yyb78 = yyj78 > l
+	var yyj74 int
+	var yyb74 bool
+	var yyhl74 bool = l >= 0
+	yyj74++
+	if yyhl74 {
+		yyb74 = yyj74 > l
 	} else {
-		yyb78 = r.CheckBreak()
+		yyb74 = r.CheckBreak()
 	}
-	if yyb78 {
+	if yyb74 {
 		r.ReadEnd()
 		return
 	}
@@ -958,13 +934,13 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj78++
-	if yyhl78 {
-		yyb78 = yyj78 > l
+	yyj74++
+	if yyhl74 {
+		yyb74 = yyj74 > l
 	} else {
-		yyb78 = r.CheckBreak()
+		yyb74 = r.CheckBreak()
 	}
-	if yyb78 {
+	if yyb74 {
 		r.ReadEnd()
 		return
 	}
@@ -974,16 +950,16 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj78++
-		if yyhl78 {
-			yyb78 = yyj78 > l
+		yyj74++
+		if yyhl74 {
+			yyb74 = yyj74 > l
 		} else {
-			yyb78 = r.CheckBreak()
+			yyb74 = r.CheckBreak()
 		}
-		if yyb78 {
+		if yyb74 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj78-1, "")
+		z.DecStructFieldNotFound(yyj74-1, "")
 	}
 	r.ReadEnd()
 }
@@ -995,120 +971,120 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym81 := z.EncBinary()
-		_ = yym81
+		yym77 := z.EncBinary()
+		_ = yym77
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep82 := !z.EncBinary()
-			yy2arr82 := z.EncBasicHandle().StructToArray
-			var yyq82 [4]bool
-			_, _, _ = yysep82, yyq82, yy2arr82
-			const yyr82 bool = false
-			yyq82[0] = x.Kind != ""
-			yyq82[1] = x.Name != ""
-			yyq82[2] = x.APIVersion != ""
-			yyq82[3] = x.Subresource != ""
-			if yyr82 || yy2arr82 {
+			yysep78 := !z.EncBinary()
+			yy2arr78 := z.EncBasicHandle().StructToArray
+			var yyq78 [4]bool
+			_, _, _ = yysep78, yyq78, yy2arr78
+			const yyr78 bool = false
+			yyq78[0] = x.Kind != ""
+			yyq78[1] = x.Name != ""
+			yyq78[2] = x.APIVersion != ""
+			yyq78[3] = x.Subresource != ""
+			if yyr78 || yy2arr78 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn82 int = 0
-				for _, b := range yyq82 {
+				var yynn78 int = 0
+				for _, b := range yyq78 {
 					if b {
-						yynn82++
+						yynn78++
 					}
 				}
-				r.EncodeMapStart(yynn82)
+				r.EncodeMapStart(yynn78)
 			}
-			if yyr82 || yy2arr82 {
-				if yyq82[0] {
+			if yyr78 || yy2arr78 {
+				if yyq78[0] {
+					yym80 := z.EncBinary()
+					_ = yym80
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq78[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym81 := z.EncBinary()
+					_ = yym81
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr78 || yy2arr78 {
+				if yyq78[1] {
+					yym83 := z.EncBinary()
+					_ = yym83
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq78[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					yym84 := z.EncBinary()
 					_ = yym84
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				}
+			}
+			if yyr78 || yy2arr78 {
+				if yyq78[2] {
+					yym86 := z.EncBinary()
+					_ = yym86
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq82[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym85 := z.EncBinary()
-					_ = yym85
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr82 || yy2arr82 {
-				if yyq82[1] {
+				if yyq78[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym87 := z.EncBinary()
 					_ = yym87
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr78 || yy2arr78 {
+				if yyq78[3] {
+					yym89 := z.EncBinary()
+					_ = yym89
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq82[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym88 := z.EncBinary()
-					_ = yym88
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				}
-			}
-			if yyr82 || yy2arr82 {
-				if yyq82[2] {
+				if yyq78[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("subresource"))
 					yym90 := z.EncBinary()
 					_ = yym90
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq82[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym91 := z.EncBinary()
-					_ = yym91
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr82 || yy2arr82 {
-				if yyq82[3] {
-					yym93 := z.EncBinary()
-					_ = yym93
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq82[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("subresource"))
-					yym94 := z.EncBinary()
-					_ = yym94
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
 					}
 				}
 			}
-			if yysep82 {
+			if yysep78 {
 				r.EncodeEnd()
 			}
 		}
@@ -1119,24 +1095,24 @@ func (x *SubresourceReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym95 := z.DecBinary()
-	_ = yym95
+	yym91 := z.DecBinary()
+	_ = yym91
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl96 := r.ReadMapStart()
-			if yyl96 == 0 {
+			yyl92 := r.ReadMapStart()
+			if yyl92 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl96, d)
+				x.codecDecodeSelfFromMap(yyl92, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl96 := r.ReadArrayStart()
-			if yyl96 == 0 {
+			yyl92 := r.ReadArrayStart()
+			if yyl92 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl96, d)
+				x.codecDecodeSelfFromArray(yyl92, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1148,12 +1124,12 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys97Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys97Slc
-	var yyhl97 bool = l >= 0
-	for yyj97 := 0; ; yyj97++ {
-		if yyhl97 {
-			if yyj97 >= l {
+	var yys93Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys93Slc
+	var yyhl93 bool = l >= 0
+	for yyj93 := 0; ; yyj93++ {
+		if yyhl93 {
+			if yyj93 >= l {
 				break
 			}
 		} else {
@@ -1161,9 +1137,9 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys97Slc = r.DecodeBytes(yys97Slc, true, true)
-		yys97 := string(yys97Slc)
-		switch yys97 {
+		yys93Slc = r.DecodeBytes(yys93Slc, true, true)
+		yys93 := string(yys93Slc)
+		switch yys93 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -1189,10 +1165,10 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.Subresource = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys97)
-		} // end switch yys97
-	} // end for yyj97
-	if !yyhl97 {
+			z.DecStructFieldNotFound(-1, yys93)
+		} // end switch yys93
+	} // end for yyj93
+	if !yyhl93 {
 		r.ReadEnd()
 	}
 }
@@ -1201,16 +1177,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj102 int
-	var yyb102 bool
-	var yyhl102 bool = l >= 0
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	var yyj98 int
+	var yyb98 bool
+	var yyhl98 bool = l >= 0
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1219,13 +1195,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1234,13 +1210,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1249,13 +1225,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1265,16 +1241,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.Subresource = string(r.DecodeString())
 	}
 	for {
-		yyj102++
-		if yyhl102 {
-			yyb102 = yyj102 > l
+		yyj98++
+		if yyhl98 {
+			yyb98 = yyj98 > l
 		} else {
-			yyb102 = r.CheckBreak()
+			yyb98 = r.CheckBreak()
 		}
-		if yyb102 {
+		if yyb98 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj102-1, "")
+		z.DecStructFieldNotFound(yyj98-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1286,44 +1262,44 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym107 := z.EncBinary()
-		_ = yym107
+		yym103 := z.EncBinary()
+		_ = yym103
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep108 := !z.EncBinary()
-			yy2arr108 := z.EncBasicHandle().StructToArray
-			var yyq108 [1]bool
-			_, _, _ = yysep108, yyq108, yy2arr108
-			const yyr108 bool = false
-			if yyr108 || yy2arr108 {
+			yysep104 := !z.EncBinary()
+			yy2arr104 := z.EncBasicHandle().StructToArray
+			var yyq104 [1]bool
+			_, _, _ = yysep104, yyq104, yy2arr104
+			const yyr104 bool = false
+			if yyr104 || yy2arr104 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn108 int = 1
-				for _, b := range yyq108 {
+				var yynn104 int = 1
+				for _, b := range yyq104 {
 					if b {
-						yynn108++
+						yynn104++
 					}
 				}
-				r.EncodeMapStart(yynn108)
+				r.EncodeMapStart(yynn104)
 			}
-			if yyr108 || yy2arr108 {
-				yym110 := z.EncBinary()
-				_ = yym110
+			if yyr104 || yy2arr104 {
+				yym106 := z.EncBinary()
+				_ = yym106
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("targetPercentage"))
-				yym111 := z.EncBinary()
-				_ = yym111
+				yym107 := z.EncBinary()
+				_ = yym107
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			}
-			if yysep108 {
+			if yysep104 {
 				r.EncodeEnd()
 			}
 		}
@@ -1334,24 +1310,24 @@ func (x *CPUTargetUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym112 := z.DecBinary()
-	_ = yym112
+	yym108 := z.DecBinary()
+	_ = yym108
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl113 := r.ReadMapStart()
-			if yyl113 == 0 {
+			yyl109 := r.ReadMapStart()
+			if yyl109 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl113, d)
+				x.codecDecodeSelfFromMap(yyl109, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl113 := r.ReadArrayStart()
-			if yyl113 == 0 {
+			yyl109 := r.ReadArrayStart()
+			if yyl109 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl113, d)
+				x.codecDecodeSelfFromArray(yyl109, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1363,12 +1339,12 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys114Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys114Slc
-	var yyhl114 bool = l >= 0
-	for yyj114 := 0; ; yyj114++ {
-		if yyhl114 {
-			if yyj114 >= l {
+	var yys110Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys110Slc
+	var yyhl110 bool = l >= 0
+	for yyj110 := 0; ; yyj110++ {
+		if yyhl110 {
+			if yyj110 >= l {
 				break
 			}
 		} else {
@@ -1376,9 +1352,9 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys114Slc = r.DecodeBytes(yys114Slc, true, true)
-		yys114 := string(yys114Slc)
-		switch yys114 {
+		yys110Slc = r.DecodeBytes(yys110Slc, true, true)
+		yys110 := string(yys110Slc)
+		switch yys110 {
 		case "targetPercentage":
 			if r.TryDecodeAsNil() {
 				x.TargetPercentage = 0
@@ -1386,10 +1362,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys114)
-		} // end switch yys114
-	} // end for yyj114
-	if !yyhl114 {
+			z.DecStructFieldNotFound(-1, yys110)
+		} // end switch yys110
+	} // end for yyj110
+	if !yyhl110 {
 		r.ReadEnd()
 	}
 }
@@ -1398,16 +1374,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj116 int
-	var yyb116 bool
-	var yyhl116 bool = l >= 0
-	yyj116++
-	if yyhl116 {
-		yyb116 = yyj116 > l
+	var yyj112 int
+	var yyb112 bool
+	var yyhl112 bool = l >= 0
+	yyj112++
+	if yyhl112 {
+		yyb112 = yyj112 > l
 	} else {
-		yyb116 = r.CheckBreak()
+		yyb112 = r.CheckBreak()
 	}
-	if yyb116 {
+	if yyb112 {
 		r.ReadEnd()
 		return
 	}
@@ -1417,16 +1393,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj116++
-		if yyhl116 {
-			yyb116 = yyj116 > l
+		yyj112++
+		if yyhl112 {
+			yyb112 = yyj112 > l
 		} else {
-			yyb116 = r.CheckBreak()
+			yyb112 = r.CheckBreak()
 		}
-		if yyb116 {
+		if yyb112 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj116-1, "")
+		z.DecStructFieldNotFound(yyj112-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1438,87 +1414,87 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym118 := z.EncBinary()
-		_ = yym118
+		yym114 := z.EncBinary()
+		_ = yym114
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep119 := !z.EncBinary()
-			yy2arr119 := z.EncBasicHandle().StructToArray
-			var yyq119 [4]bool
-			_, _, _ = yysep119, yyq119, yy2arr119
-			const yyr119 bool = false
-			yyq119[1] = x.MinReplicas != nil
-			yyq119[3] = x.CPUUtilization != nil
-			if yyr119 || yy2arr119 {
+			yysep115 := !z.EncBinary()
+			yy2arr115 := z.EncBasicHandle().StructToArray
+			var yyq115 [4]bool
+			_, _, _ = yysep115, yyq115, yy2arr115
+			const yyr115 bool = false
+			yyq115[1] = x.MinReplicas != nil
+			yyq115[3] = x.CPUUtilization != nil
+			if yyr115 || yy2arr115 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn119 int = 2
-				for _, b := range yyq119 {
+				var yynn115 int = 2
+				for _, b := range yyq115 {
 					if b {
-						yynn119++
+						yynn115++
 					}
 				}
-				r.EncodeMapStart(yynn119)
+				r.EncodeMapStart(yynn115)
 			}
-			if yyr119 || yy2arr119 {
-				yy121 := &x.ScaleRef
-				yy121.CodecEncodeSelf(e)
+			if yyr115 || yy2arr115 {
+				yy117 := &x.ScaleRef
+				yy117.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("scaleRef"))
-				yy122 := &x.ScaleRef
-				yy122.CodecEncodeSelf(e)
+				yy118 := &x.ScaleRef
+				yy118.CodecEncodeSelf(e)
 			}
-			if yyr119 || yy2arr119 {
-				if yyq119[1] {
+			if yyr115 || yy2arr115 {
+				if yyq115[1] {
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy124 := *x.MinReplicas
-						yym125 := z.EncBinary()
-						_ = yym125
+						yy120 := *x.MinReplicas
+						yym121 := z.EncBinary()
+						_ = yym121
 						if false {
 						} else {
-							r.EncodeInt(int64(yy124))
+							r.EncodeInt(int64(yy120))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq119[1] {
+				if yyq115[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReplicas"))
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy126 := *x.MinReplicas
-						yym127 := z.EncBinary()
-						_ = yym127
+						yy122 := *x.MinReplicas
+						yym123 := z.EncBinary()
+						_ = yym123
 						if false {
 						} else {
-							r.EncodeInt(int64(yy126))
+							r.EncodeInt(int64(yy122))
 						}
 					}
 				}
 			}
-			if yyr119 || yy2arr119 {
-				yym129 := z.EncBinary()
-				_ = yym129
+			if yyr115 || yy2arr115 {
+				yym125 := z.EncBinary()
+				_ = yym125
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxReplicas"))
-				yym130 := z.EncBinary()
-				_ = yym130
+				yym126 := z.EncBinary()
+				_ = yym126
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			}
-			if yyr119 || yy2arr119 {
-				if yyq119[3] {
+			if yyr115 || yy2arr115 {
+				if yyq115[3] {
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
 					} else {
@@ -1528,7 +1504,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq119[3] {
+				if yyq115[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpuUtilization"))
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
@@ -1537,7 +1513,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep119 {
+			if yysep115 {
 				r.EncodeEnd()
 			}
 		}
@@ -1548,24 +1524,24 @@ func (x *HorizontalPodAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym132 := z.DecBinary()
-	_ = yym132
+	yym128 := z.DecBinary()
+	_ = yym128
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl133 := r.ReadMapStart()
-			if yyl133 == 0 {
+			yyl129 := r.ReadMapStart()
+			if yyl129 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl133, d)
+				x.codecDecodeSelfFromMap(yyl129, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl133 := r.ReadArrayStart()
-			if yyl133 == 0 {
+			yyl129 := r.ReadArrayStart()
+			if yyl129 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl133, d)
+				x.codecDecodeSelfFromArray(yyl129, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1577,12 +1553,12 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys134Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys134Slc
-	var yyhl134 bool = l >= 0
-	for yyj134 := 0; ; yyj134++ {
-		if yyhl134 {
-			if yyj134 >= l {
+	var yys130Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys130Slc
+	var yyhl130 bool = l >= 0
+	for yyj130 := 0; ; yyj130++ {
+		if yyhl130 {
+			if yyj130 >= l {
 				break
 			}
 		} else {
@@ -1590,15 +1566,15 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys134Slc = r.DecodeBytes(yys134Slc, true, true)
-		yys134 := string(yys134Slc)
-		switch yys134 {
+		yys130Slc = r.DecodeBytes(yys130Slc, true, true)
+		yys130 := string(yys130Slc)
+		switch yys130 {
 		case "scaleRef":
 			if r.TryDecodeAsNil() {
 				x.ScaleRef = SubresourceReference{}
 			} else {
-				yyv135 := &x.ScaleRef
-				yyv135.CodecDecodeSelf(d)
+				yyv131 := &x.ScaleRef
+				yyv131.CodecDecodeSelf(d)
 			}
 		case "minReplicas":
 			if r.TryDecodeAsNil() {
@@ -1609,8 +1585,8 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				if x.MinReplicas == nil {
 					x.MinReplicas = new(int)
 				}
-				yym137 := z.DecBinary()
-				_ = yym137
+				yym133 := z.DecBinary()
+				_ = yym133
 				if false {
 				} else {
 					*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -1634,10 +1610,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				x.CPUUtilization.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys134)
-		} // end switch yys134
-	} // end for yyj134
-	if !yyhl134 {
+			z.DecStructFieldNotFound(-1, yys130)
+		} // end switch yys130
+	} // end for yyj130
+	if !yyhl130 {
 		r.ReadEnd()
 	}
 }
@@ -1646,32 +1622,32 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj140 int
-	var yyb140 bool
-	var yyhl140 bool = l >= 0
-	yyj140++
-	if yyhl140 {
-		yyb140 = yyj140 > l
+	var yyj136 int
+	var yyb136 bool
+	var yyhl136 bool = l >= 0
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb140 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb140 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ScaleRef = SubresourceReference{}
 	} else {
-		yyv141 := &x.ScaleRef
-		yyv141.CodecDecodeSelf(d)
+		yyv137 := &x.ScaleRef
+		yyv137.CodecDecodeSelf(d)
 	}
-	yyj140++
-	if yyhl140 {
-		yyb140 = yyj140 > l
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb140 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb140 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
@@ -1683,20 +1659,20 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		if x.MinReplicas == nil {
 			x.MinReplicas = new(int)
 		}
-		yym143 := z.DecBinary()
-		_ = yym143
+		yym139 := z.DecBinary()
+		_ = yym139
 		if false {
 		} else {
 			*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj140++
-	if yyhl140 {
-		yyb140 = yyj140 > l
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb140 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb140 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
@@ -1705,13 +1681,13 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.MaxReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj140++
-	if yyhl140 {
-		yyb140 = yyj140 > l
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb140 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb140 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
@@ -1726,16 +1702,16 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		x.CPUUtilization.CodecDecodeSelf(d)
 	}
 	for {
-		yyj140++
-		if yyhl140 {
-			yyb140 = yyj140 > l
+		yyj136++
+		if yyhl136 {
+			yyb136 = yyj136 > l
 		} else {
-			yyb140 = r.CheckBreak()
+			yyb136 = r.CheckBreak()
 		}
-		if yyb140 {
+		if yyb136 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj140-1, "")
+		z.DecStructFieldNotFound(yyj136-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1747,74 +1723,74 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym146 := z.EncBinary()
-		_ = yym146
+		yym142 := z.EncBinary()
+		_ = yym142
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep147 := !z.EncBinary()
-			yy2arr147 := z.EncBasicHandle().StructToArray
-			var yyq147 [5]bool
-			_, _, _ = yysep147, yyq147, yy2arr147
-			const yyr147 bool = false
-			yyq147[0] = x.ObservedGeneration != nil
-			yyq147[1] = x.LastScaleTime != nil
-			yyq147[4] = x.CurrentCPUUtilizationPercentage != nil
-			if yyr147 || yy2arr147 {
+			yysep143 := !z.EncBinary()
+			yy2arr143 := z.EncBasicHandle().StructToArray
+			var yyq143 [5]bool
+			_, _, _ = yysep143, yyq143, yy2arr143
+			const yyr143 bool = false
+			yyq143[0] = x.ObservedGeneration != nil
+			yyq143[1] = x.LastScaleTime != nil
+			yyq143[4] = x.CurrentCPUUtilizationPercentage != nil
+			if yyr143 || yy2arr143 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn147 int = 2
-				for _, b := range yyq147 {
+				var yynn143 int = 2
+				for _, b := range yyq143 {
 					if b {
-						yynn147++
+						yynn143++
 					}
 				}
-				r.EncodeMapStart(yynn147)
+				r.EncodeMapStart(yynn143)
 			}
-			if yyr147 || yy2arr147 {
-				if yyq147[0] {
+			if yyr143 || yy2arr143 {
+				if yyq143[0] {
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy149 := *x.ObservedGeneration
-						yym150 := z.EncBinary()
-						_ = yym150
+						yy145 := *x.ObservedGeneration
+						yym146 := z.EncBinary()
+						_ = yym146
 						if false {
 						} else {
-							r.EncodeInt(int64(yy149))
+							r.EncodeInt(int64(yy145))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq147[0] {
+				if yyq143[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy151 := *x.ObservedGeneration
-						yym152 := z.EncBinary()
-						_ = yym152
+						yy147 := *x.ObservedGeneration
+						yym148 := z.EncBinary()
+						_ = yym148
 						if false {
 						} else {
-							r.EncodeInt(int64(yy151))
+							r.EncodeInt(int64(yy147))
 						}
 					}
 				}
 			}
-			if yyr147 || yy2arr147 {
-				if yyq147[1] {
+			if yyr143 || yy2arr143 {
+				if yyq143[1] {
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym154 := z.EncBinary()
-						_ = yym154
+						yym150 := z.EncBinary()
+						_ = yym150
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym154 {
+						} else if yym150 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym154 && z.IsJSONHandle() {
+						} else if !yym150 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1824,18 +1800,18 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq147[1] {
+				if yyq143[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastScaleTime"))
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym155 := z.EncBinary()
-						_ = yym155
+						yym151 := z.EncBinary()
+						_ = yym151
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym155 {
+						} else if yym151 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym155 && z.IsJSONHandle() {
+						} else if !yym151 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1843,71 +1819,71 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr147 || yy2arr147 {
-				yym157 := z.EncBinary()
-				_ = yym157
+			if yyr143 || yy2arr143 {
+				yym153 := z.EncBinary()
+				_ = yym153
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentReplicas"))
-				yym158 := z.EncBinary()
-				_ = yym158
+				yym154 := z.EncBinary()
+				_ = yym154
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			}
-			if yyr147 || yy2arr147 {
-				yym160 := z.EncBinary()
-				_ = yym160
+			if yyr143 || yy2arr143 {
+				yym156 := z.EncBinary()
+				_ = yym156
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredReplicas"))
-				yym161 := z.EncBinary()
-				_ = yym161
+				yym157 := z.EncBinary()
+				_ = yym157
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			}
-			if yyr147 || yy2arr147 {
-				if yyq147[4] {
+			if yyr143 || yy2arr143 {
+				if yyq143[4] {
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy163 := *x.CurrentCPUUtilizationPercentage
-						yym164 := z.EncBinary()
-						_ = yym164
+						yy159 := *x.CurrentCPUUtilizationPercentage
+						yym160 := z.EncBinary()
+						_ = yym160
 						if false {
 						} else {
-							r.EncodeInt(int64(yy163))
+							r.EncodeInt(int64(yy159))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq147[4] {
+				if yyq143[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("currentCPUUtilizationPercentage"))
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy165 := *x.CurrentCPUUtilizationPercentage
-						yym166 := z.EncBinary()
-						_ = yym166
+						yy161 := *x.CurrentCPUUtilizationPercentage
+						yym162 := z.EncBinary()
+						_ = yym162
 						if false {
 						} else {
-							r.EncodeInt(int64(yy165))
+							r.EncodeInt(int64(yy161))
 						}
 					}
 				}
 			}
-			if yysep147 {
+			if yysep143 {
 				r.EncodeEnd()
 			}
 		}
@@ -1918,24 +1894,24 @@ func (x *HorizontalPodAutoscalerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym167 := z.DecBinary()
-	_ = yym167
+	yym163 := z.DecBinary()
+	_ = yym163
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl168 := r.ReadMapStart()
-			if yyl168 == 0 {
+			yyl164 := r.ReadMapStart()
+			if yyl164 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl168, d)
+				x.codecDecodeSelfFromMap(yyl164, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl168 := r.ReadArrayStart()
-			if yyl168 == 0 {
+			yyl164 := r.ReadArrayStart()
+			if yyl164 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl168, d)
+				x.codecDecodeSelfFromArray(yyl164, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1947,12 +1923,12 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys169Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys169Slc
-	var yyhl169 bool = l >= 0
-	for yyj169 := 0; ; yyj169++ {
-		if yyhl169 {
-			if yyj169 >= l {
+	var yys165Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys165Slc
+	var yyhl165 bool = l >= 0
+	for yyj165 := 0; ; yyj165++ {
+		if yyhl165 {
+			if yyj165 >= l {
 				break
 			}
 		} else {
@@ -1960,9 +1936,9 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				break
 			}
 		}
-		yys169Slc = r.DecodeBytes(yys169Slc, true, true)
-		yys169 := string(yys169Slc)
-		switch yys169 {
+		yys165Slc = r.DecodeBytes(yys165Slc, true, true)
+		yys165 := string(yys165Slc)
+		switch yys165 {
 		case "observedGeneration":
 			if r.TryDecodeAsNil() {
 				if x.ObservedGeneration != nil {
@@ -1972,8 +1948,8 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.ObservedGeneration == nil {
 					x.ObservedGeneration = new(int64)
 				}
-				yym171 := z.DecBinary()
-				_ = yym171
+				yym167 := z.DecBinary()
+				_ = yym167
 				if false {
 				} else {
 					*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
@@ -1988,13 +1964,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.LastScaleTime == nil {
 					x.LastScaleTime = new(pkg1_unversioned.Time)
 				}
-				yym173 := z.DecBinary()
-				_ = yym173
+				yym169 := z.DecBinary()
+				_ = yym169
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-				} else if yym173 {
+				} else if yym169 {
 					z.DecBinaryUnmarshal(x.LastScaleTime)
-				} else if !yym173 && z.IsJSONHandle() {
+				} else if !yym169 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LastScaleTime)
 				} else {
 					z.DecFallback(x.LastScaleTime, false)
@@ -2021,18 +1997,18 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.CurrentCPUUtilizationPercentage == nil {
 					x.CurrentCPUUtilizationPercentage = new(int)
 				}
-				yym177 := z.DecBinary()
-				_ = yym177
+				yym173 := z.DecBinary()
+				_ = yym173
 				if false {
 				} else {
 					*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys169)
-		} // end switch yys169
-	} // end for yyj169
-	if !yyhl169 {
+			z.DecStructFieldNotFound(-1, yys165)
+		} // end switch yys165
+	} // end for yyj165
+	if !yyhl165 {
 		r.ReadEnd()
 	}
 }
@@ -2041,16 +2017,16 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj178 int
-	var yyb178 bool
-	var yyhl178 bool = l >= 0
-	yyj178++
-	if yyhl178 {
-		yyb178 = yyj178 > l
+	var yyj174 int
+	var yyb174 bool
+	var yyhl174 bool = l >= 0
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb178 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb178 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2062,20 +2038,20 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.ObservedGeneration == nil {
 			x.ObservedGeneration = new(int64)
 		}
-		yym180 := z.DecBinary()
-		_ = yym180
+		yym176 := z.DecBinary()
+		_ = yym176
 		if false {
 		} else {
 			*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj178++
-	if yyhl178 {
-		yyb178 = yyj178 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb178 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb178 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2087,25 +2063,25 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.LastScaleTime == nil {
 			x.LastScaleTime = new(pkg1_unversioned.Time)
 		}
-		yym182 := z.DecBinary()
-		_ = yym182
+		yym178 := z.DecBinary()
+		_ = yym178
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-		} else if yym182 {
+		} else if yym178 {
 			z.DecBinaryUnmarshal(x.LastScaleTime)
-		} else if !yym182 && z.IsJSONHandle() {
+		} else if !yym178 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LastScaleTime)
 		} else {
 			z.DecFallback(x.LastScaleTime, false)
 		}
 	}
-	yyj178++
-	if yyhl178 {
-		yyb178 = yyj178 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb178 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb178 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2114,13 +2090,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.CurrentReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj178++
-	if yyhl178 {
-		yyb178 = yyj178 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb178 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb178 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2129,13 +2105,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.DesiredReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj178++
-	if yyhl178 {
-		yyb178 = yyj178 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb178 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb178 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2147,24 +2123,24 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.CurrentCPUUtilizationPercentage == nil {
 			x.CurrentCPUUtilizationPercentage = new(int)
 		}
-		yym186 := z.DecBinary()
-		_ = yym186
+		yym182 := z.DecBinary()
+		_ = yym182
 		if false {
 		} else {
 			*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
 	for {
-		yyj178++
-		if yyhl178 {
-			yyb178 = yyj178 > l
+		yyj174++
+		if yyhl174 {
+			yyb174 = yyj174 > l
 		} else {
-			yyb178 = r.CheckBreak()
+			yyb174 = r.CheckBreak()
 		}
-		if yyb178 {
+		if yyb174 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj178-1, "")
+		z.DecStructFieldNotFound(yyj174-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2176,131 +2152,119 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym187 := z.EncBinary()
-		_ = yym187
+		yym183 := z.EncBinary()
+		_ = yym183
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep188 := !z.EncBinary()
-			yy2arr188 := z.EncBasicHandle().StructToArray
-			var yyq188 [5]bool
-			_, _, _ = yysep188, yyq188, yy2arr188
-			const yyr188 bool = false
-			yyq188[0] = x.Kind != ""
-			yyq188[1] = x.APIVersion != ""
-			yyq188[2] = true
-			yyq188[3] = true
-			yyq188[4] = true
-			if yyr188 || yy2arr188 {
+			yysep184 := !z.EncBinary()
+			yy2arr184 := z.EncBasicHandle().StructToArray
+			var yyq184 [5]bool
+			_, _, _ = yysep184, yyq184, yy2arr184
+			const yyr184 bool = false
+			yyq184[0] = x.Kind != ""
+			yyq184[1] = x.APIVersion != ""
+			yyq184[2] = true
+			yyq184[3] = true
+			yyq184[4] = true
+			if yyr184 || yy2arr184 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn188 int = 0
-				for _, b := range yyq188 {
+				var yynn184 int = 0
+				for _, b := range yyq184 {
 					if b {
-						yynn188++
+						yynn184++
 					}
 				}
-				r.EncodeMapStart(yynn188)
+				r.EncodeMapStart(yynn184)
 			}
-			if yyr188 || yy2arr188 {
-				if yyq188[0] {
+			if yyr184 || yy2arr184 {
+				if yyq184[0] {
+					yym186 := z.EncBinary()
+					_ = yym186
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq184[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym187 := z.EncBinary()
+					_ = yym187
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr184 || yy2arr184 {
+				if yyq184[1] {
+					yym189 := z.EncBinary()
+					_ = yym189
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq184[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym190 := z.EncBinary()
 					_ = yym190
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq188[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym191 := z.EncBinary()
-					_ = yym191
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr188 || yy2arr188 {
-				if yyq188[1] {
-					yym193 := z.EncBinary()
-					_ = yym193
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq188[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym194 := z.EncBinary()
-					_ = yym194
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr188 || yy2arr188 {
-				if yyq188[2] {
-					yy196 := &x.ObjectMeta
-					yym197 := z.EncBinary()
-					_ = yym197
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy196) {
-					} else {
-						z.EncFallback(yy196)
-					}
+			if yyr184 || yy2arr184 {
+				if yyq184[2] {
+					yy192 := &x.ObjectMeta
+					yy192.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq188[2] {
+				if yyq184[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy198 := &x.ObjectMeta
-					yym199 := z.EncBinary()
-					_ = yym199
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy198) {
-					} else {
-						z.EncFallback(yy198)
-					}
+					yy193 := &x.ObjectMeta
+					yy193.CodecEncodeSelf(e)
 				}
 			}
-			if yyr188 || yy2arr188 {
-				if yyq188[3] {
-					yy201 := &x.Spec
-					yy201.CodecEncodeSelf(e)
+			if yyr184 || yy2arr184 {
+				if yyq184[3] {
+					yy195 := &x.Spec
+					yy195.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq188[3] {
+				if yyq184[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy202 := &x.Spec
-					yy202.CodecEncodeSelf(e)
+					yy196 := &x.Spec
+					yy196.CodecEncodeSelf(e)
 				}
 			}
-			if yyr188 || yy2arr188 {
-				if yyq188[4] {
-					yy204 := &x.Status
-					yy204.CodecEncodeSelf(e)
+			if yyr184 || yy2arr184 {
+				if yyq184[4] {
+					yy198 := &x.Status
+					yy198.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq188[4] {
+				if yyq184[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy205 := &x.Status
-					yy205.CodecEncodeSelf(e)
+					yy199 := &x.Status
+					yy199.CodecEncodeSelf(e)
 				}
 			}
-			if yysep188 {
+			if yysep184 {
 				r.EncodeEnd()
 			}
 		}
@@ -2311,24 +2275,24 @@ func (x *HorizontalPodAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym206 := z.DecBinary()
-	_ = yym206
+	yym200 := z.DecBinary()
+	_ = yym200
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl207 := r.ReadMapStart()
-			if yyl207 == 0 {
+			yyl201 := r.ReadMapStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl207, d)
+				x.codecDecodeSelfFromMap(yyl201, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl207 := r.ReadArrayStart()
-			if yyl207 == 0 {
+			yyl201 := r.ReadArrayStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl207, d)
+				x.codecDecodeSelfFromArray(yyl201, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2340,12 +2304,12 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys208Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys208Slc
-	var yyhl208 bool = l >= 0
-	for yyj208 := 0; ; yyj208++ {
-		if yyhl208 {
-			if yyj208 >= l {
+	var yys202Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys202Slc
+	var yyhl202 bool = l >= 0
+	for yyj202 := 0; ; yyj202++ {
+		if yyhl202 {
+			if yyj202 >= l {
 				break
 			}
 		} else {
@@ -2353,9 +2317,9 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys208Slc = r.DecodeBytes(yys208Slc, true, true)
-		yys208 := string(yys208Slc)
-		switch yys208 {
+		yys202Slc = r.DecodeBytes(yys202Slc, true, true)
+		yys202 := string(yys202Slc)
+		switch yys202 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2372,34 +2336,28 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv211 := &x.ObjectMeta
-				yym212 := z.DecBinary()
-				_ = yym212
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv211) {
-				} else {
-					z.DecFallback(yyv211, false)
-				}
+				yyv205 := &x.ObjectMeta
+				yyv205.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = HorizontalPodAutoscalerSpec{}
 			} else {
-				yyv213 := &x.Spec
-				yyv213.CodecDecodeSelf(d)
+				yyv206 := &x.Spec
+				yyv206.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = HorizontalPodAutoscalerStatus{}
 			} else {
-				yyv214 := &x.Status
-				yyv214.CodecDecodeSelf(d)
+				yyv207 := &x.Status
+				yyv207.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys208)
-		} // end switch yys208
-	} // end for yyj208
-	if !yyhl208 {
+			z.DecStructFieldNotFound(-1, yys202)
+		} // end switch yys202
+	} // end for yyj202
+	if !yyhl202 {
 		r.ReadEnd()
 	}
 }
@@ -2408,16 +2366,16 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj215 int
-	var yyb215 bool
-	var yyhl215 bool = l >= 0
-	yyj215++
-	if yyhl215 {
-		yyb215 = yyj215 > l
+	var yyj208 int
+	var yyb208 bool
+	var yyhl208 bool = l >= 0
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb215 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb215 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
@@ -2426,13 +2384,13 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj215++
-	if yyhl215 {
-		yyb215 = yyj215 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb215 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb215 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
@@ -2441,71 +2399,65 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj215++
-	if yyhl215 {
-		yyb215 = yyj215 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb215 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb215 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv218 := &x.ObjectMeta
-		yym219 := z.DecBinary()
-		_ = yym219
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv218) {
-		} else {
-			z.DecFallback(yyv218, false)
-		}
+		yyv211 := &x.ObjectMeta
+		yyv211.CodecDecodeSelf(d)
 	}
-	yyj215++
-	if yyhl215 {
-		yyb215 = yyj215 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb215 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb215 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = HorizontalPodAutoscalerSpec{}
 	} else {
-		yyv220 := &x.Spec
-		yyv220.CodecDecodeSelf(d)
+		yyv212 := &x.Spec
+		yyv212.CodecDecodeSelf(d)
 	}
-	yyj215++
-	if yyhl215 {
-		yyb215 = yyj215 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb215 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb215 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = HorizontalPodAutoscalerStatus{}
 	} else {
-		yyv221 := &x.Status
-		yyv221.CodecDecodeSelf(d)
+		yyv213 := &x.Status
+		yyv213.CodecDecodeSelf(d)
 	}
 	for {
-		yyj215++
-		if yyhl215 {
-			yyb215 = yyj215 > l
+		yyj208++
+		if yyhl208 {
+			yyb208 = yyj208 > l
 		} else {
-			yyb215 = r.CheckBreak()
+			yyb208 = r.CheckBreak()
 		}
-		if yyb215 {
+		if yyb208 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj215-1, "")
+		z.DecStructFieldNotFound(yyj208-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2517,34 +2469,34 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym222 := z.EncBinary()
-		_ = yym222
+		yym214 := z.EncBinary()
+		_ = yym214
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep223 := !z.EncBinary()
-			yy2arr223 := z.EncBasicHandle().StructToArray
-			var yyq223 [4]bool
-			_, _, _ = yysep223, yyq223, yy2arr223
-			const yyr223 bool = false
-			yyq223[0] = x.Kind != ""
-			yyq223[1] = x.APIVersion != ""
-			yyq223[2] = true
-			if yyr223 || yy2arr223 {
+			yysep215 := !z.EncBinary()
+			yy2arr215 := z.EncBasicHandle().StructToArray
+			var yyq215 [4]bool
+			_, _, _ = yysep215, yyq215, yy2arr215
+			const yyr215 bool = false
+			yyq215[0] = x.Kind != ""
+			yyq215[1] = x.APIVersion != ""
+			yyq215[2] = true
+			if yyr215 || yy2arr215 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn223 int = 1
-				for _, b := range yyq223 {
+				var yynn215 int = 1
+				for _, b := range yyq215 {
 					if b {
-						yynn223++
+						yynn215++
 					}
 				}
-				r.EncodeMapStart(yynn223)
+				r.EncodeMapStart(yynn215)
 			}
-			if yyr223 || yy2arr223 {
-				if yyq223[0] {
-					yym225 := z.EncBinary()
-					_ = yym225
+			if yyr215 || yy2arr215 {
+				if yyq215[0] {
+					yym217 := z.EncBinary()
+					_ = yym217
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2553,70 +2505,70 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq223[0] {
+				if yyq215[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym218 := z.EncBinary()
+					_ = yym218
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr215 || yy2arr215 {
+				if yyq215[1] {
+					yym220 := z.EncBinary()
+					_ = yym220
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq215[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym221 := z.EncBinary()
+					_ = yym221
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr215 || yy2arr215 {
+				if yyq215[2] {
+					yy223 := &x.ListMeta
+					yym224 := z.EncBinary()
+					_ = yym224
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy223) {
+					} else {
+						z.EncFallback(yy223)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq215[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy225 := &x.ListMeta
 					yym226 := z.EncBinary()
 					_ = yym226
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy225) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						z.EncFallback(yy225)
 					}
 				}
 			}
-			if yyr223 || yy2arr223 {
-				if yyq223[1] {
-					yym228 := z.EncBinary()
-					_ = yym228
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq223[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym229 := z.EncBinary()
-					_ = yym229
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr223 || yy2arr223 {
-				if yyq223[2] {
-					yy231 := &x.ListMeta
-					yym232 := z.EncBinary()
-					_ = yym232
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy231) {
-					} else {
-						z.EncFallback(yy231)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq223[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy233 := &x.ListMeta
-					yym234 := z.EncBinary()
-					_ = yym234
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy233) {
-					} else {
-						z.EncFallback(yy233)
-					}
-				}
-			}
-			if yyr223 || yy2arr223 {
+			if yyr215 || yy2arr215 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym236 := z.EncBinary()
-					_ = yym236
+					yym228 := z.EncBinary()
+					_ = yym228
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
@@ -2627,15 +2579,15 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym237 := z.EncBinary()
-					_ = yym237
+					yym229 := z.EncBinary()
+					_ = yym229
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep223 {
+			if yysep215 {
 				r.EncodeEnd()
 			}
 		}
@@ -2646,24 +2598,24 @@ func (x *HorizontalPodAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym238 := z.DecBinary()
-	_ = yym238
+	yym230 := z.DecBinary()
+	_ = yym230
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl239 := r.ReadMapStart()
-			if yyl239 == 0 {
+			yyl231 := r.ReadMapStart()
+			if yyl231 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl239, d)
+				x.codecDecodeSelfFromMap(yyl231, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl239 := r.ReadArrayStart()
-			if yyl239 == 0 {
+			yyl231 := r.ReadArrayStart()
+			if yyl231 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl239, d)
+				x.codecDecodeSelfFromArray(yyl231, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2675,12 +2627,12 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys240Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys240Slc
-	var yyhl240 bool = l >= 0
-	for yyj240 := 0; ; yyj240++ {
-		if yyhl240 {
-			if yyj240 >= l {
+	var yys232Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys232Slc
+	var yyhl232 bool = l >= 0
+	for yyj232 := 0; ; yyj232++ {
+		if yyhl232 {
+			if yyj232 >= l {
 				break
 			}
 		} else {
@@ -2688,9 +2640,9 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys240Slc = r.DecodeBytes(yys240Slc, true, true)
-		yys240 := string(yys240Slc)
-		switch yys240 {
+		yys232Slc = r.DecodeBytes(yys232Slc, true, true)
+		yys232 := string(yys232Slc)
+		switch yys232 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2707,32 +2659,32 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv243 := &x.ListMeta
-				yym244 := z.DecBinary()
-				_ = yym244
+				yyv235 := &x.ListMeta
+				yym236 := z.DecBinary()
+				_ = yym236
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv243) {
+				} else if z.HasExtensions() && z.DecExt(yyv235) {
 				} else {
-					z.DecFallback(yyv243, false)
+					z.DecFallback(yyv235, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv245 := &x.Items
-				yym246 := z.DecBinary()
-				_ = yym246
+				yyv237 := &x.Items
+				yym238 := z.DecBinary()
+				_ = yym238
 				if false {
 				} else {
-					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv245), d)
+					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv237), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys240)
-		} // end switch yys240
-	} // end for yyj240
-	if !yyhl240 {
+			z.DecStructFieldNotFound(-1, yys232)
+		} // end switch yys232
+	} // end for yyj232
+	if !yyhl232 {
 		r.ReadEnd()
 	}
 }
@@ -2741,16 +2693,16 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj247 int
-	var yyb247 bool
-	var yyhl247 bool = l >= 0
-	yyj247++
-	if yyhl247 {
-		yyb247 = yyj247 > l
+	var yyj239 int
+	var yyb239 bool
+	var yyhl239 bool = l >= 0
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb247 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb247 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
@@ -2759,13 +2711,13 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj247++
-	if yyhl247 {
-		yyb247 = yyj247 > l
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb247 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb247 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
@@ -2774,60 +2726,60 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj247++
-	if yyhl247 {
-		yyb247 = yyj247 > l
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb247 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb247 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv250 := &x.ListMeta
-		yym251 := z.DecBinary()
-		_ = yym251
+		yyv242 := &x.ListMeta
+		yym243 := z.DecBinary()
+		_ = yym243
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv250) {
+		} else if z.HasExtensions() && z.DecExt(yyv242) {
 		} else {
-			z.DecFallback(yyv250, false)
+			z.DecFallback(yyv242, false)
 		}
 	}
-	yyj247++
-	if yyhl247 {
-		yyb247 = yyj247 > l
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb247 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb247 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv252 := &x.Items
-		yym253 := z.DecBinary()
-		_ = yym253
+		yyv244 := &x.Items
+		yym245 := z.DecBinary()
+		_ = yym245
 		if false {
 		} else {
-			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv252), d)
+			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv244), d)
 		}
 	}
 	for {
-		yyj247++
-		if yyhl247 {
-			yyb247 = yyj247 > l
+		yyj239++
+		if yyhl239 {
+			yyb239 = yyj239 > l
 		} else {
-			yyb247 = r.CheckBreak()
+			yyb239 = r.CheckBreak()
 		}
-		if yyb247 {
+		if yyb239 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj247-1, "")
+		z.DecStructFieldNotFound(yyj239-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2839,36 +2791,36 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym254 := z.EncBinary()
-		_ = yym254
+		yym246 := z.EncBinary()
+		_ = yym246
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep255 := !z.EncBinary()
-			yy2arr255 := z.EncBasicHandle().StructToArray
-			var yyq255 [5]bool
-			_, _, _ = yysep255, yyq255, yy2arr255
-			const yyr255 bool = false
-			yyq255[0] = x.Kind != ""
-			yyq255[1] = x.APIVersion != ""
-			yyq255[2] = true
-			yyq255[3] = x.Description != ""
-			yyq255[4] = len(x.Versions) != 0
-			if yyr255 || yy2arr255 {
+			yysep247 := !z.EncBinary()
+			yy2arr247 := z.EncBasicHandle().StructToArray
+			var yyq247 [5]bool
+			_, _, _ = yysep247, yyq247, yy2arr247
+			const yyr247 bool = false
+			yyq247[0] = x.Kind != ""
+			yyq247[1] = x.APIVersion != ""
+			yyq247[2] = true
+			yyq247[3] = x.Description != ""
+			yyq247[4] = len(x.Versions) != 0
+			if yyr247 || yy2arr247 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn255 int = 0
-				for _, b := range yyq255 {
+				var yynn247 int = 0
+				for _, b := range yyq247 {
 					if b {
-						yynn255++
+						yynn247++
 					}
 				}
-				r.EncodeMapStart(yynn255)
+				r.EncodeMapStart(yynn247)
 			}
-			if yyr255 || yy2arr255 {
-				if yyq255[0] {
-					yym257 := z.EncBinary()
-					_ = yym257
+			if yyr247 || yy2arr247 {
+				if yyq247[0] {
+					yym249 := z.EncBinary()
+					_ = yym249
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2877,93 +2829,81 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq255[0] {
+				if yyq247[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym250 := z.EncBinary()
+					_ = yym250
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr247 || yy2arr247 {
+				if yyq247[1] {
+					yym252 := z.EncBinary()
+					_ = yym252
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq247[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym253 := z.EncBinary()
+					_ = yym253
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr247 || yy2arr247 {
+				if yyq247[2] {
+					yy255 := &x.ObjectMeta
+					yy255.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq247[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy256 := &x.ObjectMeta
+					yy256.CodecEncodeSelf(e)
+				}
+			}
+			if yyr247 || yy2arr247 {
+				if yyq247[3] {
 					yym258 := z.EncBinary()
 					_ = yym258
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr255 || yy2arr255 {
-				if yyq255[1] {
-					yym260 := z.EncBinary()
-					_ = yym260
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq255[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym261 := z.EncBinary()
-					_ = yym261
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr255 || yy2arr255 {
-				if yyq255[2] {
-					yy263 := &x.ObjectMeta
-					yym264 := z.EncBinary()
-					_ = yym264
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy263) {
-					} else {
-						z.EncFallback(yy263)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq255[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy265 := &x.ObjectMeta
-					yym266 := z.EncBinary()
-					_ = yym266
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy265) {
-					} else {
-						z.EncFallback(yy265)
-					}
-				}
-			}
-			if yyr255 || yy2arr255 {
-				if yyq255[3] {
-					yym268 := z.EncBinary()
-					_ = yym268
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq255[3] {
+				if yyq247[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("description"))
-					yym269 := z.EncBinary()
-					_ = yym269
+					yym259 := z.EncBinary()
+					_ = yym259
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				}
 			}
-			if yyr255 || yy2arr255 {
-				if yyq255[4] {
+			if yyr247 || yy2arr247 {
+				if yyq247[4] {
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym271 := z.EncBinary()
-						_ = yym271
+						yym261 := z.EncBinary()
+						_ = yym261
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2973,13 +2913,13 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq255[4] {
+				if yyq247[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("versions"))
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym272 := z.EncBinary()
-						_ = yym272
+						yym262 := z.EncBinary()
+						_ = yym262
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2987,7 +2927,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep255 {
+			if yysep247 {
 				r.EncodeEnd()
 			}
 		}
@@ -2998,24 +2938,24 @@ func (x *ThirdPartyResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym273 := z.DecBinary()
-	_ = yym273
+	yym263 := z.DecBinary()
+	_ = yym263
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl274 := r.ReadMapStart()
-			if yyl274 == 0 {
+			yyl264 := r.ReadMapStart()
+			if yyl264 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl274, d)
+				x.codecDecodeSelfFromMap(yyl264, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl274 := r.ReadArrayStart()
-			if yyl274 == 0 {
+			yyl264 := r.ReadArrayStart()
+			if yyl264 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl274, d)
+				x.codecDecodeSelfFromArray(yyl264, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3027,12 +2967,12 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys275Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys275Slc
-	var yyhl275 bool = l >= 0
-	for yyj275 := 0; ; yyj275++ {
-		if yyhl275 {
-			if yyj275 >= l {
+	var yys265Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys265Slc
+	var yyhl265 bool = l >= 0
+	for yyj265 := 0; ; yyj265++ {
+		if yyhl265 {
+			if yyj265 >= l {
 				break
 			}
 		} else {
@@ -3040,9 +2980,9 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys275Slc = r.DecodeBytes(yys275Slc, true, true)
-		yys275 := string(yys275Slc)
-		switch yys275 {
+		yys265Slc = r.DecodeBytes(yys265Slc, true, true)
+		yys265 := string(yys265Slc)
+		switch yys265 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3059,14 +2999,8 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv278 := &x.ObjectMeta
-				yym279 := z.DecBinary()
-				_ = yym279
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv278) {
-				} else {
-					z.DecFallback(yyv278, false)
-				}
+				yyv268 := &x.ObjectMeta
+				yyv268.CodecDecodeSelf(d)
 			}
 		case "description":
 			if r.TryDecodeAsNil() {
@@ -3078,19 +3012,19 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Versions = nil
 			} else {
-				yyv281 := &x.Versions
-				yym282 := z.DecBinary()
-				_ = yym282
+				yyv270 := &x.Versions
+				yym271 := z.DecBinary()
+				_ = yym271
 				if false {
 				} else {
-					h.decSliceAPIVersion((*[]APIVersion)(yyv281), d)
+					h.decSliceAPIVersion((*[]APIVersion)(yyv270), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys275)
-		} // end switch yys275
-	} // end for yyj275
-	if !yyhl275 {
+			z.DecStructFieldNotFound(-1, yys265)
+		} // end switch yys265
+	} // end for yyj265
+	if !yyhl265 {
 		r.ReadEnd()
 	}
 }
@@ -3099,16 +3033,16 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj283 int
-	var yyb283 bool
-	var yyhl283 bool = l >= 0
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
+	var yyj272 int
+	var yyb272 bool
+	var yyhl272 bool = l >= 0
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb283 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb283 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
@@ -3117,13 +3051,13 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb283 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb283 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
@@ -3132,35 +3066,29 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb283 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb283 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv286 := &x.ObjectMeta
-		yym287 := z.DecBinary()
-		_ = yym287
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv286) {
-		} else {
-			z.DecFallback(yyv286, false)
-		}
+		yyv275 := &x.ObjectMeta
+		yyv275.CodecDecodeSelf(d)
 	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb283 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb283 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
@@ -3169,38 +3097,38 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Description = string(r.DecodeString())
 	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb283 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb283 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Versions = nil
 	} else {
-		yyv289 := &x.Versions
-		yym290 := z.DecBinary()
-		_ = yym290
+		yyv277 := &x.Versions
+		yym278 := z.DecBinary()
+		_ = yym278
 		if false {
 		} else {
-			h.decSliceAPIVersion((*[]APIVersion)(yyv289), d)
+			h.decSliceAPIVersion((*[]APIVersion)(yyv277), d)
 		}
 	}
 	for {
-		yyj283++
-		if yyhl283 {
-			yyb283 = yyj283 > l
+		yyj272++
+		if yyhl272 {
+			yyb272 = yyj272 > l
 		} else {
-			yyb283 = r.CheckBreak()
+			yyb272 = r.CheckBreak()
 		}
-		if yyb283 {
+		if yyb272 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj283-1, "")
+		z.DecStructFieldNotFound(yyj272-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3212,34 +3140,34 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym291 := z.EncBinary()
-		_ = yym291
+		yym279 := z.EncBinary()
+		_ = yym279
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep292 := !z.EncBinary()
-			yy2arr292 := z.EncBasicHandle().StructToArray
-			var yyq292 [4]bool
-			_, _, _ = yysep292, yyq292, yy2arr292
-			const yyr292 bool = false
-			yyq292[0] = x.Kind != ""
-			yyq292[1] = x.APIVersion != ""
-			yyq292[2] = true
-			if yyr292 || yy2arr292 {
+			yysep280 := !z.EncBinary()
+			yy2arr280 := z.EncBasicHandle().StructToArray
+			var yyq280 [4]bool
+			_, _, _ = yysep280, yyq280, yy2arr280
+			const yyr280 bool = false
+			yyq280[0] = x.Kind != ""
+			yyq280[1] = x.APIVersion != ""
+			yyq280[2] = true
+			if yyr280 || yy2arr280 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn292 int = 1
-				for _, b := range yyq292 {
+				var yynn280 int = 1
+				for _, b := range yyq280 {
 					if b {
-						yynn292++
+						yynn280++
 					}
 				}
-				r.EncodeMapStart(yynn292)
+				r.EncodeMapStart(yynn280)
 			}
-			if yyr292 || yy2arr292 {
-				if yyq292[0] {
-					yym294 := z.EncBinary()
-					_ = yym294
+			if yyr280 || yy2arr280 {
+				if yyq280[0] {
+					yym282 := z.EncBinary()
+					_ = yym282
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3248,20 +3176,20 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq292[0] {
+				if yyq280[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym295 := z.EncBinary()
-					_ = yym295
+					yym283 := z.EncBinary()
+					_ = yym283
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr292 || yy2arr292 {
-				if yyq292[1] {
-					yym297 := z.EncBinary()
-					_ = yym297
+			if yyr280 || yy2arr280 {
+				if yyq280[1] {
+					yym285 := z.EncBinary()
+					_ = yym285
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3270,48 +3198,48 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq292[1] {
+				if yyq280[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym298 := z.EncBinary()
-					_ = yym298
+					yym286 := z.EncBinary()
+					_ = yym286
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr292 || yy2arr292 {
-				if yyq292[2] {
-					yy300 := &x.ListMeta
-					yym301 := z.EncBinary()
-					_ = yym301
+			if yyr280 || yy2arr280 {
+				if yyq280[2] {
+					yy288 := &x.ListMeta
+					yym289 := z.EncBinary()
+					_ = yym289
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy300) {
+					} else if z.HasExtensions() && z.EncExt(yy288) {
 					} else {
-						z.EncFallback(yy300)
+						z.EncFallback(yy288)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq292[2] {
+				if yyq280[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy302 := &x.ListMeta
-					yym303 := z.EncBinary()
-					_ = yym303
+					yy290 := &x.ListMeta
+					yym291 := z.EncBinary()
+					_ = yym291
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy302) {
+					} else if z.HasExtensions() && z.EncExt(yy290) {
 					} else {
-						z.EncFallback(yy302)
+						z.EncFallback(yy290)
 					}
 				}
 			}
-			if yyr292 || yy2arr292 {
+			if yyr280 || yy2arr280 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym305 := z.EncBinary()
-					_ = yym305
+					yym293 := z.EncBinary()
+					_ = yym293
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
@@ -3322,15 +3250,15 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym306 := z.EncBinary()
-					_ = yym306
+					yym294 := z.EncBinary()
+					_ = yym294
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
 					}
 				}
 			}
-			if yysep292 {
+			if yysep280 {
 				r.EncodeEnd()
 			}
 		}
@@ -3341,24 +3269,24 @@ func (x *ThirdPartyResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym307 := z.DecBinary()
-	_ = yym307
+	yym295 := z.DecBinary()
+	_ = yym295
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl308 := r.ReadMapStart()
-			if yyl308 == 0 {
+			yyl296 := r.ReadMapStart()
+			if yyl296 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl308, d)
+				x.codecDecodeSelfFromMap(yyl296, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl308 := r.ReadArrayStart()
-			if yyl308 == 0 {
+			yyl296 := r.ReadArrayStart()
+			if yyl296 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl308, d)
+				x.codecDecodeSelfFromArray(yyl296, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3370,12 +3298,12 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys309Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys309Slc
-	var yyhl309 bool = l >= 0
-	for yyj309 := 0; ; yyj309++ {
-		if yyhl309 {
-			if yyj309 >= l {
+	var yys297Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys297Slc
+	var yyhl297 bool = l >= 0
+	for yyj297 := 0; ; yyj297++ {
+		if yyhl297 {
+			if yyj297 >= l {
 				break
 			}
 		} else {
@@ -3383,9 +3311,9 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys309Slc = r.DecodeBytes(yys309Slc, true, true)
-		yys309 := string(yys309Slc)
-		switch yys309 {
+		yys297Slc = r.DecodeBytes(yys297Slc, true, true)
+		yys297 := string(yys297Slc)
+		switch yys297 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3402,32 +3330,32 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv312 := &x.ListMeta
-				yym313 := z.DecBinary()
-				_ = yym313
+				yyv300 := &x.ListMeta
+				yym301 := z.DecBinary()
+				_ = yym301
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv312) {
+				} else if z.HasExtensions() && z.DecExt(yyv300) {
 				} else {
-					z.DecFallback(yyv312, false)
+					z.DecFallback(yyv300, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv314 := &x.Items
-				yym315 := z.DecBinary()
-				_ = yym315
+				yyv302 := &x.Items
+				yym303 := z.DecBinary()
+				_ = yym303
 				if false {
 				} else {
-					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv314), d)
+					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv302), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys309)
-		} // end switch yys309
-	} // end for yyj309
-	if !yyhl309 {
+			z.DecStructFieldNotFound(-1, yys297)
+		} // end switch yys297
+	} // end for yyj297
+	if !yyhl297 {
 		r.ReadEnd()
 	}
 }
@@ -3436,16 +3364,16 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj316 int
-	var yyb316 bool
-	var yyhl316 bool = l >= 0
-	yyj316++
-	if yyhl316 {
-		yyb316 = yyj316 > l
+	var yyj304 int
+	var yyb304 bool
+	var yyhl304 bool = l >= 0
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb316 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb316 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
@@ -3454,13 +3382,13 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj316++
-	if yyhl316 {
-		yyb316 = yyj316 > l
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb316 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb316 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
@@ -3469,60 +3397,60 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj316++
-	if yyhl316 {
-		yyb316 = yyj316 > l
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb316 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb316 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv319 := &x.ListMeta
-		yym320 := z.DecBinary()
-		_ = yym320
+		yyv307 := &x.ListMeta
+		yym308 := z.DecBinary()
+		_ = yym308
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv319) {
+		} else if z.HasExtensions() && z.DecExt(yyv307) {
 		} else {
-			z.DecFallback(yyv319, false)
+			z.DecFallback(yyv307, false)
 		}
 	}
-	yyj316++
-	if yyhl316 {
-		yyb316 = yyj316 > l
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb316 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb316 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv321 := &x.Items
-		yym322 := z.DecBinary()
-		_ = yym322
+		yyv309 := &x.Items
+		yym310 := z.DecBinary()
+		_ = yym310
 		if false {
 		} else {
-			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv321), d)
+			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv309), d)
 		}
 	}
 	for {
-		yyj316++
-		if yyhl316 {
-			yyb316 = yyj316 > l
+		yyj304++
+		if yyhl304 {
+			yyb304 = yyj304 > l
 		} else {
-			yyb316 = r.CheckBreak()
+			yyb304 = r.CheckBreak()
 		}
-		if yyb316 {
+		if yyb304 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj316-1, "")
+		z.DecStructFieldNotFound(yyj304-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3534,33 +3462,33 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym323 := z.EncBinary()
-		_ = yym323
+		yym311 := z.EncBinary()
+		_ = yym311
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep324 := !z.EncBinary()
-			yy2arr324 := z.EncBasicHandle().StructToArray
-			var yyq324 [2]bool
-			_, _, _ = yysep324, yyq324, yy2arr324
-			const yyr324 bool = false
-			yyq324[0] = x.Name != ""
-			yyq324[1] = x.APIGroup != ""
-			if yyr324 || yy2arr324 {
+			yysep312 := !z.EncBinary()
+			yy2arr312 := z.EncBasicHandle().StructToArray
+			var yyq312 [2]bool
+			_, _, _ = yysep312, yyq312, yy2arr312
+			const yyr312 bool = false
+			yyq312[0] = x.Name != ""
+			yyq312[1] = x.APIGroup != ""
+			if yyr312 || yy2arr312 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn324 int = 0
-				for _, b := range yyq324 {
+				var yynn312 int = 0
+				for _, b := range yyq312 {
 					if b {
-						yynn324++
+						yynn312++
 					}
 				}
-				r.EncodeMapStart(yynn324)
+				r.EncodeMapStart(yynn312)
 			}
-			if yyr324 || yy2arr324 {
-				if yyq324[0] {
-					yym326 := z.EncBinary()
-					_ = yym326
+			if yyr312 || yy2arr312 {
+				if yyq312[0] {
+					yym314 := z.EncBinary()
+					_ = yym314
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -3569,20 +3497,20 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq324[0] {
+				if yyq312[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym327 := z.EncBinary()
-					_ = yym327
+					yym315 := z.EncBinary()
+					_ = yym315
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yyr324 || yy2arr324 {
-				if yyq324[1] {
-					yym329 := z.EncBinary()
-					_ = yym329
+			if yyr312 || yy2arr312 {
+				if yyq312[1] {
+					yym317 := z.EncBinary()
+					_ = yym317
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
@@ -3591,17 +3519,17 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq324[1] {
+				if yyq312[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiGroup"))
-					yym330 := z.EncBinary()
-					_ = yym330
+					yym318 := z.EncBinary()
+					_ = yym318
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
 					}
 				}
 			}
-			if yysep324 {
+			if yysep312 {
 				r.EncodeEnd()
 			}
 		}
@@ -3612,24 +3540,24 @@ func (x *APIVersion) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym331 := z.DecBinary()
-	_ = yym331
+	yym319 := z.DecBinary()
+	_ = yym319
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl332 := r.ReadMapStart()
-			if yyl332 == 0 {
+			yyl320 := r.ReadMapStart()
+			if yyl320 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl332, d)
+				x.codecDecodeSelfFromMap(yyl320, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl332 := r.ReadArrayStart()
-			if yyl332 == 0 {
+			yyl320 := r.ReadArrayStart()
+			if yyl320 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl332, d)
+				x.codecDecodeSelfFromArray(yyl320, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3641,12 +3569,12 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys333Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys333Slc
-	var yyhl333 bool = l >= 0
-	for yyj333 := 0; ; yyj333++ {
-		if yyhl333 {
-			if yyj333 >= l {
+	var yys321Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys321Slc
+	var yyhl321 bool = l >= 0
+	for yyj321 := 0; ; yyj321++ {
+		if yyhl321 {
+			if yyj321 >= l {
 				break
 			}
 		} else {
@@ -3654,9 +3582,9 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys333Slc = r.DecodeBytes(yys333Slc, true, true)
-		yys333 := string(yys333Slc)
-		switch yys333 {
+		yys321Slc = r.DecodeBytes(yys321Slc, true, true)
+		yys321 := string(yys321Slc)
+		switch yys321 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -3670,10 +3598,10 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIGroup = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys333)
-		} // end switch yys333
-	} // end for yyj333
-	if !yyhl333 {
+			z.DecStructFieldNotFound(-1, yys321)
+		} // end switch yys321
+	} // end for yyj321
+	if !yyhl321 {
 		r.ReadEnd()
 	}
 }
@@ -3682,16 +3610,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj336 int
-	var yyb336 bool
-	var yyhl336 bool = l >= 0
-	yyj336++
-	if yyhl336 {
-		yyb336 = yyj336 > l
+	var yyj324 int
+	var yyb324 bool
+	var yyhl324 bool = l >= 0
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
 	} else {
-		yyb336 = r.CheckBreak()
+		yyb324 = r.CheckBreak()
 	}
-	if yyb336 {
+	if yyb324 {
 		r.ReadEnd()
 		return
 	}
@@ -3700,13 +3628,13 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj336++
-	if yyhl336 {
-		yyb336 = yyj336 > l
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
 	} else {
-		yyb336 = r.CheckBreak()
+		yyb324 = r.CheckBreak()
 	}
-	if yyb336 {
+	if yyb324 {
 		r.ReadEnd()
 		return
 	}
@@ -3716,16 +3644,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIGroup = string(r.DecodeString())
 	}
 	for {
-		yyj336++
-		if yyhl336 {
-			yyb336 = yyj336 > l
+		yyj324++
+		if yyhl324 {
+			yyb324 = yyj324 > l
 		} else {
-			yyb336 = r.CheckBreak()
+			yyb324 = r.CheckBreak()
 		}
-		if yyb336 {
+		if yyb324 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj336-1, "")
+		z.DecStructFieldNotFound(yyj324-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3737,35 +3665,35 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym339 := z.EncBinary()
-		_ = yym339
+		yym327 := z.EncBinary()
+		_ = yym327
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep340 := !z.EncBinary()
-			yy2arr340 := z.EncBasicHandle().StructToArray
-			var yyq340 [4]bool
-			_, _, _ = yysep340, yyq340, yy2arr340
-			const yyr340 bool = false
-			yyq340[0] = x.Kind != ""
-			yyq340[1] = x.APIVersion != ""
-			yyq340[2] = true
-			yyq340[3] = len(x.Data) != 0
-			if yyr340 || yy2arr340 {
+			yysep328 := !z.EncBinary()
+			yy2arr328 := z.EncBasicHandle().StructToArray
+			var yyq328 [4]bool
+			_, _, _ = yysep328, yyq328, yy2arr328
+			const yyr328 bool = false
+			yyq328[0] = x.Kind != ""
+			yyq328[1] = x.APIVersion != ""
+			yyq328[2] = true
+			yyq328[3] = len(x.Data) != 0
+			if yyr328 || yy2arr328 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn340 int = 0
-				for _, b := range yyq340 {
+				var yynn328 int = 0
+				for _, b := range yyq328 {
 					if b {
-						yynn340++
+						yynn328++
 					}
 				}
-				r.EncodeMapStart(yynn340)
+				r.EncodeMapStart(yynn328)
 			}
-			if yyr340 || yy2arr340 {
-				if yyq340[0] {
-					yym342 := z.EncBinary()
-					_ = yym342
+			if yyr328 || yy2arr328 {
+				if yyq328[0] {
+					yym330 := z.EncBinary()
+					_ = yym330
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3774,20 +3702,20 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq340[0] {
+				if yyq328[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym343 := z.EncBinary()
-					_ = yym343
+					yym331 := z.EncBinary()
+					_ = yym331
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr340 || yy2arr340 {
-				if yyq340[1] {
-					yym345 := z.EncBinary()
-					_ = yym345
+			if yyr328 || yy2arr328 {
+				if yyq328[1] {
+					yym333 := z.EncBinary()
+					_ = yym333
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3796,49 +3724,37 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq340[1] {
+				if yyq328[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym346 := z.EncBinary()
-					_ = yym346
+					yym334 := z.EncBinary()
+					_ = yym334
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr340 || yy2arr340 {
-				if yyq340[2] {
-					yy348 := &x.ObjectMeta
-					yym349 := z.EncBinary()
-					_ = yym349
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy348) {
-					} else {
-						z.EncFallback(yy348)
-					}
+			if yyr328 || yy2arr328 {
+				if yyq328[2] {
+					yy336 := &x.ObjectMeta
+					yy336.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq340[2] {
+				if yyq328[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy350 := &x.ObjectMeta
-					yym351 := z.EncBinary()
-					_ = yym351
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy350) {
-					} else {
-						z.EncFallback(yy350)
-					}
+					yy337 := &x.ObjectMeta
+					yy337.CodecEncodeSelf(e)
 				}
 			}
-			if yyr340 || yy2arr340 {
-				if yyq340[3] {
+			if yyr328 || yy2arr328 {
+				if yyq328[3] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym353 := z.EncBinary()
-						_ = yym353
+						yym339 := z.EncBinary()
+						_ = yym339
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3848,13 +3764,13 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq340[3] {
+				if yyq328[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym354 := z.EncBinary()
-						_ = yym354
+						yym340 := z.EncBinary()
+						_ = yym340
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3862,7 +3778,7 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep340 {
+			if yysep328 {
 				r.EncodeEnd()
 			}
 		}
@@ -3873,24 +3789,24 @@ func (x *ThirdPartyResourceData) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym355 := z.DecBinary()
-	_ = yym355
+	yym341 := z.DecBinary()
+	_ = yym341
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl356 := r.ReadMapStart()
-			if yyl356 == 0 {
+			yyl342 := r.ReadMapStart()
+			if yyl342 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl356, d)
+				x.codecDecodeSelfFromMap(yyl342, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl356 := r.ReadArrayStart()
-			if yyl356 == 0 {
+			yyl342 := r.ReadArrayStart()
+			if yyl342 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl356, d)
+				x.codecDecodeSelfFromArray(yyl342, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3902,12 +3818,12 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys357Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys357Slc
-	var yyhl357 bool = l >= 0
-	for yyj357 := 0; ; yyj357++ {
-		if yyhl357 {
-			if yyj357 >= l {
+	var yys343Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys343Slc
+	var yyhl343 bool = l >= 0
+	for yyj343 := 0; ; yyj343++ {
+		if yyhl343 {
+			if yyj343 >= l {
 				break
 			}
 		} else {
@@ -3915,9 +3831,9 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys357Slc = r.DecodeBytes(yys357Slc, true, true)
-		yys357 := string(yys357Slc)
-		switch yys357 {
+		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
+		yys343 := string(yys343Slc)
+		switch yys343 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3934,32 +3850,26 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv360 := &x.ObjectMeta
-				yym361 := z.DecBinary()
-				_ = yym361
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv360) {
-				} else {
-					z.DecFallback(yyv360, false)
-				}
+				yyv346 := &x.ObjectMeta
+				yyv346.CodecDecodeSelf(d)
 			}
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv362 := &x.Data
-				yym363 := z.DecBinary()
-				_ = yym363
+				yyv347 := &x.Data
+				yym348 := z.DecBinary()
+				_ = yym348
 				if false {
 				} else {
-					*yyv362 = r.DecodeBytes(*(*[]byte)(yyv362), false, false)
+					*yyv347 = r.DecodeBytes(*(*[]byte)(yyv347), false, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys357)
-		} // end switch yys357
-	} // end for yyj357
-	if !yyhl357 {
+			z.DecStructFieldNotFound(-1, yys343)
+		} // end switch yys343
+	} // end for yyj343
+	if !yyhl343 {
 		r.ReadEnd()
 	}
 }
@@ -3968,16 +3878,16 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj364 int
-	var yyb364 bool
-	var yyhl364 bool = l >= 0
-	yyj364++
-	if yyhl364 {
-		yyb364 = yyj364 > l
+	var yyj349 int
+	var yyb349 bool
+	var yyhl349 bool = l >= 0
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb364 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb364 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
@@ -3986,13 +3896,13 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj364++
-	if yyhl364 {
-		yyb364 = yyj364 > l
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb364 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb364 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
@@ -4001,60 +3911,54 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj364++
-	if yyhl364 {
-		yyb364 = yyj364 > l
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb364 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb364 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv367 := &x.ObjectMeta
-		yym368 := z.DecBinary()
-		_ = yym368
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv367) {
-		} else {
-			z.DecFallback(yyv367, false)
-		}
+		yyv352 := &x.ObjectMeta
+		yyv352.CodecDecodeSelf(d)
 	}
-	yyj364++
-	if yyhl364 {
-		yyb364 = yyj364 > l
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb364 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb364 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv369 := &x.Data
-		yym370 := z.DecBinary()
-		_ = yym370
+		yyv353 := &x.Data
+		yym354 := z.DecBinary()
+		_ = yym354
 		if false {
 		} else {
-			*yyv369 = r.DecodeBytes(*(*[]byte)(yyv369), false, false)
+			*yyv353 = r.DecodeBytes(*(*[]byte)(yyv353), false, false)
 		}
 	}
 	for {
-		yyj364++
-		if yyhl364 {
-			yyb364 = yyj364 > l
+		yyj349++
+		if yyhl349 {
+			yyb349 = yyj349 > l
 		} else {
-			yyb364 = r.CheckBreak()
+			yyb349 = r.CheckBreak()
 		}
-		if yyb364 {
+		if yyb349 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj364-1, "")
+		z.DecStructFieldNotFound(yyj349-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4066,36 +3970,36 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym371 := z.EncBinary()
-		_ = yym371
+		yym355 := z.EncBinary()
+		_ = yym355
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep372 := !z.EncBinary()
-			yy2arr372 := z.EncBasicHandle().StructToArray
-			var yyq372 [5]bool
-			_, _, _ = yysep372, yyq372, yy2arr372
-			const yyr372 bool = false
-			yyq372[0] = x.Kind != ""
-			yyq372[1] = x.APIVersion != ""
-			yyq372[2] = true
-			yyq372[3] = true
-			yyq372[4] = true
-			if yyr372 || yy2arr372 {
+			yysep356 := !z.EncBinary()
+			yy2arr356 := z.EncBasicHandle().StructToArray
+			var yyq356 [5]bool
+			_, _, _ = yysep356, yyq356, yy2arr356
+			const yyr356 bool = false
+			yyq356[0] = x.Kind != ""
+			yyq356[1] = x.APIVersion != ""
+			yyq356[2] = true
+			yyq356[3] = true
+			yyq356[4] = true
+			if yyr356 || yy2arr356 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn372 int = 0
-				for _, b := range yyq372 {
+				var yynn356 int = 0
+				for _, b := range yyq356 {
 					if b {
-						yynn372++
+						yynn356++
 					}
 				}
-				r.EncodeMapStart(yynn372)
+				r.EncodeMapStart(yynn356)
 			}
-			if yyr372 || yy2arr372 {
-				if yyq372[0] {
-					yym374 := z.EncBinary()
-					_ = yym374
+			if yyr356 || yy2arr356 {
+				if yyq356[0] {
+					yym358 := z.EncBinary()
+					_ = yym358
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -4104,20 +4008,20 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq372[0] {
+				if yyq356[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym375 := z.EncBinary()
-					_ = yym375
+					yym359 := z.EncBinary()
+					_ = yym359
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr372 || yy2arr372 {
-				if yyq372[1] {
-					yym377 := z.EncBinary()
-					_ = yym377
+			if yyr356 || yy2arr356 {
+				if yyq356[1] {
+					yym361 := z.EncBinary()
+					_ = yym361
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -4126,71 +4030,59 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq372[1] {
+				if yyq356[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym378 := z.EncBinary()
-					_ = yym378
+					yym362 := z.EncBinary()
+					_ = yym362
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr372 || yy2arr372 {
-				if yyq372[2] {
-					yy380 := &x.ObjectMeta
-					yym381 := z.EncBinary()
-					_ = yym381
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy380) {
-					} else {
-						z.EncFallback(yy380)
-					}
+			if yyr356 || yy2arr356 {
+				if yyq356[2] {
+					yy364 := &x.ObjectMeta
+					yy364.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq372[2] {
+				if yyq356[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy382 := &x.ObjectMeta
-					yym383 := z.EncBinary()
-					_ = yym383
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy382) {
-					} else {
-						z.EncFallback(yy382)
-					}
+					yy365 := &x.ObjectMeta
+					yy365.CodecEncodeSelf(e)
 				}
 			}
-			if yyr372 || yy2arr372 {
-				if yyq372[3] {
-					yy385 := &x.Spec
-					yy385.CodecEncodeSelf(e)
+			if yyr356 || yy2arr356 {
+				if yyq356[3] {
+					yy367 := &x.Spec
+					yy367.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq372[3] {
+				if yyq356[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy386 := &x.Spec
-					yy386.CodecEncodeSelf(e)
+					yy368 := &x.Spec
+					yy368.CodecEncodeSelf(e)
 				}
 			}
-			if yyr372 || yy2arr372 {
-				if yyq372[4] {
-					yy388 := &x.Status
-					yy388.CodecEncodeSelf(e)
+			if yyr356 || yy2arr356 {
+				if yyq356[4] {
+					yy370 := &x.Status
+					yy370.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq372[4] {
+				if yyq356[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy389 := &x.Status
-					yy389.CodecEncodeSelf(e)
+					yy371 := &x.Status
+					yy371.CodecEncodeSelf(e)
 				}
 			}
-			if yysep372 {
+			if yysep356 {
 				r.EncodeEnd()
 			}
 		}
@@ -4201,24 +4093,24 @@ func (x *Deployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym390 := z.DecBinary()
-	_ = yym390
+	yym372 := z.DecBinary()
+	_ = yym372
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl391 := r.ReadMapStart()
-			if yyl391 == 0 {
+			yyl373 := r.ReadMapStart()
+			if yyl373 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl391, d)
+				x.codecDecodeSelfFromMap(yyl373, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl391 := r.ReadArrayStart()
-			if yyl391 == 0 {
+			yyl373 := r.ReadArrayStart()
+			if yyl373 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl391, d)
+				x.codecDecodeSelfFromArray(yyl373, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4230,12 +4122,12 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys392Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys392Slc
-	var yyhl392 bool = l >= 0
-	for yyj392 := 0; ; yyj392++ {
-		if yyhl392 {
-			if yyj392 >= l {
+	var yys374Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys374Slc
+	var yyhl374 bool = l >= 0
+	for yyj374 := 0; ; yyj374++ {
+		if yyhl374 {
+			if yyj374 >= l {
 				break
 			}
 		} else {
@@ -4243,9 +4135,9 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys392Slc = r.DecodeBytes(yys392Slc, true, true)
-		yys392 := string(yys392Slc)
-		switch yys392 {
+		yys374Slc = r.DecodeBytes(yys374Slc, true, true)
+		yys374 := string(yys374Slc)
+		switch yys374 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4262,34 +4154,28 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv395 := &x.ObjectMeta
-				yym396 := z.DecBinary()
-				_ = yym396
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv395) {
-				} else {
-					z.DecFallback(yyv395, false)
-				}
+				yyv377 := &x.ObjectMeta
+				yyv377.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DeploymentSpec{}
 			} else {
-				yyv397 := &x.Spec
-				yyv397.CodecDecodeSelf(d)
+				yyv378 := &x.Spec
+				yyv378.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DeploymentStatus{}
 			} else {
-				yyv398 := &x.Status
-				yyv398.CodecDecodeSelf(d)
+				yyv379 := &x.Status
+				yyv379.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys392)
-		} // end switch yys392
-	} // end for yyj392
-	if !yyhl392 {
+			z.DecStructFieldNotFound(-1, yys374)
+		} // end switch yys374
+	} // end for yyj374
+	if !yyhl374 {
 		r.ReadEnd()
 	}
 }
@@ -4298,16 +4184,16 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj399 int
-	var yyb399 bool
-	var yyhl399 bool = l >= 0
-	yyj399++
-	if yyhl399 {
-		yyb399 = yyj399 > l
+	var yyj380 int
+	var yyb380 bool
+	var yyhl380 bool = l >= 0
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb399 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb399 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
@@ -4316,13 +4202,13 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj399++
-	if yyhl399 {
-		yyb399 = yyj399 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb399 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb399 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
@@ -4331,71 +4217,65 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj399++
-	if yyhl399 {
-		yyb399 = yyj399 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb399 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb399 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv402 := &x.ObjectMeta
-		yym403 := z.DecBinary()
-		_ = yym403
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv402) {
-		} else {
-			z.DecFallback(yyv402, false)
-		}
+		yyv383 := &x.ObjectMeta
+		yyv383.CodecDecodeSelf(d)
 	}
-	yyj399++
-	if yyhl399 {
-		yyb399 = yyj399 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb399 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb399 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = DeploymentSpec{}
 	} else {
-		yyv404 := &x.Spec
-		yyv404.CodecDecodeSelf(d)
+		yyv384 := &x.Spec
+		yyv384.CodecDecodeSelf(d)
 	}
-	yyj399++
-	if yyhl399 {
-		yyb399 = yyj399 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb399 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb399 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = DeploymentStatus{}
 	} else {
-		yyv405 := &x.Status
-		yyv405.CodecDecodeSelf(d)
+		yyv385 := &x.Status
+		yyv385.CodecDecodeSelf(d)
 	}
 	for {
-		yyj399++
-		if yyhl399 {
-			yyb399 = yyj399 > l
+		yyj380++
+		if yyhl380 {
+			yyb380 = yyj380 > l
 		} else {
-			yyb399 = r.CheckBreak()
+			yyb380 = r.CheckBreak()
 		}
-		if yyb399 {
+		if yyb380 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj399-1, "")
+		z.DecStructFieldNotFound(yyj380-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4407,35 +4287,35 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym406 := z.EncBinary()
-		_ = yym406
+		yym386 := z.EncBinary()
+		_ = yym386
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep407 := !z.EncBinary()
-			yy2arr407 := z.EncBasicHandle().StructToArray
-			var yyq407 [5]bool
-			_, _, _ = yysep407, yyq407, yy2arr407
-			const yyr407 bool = false
-			yyq407[0] = x.Replicas != 0
-			yyq407[1] = len(x.Selector) != 0
-			yyq407[3] = true
-			yyq407[4] = x.UniqueLabelKey != ""
-			if yyr407 || yy2arr407 {
+			yysep387 := !z.EncBinary()
+			yy2arr387 := z.EncBasicHandle().StructToArray
+			var yyq387 [5]bool
+			_, _, _ = yysep387, yyq387, yy2arr387
+			const yyr387 bool = false
+			yyq387[0] = x.Replicas != 0
+			yyq387[1] = len(x.Selector) != 0
+			yyq387[3] = true
+			yyq387[4] = x.UniqueLabelKey != ""
+			if yyr387 || yy2arr387 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn407 int = 1
-				for _, b := range yyq407 {
+				var yynn387 int = 1
+				for _, b := range yyq387 {
 					if b {
-						yynn407++
+						yynn387++
 					}
 				}
-				r.EncodeMapStart(yynn407)
+				r.EncodeMapStart(yynn387)
 			}
-			if yyr407 || yy2arr407 {
-				if yyq407[0] {
-					yym409 := z.EncBinary()
-					_ = yym409
+			if yyr387 || yy2arr387 {
+				if yyq387[0] {
+					yym389 := z.EncBinary()
+					_ = yym389
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -4444,23 +4324,23 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq407[0] {
+				if yyq387[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-					yym410 := z.EncBinary()
-					_ = yym410
+					yym390 := z.EncBinary()
+					_ = yym390
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr407 || yy2arr407 {
-				if yyq407[1] {
+			if yyr387 || yy2arr387 {
+				if yyq387[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym412 := z.EncBinary()
-						_ = yym412
+						yym392 := z.EncBinary()
+						_ = yym392
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4470,13 +4350,13 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq407[1] {
+				if yyq387[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym413 := z.EncBinary()
-						_ = yym413
+						yym393 := z.EncBinary()
+						_ = yym393
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4484,44 +4364,32 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr407 || yy2arr407 {
-				yy415 := &x.Template
-				yym416 := z.EncBinary()
-				_ = yym416
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy415) {
-				} else {
-					z.EncFallback(yy415)
-				}
+			if yyr387 || yy2arr387 {
+				yy395 := &x.Template
+				yy395.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
-				yy417 := &x.Template
-				yym418 := z.EncBinary()
-				_ = yym418
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy417) {
-				} else {
-					z.EncFallback(yy417)
-				}
+				yy396 := &x.Template
+				yy396.CodecEncodeSelf(e)
 			}
-			if yyr407 || yy2arr407 {
-				if yyq407[3] {
-					yy420 := &x.Strategy
-					yy420.CodecEncodeSelf(e)
+			if yyr387 || yy2arr387 {
+				if yyq387[3] {
+					yy398 := &x.Strategy
+					yy398.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq407[3] {
+				if yyq387[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("strategy"))
-					yy421 := &x.Strategy
-					yy421.CodecEncodeSelf(e)
+					yy399 := &x.Strategy
+					yy399.CodecEncodeSelf(e)
 				}
 			}
-			if yyr407 || yy2arr407 {
-				if yyq407[4] {
-					yym423 := z.EncBinary()
-					_ = yym423
+			if yyr387 || yy2arr387 {
+				if yyq387[4] {
+					yym401 := z.EncBinary()
+					_ = yym401
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
@@ -4530,17 +4398,17 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq407[4] {
+				if yyq387[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
-					yym424 := z.EncBinary()
-					_ = yym424
+					yym402 := z.EncBinary()
+					_ = yym402
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
 					}
 				}
 			}
-			if yysep407 {
+			if yysep387 {
 				r.EncodeEnd()
 			}
 		}
@@ -4551,24 +4419,24 @@ func (x *DeploymentSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym425 := z.DecBinary()
-	_ = yym425
+	yym403 := z.DecBinary()
+	_ = yym403
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl426 := r.ReadMapStart()
-			if yyl426 == 0 {
+			yyl404 := r.ReadMapStart()
+			if yyl404 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl426, d)
+				x.codecDecodeSelfFromMap(yyl404, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl426 := r.ReadArrayStart()
-			if yyl426 == 0 {
+			yyl404 := r.ReadArrayStart()
+			if yyl404 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl426, d)
+				x.codecDecodeSelfFromArray(yyl404, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4580,12 +4448,12 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys427Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys427Slc
-	var yyhl427 bool = l >= 0
-	for yyj427 := 0; ; yyj427++ {
-		if yyhl427 {
-			if yyj427 >= l {
+	var yys405Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys405Slc
+	var yyhl405 bool = l >= 0
+	for yyj405 := 0; ; yyj405++ {
+		if yyhl405 {
+			if yyj405 >= l {
 				break
 			}
 		} else {
@@ -4593,9 +4461,9 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys427Slc = r.DecodeBytes(yys427Slc, true, true)
-		yys427 := string(yys427Slc)
-		switch yys427 {
+		yys405Slc = r.DecodeBytes(yys405Slc, true, true)
+		yys405 := string(yys405Slc)
+		switch yys405 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -4606,33 +4474,27 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv429 := &x.Selector
-				yym430 := z.DecBinary()
-				_ = yym430
+				yyv407 := &x.Selector
+				yym408 := z.DecBinary()
+				_ = yym408
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv429, false, d)
+					z.F.DecMapStringStringX(yyv407, false, d)
 				}
 			}
 		case "template":
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv431 := &x.Template
-				yym432 := z.DecBinary()
-				_ = yym432
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv431) {
-				} else {
-					z.DecFallback(yyv431, false)
-				}
+				yyv409 := &x.Template
+				yyv409.CodecDecodeSelf(d)
 			}
 		case "strategy":
 			if r.TryDecodeAsNil() {
 				x.Strategy = DeploymentStrategy{}
 			} else {
-				yyv433 := &x.Strategy
-				yyv433.CodecDecodeSelf(d)
+				yyv410 := &x.Strategy
+				yyv410.CodecDecodeSelf(d)
 			}
 		case "uniqueLabelKey":
 			if r.TryDecodeAsNil() {
@@ -4641,10 +4503,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.UniqueLabelKey = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys427)
-		} // end switch yys427
-	} // end for yyj427
-	if !yyhl427 {
+			z.DecStructFieldNotFound(-1, yys405)
+		} // end switch yys405
+	} // end for yyj405
+	if !yyhl405 {
 		r.ReadEnd()
 	}
 }
@@ -4653,16 +4515,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj435 int
-	var yyb435 bool
-	var yyhl435 bool = l >= 0
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
+	var yyj412 int
+	var yyb412 bool
+	var yyhl412 bool = l >= 0
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb435 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb435 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
@@ -4671,72 +4533,66 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb435 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb435 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv437 := &x.Selector
-		yym438 := z.DecBinary()
-		_ = yym438
+		yyv414 := &x.Selector
+		yym415 := z.DecBinary()
+		_ = yym415
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv437, false, d)
+			z.F.DecMapStringStringX(yyv414, false, d)
 		}
 	}
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb435 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb435 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv439 := &x.Template
-		yym440 := z.DecBinary()
-		_ = yym440
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv439) {
-		} else {
-			z.DecFallback(yyv439, false)
-		}
+		yyv416 := &x.Template
+		yyv416.CodecDecodeSelf(d)
 	}
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb435 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb435 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Strategy = DeploymentStrategy{}
 	} else {
-		yyv441 := &x.Strategy
-		yyv441.CodecDecodeSelf(d)
+		yyv417 := &x.Strategy
+		yyv417.CodecDecodeSelf(d)
 	}
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb435 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb435 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
@@ -4746,16 +4602,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.UniqueLabelKey = string(r.DecodeString())
 	}
 	for {
-		yyj435++
-		if yyhl435 {
-			yyb435 = yyj435 > l
+		yyj412++
+		if yyhl412 {
+			yyb412 = yyj412 > l
 		} else {
-			yyb435 = r.CheckBreak()
+			yyb412 = r.CheckBreak()
 		}
-		if yyb435 {
+		if yyb412 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj435-1, "")
+		z.DecStructFieldNotFound(yyj412-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4767,43 +4623,43 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym443 := z.EncBinary()
-		_ = yym443
+		yym419 := z.EncBinary()
+		_ = yym419
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep444 := !z.EncBinary()
-			yy2arr444 := z.EncBasicHandle().StructToArray
-			var yyq444 [2]bool
-			_, _, _ = yysep444, yyq444, yy2arr444
-			const yyr444 bool = false
-			yyq444[0] = x.Type != ""
-			yyq444[1] = x.RollingUpdate != nil
-			if yyr444 || yy2arr444 {
+			yysep420 := !z.EncBinary()
+			yy2arr420 := z.EncBasicHandle().StructToArray
+			var yyq420 [2]bool
+			_, _, _ = yysep420, yyq420, yy2arr420
+			const yyr420 bool = false
+			yyq420[0] = x.Type != ""
+			yyq420[1] = x.RollingUpdate != nil
+			if yyr420 || yy2arr420 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn444 int = 0
-				for _, b := range yyq444 {
+				var yynn420 int = 0
+				for _, b := range yyq420 {
 					if b {
-						yynn444++
+						yynn420++
 					}
 				}
-				r.EncodeMapStart(yynn444)
+				r.EncodeMapStart(yynn420)
 			}
-			if yyr444 || yy2arr444 {
-				if yyq444[0] {
+			if yyr420 || yy2arr420 {
+				if yyq420[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq444[0] {
+				if yyq420[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr444 || yy2arr444 {
-				if yyq444[1] {
+			if yyr420 || yy2arr420 {
+				if yyq420[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -4813,7 +4669,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq444[1] {
+				if yyq420[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
@@ -4822,7 +4678,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep444 {
+			if yysep420 {
 				r.EncodeEnd()
 			}
 		}
@@ -4833,24 +4689,24 @@ func (x *DeploymentStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym447 := z.DecBinary()
-	_ = yym447
+	yym423 := z.DecBinary()
+	_ = yym423
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl448 := r.ReadMapStart()
-			if yyl448 == 0 {
+			yyl424 := r.ReadMapStart()
+			if yyl424 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl448, d)
+				x.codecDecodeSelfFromMap(yyl424, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl448 := r.ReadArrayStart()
-			if yyl448 == 0 {
+			yyl424 := r.ReadArrayStart()
+			if yyl424 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl448, d)
+				x.codecDecodeSelfFromArray(yyl424, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4862,12 +4718,12 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys449Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys449Slc
-	var yyhl449 bool = l >= 0
-	for yyj449 := 0; ; yyj449++ {
-		if yyhl449 {
-			if yyj449 >= l {
+	var yys425Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys425Slc
+	var yyhl425 bool = l >= 0
+	for yyj425 := 0; ; yyj425++ {
+		if yyhl425 {
+			if yyj425 >= l {
 				break
 			}
 		} else {
@@ -4875,9 +4731,9 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys449Slc = r.DecodeBytes(yys449Slc, true, true)
-		yys449 := string(yys449Slc)
-		switch yys449 {
+		yys425Slc = r.DecodeBytes(yys425Slc, true, true)
+		yys425 := string(yys425Slc)
+		switch yys425 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -4896,10 +4752,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.RollingUpdate.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys449)
-		} // end switch yys449
-	} // end for yyj449
-	if !yyhl449 {
+			z.DecStructFieldNotFound(-1, yys425)
+		} // end switch yys425
+	} // end for yyj425
+	if !yyhl425 {
 		r.ReadEnd()
 	}
 }
@@ -4908,16 +4764,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj452 int
-	var yyb452 bool
-	var yyhl452 bool = l >= 0
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	var yyj428 int
+	var yyb428 bool
+	var yyhl428 bool = l >= 0
+	yyj428++
+	if yyhl428 {
+		yyb428 = yyj428 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb428 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb428 {
 		r.ReadEnd()
 		return
 	}
@@ -4926,13 +4782,13 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = DeploymentStrategyType(r.DecodeString())
 	}
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	yyj428++
+	if yyhl428 {
+		yyb428 = yyj428 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb428 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb428 {
 		r.ReadEnd()
 		return
 	}
@@ -4947,16 +4803,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.RollingUpdate.CodecDecodeSelf(d)
 	}
 	for {
-		yyj452++
-		if yyhl452 {
-			yyb452 = yyj452 > l
+		yyj428++
+		if yyhl428 {
+			yyb428 = yyj428 > l
 		} else {
-			yyb452 = r.CheckBreak()
+			yyb428 = r.CheckBreak()
 		}
-		if yyb452 {
+		if yyb428 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj452-1, "")
+		z.DecStructFieldNotFound(yyj428-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4965,8 +4821,8 @@ func (x DeploymentStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym455 := z.EncBinary()
-	_ = yym455
+	yym431 := z.EncBinary()
+	_ = yym431
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -4978,8 +4834,8 @@ func (x *DeploymentStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym456 := z.DecBinary()
-	_ = yym456
+	yym432 := z.DecBinary()
+	_ = yym432
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -4994,94 +4850,94 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym457 := z.EncBinary()
-		_ = yym457
+		yym433 := z.EncBinary()
+		_ = yym433
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep458 := !z.EncBinary()
-			yy2arr458 := z.EncBasicHandle().StructToArray
-			var yyq458 [3]bool
-			_, _, _ = yysep458, yyq458, yy2arr458
-			const yyr458 bool = false
-			yyq458[0] = true
-			yyq458[1] = true
-			yyq458[2] = x.MinReadySeconds != 0
-			if yyr458 || yy2arr458 {
+			yysep434 := !z.EncBinary()
+			yy2arr434 := z.EncBasicHandle().StructToArray
+			var yyq434 [3]bool
+			_, _, _ = yysep434, yyq434, yy2arr434
+			const yyr434 bool = false
+			yyq434[0] = true
+			yyq434[1] = true
+			yyq434[2] = x.MinReadySeconds != 0
+			if yyr434 || yy2arr434 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn458 int = 0
-				for _, b := range yyq458 {
+				var yynn434 int = 0
+				for _, b := range yyq434 {
 					if b {
-						yynn458++
+						yynn434++
 					}
 				}
-				r.EncodeMapStart(yynn458)
+				r.EncodeMapStart(yynn434)
 			}
-			if yyr458 || yy2arr458 {
-				if yyq458[0] {
-					yy460 := &x.MaxUnavailable
-					yym461 := z.EncBinary()
-					_ = yym461
+			if yyr434 || yy2arr434 {
+				if yyq434[0] {
+					yy436 := &x.MaxUnavailable
+					yym437 := z.EncBinary()
+					_ = yym437
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy460) {
-					} else if !yym461 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy460)
+					} else if z.HasExtensions() && z.EncExt(yy436) {
+					} else if !yym437 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy436)
 					} else {
-						z.EncFallback(yy460)
+						z.EncFallback(yy436)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq458[0] {
+				if yyq434[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
-					yy462 := &x.MaxUnavailable
-					yym463 := z.EncBinary()
-					_ = yym463
+					yy438 := &x.MaxUnavailable
+					yym439 := z.EncBinary()
+					_ = yym439
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy462) {
-					} else if !yym463 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy462)
+					} else if z.HasExtensions() && z.EncExt(yy438) {
+					} else if !yym439 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy438)
 					} else {
-						z.EncFallback(yy462)
+						z.EncFallback(yy438)
 					}
 				}
 			}
-			if yyr458 || yy2arr458 {
-				if yyq458[1] {
-					yy465 := &x.MaxSurge
-					yym466 := z.EncBinary()
-					_ = yym466
+			if yyr434 || yy2arr434 {
+				if yyq434[1] {
+					yy441 := &x.MaxSurge
+					yym442 := z.EncBinary()
+					_ = yym442
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy465) {
-					} else if !yym466 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy465)
+					} else if z.HasExtensions() && z.EncExt(yy441) {
+					} else if !yym442 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy441)
 					} else {
-						z.EncFallback(yy465)
+						z.EncFallback(yy441)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq458[1] {
+				if yyq434[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
-					yy467 := &x.MaxSurge
-					yym468 := z.EncBinary()
-					_ = yym468
+					yy443 := &x.MaxSurge
+					yym444 := z.EncBinary()
+					_ = yym444
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy467) {
-					} else if !yym468 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy467)
+					} else if z.HasExtensions() && z.EncExt(yy443) {
+					} else if !yym444 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy443)
 					} else {
-						z.EncFallback(yy467)
+						z.EncFallback(yy443)
 					}
 				}
 			}
-			if yyr458 || yy2arr458 {
-				if yyq458[2] {
-					yym470 := z.EncBinary()
-					_ = yym470
+			if yyr434 || yy2arr434 {
+				if yyq434[2] {
+					yym446 := z.EncBinary()
+					_ = yym446
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
@@ -5090,17 +4946,17 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq458[2] {
+				if yyq434[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
-					yym471 := z.EncBinary()
-					_ = yym471
+					yym447 := z.EncBinary()
+					_ = yym447
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
 					}
 				}
 			}
-			if yysep458 {
+			if yysep434 {
 				r.EncodeEnd()
 			}
 		}
@@ -5111,24 +4967,24 @@ func (x *RollingUpdateDeployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym472 := z.DecBinary()
-	_ = yym472
+	yym448 := z.DecBinary()
+	_ = yym448
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl473 := r.ReadMapStart()
-			if yyl473 == 0 {
+			yyl449 := r.ReadMapStart()
+			if yyl449 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl473, d)
+				x.codecDecodeSelfFromMap(yyl449, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl473 := r.ReadArrayStart()
-			if yyl473 == 0 {
+			yyl449 := r.ReadArrayStart()
+			if yyl449 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl473, d)
+				x.codecDecodeSelfFromArray(yyl449, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5140,12 +4996,12 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys474Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys474Slc
-	var yyhl474 bool = l >= 0
-	for yyj474 := 0; ; yyj474++ {
-		if yyhl474 {
-			if yyj474 >= l {
+	var yys450Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys450Slc
+	var yyhl450 bool = l >= 0
+	for yyj450 := 0; ; yyj450++ {
+		if yyhl450 {
+			if yyj450 >= l {
 				break
 			}
 		} else {
@@ -5153,37 +5009,37 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys474Slc = r.DecodeBytes(yys474Slc, true, true)
-		yys474 := string(yys474Slc)
-		switch yys474 {
+		yys450Slc = r.DecodeBytes(yys450Slc, true, true)
+		yys450 := string(yys450Slc)
+		switch yys450 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
 				x.MaxUnavailable = pkg6_intstr.IntOrString{}
 			} else {
-				yyv475 := &x.MaxUnavailable
-				yym476 := z.DecBinary()
-				_ = yym476
+				yyv451 := &x.MaxUnavailable
+				yym452 := z.DecBinary()
+				_ = yym452
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv475) {
-				} else if !yym476 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv475)
+				} else if z.HasExtensions() && z.DecExt(yyv451) {
+				} else if !yym452 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv451)
 				} else {
-					z.DecFallback(yyv475, false)
+					z.DecFallback(yyv451, false)
 				}
 			}
 		case "maxSurge":
 			if r.TryDecodeAsNil() {
 				x.MaxSurge = pkg6_intstr.IntOrString{}
 			} else {
-				yyv477 := &x.MaxSurge
-				yym478 := z.DecBinary()
-				_ = yym478
+				yyv453 := &x.MaxSurge
+				yym454 := z.DecBinary()
+				_ = yym454
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv477) {
-				} else if !yym478 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv477)
+				} else if z.HasExtensions() && z.DecExt(yyv453) {
+				} else if !yym454 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv453)
 				} else {
-					z.DecFallback(yyv477, false)
+					z.DecFallback(yyv453, false)
 				}
 			}
 		case "minReadySeconds":
@@ -5193,10 +5049,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys474)
-		} // end switch yys474
-	} // end for yyj474
-	if !yyhl474 {
+			z.DecStructFieldNotFound(-1, yys450)
+		} // end switch yys450
+	} // end for yyj450
+	if !yyhl450 {
 		r.ReadEnd()
 	}
 }
@@ -5205,64 +5061,64 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj480 int
-	var yyb480 bool
-	var yyhl480 bool = l >= 0
-	yyj480++
-	if yyhl480 {
-		yyb480 = yyj480 > l
+	var yyj456 int
+	var yyb456 bool
+	var yyhl456 bool = l >= 0
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
 	} else {
-		yyb480 = r.CheckBreak()
+		yyb456 = r.CheckBreak()
 	}
-	if yyb480 {
+	if yyb456 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxUnavailable = pkg6_intstr.IntOrString{}
 	} else {
-		yyv481 := &x.MaxUnavailable
-		yym482 := z.DecBinary()
-		_ = yym482
+		yyv457 := &x.MaxUnavailable
+		yym458 := z.DecBinary()
+		_ = yym458
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv481) {
-		} else if !yym482 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv481)
+		} else if z.HasExtensions() && z.DecExt(yyv457) {
+		} else if !yym458 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv457)
 		} else {
-			z.DecFallback(yyv481, false)
+			z.DecFallback(yyv457, false)
 		}
 	}
-	yyj480++
-	if yyhl480 {
-		yyb480 = yyj480 > l
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
 	} else {
-		yyb480 = r.CheckBreak()
+		yyb456 = r.CheckBreak()
 	}
-	if yyb480 {
+	if yyb456 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxSurge = pkg6_intstr.IntOrString{}
 	} else {
-		yyv483 := &x.MaxSurge
-		yym484 := z.DecBinary()
-		_ = yym484
+		yyv459 := &x.MaxSurge
+		yym460 := z.DecBinary()
+		_ = yym460
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv483) {
-		} else if !yym484 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv483)
+		} else if z.HasExtensions() && z.DecExt(yyv459) {
+		} else if !yym460 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv459)
 		} else {
-			z.DecFallback(yyv483, false)
+			z.DecFallback(yyv459, false)
 		}
 	}
-	yyj480++
-	if yyhl480 {
-		yyb480 = yyj480 > l
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
 	} else {
-		yyb480 = r.CheckBreak()
+		yyb456 = r.CheckBreak()
 	}
-	if yyb480 {
+	if yyb456 {
 		r.ReadEnd()
 		return
 	}
@@ -5272,16 +5128,16 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj480++
-		if yyhl480 {
-			yyb480 = yyj480 > l
+		yyj456++
+		if yyhl456 {
+			yyb456 = yyj456 > l
 		} else {
-			yyb480 = r.CheckBreak()
+			yyb456 = r.CheckBreak()
 		}
-		if yyb480 {
+		if yyb456 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj480-1, "")
+		z.DecStructFieldNotFound(yyj456-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5293,33 +5149,33 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym486 := z.EncBinary()
-		_ = yym486
+		yym462 := z.EncBinary()
+		_ = yym462
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep487 := !z.EncBinary()
-			yy2arr487 := z.EncBasicHandle().StructToArray
-			var yyq487 [2]bool
-			_, _, _ = yysep487, yyq487, yy2arr487
-			const yyr487 bool = false
-			yyq487[0] = x.Replicas != 0
-			yyq487[1] = x.UpdatedReplicas != 0
-			if yyr487 || yy2arr487 {
+			yysep463 := !z.EncBinary()
+			yy2arr463 := z.EncBasicHandle().StructToArray
+			var yyq463 [2]bool
+			_, _, _ = yysep463, yyq463, yy2arr463
+			const yyr463 bool = false
+			yyq463[0] = x.Replicas != 0
+			yyq463[1] = x.UpdatedReplicas != 0
+			if yyr463 || yy2arr463 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn487 int = 0
-				for _, b := range yyq487 {
+				var yynn463 int = 0
+				for _, b := range yyq463 {
 					if b {
-						yynn487++
+						yynn463++
 					}
 				}
-				r.EncodeMapStart(yynn487)
+				r.EncodeMapStart(yynn463)
 			}
-			if yyr487 || yy2arr487 {
-				if yyq487[0] {
-					yym489 := z.EncBinary()
-					_ = yym489
+			if yyr463 || yy2arr463 {
+				if yyq463[0] {
+					yym465 := z.EncBinary()
+					_ = yym465
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -5328,20 +5184,20 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq487[0] {
+				if yyq463[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-					yym490 := z.EncBinary()
-					_ = yym490
+					yym466 := z.EncBinary()
+					_ = yym466
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr487 || yy2arr487 {
-				if yyq487[1] {
-					yym492 := z.EncBinary()
-					_ = yym492
+			if yyr463 || yy2arr463 {
+				if yyq463[1] {
+					yym468 := z.EncBinary()
+					_ = yym468
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
@@ -5350,17 +5206,17 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq487[1] {
+				if yyq463[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("updatedReplicas"))
-					yym493 := z.EncBinary()
-					_ = yym493
+					yym469 := z.EncBinary()
+					_ = yym469
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
 					}
 				}
 			}
-			if yysep487 {
+			if yysep463 {
 				r.EncodeEnd()
 			}
 		}
@@ -5368,6 +5224,260 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym470 := z.DecBinary()
+	_ = yym470
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl471 := r.ReadMapStart()
+			if yyl471 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl471, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl471 := r.ReadArrayStart()
+			if yyl471 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl471, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys472Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys472Slc
+	var yyhl472 bool = l >= 0
+	for yyj472 := 0; ; yyj472++ {
+		if yyhl472 {
+			if yyj472 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys472Slc = r.DecodeBytes(yys472Slc, true, true)
+		yys472 := string(yys472Slc)
+		switch yys472 {
+		case "replicas":
+			if r.TryDecodeAsNil() {
+				x.Replicas = 0
+			} else {
+				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		case "updatedReplicas":
+			if r.TryDecodeAsNil() {
+				x.UpdatedReplicas = 0
+			} else {
+				x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys472)
+		} // end switch yys472
+	} // end for yyj472
+	if !yyhl472 {
+		r.ReadEnd()
+	}
+}
+
+func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj475 int
+	var yyb475 bool
+	var yyhl475 bool = l >= 0
+	yyj475++
+	if yyhl475 {
+		yyb475 = yyj475 > l
+	} else {
+		yyb475 = r.CheckBreak()
+	}
+	if yyb475 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Replicas = 0
+	} else {
+		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+	}
+	yyj475++
+	if yyhl475 {
+		yyb475 = yyj475 > l
+	} else {
+		yyb475 = r.CheckBreak()
+	}
+	if yyb475 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.UpdatedReplicas = 0
+	} else {
+		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+	}
+	for {
+		yyj475++
+		if yyhl475 {
+			yyb475 = yyj475 > l
+		} else {
+			yyb475 = r.CheckBreak()
+		}
+		if yyb475 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj475-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym478 := z.EncBinary()
+		_ = yym478
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep479 := !z.EncBinary()
+			yy2arr479 := z.EncBasicHandle().StructToArray
+			var yyq479 [4]bool
+			_, _, _ = yysep479, yyq479, yy2arr479
+			const yyr479 bool = false
+			yyq479[0] = x.Kind != ""
+			yyq479[1] = x.APIVersion != ""
+			yyq479[2] = true
+			if yyr479 || yy2arr479 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn479 int = 1
+				for _, b := range yyq479 {
+					if b {
+						yynn479++
+					}
+				}
+				r.EncodeMapStart(yynn479)
+			}
+			if yyr479 || yy2arr479 {
+				if yyq479[0] {
+					yym481 := z.EncBinary()
+					_ = yym481
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq479[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym482 := z.EncBinary()
+					_ = yym482
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr479 || yy2arr479 {
+				if yyq479[1] {
+					yym484 := z.EncBinary()
+					_ = yym484
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq479[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym485 := z.EncBinary()
+					_ = yym485
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr479 || yy2arr479 {
+				if yyq479[2] {
+					yy487 := &x.ListMeta
+					yym488 := z.EncBinary()
+					_ = yym488
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy487) {
+					} else {
+						z.EncFallback(yy487)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq479[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy489 := &x.ListMeta
+					yym490 := z.EncBinary()
+					_ = yym490
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy489) {
+					} else {
+						z.EncFallback(yy489)
+					}
+				}
+			}
+			if yyr479 || yy2arr479 {
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym492 := z.EncBinary()
+					_ = yym492
+					if false {
+					} else {
+						h.encSliceDeployment(([]Deployment)(x.Items), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym493 := z.EncBinary()
+					_ = yym493
+					if false {
+					} else {
+						h.encSliceDeployment(([]Deployment)(x.Items), e)
+					}
+				}
+			}
+			if yysep479 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -5396,7 +5506,7 @@ func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -5416,260 +5526,6 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys496Slc = r.DecodeBytes(yys496Slc, true, true)
 		yys496 := string(yys496Slc)
 		switch yys496 {
-		case "replicas":
-			if r.TryDecodeAsNil() {
-				x.Replicas = 0
-			} else {
-				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		case "updatedReplicas":
-			if r.TryDecodeAsNil() {
-				x.UpdatedReplicas = 0
-			} else {
-				x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys496)
-		} // end switch yys496
-	} // end for yyj496
-	if !yyhl496 {
-		r.ReadEnd()
-	}
-}
-
-func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj499 int
-	var yyb499 bool
-	var yyhl499 bool = l >= 0
-	yyj499++
-	if yyhl499 {
-		yyb499 = yyj499 > l
-	} else {
-		yyb499 = r.CheckBreak()
-	}
-	if yyb499 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Replicas = 0
-	} else {
-		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
-	}
-	yyj499++
-	if yyhl499 {
-		yyb499 = yyj499 > l
-	} else {
-		yyb499 = r.CheckBreak()
-	}
-	if yyb499 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.UpdatedReplicas = 0
-	} else {
-		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
-	}
-	for {
-		yyj499++
-		if yyhl499 {
-			yyb499 = yyj499 > l
-		} else {
-			yyb499 = r.CheckBreak()
-		}
-		if yyb499 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj499-1, "")
-	}
-	r.ReadEnd()
-}
-
-func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym502 := z.EncBinary()
-		_ = yym502
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep503 := !z.EncBinary()
-			yy2arr503 := z.EncBasicHandle().StructToArray
-			var yyq503 [4]bool
-			_, _, _ = yysep503, yyq503, yy2arr503
-			const yyr503 bool = false
-			yyq503[0] = x.Kind != ""
-			yyq503[1] = x.APIVersion != ""
-			yyq503[2] = true
-			if yyr503 || yy2arr503 {
-				r.EncodeArrayStart(4)
-			} else {
-				var yynn503 int = 1
-				for _, b := range yyq503 {
-					if b {
-						yynn503++
-					}
-				}
-				r.EncodeMapStart(yynn503)
-			}
-			if yyr503 || yy2arr503 {
-				if yyq503[0] {
-					yym505 := z.EncBinary()
-					_ = yym505
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq503[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym506 := z.EncBinary()
-					_ = yym506
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr503 || yy2arr503 {
-				if yyq503[1] {
-					yym508 := z.EncBinary()
-					_ = yym508
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq503[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym509 := z.EncBinary()
-					_ = yym509
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr503 || yy2arr503 {
-				if yyq503[2] {
-					yy511 := &x.ListMeta
-					yym512 := z.EncBinary()
-					_ = yym512
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy511) {
-					} else {
-						z.EncFallback(yy511)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq503[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy513 := &x.ListMeta
-					yym514 := z.EncBinary()
-					_ = yym514
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy513) {
-					} else {
-						z.EncFallback(yy513)
-					}
-				}
-			}
-			if yyr503 || yy2arr503 {
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym516 := z.EncBinary()
-					_ = yym516
-					if false {
-					} else {
-						h.encSliceDeployment(([]Deployment)(x.Items), e)
-					}
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("items"))
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym517 := z.EncBinary()
-					_ = yym517
-					if false {
-					} else {
-						h.encSliceDeployment(([]Deployment)(x.Items), e)
-					}
-				}
-			}
-			if yysep503 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym518 := z.DecBinary()
-	_ = yym518
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl519 := r.ReadMapStart()
-			if yyl519 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl519, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl519 := r.ReadArrayStart()
-			if yyl519 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl519, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys520Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys520Slc
-	var yyhl520 bool = l >= 0
-	for yyj520 := 0; ; yyj520++ {
-		if yyhl520 {
-			if yyj520 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys520Slc = r.DecodeBytes(yys520Slc, true, true)
-		yys520 := string(yys520Slc)
-		switch yys520 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -5686,32 +5542,32 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv523 := &x.ListMeta
-				yym524 := z.DecBinary()
-				_ = yym524
+				yyv499 := &x.ListMeta
+				yym500 := z.DecBinary()
+				_ = yym500
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv523) {
+				} else if z.HasExtensions() && z.DecExt(yyv499) {
 				} else {
-					z.DecFallback(yyv523, false)
+					z.DecFallback(yyv499, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv525 := &x.Items
-				yym526 := z.DecBinary()
-				_ = yym526
+				yyv501 := &x.Items
+				yym502 := z.DecBinary()
+				_ = yym502
 				if false {
 				} else {
-					h.decSliceDeployment((*[]Deployment)(yyv525), d)
+					h.decSliceDeployment((*[]Deployment)(yyv501), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys520)
-		} // end switch yys520
-	} // end for yyj520
-	if !yyhl520 {
+			z.DecStructFieldNotFound(-1, yys496)
+		} // end switch yys496
+	} // end for yyj496
+	if !yyhl496 {
 		r.ReadEnd()
 	}
 }
@@ -5720,16 +5576,16 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj527 int
-	var yyb527 bool
-	var yyhl527 bool = l >= 0
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	var yyj503 int
+	var yyb503 bool
+	var yyhl503 bool = l >= 0
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5738,13 +5594,13 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5753,60 +5609,60 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv530 := &x.ListMeta
-		yym531 := z.DecBinary()
-		_ = yym531
+		yyv506 := &x.ListMeta
+		yym507 := z.DecBinary()
+		_ = yym507
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv530) {
+		} else if z.HasExtensions() && z.DecExt(yyv506) {
 		} else {
-			z.DecFallback(yyv530, false)
+			z.DecFallback(yyv506, false)
 		}
 	}
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv532 := &x.Items
-		yym533 := z.DecBinary()
-		_ = yym533
+		yyv508 := &x.Items
+		yym509 := z.DecBinary()
+		_ = yym509
 		if false {
 		} else {
-			h.decSliceDeployment((*[]Deployment)(yyv532), d)
+			h.decSliceDeployment((*[]Deployment)(yyv508), d)
 		}
 	}
 	for {
-		yyj527++
-		if yyhl527 {
-			yyb527 = yyj527 > l
+		yyj503++
+		if yyhl503 {
+			yyb503 = yyj503 > l
 		} else {
-			yyb527 = r.CheckBreak()
+			yyb503 = r.CheckBreak()
 		}
-		if yyb527 {
+		if yyb503 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj527-1, "")
+		z.DecStructFieldNotFound(yyj503-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5818,31 +5674,31 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym534 := z.EncBinary()
-		_ = yym534
+		yym510 := z.EncBinary()
+		_ = yym510
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep535 := !z.EncBinary()
-			yy2arr535 := z.EncBasicHandle().StructToArray
-			var yyq535 [2]bool
-			_, _, _ = yysep535, yyq535, yy2arr535
-			const yyr535 bool = false
-			yyq535[0] = x.Selector != nil
-			yyq535[1] = x.Template != nil
-			if yyr535 || yy2arr535 {
+			yysep511 := !z.EncBinary()
+			yy2arr511 := z.EncBasicHandle().StructToArray
+			var yyq511 [2]bool
+			_, _, _ = yysep511, yyq511, yy2arr511
+			const yyr511 bool = false
+			yyq511[0] = x.Selector != nil
+			yyq511[1] = x.Template != nil
+			if yyr511 || yy2arr511 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn535 int = 0
-				for _, b := range yyq535 {
+				var yynn511 int = 0
+				for _, b := range yyq511 {
 					if b {
-						yynn535++
+						yynn511++
 					}
 				}
-				r.EncodeMapStart(yynn535)
+				r.EncodeMapStart(yynn511)
 			}
-			if yyr535 || yy2arr535 {
-				if yyq535[0] {
+			if yyr511 || yy2arr511 {
+				if yyq511[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -5852,7 +5708,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq535[0] {
+				if yyq511[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -5861,39 +5717,27 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr535 || yy2arr535 {
-				if yyq535[1] {
+			if yyr511 || yy2arr511 {
+				if yyq511[1] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
-						yym538 := z.EncBinary()
-						_ = yym538
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.Template) {
-						} else {
-							z.EncFallback(x.Template)
-						}
+						x.Template.CodecEncodeSelf(e)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq535[1] {
+				if yyq511[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
-						yym539 := z.EncBinary()
-						_ = yym539
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.Template) {
-						} else {
-							z.EncFallback(x.Template)
-						}
+						x.Template.CodecEncodeSelf(e)
 					}
 				}
 			}
-			if yysep535 {
+			if yysep511 {
 				r.EncodeEnd()
 			}
 		}
@@ -5904,24 +5748,24 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym540 := z.DecBinary()
-	_ = yym540
+	yym514 := z.DecBinary()
+	_ = yym514
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl541 := r.ReadMapStart()
-			if yyl541 == 0 {
+			yyl515 := r.ReadMapStart()
+			if yyl515 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl541, d)
+				x.codecDecodeSelfFromMap(yyl515, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl541 := r.ReadArrayStart()
-			if yyl541 == 0 {
+			yyl515 := r.ReadArrayStart()
+			if yyl515 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl541, d)
+				x.codecDecodeSelfFromArray(yyl515, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5933,12 +5777,12 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys542Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys542Slc
-	var yyhl542 bool = l >= 0
-	for yyj542 := 0; ; yyj542++ {
-		if yyhl542 {
-			if yyj542 >= l {
+	var yys516Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys516Slc
+	var yyhl516 bool = l >= 0
+	for yyj516 := 0; ; yyj516++ {
+		if yyhl516 {
+			if yyj516 >= l {
 				break
 			}
 		} else {
@@ -5946,9 +5790,9 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys542Slc = r.DecodeBytes(yys542Slc, true, true)
-		yys542 := string(yys542Slc)
-		switch yys542 {
+		yys516Slc = r.DecodeBytes(yys516Slc, true, true)
+		yys516 := string(yys516Slc)
+		switch yys516 {
 		case "selector":
 			if r.TryDecodeAsNil() {
 				if x.Selector != nil {
@@ -5969,19 +5813,13 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Template == nil {
 					x.Template = new(pkg2_api.PodTemplateSpec)
 				}
-				yym545 := z.DecBinary()
-				_ = yym545
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.Template) {
-				} else {
-					z.DecFallback(x.Template, false)
-				}
+				x.Template.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys542)
-		} // end switch yys542
-	} // end for yyj542
-	if !yyhl542 {
+			z.DecStructFieldNotFound(-1, yys516)
+		} // end switch yys516
+	} // end for yyj516
+	if !yyhl516 {
 		r.ReadEnd()
 	}
 }
@@ -5990,16 +5828,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj546 int
-	var yyb546 bool
-	var yyhl546 bool = l >= 0
-	yyj546++
-	if yyhl546 {
-		yyb546 = yyj546 > l
+	var yyj519 int
+	var yyb519 bool
+	var yyhl519 bool = l >= 0
+	yyj519++
+	if yyhl519 {
+		yyb519 = yyj519 > l
 	} else {
-		yyb546 = r.CheckBreak()
+		yyb519 = r.CheckBreak()
 	}
-	if yyb546 {
+	if yyb519 {
 		r.ReadEnd()
 		return
 	}
@@ -6013,13 +5851,13 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj546++
-	if yyhl546 {
-		yyb546 = yyj546 > l
+	yyj519++
+	if yyhl519 {
+		yyb519 = yyj519 > l
 	} else {
-		yyb546 = r.CheckBreak()
+		yyb519 = r.CheckBreak()
 	}
-	if yyb546 {
+	if yyb519 {
 		r.ReadEnd()
 		return
 	}
@@ -6031,25 +5869,19 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Template == nil {
 			x.Template = new(pkg2_api.PodTemplateSpec)
 		}
-		yym549 := z.DecBinary()
-		_ = yym549
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.Template) {
-		} else {
-			z.DecFallback(x.Template, false)
-		}
+		x.Template.CodecDecodeSelf(d)
 	}
 	for {
-		yyj546++
-		if yyhl546 {
-			yyb546 = yyj546 > l
+		yyj519++
+		if yyhl519 {
+			yyb519 = yyj519 > l
 		} else {
-			yyb546 = r.CheckBreak()
+			yyb519 = r.CheckBreak()
 		}
-		if yyb546 {
+		if yyb519 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj546-1, "")
+		z.DecStructFieldNotFound(yyj519-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6061,76 +5893,76 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym550 := z.EncBinary()
-		_ = yym550
+		yym522 := z.EncBinary()
+		_ = yym522
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep551 := !z.EncBinary()
-			yy2arr551 := z.EncBasicHandle().StructToArray
-			var yyq551 [3]bool
-			_, _, _ = yysep551, yyq551, yy2arr551
-			const yyr551 bool = false
-			if yyr551 || yy2arr551 {
+			yysep523 := !z.EncBinary()
+			yy2arr523 := z.EncBasicHandle().StructToArray
+			var yyq523 [3]bool
+			_, _, _ = yysep523, yyq523, yy2arr523
+			const yyr523 bool = false
+			if yyr523 || yy2arr523 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn551 int = 3
-				for _, b := range yyq551 {
+				var yynn523 int = 3
+				for _, b := range yyq523 {
 					if b {
-						yynn551++
+						yynn523++
 					}
 				}
-				r.EncodeMapStart(yynn551)
+				r.EncodeMapStart(yynn523)
 			}
-			if yyr551 || yy2arr551 {
-				yym553 := z.EncBinary()
-				_ = yym553
+			if yyr523 || yy2arr523 {
+				yym525 := z.EncBinary()
+				_ = yym525
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
-				yym554 := z.EncBinary()
-				_ = yym554
+				yym526 := z.EncBinary()
+				_ = yym526
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			}
-			if yyr551 || yy2arr551 {
-				yym556 := z.EncBinary()
-				_ = yym556
+			if yyr523 || yy2arr523 {
+				yym528 := z.EncBinary()
+				_ = yym528
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
-				yym557 := z.EncBinary()
-				_ = yym557
+				yym529 := z.EncBinary()
+				_ = yym529
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			}
-			if yyr551 || yy2arr551 {
-				yym559 := z.EncBinary()
-				_ = yym559
+			if yyr523 || yy2arr523 {
+				yym531 := z.EncBinary()
+				_ = yym531
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
-				yym560 := z.EncBinary()
-				_ = yym560
+				yym532 := z.EncBinary()
+				_ = yym532
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yysep551 {
+			if yysep523 {
 				r.EncodeEnd()
 			}
 		}
@@ -6141,24 +5973,24 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym561 := z.DecBinary()
-	_ = yym561
+	yym533 := z.DecBinary()
+	_ = yym533
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl562 := r.ReadMapStart()
-			if yyl562 == 0 {
+			yyl534 := r.ReadMapStart()
+			if yyl534 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl562, d)
+				x.codecDecodeSelfFromMap(yyl534, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl562 := r.ReadArrayStart()
-			if yyl562 == 0 {
+			yyl534 := r.ReadArrayStart()
+			if yyl534 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl562, d)
+				x.codecDecodeSelfFromArray(yyl534, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6170,12 +6002,12 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys563Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys563Slc
-	var yyhl563 bool = l >= 0
-	for yyj563 := 0; ; yyj563++ {
-		if yyhl563 {
-			if yyj563 >= l {
+	var yys535Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys535Slc
+	var yyhl535 bool = l >= 0
+	for yyj535 := 0; ; yyj535++ {
+		if yyhl535 {
+			if yyj535 >= l {
 				break
 			}
 		} else {
@@ -6183,9 +6015,9 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys563Slc = r.DecodeBytes(yys563Slc, true, true)
-		yys563 := string(yys563Slc)
-		switch yys563 {
+		yys535Slc = r.DecodeBytes(yys535Slc, true, true)
+		yys535 := string(yys535Slc)
+		switch yys535 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
@@ -6205,10 +6037,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys563)
-		} // end switch yys563
-	} // end for yyj563
-	if !yyhl563 {
+			z.DecStructFieldNotFound(-1, yys535)
+		} // end switch yys535
+	} // end for yyj535
+	if !yyhl535 {
 		r.ReadEnd()
 	}
 }
@@ -6217,16 +6049,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj567 int
-	var yyb567 bool
-	var yyhl567 bool = l >= 0
-	yyj567++
-	if yyhl567 {
-		yyb567 = yyj567 > l
+	var yyj539 int
+	var yyb539 bool
+	var yyhl539 bool = l >= 0
+	yyj539++
+	if yyhl539 {
+		yyb539 = yyj539 > l
 	} else {
-		yyb567 = r.CheckBreak()
+		yyb539 = r.CheckBreak()
 	}
-	if yyb567 {
+	if yyb539 {
 		r.ReadEnd()
 		return
 	}
@@ -6235,13 +6067,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.CurrentNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj567++
-	if yyhl567 {
-		yyb567 = yyj567 > l
+	yyj539++
+	if yyhl539 {
+		yyb539 = yyj539 > l
 	} else {
-		yyb567 = r.CheckBreak()
+		yyb539 = r.CheckBreak()
 	}
-	if yyb567 {
+	if yyb539 {
 		r.ReadEnd()
 		return
 	}
@@ -6250,13 +6082,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.NumberMisscheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj567++
-	if yyhl567 {
-		yyb567 = yyj567 > l
+	yyj539++
+	if yyhl539 {
+		yyb539 = yyj539 > l
 	} else {
-		yyb567 = r.CheckBreak()
+		yyb539 = r.CheckBreak()
 	}
-	if yyb567 {
+	if yyb539 {
 		r.ReadEnd()
 		return
 	}
@@ -6266,16 +6098,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj567++
-		if yyhl567 {
-			yyb567 = yyj567 > l
+		yyj539++
+		if yyhl539 {
+			yyb539 = yyj539 > l
 		} else {
-			yyb567 = r.CheckBreak()
+			yyb539 = r.CheckBreak()
 		}
-		if yyb567 {
+		if yyb539 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj567-1, "")
+		z.DecStructFieldNotFound(yyj539-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6287,36 +6119,36 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym571 := z.EncBinary()
-		_ = yym571
+		yym543 := z.EncBinary()
+		_ = yym543
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep572 := !z.EncBinary()
-			yy2arr572 := z.EncBasicHandle().StructToArray
-			var yyq572 [5]bool
-			_, _, _ = yysep572, yyq572, yy2arr572
-			const yyr572 bool = false
-			yyq572[0] = x.Kind != ""
-			yyq572[1] = x.APIVersion != ""
-			yyq572[2] = true
-			yyq572[3] = true
-			yyq572[4] = true
-			if yyr572 || yy2arr572 {
+			yysep544 := !z.EncBinary()
+			yy2arr544 := z.EncBasicHandle().StructToArray
+			var yyq544 [5]bool
+			_, _, _ = yysep544, yyq544, yy2arr544
+			const yyr544 bool = false
+			yyq544[0] = x.Kind != ""
+			yyq544[1] = x.APIVersion != ""
+			yyq544[2] = true
+			yyq544[3] = true
+			yyq544[4] = true
+			if yyr544 || yy2arr544 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn572 int = 0
-				for _, b := range yyq572 {
+				var yynn544 int = 0
+				for _, b := range yyq544 {
 					if b {
-						yynn572++
+						yynn544++
 					}
 				}
-				r.EncodeMapStart(yynn572)
+				r.EncodeMapStart(yynn544)
 			}
-			if yyr572 || yy2arr572 {
-				if yyq572[0] {
-					yym574 := z.EncBinary()
-					_ = yym574
+			if yyr544 || yy2arr544 {
+				if yyq544[0] {
+					yym546 := z.EncBinary()
+					_ = yym546
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6325,20 +6157,20 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq572[0] {
+				if yyq544[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym575 := z.EncBinary()
-					_ = yym575
+					yym547 := z.EncBinary()
+					_ = yym547
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr572 || yy2arr572 {
-				if yyq572[1] {
-					yym577 := z.EncBinary()
-					_ = yym577
+			if yyr544 || yy2arr544 {
+				if yyq544[1] {
+					yym549 := z.EncBinary()
+					_ = yym549
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6347,71 +6179,59 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq572[1] {
+				if yyq544[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym578 := z.EncBinary()
-					_ = yym578
+					yym550 := z.EncBinary()
+					_ = yym550
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr572 || yy2arr572 {
-				if yyq572[2] {
-					yy580 := &x.ObjectMeta
-					yym581 := z.EncBinary()
-					_ = yym581
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy580) {
-					} else {
-						z.EncFallback(yy580)
-					}
+			if yyr544 || yy2arr544 {
+				if yyq544[2] {
+					yy552 := &x.ObjectMeta
+					yy552.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq572[2] {
+				if yyq544[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy582 := &x.ObjectMeta
-					yym583 := z.EncBinary()
-					_ = yym583
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy582) {
-					} else {
-						z.EncFallback(yy582)
-					}
+					yy553 := &x.ObjectMeta
+					yy553.CodecEncodeSelf(e)
 				}
 			}
-			if yyr572 || yy2arr572 {
-				if yyq572[3] {
-					yy585 := &x.Spec
-					yy585.CodecEncodeSelf(e)
+			if yyr544 || yy2arr544 {
+				if yyq544[3] {
+					yy555 := &x.Spec
+					yy555.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq572[3] {
+				if yyq544[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy586 := &x.Spec
-					yy586.CodecEncodeSelf(e)
+					yy556 := &x.Spec
+					yy556.CodecEncodeSelf(e)
 				}
 			}
-			if yyr572 || yy2arr572 {
-				if yyq572[4] {
-					yy588 := &x.Status
-					yy588.CodecEncodeSelf(e)
+			if yyr544 || yy2arr544 {
+				if yyq544[4] {
+					yy558 := &x.Status
+					yy558.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq572[4] {
+				if yyq544[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy589 := &x.Status
-					yy589.CodecEncodeSelf(e)
+					yy559 := &x.Status
+					yy559.CodecEncodeSelf(e)
 				}
 			}
-			if yysep572 {
+			if yysep544 {
 				r.EncodeEnd()
 			}
 		}
@@ -6419,6 +6239,329 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym560 := z.DecBinary()
+	_ = yym560
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl561 := r.ReadMapStart()
+			if yyl561 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl561, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl561 := r.ReadArrayStart()
+			if yyl561 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl561, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys562Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys562Slc
+	var yyhl562 bool = l >= 0
+	for yyj562 := 0; ; yyj562++ {
+		if yyhl562 {
+			if yyj562 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys562Slc = r.DecodeBytes(yys562Slc, true, true)
+		yys562 := string(yys562Slc)
+		switch yys562 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv565 := &x.ObjectMeta
+				yyv565.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = DaemonSetSpec{}
+			} else {
+				yyv566 := &x.Spec
+				yyv566.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = DaemonSetStatus{}
+			} else {
+				yyv567 := &x.Status
+				yyv567.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys562)
+		} // end switch yys562
+	} // end for yyj562
+	if !yyhl562 {
+		r.ReadEnd()
+	}
+}
+
+func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj568 int
+	var yyb568 bool
+	var yyhl568 bool = l >= 0
+	yyj568++
+	if yyhl568 {
+		yyb568 = yyj568 > l
+	} else {
+		yyb568 = r.CheckBreak()
+	}
+	if yyb568 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj568++
+	if yyhl568 {
+		yyb568 = yyj568 > l
+	} else {
+		yyb568 = r.CheckBreak()
+	}
+	if yyb568 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj568++
+	if yyhl568 {
+		yyb568 = yyj568 > l
+	} else {
+		yyb568 = r.CheckBreak()
+	}
+	if yyb568 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv571 := &x.ObjectMeta
+		yyv571.CodecDecodeSelf(d)
+	}
+	yyj568++
+	if yyhl568 {
+		yyb568 = yyj568 > l
+	} else {
+		yyb568 = r.CheckBreak()
+	}
+	if yyb568 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Spec = DaemonSetSpec{}
+	} else {
+		yyv572 := &x.Spec
+		yyv572.CodecDecodeSelf(d)
+	}
+	yyj568++
+	if yyhl568 {
+		yyb568 = yyj568 > l
+	} else {
+		yyb568 = r.CheckBreak()
+	}
+	if yyb568 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Status = DaemonSetStatus{}
+	} else {
+		yyv573 := &x.Status
+		yyv573.CodecDecodeSelf(d)
+	}
+	for {
+		yyj568++
+		if yyhl568 {
+			yyb568 = yyj568 > l
+		} else {
+			yyb568 = r.CheckBreak()
+		}
+		if yyb568 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj568-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym574 := z.EncBinary()
+		_ = yym574
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep575 := !z.EncBinary()
+			yy2arr575 := z.EncBasicHandle().StructToArray
+			var yyq575 [4]bool
+			_, _, _ = yysep575, yyq575, yy2arr575
+			const yyr575 bool = false
+			yyq575[0] = x.Kind != ""
+			yyq575[1] = x.APIVersion != ""
+			yyq575[2] = true
+			if yyr575 || yy2arr575 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn575 int = 1
+				for _, b := range yyq575 {
+					if b {
+						yynn575++
+					}
+				}
+				r.EncodeMapStart(yynn575)
+			}
+			if yyr575 || yy2arr575 {
+				if yyq575[0] {
+					yym577 := z.EncBinary()
+					_ = yym577
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq575[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym578 := z.EncBinary()
+					_ = yym578
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr575 || yy2arr575 {
+				if yyq575[1] {
+					yym580 := z.EncBinary()
+					_ = yym580
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq575[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym581 := z.EncBinary()
+					_ = yym581
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr575 || yy2arr575 {
+				if yyq575[2] {
+					yy583 := &x.ListMeta
+					yym584 := z.EncBinary()
+					_ = yym584
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy583) {
+					} else {
+						z.EncFallback(yy583)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq575[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy585 := &x.ListMeta
+					yym586 := z.EncBinary()
+					_ = yym586
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy585) {
+					} else {
+						z.EncFallback(yy585)
+					}
+				}
+			}
+			if yyr575 || yy2arr575 {
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym588 := z.EncBinary()
+					_ = yym588
+					if false {
+					} else {
+						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym589 := z.EncBinary()
+					_ = yym589
+					if false {
+					} else {
+						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
+					}
+				}
+			}
+			if yysep575 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6447,7 +6590,7 @@ func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6481,9 +6624,9 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
+				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv595 := &x.ObjectMeta
+				yyv595 := &x.ListMeta
 				yym596 := z.DecBinary()
 				_ = yym596
 				if false {
@@ -6492,19 +6635,17 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.DecFallback(yyv595, false)
 				}
 			}
-		case "spec":
+		case "items":
 			if r.TryDecodeAsNil() {
-				x.Spec = DaemonSetSpec{}
+				x.Items = nil
 			} else {
-				yyv597 := &x.Spec
-				yyv597.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = DaemonSetStatus{}
-			} else {
-				yyv598 := &x.Status
-				yyv598.CodecDecodeSelf(d)
+				yyv597 := &x.Items
+				yym598 := z.DecBinary()
+				_ = yym598
+				if false {
+				} else {
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv597), d)
+				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys592)
@@ -6515,7 +6656,7 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	}
 }
 
-func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6563,9 +6704,9 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
+		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv602 := &x.ObjectMeta
+		yyv602 := &x.ListMeta
 		yym603 := z.DecBinary()
 		_ = yym603
 		if false {
@@ -6585,26 +6726,15 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.Spec = DaemonSetSpec{}
+		x.Items = nil
 	} else {
-		yyv604 := &x.Spec
-		yyv604.CodecDecodeSelf(d)
-	}
-	yyj599++
-	if yyhl599 {
-		yyb599 = yyj599 > l
-	} else {
-		yyb599 = r.CheckBreak()
-	}
-	if yyb599 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Status = DaemonSetStatus{}
-	} else {
-		yyv605 := &x.Status
-		yyv605.CodecDecodeSelf(d)
+		yyv604 := &x.Items
+		yym605 := z.DecBinary()
+		_ = yym605
+		if false {
+		} else {
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv604), d)
+		}
 	}
 	for {
 		yyj599++
@@ -6621,7 +6751,7 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	r.ReadEnd()
 }
 
-func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -6730,7 +6860,7 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym620
 					if false {
 					} else {
-						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
+						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
 					}
 				}
 			} else {
@@ -6742,7 +6872,7 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym621
 					if false {
 					} else {
-						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
+						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
 					}
 				}
 			}
@@ -6753,7 +6883,7 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6782,7 +6912,7 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6836,7 +6966,7 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				_ = yym630
 				if false {
 				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv629), d)
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv629), d)
 				}
 			}
 		default:
@@ -6848,7 +6978,7 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	}
 }
 
-func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6925,7 +7055,7 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		_ = yym637
 		if false {
 		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv636), d)
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv636), d)
 		}
 	}
 	for {
@@ -6943,7 +7073,7 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	r.ReadEnd()
 }
 
-func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -6957,16 +7087,18 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep639 := !z.EncBinary()
 			yy2arr639 := z.EncBasicHandle().StructToArray
-			var yyq639 [4]bool
+			var yyq639 [5]bool
 			_, _, _ = yysep639, yyq639, yy2arr639
 			const yyr639 bool = false
 			yyq639[0] = x.Kind != ""
 			yyq639[1] = x.APIVersion != ""
 			yyq639[2] = true
+			yyq639[3] = true
+			yyq639[4] = true
 			if yyr639 || yy2arr639 {
-				r.EncodeArrayStart(4)
+				r.EncodeArrayStart(5)
 			} else {
-				var yynn639 int = 1
+				var yynn639 int = 0
 				for _, b := range yyq639 {
 					if b {
 						yynn639++
@@ -7020,52 +7152,44 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr639 || yy2arr639 {
 				if yyq639[2] {
-					yy647 := &x.ListMeta
-					yym648 := z.EncBinary()
-					_ = yym648
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy647) {
-					} else {
-						z.EncFallback(yy647)
-					}
+					yy647 := &x.ObjectMeta
+					yy647.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq639[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy649 := &x.ListMeta
-					yym650 := z.EncBinary()
-					_ = yym650
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy649) {
-					} else {
-						z.EncFallback(yy649)
-					}
+					yy648 := &x.ObjectMeta
+					yy648.CodecEncodeSelf(e)
 				}
 			}
 			if yyr639 || yy2arr639 {
-				if x.Items == nil {
-					r.EncodeNil()
+				if yyq639[3] {
+					yy650 := &x.Spec
+					yy650.CodecEncodeSelf(e)
 				} else {
-					yym652 := z.EncBinary()
-					_ = yym652
-					if false {
-					} else {
-						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
-					}
+					r.EncodeNil()
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("items"))
-				if x.Items == nil {
-					r.EncodeNil()
+				if yyq639[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy651 := &x.Spec
+					yy651.CodecEncodeSelf(e)
+				}
+			}
+			if yyr639 || yy2arr639 {
+				if yyq639[4] {
+					yy653 := &x.Status
+					yy653.CodecEncodeSelf(e)
 				} else {
-					yym653 := z.EncBinary()
-					_ = yym653
-					if false {
-					} else {
-						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
-					}
+					r.EncodeNil()
+				}
+			} else {
+				if yyq639[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy654 := &x.Status
+					yy654.CodecEncodeSelf(e)
 				}
 			}
 			if yysep639 {
@@ -7075,28 +7199,28 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym654 := z.DecBinary()
-	_ = yym654
+	yym655 := z.DecBinary()
+	_ = yym655
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl655 := r.ReadMapStart()
-			if yyl655 == 0 {
+			yyl656 := r.ReadMapStart()
+			if yyl656 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl655, d)
+				x.codecDecodeSelfFromMap(yyl656, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl655 := r.ReadArrayStart()
-			if yyl655 == 0 {
+			yyl656 := r.ReadArrayStart()
+			if yyl656 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl655, d)
+				x.codecDecodeSelfFromArray(yyl656, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7104,16 +7228,16 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys656Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys656Slc
-	var yyhl656 bool = l >= 0
-	for yyj656 := 0; ; yyj656++ {
-		if yyhl656 {
-			if yyj656 >= l {
+	var yys657Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys657Slc
+	var yyhl657 bool = l >= 0
+	for yyj657 := 0; ; yyj657++ {
+		if yyhl657 {
+			if yyj657 >= l {
 				break
 			}
 		} else {
@@ -7121,9 +7245,9 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
-		yys656Slc = r.DecodeBytes(yys656Slc, true, true)
-		yys656 := string(yys656Slc)
-		switch yys656 {
+		yys657Slc = r.DecodeBytes(yys657Slc, true, true)
+		yys657 := string(yys657Slc)
+		switch yys657 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7138,39 +7262,35 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv659 := &x.ListMeta
-				yym660 := z.DecBinary()
-				_ = yym660
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv659) {
-				} else {
-					z.DecFallback(yyv659, false)
-				}
+				yyv660 := &x.ObjectMeta
+				yyv660.CodecDecodeSelf(d)
 			}
-		case "items":
+		case "spec":
 			if r.TryDecodeAsNil() {
-				x.Items = nil
+				x.Spec = JobSpec{}
 			} else {
-				yyv661 := &x.Items
-				yym662 := z.DecBinary()
-				_ = yym662
-				if false {
-				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv661), d)
-				}
+				yyv661 := &x.Spec
+				yyv661.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = JobStatus{}
+			} else {
+				yyv662 := &x.Status
+				yyv662.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys656)
-		} // end switch yys656
-	} // end for yyj656
-	if !yyhl656 {
+			z.DecStructFieldNotFound(-1, yys657)
+		} // end switch yys657
+	} // end for yyj657
+	if !yyhl657 {
 		r.ReadEnd()
 	}
 }
 
-func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -7218,16 +7338,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv666 := &x.ListMeta
-		yym667 := z.DecBinary()
-		_ = yym667
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv666) {
-		} else {
-			z.DecFallback(yyv666, false)
-		}
+		yyv666 := &x.ObjectMeta
+		yyv666.CodecDecodeSelf(d)
 	}
 	yyj663++
 	if yyhl663 {
@@ -7240,15 +7354,26 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.Items = nil
+		x.Spec = JobSpec{}
 	} else {
-		yyv668 := &x.Items
-		yym669 := z.DecBinary()
-		_ = yym669
-		if false {
-		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv668), d)
-		}
+		yyv667 := &x.Spec
+		yyv667.CodecDecodeSelf(d)
+	}
+	yyj663++
+	if yyhl663 {
+		yyb663 = yyj663 > l
+	} else {
+		yyb663 = r.CheckBreak()
+	}
+	if yyb663 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Status = JobStatus{}
+	} else {
+		yyv668 := &x.Status
+		yyv668.CodecDecodeSelf(d)
 	}
 	for {
 		yyj663++
@@ -7265,347 +7390,6 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	r.ReadEnd()
 }
 
-func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym670 := z.EncBinary()
-		_ = yym670
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep671 := !z.EncBinary()
-			yy2arr671 := z.EncBasicHandle().StructToArray
-			var yyq671 [5]bool
-			_, _, _ = yysep671, yyq671, yy2arr671
-			const yyr671 bool = false
-			yyq671[0] = x.Kind != ""
-			yyq671[1] = x.APIVersion != ""
-			yyq671[2] = true
-			yyq671[3] = true
-			yyq671[4] = true
-			if yyr671 || yy2arr671 {
-				r.EncodeArrayStart(5)
-			} else {
-				var yynn671 int = 0
-				for _, b := range yyq671 {
-					if b {
-						yynn671++
-					}
-				}
-				r.EncodeMapStart(yynn671)
-			}
-			if yyr671 || yy2arr671 {
-				if yyq671[0] {
-					yym673 := z.EncBinary()
-					_ = yym673
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq671[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym674 := z.EncBinary()
-					_ = yym674
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr671 || yy2arr671 {
-				if yyq671[1] {
-					yym676 := z.EncBinary()
-					_ = yym676
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq671[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym677 := z.EncBinary()
-					_ = yym677
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr671 || yy2arr671 {
-				if yyq671[2] {
-					yy679 := &x.ObjectMeta
-					yym680 := z.EncBinary()
-					_ = yym680
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy679) {
-					} else {
-						z.EncFallback(yy679)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq671[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy681 := &x.ObjectMeta
-					yym682 := z.EncBinary()
-					_ = yym682
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy681) {
-					} else {
-						z.EncFallback(yy681)
-					}
-				}
-			}
-			if yyr671 || yy2arr671 {
-				if yyq671[3] {
-					yy684 := &x.Spec
-					yy684.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq671[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy685 := &x.Spec
-					yy685.CodecEncodeSelf(e)
-				}
-			}
-			if yyr671 || yy2arr671 {
-				if yyq671[4] {
-					yy687 := &x.Status
-					yy687.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq671[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy688 := &x.Status
-					yy688.CodecEncodeSelf(e)
-				}
-			}
-			if yysep671 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym689 := z.DecBinary()
-	_ = yym689
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl690 := r.ReadMapStart()
-			if yyl690 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl690, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl690 := r.ReadArrayStart()
-			if yyl690 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl690, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys691Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys691Slc
-	var yyhl691 bool = l >= 0
-	for yyj691 := 0; ; yyj691++ {
-		if yyhl691 {
-			if yyj691 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys691Slc = r.DecodeBytes(yys691Slc, true, true)
-		yys691 := string(yys691Slc)
-		switch yys691 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv694 := &x.ObjectMeta
-				yym695 := z.DecBinary()
-				_ = yym695
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv694) {
-				} else {
-					z.DecFallback(yyv694, false)
-				}
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = JobSpec{}
-			} else {
-				yyv696 := &x.Spec
-				yyv696.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = JobStatus{}
-			} else {
-				yyv697 := &x.Status
-				yyv697.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys691)
-		} // end switch yys691
-	} // end for yyj691
-	if !yyhl691 {
-		r.ReadEnd()
-	}
-}
-
-func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj698 int
-	var yyb698 bool
-	var yyhl698 bool = l >= 0
-	yyj698++
-	if yyhl698 {
-		yyb698 = yyj698 > l
-	} else {
-		yyb698 = r.CheckBreak()
-	}
-	if yyb698 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj698++
-	if yyhl698 {
-		yyb698 = yyj698 > l
-	} else {
-		yyb698 = r.CheckBreak()
-	}
-	if yyb698 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj698++
-	if yyhl698 {
-		yyb698 = yyj698 > l
-	} else {
-		yyb698 = r.CheckBreak()
-	}
-	if yyb698 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv701 := &x.ObjectMeta
-		yym702 := z.DecBinary()
-		_ = yym702
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv701) {
-		} else {
-			z.DecFallback(yyv701, false)
-		}
-	}
-	yyj698++
-	if yyhl698 {
-		yyb698 = yyj698 > l
-	} else {
-		yyb698 = r.CheckBreak()
-	}
-	if yyb698 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Spec = JobSpec{}
-	} else {
-		yyv703 := &x.Spec
-		yyv703.CodecDecodeSelf(d)
-	}
-	yyj698++
-	if yyhl698 {
-		yyb698 = yyj698 > l
-	} else {
-		yyb698 = r.CheckBreak()
-	}
-	if yyb698 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Status = JobStatus{}
-	} else {
-		yyv704 := &x.Status
-		yyv704.CodecDecodeSelf(d)
-	}
-	for {
-		yyj698++
-		if yyhl698 {
-			yyb698 = yyj698 > l
-		} else {
-			yyb698 = r.CheckBreak()
-		}
-		if yyb698 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj698-1, "")
-	}
-	r.ReadEnd()
-}
-
 func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
@@ -7613,34 +7397,34 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym705 := z.EncBinary()
-		_ = yym705
+		yym669 := z.EncBinary()
+		_ = yym669
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep706 := !z.EncBinary()
-			yy2arr706 := z.EncBasicHandle().StructToArray
-			var yyq706 [4]bool
-			_, _, _ = yysep706, yyq706, yy2arr706
-			const yyr706 bool = false
-			yyq706[0] = x.Kind != ""
-			yyq706[1] = x.APIVersion != ""
-			yyq706[2] = true
-			if yyr706 || yy2arr706 {
+			yysep670 := !z.EncBinary()
+			yy2arr670 := z.EncBasicHandle().StructToArray
+			var yyq670 [4]bool
+			_, _, _ = yysep670, yyq670, yy2arr670
+			const yyr670 bool = false
+			yyq670[0] = x.Kind != ""
+			yyq670[1] = x.APIVersion != ""
+			yyq670[2] = true
+			if yyr670 || yy2arr670 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn706 int = 1
-				for _, b := range yyq706 {
+				var yynn670 int = 1
+				for _, b := range yyq670 {
 					if b {
-						yynn706++
+						yynn670++
 					}
 				}
-				r.EncodeMapStart(yynn706)
+				r.EncodeMapStart(yynn670)
 			}
-			if yyr706 || yy2arr706 {
-				if yyq706[0] {
-					yym708 := z.EncBinary()
-					_ = yym708
+			if yyr670 || yy2arr670 {
+				if yyq670[0] {
+					yym672 := z.EncBinary()
+					_ = yym672
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7649,20 +7433,20 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq706[0] {
+				if yyq670[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym709 := z.EncBinary()
-					_ = yym709
+					yym673 := z.EncBinary()
+					_ = yym673
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr706 || yy2arr706 {
-				if yyq706[1] {
-					yym711 := z.EncBinary()
-					_ = yym711
+			if yyr670 || yy2arr670 {
+				if yyq670[1] {
+					yym675 := z.EncBinary()
+					_ = yym675
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7671,48 +7455,48 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq706[1] {
+				if yyq670[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym712 := z.EncBinary()
-					_ = yym712
+					yym676 := z.EncBinary()
+					_ = yym676
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr706 || yy2arr706 {
-				if yyq706[2] {
-					yy714 := &x.ListMeta
-					yym715 := z.EncBinary()
-					_ = yym715
+			if yyr670 || yy2arr670 {
+				if yyq670[2] {
+					yy678 := &x.ListMeta
+					yym679 := z.EncBinary()
+					_ = yym679
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy714) {
+					} else if z.HasExtensions() && z.EncExt(yy678) {
 					} else {
-						z.EncFallback(yy714)
+						z.EncFallback(yy678)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq706[2] {
+				if yyq670[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy716 := &x.ListMeta
-					yym717 := z.EncBinary()
-					_ = yym717
+					yy680 := &x.ListMeta
+					yym681 := z.EncBinary()
+					_ = yym681
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy716) {
+					} else if z.HasExtensions() && z.EncExt(yy680) {
 					} else {
-						z.EncFallback(yy716)
+						z.EncFallback(yy680)
 					}
 				}
 			}
-			if yyr706 || yy2arr706 {
+			if yyr670 || yy2arr670 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym719 := z.EncBinary()
-					_ = yym719
+					yym683 := z.EncBinary()
+					_ = yym683
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -7723,15 +7507,15 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym720 := z.EncBinary()
-					_ = yym720
+					yym684 := z.EncBinary()
+					_ = yym684
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
 					}
 				}
 			}
-			if yysep706 {
+			if yysep670 {
 				r.EncodeEnd()
 			}
 		}
@@ -7742,24 +7526,24 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym721 := z.DecBinary()
-	_ = yym721
+	yym685 := z.DecBinary()
+	_ = yym685
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl722 := r.ReadMapStart()
-			if yyl722 == 0 {
+			yyl686 := r.ReadMapStart()
+			if yyl686 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl722, d)
+				x.codecDecodeSelfFromMap(yyl686, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl722 := r.ReadArrayStart()
-			if yyl722 == 0 {
+			yyl686 := r.ReadArrayStart()
+			if yyl686 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl722, d)
+				x.codecDecodeSelfFromArray(yyl686, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7771,12 +7555,12 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys723Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys723Slc
-	var yyhl723 bool = l >= 0
-	for yyj723 := 0; ; yyj723++ {
-		if yyhl723 {
-			if yyj723 >= l {
+	var yys687Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys687Slc
+	var yyhl687 bool = l >= 0
+	for yyj687 := 0; ; yyj687++ {
+		if yyhl687 {
+			if yyj687 >= l {
 				break
 			}
 		} else {
@@ -7784,9 +7568,9 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys723Slc = r.DecodeBytes(yys723Slc, true, true)
-		yys723 := string(yys723Slc)
-		switch yys723 {
+		yys687Slc = r.DecodeBytes(yys687Slc, true, true)
+		yys687 := string(yys687Slc)
+		switch yys687 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7803,32 +7587,32 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv726 := &x.ListMeta
-				yym727 := z.DecBinary()
-				_ = yym727
+				yyv690 := &x.ListMeta
+				yym691 := z.DecBinary()
+				_ = yym691
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv726) {
+				} else if z.HasExtensions() && z.DecExt(yyv690) {
 				} else {
-					z.DecFallback(yyv726, false)
+					z.DecFallback(yyv690, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv728 := &x.Items
-				yym729 := z.DecBinary()
-				_ = yym729
+				yyv692 := &x.Items
+				yym693 := z.DecBinary()
+				_ = yym693
 				if false {
 				} else {
-					h.decSliceJob((*[]Job)(yyv728), d)
+					h.decSliceJob((*[]Job)(yyv692), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys723)
-		} // end switch yys723
-	} // end for yyj723
-	if !yyhl723 {
+			z.DecStructFieldNotFound(-1, yys687)
+		} // end switch yys687
+	} // end for yyj687
+	if !yyhl687 {
 		r.ReadEnd()
 	}
 }
@@ -7837,16 +7621,16 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj730 int
-	var yyb730 bool
-	var yyhl730 bool = l >= 0
-	yyj730++
-	if yyhl730 {
-		yyb730 = yyj730 > l
+	var yyj694 int
+	var yyb694 bool
+	var yyhl694 bool = l >= 0
+	yyj694++
+	if yyhl694 {
+		yyb694 = yyj694 > l
 	} else {
-		yyb730 = r.CheckBreak()
+		yyb694 = r.CheckBreak()
 	}
-	if yyb730 {
+	if yyb694 {
 		r.ReadEnd()
 		return
 	}
@@ -7855,13 +7639,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj730++
-	if yyhl730 {
-		yyb730 = yyj730 > l
+	yyj694++
+	if yyhl694 {
+		yyb694 = yyj694 > l
 	} else {
-		yyb730 = r.CheckBreak()
+		yyb694 = r.CheckBreak()
 	}
-	if yyb730 {
+	if yyb694 {
 		r.ReadEnd()
 		return
 	}
@@ -7870,60 +7654,60 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj730++
-	if yyhl730 {
-		yyb730 = yyj730 > l
+	yyj694++
+	if yyhl694 {
+		yyb694 = yyj694 > l
 	} else {
-		yyb730 = r.CheckBreak()
+		yyb694 = r.CheckBreak()
 	}
-	if yyb730 {
+	if yyb694 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv733 := &x.ListMeta
-		yym734 := z.DecBinary()
-		_ = yym734
+		yyv697 := &x.ListMeta
+		yym698 := z.DecBinary()
+		_ = yym698
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv733) {
+		} else if z.HasExtensions() && z.DecExt(yyv697) {
 		} else {
-			z.DecFallback(yyv733, false)
+			z.DecFallback(yyv697, false)
 		}
 	}
-	yyj730++
-	if yyhl730 {
-		yyb730 = yyj730 > l
+	yyj694++
+	if yyhl694 {
+		yyb694 = yyj694 > l
 	} else {
-		yyb730 = r.CheckBreak()
+		yyb694 = r.CheckBreak()
 	}
-	if yyb730 {
+	if yyb694 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv735 := &x.Items
-		yym736 := z.DecBinary()
-		_ = yym736
+		yyv699 := &x.Items
+		yym700 := z.DecBinary()
+		_ = yym700
 		if false {
 		} else {
-			h.decSliceJob((*[]Job)(yyv735), d)
+			h.decSliceJob((*[]Job)(yyv699), d)
 		}
 	}
 	for {
-		yyj730++
-		if yyhl730 {
-			yyb730 = yyj730 > l
+		yyj694++
+		if yyhl694 {
+			yyb694 = yyj694 > l
 		} else {
-			yyb730 = r.CheckBreak()
+			yyb694 = r.CheckBreak()
 		}
-		if yyb730 {
+		if yyb694 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj730-1, "")
+		z.DecStructFieldNotFound(yyj694-1, "")
 	}
 	r.ReadEnd()
 }
@@ -7935,96 +7719,96 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym737 := z.EncBinary()
-		_ = yym737
+		yym701 := z.EncBinary()
+		_ = yym701
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep738 := !z.EncBinary()
-			yy2arr738 := z.EncBasicHandle().StructToArray
-			var yyq738 [4]bool
-			_, _, _ = yysep738, yyq738, yy2arr738
-			const yyr738 bool = false
-			yyq738[0] = x.Parallelism != nil
-			yyq738[1] = x.Completions != nil
-			yyq738[2] = x.Selector != nil
-			if yyr738 || yy2arr738 {
+			yysep702 := !z.EncBinary()
+			yy2arr702 := z.EncBasicHandle().StructToArray
+			var yyq702 [4]bool
+			_, _, _ = yysep702, yyq702, yy2arr702
+			const yyr702 bool = false
+			yyq702[0] = x.Parallelism != nil
+			yyq702[1] = x.Completions != nil
+			yyq702[2] = x.Selector != nil
+			if yyr702 || yy2arr702 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn738 int = 1
-				for _, b := range yyq738 {
+				var yynn702 int = 1
+				for _, b := range yyq702 {
 					if b {
-						yynn738++
+						yynn702++
 					}
 				}
-				r.EncodeMapStart(yynn738)
+				r.EncodeMapStart(yynn702)
 			}
-			if yyr738 || yy2arr738 {
-				if yyq738[0] {
+			if yyr702 || yy2arr702 {
+				if yyq702[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy740 := *x.Parallelism
-						yym741 := z.EncBinary()
-						_ = yym741
+						yy704 := *x.Parallelism
+						yym705 := z.EncBinary()
+						_ = yym705
 						if false {
 						} else {
-							r.EncodeInt(int64(yy740))
+							r.EncodeInt(int64(yy704))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq738[0] {
+				if yyq702[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy742 := *x.Parallelism
-						yym743 := z.EncBinary()
-						_ = yym743
+						yy706 := *x.Parallelism
+						yym707 := z.EncBinary()
+						_ = yym707
 						if false {
 						} else {
-							r.EncodeInt(int64(yy742))
+							r.EncodeInt(int64(yy706))
 						}
 					}
 				}
 			}
-			if yyr738 || yy2arr738 {
-				if yyq738[1] {
+			if yyr702 || yy2arr702 {
+				if yyq702[1] {
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy745 := *x.Completions
-						yym746 := z.EncBinary()
-						_ = yym746
+						yy709 := *x.Completions
+						yym710 := z.EncBinary()
+						_ = yym710
 						if false {
 						} else {
-							r.EncodeInt(int64(yy745))
+							r.EncodeInt(int64(yy709))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq738[1] {
+				if yyq702[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("completions"))
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy747 := *x.Completions
-						yym748 := z.EncBinary()
-						_ = yym748
+						yy711 := *x.Completions
+						yym712 := z.EncBinary()
+						_ = yym712
 						if false {
 						} else {
-							r.EncodeInt(int64(yy747))
+							r.EncodeInt(int64(yy711))
 						}
 					}
 				}
 			}
-			if yyr738 || yy2arr738 {
-				if yyq738[2] {
+			if yyr702 || yy2arr702 {
+				if yyq702[2] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -8034,7 +7818,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq738[2] {
+				if yyq702[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -8043,27 +7827,15 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr738 || yy2arr738 {
-				yy751 := &x.Template
-				yym752 := z.EncBinary()
-				_ = yym752
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy751) {
-				} else {
-					z.EncFallback(yy751)
-				}
+			if yyr702 || yy2arr702 {
+				yy715 := &x.Template
+				yy715.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
-				yy753 := &x.Template
-				yym754 := z.EncBinary()
-				_ = yym754
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy753) {
-				} else {
-					z.EncFallback(yy753)
-				}
+				yy716 := &x.Template
+				yy716.CodecEncodeSelf(e)
 			}
-			if yysep738 {
+			if yysep702 {
 				r.EncodeEnd()
 			}
 		}
@@ -8074,24 +7846,24 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym755 := z.DecBinary()
-	_ = yym755
+	yym717 := z.DecBinary()
+	_ = yym717
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl756 := r.ReadMapStart()
-			if yyl756 == 0 {
+			yyl718 := r.ReadMapStart()
+			if yyl718 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl756, d)
+				x.codecDecodeSelfFromMap(yyl718, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl756 := r.ReadArrayStart()
-			if yyl756 == 0 {
+			yyl718 := r.ReadArrayStart()
+			if yyl718 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl756, d)
+				x.codecDecodeSelfFromArray(yyl718, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8103,12 +7875,12 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys757Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys757Slc
-	var yyhl757 bool = l >= 0
-	for yyj757 := 0; ; yyj757++ {
-		if yyhl757 {
-			if yyj757 >= l {
+	var yys719Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys719Slc
+	var yyhl719 bool = l >= 0
+	for yyj719 := 0; ; yyj719++ {
+		if yyhl719 {
+			if yyj719 >= l {
 				break
 			}
 		} else {
@@ -8116,9 +7888,9 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys757Slc = r.DecodeBytes(yys757Slc, true, true)
-		yys757 := string(yys757Slc)
-		switch yys757 {
+		yys719Slc = r.DecodeBytes(yys719Slc, true, true)
+		yys719 := string(yys719Slc)
+		switch yys719 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
 				if x.Parallelism != nil {
@@ -8128,8 +7900,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Parallelism == nil {
 					x.Parallelism = new(int)
 				}
-				yym759 := z.DecBinary()
-				_ = yym759
+				yym721 := z.DecBinary()
+				_ = yym721
 				if false {
 				} else {
 					*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -8144,8 +7916,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Completions == nil {
 					x.Completions = new(int)
 				}
-				yym761 := z.DecBinary()
-				_ = yym761
+				yym723 := z.DecBinary()
+				_ = yym723
 				if false {
 				} else {
 					*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -8166,20 +7938,14 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv763 := &x.Template
-				yym764 := z.DecBinary()
-				_ = yym764
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv763) {
-				} else {
-					z.DecFallback(yyv763, false)
-				}
+				yyv725 := &x.Template
+				yyv725.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys757)
-		} // end switch yys757
-	} // end for yyj757
-	if !yyhl757 {
+			z.DecStructFieldNotFound(-1, yys719)
+		} // end switch yys719
+	} // end for yyj719
+	if !yyhl719 {
 		r.ReadEnd()
 	}
 }
@@ -8188,16 +7954,16 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj765 int
-	var yyb765 bool
-	var yyhl765 bool = l >= 0
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	var yyj726 int
+	var yyb726 bool
+	var yyhl726 bool = l >= 0
+	yyj726++
+	if yyhl726 {
+		yyb726 = yyj726 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb726 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb726 {
 		r.ReadEnd()
 		return
 	}
@@ -8209,20 +7975,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parallelism == nil {
 			x.Parallelism = new(int)
 		}
-		yym767 := z.DecBinary()
-		_ = yym767
+		yym728 := z.DecBinary()
+		_ = yym728
 		if false {
 		} else {
 			*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	yyj726++
+	if yyhl726 {
+		yyb726 = yyj726 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb726 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb726 {
 		r.ReadEnd()
 		return
 	}
@@ -8234,20 +8000,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Completions == nil {
 			x.Completions = new(int)
 		}
-		yym769 := z.DecBinary()
-		_ = yym769
+		yym730 := z.DecBinary()
+		_ = yym730
 		if false {
 		} else {
 			*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	yyj726++
+	if yyhl726 {
+		yyb726 = yyj726 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb726 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb726 {
 		r.ReadEnd()
 		return
 	}
@@ -8261,39 +8027,33 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj765++
-	if yyhl765 {
-		yyb765 = yyj765 > l
+	yyj726++
+	if yyhl726 {
+		yyb726 = yyj726 > l
 	} else {
-		yyb765 = r.CheckBreak()
+		yyb726 = r.CheckBreak()
 	}
-	if yyb765 {
+	if yyb726 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv771 := &x.Template
-		yym772 := z.DecBinary()
-		_ = yym772
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv771) {
-		} else {
-			z.DecFallback(yyv771, false)
-		}
+		yyv732 := &x.Template
+		yyv732.CodecDecodeSelf(d)
 	}
 	for {
-		yyj765++
-		if yyhl765 {
-			yyb765 = yyj765 > l
+		yyj726++
+		if yyhl726 {
+			yyb726 = yyj726 > l
 		} else {
-			yyb765 = r.CheckBreak()
+			yyb726 = r.CheckBreak()
 		}
-		if yyb765 {
+		if yyb726 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj765-1, "")
+		z.DecStructFieldNotFound(yyj726-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8305,40 +8065,40 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym773 := z.EncBinary()
-		_ = yym773
+		yym733 := z.EncBinary()
+		_ = yym733
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep774 := !z.EncBinary()
-			yy2arr774 := z.EncBasicHandle().StructToArray
-			var yyq774 [6]bool
-			_, _, _ = yysep774, yyq774, yy2arr774
-			const yyr774 bool = false
-			yyq774[0] = len(x.Conditions) != 0
-			yyq774[1] = x.StartTime != nil
-			yyq774[2] = x.CompletionTime != nil
-			yyq774[3] = x.Active != 0
-			yyq774[4] = x.Succeeded != 0
-			yyq774[5] = x.Failed != 0
-			if yyr774 || yy2arr774 {
+			yysep734 := !z.EncBinary()
+			yy2arr734 := z.EncBasicHandle().StructToArray
+			var yyq734 [6]bool
+			_, _, _ = yysep734, yyq734, yy2arr734
+			const yyr734 bool = false
+			yyq734[0] = len(x.Conditions) != 0
+			yyq734[1] = x.StartTime != nil
+			yyq734[2] = x.CompletionTime != nil
+			yyq734[3] = x.Active != 0
+			yyq734[4] = x.Succeeded != 0
+			yyq734[5] = x.Failed != 0
+			if yyr734 || yy2arr734 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn774 int = 0
-				for _, b := range yyq774 {
+				var yynn734 int = 0
+				for _, b := range yyq734 {
 					if b {
-						yynn774++
+						yynn734++
 					}
 				}
-				r.EncodeMapStart(yynn774)
+				r.EncodeMapStart(yynn734)
 			}
-			if yyr774 || yy2arr774 {
-				if yyq774[0] {
+			if yyr734 || yy2arr734 {
+				if yyq734[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym776 := z.EncBinary()
-						_ = yym776
+						yym736 := z.EncBinary()
+						_ = yym736
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -8348,13 +8108,13 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq774[0] {
+				if yyq734[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym777 := z.EncBinary()
-						_ = yym777
+						yym737 := z.EncBinary()
+						_ = yym737
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -8362,18 +8122,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr774 || yy2arr774 {
-				if yyq774[1] {
+			if yyr734 || yy2arr734 {
+				if yyq734[1] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym779 := z.EncBinary()
-						_ = yym779
+						yym739 := z.EncBinary()
+						_ = yym739
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym779 {
+						} else if yym739 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym779 && z.IsJSONHandle() {
+						} else if !yym739 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -8383,18 +8143,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq774[1] {
+				if yyq734[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym780 := z.EncBinary()
-						_ = yym780
+						yym740 := z.EncBinary()
+						_ = yym740
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym780 {
+						} else if yym740 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym780 && z.IsJSONHandle() {
+						} else if !yym740 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -8402,18 +8162,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr774 || yy2arr774 {
-				if yyq774[2] {
+			if yyr734 || yy2arr734 {
+				if yyq734[2] {
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym782 := z.EncBinary()
-						_ = yym782
+						yym742 := z.EncBinary()
+						_ = yym742
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym782 {
+						} else if yym742 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym782 && z.IsJSONHandle() {
+						} else if !yym742 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8423,18 +8183,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq774[2] {
+				if yyq734[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym783 := z.EncBinary()
-						_ = yym783
+						yym743 := z.EncBinary()
+						_ = yym743
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym783 {
+						} else if yym743 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym783 && z.IsJSONHandle() {
+						} else if !yym743 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8442,10 +8202,10 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr774 || yy2arr774 {
-				if yyq774[3] {
-					yym785 := z.EncBinary()
-					_ = yym785
+			if yyr734 || yy2arr734 {
+				if yyq734[3] {
+					yym745 := z.EncBinary()
+					_ = yym745
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
@@ -8454,20 +8214,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq774[3] {
+				if yyq734[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
-					yym786 := z.EncBinary()
-					_ = yym786
+					yym746 := z.EncBinary()
+					_ = yym746
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
 					}
 				}
 			}
-			if yyr774 || yy2arr774 {
-				if yyq774[4] {
-					yym788 := z.EncBinary()
-					_ = yym788
+			if yyr734 || yy2arr734 {
+				if yyq734[4] {
+					yym748 := z.EncBinary()
+					_ = yym748
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
@@ -8476,20 +8236,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq774[4] {
+				if yyq734[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
-					yym789 := z.EncBinary()
-					_ = yym789
+					yym749 := z.EncBinary()
+					_ = yym749
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
 					}
 				}
 			}
-			if yyr774 || yy2arr774 {
-				if yyq774[5] {
-					yym791 := z.EncBinary()
-					_ = yym791
+			if yyr734 || yy2arr734 {
+				if yyq734[5] {
+					yym751 := z.EncBinary()
+					_ = yym751
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
@@ -8498,17 +8258,17 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq774[5] {
+				if yyq734[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
-					yym792 := z.EncBinary()
-					_ = yym792
+					yym752 := z.EncBinary()
+					_ = yym752
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				}
 			}
-			if yysep774 {
+			if yysep734 {
 				r.EncodeEnd()
 			}
 		}
@@ -8519,24 +8279,24 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym793 := z.DecBinary()
-	_ = yym793
+	yym753 := z.DecBinary()
+	_ = yym753
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl794 := r.ReadMapStart()
-			if yyl794 == 0 {
+			yyl754 := r.ReadMapStart()
+			if yyl754 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl794, d)
+				x.codecDecodeSelfFromMap(yyl754, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl794 := r.ReadArrayStart()
-			if yyl794 == 0 {
+			yyl754 := r.ReadArrayStart()
+			if yyl754 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl794, d)
+				x.codecDecodeSelfFromArray(yyl754, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8548,12 +8308,12 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys795Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys795Slc
-	var yyhl795 bool = l >= 0
-	for yyj795 := 0; ; yyj795++ {
-		if yyhl795 {
-			if yyj795 >= l {
+	var yys755Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys755Slc
+	var yyhl755 bool = l >= 0
+	for yyj755 := 0; ; yyj755++ {
+		if yyhl755 {
+			if yyj755 >= l {
 				break
 			}
 		} else {
@@ -8561,19 +8321,19 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys795Slc = r.DecodeBytes(yys795Slc, true, true)
-		yys795 := string(yys795Slc)
-		switch yys795 {
+		yys755Slc = r.DecodeBytes(yys755Slc, true, true)
+		yys755 := string(yys755Slc)
+		switch yys755 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv796 := &x.Conditions
-				yym797 := z.DecBinary()
-				_ = yym797
+				yyv756 := &x.Conditions
+				yym757 := z.DecBinary()
+				_ = yym757
 				if false {
 				} else {
-					h.decSliceJobCondition((*[]JobCondition)(yyv796), d)
+					h.decSliceJobCondition((*[]JobCondition)(yyv756), d)
 				}
 			}
 		case "startTime":
@@ -8585,13 +8345,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg1_unversioned.Time)
 				}
-				yym799 := z.DecBinary()
-				_ = yym799
+				yym759 := z.DecBinary()
+				_ = yym759
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym799 {
+				} else if yym759 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym799 && z.IsJSONHandle() {
+				} else if !yym759 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -8606,13 +8366,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.CompletionTime == nil {
 					x.CompletionTime = new(pkg1_unversioned.Time)
 				}
-				yym801 := z.DecBinary()
-				_ = yym801
+				yym761 := z.DecBinary()
+				_ = yym761
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-				} else if yym801 {
+				} else if yym761 {
 					z.DecBinaryUnmarshal(x.CompletionTime)
-				} else if !yym801 && z.IsJSONHandle() {
+				} else if !yym761 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.CompletionTime)
 				} else {
 					z.DecFallback(x.CompletionTime, false)
@@ -8637,10 +8397,10 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys795)
-		} // end switch yys795
-	} // end for yyj795
-	if !yyhl795 {
+			z.DecStructFieldNotFound(-1, yys755)
+		} // end switch yys755
+	} // end for yyj755
+	if !yyhl755 {
 		r.ReadEnd()
 	}
 }
@@ -8649,37 +8409,37 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj805 int
-	var yyb805 bool
-	var yyhl805 bool = l >= 0
-	yyj805++
-	if yyhl805 {
-		yyb805 = yyj805 > l
+	var yyj765 int
+	var yyb765 bool
+	var yyhl765 bool = l >= 0
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb805 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb805 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv806 := &x.Conditions
-		yym807 := z.DecBinary()
-		_ = yym807
+		yyv766 := &x.Conditions
+		yym767 := z.DecBinary()
+		_ = yym767
 		if false {
 		} else {
-			h.decSliceJobCondition((*[]JobCondition)(yyv806), d)
+			h.decSliceJobCondition((*[]JobCondition)(yyv766), d)
 		}
 	}
-	yyj805++
-	if yyhl805 {
-		yyb805 = yyj805 > l
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb805 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb805 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
@@ -8691,25 +8451,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg1_unversioned.Time)
 		}
-		yym809 := z.DecBinary()
-		_ = yym809
+		yym769 := z.DecBinary()
+		_ = yym769
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym809 {
+		} else if yym769 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym809 && z.IsJSONHandle() {
+		} else if !yym769 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj805++
-	if yyhl805 {
-		yyb805 = yyj805 > l
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb805 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb805 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
@@ -8721,25 +8481,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.CompletionTime == nil {
 			x.CompletionTime = new(pkg1_unversioned.Time)
 		}
-		yym811 := z.DecBinary()
-		_ = yym811
+		yym771 := z.DecBinary()
+		_ = yym771
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-		} else if yym811 {
+		} else if yym771 {
 			z.DecBinaryUnmarshal(x.CompletionTime)
-		} else if !yym811 && z.IsJSONHandle() {
+		} else if !yym771 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.CompletionTime)
 		} else {
 			z.DecFallback(x.CompletionTime, false)
 		}
 	}
-	yyj805++
-	if yyhl805 {
-		yyb805 = yyj805 > l
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb805 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb805 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
@@ -8748,13 +8508,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Active = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj805++
-	if yyhl805 {
-		yyb805 = yyj805 > l
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb805 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb805 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
@@ -8763,13 +8523,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Succeeded = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj805++
-	if yyhl805 {
-		yyb805 = yyj805 > l
+	yyj765++
+	if yyhl765 {
+		yyb765 = yyj765 > l
 	} else {
-		yyb805 = r.CheckBreak()
+		yyb765 = r.CheckBreak()
 	}
-	if yyb805 {
+	if yyb765 {
 		r.ReadEnd()
 		return
 	}
@@ -8779,16 +8539,16 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj805++
-		if yyhl805 {
-			yyb805 = yyj805 > l
+		yyj765++
+		if yyhl765 {
+			yyb765 = yyj765 > l
 		} else {
-			yyb805 = r.CheckBreak()
+			yyb765 = r.CheckBreak()
 		}
-		if yyb805 {
+		if yyb765 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj805-1, "")
+		z.DecStructFieldNotFound(yyj765-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8797,8 +8557,8 @@ func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym815 := z.EncBinary()
-	_ = yym815
+	yym775 := z.EncBinary()
+	_ = yym775
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -8810,8 +8570,8 @@ func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym816 := z.DecBinary()
-	_ = yym816
+	yym776 := z.DecBinary()
+	_ = yym776
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -8826,40 +8586,40 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym817 := z.EncBinary()
-		_ = yym817
+		yym777 := z.EncBinary()
+		_ = yym777
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep818 := !z.EncBinary()
-			yy2arr818 := z.EncBasicHandle().StructToArray
-			var yyq818 [6]bool
-			_, _, _ = yysep818, yyq818, yy2arr818
-			const yyr818 bool = false
-			yyq818[2] = true
-			yyq818[3] = true
-			yyq818[4] = x.Reason != ""
-			yyq818[5] = x.Message != ""
-			if yyr818 || yy2arr818 {
+			yysep778 := !z.EncBinary()
+			yy2arr778 := z.EncBasicHandle().StructToArray
+			var yyq778 [6]bool
+			_, _, _ = yysep778, yyq778, yy2arr778
+			const yyr778 bool = false
+			yyq778[2] = true
+			yyq778[3] = true
+			yyq778[4] = x.Reason != ""
+			yyq778[5] = x.Message != ""
+			if yyr778 || yy2arr778 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn818 int = 2
-				for _, b := range yyq818 {
+				var yynn778 int = 2
+				for _, b := range yyq778 {
 					if b {
-						yynn818++
+						yynn778++
 					}
 				}
-				r.EncodeMapStart(yynn818)
+				r.EncodeMapStart(yynn778)
 			}
-			if yyr818 || yy2arr818 {
+			if yyr778 || yy2arr778 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr818 || yy2arr818 {
-				yym821 := z.EncBinary()
-				_ = yym821
+			if yyr778 || yy2arr778 {
+				yym781 := z.EncBinary()
+				_ = yym781
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
@@ -8867,86 +8627,86 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
-				yym822 := z.EncBinary()
-				_ = yym822
+				yym782 := z.EncBinary()
+				_ = yym782
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			}
-			if yyr818 || yy2arr818 {
-				if yyq818[2] {
-					yy824 := &x.LastProbeTime
-					yym825 := z.EncBinary()
-					_ = yym825
+			if yyr778 || yy2arr778 {
+				if yyq778[2] {
+					yy784 := &x.LastProbeTime
+					yym785 := z.EncBinary()
+					_ = yym785
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy824) {
-					} else if yym825 {
-						z.EncBinaryMarshal(yy824)
-					} else if !yym825 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy824)
+					} else if z.HasExtensions() && z.EncExt(yy784) {
+					} else if yym785 {
+						z.EncBinaryMarshal(yy784)
+					} else if !yym785 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy784)
 					} else {
-						z.EncFallback(yy824)
+						z.EncFallback(yy784)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq818[2] {
+				if yyq778[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
-					yy826 := &x.LastProbeTime
-					yym827 := z.EncBinary()
-					_ = yym827
+					yy786 := &x.LastProbeTime
+					yym787 := z.EncBinary()
+					_ = yym787
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy826) {
-					} else if yym827 {
-						z.EncBinaryMarshal(yy826)
-					} else if !yym827 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy826)
+					} else if z.HasExtensions() && z.EncExt(yy786) {
+					} else if yym787 {
+						z.EncBinaryMarshal(yy786)
+					} else if !yym787 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy786)
 					} else {
-						z.EncFallback(yy826)
+						z.EncFallback(yy786)
 					}
 				}
 			}
-			if yyr818 || yy2arr818 {
-				if yyq818[3] {
-					yy829 := &x.LastTransitionTime
-					yym830 := z.EncBinary()
-					_ = yym830
+			if yyr778 || yy2arr778 {
+				if yyq778[3] {
+					yy789 := &x.LastTransitionTime
+					yym790 := z.EncBinary()
+					_ = yym790
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy829) {
-					} else if yym830 {
-						z.EncBinaryMarshal(yy829)
-					} else if !yym830 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy829)
+					} else if z.HasExtensions() && z.EncExt(yy789) {
+					} else if yym790 {
+						z.EncBinaryMarshal(yy789)
+					} else if !yym790 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy789)
 					} else {
-						z.EncFallback(yy829)
+						z.EncFallback(yy789)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq818[3] {
+				if yyq778[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
-					yy831 := &x.LastTransitionTime
-					yym832 := z.EncBinary()
-					_ = yym832
+					yy791 := &x.LastTransitionTime
+					yym792 := z.EncBinary()
+					_ = yym792
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy831) {
-					} else if yym832 {
-						z.EncBinaryMarshal(yy831)
-					} else if !yym832 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy831)
+					} else if z.HasExtensions() && z.EncExt(yy791) {
+					} else if yym792 {
+						z.EncBinaryMarshal(yy791)
+					} else if !yym792 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy791)
 					} else {
-						z.EncFallback(yy831)
+						z.EncFallback(yy791)
 					}
 				}
 			}
-			if yyr818 || yy2arr818 {
-				if yyq818[4] {
-					yym834 := z.EncBinary()
-					_ = yym834
+			if yyr778 || yy2arr778 {
+				if yyq778[4] {
+					yym794 := z.EncBinary()
+					_ = yym794
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -8955,20 +8715,20 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq818[4] {
+				if yyq778[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym835 := z.EncBinary()
-					_ = yym835
+					yym795 := z.EncBinary()
+					_ = yym795
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr818 || yy2arr818 {
-				if yyq818[5] {
-					yym837 := z.EncBinary()
-					_ = yym837
+			if yyr778 || yy2arr778 {
+				if yyq778[5] {
+					yym797 := z.EncBinary()
+					_ = yym797
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -8977,17 +8737,17 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq818[5] {
+				if yyq778[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym838 := z.EncBinary()
-					_ = yym838
+					yym798 := z.EncBinary()
+					_ = yym798
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yysep818 {
+			if yysep778 {
 				r.EncodeEnd()
 			}
 		}
@@ -8998,24 +8758,24 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym839 := z.DecBinary()
-	_ = yym839
+	yym799 := z.DecBinary()
+	_ = yym799
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl840 := r.ReadMapStart()
-			if yyl840 == 0 {
+			yyl800 := r.ReadMapStart()
+			if yyl800 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl840, d)
+				x.codecDecodeSelfFromMap(yyl800, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl840 := r.ReadArrayStart()
-			if yyl840 == 0 {
+			yyl800 := r.ReadArrayStart()
+			if yyl800 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl840, d)
+				x.codecDecodeSelfFromArray(yyl800, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9027,12 +8787,12 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys841Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys841Slc
-	var yyhl841 bool = l >= 0
-	for yyj841 := 0; ; yyj841++ {
-		if yyhl841 {
-			if yyj841 >= l {
+	var yys801Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys801Slc
+	var yyhl801 bool = l >= 0
+	for yyj801 := 0; ; yyj801++ {
+		if yyhl801 {
+			if yyj801 >= l {
 				break
 			}
 		} else {
@@ -9040,9 +8800,9 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys841Slc = r.DecodeBytes(yys841Slc, true, true)
-		yys841 := string(yys841Slc)
-		switch yys841 {
+		yys801Slc = r.DecodeBytes(yys801Slc, true, true)
+		yys801 := string(yys801Slc)
+		switch yys801 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -9059,34 +8819,34 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastProbeTime = pkg1_unversioned.Time{}
 			} else {
-				yyv844 := &x.LastProbeTime
-				yym845 := z.DecBinary()
-				_ = yym845
+				yyv804 := &x.LastProbeTime
+				yym805 := z.DecBinary()
+				_ = yym805
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv844) {
-				} else if yym845 {
-					z.DecBinaryUnmarshal(yyv844)
-				} else if !yym845 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv844)
+				} else if z.HasExtensions() && z.DecExt(yyv804) {
+				} else if yym805 {
+					z.DecBinaryUnmarshal(yyv804)
+				} else if !yym805 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv804)
 				} else {
-					z.DecFallback(yyv844, false)
+					z.DecFallback(yyv804, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg1_unversioned.Time{}
 			} else {
-				yyv846 := &x.LastTransitionTime
-				yym847 := z.DecBinary()
-				_ = yym847
+				yyv806 := &x.LastTransitionTime
+				yym807 := z.DecBinary()
+				_ = yym807
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv846) {
-				} else if yym847 {
-					z.DecBinaryUnmarshal(yyv846)
-				} else if !yym847 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv846)
+				} else if z.HasExtensions() && z.DecExt(yyv806) {
+				} else if yym807 {
+					z.DecBinaryUnmarshal(yyv806)
+				} else if !yym807 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv806)
 				} else {
-					z.DecFallback(yyv846, false)
+					z.DecFallback(yyv806, false)
 				}
 			}
 		case "reason":
@@ -9102,10 +8862,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys841)
-		} // end switch yys841
-	} // end for yyj841
-	if !yyhl841 {
+			z.DecStructFieldNotFound(-1, yys801)
+		} // end switch yys801
+	} // end for yyj801
+	if !yyhl801 {
 		r.ReadEnd()
 	}
 }
@@ -9114,16 +8874,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj850 int
-	var yyb850 bool
-	var yyhl850 bool = l >= 0
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	var yyj810 int
+	var yyb810 bool
+	var yyhl810 bool = l >= 0
+	yyj810++
+	if yyhl810 {
+		yyb810 = yyj810 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb810 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb810 {
 		r.ReadEnd()
 		return
 	}
@@ -9132,13 +8892,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = JobConditionType(r.DecodeString())
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj810++
+	if yyhl810 {
+		yyb810 = yyj810 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb810 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb810 {
 		r.ReadEnd()
 		return
 	}
@@ -9147,65 +8907,65 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = pkg2_api.ConditionStatus(r.DecodeString())
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj810++
+	if yyhl810 {
+		yyb810 = yyj810 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb810 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb810 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
-		yyv853 := &x.LastProbeTime
-		yym854 := z.DecBinary()
-		_ = yym854
+		yyv813 := &x.LastProbeTime
+		yym814 := z.DecBinary()
+		_ = yym814
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv853) {
-		} else if yym854 {
-			z.DecBinaryUnmarshal(yyv853)
-		} else if !yym854 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv853)
+		} else if z.HasExtensions() && z.DecExt(yyv813) {
+		} else if yym814 {
+			z.DecBinaryUnmarshal(yyv813)
+		} else if !yym814 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv813)
 		} else {
-			z.DecFallback(yyv853, false)
+			z.DecFallback(yyv813, false)
 		}
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj810++
+	if yyhl810 {
+		yyb810 = yyj810 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb810 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb810 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
-		yyv855 := &x.LastTransitionTime
-		yym856 := z.DecBinary()
-		_ = yym856
+		yyv815 := &x.LastTransitionTime
+		yym816 := z.DecBinary()
+		_ = yym816
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv855) {
-		} else if yym856 {
-			z.DecBinaryUnmarshal(yyv855)
-		} else if !yym856 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv855)
+		} else if z.HasExtensions() && z.DecExt(yyv815) {
+		} else if yym816 {
+			z.DecBinaryUnmarshal(yyv815)
+		} else if !yym816 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv815)
 		} else {
-			z.DecFallback(yyv855, false)
+			z.DecFallback(yyv815, false)
 		}
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj810++
+	if yyhl810 {
+		yyb810 = yyj810 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb810 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb810 {
 		r.ReadEnd()
 		return
 	}
@@ -9214,13 +8974,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj810++
+	if yyhl810 {
+		yyb810 = yyj810 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb810 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb810 {
 		r.ReadEnd()
 		return
 	}
@@ -9230,16 +8990,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj850++
-		if yyhl850 {
-			yyb850 = yyj850 > l
+		yyj810++
+		if yyhl810 {
+			yyb810 = yyj810 > l
 		} else {
-			yyb850 = r.CheckBreak()
+			yyb810 = r.CheckBreak()
 		}
-		if yyb850 {
+		if yyb810 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj850-1, "")
+		z.DecStructFieldNotFound(yyj810-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9251,36 +9011,36 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym859 := z.EncBinary()
-		_ = yym859
+		yym819 := z.EncBinary()
+		_ = yym819
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep860 := !z.EncBinary()
-			yy2arr860 := z.EncBasicHandle().StructToArray
-			var yyq860 [5]bool
-			_, _, _ = yysep860, yyq860, yy2arr860
-			const yyr860 bool = false
-			yyq860[0] = x.Kind != ""
-			yyq860[1] = x.APIVersion != ""
-			yyq860[2] = true
-			yyq860[3] = true
-			yyq860[4] = true
-			if yyr860 || yy2arr860 {
+			yysep820 := !z.EncBinary()
+			yy2arr820 := z.EncBasicHandle().StructToArray
+			var yyq820 [5]bool
+			_, _, _ = yysep820, yyq820, yy2arr820
+			const yyr820 bool = false
+			yyq820[0] = x.Kind != ""
+			yyq820[1] = x.APIVersion != ""
+			yyq820[2] = true
+			yyq820[3] = true
+			yyq820[4] = true
+			if yyr820 || yy2arr820 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn860 int = 0
-				for _, b := range yyq860 {
+				var yynn820 int = 0
+				for _, b := range yyq820 {
 					if b {
-						yynn860++
+						yynn820++
 					}
 				}
-				r.EncodeMapStart(yynn860)
+				r.EncodeMapStart(yynn820)
 			}
-			if yyr860 || yy2arr860 {
-				if yyq860[0] {
-					yym862 := z.EncBinary()
-					_ = yym862
+			if yyr820 || yy2arr820 {
+				if yyq820[0] {
+					yym822 := z.EncBinary()
+					_ = yym822
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9289,20 +9049,20 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq860[0] {
+				if yyq820[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym863 := z.EncBinary()
-					_ = yym863
+					yym823 := z.EncBinary()
+					_ = yym823
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr860 || yy2arr860 {
-				if yyq860[1] {
-					yym865 := z.EncBinary()
-					_ = yym865
+			if yyr820 || yy2arr820 {
+				if yyq820[1] {
+					yym825 := z.EncBinary()
+					_ = yym825
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9311,71 +9071,59 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq860[1] {
+				if yyq820[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym866 := z.EncBinary()
-					_ = yym866
+					yym826 := z.EncBinary()
+					_ = yym826
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr860 || yy2arr860 {
-				if yyq860[2] {
-					yy868 := &x.ObjectMeta
-					yym869 := z.EncBinary()
-					_ = yym869
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy868) {
-					} else {
-						z.EncFallback(yy868)
-					}
+			if yyr820 || yy2arr820 {
+				if yyq820[2] {
+					yy828 := &x.ObjectMeta
+					yy828.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq860[2] {
+				if yyq820[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy870 := &x.ObjectMeta
-					yym871 := z.EncBinary()
-					_ = yym871
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy870) {
-					} else {
-						z.EncFallback(yy870)
-					}
+					yy829 := &x.ObjectMeta
+					yy829.CodecEncodeSelf(e)
 				}
 			}
-			if yyr860 || yy2arr860 {
-				if yyq860[3] {
-					yy873 := &x.Spec
-					yy873.CodecEncodeSelf(e)
+			if yyr820 || yy2arr820 {
+				if yyq820[3] {
+					yy831 := &x.Spec
+					yy831.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq860[3] {
+				if yyq820[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy874 := &x.Spec
-					yy874.CodecEncodeSelf(e)
+					yy832 := &x.Spec
+					yy832.CodecEncodeSelf(e)
 				}
 			}
-			if yyr860 || yy2arr860 {
-				if yyq860[4] {
-					yy876 := &x.Status
-					yy876.CodecEncodeSelf(e)
+			if yyr820 || yy2arr820 {
+				if yyq820[4] {
+					yy834 := &x.Status
+					yy834.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq860[4] {
+				if yyq820[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy877 := &x.Status
-					yy877.CodecEncodeSelf(e)
+					yy835 := &x.Status
+					yy835.CodecEncodeSelf(e)
 				}
 			}
-			if yysep860 {
+			if yysep820 {
 				r.EncodeEnd()
 			}
 		}
@@ -9386,24 +9134,24 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym878 := z.DecBinary()
-	_ = yym878
+	yym836 := z.DecBinary()
+	_ = yym836
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl879 := r.ReadMapStart()
-			if yyl879 == 0 {
+			yyl837 := r.ReadMapStart()
+			if yyl837 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl879, d)
+				x.codecDecodeSelfFromMap(yyl837, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl879 := r.ReadArrayStart()
-			if yyl879 == 0 {
+			yyl837 := r.ReadArrayStart()
+			if yyl837 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl879, d)
+				x.codecDecodeSelfFromArray(yyl837, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9415,12 +9163,12 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys880Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys880Slc
-	var yyhl880 bool = l >= 0
-	for yyj880 := 0; ; yyj880++ {
-		if yyhl880 {
-			if yyj880 >= l {
+	var yys838Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys838Slc
+	var yyhl838 bool = l >= 0
+	for yyj838 := 0; ; yyj838++ {
+		if yyhl838 {
+			if yyj838 >= l {
 				break
 			}
 		} else {
@@ -9428,9 +9176,9 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys880Slc = r.DecodeBytes(yys880Slc, true, true)
-		yys880 := string(yys880Slc)
-		switch yys880 {
+		yys838Slc = r.DecodeBytes(yys838Slc, true, true)
+		yys838 := string(yys838Slc)
+		switch yys838 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9447,34 +9195,28 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv883 := &x.ObjectMeta
-				yym884 := z.DecBinary()
-				_ = yym884
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv883) {
-				} else {
-					z.DecFallback(yyv883, false)
-				}
+				yyv841 := &x.ObjectMeta
+				yyv841.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = IngressSpec{}
 			} else {
-				yyv885 := &x.Spec
-				yyv885.CodecDecodeSelf(d)
+				yyv842 := &x.Spec
+				yyv842.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = IngressStatus{}
 			} else {
-				yyv886 := &x.Status
-				yyv886.CodecDecodeSelf(d)
+				yyv843 := &x.Status
+				yyv843.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys880)
-		} // end switch yys880
-	} // end for yyj880
-	if !yyhl880 {
+			z.DecStructFieldNotFound(-1, yys838)
+		} // end switch yys838
+	} // end for yyj838
+	if !yyhl838 {
 		r.ReadEnd()
 	}
 }
@@ -9483,16 +9225,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj887 int
-	var yyb887 bool
-	var yyhl887 bool = l >= 0
-	yyj887++
-	if yyhl887 {
-		yyb887 = yyj887 > l
+	var yyj844 int
+	var yyb844 bool
+	var yyhl844 bool = l >= 0
+	yyj844++
+	if yyhl844 {
+		yyb844 = yyj844 > l
 	} else {
-		yyb887 = r.CheckBreak()
+		yyb844 = r.CheckBreak()
 	}
-	if yyb887 {
+	if yyb844 {
 		r.ReadEnd()
 		return
 	}
@@ -9501,13 +9243,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj887++
-	if yyhl887 {
-		yyb887 = yyj887 > l
+	yyj844++
+	if yyhl844 {
+		yyb844 = yyj844 > l
 	} else {
-		yyb887 = r.CheckBreak()
+		yyb844 = r.CheckBreak()
 	}
-	if yyb887 {
+	if yyb844 {
 		r.ReadEnd()
 		return
 	}
@@ -9516,71 +9258,65 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj887++
-	if yyhl887 {
-		yyb887 = yyj887 > l
+	yyj844++
+	if yyhl844 {
+		yyb844 = yyj844 > l
 	} else {
-		yyb887 = r.CheckBreak()
+		yyb844 = r.CheckBreak()
 	}
-	if yyb887 {
+	if yyb844 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv890 := &x.ObjectMeta
-		yym891 := z.DecBinary()
-		_ = yym891
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv890) {
-		} else {
-			z.DecFallback(yyv890, false)
-		}
+		yyv847 := &x.ObjectMeta
+		yyv847.CodecDecodeSelf(d)
 	}
-	yyj887++
-	if yyhl887 {
-		yyb887 = yyj887 > l
+	yyj844++
+	if yyhl844 {
+		yyb844 = yyj844 > l
 	} else {
-		yyb887 = r.CheckBreak()
+		yyb844 = r.CheckBreak()
 	}
-	if yyb887 {
+	if yyb844 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
-		yyv892 := &x.Spec
-		yyv892.CodecDecodeSelf(d)
+		yyv848 := &x.Spec
+		yyv848.CodecDecodeSelf(d)
 	}
-	yyj887++
-	if yyhl887 {
-		yyb887 = yyj887 > l
+	yyj844++
+	if yyhl844 {
+		yyb844 = yyj844 > l
 	} else {
-		yyb887 = r.CheckBreak()
+		yyb844 = r.CheckBreak()
 	}
-	if yyb887 {
+	if yyb844 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
-		yyv893 := &x.Status
-		yyv893.CodecDecodeSelf(d)
+		yyv849 := &x.Status
+		yyv849.CodecDecodeSelf(d)
 	}
 	for {
-		yyj887++
-		if yyhl887 {
-			yyb887 = yyj887 > l
+		yyj844++
+		if yyhl844 {
+			yyb844 = yyj844 > l
 		} else {
-			yyb887 = r.CheckBreak()
+			yyb844 = r.CheckBreak()
 		}
-		if yyb887 {
+		if yyb844 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj887-1, "")
+		z.DecStructFieldNotFound(yyj844-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9592,34 +9328,34 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym894 := z.EncBinary()
-		_ = yym894
+		yym850 := z.EncBinary()
+		_ = yym850
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep895 := !z.EncBinary()
-			yy2arr895 := z.EncBasicHandle().StructToArray
-			var yyq895 [4]bool
-			_, _, _ = yysep895, yyq895, yy2arr895
-			const yyr895 bool = false
-			yyq895[0] = x.Kind != ""
-			yyq895[1] = x.APIVersion != ""
-			yyq895[2] = true
-			if yyr895 || yy2arr895 {
+			yysep851 := !z.EncBinary()
+			yy2arr851 := z.EncBasicHandle().StructToArray
+			var yyq851 [4]bool
+			_, _, _ = yysep851, yyq851, yy2arr851
+			const yyr851 bool = false
+			yyq851[0] = x.Kind != ""
+			yyq851[1] = x.APIVersion != ""
+			yyq851[2] = true
+			if yyr851 || yy2arr851 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn895 int = 1
-				for _, b := range yyq895 {
+				var yynn851 int = 1
+				for _, b := range yyq851 {
 					if b {
-						yynn895++
+						yynn851++
 					}
 				}
-				r.EncodeMapStart(yynn895)
+				r.EncodeMapStart(yynn851)
 			}
-			if yyr895 || yy2arr895 {
-				if yyq895[0] {
-					yym897 := z.EncBinary()
-					_ = yym897
+			if yyr851 || yy2arr851 {
+				if yyq851[0] {
+					yym853 := z.EncBinary()
+					_ = yym853
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9628,20 +9364,20 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq895[0] {
+				if yyq851[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym898 := z.EncBinary()
-					_ = yym898
+					yym854 := z.EncBinary()
+					_ = yym854
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr895 || yy2arr895 {
-				if yyq895[1] {
-					yym900 := z.EncBinary()
-					_ = yym900
+			if yyr851 || yy2arr851 {
+				if yyq851[1] {
+					yym856 := z.EncBinary()
+					_ = yym856
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9650,48 +9386,48 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq895[1] {
+				if yyq851[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym901 := z.EncBinary()
-					_ = yym901
+					yym857 := z.EncBinary()
+					_ = yym857
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr895 || yy2arr895 {
-				if yyq895[2] {
-					yy903 := &x.ListMeta
-					yym904 := z.EncBinary()
-					_ = yym904
+			if yyr851 || yy2arr851 {
+				if yyq851[2] {
+					yy859 := &x.ListMeta
+					yym860 := z.EncBinary()
+					_ = yym860
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy903) {
+					} else if z.HasExtensions() && z.EncExt(yy859) {
 					} else {
-						z.EncFallback(yy903)
+						z.EncFallback(yy859)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq895[2] {
+				if yyq851[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy905 := &x.ListMeta
-					yym906 := z.EncBinary()
-					_ = yym906
+					yy861 := &x.ListMeta
+					yym862 := z.EncBinary()
+					_ = yym862
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy905) {
+					} else if z.HasExtensions() && z.EncExt(yy861) {
 					} else {
-						z.EncFallback(yy905)
+						z.EncFallback(yy861)
 					}
 				}
 			}
-			if yyr895 || yy2arr895 {
+			if yyr851 || yy2arr851 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym908 := z.EncBinary()
-					_ = yym908
+					yym864 := z.EncBinary()
+					_ = yym864
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -9702,15 +9438,15 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym909 := z.EncBinary()
-					_ = yym909
+					yym865 := z.EncBinary()
+					_ = yym865
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
 					}
 				}
 			}
-			if yysep895 {
+			if yysep851 {
 				r.EncodeEnd()
 			}
 		}
@@ -9721,24 +9457,24 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym910 := z.DecBinary()
-	_ = yym910
+	yym866 := z.DecBinary()
+	_ = yym866
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl911 := r.ReadMapStart()
-			if yyl911 == 0 {
+			yyl867 := r.ReadMapStart()
+			if yyl867 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl911, d)
+				x.codecDecodeSelfFromMap(yyl867, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl911 := r.ReadArrayStart()
-			if yyl911 == 0 {
+			yyl867 := r.ReadArrayStart()
+			if yyl867 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl911, d)
+				x.codecDecodeSelfFromArray(yyl867, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9750,12 +9486,12 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys912Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys912Slc
-	var yyhl912 bool = l >= 0
-	for yyj912 := 0; ; yyj912++ {
-		if yyhl912 {
-			if yyj912 >= l {
+	var yys868Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys868Slc
+	var yyhl868 bool = l >= 0
+	for yyj868 := 0; ; yyj868++ {
+		if yyhl868 {
+			if yyj868 >= l {
 				break
 			}
 		} else {
@@ -9763,9 +9499,9 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys912Slc = r.DecodeBytes(yys912Slc, true, true)
-		yys912 := string(yys912Slc)
-		switch yys912 {
+		yys868Slc = r.DecodeBytes(yys868Slc, true, true)
+		yys868 := string(yys868Slc)
+		switch yys868 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9782,32 +9518,32 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv915 := &x.ListMeta
-				yym916 := z.DecBinary()
-				_ = yym916
+				yyv871 := &x.ListMeta
+				yym872 := z.DecBinary()
+				_ = yym872
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv915) {
+				} else if z.HasExtensions() && z.DecExt(yyv871) {
 				} else {
-					z.DecFallback(yyv915, false)
+					z.DecFallback(yyv871, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv917 := &x.Items
-				yym918 := z.DecBinary()
-				_ = yym918
+				yyv873 := &x.Items
+				yym874 := z.DecBinary()
+				_ = yym874
 				if false {
 				} else {
-					h.decSliceIngress((*[]Ingress)(yyv917), d)
+					h.decSliceIngress((*[]Ingress)(yyv873), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys912)
-		} // end switch yys912
-	} // end for yyj912
-	if !yyhl912 {
+			z.DecStructFieldNotFound(-1, yys868)
+		} // end switch yys868
+	} // end for yyj868
+	if !yyhl868 {
 		r.ReadEnd()
 	}
 }
@@ -9816,16 +9552,16 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj919 int
-	var yyb919 bool
-	var yyhl919 bool = l >= 0
-	yyj919++
-	if yyhl919 {
-		yyb919 = yyj919 > l
+	var yyj875 int
+	var yyb875 bool
+	var yyhl875 bool = l >= 0
+	yyj875++
+	if yyhl875 {
+		yyb875 = yyj875 > l
 	} else {
-		yyb919 = r.CheckBreak()
+		yyb875 = r.CheckBreak()
 	}
-	if yyb919 {
+	if yyb875 {
 		r.ReadEnd()
 		return
 	}
@@ -9834,13 +9570,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj919++
-	if yyhl919 {
-		yyb919 = yyj919 > l
+	yyj875++
+	if yyhl875 {
+		yyb875 = yyj875 > l
 	} else {
-		yyb919 = r.CheckBreak()
+		yyb875 = r.CheckBreak()
 	}
-	if yyb919 {
+	if yyb875 {
 		r.ReadEnd()
 		return
 	}
@@ -9849,60 +9585,60 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj919++
-	if yyhl919 {
-		yyb919 = yyj919 > l
+	yyj875++
+	if yyhl875 {
+		yyb875 = yyj875 > l
 	} else {
-		yyb919 = r.CheckBreak()
+		yyb875 = r.CheckBreak()
 	}
-	if yyb919 {
+	if yyb875 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv922 := &x.ListMeta
-		yym923 := z.DecBinary()
-		_ = yym923
+		yyv878 := &x.ListMeta
+		yym879 := z.DecBinary()
+		_ = yym879
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv922) {
+		} else if z.HasExtensions() && z.DecExt(yyv878) {
 		} else {
-			z.DecFallback(yyv922, false)
+			z.DecFallback(yyv878, false)
 		}
 	}
-	yyj919++
-	if yyhl919 {
-		yyb919 = yyj919 > l
+	yyj875++
+	if yyhl875 {
+		yyb875 = yyj875 > l
 	} else {
-		yyb919 = r.CheckBreak()
+		yyb875 = r.CheckBreak()
 	}
-	if yyb919 {
+	if yyb875 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv924 := &x.Items
-		yym925 := z.DecBinary()
-		_ = yym925
+		yyv880 := &x.Items
+		yym881 := z.DecBinary()
+		_ = yym881
 		if false {
 		} else {
-			h.decSliceIngress((*[]Ingress)(yyv924), d)
+			h.decSliceIngress((*[]Ingress)(yyv880), d)
 		}
 	}
 	for {
-		yyj919++
-		if yyhl919 {
-			yyb919 = yyj919 > l
+		yyj875++
+		if yyhl875 {
+			yyb875 = yyj875 > l
 		} else {
-			yyb919 = r.CheckBreak()
+			yyb875 = r.CheckBreak()
 		}
-		if yyb919 {
+		if yyb875 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj919-1, "")
+		z.DecStructFieldNotFound(yyj875-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9914,31 +9650,31 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym926 := z.EncBinary()
-		_ = yym926
+		yym882 := z.EncBinary()
+		_ = yym882
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep927 := !z.EncBinary()
-			yy2arr927 := z.EncBasicHandle().StructToArray
-			var yyq927 [2]bool
-			_, _, _ = yysep927, yyq927, yy2arr927
-			const yyr927 bool = false
-			yyq927[0] = x.Backend != nil
-			yyq927[1] = len(x.Rules) != 0
-			if yyr927 || yy2arr927 {
+			yysep883 := !z.EncBinary()
+			yy2arr883 := z.EncBasicHandle().StructToArray
+			var yyq883 [2]bool
+			_, _, _ = yysep883, yyq883, yy2arr883
+			const yyr883 bool = false
+			yyq883[0] = x.Backend != nil
+			yyq883[1] = len(x.Rules) != 0
+			if yyr883 || yy2arr883 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn927 int = 0
-				for _, b := range yyq927 {
+				var yynn883 int = 0
+				for _, b := range yyq883 {
 					if b {
-						yynn927++
+						yynn883++
 					}
 				}
-				r.EncodeMapStart(yynn927)
+				r.EncodeMapStart(yynn883)
 			}
-			if yyr927 || yy2arr927 {
-				if yyq927[0] {
+			if yyr883 || yy2arr883 {
+				if yyq883[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -9948,7 +9684,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq927[0] {
+				if yyq883[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
 					if x.Backend == nil {
 						r.EncodeNil()
@@ -9957,13 +9693,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr927 || yy2arr927 {
-				if yyq927[1] {
+			if yyr883 || yy2arr883 {
+				if yyq883[1] {
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym930 := z.EncBinary()
-						_ = yym930
+						yym886 := z.EncBinary()
+						_ = yym886
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9973,13 +9709,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq927[1] {
+				if yyq883[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym931 := z.EncBinary()
-						_ = yym931
+						yym887 := z.EncBinary()
+						_ = yym887
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9987,7 +9723,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep927 {
+			if yysep883 {
 				r.EncodeEnd()
 			}
 		}
@@ -9998,24 +9734,24 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym932 := z.DecBinary()
-	_ = yym932
+	yym888 := z.DecBinary()
+	_ = yym888
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl933 := r.ReadMapStart()
-			if yyl933 == 0 {
+			yyl889 := r.ReadMapStart()
+			if yyl889 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl933, d)
+				x.codecDecodeSelfFromMap(yyl889, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl933 := r.ReadArrayStart()
-			if yyl933 == 0 {
+			yyl889 := r.ReadArrayStart()
+			if yyl889 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl933, d)
+				x.codecDecodeSelfFromArray(yyl889, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10027,12 +9763,12 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys934Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys934Slc
-	var yyhl934 bool = l >= 0
-	for yyj934 := 0; ; yyj934++ {
-		if yyhl934 {
-			if yyj934 >= l {
+	var yys890Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys890Slc
+	var yyhl890 bool = l >= 0
+	for yyj890 := 0; ; yyj890++ {
+		if yyhl890 {
+			if yyj890 >= l {
 				break
 			}
 		} else {
@@ -10040,9 +9776,9 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys934Slc = r.DecodeBytes(yys934Slc, true, true)
-		yys934 := string(yys934Slc)
-		switch yys934 {
+		yys890Slc = r.DecodeBytes(yys890Slc, true, true)
+		yys890 := string(yys890Slc)
+		switch yys890 {
 		case "backend":
 			if r.TryDecodeAsNil() {
 				if x.Backend != nil {
@@ -10058,19 +9794,19 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Rules = nil
 			} else {
-				yyv936 := &x.Rules
-				yym937 := z.DecBinary()
-				_ = yym937
+				yyv892 := &x.Rules
+				yym893 := z.DecBinary()
+				_ = yym893
 				if false {
 				} else {
-					h.decSliceIngressRule((*[]IngressRule)(yyv936), d)
+					h.decSliceIngressRule((*[]IngressRule)(yyv892), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys934)
-		} // end switch yys934
-	} // end for yyj934
-	if !yyhl934 {
+			z.DecStructFieldNotFound(-1, yys890)
+		} // end switch yys890
+	} // end for yyj890
+	if !yyhl890 {
 		r.ReadEnd()
 	}
 }
@@ -10079,16 +9815,16 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj938 int
-	var yyb938 bool
-	var yyhl938 bool = l >= 0
-	yyj938++
-	if yyhl938 {
-		yyb938 = yyj938 > l
+	var yyj894 int
+	var yyb894 bool
+	var yyhl894 bool = l >= 0
+	yyj894++
+	if yyhl894 {
+		yyb894 = yyj894 > l
 	} else {
-		yyb938 = r.CheckBreak()
+		yyb894 = r.CheckBreak()
 	}
-	if yyb938 {
+	if yyb894 {
 		r.ReadEnd()
 		return
 	}
@@ -10102,38 +9838,38 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Backend.CodecDecodeSelf(d)
 	}
-	yyj938++
-	if yyhl938 {
-		yyb938 = yyj938 > l
+	yyj894++
+	if yyhl894 {
+		yyb894 = yyj894 > l
 	} else {
-		yyb938 = r.CheckBreak()
+		yyb894 = r.CheckBreak()
 	}
-	if yyb938 {
+	if yyb894 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
-		yyv940 := &x.Rules
-		yym941 := z.DecBinary()
-		_ = yym941
+		yyv896 := &x.Rules
+		yym897 := z.DecBinary()
+		_ = yym897
 		if false {
 		} else {
-			h.decSliceIngressRule((*[]IngressRule)(yyv940), d)
+			h.decSliceIngressRule((*[]IngressRule)(yyv896), d)
 		}
 	}
 	for {
-		yyj938++
-		if yyhl938 {
-			yyb938 = yyj938 > l
+		yyj894++
+		if yyhl894 {
+			yyb894 = yyj894 > l
 		} else {
-			yyb938 = r.CheckBreak()
+			yyb894 = r.CheckBreak()
 		}
-		if yyb938 {
+		if yyb894 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj938-1, "")
+		z.DecStructFieldNotFound(yyj894-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10145,55 +9881,43 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym942 := z.EncBinary()
-		_ = yym942
+		yym898 := z.EncBinary()
+		_ = yym898
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep943 := !z.EncBinary()
-			yy2arr943 := z.EncBasicHandle().StructToArray
-			var yyq943 [1]bool
-			_, _, _ = yysep943, yyq943, yy2arr943
-			const yyr943 bool = false
-			yyq943[0] = true
-			if yyr943 || yy2arr943 {
+			yysep899 := !z.EncBinary()
+			yy2arr899 := z.EncBasicHandle().StructToArray
+			var yyq899 [1]bool
+			_, _, _ = yysep899, yyq899, yy2arr899
+			const yyr899 bool = false
+			yyq899[0] = true
+			if yyr899 || yy2arr899 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn943 int = 0
-				for _, b := range yyq943 {
+				var yynn899 int = 0
+				for _, b := range yyq899 {
 					if b {
-						yynn943++
+						yynn899++
 					}
 				}
-				r.EncodeMapStart(yynn943)
+				r.EncodeMapStart(yynn899)
 			}
-			if yyr943 || yy2arr943 {
-				if yyq943[0] {
-					yy945 := &x.LoadBalancer
-					yym946 := z.EncBinary()
-					_ = yym946
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy945) {
-					} else {
-						z.EncFallback(yy945)
-					}
+			if yyr899 || yy2arr899 {
+				if yyq899[0] {
+					yy901 := &x.LoadBalancer
+					yy901.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq943[0] {
+				if yyq899[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
-					yy947 := &x.LoadBalancer
-					yym948 := z.EncBinary()
-					_ = yym948
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy947) {
-					} else {
-						z.EncFallback(yy947)
-					}
+					yy902 := &x.LoadBalancer
+					yy902.CodecEncodeSelf(e)
 				}
 			}
-			if yysep943 {
+			if yysep899 {
 				r.EncodeEnd()
 			}
 		}
@@ -10204,24 +9928,24 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym949 := z.DecBinary()
-	_ = yym949
+	yym903 := z.DecBinary()
+	_ = yym903
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl950 := r.ReadMapStart()
-			if yyl950 == 0 {
+			yyl904 := r.ReadMapStart()
+			if yyl904 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl950, d)
+				x.codecDecodeSelfFromMap(yyl904, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl950 := r.ReadArrayStart()
-			if yyl950 == 0 {
+			yyl904 := r.ReadArrayStart()
+			if yyl904 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl950, d)
+				x.codecDecodeSelfFromArray(yyl904, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10233,12 +9957,12 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys951Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys951Slc
-	var yyhl951 bool = l >= 0
-	for yyj951 := 0; ; yyj951++ {
-		if yyhl951 {
-			if yyj951 >= l {
+	var yys905Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys905Slc
+	var yyhl905 bool = l >= 0
+	for yyj905 := 0; ; yyj905++ {
+		if yyhl905 {
+			if yyj905 >= l {
 				break
 			}
 		} else {
@@ -10246,27 +9970,21 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys951Slc = r.DecodeBytes(yys951Slc, true, true)
-		yys951 := string(yys951Slc)
-		switch yys951 {
+		yys905Slc = r.DecodeBytes(yys905Slc, true, true)
+		yys905 := string(yys905Slc)
+		switch yys905 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 			} else {
-				yyv952 := &x.LoadBalancer
-				yym953 := z.DecBinary()
-				_ = yym953
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv952) {
-				} else {
-					z.DecFallback(yyv952, false)
-				}
+				yyv906 := &x.LoadBalancer
+				yyv906.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys951)
-		} // end switch yys951
-	} // end for yyj951
-	if !yyhl951 {
+			z.DecStructFieldNotFound(-1, yys905)
+		} // end switch yys905
+	} // end for yyj905
+	if !yyhl905 {
 		r.ReadEnd()
 	}
 }
@@ -10275,42 +9993,36 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj954 int
-	var yyb954 bool
-	var yyhl954 bool = l >= 0
-	yyj954++
-	if yyhl954 {
-		yyb954 = yyj954 > l
+	var yyj907 int
+	var yyb907 bool
+	var yyhl907 bool = l >= 0
+	yyj907++
+	if yyhl907 {
+		yyb907 = yyj907 > l
 	} else {
-		yyb954 = r.CheckBreak()
+		yyb907 = r.CheckBreak()
 	}
-	if yyb954 {
+	if yyb907 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 	} else {
-		yyv955 := &x.LoadBalancer
-		yym956 := z.DecBinary()
-		_ = yym956
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv955) {
-		} else {
-			z.DecFallback(yyv955, false)
-		}
+		yyv908 := &x.LoadBalancer
+		yyv908.CodecDecodeSelf(d)
 	}
 	for {
-		yyj954++
-		if yyhl954 {
-			yyb954 = yyj954 > l
+		yyj907++
+		if yyhl907 {
+			yyb907 = yyj907 > l
 		} else {
-			yyb954 = r.CheckBreak()
+			yyb907 = r.CheckBreak()
 		}
-		if yyb954 {
+		if yyb907 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj954-1, "")
+		z.DecStructFieldNotFound(yyj907-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10322,33 +10034,33 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym957 := z.EncBinary()
-		_ = yym957
+		yym909 := z.EncBinary()
+		_ = yym909
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep958 := !z.EncBinary()
-			yy2arr958 := z.EncBasicHandle().StructToArray
-			var yyq958 [2]bool
-			_, _, _ = yysep958, yyq958, yy2arr958
-			const yyr958 bool = false
-			yyq958[0] = x.Host != ""
-			yyq958[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
-			if yyr958 || yy2arr958 {
+			yysep910 := !z.EncBinary()
+			yy2arr910 := z.EncBasicHandle().StructToArray
+			var yyq910 [2]bool
+			_, _, _ = yysep910, yyq910, yy2arr910
+			const yyr910 bool = false
+			yyq910[0] = x.Host != ""
+			yyq910[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			if yyr910 || yy2arr910 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn958 int = 0
-				for _, b := range yyq958 {
+				var yynn910 int = 0
+				for _, b := range yyq910 {
 					if b {
-						yynn958++
+						yynn910++
 					}
 				}
-				r.EncodeMapStart(yynn958)
+				r.EncodeMapStart(yynn910)
 			}
-			if yyr958 || yy2arr958 {
-				if yyq958[0] {
-					yym960 := z.EncBinary()
-					_ = yym960
+			if yyr910 || yy2arr910 {
+				if yyq910[0] {
+					yym912 := z.EncBinary()
+					_ = yym912
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -10357,27 +10069,27 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq958[0] {
+				if yyq910[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
-					yym961 := z.EncBinary()
-					_ = yym961
+					yym913 := z.EncBinary()
+					_ = yym913
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			var yyn962 bool
+			var yyn914 bool
 			if x.IngressRuleValue.HTTP == nil {
-				yyn962 = true
-				goto LABEL962
+				yyn914 = true
+				goto LABEL914
 			}
-		LABEL962:
-			if yyr958 || yy2arr958 {
-				if yyn962 {
+		LABEL914:
+			if yyr910 || yy2arr910 {
+				if yyn914 {
 					r.EncodeNil()
 				} else {
-					if yyq958[1] {
+					if yyq910[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
 						} else {
@@ -10388,9 +10100,9 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				if yyq958[1] {
+				if yyq910[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
-					if yyn962 {
+					if yyn914 {
 						r.EncodeNil()
 					} else {
 						if x.HTTP == nil {
@@ -10401,7 +10113,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep958 {
+			if yysep910 {
 				r.EncodeEnd()
 			}
 		}
@@ -10412,24 +10124,24 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym963 := z.DecBinary()
-	_ = yym963
+	yym915 := z.DecBinary()
+	_ = yym915
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl964 := r.ReadMapStart()
-			if yyl964 == 0 {
+			yyl916 := r.ReadMapStart()
+			if yyl916 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl964, d)
+				x.codecDecodeSelfFromMap(yyl916, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl964 := r.ReadArrayStart()
-			if yyl964 == 0 {
+			yyl916 := r.ReadArrayStart()
+			if yyl916 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl964, d)
+				x.codecDecodeSelfFromArray(yyl916, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10441,12 +10153,12 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys965Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys965Slc
-	var yyhl965 bool = l >= 0
-	for yyj965 := 0; ; yyj965++ {
-		if yyhl965 {
-			if yyj965 >= l {
+	var yys917Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys917Slc
+	var yyhl917 bool = l >= 0
+	for yyj917 := 0; ; yyj917++ {
+		if yyhl917 {
+			if yyj917 >= l {
 				break
 			}
 		} else {
@@ -10454,9 +10166,9 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys965Slc = r.DecodeBytes(yys965Slc, true, true)
-		yys965 := string(yys965Slc)
-		switch yys965 {
+		yys917Slc = r.DecodeBytes(yys917Slc, true, true)
+		yys917 := string(yys917Slc)
+		switch yys917 {
 		case "host":
 			if r.TryDecodeAsNil() {
 				x.Host = ""
@@ -10478,10 +10190,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys965)
-		} // end switch yys965
-	} // end for yyj965
-	if !yyhl965 {
+			z.DecStructFieldNotFound(-1, yys917)
+		} // end switch yys917
+	} // end for yyj917
+	if !yyhl917 {
 		r.ReadEnd()
 	}
 }
@@ -10490,16 +10202,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj968 int
-	var yyb968 bool
-	var yyhl968 bool = l >= 0
-	yyj968++
-	if yyhl968 {
-		yyb968 = yyj968 > l
+	var yyj920 int
+	var yyb920 bool
+	var yyhl920 bool = l >= 0
+	yyj920++
+	if yyhl920 {
+		yyb920 = yyj920 > l
 	} else {
-		yyb968 = r.CheckBreak()
+		yyb920 = r.CheckBreak()
 	}
-	if yyb968 {
+	if yyb920 {
 		r.ReadEnd()
 		return
 	}
@@ -10508,13 +10220,13 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Host = string(r.DecodeString())
 	}
-	yyj968++
-	if yyhl968 {
-		yyb968 = yyj968 > l
+	yyj920++
+	if yyhl920 {
+		yyb920 = yyj920 > l
 	} else {
-		yyb968 = r.CheckBreak()
+		yyb920 = r.CheckBreak()
 	}
-	if yyb968 {
+	if yyb920 {
 		r.ReadEnd()
 		return
 	}
@@ -10529,16 +10241,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj968++
-		if yyhl968 {
-			yyb968 = yyj968 > l
+		yyj920++
+		if yyhl920 {
+			yyb920 = yyj920 > l
 		} else {
-			yyb968 = r.CheckBreak()
+			yyb920 = r.CheckBreak()
 		}
-		if yyb968 {
+		if yyb920 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj968-1, "")
+		z.DecStructFieldNotFound(yyj920-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10550,30 +10262,30 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym971 := z.EncBinary()
-		_ = yym971
+		yym923 := z.EncBinary()
+		_ = yym923
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep972 := !z.EncBinary()
-			yy2arr972 := z.EncBasicHandle().StructToArray
-			var yyq972 [1]bool
-			_, _, _ = yysep972, yyq972, yy2arr972
-			const yyr972 bool = false
-			yyq972[0] = x.HTTP != nil
-			if yyr972 || yy2arr972 {
+			yysep924 := !z.EncBinary()
+			yy2arr924 := z.EncBasicHandle().StructToArray
+			var yyq924 [1]bool
+			_, _, _ = yysep924, yyq924, yy2arr924
+			const yyr924 bool = false
+			yyq924[0] = x.HTTP != nil
+			if yyr924 || yy2arr924 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn972 int = 0
-				for _, b := range yyq972 {
+				var yynn924 int = 0
+				for _, b := range yyq924 {
 					if b {
-						yynn972++
+						yynn924++
 					}
 				}
-				r.EncodeMapStart(yynn972)
+				r.EncodeMapStart(yynn924)
 			}
-			if yyr972 || yy2arr972 {
-				if yyq972[0] {
+			if yyr924 || yy2arr924 {
+				if yyq924[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -10583,7 +10295,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq972[0] {
+				if yyq924[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					if x.HTTP == nil {
 						r.EncodeNil()
@@ -10592,7 +10304,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep972 {
+			if yysep924 {
 				r.EncodeEnd()
 			}
 		}
@@ -10603,24 +10315,24 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym974 := z.DecBinary()
-	_ = yym974
+	yym926 := z.DecBinary()
+	_ = yym926
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl975 := r.ReadMapStart()
-			if yyl975 == 0 {
+			yyl927 := r.ReadMapStart()
+			if yyl927 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl975, d)
+				x.codecDecodeSelfFromMap(yyl927, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl975 := r.ReadArrayStart()
-			if yyl975 == 0 {
+			yyl927 := r.ReadArrayStart()
+			if yyl927 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl975, d)
+				x.codecDecodeSelfFromArray(yyl927, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10632,12 +10344,12 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys976Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys976Slc
-	var yyhl976 bool = l >= 0
-	for yyj976 := 0; ; yyj976++ {
-		if yyhl976 {
-			if yyj976 >= l {
+	var yys928Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys928Slc
+	var yyhl928 bool = l >= 0
+	for yyj928 := 0; ; yyj928++ {
+		if yyhl928 {
+			if yyj928 >= l {
 				break
 			}
 		} else {
@@ -10645,9 +10357,9 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys976Slc = r.DecodeBytes(yys976Slc, true, true)
-		yys976 := string(yys976Slc)
-		switch yys976 {
+		yys928Slc = r.DecodeBytes(yys928Slc, true, true)
+		yys928 := string(yys928Slc)
+		switch yys928 {
 		case "http":
 			if r.TryDecodeAsNil() {
 				if x.HTTP != nil {
@@ -10660,10 +10372,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys976)
-		} // end switch yys976
-	} // end for yyj976
-	if !yyhl976 {
+			z.DecStructFieldNotFound(-1, yys928)
+		} // end switch yys928
+	} // end for yyj928
+	if !yyhl928 {
 		r.ReadEnd()
 	}
 }
@@ -10672,16 +10384,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj978 int
-	var yyb978 bool
-	var yyhl978 bool = l >= 0
-	yyj978++
-	if yyhl978 {
-		yyb978 = yyj978 > l
+	var yyj930 int
+	var yyb930 bool
+	var yyhl930 bool = l >= 0
+	yyj930++
+	if yyhl930 {
+		yyb930 = yyj930 > l
 	} else {
-		yyb978 = r.CheckBreak()
+		yyb930 = r.CheckBreak()
 	}
-	if yyb978 {
+	if yyb930 {
 		r.ReadEnd()
 		return
 	}
@@ -10696,16 +10408,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj978++
-		if yyhl978 {
-			yyb978 = yyj978 > l
+		yyj930++
+		if yyhl930 {
+			yyb930 = yyj930 > l
 		} else {
-			yyb978 = r.CheckBreak()
+			yyb930 = r.CheckBreak()
 		}
-		if yyb978 {
+		if yyb930 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj978-1, "")
+		z.DecStructFieldNotFound(yyj930-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10717,33 +10429,33 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym980 := z.EncBinary()
-		_ = yym980
+		yym932 := z.EncBinary()
+		_ = yym932
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep981 := !z.EncBinary()
-			yy2arr981 := z.EncBasicHandle().StructToArray
-			var yyq981 [1]bool
-			_, _, _ = yysep981, yyq981, yy2arr981
-			const yyr981 bool = false
-			if yyr981 || yy2arr981 {
+			yysep933 := !z.EncBinary()
+			yy2arr933 := z.EncBasicHandle().StructToArray
+			var yyq933 [1]bool
+			_, _, _ = yysep933, yyq933, yy2arr933
+			const yyr933 bool = false
+			if yyr933 || yy2arr933 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn981 int = 1
-				for _, b := range yyq981 {
+				var yynn933 int = 1
+				for _, b := range yyq933 {
 					if b {
-						yynn981++
+						yynn933++
 					}
 				}
-				r.EncodeMapStart(yynn981)
+				r.EncodeMapStart(yynn933)
 			}
-			if yyr981 || yy2arr981 {
+			if yyr933 || yy2arr933 {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym983 := z.EncBinary()
-					_ = yym983
+					yym935 := z.EncBinary()
+					_ = yym935
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
@@ -10754,15 +10466,15 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym984 := z.EncBinary()
-					_ = yym984
+					yym936 := z.EncBinary()
+					_ = yym936
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
 					}
 				}
 			}
-			if yysep981 {
+			if yysep933 {
 				r.EncodeEnd()
 			}
 		}
@@ -10773,24 +10485,24 @@ func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym985 := z.DecBinary()
-	_ = yym985
+	yym937 := z.DecBinary()
+	_ = yym937
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl986 := r.ReadMapStart()
-			if yyl986 == 0 {
+			yyl938 := r.ReadMapStart()
+			if yyl938 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl986, d)
+				x.codecDecodeSelfFromMap(yyl938, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl986 := r.ReadArrayStart()
-			if yyl986 == 0 {
+			yyl938 := r.ReadArrayStart()
+			if yyl938 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl986, d)
+				x.codecDecodeSelfFromArray(yyl938, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10802,12 +10514,12 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys987Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys987Slc
-	var yyhl987 bool = l >= 0
-	for yyj987 := 0; ; yyj987++ {
-		if yyhl987 {
-			if yyj987 >= l {
+	var yys939Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys939Slc
+	var yyhl939 bool = l >= 0
+	for yyj939 := 0; ; yyj939++ {
+		if yyhl939 {
+			if yyj939 >= l {
 				break
 			}
 		} else {
@@ -10815,26 +10527,26 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys987Slc = r.DecodeBytes(yys987Slc, true, true)
-		yys987 := string(yys987Slc)
-		switch yys987 {
+		yys939Slc = r.DecodeBytes(yys939Slc, true, true)
+		yys939 := string(yys939Slc)
+		switch yys939 {
 		case "paths":
 			if r.TryDecodeAsNil() {
 				x.Paths = nil
 			} else {
-				yyv988 := &x.Paths
-				yym989 := z.DecBinary()
-				_ = yym989
+				yyv940 := &x.Paths
+				yym941 := z.DecBinary()
+				_ = yym941
 				if false {
 				} else {
-					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv988), d)
+					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv940), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys987)
-		} // end switch yys987
-	} // end for yyj987
-	if !yyhl987 {
+			z.DecStructFieldNotFound(-1, yys939)
+		} // end switch yys939
+	} // end for yyj939
+	if !yyhl939 {
 		r.ReadEnd()
 	}
 }
@@ -10843,41 +10555,41 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj990 int
-	var yyb990 bool
-	var yyhl990 bool = l >= 0
-	yyj990++
-	if yyhl990 {
-		yyb990 = yyj990 > l
+	var yyj942 int
+	var yyb942 bool
+	var yyhl942 bool = l >= 0
+	yyj942++
+	if yyhl942 {
+		yyb942 = yyj942 > l
 	} else {
-		yyb990 = r.CheckBreak()
+		yyb942 = r.CheckBreak()
 	}
-	if yyb990 {
+	if yyb942 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Paths = nil
 	} else {
-		yyv991 := &x.Paths
-		yym992 := z.DecBinary()
-		_ = yym992
+		yyv943 := &x.Paths
+		yym944 := z.DecBinary()
+		_ = yym944
 		if false {
 		} else {
-			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv991), d)
+			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv943), d)
 		}
 	}
 	for {
-		yyj990++
-		if yyhl990 {
-			yyb990 = yyj990 > l
+		yyj942++
+		if yyhl942 {
+			yyb942 = yyj942 > l
 		} else {
-			yyb990 = r.CheckBreak()
+			yyb942 = r.CheckBreak()
 		}
-		if yyb990 {
+		if yyb942 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj990-1, "")
+		z.DecStructFieldNotFound(yyj942-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10889,32 +10601,32 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym993 := z.EncBinary()
-		_ = yym993
+		yym945 := z.EncBinary()
+		_ = yym945
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep994 := !z.EncBinary()
-			yy2arr994 := z.EncBasicHandle().StructToArray
-			var yyq994 [2]bool
-			_, _, _ = yysep994, yyq994, yy2arr994
-			const yyr994 bool = false
-			yyq994[0] = x.Path != ""
-			if yyr994 || yy2arr994 {
+			yysep946 := !z.EncBinary()
+			yy2arr946 := z.EncBasicHandle().StructToArray
+			var yyq946 [2]bool
+			_, _, _ = yysep946, yyq946, yy2arr946
+			const yyr946 bool = false
+			yyq946[0] = x.Path != ""
+			if yyr946 || yy2arr946 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn994 int = 1
-				for _, b := range yyq994 {
+				var yynn946 int = 1
+				for _, b := range yyq946 {
 					if b {
-						yynn994++
+						yynn946++
 					}
 				}
-				r.EncodeMapStart(yynn994)
+				r.EncodeMapStart(yynn946)
 			}
-			if yyr994 || yy2arr994 {
-				if yyq994[0] {
-					yym996 := z.EncBinary()
-					_ = yym996
+			if yyr946 || yy2arr946 {
+				if yyq946[0] {
+					yym948 := z.EncBinary()
+					_ = yym948
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
@@ -10923,25 +10635,25 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq994[0] {
+				if yyq946[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
-					yym997 := z.EncBinary()
-					_ = yym997
+					yym949 := z.EncBinary()
+					_ = yym949
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
-			if yyr994 || yy2arr994 {
-				yy999 := &x.Backend
-				yy999.CodecEncodeSelf(e)
+			if yyr946 || yy2arr946 {
+				yy951 := &x.Backend
+				yy951.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("backend"))
-				yy1000 := &x.Backend
-				yy1000.CodecEncodeSelf(e)
+				yy952 := &x.Backend
+				yy952.CodecEncodeSelf(e)
 			}
-			if yysep994 {
+			if yysep946 {
 				r.EncodeEnd()
 			}
 		}
@@ -10952,24 +10664,24 @@ func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1001 := z.DecBinary()
-	_ = yym1001
+	yym953 := z.DecBinary()
+	_ = yym953
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1002 := r.ReadMapStart()
-			if yyl1002 == 0 {
+			yyl954 := r.ReadMapStart()
+			if yyl954 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1002, d)
+				x.codecDecodeSelfFromMap(yyl954, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1002 := r.ReadArrayStart()
-			if yyl1002 == 0 {
+			yyl954 := r.ReadArrayStart()
+			if yyl954 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1002, d)
+				x.codecDecodeSelfFromArray(yyl954, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10981,12 +10693,12 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1003Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1003Slc
-	var yyhl1003 bool = l >= 0
-	for yyj1003 := 0; ; yyj1003++ {
-		if yyhl1003 {
-			if yyj1003 >= l {
+	var yys955Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys955Slc
+	var yyhl955 bool = l >= 0
+	for yyj955 := 0; ; yyj955++ {
+		if yyhl955 {
+			if yyj955 >= l {
 				break
 			}
 		} else {
@@ -10994,9 +10706,9 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1003Slc = r.DecodeBytes(yys1003Slc, true, true)
-		yys1003 := string(yys1003Slc)
-		switch yys1003 {
+		yys955Slc = r.DecodeBytes(yys955Slc, true, true)
+		yys955 := string(yys955Slc)
+		switch yys955 {
 		case "path":
 			if r.TryDecodeAsNil() {
 				x.Path = ""
@@ -11007,14 +10719,14 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Backend = IngressBackend{}
 			} else {
-				yyv1005 := &x.Backend
-				yyv1005.CodecDecodeSelf(d)
+				yyv957 := &x.Backend
+				yyv957.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1003)
-		} // end switch yys1003
-	} // end for yyj1003
-	if !yyhl1003 {
+			z.DecStructFieldNotFound(-1, yys955)
+		} // end switch yys955
+	} // end for yyj955
+	if !yyhl955 {
 		r.ReadEnd()
 	}
 }
@@ -11023,16 +10735,16 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1006 int
-	var yyb1006 bool
-	var yyhl1006 bool = l >= 0
-	yyj1006++
-	if yyhl1006 {
-		yyb1006 = yyj1006 > l
+	var yyj958 int
+	var yyb958 bool
+	var yyhl958 bool = l >= 0
+	yyj958++
+	if yyhl958 {
+		yyb958 = yyj958 > l
 	} else {
-		yyb1006 = r.CheckBreak()
+		yyb958 = r.CheckBreak()
 	}
-	if yyb1006 {
+	if yyb958 {
 		r.ReadEnd()
 		return
 	}
@@ -11041,33 +10753,33 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Path = string(r.DecodeString())
 	}
-	yyj1006++
-	if yyhl1006 {
-		yyb1006 = yyj1006 > l
+	yyj958++
+	if yyhl958 {
+		yyb958 = yyj958 > l
 	} else {
-		yyb1006 = r.CheckBreak()
+		yyb958 = r.CheckBreak()
 	}
-	if yyb1006 {
+	if yyb958 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Backend = IngressBackend{}
 	} else {
-		yyv1008 := &x.Backend
-		yyv1008.CodecDecodeSelf(d)
+		yyv960 := &x.Backend
+		yyv960.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1006++
-		if yyhl1006 {
-			yyb1006 = yyj1006 > l
+		yyj958++
+		if yyhl958 {
+			yyb958 = yyj958 > l
 		} else {
-			yyb1006 = r.CheckBreak()
+			yyb958 = r.CheckBreak()
 		}
-		if yyb1006 {
+		if yyb958 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1006-1, "")
+		z.DecStructFieldNotFound(yyj958-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11079,68 +10791,68 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1009 := z.EncBinary()
-		_ = yym1009
+		yym961 := z.EncBinary()
+		_ = yym961
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1010 := !z.EncBinary()
-			yy2arr1010 := z.EncBasicHandle().StructToArray
-			var yyq1010 [2]bool
-			_, _, _ = yysep1010, yyq1010, yy2arr1010
-			const yyr1010 bool = false
-			if yyr1010 || yy2arr1010 {
+			yysep962 := !z.EncBinary()
+			yy2arr962 := z.EncBasicHandle().StructToArray
+			var yyq962 [2]bool
+			_, _, _ = yysep962, yyq962, yy2arr962
+			const yyr962 bool = false
+			if yyr962 || yy2arr962 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1010 int = 2
-				for _, b := range yyq1010 {
+				var yynn962 int = 2
+				for _, b := range yyq962 {
 					if b {
-						yynn1010++
+						yynn962++
 					}
 				}
-				r.EncodeMapStart(yynn1010)
+				r.EncodeMapStart(yynn962)
 			}
-			if yyr1010 || yy2arr1010 {
-				yym1012 := z.EncBinary()
-				_ = yym1012
+			if yyr962 || yy2arr962 {
+				yym964 := z.EncBinary()
+				_ = yym964
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
-				yym1013 := z.EncBinary()
-				_ = yym1013
+				yym965 := z.EncBinary()
+				_ = yym965
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			}
-			if yyr1010 || yy2arr1010 {
-				yy1015 := &x.ServicePort
-				yym1016 := z.EncBinary()
-				_ = yym1016
+			if yyr962 || yy2arr962 {
+				yy967 := &x.ServicePort
+				yym968 := z.EncBinary()
+				_ = yym968
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1015) {
-				} else if !yym1016 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1015)
+				} else if z.HasExtensions() && z.EncExt(yy967) {
+				} else if !yym968 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy967)
 				} else {
-					z.EncFallback(yy1015)
+					z.EncFallback(yy967)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
-				yy1017 := &x.ServicePort
-				yym1018 := z.EncBinary()
-				_ = yym1018
+				yy969 := &x.ServicePort
+				yym970 := z.EncBinary()
+				_ = yym970
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1017) {
-				} else if !yym1018 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1017)
+				} else if z.HasExtensions() && z.EncExt(yy969) {
+				} else if !yym970 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy969)
 				} else {
-					z.EncFallback(yy1017)
+					z.EncFallback(yy969)
 				}
 			}
-			if yysep1010 {
+			if yysep962 {
 				r.EncodeEnd()
 			}
 		}
@@ -11151,24 +10863,24 @@ func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1019 := z.DecBinary()
-	_ = yym1019
+	yym971 := z.DecBinary()
+	_ = yym971
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1020 := r.ReadMapStart()
-			if yyl1020 == 0 {
+			yyl972 := r.ReadMapStart()
+			if yyl972 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1020, d)
+				x.codecDecodeSelfFromMap(yyl972, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1020 := r.ReadArrayStart()
-			if yyl1020 == 0 {
+			yyl972 := r.ReadArrayStart()
+			if yyl972 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1020, d)
+				x.codecDecodeSelfFromArray(yyl972, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11180,12 +10892,12 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1021Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1021Slc
-	var yyhl1021 bool = l >= 0
-	for yyj1021 := 0; ; yyj1021++ {
-		if yyhl1021 {
-			if yyj1021 >= l {
+	var yys973Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys973Slc
+	var yyhl973 bool = l >= 0
+	for yyj973 := 0; ; yyj973++ {
+		if yyhl973 {
+			if yyj973 >= l {
 				break
 			}
 		} else {
@@ -11193,9 +10905,9 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1021Slc = r.DecodeBytes(yys1021Slc, true, true)
-		yys1021 := string(yys1021Slc)
-		switch yys1021 {
+		yys973Slc = r.DecodeBytes(yys973Slc, true, true)
+		yys973 := string(yys973Slc)
+		switch yys973 {
 		case "serviceName":
 			if r.TryDecodeAsNil() {
 				x.ServiceName = ""
@@ -11206,22 +10918,22 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ServicePort = pkg6_intstr.IntOrString{}
 			} else {
-				yyv1023 := &x.ServicePort
-				yym1024 := z.DecBinary()
-				_ = yym1024
+				yyv975 := &x.ServicePort
+				yym976 := z.DecBinary()
+				_ = yym976
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1023) {
-				} else if !yym1024 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1023)
+				} else if z.HasExtensions() && z.DecExt(yyv975) {
+				} else if !yym976 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv975)
 				} else {
-					z.DecFallback(yyv1023, false)
+					z.DecFallback(yyv975, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1021)
-		} // end switch yys1021
-	} // end for yyj1021
-	if !yyhl1021 {
+			z.DecStructFieldNotFound(-1, yys973)
+		} // end switch yys973
+	} // end for yyj973
+	if !yyhl973 {
 		r.ReadEnd()
 	}
 }
@@ -11230,16 +10942,16 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1025 int
-	var yyb1025 bool
-	var yyhl1025 bool = l >= 0
-	yyj1025++
-	if yyhl1025 {
-		yyb1025 = yyj1025 > l
+	var yyj977 int
+	var yyb977 bool
+	var yyhl977 bool = l >= 0
+	yyj977++
+	if yyhl977 {
+		yyb977 = yyj977 > l
 	} else {
-		yyb1025 = r.CheckBreak()
+		yyb977 = r.CheckBreak()
 	}
-	if yyb1025 {
+	if yyb977 {
 		r.ReadEnd()
 		return
 	}
@@ -11248,41 +10960,41 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ServiceName = string(r.DecodeString())
 	}
-	yyj1025++
-	if yyhl1025 {
-		yyb1025 = yyj1025 > l
+	yyj977++
+	if yyhl977 {
+		yyb977 = yyj977 > l
 	} else {
-		yyb1025 = r.CheckBreak()
+		yyb977 = r.CheckBreak()
 	}
-	if yyb1025 {
+	if yyb977 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ServicePort = pkg6_intstr.IntOrString{}
 	} else {
-		yyv1027 := &x.ServicePort
-		yym1028 := z.DecBinary()
-		_ = yym1028
+		yyv979 := &x.ServicePort
+		yym980 := z.DecBinary()
+		_ = yym980
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1027) {
-		} else if !yym1028 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1027)
+		} else if z.HasExtensions() && z.DecExt(yyv979) {
+		} else if !yym980 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv979)
 		} else {
-			z.DecFallback(yyv1027, false)
+			z.DecFallback(yyv979, false)
 		}
 	}
 	for {
-		yyj1025++
-		if yyhl1025 {
-			yyb1025 = yyj1025 > l
+		yyj977++
+		if yyhl977 {
+			yyb977 = yyj977 > l
 		} else {
-			yyb1025 = r.CheckBreak()
+			yyb977 = r.CheckBreak()
 		}
-		if yyb1025 {
+		if yyb977 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1025-1, "")
+		z.DecStructFieldNotFound(yyj977-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11291,8 +11003,8 @@ func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1029 := z.EncBinary()
-	_ = yym1029
+	yym981 := z.EncBinary()
+	_ = yym981
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -11304,8 +11016,8 @@ func (x *NodeResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1030 := z.DecBinary()
-	_ = yym1030
+	yym982 := z.DecBinary()
+	_ = yym982
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -11320,50 +11032,50 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1031 := z.EncBinary()
-		_ = yym1031
+		yym983 := z.EncBinary()
+		_ = yym983
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1032 := !z.EncBinary()
-			yy2arr1032 := z.EncBasicHandle().StructToArray
-			var yyq1032 [2]bool
-			_, _, _ = yysep1032, yyq1032, yy2arr1032
-			const yyr1032 bool = false
-			if yyr1032 || yy2arr1032 {
+			yysep984 := !z.EncBinary()
+			yy2arr984 := z.EncBasicHandle().StructToArray
+			var yyq984 [2]bool
+			_, _, _ = yysep984, yyq984, yy2arr984
+			const yyr984 bool = false
+			if yyr984 || yy2arr984 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1032 int = 2
-				for _, b := range yyq1032 {
+				var yynn984 int = 2
+				for _, b := range yyq984 {
 					if b {
-						yynn1032++
+						yynn984++
 					}
 				}
-				r.EncodeMapStart(yynn1032)
+				r.EncodeMapStart(yynn984)
 			}
-			if yyr1032 || yy2arr1032 {
+			if yyr984 || yy2arr984 {
 				x.Resource.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("resource"))
 				x.Resource.CodecEncodeSelf(e)
 			}
-			if yyr1032 || yy2arr1032 {
-				yym1035 := z.EncBinary()
-				_ = yym1035
+			if yyr984 || yy2arr984 {
+				yym987 := z.EncBinary()
+				_ = yym987
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yym1036 := z.EncBinary()
-				_ = yym1036
+				yym988 := z.EncBinary()
+				_ = yym988
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yysep1032 {
+			if yysep984 {
 				r.EncodeEnd()
 			}
 		}
@@ -11374,24 +11086,24 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1037 := z.DecBinary()
-	_ = yym1037
+	yym989 := z.DecBinary()
+	_ = yym989
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1038 := r.ReadMapStart()
-			if yyl1038 == 0 {
+			yyl990 := r.ReadMapStart()
+			if yyl990 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1038, d)
+				x.codecDecodeSelfFromMap(yyl990, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1038 := r.ReadArrayStart()
-			if yyl1038 == 0 {
+			yyl990 := r.ReadArrayStart()
+			if yyl990 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1038, d)
+				x.codecDecodeSelfFromArray(yyl990, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11403,12 +11115,12 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1039Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1039Slc
-	var yyhl1039 bool = l >= 0
-	for yyj1039 := 0; ; yyj1039++ {
-		if yyhl1039 {
-			if yyj1039 >= l {
+	var yys991Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys991Slc
+	var yyhl991 bool = l >= 0
+	for yyj991 := 0; ; yyj991++ {
+		if yyhl991 {
+			if yyj991 >= l {
 				break
 			}
 		} else {
@@ -11416,9 +11128,9 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1039Slc = r.DecodeBytes(yys1039Slc, true, true)
-		yys1039 := string(yys1039Slc)
-		switch yys1039 {
+		yys991Slc = r.DecodeBytes(yys991Slc, true, true)
+		yys991 := string(yys991Slc)
+		switch yys991 {
 		case "resource":
 			if r.TryDecodeAsNil() {
 				x.Resource = ""
@@ -11432,10 +11144,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = float64(r.DecodeFloat(false))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1039)
-		} // end switch yys1039
-	} // end for yyj1039
-	if !yyhl1039 {
+			z.DecStructFieldNotFound(-1, yys991)
+		} // end switch yys991
+	} // end for yyj991
+	if !yyhl991 {
 		r.ReadEnd()
 	}
 }
@@ -11444,16 +11156,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1042 int
-	var yyb1042 bool
-	var yyhl1042 bool = l >= 0
-	yyj1042++
-	if yyhl1042 {
-		yyb1042 = yyj1042 > l
+	var yyj994 int
+	var yyb994 bool
+	var yyhl994 bool = l >= 0
+	yyj994++
+	if yyhl994 {
+		yyb994 = yyj994 > l
 	} else {
-		yyb1042 = r.CheckBreak()
+		yyb994 = r.CheckBreak()
 	}
-	if yyb1042 {
+	if yyb994 {
 		r.ReadEnd()
 		return
 	}
@@ -11462,13 +11174,13 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Resource = NodeResource(r.DecodeString())
 	}
-	yyj1042++
-	if yyhl1042 {
-		yyb1042 = yyj1042 > l
+	yyj994++
+	if yyhl994 {
+		yyb994 = yyj994 > l
 	} else {
-		yyb1042 = r.CheckBreak()
+		yyb994 = r.CheckBreak()
 	}
-	if yyb1042 {
+	if yyb994 {
 		r.ReadEnd()
 		return
 	}
@@ -11478,16 +11190,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Value = float64(r.DecodeFloat(false))
 	}
 	for {
-		yyj1042++
-		if yyhl1042 {
-			yyb1042 = yyj1042 > l
+		yyj994++
+		if yyhl994 {
+			yyb994 = yyj994 > l
 		} else {
-			yyb1042 = r.CheckBreak()
+			yyb994 = r.CheckBreak()
 		}
-		if yyb1042 {
+		if yyb994 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1042-1, "")
+		z.DecStructFieldNotFound(yyj994-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11499,65 +11211,65 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1045 := z.EncBinary()
-		_ = yym1045
+		yym997 := z.EncBinary()
+		_ = yym997
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1046 := !z.EncBinary()
-			yy2arr1046 := z.EncBasicHandle().StructToArray
-			var yyq1046 [3]bool
-			_, _, _ = yysep1046, yyq1046, yy2arr1046
-			const yyr1046 bool = false
-			if yyr1046 || yy2arr1046 {
+			yysep998 := !z.EncBinary()
+			yy2arr998 := z.EncBasicHandle().StructToArray
+			var yyq998 [3]bool
+			_, _, _ = yysep998, yyq998, yy2arr998
+			const yyr998 bool = false
+			if yyr998 || yy2arr998 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1046 int = 3
-				for _, b := range yyq1046 {
+				var yynn998 int = 3
+				for _, b := range yyq998 {
 					if b {
-						yynn1046++
+						yynn998++
 					}
 				}
-				r.EncodeMapStart(yynn1046)
+				r.EncodeMapStart(yynn998)
 			}
-			if yyr1046 || yy2arr1046 {
-				yym1048 := z.EncBinary()
-				_ = yym1048
+			if yyr998 || yy2arr998 {
+				yym1000 := z.EncBinary()
+				_ = yym1000
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
-				yym1049 := z.EncBinary()
-				_ = yym1049
+				yym1001 := z.EncBinary()
+				_ = yym1001
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			}
-			if yyr1046 || yy2arr1046 {
-				yym1051 := z.EncBinary()
-				_ = yym1051
+			if yyr998 || yy2arr998 {
+				yym1003 := z.EncBinary()
+				_ = yym1003
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
-				yym1052 := z.EncBinary()
-				_ = yym1052
+				yym1004 := z.EncBinary()
+				_ = yym1004
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			}
-			if yyr1046 || yy2arr1046 {
+			if yyr998 || yy2arr998 {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1054 := z.EncBinary()
-					_ = yym1054
+					yym1006 := z.EncBinary()
+					_ = yym1006
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
@@ -11568,15 +11280,15 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1055 := z.EncBinary()
-					_ = yym1055
+					yym1007 := z.EncBinary()
+					_ = yym1007
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
 					}
 				}
 			}
-			if yysep1046 {
+			if yysep998 {
 				r.EncodeEnd()
 			}
 		}
@@ -11587,24 +11299,24 @@ func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1056 := z.DecBinary()
-	_ = yym1056
+	yym1008 := z.DecBinary()
+	_ = yym1008
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1057 := r.ReadMapStart()
-			if yyl1057 == 0 {
+			yyl1009 := r.ReadMapStart()
+			if yyl1009 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1057, d)
+				x.codecDecodeSelfFromMap(yyl1009, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1057 := r.ReadArrayStart()
-			if yyl1057 == 0 {
+			yyl1009 := r.ReadArrayStart()
+			if yyl1009 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1057, d)
+				x.codecDecodeSelfFromArray(yyl1009, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11616,12 +11328,12 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1058Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1058Slc
-	var yyhl1058 bool = l >= 0
-	for yyj1058 := 0; ; yyj1058++ {
-		if yyhl1058 {
-			if yyj1058 >= l {
+	var yys1010Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1010Slc
+	var yyhl1010 bool = l >= 0
+	for yyj1010 := 0; ; yyj1010++ {
+		if yyhl1010 {
+			if yyj1010 >= l {
 				break
 			}
 		} else {
@@ -11629,9 +11341,9 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1058Slc = r.DecodeBytes(yys1058Slc, true, true)
-		yys1058 := string(yys1058Slc)
-		switch yys1058 {
+		yys1010Slc = r.DecodeBytes(yys1010Slc, true, true)
+		yys1010 := string(yys1010Slc)
+		switch yys1010 {
 		case "minNodes":
 			if r.TryDecodeAsNil() {
 				x.MinNodes = 0
@@ -11648,19 +11360,19 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.TargetUtilization = nil
 			} else {
-				yyv1061 := &x.TargetUtilization
-				yym1062 := z.DecBinary()
-				_ = yym1062
+				yyv1013 := &x.TargetUtilization
+				yym1014 := z.DecBinary()
+				_ = yym1014
 				if false {
 				} else {
-					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1061), d)
+					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1013), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1058)
-		} // end switch yys1058
-	} // end for yyj1058
-	if !yyhl1058 {
+			z.DecStructFieldNotFound(-1, yys1010)
+		} // end switch yys1010
+	} // end for yyj1010
+	if !yyhl1010 {
 		r.ReadEnd()
 	}
 }
@@ -11669,16 +11381,16 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1063 int
-	var yyb1063 bool
-	var yyhl1063 bool = l >= 0
-	yyj1063++
-	if yyhl1063 {
-		yyb1063 = yyj1063 > l
+	var yyj1015 int
+	var yyb1015 bool
+	var yyhl1015 bool = l >= 0
+	yyj1015++
+	if yyhl1015 {
+		yyb1015 = yyj1015 > l
 	} else {
-		yyb1063 = r.CheckBreak()
+		yyb1015 = r.CheckBreak()
 	}
-	if yyb1063 {
+	if yyb1015 {
 		r.ReadEnd()
 		return
 	}
@@ -11687,13 +11399,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1063++
-	if yyhl1063 {
-		yyb1063 = yyj1063 > l
+	yyj1015++
+	if yyhl1015 {
+		yyb1015 = yyj1015 > l
 	} else {
-		yyb1063 = r.CheckBreak()
+		yyb1015 = r.CheckBreak()
 	}
-	if yyb1063 {
+	if yyb1015 {
 		r.ReadEnd()
 		return
 	}
@@ -11702,38 +11414,38 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1063++
-	if yyhl1063 {
-		yyb1063 = yyj1063 > l
+	yyj1015++
+	if yyhl1015 {
+		yyb1015 = yyj1015 > l
 	} else {
-		yyb1063 = r.CheckBreak()
+		yyb1015 = r.CheckBreak()
 	}
-	if yyb1063 {
+	if yyb1015 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.TargetUtilization = nil
 	} else {
-		yyv1066 := &x.TargetUtilization
-		yym1067 := z.DecBinary()
-		_ = yym1067
+		yyv1018 := &x.TargetUtilization
+		yym1019 := z.DecBinary()
+		_ = yym1019
 		if false {
 		} else {
-			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1066), d)
+			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1018), d)
 		}
 	}
 	for {
-		yyj1063++
-		if yyhl1063 {
-			yyb1063 = yyj1063 > l
+		yyj1015++
+		if yyhl1015 {
+			yyb1015 = yyj1015 > l
 		} else {
-			yyb1063 = r.CheckBreak()
+			yyb1015 = r.CheckBreak()
 		}
-		if yyb1063 {
+		if yyb1015 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1063-1, "")
+		z.DecStructFieldNotFound(yyj1015-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11745,35 +11457,35 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1068 := z.EncBinary()
-		_ = yym1068
+		yym1020 := z.EncBinary()
+		_ = yym1020
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1069 := !z.EncBinary()
-			yy2arr1069 := z.EncBasicHandle().StructToArray
-			var yyq1069 [4]bool
-			_, _, _ = yysep1069, yyq1069, yy2arr1069
-			const yyr1069 bool = false
-			yyq1069[0] = x.Kind != ""
-			yyq1069[1] = x.APIVersion != ""
-			yyq1069[2] = true
-			yyq1069[3] = true
-			if yyr1069 || yy2arr1069 {
+			yysep1021 := !z.EncBinary()
+			yy2arr1021 := z.EncBasicHandle().StructToArray
+			var yyq1021 [4]bool
+			_, _, _ = yysep1021, yyq1021, yy2arr1021
+			const yyr1021 bool = false
+			yyq1021[0] = x.Kind != ""
+			yyq1021[1] = x.APIVersion != ""
+			yyq1021[2] = true
+			yyq1021[3] = true
+			if yyr1021 || yy2arr1021 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1069 int = 0
-				for _, b := range yyq1069 {
+				var yynn1021 int = 0
+				for _, b := range yyq1021 {
 					if b {
-						yynn1069++
+						yynn1021++
 					}
 				}
-				r.EncodeMapStart(yynn1069)
+				r.EncodeMapStart(yynn1021)
 			}
-			if yyr1069 || yy2arr1069 {
-				if yyq1069[0] {
-					yym1071 := z.EncBinary()
-					_ = yym1071
+			if yyr1021 || yy2arr1021 {
+				if yyq1021[0] {
+					yym1023 := z.EncBinary()
+					_ = yym1023
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11782,20 +11494,20 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1069[0] {
+				if yyq1021[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1072 := z.EncBinary()
-					_ = yym1072
+					yym1024 := z.EncBinary()
+					_ = yym1024
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1069 || yy2arr1069 {
-				if yyq1069[1] {
-					yym1074 := z.EncBinary()
-					_ = yym1074
+			if yyr1021 || yy2arr1021 {
+				if yyq1021[1] {
+					yym1026 := z.EncBinary()
+					_ = yym1026
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11804,57 +11516,45 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1069[1] {
+				if yyq1021[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1075 := z.EncBinary()
-					_ = yym1075
+					yym1027 := z.EncBinary()
+					_ = yym1027
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1069 || yy2arr1069 {
-				if yyq1069[2] {
-					yy1077 := &x.ObjectMeta
-					yym1078 := z.EncBinary()
-					_ = yym1078
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1077) {
-					} else {
-						z.EncFallback(yy1077)
-					}
+			if yyr1021 || yy2arr1021 {
+				if yyq1021[2] {
+					yy1029 := &x.ObjectMeta
+					yy1029.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1069[2] {
+				if yyq1021[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1079 := &x.ObjectMeta
-					yym1080 := z.EncBinary()
-					_ = yym1080
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1079) {
-					} else {
-						z.EncFallback(yy1079)
-					}
+					yy1030 := &x.ObjectMeta
+					yy1030.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1069 || yy2arr1069 {
-				if yyq1069[3] {
-					yy1082 := &x.Spec
-					yy1082.CodecEncodeSelf(e)
+			if yyr1021 || yy2arr1021 {
+				if yyq1021[3] {
+					yy1032 := &x.Spec
+					yy1032.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1069[3] {
+				if yyq1021[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1083 := &x.Spec
-					yy1083.CodecEncodeSelf(e)
+					yy1033 := &x.Spec
+					yy1033.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1069 {
+			if yysep1021 {
 				r.EncodeEnd()
 			}
 		}
@@ -11865,24 +11565,24 @@ func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1084 := z.DecBinary()
-	_ = yym1084
+	yym1034 := z.DecBinary()
+	_ = yym1034
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1085 := r.ReadMapStart()
-			if yyl1085 == 0 {
+			yyl1035 := r.ReadMapStart()
+			if yyl1035 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1085, d)
+				x.codecDecodeSelfFromMap(yyl1035, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1085 := r.ReadArrayStart()
-			if yyl1085 == 0 {
+			yyl1035 := r.ReadArrayStart()
+			if yyl1035 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1085, d)
+				x.codecDecodeSelfFromArray(yyl1035, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11894,12 +11594,12 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1086Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1086Slc
-	var yyhl1086 bool = l >= 0
-	for yyj1086 := 0; ; yyj1086++ {
-		if yyhl1086 {
-			if yyj1086 >= l {
+	var yys1036Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1036Slc
+	var yyhl1036 bool = l >= 0
+	for yyj1036 := 0; ; yyj1036++ {
+		if yyhl1036 {
+			if yyj1036 >= l {
 				break
 			}
 		} else {
@@ -11907,9 +11607,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys1086Slc = r.DecodeBytes(yys1086Slc, true, true)
-		yys1086 := string(yys1086Slc)
-		switch yys1086 {
+		yys1036Slc = r.DecodeBytes(yys1036Slc, true, true)
+		yys1036 := string(yys1036Slc)
+		switch yys1036 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -11926,27 +11626,21 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv1089 := &x.ObjectMeta
-				yym1090 := z.DecBinary()
-				_ = yym1090
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1089) {
-				} else {
-					z.DecFallback(yyv1089, false)
-				}
+				yyv1039 := &x.ObjectMeta
+				yyv1039.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ClusterAutoscalerSpec{}
 			} else {
-				yyv1091 := &x.Spec
-				yyv1091.CodecDecodeSelf(d)
+				yyv1040 := &x.Spec
+				yyv1040.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1086)
-		} // end switch yys1086
-	} // end for yyj1086
-	if !yyhl1086 {
+			z.DecStructFieldNotFound(-1, yys1036)
+		} // end switch yys1036
+	} // end for yyj1036
+	if !yyhl1036 {
 		r.ReadEnd()
 	}
 }
@@ -11955,16 +11649,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1092 int
-	var yyb1092 bool
-	var yyhl1092 bool = l >= 0
-	yyj1092++
-	if yyhl1092 {
-		yyb1092 = yyj1092 > l
+	var yyj1041 int
+	var yyb1041 bool
+	var yyhl1041 bool = l >= 0
+	yyj1041++
+	if yyhl1041 {
+		yyb1041 = yyj1041 > l
 	} else {
-		yyb1092 = r.CheckBreak()
+		yyb1041 = r.CheckBreak()
 	}
-	if yyb1092 {
+	if yyb1041 {
 		r.ReadEnd()
 		return
 	}
@@ -11973,13 +11667,13 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1092++
-	if yyhl1092 {
-		yyb1092 = yyj1092 > l
+	yyj1041++
+	if yyhl1041 {
+		yyb1041 = yyj1041 > l
 	} else {
-		yyb1092 = r.CheckBreak()
+		yyb1041 = r.CheckBreak()
 	}
-	if yyb1092 {
+	if yyb1041 {
 		r.ReadEnd()
 		return
 	}
@@ -11988,55 +11682,49 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1092++
-	if yyhl1092 {
-		yyb1092 = yyj1092 > l
+	yyj1041++
+	if yyhl1041 {
+		yyb1041 = yyj1041 > l
 	} else {
-		yyb1092 = r.CheckBreak()
+		yyb1041 = r.CheckBreak()
 	}
-	if yyb1092 {
+	if yyb1041 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv1095 := &x.ObjectMeta
-		yym1096 := z.DecBinary()
-		_ = yym1096
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1095) {
-		} else {
-			z.DecFallback(yyv1095, false)
-		}
+		yyv1044 := &x.ObjectMeta
+		yyv1044.CodecDecodeSelf(d)
 	}
-	yyj1092++
-	if yyhl1092 {
-		yyb1092 = yyj1092 > l
+	yyj1041++
+	if yyhl1041 {
+		yyb1041 = yyj1041 > l
 	} else {
-		yyb1092 = r.CheckBreak()
+		yyb1041 = r.CheckBreak()
 	}
-	if yyb1092 {
+	if yyb1041 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ClusterAutoscalerSpec{}
 	} else {
-		yyv1097 := &x.Spec
-		yyv1097.CodecDecodeSelf(d)
+		yyv1045 := &x.Spec
+		yyv1045.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1092++
-		if yyhl1092 {
-			yyb1092 = yyj1092 > l
+		yyj1041++
+		if yyhl1041 {
+			yyb1041 = yyj1041 > l
 		} else {
-			yyb1092 = r.CheckBreak()
+			yyb1041 = r.CheckBreak()
 		}
-		if yyb1092 {
+		if yyb1041 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1092-1, "")
+		z.DecStructFieldNotFound(yyj1041-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12048,34 +11736,34 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1098 := z.EncBinary()
-		_ = yym1098
+		yym1046 := z.EncBinary()
+		_ = yym1046
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1099 := !z.EncBinary()
-			yy2arr1099 := z.EncBasicHandle().StructToArray
-			var yyq1099 [4]bool
-			_, _, _ = yysep1099, yyq1099, yy2arr1099
-			const yyr1099 bool = false
-			yyq1099[0] = x.Kind != ""
-			yyq1099[1] = x.APIVersion != ""
-			yyq1099[2] = true
-			if yyr1099 || yy2arr1099 {
+			yysep1047 := !z.EncBinary()
+			yy2arr1047 := z.EncBasicHandle().StructToArray
+			var yyq1047 [4]bool
+			_, _, _ = yysep1047, yyq1047, yy2arr1047
+			const yyr1047 bool = false
+			yyq1047[0] = x.Kind != ""
+			yyq1047[1] = x.APIVersion != ""
+			yyq1047[2] = true
+			if yyr1047 || yy2arr1047 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1099 int = 1
-				for _, b := range yyq1099 {
+				var yynn1047 int = 1
+				for _, b := range yyq1047 {
 					if b {
-						yynn1099++
+						yynn1047++
 					}
 				}
-				r.EncodeMapStart(yynn1099)
+				r.EncodeMapStart(yynn1047)
 			}
-			if yyr1099 || yy2arr1099 {
-				if yyq1099[0] {
-					yym1101 := z.EncBinary()
-					_ = yym1101
+			if yyr1047 || yy2arr1047 {
+				if yyq1047[0] {
+					yym1049 := z.EncBinary()
+					_ = yym1049
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -12084,20 +11772,20 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1099[0] {
+				if yyq1047[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1102 := z.EncBinary()
-					_ = yym1102
+					yym1050 := z.EncBinary()
+					_ = yym1050
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1099 || yy2arr1099 {
-				if yyq1099[1] {
-					yym1104 := z.EncBinary()
-					_ = yym1104
+			if yyr1047 || yy2arr1047 {
+				if yyq1047[1] {
+					yym1052 := z.EncBinary()
+					_ = yym1052
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -12106,48 +11794,48 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1099[1] {
+				if yyq1047[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1105 := z.EncBinary()
-					_ = yym1105
+					yym1053 := z.EncBinary()
+					_ = yym1053
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1099 || yy2arr1099 {
-				if yyq1099[2] {
-					yy1107 := &x.ListMeta
-					yym1108 := z.EncBinary()
-					_ = yym1108
+			if yyr1047 || yy2arr1047 {
+				if yyq1047[2] {
+					yy1055 := &x.ListMeta
+					yym1056 := z.EncBinary()
+					_ = yym1056
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1107) {
+					} else if z.HasExtensions() && z.EncExt(yy1055) {
 					} else {
-						z.EncFallback(yy1107)
+						z.EncFallback(yy1055)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1099[2] {
+				if yyq1047[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1109 := &x.ListMeta
-					yym1110 := z.EncBinary()
-					_ = yym1110
+					yy1057 := &x.ListMeta
+					yym1058 := z.EncBinary()
+					_ = yym1058
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1109) {
+					} else if z.HasExtensions() && z.EncExt(yy1057) {
 					} else {
-						z.EncFallback(yy1109)
+						z.EncFallback(yy1057)
 					}
 				}
 			}
-			if yyr1099 || yy2arr1099 {
+			if yyr1047 || yy2arr1047 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1112 := z.EncBinary()
-					_ = yym1112
+					yym1060 := z.EncBinary()
+					_ = yym1060
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -12158,15 +11846,15 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1113 := z.EncBinary()
-					_ = yym1113
+					yym1061 := z.EncBinary()
+					_ = yym1061
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep1099 {
+			if yysep1047 {
 				r.EncodeEnd()
 			}
 		}
@@ -12177,24 +11865,24 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1114 := z.DecBinary()
-	_ = yym1114
+	yym1062 := z.DecBinary()
+	_ = yym1062
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1115 := r.ReadMapStart()
-			if yyl1115 == 0 {
+			yyl1063 := r.ReadMapStart()
+			if yyl1063 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1115, d)
+				x.codecDecodeSelfFromMap(yyl1063, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1115 := r.ReadArrayStart()
-			if yyl1115 == 0 {
+			yyl1063 := r.ReadArrayStart()
+			if yyl1063 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1115, d)
+				x.codecDecodeSelfFromArray(yyl1063, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12206,12 +11894,12 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1116Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1116Slc
-	var yyhl1116 bool = l >= 0
-	for yyj1116 := 0; ; yyj1116++ {
-		if yyhl1116 {
-			if yyj1116 >= l {
+	var yys1064Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1064Slc
+	var yyhl1064 bool = l >= 0
+	for yyj1064 := 0; ; yyj1064++ {
+		if yyhl1064 {
+			if yyj1064 >= l {
 				break
 			}
 		} else {
@@ -12219,9 +11907,9 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1116Slc = r.DecodeBytes(yys1116Slc, true, true)
-		yys1116 := string(yys1116Slc)
-		switch yys1116 {
+		yys1064Slc = r.DecodeBytes(yys1064Slc, true, true)
+		yys1064 := string(yys1064Slc)
+		switch yys1064 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -12238,32 +11926,32 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1119 := &x.ListMeta
-				yym1120 := z.DecBinary()
-				_ = yym1120
+				yyv1067 := &x.ListMeta
+				yym1068 := z.DecBinary()
+				_ = yym1068
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1119) {
+				} else if z.HasExtensions() && z.DecExt(yyv1067) {
 				} else {
-					z.DecFallback(yyv1119, false)
+					z.DecFallback(yyv1067, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1121 := &x.Items
-				yym1122 := z.DecBinary()
-				_ = yym1122
+				yyv1069 := &x.Items
+				yym1070 := z.DecBinary()
+				_ = yym1070
 				if false {
 				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1121), d)
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1069), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1116)
-		} // end switch yys1116
-	} // end for yyj1116
-	if !yyhl1116 {
+			z.DecStructFieldNotFound(-1, yys1064)
+		} // end switch yys1064
+	} // end for yyj1064
+	if !yyhl1064 {
 		r.ReadEnd()
 	}
 }
@@ -12272,16 +11960,16 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1123 int
-	var yyb1123 bool
-	var yyhl1123 bool = l >= 0
-	yyj1123++
-	if yyhl1123 {
-		yyb1123 = yyj1123 > l
+	var yyj1071 int
+	var yyb1071 bool
+	var yyhl1071 bool = l >= 0
+	yyj1071++
+	if yyhl1071 {
+		yyb1071 = yyj1071 > l
 	} else {
-		yyb1123 = r.CheckBreak()
+		yyb1071 = r.CheckBreak()
 	}
-	if yyb1123 {
+	if yyb1071 {
 		r.ReadEnd()
 		return
 	}
@@ -12290,13 +11978,13 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1123++
-	if yyhl1123 {
-		yyb1123 = yyj1123 > l
+	yyj1071++
+	if yyhl1071 {
+		yyb1071 = yyj1071 > l
 	} else {
-		yyb1123 = r.CheckBreak()
+		yyb1071 = r.CheckBreak()
 	}
-	if yyb1123 {
+	if yyb1071 {
 		r.ReadEnd()
 		return
 	}
@@ -12305,60 +11993,60 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1123++
-	if yyhl1123 {
-		yyb1123 = yyj1123 > l
+	yyj1071++
+	if yyhl1071 {
+		yyb1071 = yyj1071 > l
 	} else {
-		yyb1123 = r.CheckBreak()
+		yyb1071 = r.CheckBreak()
 	}
-	if yyb1123 {
+	if yyb1071 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1126 := &x.ListMeta
-		yym1127 := z.DecBinary()
-		_ = yym1127
+		yyv1074 := &x.ListMeta
+		yym1075 := z.DecBinary()
+		_ = yym1075
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1126) {
+		} else if z.HasExtensions() && z.DecExt(yyv1074) {
 		} else {
-			z.DecFallback(yyv1126, false)
+			z.DecFallback(yyv1074, false)
 		}
 	}
-	yyj1123++
-	if yyhl1123 {
-		yyb1123 = yyj1123 > l
+	yyj1071++
+	if yyhl1071 {
+		yyb1071 = yyj1071 > l
 	} else {
-		yyb1123 = r.CheckBreak()
+		yyb1071 = r.CheckBreak()
 	}
-	if yyb1123 {
+	if yyb1071 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1128 := &x.Items
-		yym1129 := z.DecBinary()
-		_ = yym1129
+		yyv1076 := &x.Items
+		yym1077 := z.DecBinary()
+		_ = yym1077
 		if false {
 		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1128), d)
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1076), d)
 		}
 	}
 	for {
-		yyj1123++
-		if yyhl1123 {
-			yyb1123 = yyj1123 > l
+		yyj1071++
+		if yyhl1071 {
+			yyb1071 = yyj1071 > l
 		} else {
-			yyb1123 = r.CheckBreak()
+			yyb1071 = r.CheckBreak()
 		}
-		if yyb1123 {
+		if yyb1071 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1123-1, "")
+		z.DecStructFieldNotFound(yyj1071-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12370,36 +12058,36 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1130 := z.EncBinary()
-		_ = yym1130
+		yym1078 := z.EncBinary()
+		_ = yym1078
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1131 := !z.EncBinary()
-			yy2arr1131 := z.EncBasicHandle().StructToArray
-			var yyq1131 [2]bool
-			_, _, _ = yysep1131, yyq1131, yy2arr1131
-			const yyr1131 bool = false
-			yyq1131[0] = len(x.MatchLabels) != 0
-			yyq1131[1] = len(x.MatchExpressions) != 0
-			if yyr1131 || yy2arr1131 {
+			yysep1079 := !z.EncBinary()
+			yy2arr1079 := z.EncBasicHandle().StructToArray
+			var yyq1079 [2]bool
+			_, _, _ = yysep1079, yyq1079, yy2arr1079
+			const yyr1079 bool = false
+			yyq1079[0] = len(x.MatchLabels) != 0
+			yyq1079[1] = len(x.MatchExpressions) != 0
+			if yyr1079 || yy2arr1079 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1131 int = 0
-				for _, b := range yyq1131 {
+				var yynn1079 int = 0
+				for _, b := range yyq1079 {
 					if b {
-						yynn1131++
+						yynn1079++
 					}
 				}
-				r.EncodeMapStart(yynn1131)
+				r.EncodeMapStart(yynn1079)
 			}
-			if yyr1131 || yy2arr1131 {
-				if yyq1131[0] {
+			if yyr1079 || yy2arr1079 {
+				if yyq1079[0] {
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1133 := z.EncBinary()
-						_ = yym1133
+						yym1081 := z.EncBinary()
+						_ = yym1081
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12409,13 +12097,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1131[0] {
+				if yyq1079[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1134 := z.EncBinary()
-						_ = yym1134
+						yym1082 := z.EncBinary()
+						_ = yym1082
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12423,13 +12111,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1131 || yy2arr1131 {
-				if yyq1131[1] {
+			if yyr1079 || yy2arr1079 {
+				if yyq1079[1] {
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1136 := z.EncBinary()
-						_ = yym1136
+						yym1084 := z.EncBinary()
+						_ = yym1084
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12439,13 +12127,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1131[1] {
+				if yyq1079[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1137 := z.EncBinary()
-						_ = yym1137
+						yym1085 := z.EncBinary()
+						_ = yym1085
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12453,7 +12141,7 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1131 {
+			if yysep1079 {
 				r.EncodeEnd()
 			}
 		}
@@ -12464,24 +12152,24 @@ func (x *PodSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1138 := z.DecBinary()
-	_ = yym1138
+	yym1086 := z.DecBinary()
+	_ = yym1086
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1139 := r.ReadMapStart()
-			if yyl1139 == 0 {
+			yyl1087 := r.ReadMapStart()
+			if yyl1087 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1139, d)
+				x.codecDecodeSelfFromMap(yyl1087, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1139 := r.ReadArrayStart()
-			if yyl1139 == 0 {
+			yyl1087 := r.ReadArrayStart()
+			if yyl1087 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1139, d)
+				x.codecDecodeSelfFromArray(yyl1087, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12493,12 +12181,12 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1140Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1140Slc
-	var yyhl1140 bool = l >= 0
-	for yyj1140 := 0; ; yyj1140++ {
-		if yyhl1140 {
-			if yyj1140 >= l {
+	var yys1088Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1088Slc
+	var yyhl1088 bool = l >= 0
+	for yyj1088 := 0; ; yyj1088++ {
+		if yyhl1088 {
+			if yyj1088 >= l {
 				break
 			}
 		} else {
@@ -12506,38 +12194,38 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1140Slc = r.DecodeBytes(yys1140Slc, true, true)
-		yys1140 := string(yys1140Slc)
-		switch yys1140 {
+		yys1088Slc = r.DecodeBytes(yys1088Slc, true, true)
+		yys1088 := string(yys1088Slc)
+		switch yys1088 {
 		case "matchLabels":
 			if r.TryDecodeAsNil() {
 				x.MatchLabels = nil
 			} else {
-				yyv1141 := &x.MatchLabels
-				yym1142 := z.DecBinary()
-				_ = yym1142
+				yyv1089 := &x.MatchLabels
+				yym1090 := z.DecBinary()
+				_ = yym1090
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1141, false, d)
+					z.F.DecMapStringStringX(yyv1089, false, d)
 				}
 			}
 		case "matchExpressions":
 			if r.TryDecodeAsNil() {
 				x.MatchExpressions = nil
 			} else {
-				yyv1143 := &x.MatchExpressions
-				yym1144 := z.DecBinary()
-				_ = yym1144
+				yyv1091 := &x.MatchExpressions
+				yym1092 := z.DecBinary()
+				_ = yym1092
 				if false {
 				} else {
-					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1143), d)
+					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1091), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1140)
-		} // end switch yys1140
-	} // end for yyj1140
-	if !yyhl1140 {
+			z.DecStructFieldNotFound(-1, yys1088)
+		} // end switch yys1088
+	} // end for yyj1088
+	if !yyhl1088 {
 		r.ReadEnd()
 	}
 }
@@ -12546,62 +12234,62 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1145 int
-	var yyb1145 bool
-	var yyhl1145 bool = l >= 0
-	yyj1145++
-	if yyhl1145 {
-		yyb1145 = yyj1145 > l
+	var yyj1093 int
+	var yyb1093 bool
+	var yyhl1093 bool = l >= 0
+	yyj1093++
+	if yyhl1093 {
+		yyb1093 = yyj1093 > l
 	} else {
-		yyb1145 = r.CheckBreak()
+		yyb1093 = r.CheckBreak()
 	}
-	if yyb1145 {
+	if yyb1093 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchLabels = nil
 	} else {
-		yyv1146 := &x.MatchLabels
-		yym1147 := z.DecBinary()
-		_ = yym1147
+		yyv1094 := &x.MatchLabels
+		yym1095 := z.DecBinary()
+		_ = yym1095
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1146, false, d)
+			z.F.DecMapStringStringX(yyv1094, false, d)
 		}
 	}
-	yyj1145++
-	if yyhl1145 {
-		yyb1145 = yyj1145 > l
+	yyj1093++
+	if yyhl1093 {
+		yyb1093 = yyj1093 > l
 	} else {
-		yyb1145 = r.CheckBreak()
+		yyb1093 = r.CheckBreak()
 	}
-	if yyb1145 {
+	if yyb1093 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchExpressions = nil
 	} else {
-		yyv1148 := &x.MatchExpressions
-		yym1149 := z.DecBinary()
-		_ = yym1149
+		yyv1096 := &x.MatchExpressions
+		yym1097 := z.DecBinary()
+		_ = yym1097
 		if false {
 		} else {
-			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1148), d)
+			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1096), d)
 		}
 	}
 	for {
-		yyj1145++
-		if yyhl1145 {
-			yyb1145 = yyj1145 > l
+		yyj1093++
+		if yyhl1093 {
+			yyb1093 = yyj1093 > l
 		} else {
-			yyb1145 = r.CheckBreak()
+			yyb1093 = r.CheckBreak()
 		}
-		if yyb1145 {
+		if yyb1093 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1145-1, "")
+		z.DecStructFieldNotFound(yyj1093-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12613,57 +12301,57 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1150 := z.EncBinary()
-		_ = yym1150
+		yym1098 := z.EncBinary()
+		_ = yym1098
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1151 := !z.EncBinary()
-			yy2arr1151 := z.EncBasicHandle().StructToArray
-			var yyq1151 [3]bool
-			_, _, _ = yysep1151, yyq1151, yy2arr1151
-			const yyr1151 bool = false
-			yyq1151[2] = len(x.Values) != 0
-			if yyr1151 || yy2arr1151 {
+			yysep1099 := !z.EncBinary()
+			yy2arr1099 := z.EncBasicHandle().StructToArray
+			var yyq1099 [3]bool
+			_, _, _ = yysep1099, yyq1099, yy2arr1099
+			const yyr1099 bool = false
+			yyq1099[2] = len(x.Values) != 0
+			if yyr1099 || yy2arr1099 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1151 int = 2
-				for _, b := range yyq1151 {
+				var yynn1099 int = 2
+				for _, b := range yyq1099 {
 					if b {
-						yynn1151++
+						yynn1099++
 					}
 				}
-				r.EncodeMapStart(yynn1151)
+				r.EncodeMapStart(yynn1099)
 			}
-			if yyr1151 || yy2arr1151 {
-				yym1153 := z.EncBinary()
-				_ = yym1153
+			if yyr1099 || yy2arr1099 {
+				yym1101 := z.EncBinary()
+				_ = yym1101
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
-				yym1154 := z.EncBinary()
-				_ = yym1154
+				yym1102 := z.EncBinary()
+				_ = yym1102
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			}
-			if yyr1151 || yy2arr1151 {
+			if yyr1099 || yy2arr1099 {
 				x.Operator.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("operator"))
 				x.Operator.CodecEncodeSelf(e)
 			}
-			if yyr1151 || yy2arr1151 {
-				if yyq1151[2] {
+			if yyr1099 || yy2arr1099 {
+				if yyq1099[2] {
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1157 := z.EncBinary()
-						_ = yym1157
+						yym1105 := z.EncBinary()
+						_ = yym1105
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12673,13 +12361,13 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1151[2] {
+				if yyq1099[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("values"))
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1158 := z.EncBinary()
-						_ = yym1158
+						yym1106 := z.EncBinary()
+						_ = yym1106
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12687,7 +12375,7 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1151 {
+			if yysep1099 {
 				r.EncodeEnd()
 			}
 		}
@@ -12698,24 +12386,24 @@ func (x *PodSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1159 := z.DecBinary()
-	_ = yym1159
+	yym1107 := z.DecBinary()
+	_ = yym1107
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1160 := r.ReadMapStart()
-			if yyl1160 == 0 {
+			yyl1108 := r.ReadMapStart()
+			if yyl1108 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1160, d)
+				x.codecDecodeSelfFromMap(yyl1108, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1160 := r.ReadArrayStart()
-			if yyl1160 == 0 {
+			yyl1108 := r.ReadArrayStart()
+			if yyl1108 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1160, d)
+				x.codecDecodeSelfFromArray(yyl1108, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12727,12 +12415,12 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1161Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1161Slc
-	var yyhl1161 bool = l >= 0
-	for yyj1161 := 0; ; yyj1161++ {
-		if yyhl1161 {
-			if yyj1161 >= l {
+	var yys1109Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1109Slc
+	var yyhl1109 bool = l >= 0
+	for yyj1109 := 0; ; yyj1109++ {
+		if yyhl1109 {
+			if yyj1109 >= l {
 				break
 			}
 		} else {
@@ -12740,9 +12428,9 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys1161Slc = r.DecodeBytes(yys1161Slc, true, true)
-		yys1161 := string(yys1161Slc)
-		switch yys1161 {
+		yys1109Slc = r.DecodeBytes(yys1109Slc, true, true)
+		yys1109 := string(yys1109Slc)
+		switch yys1109 {
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
@@ -12759,19 +12447,19 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.Values = nil
 			} else {
-				yyv1164 := &x.Values
-				yym1165 := z.DecBinary()
-				_ = yym1165
+				yyv1112 := &x.Values
+				yym1113 := z.DecBinary()
+				_ = yym1113
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1164, false, d)
+					z.F.DecSliceStringX(yyv1112, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1161)
-		} // end switch yys1161
-	} // end for yyj1161
-	if !yyhl1161 {
+			z.DecStructFieldNotFound(-1, yys1109)
+		} // end switch yys1109
+	} // end for yyj1109
+	if !yyhl1109 {
 		r.ReadEnd()
 	}
 }
@@ -12780,16 +12468,16 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1166 int
-	var yyb1166 bool
-	var yyhl1166 bool = l >= 0
-	yyj1166++
-	if yyhl1166 {
-		yyb1166 = yyj1166 > l
+	var yyj1114 int
+	var yyb1114 bool
+	var yyhl1114 bool = l >= 0
+	yyj1114++
+	if yyhl1114 {
+		yyb1114 = yyj1114 > l
 	} else {
-		yyb1166 = r.CheckBreak()
+		yyb1114 = r.CheckBreak()
 	}
-	if yyb1166 {
+	if yyb1114 {
 		r.ReadEnd()
 		return
 	}
@@ -12798,13 +12486,13 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj1166++
-	if yyhl1166 {
-		yyb1166 = yyj1166 > l
+	yyj1114++
+	if yyhl1114 {
+		yyb1114 = yyj1114 > l
 	} else {
-		yyb1166 = r.CheckBreak()
+		yyb1114 = r.CheckBreak()
 	}
-	if yyb1166 {
+	if yyb1114 {
 		r.ReadEnd()
 		return
 	}
@@ -12813,38 +12501,38 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Operator = PodSelectorOperator(r.DecodeString())
 	}
-	yyj1166++
-	if yyhl1166 {
-		yyb1166 = yyj1166 > l
+	yyj1114++
+	if yyhl1114 {
+		yyb1114 = yyj1114 > l
 	} else {
-		yyb1166 = r.CheckBreak()
+		yyb1114 = r.CheckBreak()
 	}
-	if yyb1166 {
+	if yyb1114 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Values = nil
 	} else {
-		yyv1169 := &x.Values
-		yym1170 := z.DecBinary()
-		_ = yym1170
+		yyv1117 := &x.Values
+		yym1118 := z.DecBinary()
+		_ = yym1118
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1169, false, d)
+			z.F.DecSliceStringX(yyv1117, false, d)
 		}
 	}
 	for {
-		yyj1166++
-		if yyhl1166 {
-			yyb1166 = yyj1166 > l
+		yyj1114++
+		if yyhl1114 {
+			yyb1114 = yyj1114 > l
 		} else {
-			yyb1166 = r.CheckBreak()
+			yyb1114 = r.CheckBreak()
 		}
-		if yyb1166 {
+		if yyb1114 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1166-1, "")
+		z.DecStructFieldNotFound(yyj1114-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12853,8 +12541,8 @@ func (x PodSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1171 := z.EncBinary()
-	_ = yym1171
+	yym1119 := z.EncBinary()
+	_ = yym1119
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -12866,8 +12554,8 @@ func (x *PodSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1172 := z.DecBinary()
-	_ = yym1172
+	yym1120 := z.DecBinary()
+	_ = yym1120
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -12880,9 +12568,9 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1173 := range v {
-		yy1174 := &yyv1173
-		yy1174.CodecEncodeSelf(e)
+	for _, yyv1121 := range v {
+		yy1122 := &yyv1121
+		yy1122.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12892,75 +12580,75 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1175 := *v
-	yyh1175, yyl1175 := z.DecSliceHelperStart()
+	yyv1123 := *v
+	yyh1123, yyl1123 := z.DecSliceHelperStart()
 
-	var yyrr1175, yyrl1175 int
-	var yyc1175, yyrt1175 bool
-	_, _, _ = yyc1175, yyrt1175, yyrl1175
-	yyrr1175 = yyl1175
+	var yyrr1123, yyrl1123 int
+	var yyc1123, yyrt1123 bool
+	_, _, _ = yyc1123, yyrt1123, yyrl1123
+	yyrr1123 = yyl1123
 
-	if yyv1175 == nil {
-		if yyrl1175, yyrt1175 = z.DecInferLen(yyl1175, z.DecBasicHandle().MaxInitLen, 320); yyrt1175 {
-			yyrr1175 = yyrl1175
+	if yyv1123 == nil {
+		if yyrl1123, yyrt1123 = z.DecInferLen(yyl1123, z.DecBasicHandle().MaxInitLen, 320); yyrt1123 {
+			yyrr1123 = yyrl1123
 		}
-		yyv1175 = make([]HorizontalPodAutoscaler, yyrl1175)
-		yyc1175 = true
+		yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
+		yyc1123 = true
 	}
 
-	if yyl1175 == 0 {
-		if len(yyv1175) != 0 {
-			yyv1175 = yyv1175[:0]
-			yyc1175 = true
+	if yyl1123 == 0 {
+		if len(yyv1123) != 0 {
+			yyv1123 = yyv1123[:0]
+			yyc1123 = true
 		}
-	} else if yyl1175 > 0 {
+	} else if yyl1123 > 0 {
 
-		if yyl1175 > cap(yyv1175) {
-			yyrl1175, yyrt1175 = z.DecInferLen(yyl1175, z.DecBasicHandle().MaxInitLen, 320)
-			yyv1175 = make([]HorizontalPodAutoscaler, yyrl1175)
-			yyc1175 = true
+		if yyl1123 > cap(yyv1123) {
+			yyrl1123, yyrt1123 = z.DecInferLen(yyl1123, z.DecBasicHandle().MaxInitLen, 320)
+			yyv1123 = make([]HorizontalPodAutoscaler, yyrl1123)
+			yyc1123 = true
 
-			yyrr1175 = len(yyv1175)
-		} else if yyl1175 != len(yyv1175) {
-			yyv1175 = yyv1175[:yyl1175]
-			yyc1175 = true
+			yyrr1123 = len(yyv1123)
+		} else if yyl1123 != len(yyv1123) {
+			yyv1123 = yyv1123[:yyl1123]
+			yyc1123 = true
 		}
-		yyj1175 := 0
-		for ; yyj1175 < yyrr1175; yyj1175++ {
+		yyj1123 := 0
+		for ; yyj1123 < yyrr1123; yyj1123++ {
 			if r.TryDecodeAsNil() {
-				yyv1175[yyj1175] = HorizontalPodAutoscaler{}
+				yyv1123[yyj1123] = HorizontalPodAutoscaler{}
 			} else {
-				yyv1176 := &yyv1175[yyj1175]
-				yyv1176.CodecDecodeSelf(d)
+				yyv1124 := &yyv1123[yyj1123]
+				yyv1124.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1175 {
-			for ; yyj1175 < yyl1175; yyj1175++ {
-				yyv1175 = append(yyv1175, HorizontalPodAutoscaler{})
+		if yyrt1123 {
+			for ; yyj1123 < yyl1123; yyj1123++ {
+				yyv1123 = append(yyv1123, HorizontalPodAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1175[yyj1175] = HorizontalPodAutoscaler{}
+					yyv1123[yyj1123] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1177 := &yyv1175[yyj1175]
-					yyv1177.CodecDecodeSelf(d)
+					yyv1125 := &yyv1123[yyj1123]
+					yyv1125.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1175 := 0; !r.CheckBreak(); yyj1175++ {
-			if yyj1175 >= len(yyv1175) {
-				yyv1175 = append(yyv1175, HorizontalPodAutoscaler{}) // var yyz1175 HorizontalPodAutoscaler
-				yyc1175 = true
+		for yyj1123 := 0; !r.CheckBreak(); yyj1123++ {
+			if yyj1123 >= len(yyv1123) {
+				yyv1123 = append(yyv1123, HorizontalPodAutoscaler{}) // var yyz1123 HorizontalPodAutoscaler
+				yyc1123 = true
 			}
 
-			if yyj1175 < len(yyv1175) {
+			if yyj1123 < len(yyv1123) {
 				if r.TryDecodeAsNil() {
-					yyv1175[yyj1175] = HorizontalPodAutoscaler{}
+					yyv1123[yyj1123] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1178 := &yyv1175[yyj1175]
-					yyv1178.CodecDecodeSelf(d)
+					yyv1126 := &yyv1123[yyj1123]
+					yyv1126.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12968,10 +12656,10 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		yyh1175.End()
+		yyh1123.End()
 	}
-	if yyc1175 {
-		*v = yyv1175
+	if yyc1123 {
+		*v = yyv1123
 	}
 
 }
@@ -12981,9 +12669,9 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1179 := range v {
-		yy1180 := &yyv1179
-		yy1180.CodecEncodeSelf(e)
+	for _, yyv1127 := range v {
+		yy1128 := &yyv1127
+		yy1128.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12993,75 +12681,75 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1181 := *v
-	yyh1181, yyl1181 := z.DecSliceHelperStart()
+	yyv1129 := *v
+	yyh1129, yyl1129 := z.DecSliceHelperStart()
 
-	var yyrr1181, yyrl1181 int
-	var yyc1181, yyrt1181 bool
-	_, _, _ = yyc1181, yyrt1181, yyrl1181
-	yyrr1181 = yyl1181
+	var yyrr1129, yyrl1129 int
+	var yyc1129, yyrt1129 bool
+	_, _, _ = yyc1129, yyrt1129, yyrl1129
+	yyrr1129 = yyl1129
 
-	if yyv1181 == nil {
-		if yyrl1181, yyrt1181 = z.DecInferLen(yyl1181, z.DecBasicHandle().MaxInitLen, 32); yyrt1181 {
-			yyrr1181 = yyrl1181
+	if yyv1129 == nil {
+		if yyrl1129, yyrt1129 = z.DecInferLen(yyl1129, z.DecBasicHandle().MaxInitLen, 32); yyrt1129 {
+			yyrr1129 = yyrl1129
 		}
-		yyv1181 = make([]APIVersion, yyrl1181)
-		yyc1181 = true
+		yyv1129 = make([]APIVersion, yyrl1129)
+		yyc1129 = true
 	}
 
-	if yyl1181 == 0 {
-		if len(yyv1181) != 0 {
-			yyv1181 = yyv1181[:0]
-			yyc1181 = true
+	if yyl1129 == 0 {
+		if len(yyv1129) != 0 {
+			yyv1129 = yyv1129[:0]
+			yyc1129 = true
 		}
-	} else if yyl1181 > 0 {
+	} else if yyl1129 > 0 {
 
-		if yyl1181 > cap(yyv1181) {
-			yyrl1181, yyrt1181 = z.DecInferLen(yyl1181, z.DecBasicHandle().MaxInitLen, 32)
-			yyv1181 = make([]APIVersion, yyrl1181)
-			yyc1181 = true
+		if yyl1129 > cap(yyv1129) {
+			yyrl1129, yyrt1129 = z.DecInferLen(yyl1129, z.DecBasicHandle().MaxInitLen, 32)
+			yyv1129 = make([]APIVersion, yyrl1129)
+			yyc1129 = true
 
-			yyrr1181 = len(yyv1181)
-		} else if yyl1181 != len(yyv1181) {
-			yyv1181 = yyv1181[:yyl1181]
-			yyc1181 = true
+			yyrr1129 = len(yyv1129)
+		} else if yyl1129 != len(yyv1129) {
+			yyv1129 = yyv1129[:yyl1129]
+			yyc1129 = true
 		}
-		yyj1181 := 0
-		for ; yyj1181 < yyrr1181; yyj1181++ {
+		yyj1129 := 0
+		for ; yyj1129 < yyrr1129; yyj1129++ {
 			if r.TryDecodeAsNil() {
-				yyv1181[yyj1181] = APIVersion{}
+				yyv1129[yyj1129] = APIVersion{}
 			} else {
-				yyv1182 := &yyv1181[yyj1181]
-				yyv1182.CodecDecodeSelf(d)
+				yyv1130 := &yyv1129[yyj1129]
+				yyv1130.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1181 {
-			for ; yyj1181 < yyl1181; yyj1181++ {
-				yyv1181 = append(yyv1181, APIVersion{})
+		if yyrt1129 {
+			for ; yyj1129 < yyl1129; yyj1129++ {
+				yyv1129 = append(yyv1129, APIVersion{})
 				if r.TryDecodeAsNil() {
-					yyv1181[yyj1181] = APIVersion{}
+					yyv1129[yyj1129] = APIVersion{}
 				} else {
-					yyv1183 := &yyv1181[yyj1181]
-					yyv1183.CodecDecodeSelf(d)
+					yyv1131 := &yyv1129[yyj1129]
+					yyv1131.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1181 := 0; !r.CheckBreak(); yyj1181++ {
-			if yyj1181 >= len(yyv1181) {
-				yyv1181 = append(yyv1181, APIVersion{}) // var yyz1181 APIVersion
-				yyc1181 = true
+		for yyj1129 := 0; !r.CheckBreak(); yyj1129++ {
+			if yyj1129 >= len(yyv1129) {
+				yyv1129 = append(yyv1129, APIVersion{}) // var yyz1129 APIVersion
+				yyc1129 = true
 			}
 
-			if yyj1181 < len(yyv1181) {
+			if yyj1129 < len(yyv1129) {
 				if r.TryDecodeAsNil() {
-					yyv1181[yyj1181] = APIVersion{}
+					yyv1129[yyj1129] = APIVersion{}
 				} else {
-					yyv1184 := &yyv1181[yyj1181]
-					yyv1184.CodecDecodeSelf(d)
+					yyv1132 := &yyv1129[yyj1129]
+					yyv1132.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13069,10 +12757,10 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		yyh1181.End()
+		yyh1129.End()
 	}
-	if yyc1181 {
-		*v = yyv1181
+	if yyc1129 {
+		*v = yyv1129
 	}
 
 }
@@ -13082,9 +12770,9 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1185 := range v {
-		yy1186 := &yyv1185
-		yy1186.CodecEncodeSelf(e)
+	for _, yyv1133 := range v {
+		yy1134 := &yyv1133
+		yy1134.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13094,75 +12782,75 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1187 := *v
-	yyh1187, yyl1187 := z.DecSliceHelperStart()
+	yyv1135 := *v
+	yyh1135, yyl1135 := z.DecSliceHelperStart()
 
-	var yyrr1187, yyrl1187 int
-	var yyc1187, yyrt1187 bool
-	_, _, _ = yyc1187, yyrt1187, yyrl1187
-	yyrr1187 = yyl1187
+	var yyrr1135, yyrl1135 int
+	var yyc1135, yyrt1135 bool
+	_, _, _ = yyc1135, yyrt1135, yyrl1135
+	yyrr1135 = yyl1135
 
-	if yyv1187 == nil {
-		if yyrl1187, yyrt1187 = z.DecInferLen(yyl1187, z.DecBasicHandle().MaxInitLen, 232); yyrt1187 {
-			yyrr1187 = yyrl1187
+	if yyv1135 == nil {
+		if yyrl1135, yyrt1135 = z.DecInferLen(yyl1135, z.DecBasicHandle().MaxInitLen, 232); yyrt1135 {
+			yyrr1135 = yyrl1135
 		}
-		yyv1187 = make([]ThirdPartyResource, yyrl1187)
-		yyc1187 = true
+		yyv1135 = make([]ThirdPartyResource, yyrl1135)
+		yyc1135 = true
 	}
 
-	if yyl1187 == 0 {
-		if len(yyv1187) != 0 {
-			yyv1187 = yyv1187[:0]
-			yyc1187 = true
+	if yyl1135 == 0 {
+		if len(yyv1135) != 0 {
+			yyv1135 = yyv1135[:0]
+			yyc1135 = true
 		}
-	} else if yyl1187 > 0 {
+	} else if yyl1135 > 0 {
 
-		if yyl1187 > cap(yyv1187) {
-			yyrl1187, yyrt1187 = z.DecInferLen(yyl1187, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1187 = make([]ThirdPartyResource, yyrl1187)
-			yyc1187 = true
+		if yyl1135 > cap(yyv1135) {
+			yyrl1135, yyrt1135 = z.DecInferLen(yyl1135, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1135 = make([]ThirdPartyResource, yyrl1135)
+			yyc1135 = true
 
-			yyrr1187 = len(yyv1187)
-		} else if yyl1187 != len(yyv1187) {
-			yyv1187 = yyv1187[:yyl1187]
-			yyc1187 = true
+			yyrr1135 = len(yyv1135)
+		} else if yyl1135 != len(yyv1135) {
+			yyv1135 = yyv1135[:yyl1135]
+			yyc1135 = true
 		}
-		yyj1187 := 0
-		for ; yyj1187 < yyrr1187; yyj1187++ {
+		yyj1135 := 0
+		for ; yyj1135 < yyrr1135; yyj1135++ {
 			if r.TryDecodeAsNil() {
-				yyv1187[yyj1187] = ThirdPartyResource{}
+				yyv1135[yyj1135] = ThirdPartyResource{}
 			} else {
-				yyv1188 := &yyv1187[yyj1187]
-				yyv1188.CodecDecodeSelf(d)
+				yyv1136 := &yyv1135[yyj1135]
+				yyv1136.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1187 {
-			for ; yyj1187 < yyl1187; yyj1187++ {
-				yyv1187 = append(yyv1187, ThirdPartyResource{})
+		if yyrt1135 {
+			for ; yyj1135 < yyl1135; yyj1135++ {
+				yyv1135 = append(yyv1135, ThirdPartyResource{})
 				if r.TryDecodeAsNil() {
-					yyv1187[yyj1187] = ThirdPartyResource{}
+					yyv1135[yyj1135] = ThirdPartyResource{}
 				} else {
-					yyv1189 := &yyv1187[yyj1187]
-					yyv1189.CodecDecodeSelf(d)
+					yyv1137 := &yyv1135[yyj1135]
+					yyv1137.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1187 := 0; !r.CheckBreak(); yyj1187++ {
-			if yyj1187 >= len(yyv1187) {
-				yyv1187 = append(yyv1187, ThirdPartyResource{}) // var yyz1187 ThirdPartyResource
-				yyc1187 = true
+		for yyj1135 := 0; !r.CheckBreak(); yyj1135++ {
+			if yyj1135 >= len(yyv1135) {
+				yyv1135 = append(yyv1135, ThirdPartyResource{}) // var yyz1135 ThirdPartyResource
+				yyc1135 = true
 			}
 
-			if yyj1187 < len(yyv1187) {
+			if yyj1135 < len(yyv1135) {
 				if r.TryDecodeAsNil() {
-					yyv1187[yyj1187] = ThirdPartyResource{}
+					yyv1135[yyj1135] = ThirdPartyResource{}
 				} else {
-					yyv1190 := &yyv1187[yyj1187]
-					yyv1190.CodecDecodeSelf(d)
+					yyv1138 := &yyv1135[yyj1135]
+					yyv1138.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13170,10 +12858,10 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		yyh1187.End()
+		yyh1135.End()
 	}
-	if yyc1187 {
-		*v = yyv1187
+	if yyc1135 {
+		*v = yyv1135
 	}
 
 }
@@ -13183,9 +12871,9 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1191 := range v {
-		yy1192 := &yyv1191
-		yy1192.CodecEncodeSelf(e)
+	for _, yyv1139 := range v {
+		yy1140 := &yyv1139
+		yy1140.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13195,75 +12883,75 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1193 := *v
-	yyh1193, yyl1193 := z.DecSliceHelperStart()
+	yyv1141 := *v
+	yyh1141, yyl1141 := z.DecSliceHelperStart()
 
-	var yyrr1193, yyrl1193 int
-	var yyc1193, yyrt1193 bool
-	_, _, _ = yyc1193, yyrt1193, yyrl1193
-	yyrr1193 = yyl1193
+	var yyrr1141, yyrl1141 int
+	var yyc1141, yyrt1141 bool
+	_, _, _ = yyc1141, yyrt1141, yyrl1141
+	yyrr1141 = yyl1141
 
-	if yyv1193 == nil {
-		if yyrl1193, yyrt1193 = z.DecInferLen(yyl1193, z.DecBasicHandle().MaxInitLen, 592); yyrt1193 {
-			yyrr1193 = yyrl1193
+	if yyv1141 == nil {
+		if yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592); yyrt1141 {
+			yyrr1141 = yyrl1141
 		}
-		yyv1193 = make([]Deployment, yyrl1193)
-		yyc1193 = true
+		yyv1141 = make([]Deployment, yyrl1141)
+		yyc1141 = true
 	}
 
-	if yyl1193 == 0 {
-		if len(yyv1193) != 0 {
-			yyv1193 = yyv1193[:0]
-			yyc1193 = true
+	if yyl1141 == 0 {
+		if len(yyv1141) != 0 {
+			yyv1141 = yyv1141[:0]
+			yyc1141 = true
 		}
-	} else if yyl1193 > 0 {
+	} else if yyl1141 > 0 {
 
-		if yyl1193 > cap(yyv1193) {
-			yyrl1193, yyrt1193 = z.DecInferLen(yyl1193, z.DecBasicHandle().MaxInitLen, 592)
-			yyv1193 = make([]Deployment, yyrl1193)
-			yyc1193 = true
+		if yyl1141 > cap(yyv1141) {
+			yyrl1141, yyrt1141 = z.DecInferLen(yyl1141, z.DecBasicHandle().MaxInitLen, 592)
+			yyv1141 = make([]Deployment, yyrl1141)
+			yyc1141 = true
 
-			yyrr1193 = len(yyv1193)
-		} else if yyl1193 != len(yyv1193) {
-			yyv1193 = yyv1193[:yyl1193]
-			yyc1193 = true
+			yyrr1141 = len(yyv1141)
+		} else if yyl1141 != len(yyv1141) {
+			yyv1141 = yyv1141[:yyl1141]
+			yyc1141 = true
 		}
-		yyj1193 := 0
-		for ; yyj1193 < yyrr1193; yyj1193++ {
+		yyj1141 := 0
+		for ; yyj1141 < yyrr1141; yyj1141++ {
 			if r.TryDecodeAsNil() {
-				yyv1193[yyj1193] = Deployment{}
+				yyv1141[yyj1141] = Deployment{}
 			} else {
-				yyv1194 := &yyv1193[yyj1193]
-				yyv1194.CodecDecodeSelf(d)
+				yyv1142 := &yyv1141[yyj1141]
+				yyv1142.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1193 {
-			for ; yyj1193 < yyl1193; yyj1193++ {
-				yyv1193 = append(yyv1193, Deployment{})
+		if yyrt1141 {
+			for ; yyj1141 < yyl1141; yyj1141++ {
+				yyv1141 = append(yyv1141, Deployment{})
 				if r.TryDecodeAsNil() {
-					yyv1193[yyj1193] = Deployment{}
+					yyv1141[yyj1141] = Deployment{}
 				} else {
-					yyv1195 := &yyv1193[yyj1193]
-					yyv1195.CodecDecodeSelf(d)
+					yyv1143 := &yyv1141[yyj1141]
+					yyv1143.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1193 := 0; !r.CheckBreak(); yyj1193++ {
-			if yyj1193 >= len(yyv1193) {
-				yyv1193 = append(yyv1193, Deployment{}) // var yyz1193 Deployment
-				yyc1193 = true
+		for yyj1141 := 0; !r.CheckBreak(); yyj1141++ {
+			if yyj1141 >= len(yyv1141) {
+				yyv1141 = append(yyv1141, Deployment{}) // var yyz1141 Deployment
+				yyc1141 = true
 			}
 
-			if yyj1193 < len(yyv1193) {
+			if yyj1141 < len(yyv1141) {
 				if r.TryDecodeAsNil() {
-					yyv1193[yyj1193] = Deployment{}
+					yyv1141[yyj1141] = Deployment{}
 				} else {
-					yyv1196 := &yyv1193[yyj1193]
-					yyv1196.CodecDecodeSelf(d)
+					yyv1144 := &yyv1141[yyj1141]
+					yyv1144.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13271,10 +12959,10 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		yyh1193.End()
+		yyh1141.End()
 	}
-	if yyc1193 {
-		*v = yyv1193
+	if yyc1141 {
+		*v = yyv1141
 	}
 
 }
@@ -13284,9 +12972,9 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1197 := range v {
-		yy1198 := &yyv1197
-		yy1198.CodecEncodeSelf(e)
+	for _, yyv1145 := range v {
+		yy1146 := &yyv1145
+		yy1146.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13296,75 +12984,75 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1199 := *v
-	yyh1199, yyl1199 := z.DecSliceHelperStart()
+	yyv1147 := *v
+	yyh1147, yyl1147 := z.DecSliceHelperStart()
 
-	var yyrr1199, yyrl1199 int
-	var yyc1199, yyrt1199 bool
-	_, _, _ = yyc1199, yyrt1199, yyrl1199
-	yyrr1199 = yyl1199
+	var yyrr1147, yyrl1147 int
+	var yyc1147, yyrt1147 bool
+	_, _, _ = yyc1147, yyrt1147, yyrl1147
+	yyrr1147 = yyl1147
 
-	if yyv1199 == nil {
-		if yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232); yyrt1199 {
-			yyrr1199 = yyrl1199
+	if yyv1147 == nil {
+		if yyrl1147, yyrt1147 = z.DecInferLen(yyl1147, z.DecBasicHandle().MaxInitLen, 232); yyrt1147 {
+			yyrr1147 = yyrl1147
 		}
-		yyv1199 = make([]DaemonSet, yyrl1199)
-		yyc1199 = true
+		yyv1147 = make([]DaemonSet, yyrl1147)
+		yyc1147 = true
 	}
 
-	if yyl1199 == 0 {
-		if len(yyv1199) != 0 {
-			yyv1199 = yyv1199[:0]
-			yyc1199 = true
+	if yyl1147 == 0 {
+		if len(yyv1147) != 0 {
+			yyv1147 = yyv1147[:0]
+			yyc1147 = true
 		}
-	} else if yyl1199 > 0 {
+	} else if yyl1147 > 0 {
 
-		if yyl1199 > cap(yyv1199) {
-			yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1199 = make([]DaemonSet, yyrl1199)
-			yyc1199 = true
+		if yyl1147 > cap(yyv1147) {
+			yyrl1147, yyrt1147 = z.DecInferLen(yyl1147, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1147 = make([]DaemonSet, yyrl1147)
+			yyc1147 = true
 
-			yyrr1199 = len(yyv1199)
-		} else if yyl1199 != len(yyv1199) {
-			yyv1199 = yyv1199[:yyl1199]
-			yyc1199 = true
+			yyrr1147 = len(yyv1147)
+		} else if yyl1147 != len(yyv1147) {
+			yyv1147 = yyv1147[:yyl1147]
+			yyc1147 = true
 		}
-		yyj1199 := 0
-		for ; yyj1199 < yyrr1199; yyj1199++ {
+		yyj1147 := 0
+		for ; yyj1147 < yyrr1147; yyj1147++ {
 			if r.TryDecodeAsNil() {
-				yyv1199[yyj1199] = DaemonSet{}
+				yyv1147[yyj1147] = DaemonSet{}
 			} else {
-				yyv1200 := &yyv1199[yyj1199]
-				yyv1200.CodecDecodeSelf(d)
+				yyv1148 := &yyv1147[yyj1147]
+				yyv1148.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1199 {
-			for ; yyj1199 < yyl1199; yyj1199++ {
-				yyv1199 = append(yyv1199, DaemonSet{})
+		if yyrt1147 {
+			for ; yyj1147 < yyl1147; yyj1147++ {
+				yyv1147 = append(yyv1147, DaemonSet{})
 				if r.TryDecodeAsNil() {
-					yyv1199[yyj1199] = DaemonSet{}
+					yyv1147[yyj1147] = DaemonSet{}
 				} else {
-					yyv1201 := &yyv1199[yyj1199]
-					yyv1201.CodecDecodeSelf(d)
+					yyv1149 := &yyv1147[yyj1147]
+					yyv1149.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1199 := 0; !r.CheckBreak(); yyj1199++ {
-			if yyj1199 >= len(yyv1199) {
-				yyv1199 = append(yyv1199, DaemonSet{}) // var yyz1199 DaemonSet
-				yyc1199 = true
+		for yyj1147 := 0; !r.CheckBreak(); yyj1147++ {
+			if yyj1147 >= len(yyv1147) {
+				yyv1147 = append(yyv1147, DaemonSet{}) // var yyz1147 DaemonSet
+				yyc1147 = true
 			}
 
-			if yyj1199 < len(yyv1199) {
+			if yyj1147 < len(yyv1147) {
 				if r.TryDecodeAsNil() {
-					yyv1199[yyj1199] = DaemonSet{}
+					yyv1147[yyj1147] = DaemonSet{}
 				} else {
-					yyv1202 := &yyv1199[yyj1199]
-					yyv1202.CodecDecodeSelf(d)
+					yyv1150 := &yyv1147[yyj1147]
+					yyv1150.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13372,10 +13060,10 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		yyh1199.End()
+		yyh1147.End()
 	}
-	if yyc1199 {
-		*v = yyv1199
+	if yyc1147 {
+		*v = yyv1147
 	}
 
 }
@@ -13385,9 +13073,9 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1203 := range v {
-		yy1204 := &yyv1203
-		yy1204.CodecEncodeSelf(e)
+	for _, yyv1151 := range v {
+		yy1152 := &yyv1151
+		yy1152.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13397,75 +13085,75 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1205 := *v
-	yyh1205, yyl1205 := z.DecSliceHelperStart()
+	yyv1153 := *v
+	yyh1153, yyl1153 := z.DecSliceHelperStart()
 
-	var yyrr1205, yyrl1205 int
-	var yyc1205, yyrt1205 bool
-	_, _, _ = yyc1205, yyrt1205, yyrl1205
-	yyrr1205 = yyl1205
+	var yyrr1153, yyrl1153 int
+	var yyc1153, yyrt1153 bool
+	_, _, _ = yyc1153, yyrt1153, yyrl1153
+	yyrr1153 = yyl1153
 
-	if yyv1205 == nil {
-		if yyrl1205, yyrt1205 = z.DecInferLen(yyl1205, z.DecBasicHandle().MaxInitLen, 216); yyrt1205 {
-			yyrr1205 = yyrl1205
+	if yyv1153 == nil {
+		if yyrl1153, yyrt1153 = z.DecInferLen(yyl1153, z.DecBasicHandle().MaxInitLen, 216); yyrt1153 {
+			yyrr1153 = yyrl1153
 		}
-		yyv1205 = make([]ThirdPartyResourceData, yyrl1205)
-		yyc1205 = true
+		yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
+		yyc1153 = true
 	}
 
-	if yyl1205 == 0 {
-		if len(yyv1205) != 0 {
-			yyv1205 = yyv1205[:0]
-			yyc1205 = true
+	if yyl1153 == 0 {
+		if len(yyv1153) != 0 {
+			yyv1153 = yyv1153[:0]
+			yyc1153 = true
 		}
-	} else if yyl1205 > 0 {
+	} else if yyl1153 > 0 {
 
-		if yyl1205 > cap(yyv1205) {
-			yyrl1205, yyrt1205 = z.DecInferLen(yyl1205, z.DecBasicHandle().MaxInitLen, 216)
-			yyv1205 = make([]ThirdPartyResourceData, yyrl1205)
-			yyc1205 = true
+		if yyl1153 > cap(yyv1153) {
+			yyrl1153, yyrt1153 = z.DecInferLen(yyl1153, z.DecBasicHandle().MaxInitLen, 216)
+			yyv1153 = make([]ThirdPartyResourceData, yyrl1153)
+			yyc1153 = true
 
-			yyrr1205 = len(yyv1205)
-		} else if yyl1205 != len(yyv1205) {
-			yyv1205 = yyv1205[:yyl1205]
-			yyc1205 = true
+			yyrr1153 = len(yyv1153)
+		} else if yyl1153 != len(yyv1153) {
+			yyv1153 = yyv1153[:yyl1153]
+			yyc1153 = true
 		}
-		yyj1205 := 0
-		for ; yyj1205 < yyrr1205; yyj1205++ {
+		yyj1153 := 0
+		for ; yyj1153 < yyrr1153; yyj1153++ {
 			if r.TryDecodeAsNil() {
-				yyv1205[yyj1205] = ThirdPartyResourceData{}
+				yyv1153[yyj1153] = ThirdPartyResourceData{}
 			} else {
-				yyv1206 := &yyv1205[yyj1205]
-				yyv1206.CodecDecodeSelf(d)
+				yyv1154 := &yyv1153[yyj1153]
+				yyv1154.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1205 {
-			for ; yyj1205 < yyl1205; yyj1205++ {
-				yyv1205 = append(yyv1205, ThirdPartyResourceData{})
+		if yyrt1153 {
+			for ; yyj1153 < yyl1153; yyj1153++ {
+				yyv1153 = append(yyv1153, ThirdPartyResourceData{})
 				if r.TryDecodeAsNil() {
-					yyv1205[yyj1205] = ThirdPartyResourceData{}
+					yyv1153[yyj1153] = ThirdPartyResourceData{}
 				} else {
-					yyv1207 := &yyv1205[yyj1205]
-					yyv1207.CodecDecodeSelf(d)
+					yyv1155 := &yyv1153[yyj1153]
+					yyv1155.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1205 := 0; !r.CheckBreak(); yyj1205++ {
-			if yyj1205 >= len(yyv1205) {
-				yyv1205 = append(yyv1205, ThirdPartyResourceData{}) // var yyz1205 ThirdPartyResourceData
-				yyc1205 = true
+		for yyj1153 := 0; !r.CheckBreak(); yyj1153++ {
+			if yyj1153 >= len(yyv1153) {
+				yyv1153 = append(yyv1153, ThirdPartyResourceData{}) // var yyz1153 ThirdPartyResourceData
+				yyc1153 = true
 			}
 
-			if yyj1205 < len(yyv1205) {
+			if yyj1153 < len(yyv1153) {
 				if r.TryDecodeAsNil() {
-					yyv1205[yyj1205] = ThirdPartyResourceData{}
+					yyv1153[yyj1153] = ThirdPartyResourceData{}
 				} else {
-					yyv1208 := &yyv1205[yyj1205]
-					yyv1208.CodecDecodeSelf(d)
+					yyv1156 := &yyv1153[yyj1153]
+					yyv1156.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13473,10 +13161,10 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		yyh1205.End()
+		yyh1153.End()
 	}
-	if yyc1205 {
-		*v = yyv1205
+	if yyc1153 {
+		*v = yyv1153
 	}
 
 }
@@ -13486,9 +13174,9 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1209 := range v {
-		yy1210 := &yyv1209
-		yy1210.CodecEncodeSelf(e)
+	for _, yyv1157 := range v {
+		yy1158 := &yyv1157
+		yy1158.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13498,75 +13186,75 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1211 := *v
-	yyh1211, yyl1211 := z.DecSliceHelperStart()
+	yyv1159 := *v
+	yyh1159, yyl1159 := z.DecSliceHelperStart()
 
-	var yyrr1211, yyrl1211 int
-	var yyc1211, yyrt1211 bool
-	_, _, _ = yyc1211, yyrt1211, yyrl1211
-	yyrr1211 = yyl1211
+	var yyrr1159, yyrl1159 int
+	var yyc1159, yyrt1159 bool
+	_, _, _ = yyc1159, yyrt1159, yyrl1159
+	yyrr1159 = yyl1159
 
-	if yyv1211 == nil {
-		if yyrl1211, yyrt1211 = z.DecInferLen(yyl1211, z.DecBasicHandle().MaxInitLen, 608); yyrt1211 {
-			yyrr1211 = yyrl1211
+	if yyv1159 == nil {
+		if yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608); yyrt1159 {
+			yyrr1159 = yyrl1159
 		}
-		yyv1211 = make([]Job, yyrl1211)
-		yyc1211 = true
+		yyv1159 = make([]Job, yyrl1159)
+		yyc1159 = true
 	}
 
-	if yyl1211 == 0 {
-		if len(yyv1211) != 0 {
-			yyv1211 = yyv1211[:0]
-			yyc1211 = true
+	if yyl1159 == 0 {
+		if len(yyv1159) != 0 {
+			yyv1159 = yyv1159[:0]
+			yyc1159 = true
 		}
-	} else if yyl1211 > 0 {
+	} else if yyl1159 > 0 {
 
-		if yyl1211 > cap(yyv1211) {
-			yyrl1211, yyrt1211 = z.DecInferLen(yyl1211, z.DecBasicHandle().MaxInitLen, 608)
-			yyv1211 = make([]Job, yyrl1211)
-			yyc1211 = true
+		if yyl1159 > cap(yyv1159) {
+			yyrl1159, yyrt1159 = z.DecInferLen(yyl1159, z.DecBasicHandle().MaxInitLen, 608)
+			yyv1159 = make([]Job, yyrl1159)
+			yyc1159 = true
 
-			yyrr1211 = len(yyv1211)
-		} else if yyl1211 != len(yyv1211) {
-			yyv1211 = yyv1211[:yyl1211]
-			yyc1211 = true
+			yyrr1159 = len(yyv1159)
+		} else if yyl1159 != len(yyv1159) {
+			yyv1159 = yyv1159[:yyl1159]
+			yyc1159 = true
 		}
-		yyj1211 := 0
-		for ; yyj1211 < yyrr1211; yyj1211++ {
+		yyj1159 := 0
+		for ; yyj1159 < yyrr1159; yyj1159++ {
 			if r.TryDecodeAsNil() {
-				yyv1211[yyj1211] = Job{}
+				yyv1159[yyj1159] = Job{}
 			} else {
-				yyv1212 := &yyv1211[yyj1211]
-				yyv1212.CodecDecodeSelf(d)
+				yyv1160 := &yyv1159[yyj1159]
+				yyv1160.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1211 {
-			for ; yyj1211 < yyl1211; yyj1211++ {
-				yyv1211 = append(yyv1211, Job{})
+		if yyrt1159 {
+			for ; yyj1159 < yyl1159; yyj1159++ {
+				yyv1159 = append(yyv1159, Job{})
 				if r.TryDecodeAsNil() {
-					yyv1211[yyj1211] = Job{}
+					yyv1159[yyj1159] = Job{}
 				} else {
-					yyv1213 := &yyv1211[yyj1211]
-					yyv1213.CodecDecodeSelf(d)
+					yyv1161 := &yyv1159[yyj1159]
+					yyv1161.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1211 := 0; !r.CheckBreak(); yyj1211++ {
-			if yyj1211 >= len(yyv1211) {
-				yyv1211 = append(yyv1211, Job{}) // var yyz1211 Job
-				yyc1211 = true
+		for yyj1159 := 0; !r.CheckBreak(); yyj1159++ {
+			if yyj1159 >= len(yyv1159) {
+				yyv1159 = append(yyv1159, Job{}) // var yyz1159 Job
+				yyc1159 = true
 			}
 
-			if yyj1211 < len(yyv1211) {
+			if yyj1159 < len(yyv1159) {
 				if r.TryDecodeAsNil() {
-					yyv1211[yyj1211] = Job{}
+					yyv1159[yyj1159] = Job{}
 				} else {
-					yyv1214 := &yyv1211[yyj1211]
-					yyv1214.CodecDecodeSelf(d)
+					yyv1162 := &yyv1159[yyj1159]
+					yyv1162.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13574,10 +13262,10 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1211.End()
+		yyh1159.End()
 	}
-	if yyc1211 {
-		*v = yyv1211
+	if yyc1159 {
+		*v = yyv1159
 	}
 
 }
@@ -13587,9 +13275,9 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1215 := range v {
-		yy1216 := &yyv1215
-		yy1216.CodecEncodeSelf(e)
+	for _, yyv1163 := range v {
+		yy1164 := &yyv1163
+		yy1164.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13599,75 +13287,75 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1217 := *v
-	yyh1217, yyl1217 := z.DecSliceHelperStart()
+	yyv1165 := *v
+	yyh1165, yyl1165 := z.DecSliceHelperStart()
 
-	var yyrr1217, yyrl1217 int
-	var yyc1217, yyrt1217 bool
-	_, _, _ = yyc1217, yyrt1217, yyrl1217
-	yyrr1217 = yyl1217
+	var yyrr1165, yyrl1165 int
+	var yyc1165, yyrt1165 bool
+	_, _, _ = yyc1165, yyrt1165, yyrl1165
+	yyrr1165 = yyl1165
 
-	if yyv1217 == nil {
-		if yyrl1217, yyrt1217 = z.DecInferLen(yyl1217, z.DecBasicHandle().MaxInitLen, 112); yyrt1217 {
-			yyrr1217 = yyrl1217
+	if yyv1165 == nil {
+		if yyrl1165, yyrt1165 = z.DecInferLen(yyl1165, z.DecBasicHandle().MaxInitLen, 112); yyrt1165 {
+			yyrr1165 = yyrl1165
 		}
-		yyv1217 = make([]JobCondition, yyrl1217)
-		yyc1217 = true
+		yyv1165 = make([]JobCondition, yyrl1165)
+		yyc1165 = true
 	}
 
-	if yyl1217 == 0 {
-		if len(yyv1217) != 0 {
-			yyv1217 = yyv1217[:0]
-			yyc1217 = true
+	if yyl1165 == 0 {
+		if len(yyv1165) != 0 {
+			yyv1165 = yyv1165[:0]
+			yyc1165 = true
 		}
-	} else if yyl1217 > 0 {
+	} else if yyl1165 > 0 {
 
-		if yyl1217 > cap(yyv1217) {
-			yyrl1217, yyrt1217 = z.DecInferLen(yyl1217, z.DecBasicHandle().MaxInitLen, 112)
-			yyv1217 = make([]JobCondition, yyrl1217)
-			yyc1217 = true
+		if yyl1165 > cap(yyv1165) {
+			yyrl1165, yyrt1165 = z.DecInferLen(yyl1165, z.DecBasicHandle().MaxInitLen, 112)
+			yyv1165 = make([]JobCondition, yyrl1165)
+			yyc1165 = true
 
-			yyrr1217 = len(yyv1217)
-		} else if yyl1217 != len(yyv1217) {
-			yyv1217 = yyv1217[:yyl1217]
-			yyc1217 = true
+			yyrr1165 = len(yyv1165)
+		} else if yyl1165 != len(yyv1165) {
+			yyv1165 = yyv1165[:yyl1165]
+			yyc1165 = true
 		}
-		yyj1217 := 0
-		for ; yyj1217 < yyrr1217; yyj1217++ {
+		yyj1165 := 0
+		for ; yyj1165 < yyrr1165; yyj1165++ {
 			if r.TryDecodeAsNil() {
-				yyv1217[yyj1217] = JobCondition{}
+				yyv1165[yyj1165] = JobCondition{}
 			} else {
-				yyv1218 := &yyv1217[yyj1217]
-				yyv1218.CodecDecodeSelf(d)
+				yyv1166 := &yyv1165[yyj1165]
+				yyv1166.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1217 {
-			for ; yyj1217 < yyl1217; yyj1217++ {
-				yyv1217 = append(yyv1217, JobCondition{})
+		if yyrt1165 {
+			for ; yyj1165 < yyl1165; yyj1165++ {
+				yyv1165 = append(yyv1165, JobCondition{})
 				if r.TryDecodeAsNil() {
-					yyv1217[yyj1217] = JobCondition{}
+					yyv1165[yyj1165] = JobCondition{}
 				} else {
-					yyv1219 := &yyv1217[yyj1217]
-					yyv1219.CodecDecodeSelf(d)
+					yyv1167 := &yyv1165[yyj1165]
+					yyv1167.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1217 := 0; !r.CheckBreak(); yyj1217++ {
-			if yyj1217 >= len(yyv1217) {
-				yyv1217 = append(yyv1217, JobCondition{}) // var yyz1217 JobCondition
-				yyc1217 = true
+		for yyj1165 := 0; !r.CheckBreak(); yyj1165++ {
+			if yyj1165 >= len(yyv1165) {
+				yyv1165 = append(yyv1165, JobCondition{}) // var yyz1165 JobCondition
+				yyc1165 = true
 			}
 
-			if yyj1217 < len(yyv1217) {
+			if yyj1165 < len(yyv1165) {
 				if r.TryDecodeAsNil() {
-					yyv1217[yyj1217] = JobCondition{}
+					yyv1165[yyj1165] = JobCondition{}
 				} else {
-					yyv1220 := &yyv1217[yyj1217]
-					yyv1220.CodecDecodeSelf(d)
+					yyv1168 := &yyv1165[yyj1165]
+					yyv1168.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13675,10 +13363,10 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		yyh1217.End()
+		yyh1165.End()
 	}
-	if yyc1217 {
-		*v = yyv1217
+	if yyc1165 {
+		*v = yyv1165
 	}
 
 }
@@ -13688,9 +13376,9 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1221 := range v {
-		yy1222 := &yyv1221
-		yy1222.CodecEncodeSelf(e)
+	for _, yyv1169 := range v {
+		yy1170 := &yyv1169
+		yy1170.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13700,75 +13388,75 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1223 := *v
-	yyh1223, yyl1223 := z.DecSliceHelperStart()
+	yyv1171 := *v
+	yyh1171, yyl1171 := z.DecSliceHelperStart()
 
-	var yyrr1223, yyrl1223 int
-	var yyc1223, yyrt1223 bool
-	_, _, _ = yyc1223, yyrt1223, yyrl1223
-	yyrr1223 = yyl1223
+	var yyrr1171, yyrl1171 int
+	var yyc1171, yyrt1171 bool
+	_, _, _ = yyc1171, yyrt1171, yyrl1171
+	yyrr1171 = yyl1171
 
-	if yyv1223 == nil {
-		if yyrl1223, yyrt1223 = z.DecInferLen(yyl1223, z.DecBasicHandle().MaxInitLen, 248); yyrt1223 {
-			yyrr1223 = yyrl1223
+	if yyv1171 == nil {
+		if yyrl1171, yyrt1171 = z.DecInferLen(yyl1171, z.DecBasicHandle().MaxInitLen, 248); yyrt1171 {
+			yyrr1171 = yyrl1171
 		}
-		yyv1223 = make([]Ingress, yyrl1223)
-		yyc1223 = true
+		yyv1171 = make([]Ingress, yyrl1171)
+		yyc1171 = true
 	}
 
-	if yyl1223 == 0 {
-		if len(yyv1223) != 0 {
-			yyv1223 = yyv1223[:0]
-			yyc1223 = true
+	if yyl1171 == 0 {
+		if len(yyv1171) != 0 {
+			yyv1171 = yyv1171[:0]
+			yyc1171 = true
 		}
-	} else if yyl1223 > 0 {
+	} else if yyl1171 > 0 {
 
-		if yyl1223 > cap(yyv1223) {
-			yyrl1223, yyrt1223 = z.DecInferLen(yyl1223, z.DecBasicHandle().MaxInitLen, 248)
-			yyv1223 = make([]Ingress, yyrl1223)
-			yyc1223 = true
+		if yyl1171 > cap(yyv1171) {
+			yyrl1171, yyrt1171 = z.DecInferLen(yyl1171, z.DecBasicHandle().MaxInitLen, 248)
+			yyv1171 = make([]Ingress, yyrl1171)
+			yyc1171 = true
 
-			yyrr1223 = len(yyv1223)
-		} else if yyl1223 != len(yyv1223) {
-			yyv1223 = yyv1223[:yyl1223]
-			yyc1223 = true
+			yyrr1171 = len(yyv1171)
+		} else if yyl1171 != len(yyv1171) {
+			yyv1171 = yyv1171[:yyl1171]
+			yyc1171 = true
 		}
-		yyj1223 := 0
-		for ; yyj1223 < yyrr1223; yyj1223++ {
+		yyj1171 := 0
+		for ; yyj1171 < yyrr1171; yyj1171++ {
 			if r.TryDecodeAsNil() {
-				yyv1223[yyj1223] = Ingress{}
+				yyv1171[yyj1171] = Ingress{}
 			} else {
-				yyv1224 := &yyv1223[yyj1223]
-				yyv1224.CodecDecodeSelf(d)
+				yyv1172 := &yyv1171[yyj1171]
+				yyv1172.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1223 {
-			for ; yyj1223 < yyl1223; yyj1223++ {
-				yyv1223 = append(yyv1223, Ingress{})
+		if yyrt1171 {
+			for ; yyj1171 < yyl1171; yyj1171++ {
+				yyv1171 = append(yyv1171, Ingress{})
 				if r.TryDecodeAsNil() {
-					yyv1223[yyj1223] = Ingress{}
+					yyv1171[yyj1171] = Ingress{}
 				} else {
-					yyv1225 := &yyv1223[yyj1223]
-					yyv1225.CodecDecodeSelf(d)
+					yyv1173 := &yyv1171[yyj1171]
+					yyv1173.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1223 := 0; !r.CheckBreak(); yyj1223++ {
-			if yyj1223 >= len(yyv1223) {
-				yyv1223 = append(yyv1223, Ingress{}) // var yyz1223 Ingress
-				yyc1223 = true
+		for yyj1171 := 0; !r.CheckBreak(); yyj1171++ {
+			if yyj1171 >= len(yyv1171) {
+				yyv1171 = append(yyv1171, Ingress{}) // var yyz1171 Ingress
+				yyc1171 = true
 			}
 
-			if yyj1223 < len(yyv1223) {
+			if yyj1171 < len(yyv1171) {
 				if r.TryDecodeAsNil() {
-					yyv1223[yyj1223] = Ingress{}
+					yyv1171[yyj1171] = Ingress{}
 				} else {
-					yyv1226 := &yyv1223[yyj1223]
-					yyv1226.CodecDecodeSelf(d)
+					yyv1174 := &yyv1171[yyj1171]
+					yyv1174.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13776,10 +13464,10 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1223.End()
+		yyh1171.End()
 	}
-	if yyc1223 {
-		*v = yyv1223
+	if yyc1171 {
+		*v = yyv1171
 	}
 
 }
@@ -13789,9 +13477,9 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1227 := range v {
-		yy1228 := &yyv1227
-		yy1228.CodecEncodeSelf(e)
+	for _, yyv1175 := range v {
+		yy1176 := &yyv1175
+		yy1176.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13801,75 +13489,75 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1229 := *v
-	yyh1229, yyl1229 := z.DecSliceHelperStart()
+	yyv1177 := *v
+	yyh1177, yyl1177 := z.DecSliceHelperStart()
 
-	var yyrr1229, yyrl1229 int
-	var yyc1229, yyrt1229 bool
-	_, _, _ = yyc1229, yyrt1229, yyrl1229
-	yyrr1229 = yyl1229
+	var yyrr1177, yyrl1177 int
+	var yyc1177, yyrt1177 bool
+	_, _, _ = yyc1177, yyrt1177, yyrl1177
+	yyrr1177 = yyl1177
 
-	if yyv1229 == nil {
-		if yyrl1229, yyrt1229 = z.DecInferLen(yyl1229, z.DecBasicHandle().MaxInitLen, 24); yyrt1229 {
-			yyrr1229 = yyrl1229
+	if yyv1177 == nil {
+		if yyrl1177, yyrt1177 = z.DecInferLen(yyl1177, z.DecBasicHandle().MaxInitLen, 24); yyrt1177 {
+			yyrr1177 = yyrl1177
 		}
-		yyv1229 = make([]IngressRule, yyrl1229)
-		yyc1229 = true
+		yyv1177 = make([]IngressRule, yyrl1177)
+		yyc1177 = true
 	}
 
-	if yyl1229 == 0 {
-		if len(yyv1229) != 0 {
-			yyv1229 = yyv1229[:0]
-			yyc1229 = true
+	if yyl1177 == 0 {
+		if len(yyv1177) != 0 {
+			yyv1177 = yyv1177[:0]
+			yyc1177 = true
 		}
-	} else if yyl1229 > 0 {
+	} else if yyl1177 > 0 {
 
-		if yyl1229 > cap(yyv1229) {
-			yyrl1229, yyrt1229 = z.DecInferLen(yyl1229, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1229 = make([]IngressRule, yyrl1229)
-			yyc1229 = true
+		if yyl1177 > cap(yyv1177) {
+			yyrl1177, yyrt1177 = z.DecInferLen(yyl1177, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1177 = make([]IngressRule, yyrl1177)
+			yyc1177 = true
 
-			yyrr1229 = len(yyv1229)
-		} else if yyl1229 != len(yyv1229) {
-			yyv1229 = yyv1229[:yyl1229]
-			yyc1229 = true
+			yyrr1177 = len(yyv1177)
+		} else if yyl1177 != len(yyv1177) {
+			yyv1177 = yyv1177[:yyl1177]
+			yyc1177 = true
 		}
-		yyj1229 := 0
-		for ; yyj1229 < yyrr1229; yyj1229++ {
+		yyj1177 := 0
+		for ; yyj1177 < yyrr1177; yyj1177++ {
 			if r.TryDecodeAsNil() {
-				yyv1229[yyj1229] = IngressRule{}
+				yyv1177[yyj1177] = IngressRule{}
 			} else {
-				yyv1230 := &yyv1229[yyj1229]
-				yyv1230.CodecDecodeSelf(d)
+				yyv1178 := &yyv1177[yyj1177]
+				yyv1178.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1229 {
-			for ; yyj1229 < yyl1229; yyj1229++ {
-				yyv1229 = append(yyv1229, IngressRule{})
+		if yyrt1177 {
+			for ; yyj1177 < yyl1177; yyj1177++ {
+				yyv1177 = append(yyv1177, IngressRule{})
 				if r.TryDecodeAsNil() {
-					yyv1229[yyj1229] = IngressRule{}
+					yyv1177[yyj1177] = IngressRule{}
 				} else {
-					yyv1231 := &yyv1229[yyj1229]
-					yyv1231.CodecDecodeSelf(d)
+					yyv1179 := &yyv1177[yyj1177]
+					yyv1179.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1229 := 0; !r.CheckBreak(); yyj1229++ {
-			if yyj1229 >= len(yyv1229) {
-				yyv1229 = append(yyv1229, IngressRule{}) // var yyz1229 IngressRule
-				yyc1229 = true
+		for yyj1177 := 0; !r.CheckBreak(); yyj1177++ {
+			if yyj1177 >= len(yyv1177) {
+				yyv1177 = append(yyv1177, IngressRule{}) // var yyz1177 IngressRule
+				yyc1177 = true
 			}
 
-			if yyj1229 < len(yyv1229) {
+			if yyj1177 < len(yyv1177) {
 				if r.TryDecodeAsNil() {
-					yyv1229[yyj1229] = IngressRule{}
+					yyv1177[yyj1177] = IngressRule{}
 				} else {
-					yyv1232 := &yyv1229[yyj1229]
-					yyv1232.CodecDecodeSelf(d)
+					yyv1180 := &yyv1177[yyj1177]
+					yyv1180.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13877,10 +13565,10 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		yyh1229.End()
+		yyh1177.End()
 	}
-	if yyc1229 {
-		*v = yyv1229
+	if yyc1177 {
+		*v = yyv1177
 	}
 
 }
@@ -13890,9 +13578,9 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1233 := range v {
-		yy1234 := &yyv1233
-		yy1234.CodecEncodeSelf(e)
+	for _, yyv1181 := range v {
+		yy1182 := &yyv1181
+		yy1182.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13902,75 +13590,75 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1235 := *v
-	yyh1235, yyl1235 := z.DecSliceHelperStart()
+	yyv1183 := *v
+	yyh1183, yyl1183 := z.DecSliceHelperStart()
 
-	var yyrr1235, yyrl1235 int
-	var yyc1235, yyrt1235 bool
-	_, _, _ = yyc1235, yyrt1235, yyrl1235
-	yyrr1235 = yyl1235
+	var yyrr1183, yyrl1183 int
+	var yyc1183, yyrt1183 bool
+	_, _, _ = yyc1183, yyrt1183, yyrl1183
+	yyrr1183 = yyl1183
 
-	if yyv1235 == nil {
-		if yyrl1235, yyrt1235 = z.DecInferLen(yyl1235, z.DecBasicHandle().MaxInitLen, 64); yyrt1235 {
-			yyrr1235 = yyrl1235
+	if yyv1183 == nil {
+		if yyrl1183, yyrt1183 = z.DecInferLen(yyl1183, z.DecBasicHandle().MaxInitLen, 64); yyrt1183 {
+			yyrr1183 = yyrl1183
 		}
-		yyv1235 = make([]HTTPIngressPath, yyrl1235)
-		yyc1235 = true
+		yyv1183 = make([]HTTPIngressPath, yyrl1183)
+		yyc1183 = true
 	}
 
-	if yyl1235 == 0 {
-		if len(yyv1235) != 0 {
-			yyv1235 = yyv1235[:0]
-			yyc1235 = true
+	if yyl1183 == 0 {
+		if len(yyv1183) != 0 {
+			yyv1183 = yyv1183[:0]
+			yyc1183 = true
 		}
-	} else if yyl1235 > 0 {
+	} else if yyl1183 > 0 {
 
-		if yyl1235 > cap(yyv1235) {
-			yyrl1235, yyrt1235 = z.DecInferLen(yyl1235, z.DecBasicHandle().MaxInitLen, 64)
-			yyv1235 = make([]HTTPIngressPath, yyrl1235)
-			yyc1235 = true
+		if yyl1183 > cap(yyv1183) {
+			yyrl1183, yyrt1183 = z.DecInferLen(yyl1183, z.DecBasicHandle().MaxInitLen, 64)
+			yyv1183 = make([]HTTPIngressPath, yyrl1183)
+			yyc1183 = true
 
-			yyrr1235 = len(yyv1235)
-		} else if yyl1235 != len(yyv1235) {
-			yyv1235 = yyv1235[:yyl1235]
-			yyc1235 = true
+			yyrr1183 = len(yyv1183)
+		} else if yyl1183 != len(yyv1183) {
+			yyv1183 = yyv1183[:yyl1183]
+			yyc1183 = true
 		}
-		yyj1235 := 0
-		for ; yyj1235 < yyrr1235; yyj1235++ {
+		yyj1183 := 0
+		for ; yyj1183 < yyrr1183; yyj1183++ {
 			if r.TryDecodeAsNil() {
-				yyv1235[yyj1235] = HTTPIngressPath{}
+				yyv1183[yyj1183] = HTTPIngressPath{}
 			} else {
-				yyv1236 := &yyv1235[yyj1235]
-				yyv1236.CodecDecodeSelf(d)
+				yyv1184 := &yyv1183[yyj1183]
+				yyv1184.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1235 {
-			for ; yyj1235 < yyl1235; yyj1235++ {
-				yyv1235 = append(yyv1235, HTTPIngressPath{})
+		if yyrt1183 {
+			for ; yyj1183 < yyl1183; yyj1183++ {
+				yyv1183 = append(yyv1183, HTTPIngressPath{})
 				if r.TryDecodeAsNil() {
-					yyv1235[yyj1235] = HTTPIngressPath{}
+					yyv1183[yyj1183] = HTTPIngressPath{}
 				} else {
-					yyv1237 := &yyv1235[yyj1235]
-					yyv1237.CodecDecodeSelf(d)
+					yyv1185 := &yyv1183[yyj1183]
+					yyv1185.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1235 := 0; !r.CheckBreak(); yyj1235++ {
-			if yyj1235 >= len(yyv1235) {
-				yyv1235 = append(yyv1235, HTTPIngressPath{}) // var yyz1235 HTTPIngressPath
-				yyc1235 = true
+		for yyj1183 := 0; !r.CheckBreak(); yyj1183++ {
+			if yyj1183 >= len(yyv1183) {
+				yyv1183 = append(yyv1183, HTTPIngressPath{}) // var yyz1183 HTTPIngressPath
+				yyc1183 = true
 			}
 
-			if yyj1235 < len(yyv1235) {
+			if yyj1183 < len(yyv1183) {
 				if r.TryDecodeAsNil() {
-					yyv1235[yyj1235] = HTTPIngressPath{}
+					yyv1183[yyj1183] = HTTPIngressPath{}
 				} else {
-					yyv1238 := &yyv1235[yyj1235]
-					yyv1238.CodecDecodeSelf(d)
+					yyv1186 := &yyv1183[yyj1183]
+					yyv1186.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13978,10 +13666,10 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		yyh1235.End()
+		yyh1183.End()
 	}
-	if yyc1235 {
-		*v = yyv1235
+	if yyc1183 {
+		*v = yyv1183
 	}
 
 }
@@ -13991,9 +13679,9 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1239 := range v {
-		yy1240 := &yyv1239
-		yy1240.CodecEncodeSelf(e)
+	for _, yyv1187 := range v {
+		yy1188 := &yyv1187
+		yy1188.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -14003,75 +13691,75 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1241 := *v
-	yyh1241, yyl1241 := z.DecSliceHelperStart()
+	yyv1189 := *v
+	yyh1189, yyl1189 := z.DecSliceHelperStart()
 
-	var yyrr1241, yyrl1241 int
-	var yyc1241, yyrt1241 bool
-	_, _, _ = yyc1241, yyrt1241, yyrl1241
-	yyrr1241 = yyl1241
+	var yyrr1189, yyrl1189 int
+	var yyc1189, yyrt1189 bool
+	_, _, _ = yyc1189, yyrt1189, yyrl1189
+	yyrr1189 = yyl1189
 
-	if yyv1241 == nil {
-		if yyrl1241, yyrt1241 = z.DecInferLen(yyl1241, z.DecBasicHandle().MaxInitLen, 24); yyrt1241 {
-			yyrr1241 = yyrl1241
+	if yyv1189 == nil {
+		if yyrl1189, yyrt1189 = z.DecInferLen(yyl1189, z.DecBasicHandle().MaxInitLen, 24); yyrt1189 {
+			yyrr1189 = yyrl1189
 		}
-		yyv1241 = make([]NodeUtilization, yyrl1241)
-		yyc1241 = true
+		yyv1189 = make([]NodeUtilization, yyrl1189)
+		yyc1189 = true
 	}
 
-	if yyl1241 == 0 {
-		if len(yyv1241) != 0 {
-			yyv1241 = yyv1241[:0]
-			yyc1241 = true
+	if yyl1189 == 0 {
+		if len(yyv1189) != 0 {
+			yyv1189 = yyv1189[:0]
+			yyc1189 = true
 		}
-	} else if yyl1241 > 0 {
+	} else if yyl1189 > 0 {
 
-		if yyl1241 > cap(yyv1241) {
-			yyrl1241, yyrt1241 = z.DecInferLen(yyl1241, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1241 = make([]NodeUtilization, yyrl1241)
-			yyc1241 = true
+		if yyl1189 > cap(yyv1189) {
+			yyrl1189, yyrt1189 = z.DecInferLen(yyl1189, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1189 = make([]NodeUtilization, yyrl1189)
+			yyc1189 = true
 
-			yyrr1241 = len(yyv1241)
-		} else if yyl1241 != len(yyv1241) {
-			yyv1241 = yyv1241[:yyl1241]
-			yyc1241 = true
+			yyrr1189 = len(yyv1189)
+		} else if yyl1189 != len(yyv1189) {
+			yyv1189 = yyv1189[:yyl1189]
+			yyc1189 = true
 		}
-		yyj1241 := 0
-		for ; yyj1241 < yyrr1241; yyj1241++ {
+		yyj1189 := 0
+		for ; yyj1189 < yyrr1189; yyj1189++ {
 			if r.TryDecodeAsNil() {
-				yyv1241[yyj1241] = NodeUtilization{}
+				yyv1189[yyj1189] = NodeUtilization{}
 			} else {
-				yyv1242 := &yyv1241[yyj1241]
-				yyv1242.CodecDecodeSelf(d)
+				yyv1190 := &yyv1189[yyj1189]
+				yyv1190.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1241 {
-			for ; yyj1241 < yyl1241; yyj1241++ {
-				yyv1241 = append(yyv1241, NodeUtilization{})
+		if yyrt1189 {
+			for ; yyj1189 < yyl1189; yyj1189++ {
+				yyv1189 = append(yyv1189, NodeUtilization{})
 				if r.TryDecodeAsNil() {
-					yyv1241[yyj1241] = NodeUtilization{}
+					yyv1189[yyj1189] = NodeUtilization{}
 				} else {
-					yyv1243 := &yyv1241[yyj1241]
-					yyv1243.CodecDecodeSelf(d)
+					yyv1191 := &yyv1189[yyj1189]
+					yyv1191.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1241 := 0; !r.CheckBreak(); yyj1241++ {
-			if yyj1241 >= len(yyv1241) {
-				yyv1241 = append(yyv1241, NodeUtilization{}) // var yyz1241 NodeUtilization
-				yyc1241 = true
+		for yyj1189 := 0; !r.CheckBreak(); yyj1189++ {
+			if yyj1189 >= len(yyv1189) {
+				yyv1189 = append(yyv1189, NodeUtilization{}) // var yyz1189 NodeUtilization
+				yyc1189 = true
 			}
 
-			if yyj1241 < len(yyv1241) {
+			if yyj1189 < len(yyv1189) {
 				if r.TryDecodeAsNil() {
-					yyv1241[yyj1241] = NodeUtilization{}
+					yyv1189[yyj1189] = NodeUtilization{}
 				} else {
-					yyv1244 := &yyv1241[yyj1241]
-					yyv1244.CodecDecodeSelf(d)
+					yyv1192 := &yyv1189[yyj1189]
+					yyv1192.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -14079,10 +13767,10 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		yyh1241.End()
+		yyh1189.End()
 	}
-	if yyc1241 {
-		*v = yyv1241
+	if yyc1189 {
+		*v = yyv1189
 	}
 
 }
@@ -14092,9 +13780,9 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1245 := range v {
-		yy1246 := &yyv1245
-		yy1246.CodecEncodeSelf(e)
+	for _, yyv1193 := range v {
+		yy1194 := &yyv1193
+		yy1194.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -14104,75 +13792,75 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1247 := *v
-	yyh1247, yyl1247 := z.DecSliceHelperStart()
+	yyv1195 := *v
+	yyh1195, yyl1195 := z.DecSliceHelperStart()
 
-	var yyrr1247, yyrl1247 int
-	var yyc1247, yyrt1247 bool
-	_, _, _ = yyc1247, yyrt1247, yyrl1247
-	yyrr1247 = yyl1247
+	var yyrr1195, yyrl1195 int
+	var yyc1195, yyrt1195 bool
+	_, _, _ = yyc1195, yyrt1195, yyrl1195
+	yyrr1195 = yyl1195
 
-	if yyv1247 == nil {
-		if yyrl1247, yyrt1247 = z.DecInferLen(yyl1247, z.DecBasicHandle().MaxInitLen, 232); yyrt1247 {
-			yyrr1247 = yyrl1247
+	if yyv1195 == nil {
+		if yyrl1195, yyrt1195 = z.DecInferLen(yyl1195, z.DecBasicHandle().MaxInitLen, 232); yyrt1195 {
+			yyrr1195 = yyrl1195
 		}
-		yyv1247 = make([]ClusterAutoscaler, yyrl1247)
-		yyc1247 = true
+		yyv1195 = make([]ClusterAutoscaler, yyrl1195)
+		yyc1195 = true
 	}
 
-	if yyl1247 == 0 {
-		if len(yyv1247) != 0 {
-			yyv1247 = yyv1247[:0]
-			yyc1247 = true
+	if yyl1195 == 0 {
+		if len(yyv1195) != 0 {
+			yyv1195 = yyv1195[:0]
+			yyc1195 = true
 		}
-	} else if yyl1247 > 0 {
+	} else if yyl1195 > 0 {
 
-		if yyl1247 > cap(yyv1247) {
-			yyrl1247, yyrt1247 = z.DecInferLen(yyl1247, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1247 = make([]ClusterAutoscaler, yyrl1247)
-			yyc1247 = true
+		if yyl1195 > cap(yyv1195) {
+			yyrl1195, yyrt1195 = z.DecInferLen(yyl1195, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1195 = make([]ClusterAutoscaler, yyrl1195)
+			yyc1195 = true
 
-			yyrr1247 = len(yyv1247)
-		} else if yyl1247 != len(yyv1247) {
-			yyv1247 = yyv1247[:yyl1247]
-			yyc1247 = true
+			yyrr1195 = len(yyv1195)
+		} else if yyl1195 != len(yyv1195) {
+			yyv1195 = yyv1195[:yyl1195]
+			yyc1195 = true
 		}
-		yyj1247 := 0
-		for ; yyj1247 < yyrr1247; yyj1247++ {
+		yyj1195 := 0
+		for ; yyj1195 < yyrr1195; yyj1195++ {
 			if r.TryDecodeAsNil() {
-				yyv1247[yyj1247] = ClusterAutoscaler{}
+				yyv1195[yyj1195] = ClusterAutoscaler{}
 			} else {
-				yyv1248 := &yyv1247[yyj1247]
-				yyv1248.CodecDecodeSelf(d)
+				yyv1196 := &yyv1195[yyj1195]
+				yyv1196.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1247 {
-			for ; yyj1247 < yyl1247; yyj1247++ {
-				yyv1247 = append(yyv1247, ClusterAutoscaler{})
+		if yyrt1195 {
+			for ; yyj1195 < yyl1195; yyj1195++ {
+				yyv1195 = append(yyv1195, ClusterAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1247[yyj1247] = ClusterAutoscaler{}
+					yyv1195[yyj1195] = ClusterAutoscaler{}
 				} else {
-					yyv1249 := &yyv1247[yyj1247]
-					yyv1249.CodecDecodeSelf(d)
+					yyv1197 := &yyv1195[yyj1195]
+					yyv1197.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1247 := 0; !r.CheckBreak(); yyj1247++ {
-			if yyj1247 >= len(yyv1247) {
-				yyv1247 = append(yyv1247, ClusterAutoscaler{}) // var yyz1247 ClusterAutoscaler
-				yyc1247 = true
+		for yyj1195 := 0; !r.CheckBreak(); yyj1195++ {
+			if yyj1195 >= len(yyv1195) {
+				yyv1195 = append(yyv1195, ClusterAutoscaler{}) // var yyz1195 ClusterAutoscaler
+				yyc1195 = true
 			}
 
-			if yyj1247 < len(yyv1247) {
+			if yyj1195 < len(yyv1195) {
 				if r.TryDecodeAsNil() {
-					yyv1247[yyj1247] = ClusterAutoscaler{}
+					yyv1195[yyj1195] = ClusterAutoscaler{}
 				} else {
-					yyv1250 := &yyv1247[yyj1247]
-					yyv1250.CodecDecodeSelf(d)
+					yyv1198 := &yyv1195[yyj1195]
+					yyv1198.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -14180,10 +13868,10 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		yyh1247.End()
+		yyh1195.End()
 	}
-	if yyc1247 {
-		*v = yyv1247
+	if yyc1195 {
+		*v = yyv1195
 	}
 
 }
@@ -14193,9 +13881,9 @@ func (x codecSelfer1234) encSlicePodSelectorRequirement(v []PodSelectorRequireme
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1251 := range v {
-		yy1252 := &yyv1251
-		yy1252.CodecEncodeSelf(e)
+	for _, yyv1199 := range v {
+		yy1200 := &yyv1199
+		yy1200.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -14205,75 +13893,75 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1253 := *v
-	yyh1253, yyl1253 := z.DecSliceHelperStart()
+	yyv1201 := *v
+	yyh1201, yyl1201 := z.DecSliceHelperStart()
 
-	var yyrr1253, yyrl1253 int
-	var yyc1253, yyrt1253 bool
-	_, _, _ = yyc1253, yyrt1253, yyrl1253
-	yyrr1253 = yyl1253
+	var yyrr1201, yyrl1201 int
+	var yyc1201, yyrt1201 bool
+	_, _, _ = yyc1201, yyrt1201, yyrl1201
+	yyrr1201 = yyl1201
 
-	if yyv1253 == nil {
-		if yyrl1253, yyrt1253 = z.DecInferLen(yyl1253, z.DecBasicHandle().MaxInitLen, 56); yyrt1253 {
-			yyrr1253 = yyrl1253
+	if yyv1201 == nil {
+		if yyrl1201, yyrt1201 = z.DecInferLen(yyl1201, z.DecBasicHandle().MaxInitLen, 56); yyrt1201 {
+			yyrr1201 = yyrl1201
 		}
-		yyv1253 = make([]PodSelectorRequirement, yyrl1253)
-		yyc1253 = true
+		yyv1201 = make([]PodSelectorRequirement, yyrl1201)
+		yyc1201 = true
 	}
 
-	if yyl1253 == 0 {
-		if len(yyv1253) != 0 {
-			yyv1253 = yyv1253[:0]
-			yyc1253 = true
+	if yyl1201 == 0 {
+		if len(yyv1201) != 0 {
+			yyv1201 = yyv1201[:0]
+			yyc1201 = true
 		}
-	} else if yyl1253 > 0 {
+	} else if yyl1201 > 0 {
 
-		if yyl1253 > cap(yyv1253) {
-			yyrl1253, yyrt1253 = z.DecInferLen(yyl1253, z.DecBasicHandle().MaxInitLen, 56)
-			yyv1253 = make([]PodSelectorRequirement, yyrl1253)
-			yyc1253 = true
+		if yyl1201 > cap(yyv1201) {
+			yyrl1201, yyrt1201 = z.DecInferLen(yyl1201, z.DecBasicHandle().MaxInitLen, 56)
+			yyv1201 = make([]PodSelectorRequirement, yyrl1201)
+			yyc1201 = true
 
-			yyrr1253 = len(yyv1253)
-		} else if yyl1253 != len(yyv1253) {
-			yyv1253 = yyv1253[:yyl1253]
-			yyc1253 = true
+			yyrr1201 = len(yyv1201)
+		} else if yyl1201 != len(yyv1201) {
+			yyv1201 = yyv1201[:yyl1201]
+			yyc1201 = true
 		}
-		yyj1253 := 0
-		for ; yyj1253 < yyrr1253; yyj1253++ {
+		yyj1201 := 0
+		for ; yyj1201 < yyrr1201; yyj1201++ {
 			if r.TryDecodeAsNil() {
-				yyv1253[yyj1253] = PodSelectorRequirement{}
+				yyv1201[yyj1201] = PodSelectorRequirement{}
 			} else {
-				yyv1254 := &yyv1253[yyj1253]
-				yyv1254.CodecDecodeSelf(d)
+				yyv1202 := &yyv1201[yyj1201]
+				yyv1202.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1253 {
-			for ; yyj1253 < yyl1253; yyj1253++ {
-				yyv1253 = append(yyv1253, PodSelectorRequirement{})
+		if yyrt1201 {
+			for ; yyj1201 < yyl1201; yyj1201++ {
+				yyv1201 = append(yyv1201, PodSelectorRequirement{})
 				if r.TryDecodeAsNil() {
-					yyv1253[yyj1253] = PodSelectorRequirement{}
+					yyv1201[yyj1201] = PodSelectorRequirement{}
 				} else {
-					yyv1255 := &yyv1253[yyj1253]
-					yyv1255.CodecDecodeSelf(d)
+					yyv1203 := &yyv1201[yyj1201]
+					yyv1203.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1253 := 0; !r.CheckBreak(); yyj1253++ {
-			if yyj1253 >= len(yyv1253) {
-				yyv1253 = append(yyv1253, PodSelectorRequirement{}) // var yyz1253 PodSelectorRequirement
-				yyc1253 = true
+		for yyj1201 := 0; !r.CheckBreak(); yyj1201++ {
+			if yyj1201 >= len(yyv1201) {
+				yyv1201 = append(yyv1201, PodSelectorRequirement{}) // var yyz1201 PodSelectorRequirement
+				yyc1201 = true
 			}
 
-			if yyj1253 < len(yyv1253) {
+			if yyj1201 < len(yyv1201) {
 				if r.TryDecodeAsNil() {
-					yyv1253[yyj1253] = PodSelectorRequirement{}
+					yyv1201[yyj1201] = PodSelectorRequirement{}
 				} else {
-					yyv1256 := &yyv1253[yyj1253]
-					yyv1256.CodecDecodeSelf(d)
+					yyv1204 := &yyv1201[yyj1201]
+					yyv1204.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -14281,10 +13969,10 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 			}
 
 		}
-		yyh1253.End()
+		yyh1201.End()
 	}
-	if yyc1253 {
-		*v = yyv1253
+	if yyc1201 {
+		*v = yyv1201
 	}
 
 }

--- a/pkg/apis/metrics/deep_copy_generated.go
+++ b/pkg/apis/metrics/deep_copy_generated.go
@@ -149,39 +149,6 @@ func deepCopy_metrics_ContainerSample(in ContainerSample, out *ContainerSample, 
 	return nil
 }
 
-func deepCopy_metrics_CustomMetric(in CustomMetric, out *CustomMetric, c *conversion.Cloner) error {
-	out.Name = in.Name
-	out.Type = in.Type
-	out.Unit = in.Unit
-	if in.Samples != nil {
-		out.Samples = make([]CustomMetricSample, len(in.Samples))
-		for i := range in.Samples {
-			if err := deepCopy_metrics_CustomMetricSample(in.Samples[i], &out.Samples[i], c); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Samples = nil
-	}
-	return nil
-}
-
-func deepCopy_metrics_CustomMetricSample(in CustomMetricSample, out *CustomMetricSample, c *conversion.Cloner) error {
-	if err := deepCopy_metrics_Sample(in.Sample, &out.Sample, c); err != nil {
-		return err
-	}
-	if in.Label != nil {
-		out.Label = new(string)
-		*out.Label = *in.Label
-	} else {
-		out.Label = nil
-	}
-	if err := deepCopy_resource_Quantity(in.Value, &out.Value, c); err != nil {
-		return err
-	}
-	return nil
-}
-
 func deepCopy_metrics_FilesystemMetrics(in FilesystemMetrics, out *FilesystemMetrics, c *conversion.Cloner) error {
 	out.Device = in.Device
 	if in.UsageBytes != nil {
@@ -313,16 +280,6 @@ func deepCopy_metrics_RawContainerMetrics(in RawContainerMetrics, out *RawContai
 		}
 	} else {
 		out.Samples = nil
-	}
-	if in.CustomMetrics != nil {
-		out.CustomMetrics = make([]CustomMetric, len(in.CustomMetrics))
-		for i := range in.CustomMetrics {
-			if err := deepCopy_metrics_CustomMetric(in.CustomMetrics[i], &out.CustomMetrics[i], c); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.CustomMetrics = nil
 	}
 	return nil
 }
@@ -468,8 +425,6 @@ func init() {
 		deepCopy_metrics_AggregateSample,
 		deepCopy_metrics_CPUMetrics,
 		deepCopy_metrics_ContainerSample,
-		deepCopy_metrics_CustomMetric,
-		deepCopy_metrics_CustomMetricSample,
 		deepCopy_metrics_FilesystemMetrics,
 		deepCopy_metrics_MemoryMetrics,
 		deepCopy_metrics_MetricsMeta,

--- a/pkg/apis/metrics/deep_copy_generated.go
+++ b/pkg/apis/metrics/deep_copy_generated.go
@@ -113,14 +113,6 @@ func deepCopy_metrics_CPUMetrics(in CPUMetrics, out *CPUMetrics, c *conversion.C
 	} else {
 		out.TotalCores = nil
 	}
-	if in.LoadAverage != nil {
-		out.LoadAverage = new(resource.Quantity)
-		if err := deepCopy_resource_Quantity(*in.LoadAverage, out.LoadAverage, c); err != nil {
-			return err
-		}
-	} else {
-		out.LoadAverage = nil
-	}
 	return nil
 }
 

--- a/pkg/apis/metrics/deep_copy_generated.go
+++ b/pkg/apis/metrics/deep_copy_generated.go
@@ -285,22 +285,6 @@ func deepCopy_metrics_RawContainerMetrics(in RawContainerMetrics, out *RawContai
 }
 
 func deepCopy_metrics_RawMetricsOptions(in RawMetricsOptions, out *RawMetricsOptions, c *conversion.Cloner) error {
-	if in.SinceTime != nil {
-		out.SinceTime = new(unversioned.Time)
-		if err := deepCopy_unversioned_Time(*in.SinceTime, out.SinceTime, c); err != nil {
-			return err
-		}
-	} else {
-		out.SinceTime = nil
-	}
-	if in.UntilTime != nil {
-		out.UntilTime = new(unversioned.Time)
-		if err := deepCopy_unversioned_Time(*in.UntilTime, out.UntilTime, c); err != nil {
-			return err
-		}
-	} else {
-		out.UntilTime = nil
-	}
 	out.MaxSamples = in.MaxSamples
 	return nil
 }

--- a/pkg/apis/metrics/deep_copy_generated.go
+++ b/pkg/apis/metrics/deep_copy_generated.go
@@ -19,10 +19,43 @@ limitations under the License.
 package metrics
 
 import (
+	time "time"
+
 	api "k8s.io/kubernetes/pkg/api"
+	resource "k8s.io/kubernetes/pkg/api/resource"
 	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	inf "speter.net/go/exp/math/dec/inf"
 )
+
+func deepCopy_resource_Quantity(in resource.Quantity, out *resource.Quantity, c *conversion.Cloner) error {
+	if in.Amount != nil {
+		if newVal, err := c.DeepCopy(in.Amount); err != nil {
+			return err
+		} else {
+			out.Amount = newVal.(*inf.Dec)
+		}
+	} else {
+		out.Amount = nil
+	}
+	out.Format = in.Format
+	return nil
+}
+
+func deepCopy_unversioned_ListMeta(in unversioned.ListMeta, out *unversioned.ListMeta, c *conversion.Cloner) error {
+	out.SelfLink = in.SelfLink
+	out.ResourceVersion = in.ResourceVersion
+	return nil
+}
+
+func deepCopy_unversioned_Time(in unversioned.Time, out *unversioned.Time, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Time); err != nil {
+		return err
+	} else {
+		out.Time = newVal.(time.Time)
+	}
+	return nil
+}
 
 func deepCopy_unversioned_TypeMeta(in unversioned.TypeMeta, out *unversioned.TypeMeta, c *conversion.Cloner) error {
 	out.Kind = in.Kind
@@ -30,15 +63,364 @@ func deepCopy_unversioned_TypeMeta(in unversioned.TypeMeta, out *unversioned.Typ
 	return nil
 }
 
-func deepCopy_metrics_RawNode(in RawNode, out *RawNode, c *conversion.Cloner) error {
-	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+func deepCopy_metrics_AggregateSample(in AggregateSample, out *AggregateSample, c *conversion.Cloner) error {
+	if err := deepCopy_metrics_Sample(in.Sample, &out.Sample, c); err != nil {
+		return err
+	}
+	if in.CPU != nil {
+		out.CPU = new(CPUMetrics)
+		if err := deepCopy_metrics_CPUMetrics(*in.CPU, out.CPU, c); err != nil {
+			return err
+		}
+	} else {
+		out.CPU = nil
+	}
+	if in.Memory != nil {
+		out.Memory = new(MemoryMetrics)
+		if err := deepCopy_metrics_MemoryMetrics(*in.Memory, out.Memory, c); err != nil {
+			return err
+		}
+	} else {
+		out.Memory = nil
+	}
+	if in.Network != nil {
+		out.Network = new(NetworkMetrics)
+		if err := deepCopy_metrics_NetworkMetrics(*in.Network, out.Network, c); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_CPUMetrics(in CPUMetrics, out *CPUMetrics, c *conversion.Cloner) error {
+	if in.TotalCores != nil {
+		out.TotalCores = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.TotalCores, out.TotalCores, c); err != nil {
+			return err
+		}
+	} else {
+		out.TotalCores = nil
+	}
+	if in.LoadAverage != nil {
+		out.LoadAverage = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.LoadAverage, out.LoadAverage, c); err != nil {
+			return err
+		}
+	} else {
+		out.LoadAverage = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_ContainerSample(in ContainerSample, out *ContainerSample, c *conversion.Cloner) error {
+	if err := deepCopy_metrics_Sample(in.Sample, &out.Sample, c); err != nil {
+		return err
+	}
+	if in.CPU != nil {
+		out.CPU = new(CPUMetrics)
+		if err := deepCopy_metrics_CPUMetrics(*in.CPU, out.CPU, c); err != nil {
+			return err
+		}
+	} else {
+		out.CPU = nil
+	}
+	if in.Memory != nil {
+		out.Memory = new(MemoryMetrics)
+		if err := deepCopy_metrics_MemoryMetrics(*in.Memory, out.Memory, c); err != nil {
+			return err
+		}
+	} else {
+		out.Memory = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_CustomMetric(in CustomMetric, out *CustomMetric, c *conversion.Cloner) error {
+	out.Name = in.Name
+	out.Type = in.Type
+	out.Unit = in.Unit
+	if in.Samples != nil {
+		out.Samples = make([]CustomMetricSample, len(in.Samples))
+		for i := range in.Samples {
+			if err := deepCopy_metrics_CustomMetricSample(in.Samples[i], &out.Samples[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Samples = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_CustomMetricSample(in CustomMetricSample, out *CustomMetricSample, c *conversion.Cloner) error {
+	if err := deepCopy_metrics_Sample(in.Sample, &out.Sample, c); err != nil {
+		return err
+	}
+	if in.Label != nil {
+		out.Label = new(string)
+		*out.Label = *in.Label
+	} else {
+		out.Label = nil
+	}
+	if err := deepCopy_resource_Quantity(in.Value, &out.Value, c); err != nil {
 		return err
 	}
 	return nil
 }
 
-func deepCopy_metrics_RawPod(in RawPod, out *RawPod, c *conversion.Cloner) error {
+func deepCopy_metrics_MemoryMetrics(in MemoryMetrics, out *MemoryMetrics, c *conversion.Cloner) error {
+	if in.TotalBytes != nil {
+		out.TotalBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.TotalBytes, out.TotalBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.TotalBytes = nil
+	}
+	if in.UsageBytes != nil {
+		out.UsageBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.UsageBytes, out.UsageBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.UsageBytes = nil
+	}
+	if in.PageFaults != nil {
+		out.PageFaults = new(int64)
+		*out.PageFaults = *in.PageFaults
+	} else {
+		out.PageFaults = nil
+	}
+	if in.MajorPageFaults != nil {
+		out.MajorPageFaults = new(int64)
+		*out.MajorPageFaults = *in.MajorPageFaults
+	} else {
+		out.MajorPageFaults = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_MetricsMeta(in MetricsMeta, out *MetricsMeta, c *conversion.Cloner) error {
+	out.SelfLink = in.SelfLink
+	return nil
+}
+
+func deepCopy_metrics_NetworkMetrics(in NetworkMetrics, out *NetworkMetrics, c *conversion.Cloner) error {
+	if in.RxBytes != nil {
+		out.RxBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.RxBytes, out.RxBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.RxBytes = nil
+	}
+	if in.RxErrors != nil {
+		out.RxErrors = new(int64)
+		*out.RxErrors = *in.RxErrors
+	} else {
+		out.RxErrors = nil
+	}
+	if in.TxBytes != nil {
+		out.TxBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.TxBytes, out.TxBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.TxBytes = nil
+	}
+	if in.TxErrors != nil {
+		out.TxErrors = new(int64)
+		*out.TxErrors = *in.TxErrors
+	} else {
+		out.TxErrors = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_NonLocalObjectReference(in NonLocalObjectReference, out *NonLocalObjectReference, c *conversion.Cloner) error {
+	out.Name = in.Name
+	out.Namespace = in.Namespace
+	out.UID = in.UID
+	return nil
+}
+
+func deepCopy_metrics_PodSample(in PodSample, out *PodSample, c *conversion.Cloner) error {
+	if err := deepCopy_metrics_Sample(in.Sample, &out.Sample, c); err != nil {
+		return err
+	}
+	if in.Network != nil {
+		out.Network = new(NetworkMetrics)
+		if err := deepCopy_metrics_NetworkMetrics(*in.Network, out.Network, c); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_RawContainerMetrics(in RawContainerMetrics, out *RawContainerMetrics, c *conversion.Cloner) error {
+	out.Name = in.Name
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Samples != nil {
+		out.Samples = make([]ContainerSample, len(in.Samples))
+		for i := range in.Samples {
+			if err := deepCopy_metrics_ContainerSample(in.Samples[i], &out.Samples[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Samples = nil
+	}
+	if in.CustomMetrics != nil {
+		out.CustomMetrics = make([]CustomMetric, len(in.CustomMetrics))
+		for i := range in.CustomMetrics {
+			if err := deepCopy_metrics_CustomMetric(in.CustomMetrics[i], &out.CustomMetrics[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.CustomMetrics = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_RawMetricsOptions(in RawMetricsOptions, out *RawMetricsOptions, c *conversion.Cloner) error {
+	if in.SinceTime != nil {
+		out.SinceTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.SinceTime, out.SinceTime, c); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	if in.UntilTime != nil {
+		out.UntilTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.UntilTime, out.UntilTime, c); err != nil {
+			return err
+		}
+	} else {
+		out.UntilTime = nil
+	}
+	out.MaxSamples = in.MaxSamples
+	return nil
+}
+
+func deepCopy_metrics_RawNodeMetrics(in RawNodeMetrics, out *RawNodeMetrics, c *conversion.Cloner) error {
 	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	out.NodeName = in.NodeName
+	if in.Total != nil {
+		out.Total = make([]AggregateSample, len(in.Total))
+		for i := range in.Total {
+			if err := deepCopy_metrics_AggregateSample(in.Total[i], &out.Total[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Total = nil
+	}
+	if in.SystemContainers != nil {
+		out.SystemContainers = make([]RawContainerMetrics, len(in.SystemContainers))
+		for i := range in.SystemContainers {
+			if err := deepCopy_metrics_RawContainerMetrics(in.SystemContainers[i], &out.SystemContainers[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.SystemContainers = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_RawNodeMetricsList(in RawNodeMetricsList, out *RawNodeMetricsList, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]RawNodeMetrics, len(in.Items))
+		for i := range in.Items {
+			if err := deepCopy_metrics_RawNodeMetrics(in.Items[i], &out.Items[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_RawPodMetrics(in RawPodMetrics, out *RawPodMetrics, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_metrics_NonLocalObjectReference(in.PodRef, &out.PodRef, c); err != nil {
+		return err
+	}
+	if in.Containers != nil {
+		out.Containers = make([]RawContainerMetrics, len(in.Containers))
+		for i := range in.Containers {
+			if err := deepCopy_metrics_RawContainerMetrics(in.Containers[i], &out.Containers[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Containers = nil
+	}
+	if in.Samples != nil {
+		out.Samples = make([]PodSample, len(in.Samples))
+		for i := range in.Samples {
+			if err := deepCopy_metrics_PodSample(in.Samples[i], &out.Samples[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Samples = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_RawPodMetricsList(in RawPodMetricsList, out *RawPodMetricsList, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]RawPodMetrics, len(in.Items))
+		for i := range in.Items {
+			if err := deepCopy_metrics_RawPodMetrics(in.Items[i], &out.Items[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_Sample(in Sample, out *Sample, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_Time(in.SampleTime, &out.SampleTime, c); err != nil {
 		return err
 	}
 	return nil
@@ -46,9 +428,27 @@ func deepCopy_metrics_RawPod(in RawPod, out *RawPod, c *conversion.Cloner) error
 
 func init() {
 	err := api.Scheme.AddGeneratedDeepCopyFuncs(
+		deepCopy_resource_Quantity,
+		deepCopy_unversioned_ListMeta,
+		deepCopy_unversioned_Time,
 		deepCopy_unversioned_TypeMeta,
-		deepCopy_metrics_RawNode,
-		deepCopy_metrics_RawPod,
+		deepCopy_metrics_AggregateSample,
+		deepCopy_metrics_CPUMetrics,
+		deepCopy_metrics_ContainerSample,
+		deepCopy_metrics_CustomMetric,
+		deepCopy_metrics_CustomMetricSample,
+		deepCopy_metrics_MemoryMetrics,
+		deepCopy_metrics_MetricsMeta,
+		deepCopy_metrics_NetworkMetrics,
+		deepCopy_metrics_NonLocalObjectReference,
+		deepCopy_metrics_PodSample,
+		deepCopy_metrics_RawContainerMetrics,
+		deepCopy_metrics_RawMetricsOptions,
+		deepCopy_metrics_RawNodeMetrics,
+		deepCopy_metrics_RawNodeMetricsList,
+		deepCopy_metrics_RawPodMetrics,
+		deepCopy_metrics_RawPodMetricsList,
+		deepCopy_metrics_Sample,
 	)
 	if err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.

--- a/pkg/apis/metrics/deep_copy_generated.go
+++ b/pkg/apis/metrics/deep_copy_generated.go
@@ -91,6 +91,16 @@ func deepCopy_metrics_AggregateSample(in AggregateSample, out *AggregateSample, 
 	} else {
 		out.Network = nil
 	}
+	if in.Filesystem != nil {
+		out.Filesystem = make([]FilesystemMetrics, len(in.Filesystem))
+		for i := range in.Filesystem {
+			if err := deepCopy_metrics_FilesystemMetrics(in.Filesystem[i], &out.Filesystem[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Filesystem = nil
+	}
 	return nil
 }
 
@@ -134,6 +144,16 @@ func deepCopy_metrics_ContainerSample(in ContainerSample, out *ContainerSample, 
 	} else {
 		out.Memory = nil
 	}
+	if in.Filesystem != nil {
+		out.Filesystem = make([]FilesystemMetrics, len(in.Filesystem))
+		for i := range in.Filesystem {
+			if err := deepCopy_metrics_FilesystemMetrics(in.Filesystem[i], &out.Filesystem[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Filesystem = nil
+	}
 	return nil
 }
 
@@ -166,6 +186,27 @@ func deepCopy_metrics_CustomMetricSample(in CustomMetricSample, out *CustomMetri
 	}
 	if err := deepCopy_resource_Quantity(in.Value, &out.Value, c); err != nil {
 		return err
+	}
+	return nil
+}
+
+func deepCopy_metrics_FilesystemMetrics(in FilesystemMetrics, out *FilesystemMetrics, c *conversion.Cloner) error {
+	out.Device = in.Device
+	if in.UsageBytes != nil {
+		out.UsageBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.UsageBytes, out.UsageBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.UsageBytes = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.LimitBytes, out.LimitBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.LimitBytes = nil
 	}
 	return nil
 }
@@ -437,6 +478,7 @@ func init() {
 		deepCopy_metrics_ContainerSample,
 		deepCopy_metrics_CustomMetric,
 		deepCopy_metrics_CustomMetricSample,
+		deepCopy_metrics_FilesystemMetrics,
 		deepCopy_metrics_MemoryMetrics,
 		deepCopy_metrics_MetricsMeta,
 		deepCopy_metrics_NetworkMetrics,

--- a/pkg/apis/metrics/register.go
+++ b/pkg/apis/metrics/register.go
@@ -42,8 +42,6 @@ func addKnownTypes() {
 		&NetworkMetrics{},
 		&CPUMetrics{},
 		&MemoryMetrics{},
-		&CustomMetric{},
-		&CustomMetricSample{},
 		&RawMetricsOptions{},
 	)
 }
@@ -62,6 +60,4 @@ func (*ContainerSample) IsAnAPIObject()         {}
 func (*NetworkMetrics) IsAnAPIObject()          {}
 func (*CPUMetrics) IsAnAPIObject()              {}
 func (*MemoryMetrics) IsAnAPIObject()           {}
-func (*CustomMetric) IsAnAPIObject()            {}
-func (*CustomMetricSample) IsAnAPIObject()      {}
 func (*RawMetricsOptions) IsAnAPIObject()       {}

--- a/pkg/apis/metrics/register.go
+++ b/pkg/apis/metrics/register.go
@@ -28,10 +28,40 @@ func init() {
 // Adds the list of known types to api.Scheme.
 func addKnownTypes() {
 	api.Scheme.AddKnownTypes("",
-		&RawNode{},
-		&RawPod{},
+		&MetricsMeta{},
+		&RawNodeMetrics{},
+		&RawNodeMetricsList{},
+		&RawPodMetrics{},
+		&RawPodMetricsList{},
+		&RawContainerMetrics{},
+		&NonLocalObjectReference{},
+		&Sample{},
+		&AggregateSample{},
+		&PodSample{},
+		&ContainerSample{},
+		&NetworkMetrics{},
+		&CPUMetrics{},
+		&MemoryMetrics{},
+		&CustomMetric{},
+		&CustomMetricSample{},
+		&RawMetricsOptions{},
 	)
 }
 
-func (*RawNode) IsAnAPIObject() {}
-func (*RawPod) IsAnAPIObject()  {}
+func (*MetricsMeta) IsAnAPIObject()             {}
+func (*RawNodeMetrics) IsAnAPIObject()          {}
+func (*RawNodeMetricsList) IsAnAPIObject()      {}
+func (*RawPodMetrics) IsAnAPIObject()           {}
+func (*RawPodMetricsList) IsAnAPIObject()       {}
+func (*RawContainerMetrics) IsAnAPIObject()     {}
+func (*NonLocalObjectReference) IsAnAPIObject() {}
+func (*Sample) IsAnAPIObject()                  {}
+func (*AggregateSample) IsAnAPIObject()         {}
+func (*PodSample) IsAnAPIObject()               {}
+func (*ContainerSample) IsAnAPIObject()         {}
+func (*NetworkMetrics) IsAnAPIObject()          {}
+func (*CPUMetrics) IsAnAPIObject()              {}
+func (*MemoryMetrics) IsAnAPIObject()           {}
+func (*CustomMetric) IsAnAPIObject()            {}
+func (*CustomMetricSample) IsAnAPIObject()      {}
+func (*RawMetricsOptions) IsAnAPIObject()       {}

--- a/pkg/apis/metrics/types.generated.go
+++ b/pkg/apis/metrics/types.generated.go
@@ -3895,13 +3895,12 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep348 := !z.EncBinary()
 			yy2arr348 := z.EncBasicHandle().StructToArray
-			var yyq348 [2]bool
+			var yyq348 [1]bool
 			_, _, _ = yysep348, yyq348, yy2arr348
 			const yyr348 bool = false
 			yyq348[0] = x.TotalCores != nil
-			yyq348[1] = x.LoadAverage != nil
 			if yyr348 || yy2arr348 {
-				r.EncodeArrayStart(2)
+				r.EncodeArrayStart(1)
 			} else {
 				var yynn348 int = 0
 				for _, b := range yyq348 {
@@ -3947,42 +3946,6 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr348 || yy2arr348 {
-				if yyq348[1] {
-					if x.LoadAverage == nil {
-						r.EncodeNil()
-					} else {
-						yym353 := z.EncBinary()
-						_ = yym353
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
-						} else if !yym353 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.LoadAverage)
-						} else {
-							z.EncFallback(x.LoadAverage)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq348[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("loadAverage"))
-					if x.LoadAverage == nil {
-						r.EncodeNil()
-					} else {
-						yym354 := z.EncBinary()
-						_ = yym354
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
-						} else if !yym354 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.LoadAverage)
-						} else {
-							z.EncFallback(x.LoadAverage)
-						}
-					}
-				}
-			}
 			if yysep348 {
 				r.EncodeEnd()
 			}
@@ -3994,24 +3957,24 @@ func (x *CPUMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym355 := z.DecBinary()
-	_ = yym355
+	yym352 := z.DecBinary()
+	_ = yym352
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl356 := r.ReadMapStart()
-			if yyl356 == 0 {
+			yyl353 := r.ReadMapStart()
+			if yyl353 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl356, d)
+				x.codecDecodeSelfFromMap(yyl353, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl356 := r.ReadArrayStart()
-			if yyl356 == 0 {
+			yyl353 := r.ReadArrayStart()
+			if yyl353 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl356, d)
+				x.codecDecodeSelfFromArray(yyl353, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4023,12 +3986,12 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys357Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys357Slc
-	var yyhl357 bool = l >= 0
-	for yyj357 := 0; ; yyj357++ {
-		if yyhl357 {
-			if yyj357 >= l {
+	var yys354Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys354Slc
+	var yyhl354 bool = l >= 0
+	for yyj354 := 0; ; yyj354++ {
+		if yyhl354 {
+			if yyj354 >= l {
 				break
 			}
 		} else {
@@ -4036,9 +3999,9 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys357Slc = r.DecodeBytes(yys357Slc, true, true)
-		yys357 := string(yys357Slc)
-		switch yys357 {
+		yys354Slc = r.DecodeBytes(yys354Slc, true, true)
+		yys354 := string(yys354Slc)
+		switch yys354 {
 		case "totalCores":
 			if r.TryDecodeAsNil() {
 				if x.TotalCores != nil {
@@ -4048,40 +4011,21 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalCores == nil {
 					x.TotalCores = new(pkg2_resource.Quantity)
 				}
-				yym359 := z.DecBinary()
-				_ = yym359
+				yym356 := z.DecBinary()
+				_ = yym356
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-				} else if !yym359 && z.IsJSONHandle() {
+				} else if !yym356 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalCores)
 				} else {
 					z.DecFallback(x.TotalCores, false)
 				}
 			}
-		case "loadAverage":
-			if r.TryDecodeAsNil() {
-				if x.LoadAverage != nil {
-					x.LoadAverage = nil
-				}
-			} else {
-				if x.LoadAverage == nil {
-					x.LoadAverage = new(pkg2_resource.Quantity)
-				}
-				yym361 := z.DecBinary()
-				_ = yym361
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
-				} else if !yym361 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.LoadAverage)
-				} else {
-					z.DecFallback(x.LoadAverage, false)
-				}
-			}
 		default:
-			z.DecStructFieldNotFound(-1, yys357)
-		} // end switch yys357
-	} // end for yyj357
-	if !yyhl357 {
+			z.DecStructFieldNotFound(-1, yys354)
+		} // end switch yys354
+	} // end for yyj354
+	if !yyhl354 {
 		r.ReadEnd()
 	}
 }
@@ -4090,16 +4034,16 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj362 int
-	var yyb362 bool
-	var yyhl362 bool = l >= 0
-	yyj362++
-	if yyhl362 {
-		yyb362 = yyj362 > l
+	var yyj357 int
+	var yyb357 bool
+	var yyhl357 bool = l >= 0
+	yyj357++
+	if yyhl357 {
+		yyb357 = yyj357 > l
 	} else {
-		yyb362 = r.CheckBreak()
+		yyb357 = r.CheckBreak()
 	}
-	if yyb362 {
+	if yyb357 {
 		r.ReadEnd()
 		return
 	}
@@ -4111,55 +4055,27 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalCores == nil {
 			x.TotalCores = new(pkg2_resource.Quantity)
 		}
-		yym364 := z.DecBinary()
-		_ = yym364
+		yym359 := z.DecBinary()
+		_ = yym359
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-		} else if !yym364 && z.IsJSONHandle() {
+		} else if !yym359 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalCores)
 		} else {
 			z.DecFallback(x.TotalCores, false)
 		}
 	}
-	yyj362++
-	if yyhl362 {
-		yyb362 = yyj362 > l
-	} else {
-		yyb362 = r.CheckBreak()
-	}
-	if yyb362 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		if x.LoadAverage != nil {
-			x.LoadAverage = nil
-		}
-	} else {
-		if x.LoadAverage == nil {
-			x.LoadAverage = new(pkg2_resource.Quantity)
-		}
-		yym366 := z.DecBinary()
-		_ = yym366
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
-		} else if !yym366 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.LoadAverage)
-		} else {
-			z.DecFallback(x.LoadAverage, false)
-		}
-	}
 	for {
-		yyj362++
-		if yyhl362 {
-			yyb362 = yyj362 > l
+		yyj357++
+		if yyhl357 {
+			yyb357 = yyj357 > l
 		} else {
-			yyb362 = r.CheckBreak()
+			yyb357 = r.CheckBreak()
 		}
-		if yyb362 {
+		if yyb357 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj362-1, "")
+		z.DecStructFieldNotFound(yyj357-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4171,41 +4087,41 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym367 := z.EncBinary()
-		_ = yym367
+		yym360 := z.EncBinary()
+		_ = yym360
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep368 := !z.EncBinary()
-			yy2arr368 := z.EncBasicHandle().StructToArray
-			var yyq368 [4]bool
-			_, _, _ = yysep368, yyq368, yy2arr368
-			const yyr368 bool = false
-			yyq368[0] = x.TotalBytes != nil
-			yyq368[1] = x.UsageBytes != nil
-			yyq368[2] = x.PageFaults != nil
-			yyq368[3] = x.MajorPageFaults != nil
-			if yyr368 || yy2arr368 {
+			yysep361 := !z.EncBinary()
+			yy2arr361 := z.EncBasicHandle().StructToArray
+			var yyq361 [4]bool
+			_, _, _ = yysep361, yyq361, yy2arr361
+			const yyr361 bool = false
+			yyq361[0] = x.TotalBytes != nil
+			yyq361[1] = x.UsageBytes != nil
+			yyq361[2] = x.PageFaults != nil
+			yyq361[3] = x.MajorPageFaults != nil
+			if yyr361 || yy2arr361 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn368 int = 0
-				for _, b := range yyq368 {
+				var yynn361 int = 0
+				for _, b := range yyq361 {
 					if b {
-						yynn368++
+						yynn361++
 					}
 				}
-				r.EncodeMapStart(yynn368)
+				r.EncodeMapStart(yynn361)
 			}
-			if yyr368 || yy2arr368 {
-				if yyq368[0] {
+			if yyr361 || yy2arr361 {
+				if yyq361[0] {
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym370 := z.EncBinary()
-						_ = yym370
+						yym363 := z.EncBinary()
+						_ = yym363
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym370 && z.IsJSONHandle() {
+						} else if !yym363 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4215,16 +4131,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq368[0] {
+				if yyq361[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalBytes"))
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym371 := z.EncBinary()
-						_ = yym371
+						yym364 := z.EncBinary()
+						_ = yym364
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym371 && z.IsJSONHandle() {
+						} else if !yym364 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4232,16 +4148,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr368 || yy2arr368 {
-				if yyq368[1] {
+			if yyr361 || yy2arr361 {
+				if yyq361[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym373 := z.EncBinary()
-						_ = yym373
+						yym366 := z.EncBinary()
+						_ = yym366
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym373 && z.IsJSONHandle() {
+						} else if !yym366 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4251,16 +4167,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq368[1] {
+				if yyq361[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym374 := z.EncBinary()
-						_ = yym374
+						yym367 := z.EncBinary()
+						_ = yym367
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym374 && z.IsJSONHandle() {
+						} else if !yym367 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4268,12 +4184,61 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr368 || yy2arr368 {
-				if yyq368[2] {
+			if yyr361 || yy2arr361 {
+				if yyq361[2] {
 					if x.PageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy376 := *x.PageFaults
+						yy369 := *x.PageFaults
+						yym370 := z.EncBinary()
+						_ = yym370
+						if false {
+						} else {
+							r.EncodeInt(int64(yy369))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq361[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
+					if x.PageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy371 := *x.PageFaults
+						yym372 := z.EncBinary()
+						_ = yym372
+						if false {
+						} else {
+							r.EncodeInt(int64(yy371))
+						}
+					}
+				}
+			}
+			if yyr361 || yy2arr361 {
+				if yyq361[3] {
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy374 := *x.MajorPageFaults
+						yym375 := z.EncBinary()
+						_ = yym375
+						if false {
+						} else {
+							r.EncodeInt(int64(yy374))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq361[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy376 := *x.MajorPageFaults
 						yym377 := z.EncBinary()
 						_ = yym377
 						if false {
@@ -4281,58 +4246,9 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 							r.EncodeInt(int64(yy376))
 						}
 					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq368[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
-					if x.PageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy378 := *x.PageFaults
-						yym379 := z.EncBinary()
-						_ = yym379
-						if false {
-						} else {
-							r.EncodeInt(int64(yy378))
-						}
-					}
 				}
 			}
-			if yyr368 || yy2arr368 {
-				if yyq368[3] {
-					if x.MajorPageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy381 := *x.MajorPageFaults
-						yym382 := z.EncBinary()
-						_ = yym382
-						if false {
-						} else {
-							r.EncodeInt(int64(yy381))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq368[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
-					if x.MajorPageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy383 := *x.MajorPageFaults
-						yym384 := z.EncBinary()
-						_ = yym384
-						if false {
-						} else {
-							r.EncodeInt(int64(yy383))
-						}
-					}
-				}
-			}
-			if yysep368 {
+			if yysep361 {
 				r.EncodeEnd()
 			}
 		}
@@ -4343,24 +4259,24 @@ func (x *MemoryMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym385 := z.DecBinary()
-	_ = yym385
+	yym378 := z.DecBinary()
+	_ = yym378
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl386 := r.ReadMapStart()
-			if yyl386 == 0 {
+			yyl379 := r.ReadMapStart()
+			if yyl379 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl386, d)
+				x.codecDecodeSelfFromMap(yyl379, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl386 := r.ReadArrayStart()
-			if yyl386 == 0 {
+			yyl379 := r.ReadArrayStart()
+			if yyl379 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl386, d)
+				x.codecDecodeSelfFromArray(yyl379, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4372,12 +4288,12 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys387Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys387Slc
-	var yyhl387 bool = l >= 0
-	for yyj387 := 0; ; yyj387++ {
-		if yyhl387 {
-			if yyj387 >= l {
+	var yys380Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys380Slc
+	var yyhl380 bool = l >= 0
+	for yyj380 := 0; ; yyj380++ {
+		if yyhl380 {
+			if yyj380 >= l {
 				break
 			}
 		} else {
@@ -4385,9 +4301,9 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys387Slc = r.DecodeBytes(yys387Slc, true, true)
-		yys387 := string(yys387Slc)
-		switch yys387 {
+		yys380Slc = r.DecodeBytes(yys380Slc, true, true)
+		yys380 := string(yys380Slc)
+		switch yys380 {
 		case "totalBytes":
 			if r.TryDecodeAsNil() {
 				if x.TotalBytes != nil {
@@ -4397,11 +4313,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalBytes == nil {
 					x.TotalBytes = new(pkg2_resource.Quantity)
 				}
-				yym389 := z.DecBinary()
-				_ = yym389
+				yym382 := z.DecBinary()
+				_ = yym382
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-				} else if !yym389 && z.IsJSONHandle() {
+				} else if !yym382 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalBytes)
 				} else {
 					z.DecFallback(x.TotalBytes, false)
@@ -4416,11 +4332,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym391 := z.DecBinary()
-				_ = yym391
+				yym384 := z.DecBinary()
+				_ = yym384
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym391 && z.IsJSONHandle() {
+				} else if !yym384 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4435,8 +4351,8 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.PageFaults == nil {
 					x.PageFaults = new(int64)
 				}
-				yym393 := z.DecBinary()
-				_ = yym393
+				yym386 := z.DecBinary()
+				_ = yym386
 				if false {
 				} else {
 					*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
@@ -4451,18 +4367,18 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.MajorPageFaults == nil {
 					x.MajorPageFaults = new(int64)
 				}
-				yym395 := z.DecBinary()
-				_ = yym395
+				yym388 := z.DecBinary()
+				_ = yym388
 				if false {
 				} else {
 					*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys387)
-		} // end switch yys387
-	} // end for yyj387
-	if !yyhl387 {
+			z.DecStructFieldNotFound(-1, yys380)
+		} // end switch yys380
+	} // end for yyj380
+	if !yyhl380 {
 		r.ReadEnd()
 	}
 }
@@ -4471,16 +4387,16 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj396 int
-	var yyb396 bool
-	var yyhl396 bool = l >= 0
-	yyj396++
-	if yyhl396 {
-		yyb396 = yyj396 > l
+	var yyj389 int
+	var yyb389 bool
+	var yyhl389 bool = l >= 0
+	yyj389++
+	if yyhl389 {
+		yyb389 = yyj389 > l
 	} else {
-		yyb396 = r.CheckBreak()
+		yyb389 = r.CheckBreak()
 	}
-	if yyb396 {
+	if yyb389 {
 		r.ReadEnd()
 		return
 	}
@@ -4492,23 +4408,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalBytes == nil {
 			x.TotalBytes = new(pkg2_resource.Quantity)
 		}
-		yym398 := z.DecBinary()
-		_ = yym398
+		yym391 := z.DecBinary()
+		_ = yym391
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-		} else if !yym398 && z.IsJSONHandle() {
+		} else if !yym391 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalBytes)
 		} else {
 			z.DecFallback(x.TotalBytes, false)
 		}
 	}
-	yyj396++
-	if yyhl396 {
-		yyb396 = yyj396 > l
+	yyj389++
+	if yyhl389 {
+		yyb389 = yyj389 > l
 	} else {
-		yyb396 = r.CheckBreak()
+		yyb389 = r.CheckBreak()
 	}
-	if yyb396 {
+	if yyb389 {
 		r.ReadEnd()
 		return
 	}
@@ -4520,23 +4436,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym400 := z.DecBinary()
-		_ = yym400
+		yym393 := z.DecBinary()
+		_ = yym393
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym400 && z.IsJSONHandle() {
+		} else if !yym393 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj396++
-	if yyhl396 {
-		yyb396 = yyj396 > l
+	yyj389++
+	if yyhl389 {
+		yyb389 = yyj389 > l
 	} else {
-		yyb396 = r.CheckBreak()
+		yyb389 = r.CheckBreak()
 	}
-	if yyb396 {
+	if yyb389 {
 		r.ReadEnd()
 		return
 	}
@@ -4548,20 +4464,20 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.PageFaults == nil {
 			x.PageFaults = new(int64)
 		}
-		yym402 := z.DecBinary()
-		_ = yym402
+		yym395 := z.DecBinary()
+		_ = yym395
 		if false {
 		} else {
 			*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj396++
-	if yyhl396 {
-		yyb396 = yyj396 > l
+	yyj389++
+	if yyhl389 {
+		yyb389 = yyj389 > l
 	} else {
-		yyb396 = r.CheckBreak()
+		yyb389 = r.CheckBreak()
 	}
-	if yyb396 {
+	if yyb389 {
 		r.ReadEnd()
 		return
 	}
@@ -4573,24 +4489,24 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.MajorPageFaults == nil {
 			x.MajorPageFaults = new(int64)
 		}
-		yym404 := z.DecBinary()
-		_ = yym404
+		yym397 := z.DecBinary()
+		_ = yym397
 		if false {
 		} else {
 			*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj396++
-		if yyhl396 {
-			yyb396 = yyj396 > l
+		yyj389++
+		if yyhl389 {
+			yyb389 = yyj389 > l
 		} else {
-			yyb396 = r.CheckBreak()
+			yyb389 = r.CheckBreak()
 		}
-		if yyb396 {
+		if yyb389 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj396-1, "")
+		z.DecStructFieldNotFound(yyj389-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4602,55 +4518,55 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym405 := z.EncBinary()
-		_ = yym405
+		yym398 := z.EncBinary()
+		_ = yym398
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep406 := !z.EncBinary()
-			yy2arr406 := z.EncBasicHandle().StructToArray
-			var yyq406 [3]bool
-			_, _, _ = yysep406, yyq406, yy2arr406
-			const yyr406 bool = false
-			yyq406[1] = x.UsageBytes != nil
-			yyq406[2] = x.LimitBytes != nil
-			if yyr406 || yy2arr406 {
+			yysep399 := !z.EncBinary()
+			yy2arr399 := z.EncBasicHandle().StructToArray
+			var yyq399 [3]bool
+			_, _, _ = yysep399, yyq399, yy2arr399
+			const yyr399 bool = false
+			yyq399[1] = x.UsageBytes != nil
+			yyq399[2] = x.LimitBytes != nil
+			if yyr399 || yy2arr399 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn406 int = 1
-				for _, b := range yyq406 {
+				var yynn399 int = 1
+				for _, b := range yyq399 {
 					if b {
-						yynn406++
+						yynn399++
 					}
 				}
-				r.EncodeMapStart(yynn406)
+				r.EncodeMapStart(yynn399)
 			}
-			if yyr406 || yy2arr406 {
-				yym408 := z.EncBinary()
-				_ = yym408
+			if yyr399 || yy2arr399 {
+				yym401 := z.EncBinary()
+				_ = yym401
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("device"))
-				yym409 := z.EncBinary()
-				_ = yym409
+				yym402 := z.EncBinary()
+				_ = yym402
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
 				}
 			}
-			if yyr406 || yy2arr406 {
-				if yyq406[1] {
+			if yyr399 || yy2arr399 {
+				if yyq399[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym411 := z.EncBinary()
-						_ = yym411
+						yym404 := z.EncBinary()
+						_ = yym404
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym411 && z.IsJSONHandle() {
+						} else if !yym404 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4660,16 +4576,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq406[1] {
+				if yyq399[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym412 := z.EncBinary()
-						_ = yym412
+						yym405 := z.EncBinary()
+						_ = yym405
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym412 && z.IsJSONHandle() {
+						} else if !yym405 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4677,16 +4593,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr406 || yy2arr406 {
-				if yyq406[2] {
+			if yyr399 || yy2arr399 {
+				if yyq399[2] {
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym414 := z.EncBinary()
-						_ = yym414
+						yym407 := z.EncBinary()
+						_ = yym407
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
-						} else if !yym414 && z.IsJSONHandle() {
+						} else if !yym407 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LimitBytes)
 						} else {
 							z.EncFallback(x.LimitBytes)
@@ -4696,16 +4612,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq406[2] {
+				if yyq399[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym415 := z.EncBinary()
-						_ = yym415
+						yym408 := z.EncBinary()
+						_ = yym408
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
-						} else if !yym415 && z.IsJSONHandle() {
+						} else if !yym408 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LimitBytes)
 						} else {
 							z.EncFallback(x.LimitBytes)
@@ -4713,7 +4629,7 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep406 {
+			if yysep399 {
 				r.EncodeEnd()
 			}
 		}
@@ -4724,24 +4640,24 @@ func (x *FilesystemMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym416 := z.DecBinary()
-	_ = yym416
+	yym409 := z.DecBinary()
+	_ = yym409
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl417 := r.ReadMapStart()
-			if yyl417 == 0 {
+			yyl410 := r.ReadMapStart()
+			if yyl410 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl417, d)
+				x.codecDecodeSelfFromMap(yyl410, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl417 := r.ReadArrayStart()
-			if yyl417 == 0 {
+			yyl410 := r.ReadArrayStart()
+			if yyl410 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl417, d)
+				x.codecDecodeSelfFromArray(yyl410, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4753,12 +4669,12 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys418Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys418Slc
-	var yyhl418 bool = l >= 0
-	for yyj418 := 0; ; yyj418++ {
-		if yyhl418 {
-			if yyj418 >= l {
+	var yys411Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys411Slc
+	var yyhl411 bool = l >= 0
+	for yyj411 := 0; ; yyj411++ {
+		if yyhl411 {
+			if yyj411 >= l {
 				break
 			}
 		} else {
@@ -4766,9 +4682,9 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys418Slc = r.DecodeBytes(yys418Slc, true, true)
-		yys418 := string(yys418Slc)
-		switch yys418 {
+		yys411Slc = r.DecodeBytes(yys411Slc, true, true)
+		yys411 := string(yys411Slc)
+		switch yys411 {
 		case "device":
 			if r.TryDecodeAsNil() {
 				x.Device = ""
@@ -4784,11 +4700,11 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym421 := z.DecBinary()
-				_ = yym421
+				yym414 := z.DecBinary()
+				_ = yym414
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym421 && z.IsJSONHandle() {
+				} else if !yym414 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4803,21 +4719,21 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(pkg2_resource.Quantity)
 				}
-				yym423 := z.DecBinary()
-				_ = yym423
+				yym416 := z.DecBinary()
+				_ = yym416
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
-				} else if !yym423 && z.IsJSONHandle() {
+				} else if !yym416 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LimitBytes)
 				} else {
 					z.DecFallback(x.LimitBytes, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys418)
-		} // end switch yys418
-	} // end for yyj418
-	if !yyhl418 {
+			z.DecStructFieldNotFound(-1, yys411)
+		} // end switch yys411
+	} // end for yyj411
+	if !yyhl411 {
 		r.ReadEnd()
 	}
 }
@@ -4826,16 +4742,16 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj424 int
-	var yyb424 bool
-	var yyhl424 bool = l >= 0
-	yyj424++
-	if yyhl424 {
-		yyb424 = yyj424 > l
+	var yyj417 int
+	var yyb417 bool
+	var yyhl417 bool = l >= 0
+	yyj417++
+	if yyhl417 {
+		yyb417 = yyj417 > l
 	} else {
-		yyb424 = r.CheckBreak()
+		yyb417 = r.CheckBreak()
 	}
-	if yyb424 {
+	if yyb417 {
 		r.ReadEnd()
 		return
 	}
@@ -4844,13 +4760,13 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Device = string(r.DecodeString())
 	}
-	yyj424++
-	if yyhl424 {
-		yyb424 = yyj424 > l
+	yyj417++
+	if yyhl417 {
+		yyb417 = yyj417 > l
 	} else {
-		yyb424 = r.CheckBreak()
+		yyb417 = r.CheckBreak()
 	}
-	if yyb424 {
+	if yyb417 {
 		r.ReadEnd()
 		return
 	}
@@ -4862,23 +4778,23 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym427 := z.DecBinary()
-		_ = yym427
+		yym420 := z.DecBinary()
+		_ = yym420
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym427 && z.IsJSONHandle() {
+		} else if !yym420 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj424++
-	if yyhl424 {
-		yyb424 = yyj424 > l
+	yyj417++
+	if yyhl417 {
+		yyb417 = yyj417 > l
 	} else {
-		yyb424 = r.CheckBreak()
+		yyb417 = r.CheckBreak()
 	}
-	if yyb424 {
+	if yyb417 {
 		r.ReadEnd()
 		return
 	}
@@ -4890,27 +4806,27 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(pkg2_resource.Quantity)
 		}
-		yym429 := z.DecBinary()
-		_ = yym429
+		yym422 := z.DecBinary()
+		_ = yym422
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
-		} else if !yym429 && z.IsJSONHandle() {
+		} else if !yym422 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LimitBytes)
 		} else {
 			z.DecFallback(x.LimitBytes, false)
 		}
 	}
 	for {
-		yyj424++
-		if yyhl424 {
-			yyb424 = yyj424 > l
+		yyj417++
+		if yyhl417 {
+			yyb417 = yyj417 > l
 		} else {
-			yyb424 = r.CheckBreak()
+			yyb417 = r.CheckBreak()
 		}
-		if yyb424 {
+		if yyb417 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj424-1, "")
+		z.DecStructFieldNotFound(yyj417-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4919,8 +4835,8 @@ func (x CustomMetricType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym430 := z.EncBinary()
-	_ = yym430
+	yym423 := z.EncBinary()
+	_ = yym423
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -4932,8 +4848,8 @@ func (x *CustomMetricType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym431 := z.DecBinary()
-	_ = yym431
+	yym424 := z.DecBinary()
+	_ = yym424
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -4948,73 +4864,73 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym432 := z.EncBinary()
-		_ = yym432
+		yym425 := z.EncBinary()
+		_ = yym425
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep433 := !z.EncBinary()
-			yy2arr433 := z.EncBasicHandle().StructToArray
-			var yyq433 [4]bool
-			_, _, _ = yysep433, yyq433, yy2arr433
-			const yyr433 bool = false
-			yyq433[3] = len(x.Samples) != 0
-			if yyr433 || yy2arr433 {
+			yysep426 := !z.EncBinary()
+			yy2arr426 := z.EncBasicHandle().StructToArray
+			var yyq426 [4]bool
+			_, _, _ = yysep426, yyq426, yy2arr426
+			const yyr426 bool = false
+			yyq426[3] = len(x.Samples) != 0
+			if yyr426 || yy2arr426 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn433 int = 3
-				for _, b := range yyq433 {
+				var yynn426 int = 3
+				for _, b := range yyq426 {
 					if b {
-						yynn433++
+						yynn426++
 					}
 				}
-				r.EncodeMapStart(yynn433)
+				r.EncodeMapStart(yynn426)
 			}
-			if yyr433 || yy2arr433 {
-				yym435 := z.EncBinary()
-				_ = yym435
+			if yyr426 || yy2arr426 {
+				yym428 := z.EncBinary()
+				_ = yym428
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
-				yym436 := z.EncBinary()
-				_ = yym436
+				yym429 := z.EncBinary()
+				_ = yym429
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yyr433 || yy2arr433 {
+			if yyr426 || yy2arr426 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr433 || yy2arr433 {
-				yym439 := z.EncBinary()
-				_ = yym439
+			if yyr426 || yy2arr426 {
+				yym432 := z.EncBinary()
+				_ = yym432
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("unit"))
-				yym440 := z.EncBinary()
-				_ = yym440
+				yym433 := z.EncBinary()
+				_ = yym433
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
 				}
 			}
-			if yyr433 || yy2arr433 {
-				if yyq433[3] {
+			if yyr426 || yy2arr426 {
+				if yyq426[3] {
 					if x.Samples == nil {
 						r.EncodeNil()
 					} else {
-						yym442 := z.EncBinary()
-						_ = yym442
+						yym435 := z.EncBinary()
+						_ = yym435
 						if false {
 						} else {
 							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
@@ -5024,13 +4940,13 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq433[3] {
+				if yyq426[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("samples"))
 					if x.Samples == nil {
 						r.EncodeNil()
 					} else {
-						yym443 := z.EncBinary()
-						_ = yym443
+						yym436 := z.EncBinary()
+						_ = yym436
 						if false {
 						} else {
 							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
@@ -5038,7 +4954,7 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep433 {
+			if yysep426 {
 				r.EncodeEnd()
 			}
 		}
@@ -5049,24 +4965,24 @@ func (x *CustomMetric) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym444 := z.DecBinary()
-	_ = yym444
+	yym437 := z.DecBinary()
+	_ = yym437
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl445 := r.ReadMapStart()
-			if yyl445 == 0 {
+			yyl438 := r.ReadMapStart()
+			if yyl438 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl445, d)
+				x.codecDecodeSelfFromMap(yyl438, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl445 := r.ReadArrayStart()
-			if yyl445 == 0 {
+			yyl438 := r.ReadArrayStart()
+			if yyl438 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl445, d)
+				x.codecDecodeSelfFromArray(yyl438, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5078,12 +4994,12 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys446Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys446Slc
-	var yyhl446 bool = l >= 0
-	for yyj446 := 0; ; yyj446++ {
-		if yyhl446 {
-			if yyj446 >= l {
+	var yys439Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys439Slc
+	var yyhl439 bool = l >= 0
+	for yyj439 := 0; ; yyj439++ {
+		if yyhl439 {
+			if yyj439 >= l {
 				break
 			}
 		} else {
@@ -5091,9 +5007,9 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys446Slc = r.DecodeBytes(yys446Slc, true, true)
-		yys446 := string(yys446Slc)
-		switch yys446 {
+		yys439Slc = r.DecodeBytes(yys439Slc, true, true)
+		yys439 := string(yys439Slc)
+		switch yys439 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -5116,19 +5032,19 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Samples = nil
 			} else {
-				yyv450 := &x.Samples
-				yym451 := z.DecBinary()
-				_ = yym451
+				yyv443 := &x.Samples
+				yym444 := z.DecBinary()
+				_ = yym444
 				if false {
 				} else {
-					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv450), d)
+					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv443), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys446)
-		} // end switch yys446
-	} // end for yyj446
-	if !yyhl446 {
+			z.DecStructFieldNotFound(-1, yys439)
+		} // end switch yys439
+	} // end for yyj439
+	if !yyhl439 {
 		r.ReadEnd()
 	}
 }
@@ -5137,16 +5053,16 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj452 int
-	var yyb452 bool
-	var yyhl452 bool = l >= 0
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	var yyj445 int
+	var yyb445 bool
+	var yyhl445 bool = l >= 0
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb445 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb445 {
 		r.ReadEnd()
 		return
 	}
@@ -5155,13 +5071,13 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb445 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb445 {
 		r.ReadEnd()
 		return
 	}
@@ -5170,13 +5086,13 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = CustomMetricType(r.DecodeString())
 	}
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb445 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb445 {
 		r.ReadEnd()
 		return
 	}
@@ -5185,38 +5101,38 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Unit = string(r.DecodeString())
 	}
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb445 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb445 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Samples = nil
 	} else {
-		yyv456 := &x.Samples
-		yym457 := z.DecBinary()
-		_ = yym457
+		yyv449 := &x.Samples
+		yym450 := z.DecBinary()
+		_ = yym450
 		if false {
 		} else {
-			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv456), d)
+			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv449), d)
 		}
 	}
 	for {
-		yyj452++
-		if yyhl452 {
-			yyb452 = yyj452 > l
+		yyj445++
+		if yyhl445 {
+			yyb445 = yyj445 > l
 		} else {
-			yyb452 = r.CheckBreak()
+			yyb445 = r.CheckBreak()
 		}
-		if yyb452 {
+		if yyb445 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj452-1, "")
+		z.DecStructFieldNotFound(yyj445-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5228,113 +5144,113 @@ func (x *CustomMetricSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym458 := z.EncBinary()
-		_ = yym458
+		yym451 := z.EncBinary()
+		_ = yym451
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep459 := !z.EncBinary()
-			yy2arr459 := z.EncBasicHandle().StructToArray
-			var yyq459 [3]bool
-			_, _, _ = yysep459, yyq459, yy2arr459
-			const yyr459 bool = false
-			yyq459[1] = x.Label != nil
-			if yyr459 || yy2arr459 {
+			yysep452 := !z.EncBinary()
+			yy2arr452 := z.EncBasicHandle().StructToArray
+			var yyq452 [3]bool
+			_, _, _ = yysep452, yyq452, yy2arr452
+			const yyr452 bool = false
+			yyq452[1] = x.Label != nil
+			if yyr452 || yy2arr452 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn459 int = 2
-				for _, b := range yyq459 {
+				var yynn452 int = 2
+				for _, b := range yyq452 {
 					if b {
-						yynn459++
+						yynn452++
 					}
 				}
-				r.EncodeMapStart(yynn459)
+				r.EncodeMapStart(yynn452)
 			}
-			if yyr459 || yy2arr459 {
-				yy461 := &x.SampleTime
-				yym462 := z.EncBinary()
-				_ = yym462
+			if yyr452 || yy2arr452 {
+				yy454 := &x.SampleTime
+				yym455 := z.EncBinary()
+				_ = yym455
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy461) {
-				} else if yym462 {
-					z.EncBinaryMarshal(yy461)
-				} else if !yym462 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy461)
+				} else if z.HasExtensions() && z.EncExt(yy454) {
+				} else if yym455 {
+					z.EncBinaryMarshal(yy454)
+				} else if !yym455 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy454)
 				} else {
-					z.EncFallback(yy461)
+					z.EncFallback(yy454)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy463 := &x.SampleTime
-				yym464 := z.EncBinary()
-				_ = yym464
+				yy456 := &x.SampleTime
+				yym457 := z.EncBinary()
+				_ = yym457
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy463) {
-				} else if yym464 {
-					z.EncBinaryMarshal(yy463)
-				} else if !yym464 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy463)
+				} else if z.HasExtensions() && z.EncExt(yy456) {
+				} else if yym457 {
+					z.EncBinaryMarshal(yy456)
+				} else if !yym457 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy456)
 				} else {
-					z.EncFallback(yy463)
+					z.EncFallback(yy456)
 				}
 			}
-			if yyr459 || yy2arr459 {
-				if yyq459[1] {
+			if yyr452 || yy2arr452 {
+				if yyq452[1] {
 					if x.Label == nil {
 						r.EncodeNil()
 					} else {
-						yy466 := *x.Label
-						yym467 := z.EncBinary()
-						_ = yym467
+						yy459 := *x.Label
+						yym460 := z.EncBinary()
+						_ = yym460
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy466))
+							r.EncodeString(codecSelferC_UTF81234, string(yy459))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq459[1] {
+				if yyq452[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("label"))
 					if x.Label == nil {
 						r.EncodeNil()
 					} else {
-						yy468 := *x.Label
-						yym469 := z.EncBinary()
-						_ = yym469
+						yy461 := *x.Label
+						yym462 := z.EncBinary()
+						_ = yym462
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy468))
+							r.EncodeString(codecSelferC_UTF81234, string(yy461))
 						}
 					}
 				}
 			}
-			if yyr459 || yy2arr459 {
-				yy471 := &x.Value
-				yym472 := z.EncBinary()
-				_ = yym472
+			if yyr452 || yy2arr452 {
+				yy464 := &x.Value
+				yym465 := z.EncBinary()
+				_ = yym465
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy471) {
-				} else if !yym472 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy471)
+				} else if z.HasExtensions() && z.EncExt(yy464) {
+				} else if !yym465 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy464)
 				} else {
-					z.EncFallback(yy471)
+					z.EncFallback(yy464)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yy473 := &x.Value
-				yym474 := z.EncBinary()
-				_ = yym474
+				yy466 := &x.Value
+				yym467 := z.EncBinary()
+				_ = yym467
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy473) {
-				} else if !yym474 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy473)
+				} else if z.HasExtensions() && z.EncExt(yy466) {
+				} else if !yym467 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy466)
 				} else {
-					z.EncFallback(yy473)
+					z.EncFallback(yy466)
 				}
 			}
-			if yysep459 {
+			if yysep452 {
 				r.EncodeEnd()
 			}
 		}
@@ -5345,24 +5261,24 @@ func (x *CustomMetricSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym475 := z.DecBinary()
-	_ = yym475
+	yym468 := z.DecBinary()
+	_ = yym468
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl476 := r.ReadMapStart()
-			if yyl476 == 0 {
+			yyl469 := r.ReadMapStart()
+			if yyl469 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl476, d)
+				x.codecDecodeSelfFromMap(yyl469, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl476 := r.ReadArrayStart()
-			if yyl476 == 0 {
+			yyl469 := r.ReadArrayStart()
+			if yyl469 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl476, d)
+				x.codecDecodeSelfFromArray(yyl469, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5374,12 +5290,12 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys477Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys477Slc
-	var yyhl477 bool = l >= 0
-	for yyj477 := 0; ; yyj477++ {
-		if yyhl477 {
-			if yyj477 >= l {
+	var yys470Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys470Slc
+	var yyhl470 bool = l >= 0
+	for yyj470 := 0; ; yyj470++ {
+		if yyhl470 {
+			if yyj470 >= l {
 				break
 			}
 		} else {
@@ -5387,24 +5303,24 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys477Slc = r.DecodeBytes(yys477Slc, true, true)
-		yys477 := string(yys477Slc)
-		switch yys477 {
+		yys470Slc = r.DecodeBytes(yys470Slc, true, true)
+		yys470 := string(yys470Slc)
+		switch yys470 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv478 := &x.SampleTime
-				yym479 := z.DecBinary()
-				_ = yym479
+				yyv471 := &x.SampleTime
+				yym472 := z.DecBinary()
+				_ = yym472
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv478) {
-				} else if yym479 {
-					z.DecBinaryUnmarshal(yyv478)
-				} else if !yym479 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv478)
+				} else if z.HasExtensions() && z.DecExt(yyv471) {
+				} else if yym472 {
+					z.DecBinaryUnmarshal(yyv471)
+				} else if !yym472 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv471)
 				} else {
-					z.DecFallback(yyv478, false)
+					z.DecFallback(yyv471, false)
 				}
 			}
 		case "label":
@@ -5416,8 +5332,8 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.Label == nil {
 					x.Label = new(string)
 				}
-				yym481 := z.DecBinary()
-				_ = yym481
+				yym474 := z.DecBinary()
+				_ = yym474
 				if false {
 				} else {
 					*((*string)(x.Label)) = r.DecodeString()
@@ -5427,22 +5343,22 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Value = pkg2_resource.Quantity{}
 			} else {
-				yyv482 := &x.Value
-				yym483 := z.DecBinary()
-				_ = yym483
+				yyv475 := &x.Value
+				yym476 := z.DecBinary()
+				_ = yym476
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv482) {
-				} else if !yym483 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv482)
+				} else if z.HasExtensions() && z.DecExt(yyv475) {
+				} else if !yym476 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv475)
 				} else {
-					z.DecFallback(yyv482, false)
+					z.DecFallback(yyv475, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys477)
-		} // end switch yys477
-	} // end for yyj477
-	if !yyhl477 {
+			z.DecStructFieldNotFound(-1, yys470)
+		} // end switch yys470
+	} // end for yyj470
+	if !yyhl470 {
 		r.ReadEnd()
 	}
 }
@@ -5451,42 +5367,42 @@ func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj484 int
-	var yyb484 bool
-	var yyhl484 bool = l >= 0
-	yyj484++
-	if yyhl484 {
-		yyb484 = yyj484 > l
+	var yyj477 int
+	var yyb477 bool
+	var yyhl477 bool = l >= 0
+	yyj477++
+	if yyhl477 {
+		yyb477 = yyj477 > l
 	} else {
-		yyb484 = r.CheckBreak()
+		yyb477 = r.CheckBreak()
 	}
-	if yyb484 {
+	if yyb477 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv485 := &x.SampleTime
-		yym486 := z.DecBinary()
-		_ = yym486
+		yyv478 := &x.SampleTime
+		yym479 := z.DecBinary()
+		_ = yym479
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv485) {
-		} else if yym486 {
-			z.DecBinaryUnmarshal(yyv485)
-		} else if !yym486 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv485)
+		} else if z.HasExtensions() && z.DecExt(yyv478) {
+		} else if yym479 {
+			z.DecBinaryUnmarshal(yyv478)
+		} else if !yym479 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv478)
 		} else {
-			z.DecFallback(yyv485, false)
+			z.DecFallback(yyv478, false)
 		}
 	}
-	yyj484++
-	if yyhl484 {
-		yyb484 = yyj484 > l
+	yyj477++
+	if yyhl477 {
+		yyb477 = yyj477 > l
 	} else {
-		yyb484 = r.CheckBreak()
+		yyb477 = r.CheckBreak()
 	}
-	if yyb484 {
+	if yyb477 {
 		r.ReadEnd()
 		return
 	}
@@ -5498,48 +5414,48 @@ func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.Label == nil {
 			x.Label = new(string)
 		}
-		yym488 := z.DecBinary()
-		_ = yym488
+		yym481 := z.DecBinary()
+		_ = yym481
 		if false {
 		} else {
 			*((*string)(x.Label)) = r.DecodeString()
 		}
 	}
-	yyj484++
-	if yyhl484 {
-		yyb484 = yyj484 > l
+	yyj477++
+	if yyhl477 {
+		yyb477 = yyj477 > l
 	} else {
-		yyb484 = r.CheckBreak()
+		yyb477 = r.CheckBreak()
 	}
-	if yyb484 {
+	if yyb477 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Value = pkg2_resource.Quantity{}
 	} else {
-		yyv489 := &x.Value
-		yym490 := z.DecBinary()
-		_ = yym490
+		yyv482 := &x.Value
+		yym483 := z.DecBinary()
+		_ = yym483
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv489) {
-		} else if !yym490 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv489)
+		} else if z.HasExtensions() && z.DecExt(yyv482) {
+		} else if !yym483 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv482)
 		} else {
-			z.DecFallback(yyv489, false)
+			z.DecFallback(yyv482, false)
 		}
 	}
 	for {
-		yyj484++
-		if yyhl484 {
-			yyb484 = yyj484 > l
+		yyj477++
+		if yyhl477 {
+			yyb477 = yyj477 > l
 		} else {
-			yyb484 = r.CheckBreak()
+			yyb477 = r.CheckBreak()
 		}
-		if yyb484 {
+		if yyb477 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj484-1, "")
+		z.DecStructFieldNotFound(yyj477-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5551,42 +5467,42 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym491 := z.EncBinary()
-		_ = yym491
+		yym484 := z.EncBinary()
+		_ = yym484
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep492 := !z.EncBinary()
-			yy2arr492 := z.EncBasicHandle().StructToArray
-			var yyq492 [3]bool
-			_, _, _ = yysep492, yyq492, yy2arr492
-			const yyr492 bool = false
-			yyq492[0] = x.SinceTime != nil
-			yyq492[1] = x.UntilTime != nil
-			yyq492[2] = x.MaxSamples != 0
-			if yyr492 || yy2arr492 {
+			yysep485 := !z.EncBinary()
+			yy2arr485 := z.EncBasicHandle().StructToArray
+			var yyq485 [3]bool
+			_, _, _ = yysep485, yyq485, yy2arr485
+			const yyr485 bool = false
+			yyq485[0] = x.SinceTime != nil
+			yyq485[1] = x.UntilTime != nil
+			yyq485[2] = x.MaxSamples != 0
+			if yyr485 || yy2arr485 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn492 int = 0
-				for _, b := range yyq492 {
+				var yynn485 int = 0
+				for _, b := range yyq485 {
 					if b {
-						yynn492++
+						yynn485++
 					}
 				}
-				r.EncodeMapStart(yynn492)
+				r.EncodeMapStart(yynn485)
 			}
-			if yyr492 || yy2arr492 {
-				if yyq492[0] {
+			if yyr485 || yy2arr485 {
+				if yyq485[0] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym494 := z.EncBinary()
-						_ = yym494
+						yym487 := z.EncBinary()
+						_ = yym487
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym494 {
+						} else if yym487 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym494 && z.IsJSONHandle() {
+						} else if !yym487 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5596,18 +5512,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq492[0] {
+				if yyq485[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym495 := z.EncBinary()
-						_ = yym495
+						yym488 := z.EncBinary()
+						_ = yym488
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym495 {
+						} else if yym488 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym495 && z.IsJSONHandle() {
+						} else if !yym488 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5615,18 +5531,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr492 || yy2arr492 {
-				if yyq492[1] {
+			if yyr485 || yy2arr485 {
+				if yyq485[1] {
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym497 := z.EncBinary()
-						_ = yym497
+						yym490 := z.EncBinary()
+						_ = yym490
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym497 {
+						} else if yym490 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym497 && z.IsJSONHandle() {
+						} else if !yym490 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5636,18 +5552,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq492[1] {
+				if yyq485[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym498 := z.EncBinary()
-						_ = yym498
+						yym491 := z.EncBinary()
+						_ = yym491
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym498 {
+						} else if yym491 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym498 && z.IsJSONHandle() {
+						} else if !yym491 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5655,10 +5571,10 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr492 || yy2arr492 {
-				if yyq492[2] {
-					yym500 := z.EncBinary()
-					_ = yym500
+			if yyr485 || yy2arr485 {
+				if yyq485[2] {
+					yym493 := z.EncBinary()
+					_ = yym493
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -5667,17 +5583,17 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq492[2] {
+				if yyq485[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
-					yym501 := z.EncBinary()
-					_ = yym501
+					yym494 := z.EncBinary()
+					_ = yym494
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
 					}
 				}
 			}
-			if yysep492 {
+			if yysep485 {
 				r.EncodeEnd()
 			}
 		}
@@ -5688,24 +5604,24 @@ func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym502 := z.DecBinary()
-	_ = yym502
+	yym495 := z.DecBinary()
+	_ = yym495
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl503 := r.ReadMapStart()
-			if yyl503 == 0 {
+			yyl496 := r.ReadMapStart()
+			if yyl496 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl503, d)
+				x.codecDecodeSelfFromMap(yyl496, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl503 := r.ReadArrayStart()
-			if yyl503 == 0 {
+			yyl496 := r.ReadArrayStart()
+			if yyl496 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl503, d)
+				x.codecDecodeSelfFromArray(yyl496, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5717,12 +5633,12 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys504Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys504Slc
-	var yyhl504 bool = l >= 0
-	for yyj504 := 0; ; yyj504++ {
-		if yyhl504 {
-			if yyj504 >= l {
+	var yys497Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys497Slc
+	var yyhl497 bool = l >= 0
+	for yyj497 := 0; ; yyj497++ {
+		if yyhl497 {
+			if yyj497 >= l {
 				break
 			}
 		} else {
@@ -5730,9 +5646,9 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys504Slc = r.DecodeBytes(yys504Slc, true, true)
-		yys504 := string(yys504Slc)
-		switch yys504 {
+		yys497Slc = r.DecodeBytes(yys497Slc, true, true)
+		yys497 := string(yys497Slc)
+		switch yys497 {
 		case "sinceTime":
 			if r.TryDecodeAsNil() {
 				if x.SinceTime != nil {
@@ -5742,13 +5658,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg1_unversioned.Time)
 				}
-				yym506 := z.DecBinary()
-				_ = yym506
+				yym499 := z.DecBinary()
+				_ = yym499
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym506 {
+				} else if yym499 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym506 && z.IsJSONHandle() {
+				} else if !yym499 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -5763,13 +5679,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UntilTime == nil {
 					x.UntilTime = new(pkg1_unversioned.Time)
 				}
-				yym508 := z.DecBinary()
-				_ = yym508
+				yym501 := z.DecBinary()
+				_ = yym501
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-				} else if yym508 {
+				} else if yym501 {
 					z.DecBinaryUnmarshal(x.UntilTime)
-				} else if !yym508 && z.IsJSONHandle() {
+				} else if !yym501 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UntilTime)
 				} else {
 					z.DecFallback(x.UntilTime, false)
@@ -5782,10 +5698,10 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys504)
-		} // end switch yys504
-	} // end for yyj504
-	if !yyhl504 {
+			z.DecStructFieldNotFound(-1, yys497)
+		} // end switch yys497
+	} // end for yyj497
+	if !yyhl497 {
 		r.ReadEnd()
 	}
 }
@@ -5794,16 +5710,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj510 int
-	var yyb510 bool
-	var yyhl510 bool = l >= 0
-	yyj510++
-	if yyhl510 {
-		yyb510 = yyj510 > l
+	var yyj503 int
+	var yyb503 bool
+	var yyhl503 bool = l >= 0
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb510 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb510 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5815,25 +5731,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg1_unversioned.Time)
 		}
-		yym512 := z.DecBinary()
-		_ = yym512
+		yym505 := z.DecBinary()
+		_ = yym505
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym512 {
+		} else if yym505 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym512 && z.IsJSONHandle() {
+		} else if !yym505 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj510++
-	if yyhl510 {
-		yyb510 = yyj510 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb510 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb510 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5845,25 +5761,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UntilTime == nil {
 			x.UntilTime = new(pkg1_unversioned.Time)
 		}
-		yym514 := z.DecBinary()
-		_ = yym514
+		yym507 := z.DecBinary()
+		_ = yym507
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-		} else if yym514 {
+		} else if yym507 {
 			z.DecBinaryUnmarshal(x.UntilTime)
-		} else if !yym514 && z.IsJSONHandle() {
+		} else if !yym507 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UntilTime)
 		} else {
 			z.DecFallback(x.UntilTime, false)
 		}
 	}
-	yyj510++
-	if yyhl510 {
-		yyb510 = yyj510 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb510 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb510 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5873,16 +5789,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj510++
-		if yyhl510 {
-			yyb510 = yyj510 > l
+		yyj503++
+		if yyhl503 {
+			yyb503 = yyj503 > l
 		} else {
-			yyb510 = r.CheckBreak()
+			yyb503 = r.CheckBreak()
 		}
-		if yyb510 {
+		if yyb503 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj510-1, "")
+		z.DecStructFieldNotFound(yyj503-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5892,9 +5808,9 @@ func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv516 := range v {
-		yy517 := &yyv516
-		yy517.CodecEncodeSelf(e)
+	for _, yyv509 := range v {
+		yy510 := &yyv509
+		yy510.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5904,75 +5820,75 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv518 := *v
-	yyh518, yyl518 := z.DecSliceHelperStart()
+	yyv511 := *v
+	yyh511, yyl511 := z.DecSliceHelperStart()
 
-	var yyrr518, yyrl518 int
-	var yyc518, yyrt518 bool
-	_, _, _ = yyc518, yyrt518, yyrl518
-	yyrr518 = yyl518
+	var yyrr511, yyrl511 int
+	var yyc511, yyrt511 bool
+	_, _, _ = yyc511, yyrt511, yyrl511
+	yyrr511 = yyl511
 
-	if yyv518 == nil {
-		if yyrl518, yyrt518 = z.DecInferLen(yyl518, z.DecBasicHandle().MaxInitLen, 72); yyrt518 {
-			yyrr518 = yyrl518
+	if yyv511 == nil {
+		if yyrl511, yyrt511 = z.DecInferLen(yyl511, z.DecBasicHandle().MaxInitLen, 72); yyrt511 {
+			yyrr511 = yyrl511
 		}
-		yyv518 = make([]AggregateSample, yyrl518)
-		yyc518 = true
+		yyv511 = make([]AggregateSample, yyrl511)
+		yyc511 = true
 	}
 
-	if yyl518 == 0 {
-		if len(yyv518) != 0 {
-			yyv518 = yyv518[:0]
-			yyc518 = true
+	if yyl511 == 0 {
+		if len(yyv511) != 0 {
+			yyv511 = yyv511[:0]
+			yyc511 = true
 		}
-	} else if yyl518 > 0 {
+	} else if yyl511 > 0 {
 
-		if yyl518 > cap(yyv518) {
-			yyrl518, yyrt518 = z.DecInferLen(yyl518, z.DecBasicHandle().MaxInitLen, 72)
-			yyv518 = make([]AggregateSample, yyrl518)
-			yyc518 = true
+		if yyl511 > cap(yyv511) {
+			yyrl511, yyrt511 = z.DecInferLen(yyl511, z.DecBasicHandle().MaxInitLen, 72)
+			yyv511 = make([]AggregateSample, yyrl511)
+			yyc511 = true
 
-			yyrr518 = len(yyv518)
-		} else if yyl518 != len(yyv518) {
-			yyv518 = yyv518[:yyl518]
-			yyc518 = true
+			yyrr511 = len(yyv511)
+		} else if yyl511 != len(yyv511) {
+			yyv511 = yyv511[:yyl511]
+			yyc511 = true
 		}
-		yyj518 := 0
-		for ; yyj518 < yyrr518; yyj518++ {
+		yyj511 := 0
+		for ; yyj511 < yyrr511; yyj511++ {
 			if r.TryDecodeAsNil() {
-				yyv518[yyj518] = AggregateSample{}
+				yyv511[yyj511] = AggregateSample{}
 			} else {
-				yyv519 := &yyv518[yyj518]
-				yyv519.CodecDecodeSelf(d)
+				yyv512 := &yyv511[yyj511]
+				yyv512.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt518 {
-			for ; yyj518 < yyl518; yyj518++ {
-				yyv518 = append(yyv518, AggregateSample{})
+		if yyrt511 {
+			for ; yyj511 < yyl511; yyj511++ {
+				yyv511 = append(yyv511, AggregateSample{})
 				if r.TryDecodeAsNil() {
-					yyv518[yyj518] = AggregateSample{}
+					yyv511[yyj511] = AggregateSample{}
 				} else {
-					yyv520 := &yyv518[yyj518]
-					yyv520.CodecDecodeSelf(d)
+					yyv513 := &yyv511[yyj511]
+					yyv513.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj518 := 0; !r.CheckBreak(); yyj518++ {
-			if yyj518 >= len(yyv518) {
-				yyv518 = append(yyv518, AggregateSample{}) // var yyz518 AggregateSample
-				yyc518 = true
+		for yyj511 := 0; !r.CheckBreak(); yyj511++ {
+			if yyj511 >= len(yyv511) {
+				yyv511 = append(yyv511, AggregateSample{}) // var yyz511 AggregateSample
+				yyc511 = true
 			}
 
-			if yyj518 < len(yyv518) {
+			if yyj511 < len(yyv511) {
 				if r.TryDecodeAsNil() {
-					yyv518[yyj518] = AggregateSample{}
+					yyv511[yyj511] = AggregateSample{}
 				} else {
-					yyv521 := &yyv518[yyj518]
-					yyv521.CodecDecodeSelf(d)
+					yyv514 := &yyv511[yyj511]
+					yyv514.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5980,10 +5896,10 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 			}
 
 		}
-		yyh518.End()
+		yyh511.End()
 	}
-	if yyc518 {
-		*v = yyv518
+	if yyc511 {
+		*v = yyv511
 	}
 
 }
@@ -5993,9 +5909,9 @@ func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv522 := range v {
-		yy523 := &yyv522
-		yy523.CodecEncodeSelf(e)
+	for _, yyv515 := range v {
+		yy516 := &yyv515
+		yy516.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6005,75 +5921,75 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv524 := *v
-	yyh524, yyl524 := z.DecSliceHelperStart()
+	yyv517 := *v
+	yyh517, yyl517 := z.DecSliceHelperStart()
 
-	var yyrr524, yyrl524 int
-	var yyc524, yyrt524 bool
-	_, _, _ = yyc524, yyrt524, yyrl524
-	yyrr524 = yyl524
+	var yyrr517, yyrl517 int
+	var yyc517, yyrt517 bool
+	_, _, _ = yyc517, yyrt517, yyrl517
+	yyrr517 = yyl517
 
-	if yyv524 == nil {
-		if yyrl524, yyrt524 = z.DecInferLen(yyl524, z.DecBasicHandle().MaxInitLen, 72); yyrt524 {
-			yyrr524 = yyrl524
+	if yyv517 == nil {
+		if yyrl517, yyrt517 = z.DecInferLen(yyl517, z.DecBasicHandle().MaxInitLen, 72); yyrt517 {
+			yyrr517 = yyrl517
 		}
-		yyv524 = make([]RawContainerMetrics, yyrl524)
-		yyc524 = true
+		yyv517 = make([]RawContainerMetrics, yyrl517)
+		yyc517 = true
 	}
 
-	if yyl524 == 0 {
-		if len(yyv524) != 0 {
-			yyv524 = yyv524[:0]
-			yyc524 = true
+	if yyl517 == 0 {
+		if len(yyv517) != 0 {
+			yyv517 = yyv517[:0]
+			yyc517 = true
 		}
-	} else if yyl524 > 0 {
+	} else if yyl517 > 0 {
 
-		if yyl524 > cap(yyv524) {
-			yyrl524, yyrt524 = z.DecInferLen(yyl524, z.DecBasicHandle().MaxInitLen, 72)
-			yyv524 = make([]RawContainerMetrics, yyrl524)
-			yyc524 = true
+		if yyl517 > cap(yyv517) {
+			yyrl517, yyrt517 = z.DecInferLen(yyl517, z.DecBasicHandle().MaxInitLen, 72)
+			yyv517 = make([]RawContainerMetrics, yyrl517)
+			yyc517 = true
 
-			yyrr524 = len(yyv524)
-		} else if yyl524 != len(yyv524) {
-			yyv524 = yyv524[:yyl524]
-			yyc524 = true
+			yyrr517 = len(yyv517)
+		} else if yyl517 != len(yyv517) {
+			yyv517 = yyv517[:yyl517]
+			yyc517 = true
 		}
-		yyj524 := 0
-		for ; yyj524 < yyrr524; yyj524++ {
+		yyj517 := 0
+		for ; yyj517 < yyrr517; yyj517++ {
 			if r.TryDecodeAsNil() {
-				yyv524[yyj524] = RawContainerMetrics{}
+				yyv517[yyj517] = RawContainerMetrics{}
 			} else {
-				yyv525 := &yyv524[yyj524]
-				yyv525.CodecDecodeSelf(d)
+				yyv518 := &yyv517[yyj517]
+				yyv518.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt524 {
-			for ; yyj524 < yyl524; yyj524++ {
-				yyv524 = append(yyv524, RawContainerMetrics{})
+		if yyrt517 {
+			for ; yyj517 < yyl517; yyj517++ {
+				yyv517 = append(yyv517, RawContainerMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv524[yyj524] = RawContainerMetrics{}
+					yyv517[yyj517] = RawContainerMetrics{}
 				} else {
-					yyv526 := &yyv524[yyj524]
-					yyv526.CodecDecodeSelf(d)
+					yyv519 := &yyv517[yyj517]
+					yyv519.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj524 := 0; !r.CheckBreak(); yyj524++ {
-			if yyj524 >= len(yyv524) {
-				yyv524 = append(yyv524, RawContainerMetrics{}) // var yyz524 RawContainerMetrics
-				yyc524 = true
+		for yyj517 := 0; !r.CheckBreak(); yyj517++ {
+			if yyj517 >= len(yyv517) {
+				yyv517 = append(yyv517, RawContainerMetrics{}) // var yyz517 RawContainerMetrics
+				yyc517 = true
 			}
 
-			if yyj524 < len(yyv524) {
+			if yyj517 < len(yyv517) {
 				if r.TryDecodeAsNil() {
-					yyv524[yyj524] = RawContainerMetrics{}
+					yyv517[yyj517] = RawContainerMetrics{}
 				} else {
-					yyv527 := &yyv524[yyj524]
-					yyv527.CodecDecodeSelf(d)
+					yyv520 := &yyv517[yyj517]
+					yyv520.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6081,10 +5997,10 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 			}
 
 		}
-		yyh524.End()
+		yyh517.End()
 	}
-	if yyc524 {
-		*v = yyv524
+	if yyc517 {
+		*v = yyv517
 	}
 
 }
@@ -6094,9 +6010,9 @@ func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv528 := range v {
-		yy529 := &yyv528
-		yy529.CodecEncodeSelf(e)
+	for _, yyv521 := range v {
+		yy522 := &yyv521
+		yy522.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6106,75 +6022,75 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv530 := *v
-	yyh530, yyl530 := z.DecSliceHelperStart()
+	yyv523 := *v
+	yyh523, yyl523 := z.DecSliceHelperStart()
 
-	var yyrr530, yyrl530 int
-	var yyc530, yyrt530 bool
-	_, _, _ = yyc530, yyrt530, yyrl530
-	yyrr530 = yyl530
+	var yyrr523, yyrl523 int
+	var yyc523, yyrt523 bool
+	_, _, _ = yyc523, yyrt523, yyrl523
+	yyrr523 = yyl523
 
-	if yyv530 == nil {
-		if yyrl530, yyrt530 = z.DecInferLen(yyl530, z.DecBasicHandle().MaxInitLen, 128); yyrt530 {
-			yyrr530 = yyrl530
+	if yyv523 == nil {
+		if yyrl523, yyrt523 = z.DecInferLen(yyl523, z.DecBasicHandle().MaxInitLen, 128); yyrt523 {
+			yyrr523 = yyrl523
 		}
-		yyv530 = make([]RawNodeMetrics, yyrl530)
-		yyc530 = true
+		yyv523 = make([]RawNodeMetrics, yyrl523)
+		yyc523 = true
 	}
 
-	if yyl530 == 0 {
-		if len(yyv530) != 0 {
-			yyv530 = yyv530[:0]
-			yyc530 = true
+	if yyl523 == 0 {
+		if len(yyv523) != 0 {
+			yyv523 = yyv523[:0]
+			yyc523 = true
 		}
-	} else if yyl530 > 0 {
+	} else if yyl523 > 0 {
 
-		if yyl530 > cap(yyv530) {
-			yyrl530, yyrt530 = z.DecInferLen(yyl530, z.DecBasicHandle().MaxInitLen, 128)
-			yyv530 = make([]RawNodeMetrics, yyrl530)
-			yyc530 = true
+		if yyl523 > cap(yyv523) {
+			yyrl523, yyrt523 = z.DecInferLen(yyl523, z.DecBasicHandle().MaxInitLen, 128)
+			yyv523 = make([]RawNodeMetrics, yyrl523)
+			yyc523 = true
 
-			yyrr530 = len(yyv530)
-		} else if yyl530 != len(yyv530) {
-			yyv530 = yyv530[:yyl530]
-			yyc530 = true
+			yyrr523 = len(yyv523)
+		} else if yyl523 != len(yyv523) {
+			yyv523 = yyv523[:yyl523]
+			yyc523 = true
 		}
-		yyj530 := 0
-		for ; yyj530 < yyrr530; yyj530++ {
+		yyj523 := 0
+		for ; yyj523 < yyrr523; yyj523++ {
 			if r.TryDecodeAsNil() {
-				yyv530[yyj530] = RawNodeMetrics{}
+				yyv523[yyj523] = RawNodeMetrics{}
 			} else {
-				yyv531 := &yyv530[yyj530]
-				yyv531.CodecDecodeSelf(d)
+				yyv524 := &yyv523[yyj523]
+				yyv524.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt530 {
-			for ; yyj530 < yyl530; yyj530++ {
-				yyv530 = append(yyv530, RawNodeMetrics{})
+		if yyrt523 {
+			for ; yyj523 < yyl523; yyj523++ {
+				yyv523 = append(yyv523, RawNodeMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv530[yyj530] = RawNodeMetrics{}
+					yyv523[yyj523] = RawNodeMetrics{}
 				} else {
-					yyv532 := &yyv530[yyj530]
-					yyv532.CodecDecodeSelf(d)
+					yyv525 := &yyv523[yyj523]
+					yyv525.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj530 := 0; !r.CheckBreak(); yyj530++ {
-			if yyj530 >= len(yyv530) {
-				yyv530 = append(yyv530, RawNodeMetrics{}) // var yyz530 RawNodeMetrics
-				yyc530 = true
+		for yyj523 := 0; !r.CheckBreak(); yyj523++ {
+			if yyj523 >= len(yyv523) {
+				yyv523 = append(yyv523, RawNodeMetrics{}) // var yyz523 RawNodeMetrics
+				yyc523 = true
 			}
 
-			if yyj530 < len(yyv530) {
+			if yyj523 < len(yyv523) {
 				if r.TryDecodeAsNil() {
-					yyv530[yyj530] = RawNodeMetrics{}
+					yyv523[yyj523] = RawNodeMetrics{}
 				} else {
-					yyv533 := &yyv530[yyj530]
-					yyv533.CodecDecodeSelf(d)
+					yyv526 := &yyv523[yyj523]
+					yyv526.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6182,10 +6098,10 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 			}
 
 		}
-		yyh530.End()
+		yyh523.End()
 	}
-	if yyc530 {
-		*v = yyv530
+	if yyc523 {
+		*v = yyv523
 	}
 
 }
@@ -6195,9 +6111,9 @@ func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv534 := range v {
-		yy535 := &yyv534
-		yy535.CodecEncodeSelf(e)
+	for _, yyv527 := range v {
+		yy528 := &yyv527
+		yy528.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6207,75 +6123,75 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv536 := *v
-	yyh536, yyl536 := z.DecSliceHelperStart()
+	yyv529 := *v
+	yyh529, yyl529 := z.DecSliceHelperStart()
 
-	var yyrr536, yyrl536 int
-	var yyc536, yyrt536 bool
-	_, _, _ = yyc536, yyrt536, yyrl536
-	yyrr536 = yyl536
+	var yyrr529, yyrl529 int
+	var yyc529, yyrt529 bool
+	_, _, _ = yyc529, yyrt529, yyrl529
+	yyrr529 = yyl529
 
-	if yyv536 == nil {
-		if yyrl536, yyrt536 = z.DecInferLen(yyl536, z.DecBasicHandle().MaxInitLen, 32); yyrt536 {
-			yyrr536 = yyrl536
+	if yyv529 == nil {
+		if yyrl529, yyrt529 = z.DecInferLen(yyl529, z.DecBasicHandle().MaxInitLen, 32); yyrt529 {
+			yyrr529 = yyrl529
 		}
-		yyv536 = make([]PodSample, yyrl536)
-		yyc536 = true
+		yyv529 = make([]PodSample, yyrl529)
+		yyc529 = true
 	}
 
-	if yyl536 == 0 {
-		if len(yyv536) != 0 {
-			yyv536 = yyv536[:0]
-			yyc536 = true
+	if yyl529 == 0 {
+		if len(yyv529) != 0 {
+			yyv529 = yyv529[:0]
+			yyc529 = true
 		}
-	} else if yyl536 > 0 {
+	} else if yyl529 > 0 {
 
-		if yyl536 > cap(yyv536) {
-			yyrl536, yyrt536 = z.DecInferLen(yyl536, z.DecBasicHandle().MaxInitLen, 32)
-			yyv536 = make([]PodSample, yyrl536)
-			yyc536 = true
+		if yyl529 > cap(yyv529) {
+			yyrl529, yyrt529 = z.DecInferLen(yyl529, z.DecBasicHandle().MaxInitLen, 32)
+			yyv529 = make([]PodSample, yyrl529)
+			yyc529 = true
 
-			yyrr536 = len(yyv536)
-		} else if yyl536 != len(yyv536) {
-			yyv536 = yyv536[:yyl536]
-			yyc536 = true
+			yyrr529 = len(yyv529)
+		} else if yyl529 != len(yyv529) {
+			yyv529 = yyv529[:yyl529]
+			yyc529 = true
 		}
-		yyj536 := 0
-		for ; yyj536 < yyrr536; yyj536++ {
+		yyj529 := 0
+		for ; yyj529 < yyrr529; yyj529++ {
 			if r.TryDecodeAsNil() {
-				yyv536[yyj536] = PodSample{}
+				yyv529[yyj529] = PodSample{}
 			} else {
-				yyv537 := &yyv536[yyj536]
-				yyv537.CodecDecodeSelf(d)
+				yyv530 := &yyv529[yyj529]
+				yyv530.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt536 {
-			for ; yyj536 < yyl536; yyj536++ {
-				yyv536 = append(yyv536, PodSample{})
+		if yyrt529 {
+			for ; yyj529 < yyl529; yyj529++ {
+				yyv529 = append(yyv529, PodSample{})
 				if r.TryDecodeAsNil() {
-					yyv536[yyj536] = PodSample{}
+					yyv529[yyj529] = PodSample{}
 				} else {
-					yyv538 := &yyv536[yyj536]
-					yyv538.CodecDecodeSelf(d)
+					yyv531 := &yyv529[yyj529]
+					yyv531.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj536 := 0; !r.CheckBreak(); yyj536++ {
-			if yyj536 >= len(yyv536) {
-				yyv536 = append(yyv536, PodSample{}) // var yyz536 PodSample
-				yyc536 = true
+		for yyj529 := 0; !r.CheckBreak(); yyj529++ {
+			if yyj529 >= len(yyv529) {
+				yyv529 = append(yyv529, PodSample{}) // var yyz529 PodSample
+				yyc529 = true
 			}
 
-			if yyj536 < len(yyv536) {
+			if yyj529 < len(yyv529) {
 				if r.TryDecodeAsNil() {
-					yyv536[yyj536] = PodSample{}
+					yyv529[yyj529] = PodSample{}
 				} else {
-					yyv539 := &yyv536[yyj536]
-					yyv539.CodecDecodeSelf(d)
+					yyv532 := &yyv529[yyj529]
+					yyv532.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6283,10 +6199,10 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 			}
 
 		}
-		yyh536.End()
+		yyh529.End()
 	}
-	if yyc536 {
-		*v = yyv536
+	if yyc529 {
+		*v = yyv529
 	}
 
 }
@@ -6296,9 +6212,9 @@ func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv540 := range v {
-		yy541 := &yyv540
-		yy541.CodecEncodeSelf(e)
+	for _, yyv533 := range v {
+		yy534 := &yyv533
+		yy534.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6308,75 +6224,75 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv542 := *v
-	yyh542, yyl542 := z.DecSliceHelperStart()
+	yyv535 := *v
+	yyh535, yyl535 := z.DecSliceHelperStart()
 
-	var yyrr542, yyrl542 int
-	var yyc542, yyrt542 bool
-	_, _, _ = yyc542, yyrt542, yyrl542
-	yyrr542 = yyl542
+	var yyrr535, yyrl535 int
+	var yyc535, yyrt535 bool
+	_, _, _ = yyc535, yyrt535, yyrl535
+	yyrr535 = yyl535
 
-	if yyv542 == nil {
-		if yyrl542, yyrt542 = z.DecInferLen(yyl542, z.DecBasicHandle().MaxInitLen, 160); yyrt542 {
-			yyrr542 = yyrl542
+	if yyv535 == nil {
+		if yyrl535, yyrt535 = z.DecInferLen(yyl535, z.DecBasicHandle().MaxInitLen, 160); yyrt535 {
+			yyrr535 = yyrl535
 		}
-		yyv542 = make([]RawPodMetrics, yyrl542)
-		yyc542 = true
+		yyv535 = make([]RawPodMetrics, yyrl535)
+		yyc535 = true
 	}
 
-	if yyl542 == 0 {
-		if len(yyv542) != 0 {
-			yyv542 = yyv542[:0]
-			yyc542 = true
+	if yyl535 == 0 {
+		if len(yyv535) != 0 {
+			yyv535 = yyv535[:0]
+			yyc535 = true
 		}
-	} else if yyl542 > 0 {
+	} else if yyl535 > 0 {
 
-		if yyl542 > cap(yyv542) {
-			yyrl542, yyrt542 = z.DecInferLen(yyl542, z.DecBasicHandle().MaxInitLen, 160)
-			yyv542 = make([]RawPodMetrics, yyrl542)
-			yyc542 = true
+		if yyl535 > cap(yyv535) {
+			yyrl535, yyrt535 = z.DecInferLen(yyl535, z.DecBasicHandle().MaxInitLen, 160)
+			yyv535 = make([]RawPodMetrics, yyrl535)
+			yyc535 = true
 
-			yyrr542 = len(yyv542)
-		} else if yyl542 != len(yyv542) {
-			yyv542 = yyv542[:yyl542]
-			yyc542 = true
+			yyrr535 = len(yyv535)
+		} else if yyl535 != len(yyv535) {
+			yyv535 = yyv535[:yyl535]
+			yyc535 = true
 		}
-		yyj542 := 0
-		for ; yyj542 < yyrr542; yyj542++ {
+		yyj535 := 0
+		for ; yyj535 < yyrr535; yyj535++ {
 			if r.TryDecodeAsNil() {
-				yyv542[yyj542] = RawPodMetrics{}
+				yyv535[yyj535] = RawPodMetrics{}
 			} else {
-				yyv543 := &yyv542[yyj542]
-				yyv543.CodecDecodeSelf(d)
+				yyv536 := &yyv535[yyj535]
+				yyv536.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt542 {
-			for ; yyj542 < yyl542; yyj542++ {
-				yyv542 = append(yyv542, RawPodMetrics{})
+		if yyrt535 {
+			for ; yyj535 < yyl535; yyj535++ {
+				yyv535 = append(yyv535, RawPodMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv542[yyj542] = RawPodMetrics{}
+					yyv535[yyj535] = RawPodMetrics{}
 				} else {
-					yyv544 := &yyv542[yyj542]
-					yyv544.CodecDecodeSelf(d)
+					yyv537 := &yyv535[yyj535]
+					yyv537.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj542 := 0; !r.CheckBreak(); yyj542++ {
-			if yyj542 >= len(yyv542) {
-				yyv542 = append(yyv542, RawPodMetrics{}) // var yyz542 RawPodMetrics
-				yyc542 = true
+		for yyj535 := 0; !r.CheckBreak(); yyj535++ {
+			if yyj535 >= len(yyv535) {
+				yyv535 = append(yyv535, RawPodMetrics{}) // var yyz535 RawPodMetrics
+				yyc535 = true
 			}
 
-			if yyj542 < len(yyv542) {
+			if yyj535 < len(yyv535) {
 				if r.TryDecodeAsNil() {
-					yyv542[yyj542] = RawPodMetrics{}
+					yyv535[yyj535] = RawPodMetrics{}
 				} else {
-					yyv545 := &yyv542[yyj542]
-					yyv545.CodecDecodeSelf(d)
+					yyv538 := &yyv535[yyj535]
+					yyv538.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6384,10 +6300,10 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 			}
 
 		}
-		yyh542.End()
+		yyh535.End()
 	}
-	if yyc542 {
-		*v = yyv542
+	if yyc535 {
+		*v = yyv535
 	}
 
 }
@@ -6397,9 +6313,9 @@ func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv546 := range v {
-		yy547 := &yyv546
-		yy547.CodecEncodeSelf(e)
+	for _, yyv539 := range v {
+		yy540 := &yyv539
+		yy540.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6409,75 +6325,75 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv548 := *v
-	yyh548, yyl548 := z.DecSliceHelperStart()
+	yyv541 := *v
+	yyh541, yyl541 := z.DecSliceHelperStart()
 
-	var yyrr548, yyrl548 int
-	var yyc548, yyrt548 bool
-	_, _, _ = yyc548, yyrt548, yyrl548
-	yyrr548 = yyl548
+	var yyrr541, yyrl541 int
+	var yyc541, yyrt541 bool
+	_, _, _ = yyc541, yyrt541, yyrl541
+	yyrr541 = yyl541
 
-	if yyv548 == nil {
-		if yyrl548, yyrt548 = z.DecInferLen(yyl548, z.DecBasicHandle().MaxInitLen, 64); yyrt548 {
-			yyrr548 = yyrl548
+	if yyv541 == nil {
+		if yyrl541, yyrt541 = z.DecInferLen(yyl541, z.DecBasicHandle().MaxInitLen, 64); yyrt541 {
+			yyrr541 = yyrl541
 		}
-		yyv548 = make([]ContainerSample, yyrl548)
-		yyc548 = true
+		yyv541 = make([]ContainerSample, yyrl541)
+		yyc541 = true
 	}
 
-	if yyl548 == 0 {
-		if len(yyv548) != 0 {
-			yyv548 = yyv548[:0]
-			yyc548 = true
+	if yyl541 == 0 {
+		if len(yyv541) != 0 {
+			yyv541 = yyv541[:0]
+			yyc541 = true
 		}
-	} else if yyl548 > 0 {
+	} else if yyl541 > 0 {
 
-		if yyl548 > cap(yyv548) {
-			yyrl548, yyrt548 = z.DecInferLen(yyl548, z.DecBasicHandle().MaxInitLen, 64)
-			yyv548 = make([]ContainerSample, yyrl548)
-			yyc548 = true
+		if yyl541 > cap(yyv541) {
+			yyrl541, yyrt541 = z.DecInferLen(yyl541, z.DecBasicHandle().MaxInitLen, 64)
+			yyv541 = make([]ContainerSample, yyrl541)
+			yyc541 = true
 
-			yyrr548 = len(yyv548)
-		} else if yyl548 != len(yyv548) {
-			yyv548 = yyv548[:yyl548]
-			yyc548 = true
+			yyrr541 = len(yyv541)
+		} else if yyl541 != len(yyv541) {
+			yyv541 = yyv541[:yyl541]
+			yyc541 = true
 		}
-		yyj548 := 0
-		for ; yyj548 < yyrr548; yyj548++ {
+		yyj541 := 0
+		for ; yyj541 < yyrr541; yyj541++ {
 			if r.TryDecodeAsNil() {
-				yyv548[yyj548] = ContainerSample{}
+				yyv541[yyj541] = ContainerSample{}
 			} else {
-				yyv549 := &yyv548[yyj548]
-				yyv549.CodecDecodeSelf(d)
+				yyv542 := &yyv541[yyj541]
+				yyv542.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt548 {
-			for ; yyj548 < yyl548; yyj548++ {
-				yyv548 = append(yyv548, ContainerSample{})
+		if yyrt541 {
+			for ; yyj541 < yyl541; yyj541++ {
+				yyv541 = append(yyv541, ContainerSample{})
 				if r.TryDecodeAsNil() {
-					yyv548[yyj548] = ContainerSample{}
+					yyv541[yyj541] = ContainerSample{}
 				} else {
-					yyv550 := &yyv548[yyj548]
-					yyv550.CodecDecodeSelf(d)
+					yyv543 := &yyv541[yyj541]
+					yyv543.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj548 := 0; !r.CheckBreak(); yyj548++ {
-			if yyj548 >= len(yyv548) {
-				yyv548 = append(yyv548, ContainerSample{}) // var yyz548 ContainerSample
-				yyc548 = true
+		for yyj541 := 0; !r.CheckBreak(); yyj541++ {
+			if yyj541 >= len(yyv541) {
+				yyv541 = append(yyv541, ContainerSample{}) // var yyz541 ContainerSample
+				yyc541 = true
 			}
 
-			if yyj548 < len(yyv548) {
+			if yyj541 < len(yyv541) {
 				if r.TryDecodeAsNil() {
-					yyv548[yyj548] = ContainerSample{}
+					yyv541[yyj541] = ContainerSample{}
 				} else {
-					yyv551 := &yyv548[yyj548]
-					yyv551.CodecDecodeSelf(d)
+					yyv544 := &yyv541[yyj541]
+					yyv544.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6485,10 +6401,10 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 			}
 
 		}
-		yyh548.End()
+		yyh541.End()
 	}
-	if yyc548 {
-		*v = yyv548
+	if yyc541 {
+		*v = yyv541
 	}
 
 }
@@ -6498,9 +6414,9 @@ func (x codecSelfer1234) encSliceCustomMetric(v []CustomMetric, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv552 := range v {
-		yy553 := &yyv552
-		yy553.CodecEncodeSelf(e)
+	for _, yyv545 := range v {
+		yy546 := &yyv545
+		yy546.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6510,75 +6426,75 @@ func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv554 := *v
-	yyh554, yyl554 := z.DecSliceHelperStart()
+	yyv547 := *v
+	yyh547, yyl547 := z.DecSliceHelperStart()
 
-	var yyrr554, yyrl554 int
-	var yyc554, yyrt554 bool
-	_, _, _ = yyc554, yyrt554, yyrl554
-	yyrr554 = yyl554
+	var yyrr547, yyrl547 int
+	var yyc547, yyrt547 bool
+	_, _, _ = yyc547, yyrt547, yyrl547
+	yyrr547 = yyl547
 
-	if yyv554 == nil {
-		if yyrl554, yyrt554 = z.DecInferLen(yyl554, z.DecBasicHandle().MaxInitLen, 72); yyrt554 {
-			yyrr554 = yyrl554
+	if yyv547 == nil {
+		if yyrl547, yyrt547 = z.DecInferLen(yyl547, z.DecBasicHandle().MaxInitLen, 72); yyrt547 {
+			yyrr547 = yyrl547
 		}
-		yyv554 = make([]CustomMetric, yyrl554)
-		yyc554 = true
+		yyv547 = make([]CustomMetric, yyrl547)
+		yyc547 = true
 	}
 
-	if yyl554 == 0 {
-		if len(yyv554) != 0 {
-			yyv554 = yyv554[:0]
-			yyc554 = true
+	if yyl547 == 0 {
+		if len(yyv547) != 0 {
+			yyv547 = yyv547[:0]
+			yyc547 = true
 		}
-	} else if yyl554 > 0 {
+	} else if yyl547 > 0 {
 
-		if yyl554 > cap(yyv554) {
-			yyrl554, yyrt554 = z.DecInferLen(yyl554, z.DecBasicHandle().MaxInitLen, 72)
-			yyv554 = make([]CustomMetric, yyrl554)
-			yyc554 = true
+		if yyl547 > cap(yyv547) {
+			yyrl547, yyrt547 = z.DecInferLen(yyl547, z.DecBasicHandle().MaxInitLen, 72)
+			yyv547 = make([]CustomMetric, yyrl547)
+			yyc547 = true
 
-			yyrr554 = len(yyv554)
-		} else if yyl554 != len(yyv554) {
-			yyv554 = yyv554[:yyl554]
-			yyc554 = true
+			yyrr547 = len(yyv547)
+		} else if yyl547 != len(yyv547) {
+			yyv547 = yyv547[:yyl547]
+			yyc547 = true
 		}
-		yyj554 := 0
-		for ; yyj554 < yyrr554; yyj554++ {
+		yyj547 := 0
+		for ; yyj547 < yyrr547; yyj547++ {
 			if r.TryDecodeAsNil() {
-				yyv554[yyj554] = CustomMetric{}
+				yyv547[yyj547] = CustomMetric{}
 			} else {
-				yyv555 := &yyv554[yyj554]
-				yyv555.CodecDecodeSelf(d)
+				yyv548 := &yyv547[yyj547]
+				yyv548.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt554 {
-			for ; yyj554 < yyl554; yyj554++ {
-				yyv554 = append(yyv554, CustomMetric{})
+		if yyrt547 {
+			for ; yyj547 < yyl547; yyj547++ {
+				yyv547 = append(yyv547, CustomMetric{})
 				if r.TryDecodeAsNil() {
-					yyv554[yyj554] = CustomMetric{}
+					yyv547[yyj547] = CustomMetric{}
 				} else {
-					yyv556 := &yyv554[yyj554]
-					yyv556.CodecDecodeSelf(d)
+					yyv549 := &yyv547[yyj547]
+					yyv549.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj554 := 0; !r.CheckBreak(); yyj554++ {
-			if yyj554 >= len(yyv554) {
-				yyv554 = append(yyv554, CustomMetric{}) // var yyz554 CustomMetric
-				yyc554 = true
+		for yyj547 := 0; !r.CheckBreak(); yyj547++ {
+			if yyj547 >= len(yyv547) {
+				yyv547 = append(yyv547, CustomMetric{}) // var yyz547 CustomMetric
+				yyc547 = true
 			}
 
-			if yyj554 < len(yyv554) {
+			if yyj547 < len(yyv547) {
 				if r.TryDecodeAsNil() {
-					yyv554[yyj554] = CustomMetric{}
+					yyv547[yyj547] = CustomMetric{}
 				} else {
-					yyv557 := &yyv554[yyj554]
-					yyv557.CodecDecodeSelf(d)
+					yyv550 := &yyv547[yyj547]
+					yyv550.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6586,10 +6502,10 @@ func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.De
 			}
 
 		}
-		yyh554.End()
+		yyh547.End()
 	}
-	if yyc554 {
-		*v = yyv554
+	if yyc547 {
+		*v = yyv547
 	}
 
 }
@@ -6599,9 +6515,9 @@ func (x codecSelfer1234) encSliceFilesystemMetrics(v []FilesystemMetrics, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv558 := range v {
-		yy559 := &yyv558
-		yy559.CodecEncodeSelf(e)
+	for _, yyv551 := range v {
+		yy552 := &yyv551
+		yy552.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6611,75 +6527,75 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv560 := *v
-	yyh560, yyl560 := z.DecSliceHelperStart()
+	yyv553 := *v
+	yyh553, yyl553 := z.DecSliceHelperStart()
 
-	var yyrr560, yyrl560 int
-	var yyc560, yyrt560 bool
-	_, _, _ = yyc560, yyrt560, yyrl560
-	yyrr560 = yyl560
+	var yyrr553, yyrl553 int
+	var yyc553, yyrt553 bool
+	_, _, _ = yyc553, yyrt553, yyrl553
+	yyrr553 = yyl553
 
-	if yyv560 == nil {
-		if yyrl560, yyrt560 = z.DecInferLen(yyl560, z.DecBasicHandle().MaxInitLen, 32); yyrt560 {
-			yyrr560 = yyrl560
+	if yyv553 == nil {
+		if yyrl553, yyrt553 = z.DecInferLen(yyl553, z.DecBasicHandle().MaxInitLen, 32); yyrt553 {
+			yyrr553 = yyrl553
 		}
-		yyv560 = make([]FilesystemMetrics, yyrl560)
-		yyc560 = true
+		yyv553 = make([]FilesystemMetrics, yyrl553)
+		yyc553 = true
 	}
 
-	if yyl560 == 0 {
-		if len(yyv560) != 0 {
-			yyv560 = yyv560[:0]
-			yyc560 = true
+	if yyl553 == 0 {
+		if len(yyv553) != 0 {
+			yyv553 = yyv553[:0]
+			yyc553 = true
 		}
-	} else if yyl560 > 0 {
+	} else if yyl553 > 0 {
 
-		if yyl560 > cap(yyv560) {
-			yyrl560, yyrt560 = z.DecInferLen(yyl560, z.DecBasicHandle().MaxInitLen, 32)
-			yyv560 = make([]FilesystemMetrics, yyrl560)
-			yyc560 = true
+		if yyl553 > cap(yyv553) {
+			yyrl553, yyrt553 = z.DecInferLen(yyl553, z.DecBasicHandle().MaxInitLen, 32)
+			yyv553 = make([]FilesystemMetrics, yyrl553)
+			yyc553 = true
 
-			yyrr560 = len(yyv560)
-		} else if yyl560 != len(yyv560) {
-			yyv560 = yyv560[:yyl560]
-			yyc560 = true
+			yyrr553 = len(yyv553)
+		} else if yyl553 != len(yyv553) {
+			yyv553 = yyv553[:yyl553]
+			yyc553 = true
 		}
-		yyj560 := 0
-		for ; yyj560 < yyrr560; yyj560++ {
+		yyj553 := 0
+		for ; yyj553 < yyrr553; yyj553++ {
 			if r.TryDecodeAsNil() {
-				yyv560[yyj560] = FilesystemMetrics{}
+				yyv553[yyj553] = FilesystemMetrics{}
 			} else {
-				yyv561 := &yyv560[yyj560]
-				yyv561.CodecDecodeSelf(d)
+				yyv554 := &yyv553[yyj553]
+				yyv554.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt560 {
-			for ; yyj560 < yyl560; yyj560++ {
-				yyv560 = append(yyv560, FilesystemMetrics{})
+		if yyrt553 {
+			for ; yyj553 < yyl553; yyj553++ {
+				yyv553 = append(yyv553, FilesystemMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv560[yyj560] = FilesystemMetrics{}
+					yyv553[yyj553] = FilesystemMetrics{}
 				} else {
-					yyv562 := &yyv560[yyj560]
-					yyv562.CodecDecodeSelf(d)
+					yyv555 := &yyv553[yyj553]
+					yyv555.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj560 := 0; !r.CheckBreak(); yyj560++ {
-			if yyj560 >= len(yyv560) {
-				yyv560 = append(yyv560, FilesystemMetrics{}) // var yyz560 FilesystemMetrics
-				yyc560 = true
+		for yyj553 := 0; !r.CheckBreak(); yyj553++ {
+			if yyj553 >= len(yyv553) {
+				yyv553 = append(yyv553, FilesystemMetrics{}) // var yyz553 FilesystemMetrics
+				yyc553 = true
 			}
 
-			if yyj560 < len(yyv560) {
+			if yyj553 < len(yyv553) {
 				if r.TryDecodeAsNil() {
-					yyv560[yyj560] = FilesystemMetrics{}
+					yyv553[yyj553] = FilesystemMetrics{}
 				} else {
-					yyv563 := &yyv560[yyj560]
-					yyv563.CodecDecodeSelf(d)
+					yyv556 := &yyv553[yyj553]
+					yyv556.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6687,10 +6603,10 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 			}
 
 		}
-		yyh560.End()
+		yyh553.End()
 	}
-	if yyc560 {
-		*v = yyv560
+	if yyc553 {
+		*v = yyv553
 	}
 
 }
@@ -6700,9 +6616,9 @@ func (x codecSelfer1234) encSliceCustomMetricSample(v []CustomMetricSample, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv564 := range v {
-		yy565 := &yyv564
-		yy565.CodecEncodeSelf(e)
+	for _, yyv557 := range v {
+		yy558 := &yyv557
+		yy558.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6712,75 +6628,75 @@ func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv566 := *v
-	yyh566, yyl566 := z.DecSliceHelperStart()
+	yyv559 := *v
+	yyh559, yyl559 := z.DecSliceHelperStart()
 
-	var yyrr566, yyrl566 int
-	var yyc566, yyrt566 bool
-	_, _, _ = yyc566, yyrt566, yyrl566
-	yyrr566 = yyl566
+	var yyrr559, yyrl559 int
+	var yyc559, yyrt559 bool
+	_, _, _ = yyc559, yyrt559, yyrl559
+	yyrr559 = yyl559
 
-	if yyv566 == nil {
-		if yyrl566, yyrt566 = z.DecInferLen(yyl566, z.DecBasicHandle().MaxInitLen, 56); yyrt566 {
-			yyrr566 = yyrl566
+	if yyv559 == nil {
+		if yyrl559, yyrt559 = z.DecInferLen(yyl559, z.DecBasicHandle().MaxInitLen, 56); yyrt559 {
+			yyrr559 = yyrl559
 		}
-		yyv566 = make([]CustomMetricSample, yyrl566)
-		yyc566 = true
+		yyv559 = make([]CustomMetricSample, yyrl559)
+		yyc559 = true
 	}
 
-	if yyl566 == 0 {
-		if len(yyv566) != 0 {
-			yyv566 = yyv566[:0]
-			yyc566 = true
+	if yyl559 == 0 {
+		if len(yyv559) != 0 {
+			yyv559 = yyv559[:0]
+			yyc559 = true
 		}
-	} else if yyl566 > 0 {
+	} else if yyl559 > 0 {
 
-		if yyl566 > cap(yyv566) {
-			yyrl566, yyrt566 = z.DecInferLen(yyl566, z.DecBasicHandle().MaxInitLen, 56)
-			yyv566 = make([]CustomMetricSample, yyrl566)
-			yyc566 = true
+		if yyl559 > cap(yyv559) {
+			yyrl559, yyrt559 = z.DecInferLen(yyl559, z.DecBasicHandle().MaxInitLen, 56)
+			yyv559 = make([]CustomMetricSample, yyrl559)
+			yyc559 = true
 
-			yyrr566 = len(yyv566)
-		} else if yyl566 != len(yyv566) {
-			yyv566 = yyv566[:yyl566]
-			yyc566 = true
+			yyrr559 = len(yyv559)
+		} else if yyl559 != len(yyv559) {
+			yyv559 = yyv559[:yyl559]
+			yyc559 = true
 		}
-		yyj566 := 0
-		for ; yyj566 < yyrr566; yyj566++ {
+		yyj559 := 0
+		for ; yyj559 < yyrr559; yyj559++ {
 			if r.TryDecodeAsNil() {
-				yyv566[yyj566] = CustomMetricSample{}
+				yyv559[yyj559] = CustomMetricSample{}
 			} else {
-				yyv567 := &yyv566[yyj566]
-				yyv567.CodecDecodeSelf(d)
+				yyv560 := &yyv559[yyj559]
+				yyv560.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt566 {
-			for ; yyj566 < yyl566; yyj566++ {
-				yyv566 = append(yyv566, CustomMetricSample{})
+		if yyrt559 {
+			for ; yyj559 < yyl559; yyj559++ {
+				yyv559 = append(yyv559, CustomMetricSample{})
 				if r.TryDecodeAsNil() {
-					yyv566[yyj566] = CustomMetricSample{}
+					yyv559[yyj559] = CustomMetricSample{}
 				} else {
-					yyv568 := &yyv566[yyj566]
-					yyv568.CodecDecodeSelf(d)
+					yyv561 := &yyv559[yyj559]
+					yyv561.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj566 := 0; !r.CheckBreak(); yyj566++ {
-			if yyj566 >= len(yyv566) {
-				yyv566 = append(yyv566, CustomMetricSample{}) // var yyz566 CustomMetricSample
-				yyc566 = true
+		for yyj559 := 0; !r.CheckBreak(); yyj559++ {
+			if yyj559 >= len(yyv559) {
+				yyv559 = append(yyv559, CustomMetricSample{}) // var yyz559 CustomMetricSample
+				yyc559 = true
 			}
 
-			if yyj566 < len(yyv566) {
+			if yyj559 < len(yyv559) {
 				if r.TryDecodeAsNil() {
-					yyv566[yyj566] = CustomMetricSample{}
+					yyv559[yyj559] = CustomMetricSample{}
 				} else {
-					yyv569 := &yyv566[yyj566]
-					yyv569.CodecDecodeSelf(d)
+					yyv562 := &yyv559[yyj559]
+					yyv562.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6788,10 +6704,10 @@ func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *
 			}
 
 		}
-		yyh566.End()
+		yyh559.End()
 	}
-	if yyc566 {
-		*v = yyv566
+	if yyc559 {
+		*v = yyv559
 	}
 
 }

--- a/pkg/apis/metrics/types.generated.go
+++ b/pkg/apis/metrics/types.generated.go
@@ -1708,13 +1708,12 @@ func (x *RawContainerMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep165 := !z.EncBinary()
 			yy2arr165 := z.EncBasicHandle().StructToArray
-			var yyq165 [4]bool
+			var yyq165 [3]bool
 			_, _, _ = yysep165, yyq165, yy2arr165
 			const yyr165 bool = false
 			yyq165[1] = len(x.Labels) != 0
-			yyq165[3] = len(x.CustomMetrics) != 0
 			if yyr165 || yy2arr165 {
-				r.EncodeArrayStart(4)
+				r.EncodeArrayStart(3)
 			} else {
 				var yynn165 int = 2
 				for _, b := range yyq165 {
@@ -1794,36 +1793,6 @@ func (x *RawContainerMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr165 || yy2arr165 {
-				if yyq165[3] {
-					if x.CustomMetrics == nil {
-						r.EncodeNil()
-					} else {
-						yym176 := z.EncBinary()
-						_ = yym176
-						if false {
-						} else {
-							h.encSliceCustomMetric(([]CustomMetric)(x.CustomMetrics), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq165[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("customMetrics"))
-					if x.CustomMetrics == nil {
-						r.EncodeNil()
-					} else {
-						yym177 := z.EncBinary()
-						_ = yym177
-						if false {
-						} else {
-							h.encSliceCustomMetric(([]CustomMetric)(x.CustomMetrics), e)
-						}
-					}
-				}
-			}
 			if yysep165 {
 				r.EncodeEnd()
 			}
@@ -1835,24 +1804,24 @@ func (x *RawContainerMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym178 := z.DecBinary()
-	_ = yym178
+	yym175 := z.DecBinary()
+	_ = yym175
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl179 := r.ReadMapStart()
-			if yyl179 == 0 {
+			yyl176 := r.ReadMapStart()
+			if yyl176 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl179, d)
+				x.codecDecodeSelfFromMap(yyl176, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl179 := r.ReadArrayStart()
-			if yyl179 == 0 {
+			yyl176 := r.ReadArrayStart()
+			if yyl176 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl179, d)
+				x.codecDecodeSelfFromArray(yyl176, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1864,12 +1833,12 @@ func (x *RawContainerMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys180Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys180Slc
-	var yyhl180 bool = l >= 0
-	for yyj180 := 0; ; yyj180++ {
-		if yyhl180 {
-			if yyj180 >= l {
+	var yys177Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys177Slc
+	var yyhl177 bool = l >= 0
+	for yyj177 := 0; ; yyj177++ {
+		if yyhl177 {
+			if yyj177 >= l {
 				break
 			}
 		} else {
@@ -1877,9 +1846,9 @@ func (x *RawContainerMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys180Slc = r.DecodeBytes(yys180Slc, true, true)
-		yys180 := string(yys180Slc)
-		switch yys180 {
+		yys177Slc = r.DecodeBytes(yys177Slc, true, true)
+		yys177 := string(yys177Slc)
+		switch yys177 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -1890,43 +1859,31 @@ func (x *RawContainerMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.Labels = nil
 			} else {
-				yyv182 := &x.Labels
-				yym183 := z.DecBinary()
-				_ = yym183
+				yyv179 := &x.Labels
+				yym180 := z.DecBinary()
+				_ = yym180
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv182, false, d)
+					z.F.DecMapStringStringX(yyv179, false, d)
 				}
 			}
 		case "samples":
 			if r.TryDecodeAsNil() {
 				x.Samples = nil
 			} else {
-				yyv184 := &x.Samples
-				yym185 := z.DecBinary()
-				_ = yym185
+				yyv181 := &x.Samples
+				yym182 := z.DecBinary()
+				_ = yym182
 				if false {
 				} else {
-					h.decSliceContainerSample((*[]ContainerSample)(yyv184), d)
-				}
-			}
-		case "customMetrics":
-			if r.TryDecodeAsNil() {
-				x.CustomMetrics = nil
-			} else {
-				yyv186 := &x.CustomMetrics
-				yym187 := z.DecBinary()
-				_ = yym187
-				if false {
-				} else {
-					h.decSliceCustomMetric((*[]CustomMetric)(yyv186), d)
+					h.decSliceContainerSample((*[]ContainerSample)(yyv181), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys180)
-		} // end switch yys180
-	} // end for yyj180
-	if !yyhl180 {
+			z.DecStructFieldNotFound(-1, yys177)
+		} // end switch yys177
+	} // end for yyj177
+	if !yyhl177 {
 		r.ReadEnd()
 	}
 }
@@ -1935,16 +1892,16 @@ func (x *RawContainerMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj188 int
-	var yyb188 bool
-	var yyhl188 bool = l >= 0
-	yyj188++
-	if yyhl188 {
-		yyb188 = yyj188 > l
+	var yyj183 int
+	var yyb183 bool
+	var yyhl183 bool = l >= 0
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb188 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb188 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
@@ -1953,80 +1910,59 @@ func (x *RawContainerMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj188++
-	if yyhl188 {
-		yyb188 = yyj188 > l
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb188 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb188 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
-		yyv190 := &x.Labels
-		yym191 := z.DecBinary()
-		_ = yym191
+		yyv185 := &x.Labels
+		yym186 := z.DecBinary()
+		_ = yym186
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv190, false, d)
+			z.F.DecMapStringStringX(yyv185, false, d)
 		}
 	}
-	yyj188++
-	if yyhl188 {
-		yyb188 = yyj188 > l
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb188 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb188 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Samples = nil
 	} else {
-		yyv192 := &x.Samples
-		yym193 := z.DecBinary()
-		_ = yym193
+		yyv187 := &x.Samples
+		yym188 := z.DecBinary()
+		_ = yym188
 		if false {
 		} else {
-			h.decSliceContainerSample((*[]ContainerSample)(yyv192), d)
-		}
-	}
-	yyj188++
-	if yyhl188 {
-		yyb188 = yyj188 > l
-	} else {
-		yyb188 = r.CheckBreak()
-	}
-	if yyb188 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.CustomMetrics = nil
-	} else {
-		yyv194 := &x.CustomMetrics
-		yym195 := z.DecBinary()
-		_ = yym195
-		if false {
-		} else {
-			h.decSliceCustomMetric((*[]CustomMetric)(yyv194), d)
+			h.decSliceContainerSample((*[]ContainerSample)(yyv187), d)
 		}
 	}
 	for {
-		yyj188++
-		if yyhl188 {
-			yyb188 = yyj188 > l
+		yyj183++
+		if yyhl183 {
+			yyb183 = yyj183 > l
 		} else {
-			yyb188 = r.CheckBreak()
+			yyb183 = r.CheckBreak()
 		}
-		if yyb188 {
+		if yyb183 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj188-1, "")
+		z.DecStructFieldNotFound(yyj183-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2038,64 +1974,64 @@ func (x *NonLocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym196 := z.EncBinary()
-		_ = yym196
+		yym189 := z.EncBinary()
+		_ = yym189
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep197 := !z.EncBinary()
-			yy2arr197 := z.EncBasicHandle().StructToArray
-			var yyq197 [3]bool
-			_, _, _ = yysep197, yyq197, yy2arr197
-			const yyr197 bool = false
-			yyq197[2] = x.UID != ""
-			if yyr197 || yy2arr197 {
+			yysep190 := !z.EncBinary()
+			yy2arr190 := z.EncBasicHandle().StructToArray
+			var yyq190 [3]bool
+			_, _, _ = yysep190, yyq190, yy2arr190
+			const yyr190 bool = false
+			yyq190[2] = x.UID != ""
+			if yyr190 || yy2arr190 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn197 int = 2
-				for _, b := range yyq197 {
+				var yynn190 int = 2
+				for _, b := range yyq190 {
 					if b {
-						yynn197++
+						yynn190++
 					}
 				}
-				r.EncodeMapStart(yynn197)
+				r.EncodeMapStart(yynn190)
 			}
-			if yyr197 || yy2arr197 {
-				yym199 := z.EncBinary()
-				_ = yym199
+			if yyr190 || yy2arr190 {
+				yym192 := z.EncBinary()
+				_ = yym192
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
-				yym200 := z.EncBinary()
-				_ = yym200
+				yym193 := z.EncBinary()
+				_ = yym193
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yyr197 || yy2arr197 {
-				yym202 := z.EncBinary()
-				_ = yym202
+			if yyr190 || yy2arr190 {
+				yym195 := z.EncBinary()
+				_ = yym195
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("namespace"))
-				yym203 := z.EncBinary()
-				_ = yym203
+				yym196 := z.EncBinary()
+				_ = yym196
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
 				}
 			}
-			if yyr197 || yy2arr197 {
-				if yyq197[2] {
-					yym205 := z.EncBinary()
-					_ = yym205
+			if yyr190 || yy2arr190 {
+				if yyq190[2] {
+					yym198 := z.EncBinary()
+					_ = yym198
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
@@ -2105,10 +2041,10 @@ func (x *NonLocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq197[2] {
+				if yyq190[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("uid"))
-					yym206 := z.EncBinary()
-					_ = yym206
+					yym199 := z.EncBinary()
+					_ = yym199
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
@@ -2116,7 +2052,7 @@ func (x *NonLocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep197 {
+			if yysep190 {
 				r.EncodeEnd()
 			}
 		}
@@ -2127,24 +2063,24 @@ func (x *NonLocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym207 := z.DecBinary()
-	_ = yym207
+	yym200 := z.DecBinary()
+	_ = yym200
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl208 := r.ReadMapStart()
-			if yyl208 == 0 {
+			yyl201 := r.ReadMapStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl208, d)
+				x.codecDecodeSelfFromMap(yyl201, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl208 := r.ReadArrayStart()
-			if yyl208 == 0 {
+			yyl201 := r.ReadArrayStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl208, d)
+				x.codecDecodeSelfFromArray(yyl201, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2156,12 +2092,12 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys209Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys209Slc
-	var yyhl209 bool = l >= 0
-	for yyj209 := 0; ; yyj209++ {
-		if yyhl209 {
-			if yyj209 >= l {
+	var yys202Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys202Slc
+	var yyhl202 bool = l >= 0
+	for yyj202 := 0; ; yyj202++ {
+		if yyhl202 {
+			if yyj202 >= l {
 				break
 			}
 		} else {
@@ -2169,9 +2105,9 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys209Slc = r.DecodeBytes(yys209Slc, true, true)
-		yys209 := string(yys209Slc)
-		switch yys209 {
+		yys202Slc = r.DecodeBytes(yys202Slc, true, true)
+		yys202 := string(yys202Slc)
+		switch yys202 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -2191,10 +2127,10 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.UID = pkg4_types.UID(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys209)
-		} // end switch yys209
-	} // end for yyj209
-	if !yyhl209 {
+			z.DecStructFieldNotFound(-1, yys202)
+		} // end switch yys202
+	} // end for yyj202
+	if !yyhl202 {
 		r.ReadEnd()
 	}
 }
@@ -2203,16 +2139,16 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj213 int
-	var yyb213 bool
-	var yyhl213 bool = l >= 0
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	var yyj206 int
+	var yyb206 bool
+	var yyhl206 bool = l >= 0
+	yyj206++
+	if yyhl206 {
+		yyb206 = yyj206 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb206 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb206 {
 		r.ReadEnd()
 		return
 	}
@@ -2221,13 +2157,13 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj206++
+	if yyhl206 {
+		yyb206 = yyj206 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb206 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb206 {
 		r.ReadEnd()
 		return
 	}
@@ -2236,13 +2172,13 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Namespace = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj206++
+	if yyhl206 {
+		yyb206 = yyj206 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb206 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb206 {
 		r.ReadEnd()
 		return
 	}
@@ -2252,16 +2188,16 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.UID = pkg4_types.UID(r.DecodeString())
 	}
 	for {
-		yyj213++
-		if yyhl213 {
-			yyb213 = yyj213 > l
+		yyj206++
+		if yyhl206 {
+			yyb206 = yyj206 > l
 		} else {
-			yyb213 = r.CheckBreak()
+			yyb206 = r.CheckBreak()
 		}
-		if yyb213 {
+		if yyb206 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj213-1, "")
+		z.DecStructFieldNotFound(yyj206-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2273,56 +2209,56 @@ func (x *Sample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym217 := z.EncBinary()
-		_ = yym217
+		yym210 := z.EncBinary()
+		_ = yym210
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep218 := !z.EncBinary()
-			yy2arr218 := z.EncBasicHandle().StructToArray
-			var yyq218 [1]bool
-			_, _, _ = yysep218, yyq218, yy2arr218
-			const yyr218 bool = false
-			if yyr218 || yy2arr218 {
+			yysep211 := !z.EncBinary()
+			yy2arr211 := z.EncBasicHandle().StructToArray
+			var yyq211 [1]bool
+			_, _, _ = yysep211, yyq211, yy2arr211
+			const yyr211 bool = false
+			if yyr211 || yy2arr211 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn218 int = 1
-				for _, b := range yyq218 {
+				var yynn211 int = 1
+				for _, b := range yyq211 {
 					if b {
-						yynn218++
+						yynn211++
 					}
 				}
-				r.EncodeMapStart(yynn218)
+				r.EncodeMapStart(yynn211)
 			}
-			if yyr218 || yy2arr218 {
-				yy220 := &x.SampleTime
-				yym221 := z.EncBinary()
-				_ = yym221
+			if yyr211 || yy2arr211 {
+				yy213 := &x.SampleTime
+				yym214 := z.EncBinary()
+				_ = yym214
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy220) {
-				} else if yym221 {
-					z.EncBinaryMarshal(yy220)
-				} else if !yym221 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy220)
+				} else if z.HasExtensions() && z.EncExt(yy213) {
+				} else if yym214 {
+					z.EncBinaryMarshal(yy213)
+				} else if !yym214 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy213)
 				} else {
-					z.EncFallback(yy220)
+					z.EncFallback(yy213)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy222 := &x.SampleTime
-				yym223 := z.EncBinary()
-				_ = yym223
+				yy215 := &x.SampleTime
+				yym216 := z.EncBinary()
+				_ = yym216
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy222) {
-				} else if yym223 {
-					z.EncBinaryMarshal(yy222)
-				} else if !yym223 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy222)
+				} else if z.HasExtensions() && z.EncExt(yy215) {
+				} else if yym216 {
+					z.EncBinaryMarshal(yy215)
+				} else if !yym216 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy215)
 				} else {
-					z.EncFallback(yy222)
+					z.EncFallback(yy215)
 				}
 			}
-			if yysep218 {
+			if yysep211 {
 				r.EncodeEnd()
 			}
 		}
@@ -2333,24 +2269,24 @@ func (x *Sample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym224 := z.DecBinary()
-	_ = yym224
+	yym217 := z.DecBinary()
+	_ = yym217
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl225 := r.ReadMapStart()
-			if yyl225 == 0 {
+			yyl218 := r.ReadMapStart()
+			if yyl218 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl225, d)
+				x.codecDecodeSelfFromMap(yyl218, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl225 := r.ReadArrayStart()
-			if yyl225 == 0 {
+			yyl218 := r.ReadArrayStart()
+			if yyl218 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl225, d)
+				x.codecDecodeSelfFromArray(yyl218, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2362,12 +2298,12 @@ func (x *Sample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys226Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys226Slc
-	var yyhl226 bool = l >= 0
-	for yyj226 := 0; ; yyj226++ {
-		if yyhl226 {
-			if yyj226 >= l {
+	var yys219Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys219Slc
+	var yyhl219 bool = l >= 0
+	for yyj219 := 0; ; yyj219++ {
+		if yyhl219 {
+			if yyj219 >= l {
 				break
 			}
 		} else {
@@ -2375,31 +2311,31 @@ func (x *Sample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys226Slc = r.DecodeBytes(yys226Slc, true, true)
-		yys226 := string(yys226Slc)
-		switch yys226 {
+		yys219Slc = r.DecodeBytes(yys219Slc, true, true)
+		yys219 := string(yys219Slc)
+		switch yys219 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv227 := &x.SampleTime
-				yym228 := z.DecBinary()
-				_ = yym228
+				yyv220 := &x.SampleTime
+				yym221 := z.DecBinary()
+				_ = yym221
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv227) {
-				} else if yym228 {
-					z.DecBinaryUnmarshal(yyv227)
-				} else if !yym228 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv227)
+				} else if z.HasExtensions() && z.DecExt(yyv220) {
+				} else if yym221 {
+					z.DecBinaryUnmarshal(yyv220)
+				} else if !yym221 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv220)
 				} else {
-					z.DecFallback(yyv227, false)
+					z.DecFallback(yyv220, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys226)
-		} // end switch yys226
-	} // end for yyj226
-	if !yyhl226 {
+			z.DecStructFieldNotFound(-1, yys219)
+		} // end switch yys219
+	} // end for yyj219
+	if !yyhl219 {
 		r.ReadEnd()
 	}
 }
@@ -2408,46 +2344,46 @@ func (x *Sample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj229 int
-	var yyb229 bool
-	var yyhl229 bool = l >= 0
-	yyj229++
-	if yyhl229 {
-		yyb229 = yyj229 > l
+	var yyj222 int
+	var yyb222 bool
+	var yyhl222 bool = l >= 0
+	yyj222++
+	if yyhl222 {
+		yyb222 = yyj222 > l
 	} else {
-		yyb229 = r.CheckBreak()
+		yyb222 = r.CheckBreak()
 	}
-	if yyb229 {
+	if yyb222 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv230 := &x.SampleTime
-		yym231 := z.DecBinary()
-		_ = yym231
+		yyv223 := &x.SampleTime
+		yym224 := z.DecBinary()
+		_ = yym224
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv230) {
-		} else if yym231 {
-			z.DecBinaryUnmarshal(yyv230)
-		} else if !yym231 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv230)
+		} else if z.HasExtensions() && z.DecExt(yyv223) {
+		} else if yym224 {
+			z.DecBinaryUnmarshal(yyv223)
+		} else if !yym224 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv223)
 		} else {
-			z.DecFallback(yyv230, false)
+			z.DecFallback(yyv223, false)
 		}
 	}
 	for {
-		yyj229++
-		if yyhl229 {
-			yyb229 = yyj229 > l
+		yyj222++
+		if yyhl222 {
+			yyb222 = yyj222 > l
 		} else {
-			yyb229 = r.CheckBreak()
+			yyb222 = r.CheckBreak()
 		}
-		if yyb229 {
+		if yyb222 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj229-1, "")
+		z.DecStructFieldNotFound(yyj222-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2459,61 +2395,61 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym232 := z.EncBinary()
-		_ = yym232
+		yym225 := z.EncBinary()
+		_ = yym225
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep233 := !z.EncBinary()
-			yy2arr233 := z.EncBasicHandle().StructToArray
-			var yyq233 [5]bool
-			_, _, _ = yysep233, yyq233, yy2arr233
-			const yyr233 bool = false
-			yyq233[1] = x.CPU != nil
-			yyq233[2] = x.Memory != nil
-			yyq233[3] = x.Network != nil
-			yyq233[4] = len(x.Filesystem) != 0
-			if yyr233 || yy2arr233 {
+			yysep226 := !z.EncBinary()
+			yy2arr226 := z.EncBasicHandle().StructToArray
+			var yyq226 [5]bool
+			_, _, _ = yysep226, yyq226, yy2arr226
+			const yyr226 bool = false
+			yyq226[1] = x.CPU != nil
+			yyq226[2] = x.Memory != nil
+			yyq226[3] = x.Network != nil
+			yyq226[4] = len(x.Filesystem) != 0
+			if yyr226 || yy2arr226 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn233 int = 1
-				for _, b := range yyq233 {
+				var yynn226 int = 1
+				for _, b := range yyq226 {
 					if b {
-						yynn233++
+						yynn226++
 					}
 				}
-				r.EncodeMapStart(yynn233)
+				r.EncodeMapStart(yynn226)
 			}
-			if yyr233 || yy2arr233 {
-				yy235 := &x.SampleTime
-				yym236 := z.EncBinary()
-				_ = yym236
+			if yyr226 || yy2arr226 {
+				yy228 := &x.SampleTime
+				yym229 := z.EncBinary()
+				_ = yym229
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy235) {
-				} else if yym236 {
-					z.EncBinaryMarshal(yy235)
-				} else if !yym236 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy235)
+				} else if z.HasExtensions() && z.EncExt(yy228) {
+				} else if yym229 {
+					z.EncBinaryMarshal(yy228)
+				} else if !yym229 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy228)
 				} else {
-					z.EncFallback(yy235)
+					z.EncFallback(yy228)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy237 := &x.SampleTime
-				yym238 := z.EncBinary()
-				_ = yym238
+				yy230 := &x.SampleTime
+				yym231 := z.EncBinary()
+				_ = yym231
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy237) {
-				} else if yym238 {
-					z.EncBinaryMarshal(yy237)
-				} else if !yym238 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy237)
+				} else if z.HasExtensions() && z.EncExt(yy230) {
+				} else if yym231 {
+					z.EncBinaryMarshal(yy230)
+				} else if !yym231 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy230)
 				} else {
-					z.EncFallback(yy237)
+					z.EncFallback(yy230)
 				}
 			}
-			if yyr233 || yy2arr233 {
-				if yyq233[1] {
+			if yyr226 || yy2arr226 {
+				if yyq226[1] {
 					if x.CPU == nil {
 						r.EncodeNil()
 					} else {
@@ -2523,7 +2459,7 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq233[1] {
+				if yyq226[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
 					if x.CPU == nil {
 						r.EncodeNil()
@@ -2532,8 +2468,8 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr233 || yy2arr233 {
-				if yyq233[2] {
+			if yyr226 || yy2arr226 {
+				if yyq226[2] {
 					if x.Memory == nil {
 						r.EncodeNil()
 					} else {
@@ -2543,7 +2479,7 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq233[2] {
+				if yyq226[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("memory"))
 					if x.Memory == nil {
 						r.EncodeNil()
@@ -2552,8 +2488,8 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr233 || yy2arr233 {
-				if yyq233[3] {
+			if yyr226 || yy2arr226 {
+				if yyq226[3] {
 					if x.Network == nil {
 						r.EncodeNil()
 					} else {
@@ -2563,7 +2499,7 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq233[3] {
+				if yyq226[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("network"))
 					if x.Network == nil {
 						r.EncodeNil()
@@ -2572,13 +2508,13 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr233 || yy2arr233 {
-				if yyq233[4] {
+			if yyr226 || yy2arr226 {
+				if yyq226[4] {
 					if x.Filesystem == nil {
 						r.EncodeNil()
 					} else {
-						yym243 := z.EncBinary()
-						_ = yym243
+						yym236 := z.EncBinary()
+						_ = yym236
 						if false {
 						} else {
 							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
@@ -2588,13 +2524,13 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq233[4] {
+				if yyq226[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("filesystem"))
 					if x.Filesystem == nil {
 						r.EncodeNil()
 					} else {
-						yym244 := z.EncBinary()
-						_ = yym244
+						yym237 := z.EncBinary()
+						_ = yym237
 						if false {
 						} else {
 							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
@@ -2602,7 +2538,7 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep233 {
+			if yysep226 {
 				r.EncodeEnd()
 			}
 		}
@@ -2613,24 +2549,24 @@ func (x *AggregateSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym245 := z.DecBinary()
-	_ = yym245
+	yym238 := z.DecBinary()
+	_ = yym238
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl246 := r.ReadMapStart()
-			if yyl246 == 0 {
+			yyl239 := r.ReadMapStart()
+			if yyl239 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl246, d)
+				x.codecDecodeSelfFromMap(yyl239, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl246 := r.ReadArrayStart()
-			if yyl246 == 0 {
+			yyl239 := r.ReadArrayStart()
+			if yyl239 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl246, d)
+				x.codecDecodeSelfFromArray(yyl239, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2642,12 +2578,12 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys247Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys247Slc
-	var yyhl247 bool = l >= 0
-	for yyj247 := 0; ; yyj247++ {
-		if yyhl247 {
-			if yyj247 >= l {
+	var yys240Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys240Slc
+	var yyhl240 bool = l >= 0
+	for yyj240 := 0; ; yyj240++ {
+		if yyhl240 {
+			if yyj240 >= l {
 				break
 			}
 		} else {
@@ -2655,24 +2591,24 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys247Slc = r.DecodeBytes(yys247Slc, true, true)
-		yys247 := string(yys247Slc)
-		switch yys247 {
+		yys240Slc = r.DecodeBytes(yys240Slc, true, true)
+		yys240 := string(yys240Slc)
+		switch yys240 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv248 := &x.SampleTime
-				yym249 := z.DecBinary()
-				_ = yym249
+				yyv241 := &x.SampleTime
+				yym242 := z.DecBinary()
+				_ = yym242
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv248) {
-				} else if yym249 {
-					z.DecBinaryUnmarshal(yyv248)
-				} else if !yym249 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv248)
+				} else if z.HasExtensions() && z.DecExt(yyv241) {
+				} else if yym242 {
+					z.DecBinaryUnmarshal(yyv241)
+				} else if !yym242 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv241)
 				} else {
-					z.DecFallback(yyv248, false)
+					z.DecFallback(yyv241, false)
 				}
 			}
 		case "cpu":
@@ -2712,19 +2648,19 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Filesystem = nil
 			} else {
-				yyv253 := &x.Filesystem
-				yym254 := z.DecBinary()
-				_ = yym254
+				yyv246 := &x.Filesystem
+				yym247 := z.DecBinary()
+				_ = yym247
 				if false {
 				} else {
-					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv253), d)
+					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv246), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys247)
-		} // end switch yys247
-	} // end for yyj247
-	if !yyhl247 {
+			z.DecStructFieldNotFound(-1, yys240)
+		} // end switch yys240
+	} // end for yyj240
+	if !yyhl240 {
 		r.ReadEnd()
 	}
 }
@@ -2733,42 +2669,42 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj255 int
-	var yyb255 bool
-	var yyhl255 bool = l >= 0
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	var yyj248 int
+	var yyb248 bool
+	var yyhl248 bool = l >= 0
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv256 := &x.SampleTime
-		yym257 := z.DecBinary()
-		_ = yym257
+		yyv249 := &x.SampleTime
+		yym250 := z.DecBinary()
+		_ = yym250
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv256) {
-		} else if yym257 {
-			z.DecBinaryUnmarshal(yyv256)
-		} else if !yym257 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv256)
+		} else if z.HasExtensions() && z.DecExt(yyv249) {
+		} else if yym250 {
+			z.DecBinaryUnmarshal(yyv249)
+		} else if !yym250 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv249)
 		} else {
-			z.DecFallback(yyv256, false)
+			z.DecFallback(yyv249, false)
 		}
 	}
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
@@ -2782,13 +2718,13 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.CPU.CodecDecodeSelf(d)
 	}
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
@@ -2802,13 +2738,13 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Memory.CodecDecodeSelf(d)
 	}
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
@@ -2822,38 +2758,38 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Network.CodecDecodeSelf(d)
 	}
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Filesystem = nil
 	} else {
-		yyv261 := &x.Filesystem
-		yym262 := z.DecBinary()
-		_ = yym262
+		yyv254 := &x.Filesystem
+		yym255 := z.DecBinary()
+		_ = yym255
 		if false {
 		} else {
-			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv261), d)
+			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv254), d)
 		}
 	}
 	for {
-		yyj255++
-		if yyhl255 {
-			yyb255 = yyj255 > l
+		yyj248++
+		if yyhl248 {
+			yyb248 = yyj248 > l
 		} else {
-			yyb255 = r.CheckBreak()
+			yyb248 = r.CheckBreak()
 		}
-		if yyb255 {
+		if yyb248 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj255-1, "")
+		z.DecStructFieldNotFound(yyj248-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2865,58 +2801,58 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym263 := z.EncBinary()
-		_ = yym263
+		yym256 := z.EncBinary()
+		_ = yym256
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep264 := !z.EncBinary()
-			yy2arr264 := z.EncBasicHandle().StructToArray
-			var yyq264 [2]bool
-			_, _, _ = yysep264, yyq264, yy2arr264
-			const yyr264 bool = false
-			yyq264[1] = x.Network != nil
-			if yyr264 || yy2arr264 {
+			yysep257 := !z.EncBinary()
+			yy2arr257 := z.EncBasicHandle().StructToArray
+			var yyq257 [2]bool
+			_, _, _ = yysep257, yyq257, yy2arr257
+			const yyr257 bool = false
+			yyq257[1] = x.Network != nil
+			if yyr257 || yy2arr257 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn264 int = 1
-				for _, b := range yyq264 {
+				var yynn257 int = 1
+				for _, b := range yyq257 {
 					if b {
-						yynn264++
+						yynn257++
 					}
 				}
-				r.EncodeMapStart(yynn264)
+				r.EncodeMapStart(yynn257)
 			}
-			if yyr264 || yy2arr264 {
-				yy266 := &x.SampleTime
-				yym267 := z.EncBinary()
-				_ = yym267
+			if yyr257 || yy2arr257 {
+				yy259 := &x.SampleTime
+				yym260 := z.EncBinary()
+				_ = yym260
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy266) {
-				} else if yym267 {
-					z.EncBinaryMarshal(yy266)
-				} else if !yym267 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy266)
+				} else if z.HasExtensions() && z.EncExt(yy259) {
+				} else if yym260 {
+					z.EncBinaryMarshal(yy259)
+				} else if !yym260 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy259)
 				} else {
-					z.EncFallback(yy266)
+					z.EncFallback(yy259)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy268 := &x.SampleTime
-				yym269 := z.EncBinary()
-				_ = yym269
+				yy261 := &x.SampleTime
+				yym262 := z.EncBinary()
+				_ = yym262
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy268) {
-				} else if yym269 {
-					z.EncBinaryMarshal(yy268)
-				} else if !yym269 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy268)
+				} else if z.HasExtensions() && z.EncExt(yy261) {
+				} else if yym262 {
+					z.EncBinaryMarshal(yy261)
+				} else if !yym262 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy261)
 				} else {
-					z.EncFallback(yy268)
+					z.EncFallback(yy261)
 				}
 			}
-			if yyr264 || yy2arr264 {
-				if yyq264[1] {
+			if yyr257 || yy2arr257 {
+				if yyq257[1] {
 					if x.Network == nil {
 						r.EncodeNil()
 					} else {
@@ -2926,7 +2862,7 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq264[1] {
+				if yyq257[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("network"))
 					if x.Network == nil {
 						r.EncodeNil()
@@ -2935,7 +2871,7 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep264 {
+			if yysep257 {
 				r.EncodeEnd()
 			}
 		}
@@ -2946,24 +2882,24 @@ func (x *PodSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym271 := z.DecBinary()
-	_ = yym271
+	yym264 := z.DecBinary()
+	_ = yym264
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl272 := r.ReadMapStart()
-			if yyl272 == 0 {
+			yyl265 := r.ReadMapStart()
+			if yyl265 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl272, d)
+				x.codecDecodeSelfFromMap(yyl265, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl272 := r.ReadArrayStart()
-			if yyl272 == 0 {
+			yyl265 := r.ReadArrayStart()
+			if yyl265 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl272, d)
+				x.codecDecodeSelfFromArray(yyl265, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2975,12 +2911,12 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys273Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys273Slc
-	var yyhl273 bool = l >= 0
-	for yyj273 := 0; ; yyj273++ {
-		if yyhl273 {
-			if yyj273 >= l {
+	var yys266Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys266Slc
+	var yyhl266 bool = l >= 0
+	for yyj266 := 0; ; yyj266++ {
+		if yyhl266 {
+			if yyj266 >= l {
 				break
 			}
 		} else {
@@ -2988,24 +2924,24 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys273Slc = r.DecodeBytes(yys273Slc, true, true)
-		yys273 := string(yys273Slc)
-		switch yys273 {
+		yys266Slc = r.DecodeBytes(yys266Slc, true, true)
+		yys266 := string(yys266Slc)
+		switch yys266 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv274 := &x.SampleTime
-				yym275 := z.DecBinary()
-				_ = yym275
+				yyv267 := &x.SampleTime
+				yym268 := z.DecBinary()
+				_ = yym268
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv274) {
-				} else if yym275 {
-					z.DecBinaryUnmarshal(yyv274)
-				} else if !yym275 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv274)
+				} else if z.HasExtensions() && z.DecExt(yyv267) {
+				} else if yym268 {
+					z.DecBinaryUnmarshal(yyv267)
+				} else if !yym268 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv267)
 				} else {
-					z.DecFallback(yyv274, false)
+					z.DecFallback(yyv267, false)
 				}
 			}
 		case "network":
@@ -3020,10 +2956,10 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Network.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys273)
-		} // end switch yys273
-	} // end for yyj273
-	if !yyhl273 {
+			z.DecStructFieldNotFound(-1, yys266)
+		} // end switch yys266
+	} // end for yyj266
+	if !yyhl266 {
 		r.ReadEnd()
 	}
 }
@@ -3032,42 +2968,42 @@ func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj277 int
-	var yyb277 bool
-	var yyhl277 bool = l >= 0
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	var yyj270 int
+	var yyb270 bool
+	var yyhl270 bool = l >= 0
+	yyj270++
+	if yyhl270 {
+		yyb270 = yyj270 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb270 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb270 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv278 := &x.SampleTime
-		yym279 := z.DecBinary()
-		_ = yym279
+		yyv271 := &x.SampleTime
+		yym272 := z.DecBinary()
+		_ = yym272
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv278) {
-		} else if yym279 {
-			z.DecBinaryUnmarshal(yyv278)
-		} else if !yym279 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv278)
+		} else if z.HasExtensions() && z.DecExt(yyv271) {
+		} else if yym272 {
+			z.DecBinaryUnmarshal(yyv271)
+		} else if !yym272 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv271)
 		} else {
-			z.DecFallback(yyv278, false)
+			z.DecFallback(yyv271, false)
 		}
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj270++
+	if yyhl270 {
+		yyb270 = yyj270 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb270 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb270 {
 		r.ReadEnd()
 		return
 	}
@@ -3082,16 +3018,16 @@ func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Network.CodecDecodeSelf(d)
 	}
 	for {
-		yyj277++
-		if yyhl277 {
-			yyb277 = yyj277 > l
+		yyj270++
+		if yyhl270 {
+			yyb270 = yyj270 > l
 		} else {
-			yyb277 = r.CheckBreak()
+			yyb270 = r.CheckBreak()
 		}
-		if yyb277 {
+		if yyb270 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj277-1, "")
+		z.DecStructFieldNotFound(yyj270-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3103,60 +3039,60 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym281 := z.EncBinary()
-		_ = yym281
+		yym274 := z.EncBinary()
+		_ = yym274
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep282 := !z.EncBinary()
-			yy2arr282 := z.EncBasicHandle().StructToArray
-			var yyq282 [4]bool
-			_, _, _ = yysep282, yyq282, yy2arr282
-			const yyr282 bool = false
-			yyq282[1] = x.CPU != nil
-			yyq282[2] = x.Memory != nil
-			yyq282[3] = len(x.Filesystem) != 0
-			if yyr282 || yy2arr282 {
+			yysep275 := !z.EncBinary()
+			yy2arr275 := z.EncBasicHandle().StructToArray
+			var yyq275 [4]bool
+			_, _, _ = yysep275, yyq275, yy2arr275
+			const yyr275 bool = false
+			yyq275[1] = x.CPU != nil
+			yyq275[2] = x.Memory != nil
+			yyq275[3] = len(x.Filesystem) != 0
+			if yyr275 || yy2arr275 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn282 int = 1
-				for _, b := range yyq282 {
+				var yynn275 int = 1
+				for _, b := range yyq275 {
 					if b {
-						yynn282++
+						yynn275++
 					}
 				}
-				r.EncodeMapStart(yynn282)
+				r.EncodeMapStart(yynn275)
 			}
-			if yyr282 || yy2arr282 {
-				yy284 := &x.SampleTime
-				yym285 := z.EncBinary()
-				_ = yym285
+			if yyr275 || yy2arr275 {
+				yy277 := &x.SampleTime
+				yym278 := z.EncBinary()
+				_ = yym278
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy284) {
-				} else if yym285 {
-					z.EncBinaryMarshal(yy284)
-				} else if !yym285 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy284)
+				} else if z.HasExtensions() && z.EncExt(yy277) {
+				} else if yym278 {
+					z.EncBinaryMarshal(yy277)
+				} else if !yym278 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy277)
 				} else {
-					z.EncFallback(yy284)
+					z.EncFallback(yy277)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy286 := &x.SampleTime
-				yym287 := z.EncBinary()
-				_ = yym287
+				yy279 := &x.SampleTime
+				yym280 := z.EncBinary()
+				_ = yym280
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy286) {
-				} else if yym287 {
-					z.EncBinaryMarshal(yy286)
-				} else if !yym287 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy286)
+				} else if z.HasExtensions() && z.EncExt(yy279) {
+				} else if yym280 {
+					z.EncBinaryMarshal(yy279)
+				} else if !yym280 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy279)
 				} else {
-					z.EncFallback(yy286)
+					z.EncFallback(yy279)
 				}
 			}
-			if yyr282 || yy2arr282 {
-				if yyq282[1] {
+			if yyr275 || yy2arr275 {
+				if yyq275[1] {
 					if x.CPU == nil {
 						r.EncodeNil()
 					} else {
@@ -3166,7 +3102,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq282[1] {
+				if yyq275[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
 					if x.CPU == nil {
 						r.EncodeNil()
@@ -3175,8 +3111,8 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr282 || yy2arr282 {
-				if yyq282[2] {
+			if yyr275 || yy2arr275 {
+				if yyq275[2] {
 					if x.Memory == nil {
 						r.EncodeNil()
 					} else {
@@ -3186,7 +3122,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq282[2] {
+				if yyq275[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("memory"))
 					if x.Memory == nil {
 						r.EncodeNil()
@@ -3195,13 +3131,13 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr282 || yy2arr282 {
-				if yyq282[3] {
+			if yyr275 || yy2arr275 {
+				if yyq275[3] {
 					if x.Filesystem == nil {
 						r.EncodeNil()
 					} else {
-						yym291 := z.EncBinary()
-						_ = yym291
+						yym284 := z.EncBinary()
+						_ = yym284
 						if false {
 						} else {
 							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
@@ -3211,13 +3147,13 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq282[3] {
+				if yyq275[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("filesystem"))
 					if x.Filesystem == nil {
 						r.EncodeNil()
 					} else {
-						yym292 := z.EncBinary()
-						_ = yym292
+						yym285 := z.EncBinary()
+						_ = yym285
 						if false {
 						} else {
 							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
@@ -3225,7 +3161,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep282 {
+			if yysep275 {
 				r.EncodeEnd()
 			}
 		}
@@ -3236,24 +3172,24 @@ func (x *ContainerSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym293 := z.DecBinary()
-	_ = yym293
+	yym286 := z.DecBinary()
+	_ = yym286
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl294 := r.ReadMapStart()
-			if yyl294 == 0 {
+			yyl287 := r.ReadMapStart()
+			if yyl287 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl294, d)
+				x.codecDecodeSelfFromMap(yyl287, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl294 := r.ReadArrayStart()
-			if yyl294 == 0 {
+			yyl287 := r.ReadArrayStart()
+			if yyl287 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl294, d)
+				x.codecDecodeSelfFromArray(yyl287, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3265,12 +3201,12 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys295Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys295Slc
-	var yyhl295 bool = l >= 0
-	for yyj295 := 0; ; yyj295++ {
-		if yyhl295 {
-			if yyj295 >= l {
+	var yys288Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys288Slc
+	var yyhl288 bool = l >= 0
+	for yyj288 := 0; ; yyj288++ {
+		if yyhl288 {
+			if yyj288 >= l {
 				break
 			}
 		} else {
@@ -3278,24 +3214,24 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys295Slc = r.DecodeBytes(yys295Slc, true, true)
-		yys295 := string(yys295Slc)
-		switch yys295 {
+		yys288Slc = r.DecodeBytes(yys288Slc, true, true)
+		yys288 := string(yys288Slc)
+		switch yys288 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv296 := &x.SampleTime
-				yym297 := z.DecBinary()
-				_ = yym297
+				yyv289 := &x.SampleTime
+				yym290 := z.DecBinary()
+				_ = yym290
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv296) {
-				} else if yym297 {
-					z.DecBinaryUnmarshal(yyv296)
-				} else if !yym297 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv296)
+				} else if z.HasExtensions() && z.DecExt(yyv289) {
+				} else if yym290 {
+					z.DecBinaryUnmarshal(yyv289)
+				} else if !yym290 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv289)
 				} else {
-					z.DecFallback(yyv296, false)
+					z.DecFallback(yyv289, false)
 				}
 			}
 		case "cpu":
@@ -3324,19 +3260,19 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Filesystem = nil
 			} else {
-				yyv300 := &x.Filesystem
-				yym301 := z.DecBinary()
-				_ = yym301
+				yyv293 := &x.Filesystem
+				yym294 := z.DecBinary()
+				_ = yym294
 				if false {
 				} else {
-					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv300), d)
+					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv293), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys295)
-		} // end switch yys295
-	} // end for yyj295
-	if !yyhl295 {
+			z.DecStructFieldNotFound(-1, yys288)
+		} // end switch yys288
+	} // end for yyj288
+	if !yyhl288 {
 		r.ReadEnd()
 	}
 }
@@ -3345,42 +3281,42 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj302 int
-	var yyb302 bool
-	var yyhl302 bool = l >= 0
-	yyj302++
-	if yyhl302 {
-		yyb302 = yyj302 > l
+	var yyj295 int
+	var yyb295 bool
+	var yyhl295 bool = l >= 0
+	yyj295++
+	if yyhl295 {
+		yyb295 = yyj295 > l
 	} else {
-		yyb302 = r.CheckBreak()
+		yyb295 = r.CheckBreak()
 	}
-	if yyb302 {
+	if yyb295 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv303 := &x.SampleTime
-		yym304 := z.DecBinary()
-		_ = yym304
+		yyv296 := &x.SampleTime
+		yym297 := z.DecBinary()
+		_ = yym297
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv303) {
-		} else if yym304 {
-			z.DecBinaryUnmarshal(yyv303)
-		} else if !yym304 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv303)
+		} else if z.HasExtensions() && z.DecExt(yyv296) {
+		} else if yym297 {
+			z.DecBinaryUnmarshal(yyv296)
+		} else if !yym297 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv296)
 		} else {
-			z.DecFallback(yyv303, false)
+			z.DecFallback(yyv296, false)
 		}
 	}
-	yyj302++
-	if yyhl302 {
-		yyb302 = yyj302 > l
+	yyj295++
+	if yyhl295 {
+		yyb295 = yyj295 > l
 	} else {
-		yyb302 = r.CheckBreak()
+		yyb295 = r.CheckBreak()
 	}
-	if yyb302 {
+	if yyb295 {
 		r.ReadEnd()
 		return
 	}
@@ -3394,13 +3330,13 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.CPU.CodecDecodeSelf(d)
 	}
-	yyj302++
-	if yyhl302 {
-		yyb302 = yyj302 > l
+	yyj295++
+	if yyhl295 {
+		yyb295 = yyj295 > l
 	} else {
-		yyb302 = r.CheckBreak()
+		yyb295 = r.CheckBreak()
 	}
-	if yyb302 {
+	if yyb295 {
 		r.ReadEnd()
 		return
 	}
@@ -3414,38 +3350,38 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Memory.CodecDecodeSelf(d)
 	}
-	yyj302++
-	if yyhl302 {
-		yyb302 = yyj302 > l
+	yyj295++
+	if yyhl295 {
+		yyb295 = yyj295 > l
 	} else {
-		yyb302 = r.CheckBreak()
+		yyb295 = r.CheckBreak()
 	}
-	if yyb302 {
+	if yyb295 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Filesystem = nil
 	} else {
-		yyv307 := &x.Filesystem
-		yym308 := z.DecBinary()
-		_ = yym308
+		yyv300 := &x.Filesystem
+		yym301 := z.DecBinary()
+		_ = yym301
 		if false {
 		} else {
-			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv307), d)
+			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv300), d)
 		}
 	}
 	for {
-		yyj302++
-		if yyhl302 {
-			yyb302 = yyj302 > l
+		yyj295++
+		if yyhl295 {
+			yyb295 = yyj295 > l
 		} else {
-			yyb302 = r.CheckBreak()
+			yyb295 = r.CheckBreak()
 		}
-		if yyb302 {
+		if yyb295 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj302-1, "")
+		z.DecStructFieldNotFound(yyj295-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3457,41 +3393,41 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym309 := z.EncBinary()
-		_ = yym309
+		yym302 := z.EncBinary()
+		_ = yym302
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep310 := !z.EncBinary()
-			yy2arr310 := z.EncBasicHandle().StructToArray
-			var yyq310 [4]bool
-			_, _, _ = yysep310, yyq310, yy2arr310
-			const yyr310 bool = false
-			yyq310[0] = x.RxBytes != nil
-			yyq310[1] = x.RxErrors != nil
-			yyq310[2] = x.TxBytes != nil
-			yyq310[3] = x.TxErrors != nil
-			if yyr310 || yy2arr310 {
+			yysep303 := !z.EncBinary()
+			yy2arr303 := z.EncBasicHandle().StructToArray
+			var yyq303 [4]bool
+			_, _, _ = yysep303, yyq303, yy2arr303
+			const yyr303 bool = false
+			yyq303[0] = x.RxBytes != nil
+			yyq303[1] = x.RxErrors != nil
+			yyq303[2] = x.TxBytes != nil
+			yyq303[3] = x.TxErrors != nil
+			if yyr303 || yy2arr303 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn310 int = 0
-				for _, b := range yyq310 {
+				var yynn303 int = 0
+				for _, b := range yyq303 {
 					if b {
-						yynn310++
+						yynn303++
 					}
 				}
-				r.EncodeMapStart(yynn310)
+				r.EncodeMapStart(yynn303)
 			}
-			if yyr310 || yy2arr310 {
-				if yyq310[0] {
+			if yyr303 || yy2arr303 {
+				if yyq303[0] {
 					if x.RxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym312 := z.EncBinary()
-						_ = yym312
+						yym305 := z.EncBinary()
+						_ = yym305
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
-						} else if !yym312 && z.IsJSONHandle() {
+						} else if !yym305 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.RxBytes)
 						} else {
 							z.EncFallback(x.RxBytes)
@@ -3501,65 +3437,65 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq310[0] {
+				if yyq303[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("rxBytes"))
 					if x.RxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym306 := z.EncBinary()
+						_ = yym306
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
+						} else if !yym306 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.RxBytes)
+						} else {
+							z.EncFallback(x.RxBytes)
+						}
+					}
+				}
+			}
+			if yyr303 || yy2arr303 {
+				if yyq303[1] {
+					if x.RxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy308 := *x.RxErrors
+						yym309 := z.EncBinary()
+						_ = yym309
+						if false {
+						} else {
+							r.EncodeInt(int64(yy308))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq303[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("rxErrors"))
+					if x.RxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy310 := *x.RxErrors
+						yym311 := z.EncBinary()
+						_ = yym311
+						if false {
+						} else {
+							r.EncodeInt(int64(yy310))
+						}
+					}
+				}
+			}
+			if yyr303 || yy2arr303 {
+				if yyq303[2] {
+					if x.TxBytes == nil {
 						r.EncodeNil()
 					} else {
 						yym313 := z.EncBinary()
 						_ = yym313
 						if false {
-						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
-						} else if !yym313 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.RxBytes)
-						} else {
-							z.EncFallback(x.RxBytes)
-						}
-					}
-				}
-			}
-			if yyr310 || yy2arr310 {
-				if yyq310[1] {
-					if x.RxErrors == nil {
-						r.EncodeNil()
-					} else {
-						yy315 := *x.RxErrors
-						yym316 := z.EncBinary()
-						_ = yym316
-						if false {
-						} else {
-							r.EncodeInt(int64(yy315))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq310[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("rxErrors"))
-					if x.RxErrors == nil {
-						r.EncodeNil()
-					} else {
-						yy317 := *x.RxErrors
-						yym318 := z.EncBinary()
-						_ = yym318
-						if false {
-						} else {
-							r.EncodeInt(int64(yy317))
-						}
-					}
-				}
-			}
-			if yyr310 || yy2arr310 {
-				if yyq310[2] {
-					if x.TxBytes == nil {
-						r.EncodeNil()
-					} else {
-						yym320 := z.EncBinary()
-						_ = yym320
-						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
-						} else if !yym320 && z.IsJSONHandle() {
+						} else if !yym313 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TxBytes)
 						} else {
 							z.EncFallback(x.TxBytes)
@@ -3569,16 +3505,16 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq310[2] {
+				if yyq303[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("txBytes"))
 					if x.TxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym321 := z.EncBinary()
-						_ = yym321
+						yym314 := z.EncBinary()
+						_ = yym314
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
-						} else if !yym321 && z.IsJSONHandle() {
+						} else if !yym314 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TxBytes)
 						} else {
 							z.EncFallback(x.TxBytes)
@@ -3586,39 +3522,39 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr310 || yy2arr310 {
-				if yyq310[3] {
+			if yyr303 || yy2arr303 {
+				if yyq303[3] {
 					if x.TxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy323 := *x.TxErrors
-						yym324 := z.EncBinary()
-						_ = yym324
+						yy316 := *x.TxErrors
+						yym317 := z.EncBinary()
+						_ = yym317
 						if false {
 						} else {
-							r.EncodeInt(int64(yy323))
+							r.EncodeInt(int64(yy316))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq310[3] {
+				if yyq303[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("txErrors"))
 					if x.TxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy325 := *x.TxErrors
-						yym326 := z.EncBinary()
-						_ = yym326
+						yy318 := *x.TxErrors
+						yym319 := z.EncBinary()
+						_ = yym319
 						if false {
 						} else {
-							r.EncodeInt(int64(yy325))
+							r.EncodeInt(int64(yy318))
 						}
 					}
 				}
 			}
-			if yysep310 {
+			if yysep303 {
 				r.EncodeEnd()
 			}
 		}
@@ -3629,24 +3565,24 @@ func (x *NetworkMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym327 := z.DecBinary()
-	_ = yym327
+	yym320 := z.DecBinary()
+	_ = yym320
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl328 := r.ReadMapStart()
-			if yyl328 == 0 {
+			yyl321 := r.ReadMapStart()
+			if yyl321 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl328, d)
+				x.codecDecodeSelfFromMap(yyl321, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl328 := r.ReadArrayStart()
-			if yyl328 == 0 {
+			yyl321 := r.ReadArrayStart()
+			if yyl321 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl328, d)
+				x.codecDecodeSelfFromArray(yyl321, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3658,12 +3594,12 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys329Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys329Slc
-	var yyhl329 bool = l >= 0
-	for yyj329 := 0; ; yyj329++ {
-		if yyhl329 {
-			if yyj329 >= l {
+	var yys322Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys322Slc
+	var yyhl322 bool = l >= 0
+	for yyj322 := 0; ; yyj322++ {
+		if yyhl322 {
+			if yyj322 >= l {
 				break
 			}
 		} else {
@@ -3671,9 +3607,9 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys329Slc = r.DecodeBytes(yys329Slc, true, true)
-		yys329 := string(yys329Slc)
-		switch yys329 {
+		yys322Slc = r.DecodeBytes(yys322Slc, true, true)
+		yys322 := string(yys322Slc)
+		switch yys322 {
 		case "rxBytes":
 			if r.TryDecodeAsNil() {
 				if x.RxBytes != nil {
@@ -3683,11 +3619,11 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RxBytes == nil {
 					x.RxBytes = new(pkg2_resource.Quantity)
 				}
-				yym331 := z.DecBinary()
-				_ = yym331
+				yym324 := z.DecBinary()
+				_ = yym324
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
-				} else if !yym331 && z.IsJSONHandle() {
+				} else if !yym324 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.RxBytes)
 				} else {
 					z.DecFallback(x.RxBytes, false)
@@ -3702,8 +3638,8 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RxErrors == nil {
 					x.RxErrors = new(int64)
 				}
-				yym333 := z.DecBinary()
-				_ = yym333
+				yym326 := z.DecBinary()
+				_ = yym326
 				if false {
 				} else {
 					*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
@@ -3718,11 +3654,11 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TxBytes == nil {
 					x.TxBytes = new(pkg2_resource.Quantity)
 				}
-				yym335 := z.DecBinary()
-				_ = yym335
+				yym328 := z.DecBinary()
+				_ = yym328
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
-				} else if !yym335 && z.IsJSONHandle() {
+				} else if !yym328 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TxBytes)
 				} else {
 					z.DecFallback(x.TxBytes, false)
@@ -3737,18 +3673,18 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TxErrors == nil {
 					x.TxErrors = new(int64)
 				}
-				yym337 := z.DecBinary()
-				_ = yym337
+				yym330 := z.DecBinary()
+				_ = yym330
 				if false {
 				} else {
 					*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys329)
-		} // end switch yys329
-	} // end for yyj329
-	if !yyhl329 {
+			z.DecStructFieldNotFound(-1, yys322)
+		} // end switch yys322
+	} // end for yyj322
+	if !yyhl322 {
 		r.ReadEnd()
 	}
 }
@@ -3757,16 +3693,16 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj338 int
-	var yyb338 bool
-	var yyhl338 bool = l >= 0
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
+	var yyj331 int
+	var yyb331 bool
+	var yyhl331 bool = l >= 0
+	yyj331++
+	if yyhl331 {
+		yyb331 = yyj331 > l
 	} else {
-		yyb338 = r.CheckBreak()
+		yyb331 = r.CheckBreak()
 	}
-	if yyb338 {
+	if yyb331 {
 		r.ReadEnd()
 		return
 	}
@@ -3778,23 +3714,23 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RxBytes == nil {
 			x.RxBytes = new(pkg2_resource.Quantity)
 		}
-		yym340 := z.DecBinary()
-		_ = yym340
+		yym333 := z.DecBinary()
+		_ = yym333
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
-		} else if !yym340 && z.IsJSONHandle() {
+		} else if !yym333 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.RxBytes)
 		} else {
 			z.DecFallback(x.RxBytes, false)
 		}
 	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
+	yyj331++
+	if yyhl331 {
+		yyb331 = yyj331 > l
 	} else {
-		yyb338 = r.CheckBreak()
+		yyb331 = r.CheckBreak()
 	}
-	if yyb338 {
+	if yyb331 {
 		r.ReadEnd()
 		return
 	}
@@ -3806,20 +3742,20 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RxErrors == nil {
 			x.RxErrors = new(int64)
 		}
-		yym342 := z.DecBinary()
-		_ = yym342
+		yym335 := z.DecBinary()
+		_ = yym335
 		if false {
 		} else {
 			*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
+	yyj331++
+	if yyhl331 {
+		yyb331 = yyj331 > l
 	} else {
-		yyb338 = r.CheckBreak()
+		yyb331 = r.CheckBreak()
 	}
-	if yyb338 {
+	if yyb331 {
 		r.ReadEnd()
 		return
 	}
@@ -3831,23 +3767,23 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TxBytes == nil {
 			x.TxBytes = new(pkg2_resource.Quantity)
 		}
-		yym344 := z.DecBinary()
-		_ = yym344
+		yym337 := z.DecBinary()
+		_ = yym337
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
-		} else if !yym344 && z.IsJSONHandle() {
+		} else if !yym337 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TxBytes)
 		} else {
 			z.DecFallback(x.TxBytes, false)
 		}
 	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
+	yyj331++
+	if yyhl331 {
+		yyb331 = yyj331 > l
 	} else {
-		yyb338 = r.CheckBreak()
+		yyb331 = r.CheckBreak()
 	}
-	if yyb338 {
+	if yyb331 {
 		r.ReadEnd()
 		return
 	}
@@ -3859,24 +3795,24 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TxErrors == nil {
 			x.TxErrors = new(int64)
 		}
-		yym346 := z.DecBinary()
-		_ = yym346
+		yym339 := z.DecBinary()
+		_ = yym339
 		if false {
 		} else {
 			*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj338++
-		if yyhl338 {
-			yyb338 = yyj338 > l
+		yyj331++
+		if yyhl331 {
+			yyb331 = yyj331 > l
 		} else {
-			yyb338 = r.CheckBreak()
+			yyb331 = r.CheckBreak()
 		}
-		if yyb338 {
+		if yyb331 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj338-1, "")
+		z.DecStructFieldNotFound(yyj331-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3888,38 +3824,38 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym347 := z.EncBinary()
-		_ = yym347
+		yym340 := z.EncBinary()
+		_ = yym340
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep348 := !z.EncBinary()
-			yy2arr348 := z.EncBasicHandle().StructToArray
-			var yyq348 [1]bool
-			_, _, _ = yysep348, yyq348, yy2arr348
-			const yyr348 bool = false
-			yyq348[0] = x.TotalCores != nil
-			if yyr348 || yy2arr348 {
+			yysep341 := !z.EncBinary()
+			yy2arr341 := z.EncBasicHandle().StructToArray
+			var yyq341 [1]bool
+			_, _, _ = yysep341, yyq341, yy2arr341
+			const yyr341 bool = false
+			yyq341[0] = x.TotalCores != nil
+			if yyr341 || yy2arr341 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn348 int = 0
-				for _, b := range yyq348 {
+				var yynn341 int = 0
+				for _, b := range yyq341 {
 					if b {
-						yynn348++
+						yynn341++
 					}
 				}
-				r.EncodeMapStart(yynn348)
+				r.EncodeMapStart(yynn341)
 			}
-			if yyr348 || yy2arr348 {
-				if yyq348[0] {
+			if yyr341 || yy2arr341 {
+				if yyq341[0] {
 					if x.TotalCores == nil {
 						r.EncodeNil()
 					} else {
-						yym350 := z.EncBinary()
-						_ = yym350
+						yym343 := z.EncBinary()
+						_ = yym343
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
-						} else if !yym350 && z.IsJSONHandle() {
+						} else if !yym343 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalCores)
 						} else {
 							z.EncFallback(x.TotalCores)
@@ -3929,16 +3865,16 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq348[0] {
+				if yyq341[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalCores"))
 					if x.TotalCores == nil {
 						r.EncodeNil()
 					} else {
-						yym351 := z.EncBinary()
-						_ = yym351
+						yym344 := z.EncBinary()
+						_ = yym344
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
-						} else if !yym351 && z.IsJSONHandle() {
+						} else if !yym344 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalCores)
 						} else {
 							z.EncFallback(x.TotalCores)
@@ -3946,7 +3882,7 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep348 {
+			if yysep341 {
 				r.EncodeEnd()
 			}
 		}
@@ -3957,24 +3893,24 @@ func (x *CPUMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym352 := z.DecBinary()
-	_ = yym352
+	yym345 := z.DecBinary()
+	_ = yym345
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl353 := r.ReadMapStart()
-			if yyl353 == 0 {
+			yyl346 := r.ReadMapStart()
+			if yyl346 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl353, d)
+				x.codecDecodeSelfFromMap(yyl346, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl353 := r.ReadArrayStart()
-			if yyl353 == 0 {
+			yyl346 := r.ReadArrayStart()
+			if yyl346 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl353, d)
+				x.codecDecodeSelfFromArray(yyl346, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3986,12 +3922,12 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys354Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys354Slc
-	var yyhl354 bool = l >= 0
-	for yyj354 := 0; ; yyj354++ {
-		if yyhl354 {
-			if yyj354 >= l {
+	var yys347Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys347Slc
+	var yyhl347 bool = l >= 0
+	for yyj347 := 0; ; yyj347++ {
+		if yyhl347 {
+			if yyj347 >= l {
 				break
 			}
 		} else {
@@ -3999,9 +3935,9 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys354Slc = r.DecodeBytes(yys354Slc, true, true)
-		yys354 := string(yys354Slc)
-		switch yys354 {
+		yys347Slc = r.DecodeBytes(yys347Slc, true, true)
+		yys347 := string(yys347Slc)
+		switch yys347 {
 		case "totalCores":
 			if r.TryDecodeAsNil() {
 				if x.TotalCores != nil {
@@ -4011,21 +3947,21 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalCores == nil {
 					x.TotalCores = new(pkg2_resource.Quantity)
 				}
-				yym356 := z.DecBinary()
-				_ = yym356
+				yym349 := z.DecBinary()
+				_ = yym349
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-				} else if !yym356 && z.IsJSONHandle() {
+				} else if !yym349 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalCores)
 				} else {
 					z.DecFallback(x.TotalCores, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys354)
-		} // end switch yys354
-	} // end for yyj354
-	if !yyhl354 {
+			z.DecStructFieldNotFound(-1, yys347)
+		} // end switch yys347
+	} // end for yyj347
+	if !yyhl347 {
 		r.ReadEnd()
 	}
 }
@@ -4034,16 +3970,16 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj357 int
-	var yyb357 bool
-	var yyhl357 bool = l >= 0
-	yyj357++
-	if yyhl357 {
-		yyb357 = yyj357 > l
+	var yyj350 int
+	var yyb350 bool
+	var yyhl350 bool = l >= 0
+	yyj350++
+	if yyhl350 {
+		yyb350 = yyj350 > l
 	} else {
-		yyb357 = r.CheckBreak()
+		yyb350 = r.CheckBreak()
 	}
-	if yyb357 {
+	if yyb350 {
 		r.ReadEnd()
 		return
 	}
@@ -4055,27 +3991,27 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalCores == nil {
 			x.TotalCores = new(pkg2_resource.Quantity)
 		}
-		yym359 := z.DecBinary()
-		_ = yym359
+		yym352 := z.DecBinary()
+		_ = yym352
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-		} else if !yym359 && z.IsJSONHandle() {
+		} else if !yym352 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalCores)
 		} else {
 			z.DecFallback(x.TotalCores, false)
 		}
 	}
 	for {
-		yyj357++
-		if yyhl357 {
-			yyb357 = yyj357 > l
+		yyj350++
+		if yyhl350 {
+			yyb350 = yyj350 > l
 		} else {
-			yyb357 = r.CheckBreak()
+			yyb350 = r.CheckBreak()
 		}
-		if yyb357 {
+		if yyb350 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj357-1, "")
+		z.DecStructFieldNotFound(yyj350-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4087,41 +4023,41 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym360 := z.EncBinary()
-		_ = yym360
+		yym353 := z.EncBinary()
+		_ = yym353
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep361 := !z.EncBinary()
-			yy2arr361 := z.EncBasicHandle().StructToArray
-			var yyq361 [4]bool
-			_, _, _ = yysep361, yyq361, yy2arr361
-			const yyr361 bool = false
-			yyq361[0] = x.TotalBytes != nil
-			yyq361[1] = x.UsageBytes != nil
-			yyq361[2] = x.PageFaults != nil
-			yyq361[3] = x.MajorPageFaults != nil
-			if yyr361 || yy2arr361 {
+			yysep354 := !z.EncBinary()
+			yy2arr354 := z.EncBasicHandle().StructToArray
+			var yyq354 [4]bool
+			_, _, _ = yysep354, yyq354, yy2arr354
+			const yyr354 bool = false
+			yyq354[0] = x.TotalBytes != nil
+			yyq354[1] = x.UsageBytes != nil
+			yyq354[2] = x.PageFaults != nil
+			yyq354[3] = x.MajorPageFaults != nil
+			if yyr354 || yy2arr354 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn361 int = 0
-				for _, b := range yyq361 {
+				var yynn354 int = 0
+				for _, b := range yyq354 {
 					if b {
-						yynn361++
+						yynn354++
 					}
 				}
-				r.EncodeMapStart(yynn361)
+				r.EncodeMapStart(yynn354)
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[0] {
+			if yyr354 || yy2arr354 {
+				if yyq354[0] {
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym363 := z.EncBinary()
-						_ = yym363
+						yym356 := z.EncBinary()
+						_ = yym356
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym363 && z.IsJSONHandle() {
+						} else if !yym356 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4131,16 +4067,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[0] {
+				if yyq354[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalBytes"))
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym364 := z.EncBinary()
-						_ = yym364
+						yym357 := z.EncBinary()
+						_ = yym357
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym364 && z.IsJSONHandle() {
+						} else if !yym357 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4148,16 +4084,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[1] {
+			if yyr354 || yy2arr354 {
+				if yyq354[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym366 := z.EncBinary()
-						_ = yym366
+						yym359 := z.EncBinary()
+						_ = yym359
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym366 && z.IsJSONHandle() {
+						} else if !yym359 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4167,16 +4103,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[1] {
+				if yyq354[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym367 := z.EncBinary()
-						_ = yym367
+						yym360 := z.EncBinary()
+						_ = yym360
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym367 && z.IsJSONHandle() {
+						} else if !yym360 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4184,12 +4120,61 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[2] {
+			if yyr354 || yy2arr354 {
+				if yyq354[2] {
 					if x.PageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy369 := *x.PageFaults
+						yy362 := *x.PageFaults
+						yym363 := z.EncBinary()
+						_ = yym363
+						if false {
+						} else {
+							r.EncodeInt(int64(yy362))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
+					if x.PageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy364 := *x.PageFaults
+						yym365 := z.EncBinary()
+						_ = yym365
+						if false {
+						} else {
+							r.EncodeInt(int64(yy364))
+						}
+					}
+				}
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[3] {
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy367 := *x.MajorPageFaults
+						yym368 := z.EncBinary()
+						_ = yym368
+						if false {
+						} else {
+							r.EncodeInt(int64(yy367))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy369 := *x.MajorPageFaults
 						yym370 := z.EncBinary()
 						_ = yym370
 						if false {
@@ -4197,58 +4182,9 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 							r.EncodeInt(int64(yy369))
 						}
 					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq361[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
-					if x.PageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy371 := *x.PageFaults
-						yym372 := z.EncBinary()
-						_ = yym372
-						if false {
-						} else {
-							r.EncodeInt(int64(yy371))
-						}
-					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[3] {
-					if x.MajorPageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy374 := *x.MajorPageFaults
-						yym375 := z.EncBinary()
-						_ = yym375
-						if false {
-						} else {
-							r.EncodeInt(int64(yy374))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq361[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
-					if x.MajorPageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy376 := *x.MajorPageFaults
-						yym377 := z.EncBinary()
-						_ = yym377
-						if false {
-						} else {
-							r.EncodeInt(int64(yy376))
-						}
-					}
-				}
-			}
-			if yysep361 {
+			if yysep354 {
 				r.EncodeEnd()
 			}
 		}
@@ -4259,24 +4195,24 @@ func (x *MemoryMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym378 := z.DecBinary()
-	_ = yym378
+	yym371 := z.DecBinary()
+	_ = yym371
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl379 := r.ReadMapStart()
-			if yyl379 == 0 {
+			yyl372 := r.ReadMapStart()
+			if yyl372 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl379, d)
+				x.codecDecodeSelfFromMap(yyl372, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl379 := r.ReadArrayStart()
-			if yyl379 == 0 {
+			yyl372 := r.ReadArrayStart()
+			if yyl372 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl379, d)
+				x.codecDecodeSelfFromArray(yyl372, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4288,12 +4224,12 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys380Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys380Slc
-	var yyhl380 bool = l >= 0
-	for yyj380 := 0; ; yyj380++ {
-		if yyhl380 {
-			if yyj380 >= l {
+	var yys373Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys373Slc
+	var yyhl373 bool = l >= 0
+	for yyj373 := 0; ; yyj373++ {
+		if yyhl373 {
+			if yyj373 >= l {
 				break
 			}
 		} else {
@@ -4301,9 +4237,9 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys380Slc = r.DecodeBytes(yys380Slc, true, true)
-		yys380 := string(yys380Slc)
-		switch yys380 {
+		yys373Slc = r.DecodeBytes(yys373Slc, true, true)
+		yys373 := string(yys373Slc)
+		switch yys373 {
 		case "totalBytes":
 			if r.TryDecodeAsNil() {
 				if x.TotalBytes != nil {
@@ -4313,11 +4249,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalBytes == nil {
 					x.TotalBytes = new(pkg2_resource.Quantity)
 				}
-				yym382 := z.DecBinary()
-				_ = yym382
+				yym375 := z.DecBinary()
+				_ = yym375
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-				} else if !yym382 && z.IsJSONHandle() {
+				} else if !yym375 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalBytes)
 				} else {
 					z.DecFallback(x.TotalBytes, false)
@@ -4332,11 +4268,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym384 := z.DecBinary()
-				_ = yym384
+				yym377 := z.DecBinary()
+				_ = yym377
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym384 && z.IsJSONHandle() {
+				} else if !yym377 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4351,8 +4287,8 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.PageFaults == nil {
 					x.PageFaults = new(int64)
 				}
-				yym386 := z.DecBinary()
-				_ = yym386
+				yym379 := z.DecBinary()
+				_ = yym379
 				if false {
 				} else {
 					*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
@@ -4367,18 +4303,18 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.MajorPageFaults == nil {
 					x.MajorPageFaults = new(int64)
 				}
-				yym388 := z.DecBinary()
-				_ = yym388
+				yym381 := z.DecBinary()
+				_ = yym381
 				if false {
 				} else {
 					*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys380)
-		} // end switch yys380
-	} // end for yyj380
-	if !yyhl380 {
+			z.DecStructFieldNotFound(-1, yys373)
+		} // end switch yys373
+	} // end for yyj373
+	if !yyhl373 {
 		r.ReadEnd()
 	}
 }
@@ -4387,16 +4323,16 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj389 int
-	var yyb389 bool
-	var yyhl389 bool = l >= 0
-	yyj389++
-	if yyhl389 {
-		yyb389 = yyj389 > l
+	var yyj382 int
+	var yyb382 bool
+	var yyhl382 bool = l >= 0
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
 	} else {
-		yyb389 = r.CheckBreak()
+		yyb382 = r.CheckBreak()
 	}
-	if yyb389 {
+	if yyb382 {
 		r.ReadEnd()
 		return
 	}
@@ -4408,23 +4344,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalBytes == nil {
 			x.TotalBytes = new(pkg2_resource.Quantity)
 		}
-		yym391 := z.DecBinary()
-		_ = yym391
+		yym384 := z.DecBinary()
+		_ = yym384
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-		} else if !yym391 && z.IsJSONHandle() {
+		} else if !yym384 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalBytes)
 		} else {
 			z.DecFallback(x.TotalBytes, false)
 		}
 	}
-	yyj389++
-	if yyhl389 {
-		yyb389 = yyj389 > l
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
 	} else {
-		yyb389 = r.CheckBreak()
+		yyb382 = r.CheckBreak()
 	}
-	if yyb389 {
+	if yyb382 {
 		r.ReadEnd()
 		return
 	}
@@ -4436,23 +4372,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym393 := z.DecBinary()
-		_ = yym393
+		yym386 := z.DecBinary()
+		_ = yym386
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym393 && z.IsJSONHandle() {
+		} else if !yym386 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj389++
-	if yyhl389 {
-		yyb389 = yyj389 > l
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
 	} else {
-		yyb389 = r.CheckBreak()
+		yyb382 = r.CheckBreak()
 	}
-	if yyb389 {
+	if yyb382 {
 		r.ReadEnd()
 		return
 	}
@@ -4464,20 +4400,20 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.PageFaults == nil {
 			x.PageFaults = new(int64)
 		}
-		yym395 := z.DecBinary()
-		_ = yym395
+		yym388 := z.DecBinary()
+		_ = yym388
 		if false {
 		} else {
 			*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj389++
-	if yyhl389 {
-		yyb389 = yyj389 > l
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
 	} else {
-		yyb389 = r.CheckBreak()
+		yyb382 = r.CheckBreak()
 	}
-	if yyb389 {
+	if yyb382 {
 		r.ReadEnd()
 		return
 	}
@@ -4489,24 +4425,24 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.MajorPageFaults == nil {
 			x.MajorPageFaults = new(int64)
 		}
-		yym397 := z.DecBinary()
-		_ = yym397
+		yym390 := z.DecBinary()
+		_ = yym390
 		if false {
 		} else {
 			*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj389++
-		if yyhl389 {
-			yyb389 = yyj389 > l
+		yyj382++
+		if yyhl382 {
+			yyb382 = yyj382 > l
 		} else {
-			yyb389 = r.CheckBreak()
+			yyb382 = r.CheckBreak()
 		}
-		if yyb389 {
+		if yyb382 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj389-1, "")
+		z.DecStructFieldNotFound(yyj382-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4518,55 +4454,55 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym398 := z.EncBinary()
-		_ = yym398
+		yym391 := z.EncBinary()
+		_ = yym391
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep399 := !z.EncBinary()
-			yy2arr399 := z.EncBasicHandle().StructToArray
-			var yyq399 [3]bool
-			_, _, _ = yysep399, yyq399, yy2arr399
-			const yyr399 bool = false
-			yyq399[1] = x.UsageBytes != nil
-			yyq399[2] = x.LimitBytes != nil
-			if yyr399 || yy2arr399 {
+			yysep392 := !z.EncBinary()
+			yy2arr392 := z.EncBasicHandle().StructToArray
+			var yyq392 [3]bool
+			_, _, _ = yysep392, yyq392, yy2arr392
+			const yyr392 bool = false
+			yyq392[1] = x.UsageBytes != nil
+			yyq392[2] = x.LimitBytes != nil
+			if yyr392 || yy2arr392 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn399 int = 1
-				for _, b := range yyq399 {
+				var yynn392 int = 1
+				for _, b := range yyq392 {
 					if b {
-						yynn399++
+						yynn392++
 					}
 				}
-				r.EncodeMapStart(yynn399)
+				r.EncodeMapStart(yynn392)
 			}
-			if yyr399 || yy2arr399 {
-				yym401 := z.EncBinary()
-				_ = yym401
+			if yyr392 || yy2arr392 {
+				yym394 := z.EncBinary()
+				_ = yym394
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("device"))
-				yym402 := z.EncBinary()
-				_ = yym402
+				yym395 := z.EncBinary()
+				_ = yym395
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
 				}
 			}
-			if yyr399 || yy2arr399 {
-				if yyq399[1] {
+			if yyr392 || yy2arr392 {
+				if yyq392[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym404 := z.EncBinary()
-						_ = yym404
+						yym397 := z.EncBinary()
+						_ = yym397
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym404 && z.IsJSONHandle() {
+						} else if !yym397 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4576,16 +4512,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq399[1] {
+				if yyq392[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym405 := z.EncBinary()
-						_ = yym405
+						yym398 := z.EncBinary()
+						_ = yym398
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym405 && z.IsJSONHandle() {
+						} else if !yym398 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4593,16 +4529,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr399 || yy2arr399 {
-				if yyq399[2] {
+			if yyr392 || yy2arr392 {
+				if yyq392[2] {
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym407 := z.EncBinary()
-						_ = yym407
+						yym400 := z.EncBinary()
+						_ = yym400
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
-						} else if !yym407 && z.IsJSONHandle() {
+						} else if !yym400 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LimitBytes)
 						} else {
 							z.EncFallback(x.LimitBytes)
@@ -4612,16 +4548,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq399[2] {
+				if yyq392[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym408 := z.EncBinary()
-						_ = yym408
+						yym401 := z.EncBinary()
+						_ = yym401
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
-						} else if !yym408 && z.IsJSONHandle() {
+						} else if !yym401 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LimitBytes)
 						} else {
 							z.EncFallback(x.LimitBytes)
@@ -4629,7 +4565,7 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep399 {
+			if yysep392 {
 				r.EncodeEnd()
 			}
 		}
@@ -4640,24 +4576,24 @@ func (x *FilesystemMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym409 := z.DecBinary()
-	_ = yym409
+	yym402 := z.DecBinary()
+	_ = yym402
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl410 := r.ReadMapStart()
-			if yyl410 == 0 {
+			yyl403 := r.ReadMapStart()
+			if yyl403 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl410, d)
+				x.codecDecodeSelfFromMap(yyl403, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl410 := r.ReadArrayStart()
-			if yyl410 == 0 {
+			yyl403 := r.ReadArrayStart()
+			if yyl403 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl410, d)
+				x.codecDecodeSelfFromArray(yyl403, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4669,12 +4605,12 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys411Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys411Slc
-	var yyhl411 bool = l >= 0
-	for yyj411 := 0; ; yyj411++ {
-		if yyhl411 {
-			if yyj411 >= l {
+	var yys404Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys404Slc
+	var yyhl404 bool = l >= 0
+	for yyj404 := 0; ; yyj404++ {
+		if yyhl404 {
+			if yyj404 >= l {
 				break
 			}
 		} else {
@@ -4682,9 +4618,9 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys411Slc = r.DecodeBytes(yys411Slc, true, true)
-		yys411 := string(yys411Slc)
-		switch yys411 {
+		yys404Slc = r.DecodeBytes(yys404Slc, true, true)
+		yys404 := string(yys404Slc)
+		switch yys404 {
 		case "device":
 			if r.TryDecodeAsNil() {
 				x.Device = ""
@@ -4700,11 +4636,11 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym414 := z.DecBinary()
-				_ = yym414
+				yym407 := z.DecBinary()
+				_ = yym407
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym414 && z.IsJSONHandle() {
+				} else if !yym407 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4719,21 +4655,21 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(pkg2_resource.Quantity)
 				}
-				yym416 := z.DecBinary()
-				_ = yym416
+				yym409 := z.DecBinary()
+				_ = yym409
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
-				} else if !yym416 && z.IsJSONHandle() {
+				} else if !yym409 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LimitBytes)
 				} else {
 					z.DecFallback(x.LimitBytes, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys411)
-		} // end switch yys411
-	} // end for yyj411
-	if !yyhl411 {
+			z.DecStructFieldNotFound(-1, yys404)
+		} // end switch yys404
+	} // end for yyj404
+	if !yyhl404 {
 		r.ReadEnd()
 	}
 }
@@ -4742,16 +4678,16 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj417 int
-	var yyb417 bool
-	var yyhl417 bool = l >= 0
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	var yyj410 int
+	var yyb410 bool
+	var yyhl410 bool = l >= 0
+	yyj410++
+	if yyhl410 {
+		yyb410 = yyj410 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb410 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb410 {
 		r.ReadEnd()
 		return
 	}
@@ -4760,13 +4696,13 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Device = string(r.DecodeString())
 	}
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	yyj410++
+	if yyhl410 {
+		yyb410 = yyj410 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb410 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb410 {
 		r.ReadEnd()
 		return
 	}
@@ -4778,23 +4714,23 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym420 := z.DecBinary()
-		_ = yym420
+		yym413 := z.DecBinary()
+		_ = yym413
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym420 && z.IsJSONHandle() {
+		} else if !yym413 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	yyj410++
+	if yyhl410 {
+		yyb410 = yyj410 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb410 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb410 {
 		r.ReadEnd()
 		return
 	}
@@ -4806,656 +4742,27 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(pkg2_resource.Quantity)
 		}
-		yym422 := z.DecBinary()
-		_ = yym422
+		yym415 := z.DecBinary()
+		_ = yym415
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
-		} else if !yym422 && z.IsJSONHandle() {
+		} else if !yym415 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LimitBytes)
 		} else {
 			z.DecFallback(x.LimitBytes, false)
 		}
 	}
 	for {
-		yyj417++
-		if yyhl417 {
-			yyb417 = yyj417 > l
+		yyj410++
+		if yyhl410 {
+			yyb410 = yyj410 > l
 		} else {
-			yyb417 = r.CheckBreak()
+			yyb410 = r.CheckBreak()
 		}
-		if yyb417 {
+		if yyb410 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj417-1, "")
-	}
-	r.ReadEnd()
-}
-
-func (x CustomMetricType) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	yym423 := z.EncBinary()
-	_ = yym423
-	if false {
-	} else if z.HasExtensions() && z.EncExt(x) {
-	} else {
-		r.EncodeString(codecSelferC_UTF81234, string(x))
-	}
-}
-
-func (x *CustomMetricType) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym424 := z.DecBinary()
-	_ = yym424
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		*((*string)(x)) = r.DecodeString()
-	}
-}
-
-func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym425 := z.EncBinary()
-		_ = yym425
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep426 := !z.EncBinary()
-			yy2arr426 := z.EncBasicHandle().StructToArray
-			var yyq426 [4]bool
-			_, _, _ = yysep426, yyq426, yy2arr426
-			const yyr426 bool = false
-			yyq426[3] = len(x.Samples) != 0
-			if yyr426 || yy2arr426 {
-				r.EncodeArrayStart(4)
-			} else {
-				var yynn426 int = 3
-				for _, b := range yyq426 {
-					if b {
-						yynn426++
-					}
-				}
-				r.EncodeMapStart(yynn426)
-			}
-			if yyr426 || yy2arr426 {
-				yym428 := z.EncBinary()
-				_ = yym428
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("name"))
-				yym429 := z.EncBinary()
-				_ = yym429
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-				}
-			}
-			if yyr426 || yy2arr426 {
-				x.Type.CodecEncodeSelf(e)
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("type"))
-				x.Type.CodecEncodeSelf(e)
-			}
-			if yyr426 || yy2arr426 {
-				yym432 := z.EncBinary()
-				_ = yym432
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("unit"))
-				yym433 := z.EncBinary()
-				_ = yym433
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
-				}
-			}
-			if yyr426 || yy2arr426 {
-				if yyq426[3] {
-					if x.Samples == nil {
-						r.EncodeNil()
-					} else {
-						yym435 := z.EncBinary()
-						_ = yym435
-						if false {
-						} else {
-							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq426[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("samples"))
-					if x.Samples == nil {
-						r.EncodeNil()
-					} else {
-						yym436 := z.EncBinary()
-						_ = yym436
-						if false {
-						} else {
-							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
-						}
-					}
-				}
-			}
-			if yysep426 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *CustomMetric) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym437 := z.DecBinary()
-	_ = yym437
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl438 := r.ReadMapStart()
-			if yyl438 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl438, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl438 := r.ReadArrayStart()
-			if yyl438 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl438, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys439Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys439Slc
-	var yyhl439 bool = l >= 0
-	for yyj439 := 0; ; yyj439++ {
-		if yyhl439 {
-			if yyj439 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys439Slc = r.DecodeBytes(yys439Slc, true, true)
-		yys439 := string(yys439Slc)
-		switch yys439 {
-		case "name":
-			if r.TryDecodeAsNil() {
-				x.Name = ""
-			} else {
-				x.Name = string(r.DecodeString())
-			}
-		case "type":
-			if r.TryDecodeAsNil() {
-				x.Type = ""
-			} else {
-				x.Type = CustomMetricType(r.DecodeString())
-			}
-		case "unit":
-			if r.TryDecodeAsNil() {
-				x.Unit = ""
-			} else {
-				x.Unit = string(r.DecodeString())
-			}
-		case "samples":
-			if r.TryDecodeAsNil() {
-				x.Samples = nil
-			} else {
-				yyv443 := &x.Samples
-				yym444 := z.DecBinary()
-				_ = yym444
-				if false {
-				} else {
-					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv443), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys439)
-		} // end switch yys439
-	} // end for yyj439
-	if !yyhl439 {
-		r.ReadEnd()
-	}
-}
-
-func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj445 int
-	var yyb445 bool
-	var yyhl445 bool = l >= 0
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
-	} else {
-		yyb445 = r.CheckBreak()
-	}
-	if yyb445 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Name = ""
-	} else {
-		x.Name = string(r.DecodeString())
-	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
-	} else {
-		yyb445 = r.CheckBreak()
-	}
-	if yyb445 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Type = ""
-	} else {
-		x.Type = CustomMetricType(r.DecodeString())
-	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
-	} else {
-		yyb445 = r.CheckBreak()
-	}
-	if yyb445 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Unit = ""
-	} else {
-		x.Unit = string(r.DecodeString())
-	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
-	} else {
-		yyb445 = r.CheckBreak()
-	}
-	if yyb445 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Samples = nil
-	} else {
-		yyv449 := &x.Samples
-		yym450 := z.DecBinary()
-		_ = yym450
-		if false {
-		} else {
-			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv449), d)
-		}
-	}
-	for {
-		yyj445++
-		if yyhl445 {
-			yyb445 = yyj445 > l
-		} else {
-			yyb445 = r.CheckBreak()
-		}
-		if yyb445 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj445-1, "")
-	}
-	r.ReadEnd()
-}
-
-func (x *CustomMetricSample) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym451 := z.EncBinary()
-		_ = yym451
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep452 := !z.EncBinary()
-			yy2arr452 := z.EncBasicHandle().StructToArray
-			var yyq452 [3]bool
-			_, _, _ = yysep452, yyq452, yy2arr452
-			const yyr452 bool = false
-			yyq452[1] = x.Label != nil
-			if yyr452 || yy2arr452 {
-				r.EncodeArrayStart(3)
-			} else {
-				var yynn452 int = 2
-				for _, b := range yyq452 {
-					if b {
-						yynn452++
-					}
-				}
-				r.EncodeMapStart(yynn452)
-			}
-			if yyr452 || yy2arr452 {
-				yy454 := &x.SampleTime
-				yym455 := z.EncBinary()
-				_ = yym455
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy454) {
-				} else if yym455 {
-					z.EncBinaryMarshal(yy454)
-				} else if !yym455 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy454)
-				} else {
-					z.EncFallback(yy454)
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy456 := &x.SampleTime
-				yym457 := z.EncBinary()
-				_ = yym457
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy456) {
-				} else if yym457 {
-					z.EncBinaryMarshal(yy456)
-				} else if !yym457 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy456)
-				} else {
-					z.EncFallback(yy456)
-				}
-			}
-			if yyr452 || yy2arr452 {
-				if yyq452[1] {
-					if x.Label == nil {
-						r.EncodeNil()
-					} else {
-						yy459 := *x.Label
-						yym460 := z.EncBinary()
-						_ = yym460
-						if false {
-						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy459))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq452[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("label"))
-					if x.Label == nil {
-						r.EncodeNil()
-					} else {
-						yy461 := *x.Label
-						yym462 := z.EncBinary()
-						_ = yym462
-						if false {
-						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy461))
-						}
-					}
-				}
-			}
-			if yyr452 || yy2arr452 {
-				yy464 := &x.Value
-				yym465 := z.EncBinary()
-				_ = yym465
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy464) {
-				} else if !yym465 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy464)
-				} else {
-					z.EncFallback(yy464)
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yy466 := &x.Value
-				yym467 := z.EncBinary()
-				_ = yym467
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy466) {
-				} else if !yym467 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy466)
-				} else {
-					z.EncFallback(yy466)
-				}
-			}
-			if yysep452 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *CustomMetricSample) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym468 := z.DecBinary()
-	_ = yym468
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl469 := r.ReadMapStart()
-			if yyl469 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl469, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl469 := r.ReadArrayStart()
-			if yyl469 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl469, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys470Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys470Slc
-	var yyhl470 bool = l >= 0
-	for yyj470 := 0; ; yyj470++ {
-		if yyhl470 {
-			if yyj470 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys470Slc = r.DecodeBytes(yys470Slc, true, true)
-		yys470 := string(yys470Slc)
-		switch yys470 {
-		case "sampleTime":
-			if r.TryDecodeAsNil() {
-				x.SampleTime = pkg1_unversioned.Time{}
-			} else {
-				yyv471 := &x.SampleTime
-				yym472 := z.DecBinary()
-				_ = yym472
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv471) {
-				} else if yym472 {
-					z.DecBinaryUnmarshal(yyv471)
-				} else if !yym472 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv471)
-				} else {
-					z.DecFallback(yyv471, false)
-				}
-			}
-		case "label":
-			if r.TryDecodeAsNil() {
-				if x.Label != nil {
-					x.Label = nil
-				}
-			} else {
-				if x.Label == nil {
-					x.Label = new(string)
-				}
-				yym474 := z.DecBinary()
-				_ = yym474
-				if false {
-				} else {
-					*((*string)(x.Label)) = r.DecodeString()
-				}
-			}
-		case "value":
-			if r.TryDecodeAsNil() {
-				x.Value = pkg2_resource.Quantity{}
-			} else {
-				yyv475 := &x.Value
-				yym476 := z.DecBinary()
-				_ = yym476
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv475) {
-				} else if !yym476 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv475)
-				} else {
-					z.DecFallback(yyv475, false)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys470)
-		} // end switch yys470
-	} // end for yyj470
-	if !yyhl470 {
-		r.ReadEnd()
-	}
-}
-
-func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj477 int
-	var yyb477 bool
-	var yyhl477 bool = l >= 0
-	yyj477++
-	if yyhl477 {
-		yyb477 = yyj477 > l
-	} else {
-		yyb477 = r.CheckBreak()
-	}
-	if yyb477 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.SampleTime = pkg1_unversioned.Time{}
-	} else {
-		yyv478 := &x.SampleTime
-		yym479 := z.DecBinary()
-		_ = yym479
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv478) {
-		} else if yym479 {
-			z.DecBinaryUnmarshal(yyv478)
-		} else if !yym479 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv478)
-		} else {
-			z.DecFallback(yyv478, false)
-		}
-	}
-	yyj477++
-	if yyhl477 {
-		yyb477 = yyj477 > l
-	} else {
-		yyb477 = r.CheckBreak()
-	}
-	if yyb477 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		if x.Label != nil {
-			x.Label = nil
-		}
-	} else {
-		if x.Label == nil {
-			x.Label = new(string)
-		}
-		yym481 := z.DecBinary()
-		_ = yym481
-		if false {
-		} else {
-			*((*string)(x.Label)) = r.DecodeString()
-		}
-	}
-	yyj477++
-	if yyhl477 {
-		yyb477 = yyj477 > l
-	} else {
-		yyb477 = r.CheckBreak()
-	}
-	if yyb477 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Value = pkg2_resource.Quantity{}
-	} else {
-		yyv482 := &x.Value
-		yym483 := z.DecBinary()
-		_ = yym483
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv482) {
-		} else if !yym483 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv482)
-		} else {
-			z.DecFallback(yyv482, false)
-		}
-	}
-	for {
-		yyj477++
-		if yyhl477 {
-			yyb477 = yyj477 > l
-		} else {
-			yyb477 = r.CheckBreak()
-		}
-		if yyb477 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj477-1, "")
+		z.DecStructFieldNotFound(yyj410-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5467,42 +4774,42 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym484 := z.EncBinary()
-		_ = yym484
+		yym416 := z.EncBinary()
+		_ = yym416
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep485 := !z.EncBinary()
-			yy2arr485 := z.EncBasicHandle().StructToArray
-			var yyq485 [3]bool
-			_, _, _ = yysep485, yyq485, yy2arr485
-			const yyr485 bool = false
-			yyq485[0] = x.SinceTime != nil
-			yyq485[1] = x.UntilTime != nil
-			yyq485[2] = x.MaxSamples != 0
-			if yyr485 || yy2arr485 {
+			yysep417 := !z.EncBinary()
+			yy2arr417 := z.EncBasicHandle().StructToArray
+			var yyq417 [3]bool
+			_, _, _ = yysep417, yyq417, yy2arr417
+			const yyr417 bool = false
+			yyq417[0] = x.SinceTime != nil
+			yyq417[1] = x.UntilTime != nil
+			yyq417[2] = x.MaxSamples != 0
+			if yyr417 || yy2arr417 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn485 int = 0
-				for _, b := range yyq485 {
+				var yynn417 int = 0
+				for _, b := range yyq417 {
 					if b {
-						yynn485++
+						yynn417++
 					}
 				}
-				r.EncodeMapStart(yynn485)
+				r.EncodeMapStart(yynn417)
 			}
-			if yyr485 || yy2arr485 {
-				if yyq485[0] {
+			if yyr417 || yy2arr417 {
+				if yyq417[0] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym487 := z.EncBinary()
-						_ = yym487
+						yym419 := z.EncBinary()
+						_ = yym419
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym487 {
+						} else if yym419 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym487 && z.IsJSONHandle() {
+						} else if !yym419 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5512,18 +4819,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq485[0] {
+				if yyq417[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym488 := z.EncBinary()
-						_ = yym488
+						yym420 := z.EncBinary()
+						_ = yym420
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym488 {
+						} else if yym420 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym488 && z.IsJSONHandle() {
+						} else if !yym420 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5531,18 +4838,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr485 || yy2arr485 {
-				if yyq485[1] {
+			if yyr417 || yy2arr417 {
+				if yyq417[1] {
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym490 := z.EncBinary()
-						_ = yym490
+						yym422 := z.EncBinary()
+						_ = yym422
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym490 {
+						} else if yym422 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym490 && z.IsJSONHandle() {
+						} else if !yym422 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5552,18 +4859,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq485[1] {
+				if yyq417[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym491 := z.EncBinary()
-						_ = yym491
+						yym423 := z.EncBinary()
+						_ = yym423
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym491 {
+						} else if yym423 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym491 && z.IsJSONHandle() {
+						} else if !yym423 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5571,10 +4878,10 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr485 || yy2arr485 {
-				if yyq485[2] {
-					yym493 := z.EncBinary()
-					_ = yym493
+			if yyr417 || yy2arr417 {
+				if yyq417[2] {
+					yym425 := z.EncBinary()
+					_ = yym425
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -5583,17 +4890,17 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq485[2] {
+				if yyq417[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
-					yym494 := z.EncBinary()
-					_ = yym494
+					yym426 := z.EncBinary()
+					_ = yym426
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
 					}
 				}
 			}
-			if yysep485 {
+			if yysep417 {
 				r.EncodeEnd()
 			}
 		}
@@ -5604,24 +4911,24 @@ func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym495 := z.DecBinary()
-	_ = yym495
+	yym427 := z.DecBinary()
+	_ = yym427
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl496 := r.ReadMapStart()
-			if yyl496 == 0 {
+			yyl428 := r.ReadMapStart()
+			if yyl428 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl496, d)
+				x.codecDecodeSelfFromMap(yyl428, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl496 := r.ReadArrayStart()
-			if yyl496 == 0 {
+			yyl428 := r.ReadArrayStart()
+			if yyl428 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl496, d)
+				x.codecDecodeSelfFromArray(yyl428, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5633,12 +4940,12 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys497Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys497Slc
-	var yyhl497 bool = l >= 0
-	for yyj497 := 0; ; yyj497++ {
-		if yyhl497 {
-			if yyj497 >= l {
+	var yys429Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys429Slc
+	var yyhl429 bool = l >= 0
+	for yyj429 := 0; ; yyj429++ {
+		if yyhl429 {
+			if yyj429 >= l {
 				break
 			}
 		} else {
@@ -5646,9 +4953,9 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys497Slc = r.DecodeBytes(yys497Slc, true, true)
-		yys497 := string(yys497Slc)
-		switch yys497 {
+		yys429Slc = r.DecodeBytes(yys429Slc, true, true)
+		yys429 := string(yys429Slc)
+		switch yys429 {
 		case "sinceTime":
 			if r.TryDecodeAsNil() {
 				if x.SinceTime != nil {
@@ -5658,13 +4965,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg1_unversioned.Time)
 				}
-				yym499 := z.DecBinary()
-				_ = yym499
+				yym431 := z.DecBinary()
+				_ = yym431
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym499 {
+				} else if yym431 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym499 && z.IsJSONHandle() {
+				} else if !yym431 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -5679,13 +4986,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UntilTime == nil {
 					x.UntilTime = new(pkg1_unversioned.Time)
 				}
-				yym501 := z.DecBinary()
-				_ = yym501
+				yym433 := z.DecBinary()
+				_ = yym433
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-				} else if yym501 {
+				} else if yym433 {
 					z.DecBinaryUnmarshal(x.UntilTime)
-				} else if !yym501 && z.IsJSONHandle() {
+				} else if !yym433 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UntilTime)
 				} else {
 					z.DecFallback(x.UntilTime, false)
@@ -5698,10 +5005,10 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys497)
-		} // end switch yys497
-	} // end for yyj497
-	if !yyhl497 {
+			z.DecStructFieldNotFound(-1, yys429)
+		} // end switch yys429
+	} // end for yyj429
+	if !yyhl429 {
 		r.ReadEnd()
 	}
 }
@@ -5710,16 +5017,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj503 int
-	var yyb503 bool
-	var yyhl503 bool = l >= 0
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	var yyj435 int
+	var yyb435 bool
+	var yyhl435 bool = l >= 0
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
@@ -5731,25 +5038,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg1_unversioned.Time)
 		}
-		yym505 := z.DecBinary()
-		_ = yym505
+		yym437 := z.DecBinary()
+		_ = yym437
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym505 {
+		} else if yym437 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym505 && z.IsJSONHandle() {
+		} else if !yym437 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
@@ -5761,25 +5068,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UntilTime == nil {
 			x.UntilTime = new(pkg1_unversioned.Time)
 		}
-		yym507 := z.DecBinary()
-		_ = yym507
+		yym439 := z.DecBinary()
+		_ = yym439
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-		} else if yym507 {
+		} else if yym439 {
 			z.DecBinaryUnmarshal(x.UntilTime)
-		} else if !yym507 && z.IsJSONHandle() {
+		} else if !yym439 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UntilTime)
 		} else {
 			z.DecFallback(x.UntilTime, false)
 		}
 	}
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
@@ -5789,16 +5096,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj503++
-		if yyhl503 {
-			yyb503 = yyj503 > l
+		yyj435++
+		if yyhl435 {
+			yyb435 = yyj435 > l
 		} else {
-			yyb503 = r.CheckBreak()
+			yyb435 = r.CheckBreak()
 		}
-		if yyb503 {
+		if yyb435 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj503-1, "")
+		z.DecStructFieldNotFound(yyj435-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5808,9 +5115,9 @@ func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv509 := range v {
-		yy510 := &yyv509
-		yy510.CodecEncodeSelf(e)
+	for _, yyv441 := range v {
+		yy442 := &yyv441
+		yy442.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5820,75 +5127,75 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv511 := *v
-	yyh511, yyl511 := z.DecSliceHelperStart()
+	yyv443 := *v
+	yyh443, yyl443 := z.DecSliceHelperStart()
 
-	var yyrr511, yyrl511 int
-	var yyc511, yyrt511 bool
-	_, _, _ = yyc511, yyrt511, yyrl511
-	yyrr511 = yyl511
+	var yyrr443, yyrl443 int
+	var yyc443, yyrt443 bool
+	_, _, _ = yyc443, yyrt443, yyrl443
+	yyrr443 = yyl443
 
-	if yyv511 == nil {
-		if yyrl511, yyrt511 = z.DecInferLen(yyl511, z.DecBasicHandle().MaxInitLen, 72); yyrt511 {
-			yyrr511 = yyrl511
+	if yyv443 == nil {
+		if yyrl443, yyrt443 = z.DecInferLen(yyl443, z.DecBasicHandle().MaxInitLen, 72); yyrt443 {
+			yyrr443 = yyrl443
 		}
-		yyv511 = make([]AggregateSample, yyrl511)
-		yyc511 = true
+		yyv443 = make([]AggregateSample, yyrl443)
+		yyc443 = true
 	}
 
-	if yyl511 == 0 {
-		if len(yyv511) != 0 {
-			yyv511 = yyv511[:0]
-			yyc511 = true
+	if yyl443 == 0 {
+		if len(yyv443) != 0 {
+			yyv443 = yyv443[:0]
+			yyc443 = true
 		}
-	} else if yyl511 > 0 {
+	} else if yyl443 > 0 {
 
-		if yyl511 > cap(yyv511) {
-			yyrl511, yyrt511 = z.DecInferLen(yyl511, z.DecBasicHandle().MaxInitLen, 72)
-			yyv511 = make([]AggregateSample, yyrl511)
-			yyc511 = true
+		if yyl443 > cap(yyv443) {
+			yyrl443, yyrt443 = z.DecInferLen(yyl443, z.DecBasicHandle().MaxInitLen, 72)
+			yyv443 = make([]AggregateSample, yyrl443)
+			yyc443 = true
 
-			yyrr511 = len(yyv511)
-		} else if yyl511 != len(yyv511) {
-			yyv511 = yyv511[:yyl511]
-			yyc511 = true
+			yyrr443 = len(yyv443)
+		} else if yyl443 != len(yyv443) {
+			yyv443 = yyv443[:yyl443]
+			yyc443 = true
 		}
-		yyj511 := 0
-		for ; yyj511 < yyrr511; yyj511++ {
+		yyj443 := 0
+		for ; yyj443 < yyrr443; yyj443++ {
 			if r.TryDecodeAsNil() {
-				yyv511[yyj511] = AggregateSample{}
+				yyv443[yyj443] = AggregateSample{}
 			} else {
-				yyv512 := &yyv511[yyj511]
-				yyv512.CodecDecodeSelf(d)
+				yyv444 := &yyv443[yyj443]
+				yyv444.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt511 {
-			for ; yyj511 < yyl511; yyj511++ {
-				yyv511 = append(yyv511, AggregateSample{})
+		if yyrt443 {
+			for ; yyj443 < yyl443; yyj443++ {
+				yyv443 = append(yyv443, AggregateSample{})
 				if r.TryDecodeAsNil() {
-					yyv511[yyj511] = AggregateSample{}
+					yyv443[yyj443] = AggregateSample{}
 				} else {
-					yyv513 := &yyv511[yyj511]
-					yyv513.CodecDecodeSelf(d)
+					yyv445 := &yyv443[yyj443]
+					yyv445.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj511 := 0; !r.CheckBreak(); yyj511++ {
-			if yyj511 >= len(yyv511) {
-				yyv511 = append(yyv511, AggregateSample{}) // var yyz511 AggregateSample
-				yyc511 = true
+		for yyj443 := 0; !r.CheckBreak(); yyj443++ {
+			if yyj443 >= len(yyv443) {
+				yyv443 = append(yyv443, AggregateSample{}) // var yyz443 AggregateSample
+				yyc443 = true
 			}
 
-			if yyj511 < len(yyv511) {
+			if yyj443 < len(yyv443) {
 				if r.TryDecodeAsNil() {
-					yyv511[yyj511] = AggregateSample{}
+					yyv443[yyj443] = AggregateSample{}
 				} else {
-					yyv514 := &yyv511[yyj511]
-					yyv514.CodecDecodeSelf(d)
+					yyv446 := &yyv443[yyj443]
+					yyv446.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5896,10 +5203,10 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 			}
 
 		}
-		yyh511.End()
+		yyh443.End()
 	}
-	if yyc511 {
-		*v = yyv511
+	if yyc443 {
+		*v = yyv443
 	}
 
 }
@@ -5909,9 +5216,9 @@ func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv515 := range v {
-		yy516 := &yyv515
-		yy516.CodecEncodeSelf(e)
+	for _, yyv447 := range v {
+		yy448 := &yyv447
+		yy448.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5921,75 +5228,75 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv517 := *v
-	yyh517, yyl517 := z.DecSliceHelperStart()
+	yyv449 := *v
+	yyh449, yyl449 := z.DecSliceHelperStart()
 
-	var yyrr517, yyrl517 int
-	var yyc517, yyrt517 bool
-	_, _, _ = yyc517, yyrt517, yyrl517
-	yyrr517 = yyl517
+	var yyrr449, yyrl449 int
+	var yyc449, yyrt449 bool
+	_, _, _ = yyc449, yyrt449, yyrl449
+	yyrr449 = yyl449
 
-	if yyv517 == nil {
-		if yyrl517, yyrt517 = z.DecInferLen(yyl517, z.DecBasicHandle().MaxInitLen, 72); yyrt517 {
-			yyrr517 = yyrl517
+	if yyv449 == nil {
+		if yyrl449, yyrt449 = z.DecInferLen(yyl449, z.DecBasicHandle().MaxInitLen, 48); yyrt449 {
+			yyrr449 = yyrl449
 		}
-		yyv517 = make([]RawContainerMetrics, yyrl517)
-		yyc517 = true
+		yyv449 = make([]RawContainerMetrics, yyrl449)
+		yyc449 = true
 	}
 
-	if yyl517 == 0 {
-		if len(yyv517) != 0 {
-			yyv517 = yyv517[:0]
-			yyc517 = true
+	if yyl449 == 0 {
+		if len(yyv449) != 0 {
+			yyv449 = yyv449[:0]
+			yyc449 = true
 		}
-	} else if yyl517 > 0 {
+	} else if yyl449 > 0 {
 
-		if yyl517 > cap(yyv517) {
-			yyrl517, yyrt517 = z.DecInferLen(yyl517, z.DecBasicHandle().MaxInitLen, 72)
-			yyv517 = make([]RawContainerMetrics, yyrl517)
-			yyc517 = true
+		if yyl449 > cap(yyv449) {
+			yyrl449, yyrt449 = z.DecInferLen(yyl449, z.DecBasicHandle().MaxInitLen, 48)
+			yyv449 = make([]RawContainerMetrics, yyrl449)
+			yyc449 = true
 
-			yyrr517 = len(yyv517)
-		} else if yyl517 != len(yyv517) {
-			yyv517 = yyv517[:yyl517]
-			yyc517 = true
+			yyrr449 = len(yyv449)
+		} else if yyl449 != len(yyv449) {
+			yyv449 = yyv449[:yyl449]
+			yyc449 = true
 		}
-		yyj517 := 0
-		for ; yyj517 < yyrr517; yyj517++ {
+		yyj449 := 0
+		for ; yyj449 < yyrr449; yyj449++ {
 			if r.TryDecodeAsNil() {
-				yyv517[yyj517] = RawContainerMetrics{}
+				yyv449[yyj449] = RawContainerMetrics{}
 			} else {
-				yyv518 := &yyv517[yyj517]
-				yyv518.CodecDecodeSelf(d)
+				yyv450 := &yyv449[yyj449]
+				yyv450.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt517 {
-			for ; yyj517 < yyl517; yyj517++ {
-				yyv517 = append(yyv517, RawContainerMetrics{})
+		if yyrt449 {
+			for ; yyj449 < yyl449; yyj449++ {
+				yyv449 = append(yyv449, RawContainerMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv517[yyj517] = RawContainerMetrics{}
+					yyv449[yyj449] = RawContainerMetrics{}
 				} else {
-					yyv519 := &yyv517[yyj517]
-					yyv519.CodecDecodeSelf(d)
+					yyv451 := &yyv449[yyj449]
+					yyv451.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj517 := 0; !r.CheckBreak(); yyj517++ {
-			if yyj517 >= len(yyv517) {
-				yyv517 = append(yyv517, RawContainerMetrics{}) // var yyz517 RawContainerMetrics
-				yyc517 = true
+		for yyj449 := 0; !r.CheckBreak(); yyj449++ {
+			if yyj449 >= len(yyv449) {
+				yyv449 = append(yyv449, RawContainerMetrics{}) // var yyz449 RawContainerMetrics
+				yyc449 = true
 			}
 
-			if yyj517 < len(yyv517) {
+			if yyj449 < len(yyv449) {
 				if r.TryDecodeAsNil() {
-					yyv517[yyj517] = RawContainerMetrics{}
+					yyv449[yyj449] = RawContainerMetrics{}
 				} else {
-					yyv520 := &yyv517[yyj517]
-					yyv520.CodecDecodeSelf(d)
+					yyv452 := &yyv449[yyj449]
+					yyv452.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5997,10 +5304,10 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 			}
 
 		}
-		yyh517.End()
+		yyh449.End()
 	}
-	if yyc517 {
-		*v = yyv517
+	if yyc449 {
+		*v = yyv449
 	}
 
 }
@@ -6010,9 +5317,9 @@ func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv521 := range v {
-		yy522 := &yyv521
-		yy522.CodecEncodeSelf(e)
+	for _, yyv453 := range v {
+		yy454 := &yyv453
+		yy454.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6022,75 +5329,75 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv523 := *v
-	yyh523, yyl523 := z.DecSliceHelperStart()
+	yyv455 := *v
+	yyh455, yyl455 := z.DecSliceHelperStart()
 
-	var yyrr523, yyrl523 int
-	var yyc523, yyrt523 bool
-	_, _, _ = yyc523, yyrt523, yyrl523
-	yyrr523 = yyl523
+	var yyrr455, yyrl455 int
+	var yyc455, yyrt455 bool
+	_, _, _ = yyc455, yyrt455, yyrl455
+	yyrr455 = yyl455
 
-	if yyv523 == nil {
-		if yyrl523, yyrt523 = z.DecInferLen(yyl523, z.DecBasicHandle().MaxInitLen, 128); yyrt523 {
-			yyrr523 = yyrl523
+	if yyv455 == nil {
+		if yyrl455, yyrt455 = z.DecInferLen(yyl455, z.DecBasicHandle().MaxInitLen, 128); yyrt455 {
+			yyrr455 = yyrl455
 		}
-		yyv523 = make([]RawNodeMetrics, yyrl523)
-		yyc523 = true
+		yyv455 = make([]RawNodeMetrics, yyrl455)
+		yyc455 = true
 	}
 
-	if yyl523 == 0 {
-		if len(yyv523) != 0 {
-			yyv523 = yyv523[:0]
-			yyc523 = true
+	if yyl455 == 0 {
+		if len(yyv455) != 0 {
+			yyv455 = yyv455[:0]
+			yyc455 = true
 		}
-	} else if yyl523 > 0 {
+	} else if yyl455 > 0 {
 
-		if yyl523 > cap(yyv523) {
-			yyrl523, yyrt523 = z.DecInferLen(yyl523, z.DecBasicHandle().MaxInitLen, 128)
-			yyv523 = make([]RawNodeMetrics, yyrl523)
-			yyc523 = true
+		if yyl455 > cap(yyv455) {
+			yyrl455, yyrt455 = z.DecInferLen(yyl455, z.DecBasicHandle().MaxInitLen, 128)
+			yyv455 = make([]RawNodeMetrics, yyrl455)
+			yyc455 = true
 
-			yyrr523 = len(yyv523)
-		} else if yyl523 != len(yyv523) {
-			yyv523 = yyv523[:yyl523]
-			yyc523 = true
+			yyrr455 = len(yyv455)
+		} else if yyl455 != len(yyv455) {
+			yyv455 = yyv455[:yyl455]
+			yyc455 = true
 		}
-		yyj523 := 0
-		for ; yyj523 < yyrr523; yyj523++ {
+		yyj455 := 0
+		for ; yyj455 < yyrr455; yyj455++ {
 			if r.TryDecodeAsNil() {
-				yyv523[yyj523] = RawNodeMetrics{}
+				yyv455[yyj455] = RawNodeMetrics{}
 			} else {
-				yyv524 := &yyv523[yyj523]
-				yyv524.CodecDecodeSelf(d)
+				yyv456 := &yyv455[yyj455]
+				yyv456.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt523 {
-			for ; yyj523 < yyl523; yyj523++ {
-				yyv523 = append(yyv523, RawNodeMetrics{})
+		if yyrt455 {
+			for ; yyj455 < yyl455; yyj455++ {
+				yyv455 = append(yyv455, RawNodeMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv523[yyj523] = RawNodeMetrics{}
+					yyv455[yyj455] = RawNodeMetrics{}
 				} else {
-					yyv525 := &yyv523[yyj523]
-					yyv525.CodecDecodeSelf(d)
+					yyv457 := &yyv455[yyj455]
+					yyv457.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj523 := 0; !r.CheckBreak(); yyj523++ {
-			if yyj523 >= len(yyv523) {
-				yyv523 = append(yyv523, RawNodeMetrics{}) // var yyz523 RawNodeMetrics
-				yyc523 = true
+		for yyj455 := 0; !r.CheckBreak(); yyj455++ {
+			if yyj455 >= len(yyv455) {
+				yyv455 = append(yyv455, RawNodeMetrics{}) // var yyz455 RawNodeMetrics
+				yyc455 = true
 			}
 
-			if yyj523 < len(yyv523) {
+			if yyj455 < len(yyv455) {
 				if r.TryDecodeAsNil() {
-					yyv523[yyj523] = RawNodeMetrics{}
+					yyv455[yyj455] = RawNodeMetrics{}
 				} else {
-					yyv526 := &yyv523[yyj523]
-					yyv526.CodecDecodeSelf(d)
+					yyv458 := &yyv455[yyj455]
+					yyv458.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6098,10 +5405,10 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 			}
 
 		}
-		yyh523.End()
+		yyh455.End()
 	}
-	if yyc523 {
-		*v = yyv523
+	if yyc455 {
+		*v = yyv455
 	}
 
 }
@@ -6111,9 +5418,9 @@ func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv527 := range v {
-		yy528 := &yyv527
-		yy528.CodecEncodeSelf(e)
+	for _, yyv459 := range v {
+		yy460 := &yyv459
+		yy460.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6123,75 +5430,75 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv529 := *v
-	yyh529, yyl529 := z.DecSliceHelperStart()
+	yyv461 := *v
+	yyh461, yyl461 := z.DecSliceHelperStart()
 
-	var yyrr529, yyrl529 int
-	var yyc529, yyrt529 bool
-	_, _, _ = yyc529, yyrt529, yyrl529
-	yyrr529 = yyl529
+	var yyrr461, yyrl461 int
+	var yyc461, yyrt461 bool
+	_, _, _ = yyc461, yyrt461, yyrl461
+	yyrr461 = yyl461
 
-	if yyv529 == nil {
-		if yyrl529, yyrt529 = z.DecInferLen(yyl529, z.DecBasicHandle().MaxInitLen, 32); yyrt529 {
-			yyrr529 = yyrl529
+	if yyv461 == nil {
+		if yyrl461, yyrt461 = z.DecInferLen(yyl461, z.DecBasicHandle().MaxInitLen, 32); yyrt461 {
+			yyrr461 = yyrl461
 		}
-		yyv529 = make([]PodSample, yyrl529)
-		yyc529 = true
+		yyv461 = make([]PodSample, yyrl461)
+		yyc461 = true
 	}
 
-	if yyl529 == 0 {
-		if len(yyv529) != 0 {
-			yyv529 = yyv529[:0]
-			yyc529 = true
+	if yyl461 == 0 {
+		if len(yyv461) != 0 {
+			yyv461 = yyv461[:0]
+			yyc461 = true
 		}
-	} else if yyl529 > 0 {
+	} else if yyl461 > 0 {
 
-		if yyl529 > cap(yyv529) {
-			yyrl529, yyrt529 = z.DecInferLen(yyl529, z.DecBasicHandle().MaxInitLen, 32)
-			yyv529 = make([]PodSample, yyrl529)
-			yyc529 = true
+		if yyl461 > cap(yyv461) {
+			yyrl461, yyrt461 = z.DecInferLen(yyl461, z.DecBasicHandle().MaxInitLen, 32)
+			yyv461 = make([]PodSample, yyrl461)
+			yyc461 = true
 
-			yyrr529 = len(yyv529)
-		} else if yyl529 != len(yyv529) {
-			yyv529 = yyv529[:yyl529]
-			yyc529 = true
+			yyrr461 = len(yyv461)
+		} else if yyl461 != len(yyv461) {
+			yyv461 = yyv461[:yyl461]
+			yyc461 = true
 		}
-		yyj529 := 0
-		for ; yyj529 < yyrr529; yyj529++ {
+		yyj461 := 0
+		for ; yyj461 < yyrr461; yyj461++ {
 			if r.TryDecodeAsNil() {
-				yyv529[yyj529] = PodSample{}
+				yyv461[yyj461] = PodSample{}
 			} else {
-				yyv530 := &yyv529[yyj529]
-				yyv530.CodecDecodeSelf(d)
+				yyv462 := &yyv461[yyj461]
+				yyv462.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt529 {
-			for ; yyj529 < yyl529; yyj529++ {
-				yyv529 = append(yyv529, PodSample{})
+		if yyrt461 {
+			for ; yyj461 < yyl461; yyj461++ {
+				yyv461 = append(yyv461, PodSample{})
 				if r.TryDecodeAsNil() {
-					yyv529[yyj529] = PodSample{}
+					yyv461[yyj461] = PodSample{}
 				} else {
-					yyv531 := &yyv529[yyj529]
-					yyv531.CodecDecodeSelf(d)
+					yyv463 := &yyv461[yyj461]
+					yyv463.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj529 := 0; !r.CheckBreak(); yyj529++ {
-			if yyj529 >= len(yyv529) {
-				yyv529 = append(yyv529, PodSample{}) // var yyz529 PodSample
-				yyc529 = true
+		for yyj461 := 0; !r.CheckBreak(); yyj461++ {
+			if yyj461 >= len(yyv461) {
+				yyv461 = append(yyv461, PodSample{}) // var yyz461 PodSample
+				yyc461 = true
 			}
 
-			if yyj529 < len(yyv529) {
+			if yyj461 < len(yyv461) {
 				if r.TryDecodeAsNil() {
-					yyv529[yyj529] = PodSample{}
+					yyv461[yyj461] = PodSample{}
 				} else {
-					yyv532 := &yyv529[yyj529]
-					yyv532.CodecDecodeSelf(d)
+					yyv464 := &yyv461[yyj461]
+					yyv464.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6199,10 +5506,10 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 			}
 
 		}
-		yyh529.End()
+		yyh461.End()
 	}
-	if yyc529 {
-		*v = yyv529
+	if yyc461 {
+		*v = yyv461
 	}
 
 }
@@ -6212,9 +5519,9 @@ func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv533 := range v {
-		yy534 := &yyv533
-		yy534.CodecEncodeSelf(e)
+	for _, yyv465 := range v {
+		yy466 := &yyv465
+		yy466.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6224,75 +5531,75 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv535 := *v
-	yyh535, yyl535 := z.DecSliceHelperStart()
+	yyv467 := *v
+	yyh467, yyl467 := z.DecSliceHelperStart()
 
-	var yyrr535, yyrl535 int
-	var yyc535, yyrt535 bool
-	_, _, _ = yyc535, yyrt535, yyrl535
-	yyrr535 = yyl535
+	var yyrr467, yyrl467 int
+	var yyc467, yyrt467 bool
+	_, _, _ = yyc467, yyrt467, yyrl467
+	yyrr467 = yyl467
 
-	if yyv535 == nil {
-		if yyrl535, yyrt535 = z.DecInferLen(yyl535, z.DecBasicHandle().MaxInitLen, 160); yyrt535 {
-			yyrr535 = yyrl535
+	if yyv467 == nil {
+		if yyrl467, yyrt467 = z.DecInferLen(yyl467, z.DecBasicHandle().MaxInitLen, 160); yyrt467 {
+			yyrr467 = yyrl467
 		}
-		yyv535 = make([]RawPodMetrics, yyrl535)
-		yyc535 = true
+		yyv467 = make([]RawPodMetrics, yyrl467)
+		yyc467 = true
 	}
 
-	if yyl535 == 0 {
-		if len(yyv535) != 0 {
-			yyv535 = yyv535[:0]
-			yyc535 = true
+	if yyl467 == 0 {
+		if len(yyv467) != 0 {
+			yyv467 = yyv467[:0]
+			yyc467 = true
 		}
-	} else if yyl535 > 0 {
+	} else if yyl467 > 0 {
 
-		if yyl535 > cap(yyv535) {
-			yyrl535, yyrt535 = z.DecInferLen(yyl535, z.DecBasicHandle().MaxInitLen, 160)
-			yyv535 = make([]RawPodMetrics, yyrl535)
-			yyc535 = true
+		if yyl467 > cap(yyv467) {
+			yyrl467, yyrt467 = z.DecInferLen(yyl467, z.DecBasicHandle().MaxInitLen, 160)
+			yyv467 = make([]RawPodMetrics, yyrl467)
+			yyc467 = true
 
-			yyrr535 = len(yyv535)
-		} else if yyl535 != len(yyv535) {
-			yyv535 = yyv535[:yyl535]
-			yyc535 = true
+			yyrr467 = len(yyv467)
+		} else if yyl467 != len(yyv467) {
+			yyv467 = yyv467[:yyl467]
+			yyc467 = true
 		}
-		yyj535 := 0
-		for ; yyj535 < yyrr535; yyj535++ {
+		yyj467 := 0
+		for ; yyj467 < yyrr467; yyj467++ {
 			if r.TryDecodeAsNil() {
-				yyv535[yyj535] = RawPodMetrics{}
+				yyv467[yyj467] = RawPodMetrics{}
 			} else {
-				yyv536 := &yyv535[yyj535]
-				yyv536.CodecDecodeSelf(d)
+				yyv468 := &yyv467[yyj467]
+				yyv468.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt535 {
-			for ; yyj535 < yyl535; yyj535++ {
-				yyv535 = append(yyv535, RawPodMetrics{})
+		if yyrt467 {
+			for ; yyj467 < yyl467; yyj467++ {
+				yyv467 = append(yyv467, RawPodMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv535[yyj535] = RawPodMetrics{}
+					yyv467[yyj467] = RawPodMetrics{}
 				} else {
-					yyv537 := &yyv535[yyj535]
-					yyv537.CodecDecodeSelf(d)
+					yyv469 := &yyv467[yyj467]
+					yyv469.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj535 := 0; !r.CheckBreak(); yyj535++ {
-			if yyj535 >= len(yyv535) {
-				yyv535 = append(yyv535, RawPodMetrics{}) // var yyz535 RawPodMetrics
-				yyc535 = true
+		for yyj467 := 0; !r.CheckBreak(); yyj467++ {
+			if yyj467 >= len(yyv467) {
+				yyv467 = append(yyv467, RawPodMetrics{}) // var yyz467 RawPodMetrics
+				yyc467 = true
 			}
 
-			if yyj535 < len(yyv535) {
+			if yyj467 < len(yyv467) {
 				if r.TryDecodeAsNil() {
-					yyv535[yyj535] = RawPodMetrics{}
+					yyv467[yyj467] = RawPodMetrics{}
 				} else {
-					yyv538 := &yyv535[yyj535]
-					yyv538.CodecDecodeSelf(d)
+					yyv470 := &yyv467[yyj467]
+					yyv470.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6300,10 +5607,10 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 			}
 
 		}
-		yyh535.End()
+		yyh467.End()
 	}
-	if yyc535 {
-		*v = yyv535
+	if yyc467 {
+		*v = yyv467
 	}
 
 }
@@ -6313,9 +5620,9 @@ func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv539 := range v {
-		yy540 := &yyv539
-		yy540.CodecEncodeSelf(e)
+	for _, yyv471 := range v {
+		yy472 := &yyv471
+		yy472.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6325,75 +5632,75 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv541 := *v
-	yyh541, yyl541 := z.DecSliceHelperStart()
+	yyv473 := *v
+	yyh473, yyl473 := z.DecSliceHelperStart()
 
-	var yyrr541, yyrl541 int
-	var yyc541, yyrt541 bool
-	_, _, _ = yyc541, yyrt541, yyrl541
-	yyrr541 = yyl541
+	var yyrr473, yyrl473 int
+	var yyc473, yyrt473 bool
+	_, _, _ = yyc473, yyrt473, yyrl473
+	yyrr473 = yyl473
 
-	if yyv541 == nil {
-		if yyrl541, yyrt541 = z.DecInferLen(yyl541, z.DecBasicHandle().MaxInitLen, 64); yyrt541 {
-			yyrr541 = yyrl541
+	if yyv473 == nil {
+		if yyrl473, yyrt473 = z.DecInferLen(yyl473, z.DecBasicHandle().MaxInitLen, 64); yyrt473 {
+			yyrr473 = yyrl473
 		}
-		yyv541 = make([]ContainerSample, yyrl541)
-		yyc541 = true
+		yyv473 = make([]ContainerSample, yyrl473)
+		yyc473 = true
 	}
 
-	if yyl541 == 0 {
-		if len(yyv541) != 0 {
-			yyv541 = yyv541[:0]
-			yyc541 = true
+	if yyl473 == 0 {
+		if len(yyv473) != 0 {
+			yyv473 = yyv473[:0]
+			yyc473 = true
 		}
-	} else if yyl541 > 0 {
+	} else if yyl473 > 0 {
 
-		if yyl541 > cap(yyv541) {
-			yyrl541, yyrt541 = z.DecInferLen(yyl541, z.DecBasicHandle().MaxInitLen, 64)
-			yyv541 = make([]ContainerSample, yyrl541)
-			yyc541 = true
+		if yyl473 > cap(yyv473) {
+			yyrl473, yyrt473 = z.DecInferLen(yyl473, z.DecBasicHandle().MaxInitLen, 64)
+			yyv473 = make([]ContainerSample, yyrl473)
+			yyc473 = true
 
-			yyrr541 = len(yyv541)
-		} else if yyl541 != len(yyv541) {
-			yyv541 = yyv541[:yyl541]
-			yyc541 = true
+			yyrr473 = len(yyv473)
+		} else if yyl473 != len(yyv473) {
+			yyv473 = yyv473[:yyl473]
+			yyc473 = true
 		}
-		yyj541 := 0
-		for ; yyj541 < yyrr541; yyj541++ {
+		yyj473 := 0
+		for ; yyj473 < yyrr473; yyj473++ {
 			if r.TryDecodeAsNil() {
-				yyv541[yyj541] = ContainerSample{}
+				yyv473[yyj473] = ContainerSample{}
 			} else {
-				yyv542 := &yyv541[yyj541]
-				yyv542.CodecDecodeSelf(d)
+				yyv474 := &yyv473[yyj473]
+				yyv474.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt541 {
-			for ; yyj541 < yyl541; yyj541++ {
-				yyv541 = append(yyv541, ContainerSample{})
+		if yyrt473 {
+			for ; yyj473 < yyl473; yyj473++ {
+				yyv473 = append(yyv473, ContainerSample{})
 				if r.TryDecodeAsNil() {
-					yyv541[yyj541] = ContainerSample{}
+					yyv473[yyj473] = ContainerSample{}
 				} else {
-					yyv543 := &yyv541[yyj541]
-					yyv543.CodecDecodeSelf(d)
+					yyv475 := &yyv473[yyj473]
+					yyv475.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj541 := 0; !r.CheckBreak(); yyj541++ {
-			if yyj541 >= len(yyv541) {
-				yyv541 = append(yyv541, ContainerSample{}) // var yyz541 ContainerSample
-				yyc541 = true
+		for yyj473 := 0; !r.CheckBreak(); yyj473++ {
+			if yyj473 >= len(yyv473) {
+				yyv473 = append(yyv473, ContainerSample{}) // var yyz473 ContainerSample
+				yyc473 = true
 			}
 
-			if yyj541 < len(yyv541) {
+			if yyj473 < len(yyv473) {
 				if r.TryDecodeAsNil() {
-					yyv541[yyj541] = ContainerSample{}
+					yyv473[yyj473] = ContainerSample{}
 				} else {
-					yyv544 := &yyv541[yyj541]
-					yyv544.CodecDecodeSelf(d)
+					yyv476 := &yyv473[yyj473]
+					yyv476.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6401,111 +5708,10 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 			}
 
 		}
-		yyh541.End()
+		yyh473.End()
 	}
-	if yyc541 {
-		*v = yyv541
-	}
-
-}
-
-func (x codecSelfer1234) encSliceCustomMetric(v []CustomMetric, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv545 := range v {
-		yy546 := &yyv545
-		yy546.CodecEncodeSelf(e)
-	}
-	r.EncodeEnd()
-}
-
-func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv547 := *v
-	yyh547, yyl547 := z.DecSliceHelperStart()
-
-	var yyrr547, yyrl547 int
-	var yyc547, yyrt547 bool
-	_, _, _ = yyc547, yyrt547, yyrl547
-	yyrr547 = yyl547
-
-	if yyv547 == nil {
-		if yyrl547, yyrt547 = z.DecInferLen(yyl547, z.DecBasicHandle().MaxInitLen, 72); yyrt547 {
-			yyrr547 = yyrl547
-		}
-		yyv547 = make([]CustomMetric, yyrl547)
-		yyc547 = true
-	}
-
-	if yyl547 == 0 {
-		if len(yyv547) != 0 {
-			yyv547 = yyv547[:0]
-			yyc547 = true
-		}
-	} else if yyl547 > 0 {
-
-		if yyl547 > cap(yyv547) {
-			yyrl547, yyrt547 = z.DecInferLen(yyl547, z.DecBasicHandle().MaxInitLen, 72)
-			yyv547 = make([]CustomMetric, yyrl547)
-			yyc547 = true
-
-			yyrr547 = len(yyv547)
-		} else if yyl547 != len(yyv547) {
-			yyv547 = yyv547[:yyl547]
-			yyc547 = true
-		}
-		yyj547 := 0
-		for ; yyj547 < yyrr547; yyj547++ {
-			if r.TryDecodeAsNil() {
-				yyv547[yyj547] = CustomMetric{}
-			} else {
-				yyv548 := &yyv547[yyj547]
-				yyv548.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt547 {
-			for ; yyj547 < yyl547; yyj547++ {
-				yyv547 = append(yyv547, CustomMetric{})
-				if r.TryDecodeAsNil() {
-					yyv547[yyj547] = CustomMetric{}
-				} else {
-					yyv549 := &yyv547[yyj547]
-					yyv549.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		for yyj547 := 0; !r.CheckBreak(); yyj547++ {
-			if yyj547 >= len(yyv547) {
-				yyv547 = append(yyv547, CustomMetric{}) // var yyz547 CustomMetric
-				yyc547 = true
-			}
-
-			if yyj547 < len(yyv547) {
-				if r.TryDecodeAsNil() {
-					yyv547[yyj547] = CustomMetric{}
-				} else {
-					yyv550 := &yyv547[yyj547]
-					yyv550.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		yyh547.End()
-	}
-	if yyc547 {
-		*v = yyv547
+	if yyc473 {
+		*v = yyv473
 	}
 
 }
@@ -6515,9 +5721,9 @@ func (x codecSelfer1234) encSliceFilesystemMetrics(v []FilesystemMetrics, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv551 := range v {
-		yy552 := &yyv551
-		yy552.CodecEncodeSelf(e)
+	for _, yyv477 := range v {
+		yy478 := &yyv477
+		yy478.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6527,75 +5733,75 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv553 := *v
-	yyh553, yyl553 := z.DecSliceHelperStart()
+	yyv479 := *v
+	yyh479, yyl479 := z.DecSliceHelperStart()
 
-	var yyrr553, yyrl553 int
-	var yyc553, yyrt553 bool
-	_, _, _ = yyc553, yyrt553, yyrl553
-	yyrr553 = yyl553
+	var yyrr479, yyrl479 int
+	var yyc479, yyrt479 bool
+	_, _, _ = yyc479, yyrt479, yyrl479
+	yyrr479 = yyl479
 
-	if yyv553 == nil {
-		if yyrl553, yyrt553 = z.DecInferLen(yyl553, z.DecBasicHandle().MaxInitLen, 32); yyrt553 {
-			yyrr553 = yyrl553
+	if yyv479 == nil {
+		if yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 32); yyrt479 {
+			yyrr479 = yyrl479
 		}
-		yyv553 = make([]FilesystemMetrics, yyrl553)
-		yyc553 = true
+		yyv479 = make([]FilesystemMetrics, yyrl479)
+		yyc479 = true
 	}
 
-	if yyl553 == 0 {
-		if len(yyv553) != 0 {
-			yyv553 = yyv553[:0]
-			yyc553 = true
+	if yyl479 == 0 {
+		if len(yyv479) != 0 {
+			yyv479 = yyv479[:0]
+			yyc479 = true
 		}
-	} else if yyl553 > 0 {
+	} else if yyl479 > 0 {
 
-		if yyl553 > cap(yyv553) {
-			yyrl553, yyrt553 = z.DecInferLen(yyl553, z.DecBasicHandle().MaxInitLen, 32)
-			yyv553 = make([]FilesystemMetrics, yyrl553)
-			yyc553 = true
+		if yyl479 > cap(yyv479) {
+			yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 32)
+			yyv479 = make([]FilesystemMetrics, yyrl479)
+			yyc479 = true
 
-			yyrr553 = len(yyv553)
-		} else if yyl553 != len(yyv553) {
-			yyv553 = yyv553[:yyl553]
-			yyc553 = true
+			yyrr479 = len(yyv479)
+		} else if yyl479 != len(yyv479) {
+			yyv479 = yyv479[:yyl479]
+			yyc479 = true
 		}
-		yyj553 := 0
-		for ; yyj553 < yyrr553; yyj553++ {
+		yyj479 := 0
+		for ; yyj479 < yyrr479; yyj479++ {
 			if r.TryDecodeAsNil() {
-				yyv553[yyj553] = FilesystemMetrics{}
+				yyv479[yyj479] = FilesystemMetrics{}
 			} else {
-				yyv554 := &yyv553[yyj553]
-				yyv554.CodecDecodeSelf(d)
+				yyv480 := &yyv479[yyj479]
+				yyv480.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt553 {
-			for ; yyj553 < yyl553; yyj553++ {
-				yyv553 = append(yyv553, FilesystemMetrics{})
+		if yyrt479 {
+			for ; yyj479 < yyl479; yyj479++ {
+				yyv479 = append(yyv479, FilesystemMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv553[yyj553] = FilesystemMetrics{}
+					yyv479[yyj479] = FilesystemMetrics{}
 				} else {
-					yyv555 := &yyv553[yyj553]
-					yyv555.CodecDecodeSelf(d)
+					yyv481 := &yyv479[yyj479]
+					yyv481.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj553 := 0; !r.CheckBreak(); yyj553++ {
-			if yyj553 >= len(yyv553) {
-				yyv553 = append(yyv553, FilesystemMetrics{}) // var yyz553 FilesystemMetrics
-				yyc553 = true
+		for yyj479 := 0; !r.CheckBreak(); yyj479++ {
+			if yyj479 >= len(yyv479) {
+				yyv479 = append(yyv479, FilesystemMetrics{}) // var yyz479 FilesystemMetrics
+				yyc479 = true
 			}
 
-			if yyj553 < len(yyv553) {
+			if yyj479 < len(yyv479) {
 				if r.TryDecodeAsNil() {
-					yyv553[yyj553] = FilesystemMetrics{}
+					yyv479[yyj479] = FilesystemMetrics{}
 				} else {
-					yyv556 := &yyv553[yyj553]
-					yyv556.CodecDecodeSelf(d)
+					yyv482 := &yyv479[yyj479]
+					yyv482.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6603,111 +5809,10 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 			}
 
 		}
-		yyh553.End()
+		yyh479.End()
 	}
-	if yyc553 {
-		*v = yyv553
-	}
-
-}
-
-func (x codecSelfer1234) encSliceCustomMetricSample(v []CustomMetricSample, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv557 := range v {
-		yy558 := &yyv557
-		yy558.CodecEncodeSelf(e)
-	}
-	r.EncodeEnd()
-}
-
-func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv559 := *v
-	yyh559, yyl559 := z.DecSliceHelperStart()
-
-	var yyrr559, yyrl559 int
-	var yyc559, yyrt559 bool
-	_, _, _ = yyc559, yyrt559, yyrl559
-	yyrr559 = yyl559
-
-	if yyv559 == nil {
-		if yyrl559, yyrt559 = z.DecInferLen(yyl559, z.DecBasicHandle().MaxInitLen, 56); yyrt559 {
-			yyrr559 = yyrl559
-		}
-		yyv559 = make([]CustomMetricSample, yyrl559)
-		yyc559 = true
-	}
-
-	if yyl559 == 0 {
-		if len(yyv559) != 0 {
-			yyv559 = yyv559[:0]
-			yyc559 = true
-		}
-	} else if yyl559 > 0 {
-
-		if yyl559 > cap(yyv559) {
-			yyrl559, yyrt559 = z.DecInferLen(yyl559, z.DecBasicHandle().MaxInitLen, 56)
-			yyv559 = make([]CustomMetricSample, yyrl559)
-			yyc559 = true
-
-			yyrr559 = len(yyv559)
-		} else if yyl559 != len(yyv559) {
-			yyv559 = yyv559[:yyl559]
-			yyc559 = true
-		}
-		yyj559 := 0
-		for ; yyj559 < yyrr559; yyj559++ {
-			if r.TryDecodeAsNil() {
-				yyv559[yyj559] = CustomMetricSample{}
-			} else {
-				yyv560 := &yyv559[yyj559]
-				yyv560.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt559 {
-			for ; yyj559 < yyl559; yyj559++ {
-				yyv559 = append(yyv559, CustomMetricSample{})
-				if r.TryDecodeAsNil() {
-					yyv559[yyj559] = CustomMetricSample{}
-				} else {
-					yyv561 := &yyv559[yyj559]
-					yyv561.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		for yyj559 := 0; !r.CheckBreak(); yyj559++ {
-			if yyj559 >= len(yyv559) {
-				yyv559 = append(yyv559, CustomMetricSample{}) // var yyz559 CustomMetricSample
-				yyc559 = true
-			}
-
-			if yyj559 < len(yyv559) {
-				if r.TryDecodeAsNil() {
-					yyv559[yyj559] = CustomMetricSample{}
-				} else {
-					yyv562 := &yyv559[yyj559]
-					yyv562.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		yyh559.End()
-	}
-	if yyc559 {
-		*v = yyv559
+	if yyc479 {
+		*v = yyv479
 	}
 
 }

--- a/pkg/apis/metrics/types.generated.go
+++ b/pkg/apis/metrics/types.generated.go
@@ -4781,14 +4781,12 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep417 := !z.EncBinary()
 			yy2arr417 := z.EncBasicHandle().StructToArray
-			var yyq417 [3]bool
+			var yyq417 [1]bool
 			_, _, _ = yysep417, yyq417, yy2arr417
 			const yyr417 bool = false
-			yyq417[0] = x.SinceTime != nil
-			yyq417[1] = x.UntilTime != nil
-			yyq417[2] = x.MaxSamples != 0
+			yyq417[0] = x.MaxSamples != 0
 			if yyr417 || yy2arr417 {
-				r.EncodeArrayStart(3)
+				r.EncodeArrayStart(1)
 			} else {
 				var yynn417 int = 0
 				for _, b := range yyq417 {
@@ -4800,88 +4798,8 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr417 || yy2arr417 {
 				if yyq417[0] {
-					if x.SinceTime == nil {
-						r.EncodeNil()
-					} else {
-						yym419 := z.EncBinary()
-						_ = yym419
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym419 {
-							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym419 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.SinceTime)
-						} else {
-							z.EncFallback(x.SinceTime)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq417[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
-					if x.SinceTime == nil {
-						r.EncodeNil()
-					} else {
-						yym420 := z.EncBinary()
-						_ = yym420
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym420 {
-							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym420 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.SinceTime)
-						} else {
-							z.EncFallback(x.SinceTime)
-						}
-					}
-				}
-			}
-			if yyr417 || yy2arr417 {
-				if yyq417[1] {
-					if x.UntilTime == nil {
-						r.EncodeNil()
-					} else {
-						yym422 := z.EncBinary()
-						_ = yym422
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym422 {
-							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym422 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.UntilTime)
-						} else {
-							z.EncFallback(x.UntilTime)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq417[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
-					if x.UntilTime == nil {
-						r.EncodeNil()
-					} else {
-						yym423 := z.EncBinary()
-						_ = yym423
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym423 {
-							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym423 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.UntilTime)
-						} else {
-							z.EncFallback(x.UntilTime)
-						}
-					}
-				}
-			}
-			if yyr417 || yy2arr417 {
-				if yyq417[2] {
-					yym425 := z.EncBinary()
-					_ = yym425
+					yym419 := z.EncBinary()
+					_ = yym419
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -4890,10 +4808,10 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq417[2] {
+				if yyq417[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
-					yym426 := z.EncBinary()
-					_ = yym426
+					yym420 := z.EncBinary()
+					_ = yym420
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -4911,24 +4829,24 @@ func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym427 := z.DecBinary()
-	_ = yym427
+	yym421 := z.DecBinary()
+	_ = yym421
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl428 := r.ReadMapStart()
-			if yyl428 == 0 {
+			yyl422 := r.ReadMapStart()
+			if yyl422 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl428, d)
+				x.codecDecodeSelfFromMap(yyl422, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl428 := r.ReadArrayStart()
-			if yyl428 == 0 {
+			yyl422 := r.ReadArrayStart()
+			if yyl422 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl428, d)
+				x.codecDecodeSelfFromArray(yyl422, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4940,12 +4858,12 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys429Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys429Slc
-	var yyhl429 bool = l >= 0
-	for yyj429 := 0; ; yyj429++ {
-		if yyhl429 {
-			if yyj429 >= l {
+	var yys423Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys423Slc
+	var yyhl423 bool = l >= 0
+	for yyj423 := 0; ; yyj423++ {
+		if yyhl423 {
+			if yyj423 >= l {
 				break
 			}
 		} else {
@@ -4953,51 +4871,9 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys429Slc = r.DecodeBytes(yys429Slc, true, true)
-		yys429 := string(yys429Slc)
-		switch yys429 {
-		case "sinceTime":
-			if r.TryDecodeAsNil() {
-				if x.SinceTime != nil {
-					x.SinceTime = nil
-				}
-			} else {
-				if x.SinceTime == nil {
-					x.SinceTime = new(pkg1_unversioned.Time)
-				}
-				yym431 := z.DecBinary()
-				_ = yym431
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym431 {
-					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym431 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.SinceTime)
-				} else {
-					z.DecFallback(x.SinceTime, false)
-				}
-			}
-		case "untilTime":
-			if r.TryDecodeAsNil() {
-				if x.UntilTime != nil {
-					x.UntilTime = nil
-				}
-			} else {
-				if x.UntilTime == nil {
-					x.UntilTime = new(pkg1_unversioned.Time)
-				}
-				yym433 := z.DecBinary()
-				_ = yym433
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-				} else if yym433 {
-					z.DecBinaryUnmarshal(x.UntilTime)
-				} else if !yym433 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.UntilTime)
-				} else {
-					z.DecFallback(x.UntilTime, false)
-				}
-			}
+		yys423Slc = r.DecodeBytes(yys423Slc, true, true)
+		yys423 := string(yys423Slc)
+		switch yys423 {
 		case "maxSamples":
 			if r.TryDecodeAsNil() {
 				x.MaxSamples = 0
@@ -5005,10 +4881,10 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys429)
-		} // end switch yys429
-	} // end for yyj429
-	if !yyhl429 {
+			z.DecStructFieldNotFound(-1, yys423)
+		} // end switch yys423
+	} // end for yyj423
+	if !yyhl423 {
 		r.ReadEnd()
 	}
 }
@@ -5017,76 +4893,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj435 int
-	var yyb435 bool
-	var yyhl435 bool = l >= 0
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
+	var yyj425 int
+	var yyb425 bool
+	var yyhl425 bool = l >= 0
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
 	} else {
-		yyb435 = r.CheckBreak()
+		yyb425 = r.CheckBreak()
 	}
-	if yyb435 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		if x.SinceTime != nil {
-			x.SinceTime = nil
-		}
-	} else {
-		if x.SinceTime == nil {
-			x.SinceTime = new(pkg1_unversioned.Time)
-		}
-		yym437 := z.DecBinary()
-		_ = yym437
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym437 {
-			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym437 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.SinceTime)
-		} else {
-			z.DecFallback(x.SinceTime, false)
-		}
-	}
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
-	} else {
-		yyb435 = r.CheckBreak()
-	}
-	if yyb435 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		if x.UntilTime != nil {
-			x.UntilTime = nil
-		}
-	} else {
-		if x.UntilTime == nil {
-			x.UntilTime = new(pkg1_unversioned.Time)
-		}
-		yym439 := z.DecBinary()
-		_ = yym439
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-		} else if yym439 {
-			z.DecBinaryUnmarshal(x.UntilTime)
-		} else if !yym439 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.UntilTime)
-		} else {
-			z.DecFallback(x.UntilTime, false)
-		}
-	}
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
-	} else {
-		yyb435 = r.CheckBreak()
-	}
-	if yyb435 {
+	if yyb425 {
 		r.ReadEnd()
 		return
 	}
@@ -5096,16 +4912,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj435++
-		if yyhl435 {
-			yyb435 = yyj435 > l
+		yyj425++
+		if yyhl425 {
+			yyb425 = yyj425 > l
 		} else {
-			yyb435 = r.CheckBreak()
+			yyb425 = r.CheckBreak()
 		}
-		if yyb435 {
+		if yyb425 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj435-1, "")
+		z.DecStructFieldNotFound(yyj425-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5115,9 +4931,9 @@ func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv441 := range v {
-		yy442 := &yyv441
-		yy442.CodecEncodeSelf(e)
+	for _, yyv427 := range v {
+		yy428 := &yyv427
+		yy428.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5127,75 +4943,75 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv443 := *v
-	yyh443, yyl443 := z.DecSliceHelperStart()
+	yyv429 := *v
+	yyh429, yyl429 := z.DecSliceHelperStart()
 
-	var yyrr443, yyrl443 int
-	var yyc443, yyrt443 bool
-	_, _, _ = yyc443, yyrt443, yyrl443
-	yyrr443 = yyl443
+	var yyrr429, yyrl429 int
+	var yyc429, yyrt429 bool
+	_, _, _ = yyc429, yyrt429, yyrl429
+	yyrr429 = yyl429
 
-	if yyv443 == nil {
-		if yyrl443, yyrt443 = z.DecInferLen(yyl443, z.DecBasicHandle().MaxInitLen, 72); yyrt443 {
-			yyrr443 = yyrl443
+	if yyv429 == nil {
+		if yyrl429, yyrt429 = z.DecInferLen(yyl429, z.DecBasicHandle().MaxInitLen, 72); yyrt429 {
+			yyrr429 = yyrl429
 		}
-		yyv443 = make([]AggregateSample, yyrl443)
-		yyc443 = true
+		yyv429 = make([]AggregateSample, yyrl429)
+		yyc429 = true
 	}
 
-	if yyl443 == 0 {
-		if len(yyv443) != 0 {
-			yyv443 = yyv443[:0]
-			yyc443 = true
+	if yyl429 == 0 {
+		if len(yyv429) != 0 {
+			yyv429 = yyv429[:0]
+			yyc429 = true
 		}
-	} else if yyl443 > 0 {
+	} else if yyl429 > 0 {
 
-		if yyl443 > cap(yyv443) {
-			yyrl443, yyrt443 = z.DecInferLen(yyl443, z.DecBasicHandle().MaxInitLen, 72)
-			yyv443 = make([]AggregateSample, yyrl443)
-			yyc443 = true
+		if yyl429 > cap(yyv429) {
+			yyrl429, yyrt429 = z.DecInferLen(yyl429, z.DecBasicHandle().MaxInitLen, 72)
+			yyv429 = make([]AggregateSample, yyrl429)
+			yyc429 = true
 
-			yyrr443 = len(yyv443)
-		} else if yyl443 != len(yyv443) {
-			yyv443 = yyv443[:yyl443]
-			yyc443 = true
+			yyrr429 = len(yyv429)
+		} else if yyl429 != len(yyv429) {
+			yyv429 = yyv429[:yyl429]
+			yyc429 = true
 		}
-		yyj443 := 0
-		for ; yyj443 < yyrr443; yyj443++ {
+		yyj429 := 0
+		for ; yyj429 < yyrr429; yyj429++ {
 			if r.TryDecodeAsNil() {
-				yyv443[yyj443] = AggregateSample{}
+				yyv429[yyj429] = AggregateSample{}
 			} else {
-				yyv444 := &yyv443[yyj443]
-				yyv444.CodecDecodeSelf(d)
+				yyv430 := &yyv429[yyj429]
+				yyv430.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt443 {
-			for ; yyj443 < yyl443; yyj443++ {
-				yyv443 = append(yyv443, AggregateSample{})
+		if yyrt429 {
+			for ; yyj429 < yyl429; yyj429++ {
+				yyv429 = append(yyv429, AggregateSample{})
 				if r.TryDecodeAsNil() {
-					yyv443[yyj443] = AggregateSample{}
+					yyv429[yyj429] = AggregateSample{}
 				} else {
-					yyv445 := &yyv443[yyj443]
-					yyv445.CodecDecodeSelf(d)
+					yyv431 := &yyv429[yyj429]
+					yyv431.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj443 := 0; !r.CheckBreak(); yyj443++ {
-			if yyj443 >= len(yyv443) {
-				yyv443 = append(yyv443, AggregateSample{}) // var yyz443 AggregateSample
-				yyc443 = true
+		for yyj429 := 0; !r.CheckBreak(); yyj429++ {
+			if yyj429 >= len(yyv429) {
+				yyv429 = append(yyv429, AggregateSample{}) // var yyz429 AggregateSample
+				yyc429 = true
 			}
 
-			if yyj443 < len(yyv443) {
+			if yyj429 < len(yyv429) {
 				if r.TryDecodeAsNil() {
-					yyv443[yyj443] = AggregateSample{}
+					yyv429[yyj429] = AggregateSample{}
 				} else {
-					yyv446 := &yyv443[yyj443]
-					yyv446.CodecDecodeSelf(d)
+					yyv432 := &yyv429[yyj429]
+					yyv432.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5203,10 +5019,10 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 			}
 
 		}
-		yyh443.End()
+		yyh429.End()
 	}
-	if yyc443 {
-		*v = yyv443
+	if yyc429 {
+		*v = yyv429
 	}
 
 }
@@ -5216,9 +5032,9 @@ func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv447 := range v {
-		yy448 := &yyv447
-		yy448.CodecEncodeSelf(e)
+	for _, yyv433 := range v {
+		yy434 := &yyv433
+		yy434.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5228,75 +5044,75 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv449 := *v
-	yyh449, yyl449 := z.DecSliceHelperStart()
+	yyv435 := *v
+	yyh435, yyl435 := z.DecSliceHelperStart()
 
-	var yyrr449, yyrl449 int
-	var yyc449, yyrt449 bool
-	_, _, _ = yyc449, yyrt449, yyrl449
-	yyrr449 = yyl449
+	var yyrr435, yyrl435 int
+	var yyc435, yyrt435 bool
+	_, _, _ = yyc435, yyrt435, yyrl435
+	yyrr435 = yyl435
 
-	if yyv449 == nil {
-		if yyrl449, yyrt449 = z.DecInferLen(yyl449, z.DecBasicHandle().MaxInitLen, 48); yyrt449 {
-			yyrr449 = yyrl449
+	if yyv435 == nil {
+		if yyrl435, yyrt435 = z.DecInferLen(yyl435, z.DecBasicHandle().MaxInitLen, 48); yyrt435 {
+			yyrr435 = yyrl435
 		}
-		yyv449 = make([]RawContainerMetrics, yyrl449)
-		yyc449 = true
+		yyv435 = make([]RawContainerMetrics, yyrl435)
+		yyc435 = true
 	}
 
-	if yyl449 == 0 {
-		if len(yyv449) != 0 {
-			yyv449 = yyv449[:0]
-			yyc449 = true
+	if yyl435 == 0 {
+		if len(yyv435) != 0 {
+			yyv435 = yyv435[:0]
+			yyc435 = true
 		}
-	} else if yyl449 > 0 {
+	} else if yyl435 > 0 {
 
-		if yyl449 > cap(yyv449) {
-			yyrl449, yyrt449 = z.DecInferLen(yyl449, z.DecBasicHandle().MaxInitLen, 48)
-			yyv449 = make([]RawContainerMetrics, yyrl449)
-			yyc449 = true
+		if yyl435 > cap(yyv435) {
+			yyrl435, yyrt435 = z.DecInferLen(yyl435, z.DecBasicHandle().MaxInitLen, 48)
+			yyv435 = make([]RawContainerMetrics, yyrl435)
+			yyc435 = true
 
-			yyrr449 = len(yyv449)
-		} else if yyl449 != len(yyv449) {
-			yyv449 = yyv449[:yyl449]
-			yyc449 = true
+			yyrr435 = len(yyv435)
+		} else if yyl435 != len(yyv435) {
+			yyv435 = yyv435[:yyl435]
+			yyc435 = true
 		}
-		yyj449 := 0
-		for ; yyj449 < yyrr449; yyj449++ {
+		yyj435 := 0
+		for ; yyj435 < yyrr435; yyj435++ {
 			if r.TryDecodeAsNil() {
-				yyv449[yyj449] = RawContainerMetrics{}
+				yyv435[yyj435] = RawContainerMetrics{}
 			} else {
-				yyv450 := &yyv449[yyj449]
-				yyv450.CodecDecodeSelf(d)
+				yyv436 := &yyv435[yyj435]
+				yyv436.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt449 {
-			for ; yyj449 < yyl449; yyj449++ {
-				yyv449 = append(yyv449, RawContainerMetrics{})
+		if yyrt435 {
+			for ; yyj435 < yyl435; yyj435++ {
+				yyv435 = append(yyv435, RawContainerMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv449[yyj449] = RawContainerMetrics{}
+					yyv435[yyj435] = RawContainerMetrics{}
 				} else {
-					yyv451 := &yyv449[yyj449]
-					yyv451.CodecDecodeSelf(d)
+					yyv437 := &yyv435[yyj435]
+					yyv437.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj449 := 0; !r.CheckBreak(); yyj449++ {
-			if yyj449 >= len(yyv449) {
-				yyv449 = append(yyv449, RawContainerMetrics{}) // var yyz449 RawContainerMetrics
-				yyc449 = true
+		for yyj435 := 0; !r.CheckBreak(); yyj435++ {
+			if yyj435 >= len(yyv435) {
+				yyv435 = append(yyv435, RawContainerMetrics{}) // var yyz435 RawContainerMetrics
+				yyc435 = true
 			}
 
-			if yyj449 < len(yyv449) {
+			if yyj435 < len(yyv435) {
 				if r.TryDecodeAsNil() {
-					yyv449[yyj449] = RawContainerMetrics{}
+					yyv435[yyj435] = RawContainerMetrics{}
 				} else {
-					yyv452 := &yyv449[yyj449]
-					yyv452.CodecDecodeSelf(d)
+					yyv438 := &yyv435[yyj435]
+					yyv438.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5304,10 +5120,10 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 			}
 
 		}
-		yyh449.End()
+		yyh435.End()
 	}
-	if yyc449 {
-		*v = yyv449
+	if yyc435 {
+		*v = yyv435
 	}
 
 }
@@ -5317,9 +5133,9 @@ func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv453 := range v {
-		yy454 := &yyv453
-		yy454.CodecEncodeSelf(e)
+	for _, yyv439 := range v {
+		yy440 := &yyv439
+		yy440.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5329,75 +5145,75 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv455 := *v
-	yyh455, yyl455 := z.DecSliceHelperStart()
+	yyv441 := *v
+	yyh441, yyl441 := z.DecSliceHelperStart()
 
-	var yyrr455, yyrl455 int
-	var yyc455, yyrt455 bool
-	_, _, _ = yyc455, yyrt455, yyrl455
-	yyrr455 = yyl455
+	var yyrr441, yyrl441 int
+	var yyc441, yyrt441 bool
+	_, _, _ = yyc441, yyrt441, yyrl441
+	yyrr441 = yyl441
 
-	if yyv455 == nil {
-		if yyrl455, yyrt455 = z.DecInferLen(yyl455, z.DecBasicHandle().MaxInitLen, 128); yyrt455 {
-			yyrr455 = yyrl455
+	if yyv441 == nil {
+		if yyrl441, yyrt441 = z.DecInferLen(yyl441, z.DecBasicHandle().MaxInitLen, 128); yyrt441 {
+			yyrr441 = yyrl441
 		}
-		yyv455 = make([]RawNodeMetrics, yyrl455)
-		yyc455 = true
+		yyv441 = make([]RawNodeMetrics, yyrl441)
+		yyc441 = true
 	}
 
-	if yyl455 == 0 {
-		if len(yyv455) != 0 {
-			yyv455 = yyv455[:0]
-			yyc455 = true
+	if yyl441 == 0 {
+		if len(yyv441) != 0 {
+			yyv441 = yyv441[:0]
+			yyc441 = true
 		}
-	} else if yyl455 > 0 {
+	} else if yyl441 > 0 {
 
-		if yyl455 > cap(yyv455) {
-			yyrl455, yyrt455 = z.DecInferLen(yyl455, z.DecBasicHandle().MaxInitLen, 128)
-			yyv455 = make([]RawNodeMetrics, yyrl455)
-			yyc455 = true
+		if yyl441 > cap(yyv441) {
+			yyrl441, yyrt441 = z.DecInferLen(yyl441, z.DecBasicHandle().MaxInitLen, 128)
+			yyv441 = make([]RawNodeMetrics, yyrl441)
+			yyc441 = true
 
-			yyrr455 = len(yyv455)
-		} else if yyl455 != len(yyv455) {
-			yyv455 = yyv455[:yyl455]
-			yyc455 = true
+			yyrr441 = len(yyv441)
+		} else if yyl441 != len(yyv441) {
+			yyv441 = yyv441[:yyl441]
+			yyc441 = true
 		}
-		yyj455 := 0
-		for ; yyj455 < yyrr455; yyj455++ {
+		yyj441 := 0
+		for ; yyj441 < yyrr441; yyj441++ {
 			if r.TryDecodeAsNil() {
-				yyv455[yyj455] = RawNodeMetrics{}
+				yyv441[yyj441] = RawNodeMetrics{}
 			} else {
-				yyv456 := &yyv455[yyj455]
-				yyv456.CodecDecodeSelf(d)
+				yyv442 := &yyv441[yyj441]
+				yyv442.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt455 {
-			for ; yyj455 < yyl455; yyj455++ {
-				yyv455 = append(yyv455, RawNodeMetrics{})
+		if yyrt441 {
+			for ; yyj441 < yyl441; yyj441++ {
+				yyv441 = append(yyv441, RawNodeMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv455[yyj455] = RawNodeMetrics{}
+					yyv441[yyj441] = RawNodeMetrics{}
 				} else {
-					yyv457 := &yyv455[yyj455]
-					yyv457.CodecDecodeSelf(d)
+					yyv443 := &yyv441[yyj441]
+					yyv443.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj455 := 0; !r.CheckBreak(); yyj455++ {
-			if yyj455 >= len(yyv455) {
-				yyv455 = append(yyv455, RawNodeMetrics{}) // var yyz455 RawNodeMetrics
-				yyc455 = true
+		for yyj441 := 0; !r.CheckBreak(); yyj441++ {
+			if yyj441 >= len(yyv441) {
+				yyv441 = append(yyv441, RawNodeMetrics{}) // var yyz441 RawNodeMetrics
+				yyc441 = true
 			}
 
-			if yyj455 < len(yyv455) {
+			if yyj441 < len(yyv441) {
 				if r.TryDecodeAsNil() {
-					yyv455[yyj455] = RawNodeMetrics{}
+					yyv441[yyj441] = RawNodeMetrics{}
 				} else {
-					yyv458 := &yyv455[yyj455]
-					yyv458.CodecDecodeSelf(d)
+					yyv444 := &yyv441[yyj441]
+					yyv444.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5405,10 +5221,10 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 			}
 
 		}
-		yyh455.End()
+		yyh441.End()
 	}
-	if yyc455 {
-		*v = yyv455
+	if yyc441 {
+		*v = yyv441
 	}
 
 }
@@ -5418,9 +5234,9 @@ func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv459 := range v {
-		yy460 := &yyv459
-		yy460.CodecEncodeSelf(e)
+	for _, yyv445 := range v {
+		yy446 := &yyv445
+		yy446.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5430,75 +5246,75 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv461 := *v
-	yyh461, yyl461 := z.DecSliceHelperStart()
+	yyv447 := *v
+	yyh447, yyl447 := z.DecSliceHelperStart()
 
-	var yyrr461, yyrl461 int
-	var yyc461, yyrt461 bool
-	_, _, _ = yyc461, yyrt461, yyrl461
-	yyrr461 = yyl461
+	var yyrr447, yyrl447 int
+	var yyc447, yyrt447 bool
+	_, _, _ = yyc447, yyrt447, yyrl447
+	yyrr447 = yyl447
 
-	if yyv461 == nil {
-		if yyrl461, yyrt461 = z.DecInferLen(yyl461, z.DecBasicHandle().MaxInitLen, 32); yyrt461 {
-			yyrr461 = yyrl461
+	if yyv447 == nil {
+		if yyrl447, yyrt447 = z.DecInferLen(yyl447, z.DecBasicHandle().MaxInitLen, 32); yyrt447 {
+			yyrr447 = yyrl447
 		}
-		yyv461 = make([]PodSample, yyrl461)
-		yyc461 = true
+		yyv447 = make([]PodSample, yyrl447)
+		yyc447 = true
 	}
 
-	if yyl461 == 0 {
-		if len(yyv461) != 0 {
-			yyv461 = yyv461[:0]
-			yyc461 = true
+	if yyl447 == 0 {
+		if len(yyv447) != 0 {
+			yyv447 = yyv447[:0]
+			yyc447 = true
 		}
-	} else if yyl461 > 0 {
+	} else if yyl447 > 0 {
 
-		if yyl461 > cap(yyv461) {
-			yyrl461, yyrt461 = z.DecInferLen(yyl461, z.DecBasicHandle().MaxInitLen, 32)
-			yyv461 = make([]PodSample, yyrl461)
-			yyc461 = true
+		if yyl447 > cap(yyv447) {
+			yyrl447, yyrt447 = z.DecInferLen(yyl447, z.DecBasicHandle().MaxInitLen, 32)
+			yyv447 = make([]PodSample, yyrl447)
+			yyc447 = true
 
-			yyrr461 = len(yyv461)
-		} else if yyl461 != len(yyv461) {
-			yyv461 = yyv461[:yyl461]
-			yyc461 = true
+			yyrr447 = len(yyv447)
+		} else if yyl447 != len(yyv447) {
+			yyv447 = yyv447[:yyl447]
+			yyc447 = true
 		}
-		yyj461 := 0
-		for ; yyj461 < yyrr461; yyj461++ {
+		yyj447 := 0
+		for ; yyj447 < yyrr447; yyj447++ {
 			if r.TryDecodeAsNil() {
-				yyv461[yyj461] = PodSample{}
+				yyv447[yyj447] = PodSample{}
 			} else {
-				yyv462 := &yyv461[yyj461]
-				yyv462.CodecDecodeSelf(d)
+				yyv448 := &yyv447[yyj447]
+				yyv448.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt461 {
-			for ; yyj461 < yyl461; yyj461++ {
-				yyv461 = append(yyv461, PodSample{})
+		if yyrt447 {
+			for ; yyj447 < yyl447; yyj447++ {
+				yyv447 = append(yyv447, PodSample{})
 				if r.TryDecodeAsNil() {
-					yyv461[yyj461] = PodSample{}
+					yyv447[yyj447] = PodSample{}
 				} else {
-					yyv463 := &yyv461[yyj461]
-					yyv463.CodecDecodeSelf(d)
+					yyv449 := &yyv447[yyj447]
+					yyv449.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj461 := 0; !r.CheckBreak(); yyj461++ {
-			if yyj461 >= len(yyv461) {
-				yyv461 = append(yyv461, PodSample{}) // var yyz461 PodSample
-				yyc461 = true
+		for yyj447 := 0; !r.CheckBreak(); yyj447++ {
+			if yyj447 >= len(yyv447) {
+				yyv447 = append(yyv447, PodSample{}) // var yyz447 PodSample
+				yyc447 = true
 			}
 
-			if yyj461 < len(yyv461) {
+			if yyj447 < len(yyv447) {
 				if r.TryDecodeAsNil() {
-					yyv461[yyj461] = PodSample{}
+					yyv447[yyj447] = PodSample{}
 				} else {
-					yyv464 := &yyv461[yyj461]
-					yyv464.CodecDecodeSelf(d)
+					yyv450 := &yyv447[yyj447]
+					yyv450.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5506,10 +5322,10 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 			}
 
 		}
-		yyh461.End()
+		yyh447.End()
 	}
-	if yyc461 {
-		*v = yyv461
+	if yyc447 {
+		*v = yyv447
 	}
 
 }
@@ -5519,9 +5335,9 @@ func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv465 := range v {
-		yy466 := &yyv465
-		yy466.CodecEncodeSelf(e)
+	for _, yyv451 := range v {
+		yy452 := &yyv451
+		yy452.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5531,75 +5347,75 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv467 := *v
-	yyh467, yyl467 := z.DecSliceHelperStart()
+	yyv453 := *v
+	yyh453, yyl453 := z.DecSliceHelperStart()
 
-	var yyrr467, yyrl467 int
-	var yyc467, yyrt467 bool
-	_, _, _ = yyc467, yyrt467, yyrl467
-	yyrr467 = yyl467
+	var yyrr453, yyrl453 int
+	var yyc453, yyrt453 bool
+	_, _, _ = yyc453, yyrt453, yyrl453
+	yyrr453 = yyl453
 
-	if yyv467 == nil {
-		if yyrl467, yyrt467 = z.DecInferLen(yyl467, z.DecBasicHandle().MaxInitLen, 160); yyrt467 {
-			yyrr467 = yyrl467
+	if yyv453 == nil {
+		if yyrl453, yyrt453 = z.DecInferLen(yyl453, z.DecBasicHandle().MaxInitLen, 160); yyrt453 {
+			yyrr453 = yyrl453
 		}
-		yyv467 = make([]RawPodMetrics, yyrl467)
-		yyc467 = true
+		yyv453 = make([]RawPodMetrics, yyrl453)
+		yyc453 = true
 	}
 
-	if yyl467 == 0 {
-		if len(yyv467) != 0 {
-			yyv467 = yyv467[:0]
-			yyc467 = true
+	if yyl453 == 0 {
+		if len(yyv453) != 0 {
+			yyv453 = yyv453[:0]
+			yyc453 = true
 		}
-	} else if yyl467 > 0 {
+	} else if yyl453 > 0 {
 
-		if yyl467 > cap(yyv467) {
-			yyrl467, yyrt467 = z.DecInferLen(yyl467, z.DecBasicHandle().MaxInitLen, 160)
-			yyv467 = make([]RawPodMetrics, yyrl467)
-			yyc467 = true
+		if yyl453 > cap(yyv453) {
+			yyrl453, yyrt453 = z.DecInferLen(yyl453, z.DecBasicHandle().MaxInitLen, 160)
+			yyv453 = make([]RawPodMetrics, yyrl453)
+			yyc453 = true
 
-			yyrr467 = len(yyv467)
-		} else if yyl467 != len(yyv467) {
-			yyv467 = yyv467[:yyl467]
-			yyc467 = true
+			yyrr453 = len(yyv453)
+		} else if yyl453 != len(yyv453) {
+			yyv453 = yyv453[:yyl453]
+			yyc453 = true
 		}
-		yyj467 := 0
-		for ; yyj467 < yyrr467; yyj467++ {
+		yyj453 := 0
+		for ; yyj453 < yyrr453; yyj453++ {
 			if r.TryDecodeAsNil() {
-				yyv467[yyj467] = RawPodMetrics{}
+				yyv453[yyj453] = RawPodMetrics{}
 			} else {
-				yyv468 := &yyv467[yyj467]
-				yyv468.CodecDecodeSelf(d)
+				yyv454 := &yyv453[yyj453]
+				yyv454.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt467 {
-			for ; yyj467 < yyl467; yyj467++ {
-				yyv467 = append(yyv467, RawPodMetrics{})
+		if yyrt453 {
+			for ; yyj453 < yyl453; yyj453++ {
+				yyv453 = append(yyv453, RawPodMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv467[yyj467] = RawPodMetrics{}
+					yyv453[yyj453] = RawPodMetrics{}
 				} else {
-					yyv469 := &yyv467[yyj467]
-					yyv469.CodecDecodeSelf(d)
+					yyv455 := &yyv453[yyj453]
+					yyv455.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj467 := 0; !r.CheckBreak(); yyj467++ {
-			if yyj467 >= len(yyv467) {
-				yyv467 = append(yyv467, RawPodMetrics{}) // var yyz467 RawPodMetrics
-				yyc467 = true
+		for yyj453 := 0; !r.CheckBreak(); yyj453++ {
+			if yyj453 >= len(yyv453) {
+				yyv453 = append(yyv453, RawPodMetrics{}) // var yyz453 RawPodMetrics
+				yyc453 = true
 			}
 
-			if yyj467 < len(yyv467) {
+			if yyj453 < len(yyv453) {
 				if r.TryDecodeAsNil() {
-					yyv467[yyj467] = RawPodMetrics{}
+					yyv453[yyj453] = RawPodMetrics{}
 				} else {
-					yyv470 := &yyv467[yyj467]
-					yyv470.CodecDecodeSelf(d)
+					yyv456 := &yyv453[yyj453]
+					yyv456.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5607,10 +5423,10 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 			}
 
 		}
-		yyh467.End()
+		yyh453.End()
 	}
-	if yyc467 {
-		*v = yyv467
+	if yyc453 {
+		*v = yyv453
 	}
 
 }
@@ -5620,9 +5436,9 @@ func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv471 := range v {
-		yy472 := &yyv471
-		yy472.CodecEncodeSelf(e)
+	for _, yyv457 := range v {
+		yy458 := &yyv457
+		yy458.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5632,75 +5448,75 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv473 := *v
-	yyh473, yyl473 := z.DecSliceHelperStart()
+	yyv459 := *v
+	yyh459, yyl459 := z.DecSliceHelperStart()
 
-	var yyrr473, yyrl473 int
-	var yyc473, yyrt473 bool
-	_, _, _ = yyc473, yyrt473, yyrl473
-	yyrr473 = yyl473
+	var yyrr459, yyrl459 int
+	var yyc459, yyrt459 bool
+	_, _, _ = yyc459, yyrt459, yyrl459
+	yyrr459 = yyl459
 
-	if yyv473 == nil {
-		if yyrl473, yyrt473 = z.DecInferLen(yyl473, z.DecBasicHandle().MaxInitLen, 64); yyrt473 {
-			yyrr473 = yyrl473
+	if yyv459 == nil {
+		if yyrl459, yyrt459 = z.DecInferLen(yyl459, z.DecBasicHandle().MaxInitLen, 64); yyrt459 {
+			yyrr459 = yyrl459
 		}
-		yyv473 = make([]ContainerSample, yyrl473)
-		yyc473 = true
+		yyv459 = make([]ContainerSample, yyrl459)
+		yyc459 = true
 	}
 
-	if yyl473 == 0 {
-		if len(yyv473) != 0 {
-			yyv473 = yyv473[:0]
-			yyc473 = true
+	if yyl459 == 0 {
+		if len(yyv459) != 0 {
+			yyv459 = yyv459[:0]
+			yyc459 = true
 		}
-	} else if yyl473 > 0 {
+	} else if yyl459 > 0 {
 
-		if yyl473 > cap(yyv473) {
-			yyrl473, yyrt473 = z.DecInferLen(yyl473, z.DecBasicHandle().MaxInitLen, 64)
-			yyv473 = make([]ContainerSample, yyrl473)
-			yyc473 = true
+		if yyl459 > cap(yyv459) {
+			yyrl459, yyrt459 = z.DecInferLen(yyl459, z.DecBasicHandle().MaxInitLen, 64)
+			yyv459 = make([]ContainerSample, yyrl459)
+			yyc459 = true
 
-			yyrr473 = len(yyv473)
-		} else if yyl473 != len(yyv473) {
-			yyv473 = yyv473[:yyl473]
-			yyc473 = true
+			yyrr459 = len(yyv459)
+		} else if yyl459 != len(yyv459) {
+			yyv459 = yyv459[:yyl459]
+			yyc459 = true
 		}
-		yyj473 := 0
-		for ; yyj473 < yyrr473; yyj473++ {
+		yyj459 := 0
+		for ; yyj459 < yyrr459; yyj459++ {
 			if r.TryDecodeAsNil() {
-				yyv473[yyj473] = ContainerSample{}
+				yyv459[yyj459] = ContainerSample{}
 			} else {
-				yyv474 := &yyv473[yyj473]
-				yyv474.CodecDecodeSelf(d)
+				yyv460 := &yyv459[yyj459]
+				yyv460.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt473 {
-			for ; yyj473 < yyl473; yyj473++ {
-				yyv473 = append(yyv473, ContainerSample{})
+		if yyrt459 {
+			for ; yyj459 < yyl459; yyj459++ {
+				yyv459 = append(yyv459, ContainerSample{})
 				if r.TryDecodeAsNil() {
-					yyv473[yyj473] = ContainerSample{}
+					yyv459[yyj459] = ContainerSample{}
 				} else {
-					yyv475 := &yyv473[yyj473]
-					yyv475.CodecDecodeSelf(d)
+					yyv461 := &yyv459[yyj459]
+					yyv461.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj473 := 0; !r.CheckBreak(); yyj473++ {
-			if yyj473 >= len(yyv473) {
-				yyv473 = append(yyv473, ContainerSample{}) // var yyz473 ContainerSample
-				yyc473 = true
+		for yyj459 := 0; !r.CheckBreak(); yyj459++ {
+			if yyj459 >= len(yyv459) {
+				yyv459 = append(yyv459, ContainerSample{}) // var yyz459 ContainerSample
+				yyc459 = true
 			}
 
-			if yyj473 < len(yyv473) {
+			if yyj459 < len(yyv459) {
 				if r.TryDecodeAsNil() {
-					yyv473[yyj473] = ContainerSample{}
+					yyv459[yyj459] = ContainerSample{}
 				} else {
-					yyv476 := &yyv473[yyj473]
-					yyv476.CodecDecodeSelf(d)
+					yyv462 := &yyv459[yyj459]
+					yyv462.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5708,10 +5524,10 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 			}
 
 		}
-		yyh473.End()
+		yyh459.End()
 	}
-	if yyc473 {
-		*v = yyv473
+	if yyc459 {
+		*v = yyv459
 	}
 
 }
@@ -5721,9 +5537,9 @@ func (x codecSelfer1234) encSliceFilesystemMetrics(v []FilesystemMetrics, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv477 := range v {
-		yy478 := &yyv477
-		yy478.CodecEncodeSelf(e)
+	for _, yyv463 := range v {
+		yy464 := &yyv463
+		yy464.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5733,75 +5549,75 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv479 := *v
-	yyh479, yyl479 := z.DecSliceHelperStart()
+	yyv465 := *v
+	yyh465, yyl465 := z.DecSliceHelperStart()
 
-	var yyrr479, yyrl479 int
-	var yyc479, yyrt479 bool
-	_, _, _ = yyc479, yyrt479, yyrl479
-	yyrr479 = yyl479
+	var yyrr465, yyrl465 int
+	var yyc465, yyrt465 bool
+	_, _, _ = yyc465, yyrt465, yyrl465
+	yyrr465 = yyl465
 
-	if yyv479 == nil {
-		if yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 32); yyrt479 {
-			yyrr479 = yyrl479
+	if yyv465 == nil {
+		if yyrl465, yyrt465 = z.DecInferLen(yyl465, z.DecBasicHandle().MaxInitLen, 32); yyrt465 {
+			yyrr465 = yyrl465
 		}
-		yyv479 = make([]FilesystemMetrics, yyrl479)
-		yyc479 = true
+		yyv465 = make([]FilesystemMetrics, yyrl465)
+		yyc465 = true
 	}
 
-	if yyl479 == 0 {
-		if len(yyv479) != 0 {
-			yyv479 = yyv479[:0]
-			yyc479 = true
+	if yyl465 == 0 {
+		if len(yyv465) != 0 {
+			yyv465 = yyv465[:0]
+			yyc465 = true
 		}
-	} else if yyl479 > 0 {
+	} else if yyl465 > 0 {
 
-		if yyl479 > cap(yyv479) {
-			yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 32)
-			yyv479 = make([]FilesystemMetrics, yyrl479)
-			yyc479 = true
+		if yyl465 > cap(yyv465) {
+			yyrl465, yyrt465 = z.DecInferLen(yyl465, z.DecBasicHandle().MaxInitLen, 32)
+			yyv465 = make([]FilesystemMetrics, yyrl465)
+			yyc465 = true
 
-			yyrr479 = len(yyv479)
-		} else if yyl479 != len(yyv479) {
-			yyv479 = yyv479[:yyl479]
-			yyc479 = true
+			yyrr465 = len(yyv465)
+		} else if yyl465 != len(yyv465) {
+			yyv465 = yyv465[:yyl465]
+			yyc465 = true
 		}
-		yyj479 := 0
-		for ; yyj479 < yyrr479; yyj479++ {
+		yyj465 := 0
+		for ; yyj465 < yyrr465; yyj465++ {
 			if r.TryDecodeAsNil() {
-				yyv479[yyj479] = FilesystemMetrics{}
+				yyv465[yyj465] = FilesystemMetrics{}
 			} else {
-				yyv480 := &yyv479[yyj479]
-				yyv480.CodecDecodeSelf(d)
+				yyv466 := &yyv465[yyj465]
+				yyv466.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt479 {
-			for ; yyj479 < yyl479; yyj479++ {
-				yyv479 = append(yyv479, FilesystemMetrics{})
+		if yyrt465 {
+			for ; yyj465 < yyl465; yyj465++ {
+				yyv465 = append(yyv465, FilesystemMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv479[yyj479] = FilesystemMetrics{}
+					yyv465[yyj465] = FilesystemMetrics{}
 				} else {
-					yyv481 := &yyv479[yyj479]
-					yyv481.CodecDecodeSelf(d)
+					yyv467 := &yyv465[yyj465]
+					yyv467.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj479 := 0; !r.CheckBreak(); yyj479++ {
-			if yyj479 >= len(yyv479) {
-				yyv479 = append(yyv479, FilesystemMetrics{}) // var yyz479 FilesystemMetrics
-				yyc479 = true
+		for yyj465 := 0; !r.CheckBreak(); yyj465++ {
+			if yyj465 >= len(yyv465) {
+				yyv465 = append(yyv465, FilesystemMetrics{}) // var yyz465 FilesystemMetrics
+				yyc465 = true
 			}
 
-			if yyj479 < len(yyv479) {
+			if yyj465 < len(yyv465) {
 				if r.TryDecodeAsNil() {
-					yyv479[yyj479] = FilesystemMetrics{}
+					yyv465[yyj465] = FilesystemMetrics{}
 				} else {
-					yyv482 := &yyv479[yyj479]
-					yyv482.CodecDecodeSelf(d)
+					yyv468 := &yyv465[yyj465]
+					yyv468.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5809,10 +5625,10 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 			}
 
 		}
-		yyh479.End()
+		yyh465.End()
 	}
-	if yyc479 {
-		*v = yyv479
+	if yyc465 {
+		*v = yyv465
 	}
 
 }

--- a/pkg/apis/metrics/types.generated.go
+++ b/pkg/apis/metrics/types.generated.go
@@ -2466,14 +2466,15 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep233 := !z.EncBinary()
 			yy2arr233 := z.EncBasicHandle().StructToArray
-			var yyq233 [4]bool
+			var yyq233 [5]bool
 			_, _, _ = yysep233, yyq233, yy2arr233
 			const yyr233 bool = false
 			yyq233[1] = x.CPU != nil
 			yyq233[2] = x.Memory != nil
 			yyq233[3] = x.Network != nil
+			yyq233[4] = len(x.Filesystem) != 0
 			if yyr233 || yy2arr233 {
-				r.EncodeArrayStart(4)
+				r.EncodeArrayStart(5)
 			} else {
 				var yynn233 int = 1
 				for _, b := range yyq233 {
@@ -2571,6 +2572,36 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
+			if yyr233 || yy2arr233 {
+				if yyq233[4] {
+					if x.Filesystem == nil {
+						r.EncodeNil()
+					} else {
+						yym243 := z.EncBinary()
+						_ = yym243
+						if false {
+						} else {
+							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq233[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("filesystem"))
+					if x.Filesystem == nil {
+						r.EncodeNil()
+					} else {
+						yym244 := z.EncBinary()
+						_ = yym244
+						if false {
+						} else {
+							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
+						}
+					}
+				}
+			}
 			if yysep233 {
 				r.EncodeEnd()
 			}
@@ -2582,24 +2613,24 @@ func (x *AggregateSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym242 := z.DecBinary()
-	_ = yym242
+	yym245 := z.DecBinary()
+	_ = yym245
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl243 := r.ReadMapStart()
-			if yyl243 == 0 {
+			yyl246 := r.ReadMapStart()
+			if yyl246 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl243, d)
+				x.codecDecodeSelfFromMap(yyl246, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl243 := r.ReadArrayStart()
-			if yyl243 == 0 {
+			yyl246 := r.ReadArrayStart()
+			if yyl246 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl243, d)
+				x.codecDecodeSelfFromArray(yyl246, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2611,12 +2642,12 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys244Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys244Slc
-	var yyhl244 bool = l >= 0
-	for yyj244 := 0; ; yyj244++ {
-		if yyhl244 {
-			if yyj244 >= l {
+	var yys247Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys247Slc
+	var yyhl247 bool = l >= 0
+	for yyj247 := 0; ; yyj247++ {
+		if yyhl247 {
+			if yyj247 >= l {
 				break
 			}
 		} else {
@@ -2624,24 +2655,24 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys244Slc = r.DecodeBytes(yys244Slc, true, true)
-		yys244 := string(yys244Slc)
-		switch yys244 {
+		yys247Slc = r.DecodeBytes(yys247Slc, true, true)
+		yys247 := string(yys247Slc)
+		switch yys247 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv245 := &x.SampleTime
-				yym246 := z.DecBinary()
-				_ = yym246
+				yyv248 := &x.SampleTime
+				yym249 := z.DecBinary()
+				_ = yym249
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv245) {
-				} else if yym246 {
-					z.DecBinaryUnmarshal(yyv245)
-				} else if !yym246 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv245)
+				} else if z.HasExtensions() && z.DecExt(yyv248) {
+				} else if yym249 {
+					z.DecBinaryUnmarshal(yyv248)
+				} else if !yym249 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv248)
 				} else {
-					z.DecFallback(yyv245, false)
+					z.DecFallback(yyv248, false)
 				}
 			}
 		case "cpu":
@@ -2677,11 +2708,23 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 				x.Network.CodecDecodeSelf(d)
 			}
+		case "filesystem":
+			if r.TryDecodeAsNil() {
+				x.Filesystem = nil
+			} else {
+				yyv253 := &x.Filesystem
+				yym254 := z.DecBinary()
+				_ = yym254
+				if false {
+				} else {
+					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv253), d)
+				}
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys244)
-		} // end switch yys244
-	} // end for yyj244
-	if !yyhl244 {
+			z.DecStructFieldNotFound(-1, yys247)
+		} // end switch yys247
+	} // end for yyj247
+	if !yyhl247 {
 		r.ReadEnd()
 	}
 }
@@ -2690,42 +2733,42 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj250 int
-	var yyb250 bool
-	var yyhl250 bool = l >= 0
-	yyj250++
-	if yyhl250 {
-		yyb250 = yyj250 > l
+	var yyj255 int
+	var yyb255 bool
+	var yyhl255 bool = l >= 0
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
 	} else {
-		yyb250 = r.CheckBreak()
+		yyb255 = r.CheckBreak()
 	}
-	if yyb250 {
+	if yyb255 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv251 := &x.SampleTime
-		yym252 := z.DecBinary()
-		_ = yym252
+		yyv256 := &x.SampleTime
+		yym257 := z.DecBinary()
+		_ = yym257
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv251) {
-		} else if yym252 {
-			z.DecBinaryUnmarshal(yyv251)
-		} else if !yym252 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv251)
+		} else if z.HasExtensions() && z.DecExt(yyv256) {
+		} else if yym257 {
+			z.DecBinaryUnmarshal(yyv256)
+		} else if !yym257 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv256)
 		} else {
-			z.DecFallback(yyv251, false)
+			z.DecFallback(yyv256, false)
 		}
 	}
-	yyj250++
-	if yyhl250 {
-		yyb250 = yyj250 > l
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
 	} else {
-		yyb250 = r.CheckBreak()
+		yyb255 = r.CheckBreak()
 	}
-	if yyb250 {
+	if yyb255 {
 		r.ReadEnd()
 		return
 	}
@@ -2739,13 +2782,13 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.CPU.CodecDecodeSelf(d)
 	}
-	yyj250++
-	if yyhl250 {
-		yyb250 = yyj250 > l
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
 	} else {
-		yyb250 = r.CheckBreak()
+		yyb255 = r.CheckBreak()
 	}
-	if yyb250 {
+	if yyb255 {
 		r.ReadEnd()
 		return
 	}
@@ -2759,13 +2802,13 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Memory.CodecDecodeSelf(d)
 	}
-	yyj250++
-	if yyhl250 {
-		yyb250 = yyj250 > l
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
 	} else {
-		yyb250 = r.CheckBreak()
+		yyb255 = r.CheckBreak()
 	}
-	if yyb250 {
+	if yyb255 {
 		r.ReadEnd()
 		return
 	}
@@ -2779,17 +2822,38 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Network.CodecDecodeSelf(d)
 	}
-	for {
-		yyj250++
-		if yyhl250 {
-			yyb250 = yyj250 > l
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
+	} else {
+		yyb255 = r.CheckBreak()
+	}
+	if yyb255 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Filesystem = nil
+	} else {
+		yyv261 := &x.Filesystem
+		yym262 := z.DecBinary()
+		_ = yym262
+		if false {
 		} else {
-			yyb250 = r.CheckBreak()
+			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv261), d)
 		}
-		if yyb250 {
+	}
+	for {
+		yyj255++
+		if yyhl255 {
+			yyb255 = yyj255 > l
+		} else {
+			yyb255 = r.CheckBreak()
+		}
+		if yyb255 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj250-1, "")
+		z.DecStructFieldNotFound(yyj255-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2801,58 +2865,58 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym256 := z.EncBinary()
-		_ = yym256
+		yym263 := z.EncBinary()
+		_ = yym263
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep257 := !z.EncBinary()
-			yy2arr257 := z.EncBasicHandle().StructToArray
-			var yyq257 [2]bool
-			_, _, _ = yysep257, yyq257, yy2arr257
-			const yyr257 bool = false
-			yyq257[1] = x.Network != nil
-			if yyr257 || yy2arr257 {
+			yysep264 := !z.EncBinary()
+			yy2arr264 := z.EncBasicHandle().StructToArray
+			var yyq264 [2]bool
+			_, _, _ = yysep264, yyq264, yy2arr264
+			const yyr264 bool = false
+			yyq264[1] = x.Network != nil
+			if yyr264 || yy2arr264 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn257 int = 1
-				for _, b := range yyq257 {
+				var yynn264 int = 1
+				for _, b := range yyq264 {
 					if b {
-						yynn257++
+						yynn264++
 					}
 				}
-				r.EncodeMapStart(yynn257)
+				r.EncodeMapStart(yynn264)
 			}
-			if yyr257 || yy2arr257 {
-				yy259 := &x.SampleTime
-				yym260 := z.EncBinary()
-				_ = yym260
+			if yyr264 || yy2arr264 {
+				yy266 := &x.SampleTime
+				yym267 := z.EncBinary()
+				_ = yym267
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy259) {
-				} else if yym260 {
-					z.EncBinaryMarshal(yy259)
-				} else if !yym260 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy259)
+				} else if z.HasExtensions() && z.EncExt(yy266) {
+				} else if yym267 {
+					z.EncBinaryMarshal(yy266)
+				} else if !yym267 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy266)
 				} else {
-					z.EncFallback(yy259)
+					z.EncFallback(yy266)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy261 := &x.SampleTime
-				yym262 := z.EncBinary()
-				_ = yym262
+				yy268 := &x.SampleTime
+				yym269 := z.EncBinary()
+				_ = yym269
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy261) {
-				} else if yym262 {
-					z.EncBinaryMarshal(yy261)
-				} else if !yym262 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy261)
+				} else if z.HasExtensions() && z.EncExt(yy268) {
+				} else if yym269 {
+					z.EncBinaryMarshal(yy268)
+				} else if !yym269 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy268)
 				} else {
-					z.EncFallback(yy261)
+					z.EncFallback(yy268)
 				}
 			}
-			if yyr257 || yy2arr257 {
-				if yyq257[1] {
+			if yyr264 || yy2arr264 {
+				if yyq264[1] {
 					if x.Network == nil {
 						r.EncodeNil()
 					} else {
@@ -2862,7 +2926,7 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq257[1] {
+				if yyq264[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("network"))
 					if x.Network == nil {
 						r.EncodeNil()
@@ -2871,7 +2935,7 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep257 {
+			if yysep264 {
 				r.EncodeEnd()
 			}
 		}
@@ -2882,24 +2946,24 @@ func (x *PodSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym264 := z.DecBinary()
-	_ = yym264
+	yym271 := z.DecBinary()
+	_ = yym271
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl265 := r.ReadMapStart()
-			if yyl265 == 0 {
+			yyl272 := r.ReadMapStart()
+			if yyl272 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl265, d)
+				x.codecDecodeSelfFromMap(yyl272, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl265 := r.ReadArrayStart()
-			if yyl265 == 0 {
+			yyl272 := r.ReadArrayStart()
+			if yyl272 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl265, d)
+				x.codecDecodeSelfFromArray(yyl272, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2911,12 +2975,12 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys266Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys266Slc
-	var yyhl266 bool = l >= 0
-	for yyj266 := 0; ; yyj266++ {
-		if yyhl266 {
-			if yyj266 >= l {
+	var yys273Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys273Slc
+	var yyhl273 bool = l >= 0
+	for yyj273 := 0; ; yyj273++ {
+		if yyhl273 {
+			if yyj273 >= l {
 				break
 			}
 		} else {
@@ -2924,24 +2988,24 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys266Slc = r.DecodeBytes(yys266Slc, true, true)
-		yys266 := string(yys266Slc)
-		switch yys266 {
+		yys273Slc = r.DecodeBytes(yys273Slc, true, true)
+		yys273 := string(yys273Slc)
+		switch yys273 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv267 := &x.SampleTime
-				yym268 := z.DecBinary()
-				_ = yym268
+				yyv274 := &x.SampleTime
+				yym275 := z.DecBinary()
+				_ = yym275
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv267) {
-				} else if yym268 {
-					z.DecBinaryUnmarshal(yyv267)
-				} else if !yym268 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv267)
+				} else if z.HasExtensions() && z.DecExt(yyv274) {
+				} else if yym275 {
+					z.DecBinaryUnmarshal(yyv274)
+				} else if !yym275 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv274)
 				} else {
-					z.DecFallback(yyv267, false)
+					z.DecFallback(yyv274, false)
 				}
 			}
 		case "network":
@@ -2956,10 +3020,10 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Network.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys266)
-		} // end switch yys266
-	} // end for yyj266
-	if !yyhl266 {
+			z.DecStructFieldNotFound(-1, yys273)
+		} // end switch yys273
+	} // end for yyj273
+	if !yyhl273 {
 		r.ReadEnd()
 	}
 }
@@ -2968,42 +3032,42 @@ func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj270 int
-	var yyb270 bool
-	var yyhl270 bool = l >= 0
-	yyj270++
-	if yyhl270 {
-		yyb270 = yyj270 > l
+	var yyj277 int
+	var yyb277 bool
+	var yyhl277 bool = l >= 0
+	yyj277++
+	if yyhl277 {
+		yyb277 = yyj277 > l
 	} else {
-		yyb270 = r.CheckBreak()
+		yyb277 = r.CheckBreak()
 	}
-	if yyb270 {
+	if yyb277 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv271 := &x.SampleTime
-		yym272 := z.DecBinary()
-		_ = yym272
+		yyv278 := &x.SampleTime
+		yym279 := z.DecBinary()
+		_ = yym279
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv271) {
-		} else if yym272 {
-			z.DecBinaryUnmarshal(yyv271)
-		} else if !yym272 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv271)
+		} else if z.HasExtensions() && z.DecExt(yyv278) {
+		} else if yym279 {
+			z.DecBinaryUnmarshal(yyv278)
+		} else if !yym279 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv278)
 		} else {
-			z.DecFallback(yyv271, false)
+			z.DecFallback(yyv278, false)
 		}
 	}
-	yyj270++
-	if yyhl270 {
-		yyb270 = yyj270 > l
+	yyj277++
+	if yyhl277 {
+		yyb277 = yyj277 > l
 	} else {
-		yyb270 = r.CheckBreak()
+		yyb277 = r.CheckBreak()
 	}
-	if yyb270 {
+	if yyb277 {
 		r.ReadEnd()
 		return
 	}
@@ -3018,16 +3082,16 @@ func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Network.CodecDecodeSelf(d)
 	}
 	for {
-		yyj270++
-		if yyhl270 {
-			yyb270 = yyj270 > l
+		yyj277++
+		if yyhl277 {
+			yyb277 = yyj277 > l
 		} else {
-			yyb270 = r.CheckBreak()
+			yyb277 = r.CheckBreak()
 		}
-		if yyb270 {
+		if yyb277 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj270-1, "")
+		z.DecStructFieldNotFound(yyj277-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3039,59 +3103,60 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym274 := z.EncBinary()
-		_ = yym274
+		yym281 := z.EncBinary()
+		_ = yym281
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep275 := !z.EncBinary()
-			yy2arr275 := z.EncBasicHandle().StructToArray
-			var yyq275 [3]bool
-			_, _, _ = yysep275, yyq275, yy2arr275
-			const yyr275 bool = false
-			yyq275[1] = x.CPU != nil
-			yyq275[2] = x.Memory != nil
-			if yyr275 || yy2arr275 {
-				r.EncodeArrayStart(3)
+			yysep282 := !z.EncBinary()
+			yy2arr282 := z.EncBasicHandle().StructToArray
+			var yyq282 [4]bool
+			_, _, _ = yysep282, yyq282, yy2arr282
+			const yyr282 bool = false
+			yyq282[1] = x.CPU != nil
+			yyq282[2] = x.Memory != nil
+			yyq282[3] = len(x.Filesystem) != 0
+			if yyr282 || yy2arr282 {
+				r.EncodeArrayStart(4)
 			} else {
-				var yynn275 int = 1
-				for _, b := range yyq275 {
+				var yynn282 int = 1
+				for _, b := range yyq282 {
 					if b {
-						yynn275++
+						yynn282++
 					}
 				}
-				r.EncodeMapStart(yynn275)
+				r.EncodeMapStart(yynn282)
 			}
-			if yyr275 || yy2arr275 {
-				yy277 := &x.SampleTime
-				yym278 := z.EncBinary()
-				_ = yym278
+			if yyr282 || yy2arr282 {
+				yy284 := &x.SampleTime
+				yym285 := z.EncBinary()
+				_ = yym285
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy277) {
-				} else if yym278 {
-					z.EncBinaryMarshal(yy277)
-				} else if !yym278 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy277)
+				} else if z.HasExtensions() && z.EncExt(yy284) {
+				} else if yym285 {
+					z.EncBinaryMarshal(yy284)
+				} else if !yym285 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy284)
 				} else {
-					z.EncFallback(yy277)
+					z.EncFallback(yy284)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy279 := &x.SampleTime
-				yym280 := z.EncBinary()
-				_ = yym280
+				yy286 := &x.SampleTime
+				yym287 := z.EncBinary()
+				_ = yym287
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy279) {
-				} else if yym280 {
-					z.EncBinaryMarshal(yy279)
-				} else if !yym280 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy279)
+				} else if z.HasExtensions() && z.EncExt(yy286) {
+				} else if yym287 {
+					z.EncBinaryMarshal(yy286)
+				} else if !yym287 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy286)
 				} else {
-					z.EncFallback(yy279)
+					z.EncFallback(yy286)
 				}
 			}
-			if yyr275 || yy2arr275 {
-				if yyq275[1] {
+			if yyr282 || yy2arr282 {
+				if yyq282[1] {
 					if x.CPU == nil {
 						r.EncodeNil()
 					} else {
@@ -3101,7 +3166,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq275[1] {
+				if yyq282[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
 					if x.CPU == nil {
 						r.EncodeNil()
@@ -3110,8 +3175,8 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr275 || yy2arr275 {
-				if yyq275[2] {
+			if yyr282 || yy2arr282 {
+				if yyq282[2] {
 					if x.Memory == nil {
 						r.EncodeNil()
 					} else {
@@ -3121,7 +3186,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq275[2] {
+				if yyq282[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("memory"))
 					if x.Memory == nil {
 						r.EncodeNil()
@@ -3130,7 +3195,37 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep275 {
+			if yyr282 || yy2arr282 {
+				if yyq282[3] {
+					if x.Filesystem == nil {
+						r.EncodeNil()
+					} else {
+						yym291 := z.EncBinary()
+						_ = yym291
+						if false {
+						} else {
+							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq282[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("filesystem"))
+					if x.Filesystem == nil {
+						r.EncodeNil()
+					} else {
+						yym292 := z.EncBinary()
+						_ = yym292
+						if false {
+						} else {
+							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
+						}
+					}
+				}
+			}
+			if yysep282 {
 				r.EncodeEnd()
 			}
 		}
@@ -3141,24 +3236,24 @@ func (x *ContainerSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym283 := z.DecBinary()
-	_ = yym283
+	yym293 := z.DecBinary()
+	_ = yym293
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl284 := r.ReadMapStart()
-			if yyl284 == 0 {
+			yyl294 := r.ReadMapStart()
+			if yyl294 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl284, d)
+				x.codecDecodeSelfFromMap(yyl294, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl284 := r.ReadArrayStart()
-			if yyl284 == 0 {
+			yyl294 := r.ReadArrayStart()
+			if yyl294 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl284, d)
+				x.codecDecodeSelfFromArray(yyl294, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3170,12 +3265,12 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys285Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys285Slc
-	var yyhl285 bool = l >= 0
-	for yyj285 := 0; ; yyj285++ {
-		if yyhl285 {
-			if yyj285 >= l {
+	var yys295Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys295Slc
+	var yyhl295 bool = l >= 0
+	for yyj295 := 0; ; yyj295++ {
+		if yyhl295 {
+			if yyj295 >= l {
 				break
 			}
 		} else {
@@ -3183,24 +3278,24 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys285Slc = r.DecodeBytes(yys285Slc, true, true)
-		yys285 := string(yys285Slc)
-		switch yys285 {
+		yys295Slc = r.DecodeBytes(yys295Slc, true, true)
+		yys295 := string(yys295Slc)
+		switch yys295 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv286 := &x.SampleTime
-				yym287 := z.DecBinary()
-				_ = yym287
+				yyv296 := &x.SampleTime
+				yym297 := z.DecBinary()
+				_ = yym297
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv286) {
-				} else if yym287 {
-					z.DecBinaryUnmarshal(yyv286)
-				} else if !yym287 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv286)
+				} else if z.HasExtensions() && z.DecExt(yyv296) {
+				} else if yym297 {
+					z.DecBinaryUnmarshal(yyv296)
+				} else if !yym297 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv296)
 				} else {
-					z.DecFallback(yyv286, false)
+					z.DecFallback(yyv296, false)
 				}
 			}
 		case "cpu":
@@ -3225,11 +3320,23 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 				x.Memory.CodecDecodeSelf(d)
 			}
+		case "filesystem":
+			if r.TryDecodeAsNil() {
+				x.Filesystem = nil
+			} else {
+				yyv300 := &x.Filesystem
+				yym301 := z.DecBinary()
+				_ = yym301
+				if false {
+				} else {
+					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv300), d)
+				}
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys285)
-		} // end switch yys285
-	} // end for yyj285
-	if !yyhl285 {
+			z.DecStructFieldNotFound(-1, yys295)
+		} // end switch yys295
+	} // end for yyj295
+	if !yyhl295 {
 		r.ReadEnd()
 	}
 }
@@ -3238,42 +3345,42 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj290 int
-	var yyb290 bool
-	var yyhl290 bool = l >= 0
-	yyj290++
-	if yyhl290 {
-		yyb290 = yyj290 > l
+	var yyj302 int
+	var yyb302 bool
+	var yyhl302 bool = l >= 0
+	yyj302++
+	if yyhl302 {
+		yyb302 = yyj302 > l
 	} else {
-		yyb290 = r.CheckBreak()
+		yyb302 = r.CheckBreak()
 	}
-	if yyb290 {
+	if yyb302 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv291 := &x.SampleTime
-		yym292 := z.DecBinary()
-		_ = yym292
+		yyv303 := &x.SampleTime
+		yym304 := z.DecBinary()
+		_ = yym304
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv291) {
-		} else if yym292 {
-			z.DecBinaryUnmarshal(yyv291)
-		} else if !yym292 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv291)
+		} else if z.HasExtensions() && z.DecExt(yyv303) {
+		} else if yym304 {
+			z.DecBinaryUnmarshal(yyv303)
+		} else if !yym304 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv303)
 		} else {
-			z.DecFallback(yyv291, false)
+			z.DecFallback(yyv303, false)
 		}
 	}
-	yyj290++
-	if yyhl290 {
-		yyb290 = yyj290 > l
+	yyj302++
+	if yyhl302 {
+		yyb302 = yyj302 > l
 	} else {
-		yyb290 = r.CheckBreak()
+		yyb302 = r.CheckBreak()
 	}
-	if yyb290 {
+	if yyb302 {
 		r.ReadEnd()
 		return
 	}
@@ -3287,13 +3394,13 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.CPU.CodecDecodeSelf(d)
 	}
-	yyj290++
-	if yyhl290 {
-		yyb290 = yyj290 > l
+	yyj302++
+	if yyhl302 {
+		yyb302 = yyj302 > l
 	} else {
-		yyb290 = r.CheckBreak()
+		yyb302 = r.CheckBreak()
 	}
-	if yyb290 {
+	if yyb302 {
 		r.ReadEnd()
 		return
 	}
@@ -3307,17 +3414,38 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Memory.CodecDecodeSelf(d)
 	}
-	for {
-		yyj290++
-		if yyhl290 {
-			yyb290 = yyj290 > l
+	yyj302++
+	if yyhl302 {
+		yyb302 = yyj302 > l
+	} else {
+		yyb302 = r.CheckBreak()
+	}
+	if yyb302 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Filesystem = nil
+	} else {
+		yyv307 := &x.Filesystem
+		yym308 := z.DecBinary()
+		_ = yym308
+		if false {
 		} else {
-			yyb290 = r.CheckBreak()
+			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv307), d)
 		}
-		if yyb290 {
+	}
+	for {
+		yyj302++
+		if yyhl302 {
+			yyb302 = yyj302 > l
+		} else {
+			yyb302 = r.CheckBreak()
+		}
+		if yyb302 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj290-1, "")
+		z.DecStructFieldNotFound(yyj302-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3329,41 +3457,41 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym295 := z.EncBinary()
-		_ = yym295
+		yym309 := z.EncBinary()
+		_ = yym309
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep296 := !z.EncBinary()
-			yy2arr296 := z.EncBasicHandle().StructToArray
-			var yyq296 [4]bool
-			_, _, _ = yysep296, yyq296, yy2arr296
-			const yyr296 bool = false
-			yyq296[0] = x.RxBytes != nil
-			yyq296[1] = x.RxErrors != nil
-			yyq296[2] = x.TxBytes != nil
-			yyq296[3] = x.TxErrors != nil
-			if yyr296 || yy2arr296 {
+			yysep310 := !z.EncBinary()
+			yy2arr310 := z.EncBasicHandle().StructToArray
+			var yyq310 [4]bool
+			_, _, _ = yysep310, yyq310, yy2arr310
+			const yyr310 bool = false
+			yyq310[0] = x.RxBytes != nil
+			yyq310[1] = x.RxErrors != nil
+			yyq310[2] = x.TxBytes != nil
+			yyq310[3] = x.TxErrors != nil
+			if yyr310 || yy2arr310 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn296 int = 0
-				for _, b := range yyq296 {
+				var yynn310 int = 0
+				for _, b := range yyq310 {
 					if b {
-						yynn296++
+						yynn310++
 					}
 				}
-				r.EncodeMapStart(yynn296)
+				r.EncodeMapStart(yynn310)
 			}
-			if yyr296 || yy2arr296 {
-				if yyq296[0] {
+			if yyr310 || yy2arr310 {
+				if yyq310[0] {
 					if x.RxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym298 := z.EncBinary()
-						_ = yym298
+						yym312 := z.EncBinary()
+						_ = yym312
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
-						} else if !yym298 && z.IsJSONHandle() {
+						} else if !yym312 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.RxBytes)
 						} else {
 							z.EncFallback(x.RxBytes)
@@ -3373,16 +3501,16 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq296[0] {
+				if yyq310[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("rxBytes"))
 					if x.RxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym299 := z.EncBinary()
-						_ = yym299
+						yym313 := z.EncBinary()
+						_ = yym313
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
-						} else if !yym299 && z.IsJSONHandle() {
+						} else if !yym313 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.RxBytes)
 						} else {
 							z.EncFallback(x.RxBytes)
@@ -3390,48 +3518,48 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr296 || yy2arr296 {
-				if yyq296[1] {
+			if yyr310 || yy2arr310 {
+				if yyq310[1] {
 					if x.RxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy301 := *x.RxErrors
-						yym302 := z.EncBinary()
-						_ = yym302
+						yy315 := *x.RxErrors
+						yym316 := z.EncBinary()
+						_ = yym316
 						if false {
 						} else {
-							r.EncodeInt(int64(yy301))
+							r.EncodeInt(int64(yy315))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq296[1] {
+				if yyq310[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rxErrors"))
 					if x.RxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy303 := *x.RxErrors
-						yym304 := z.EncBinary()
-						_ = yym304
+						yy317 := *x.RxErrors
+						yym318 := z.EncBinary()
+						_ = yym318
 						if false {
 						} else {
-							r.EncodeInt(int64(yy303))
+							r.EncodeInt(int64(yy317))
 						}
 					}
 				}
 			}
-			if yyr296 || yy2arr296 {
-				if yyq296[2] {
+			if yyr310 || yy2arr310 {
+				if yyq310[2] {
 					if x.TxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym306 := z.EncBinary()
-						_ = yym306
+						yym320 := z.EncBinary()
+						_ = yym320
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
-						} else if !yym306 && z.IsJSONHandle() {
+						} else if !yym320 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TxBytes)
 						} else {
 							z.EncFallback(x.TxBytes)
@@ -3441,16 +3569,16 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq296[2] {
+				if yyq310[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("txBytes"))
 					if x.TxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym307 := z.EncBinary()
-						_ = yym307
+						yym321 := z.EncBinary()
+						_ = yym321
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
-						} else if !yym307 && z.IsJSONHandle() {
+						} else if !yym321 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TxBytes)
 						} else {
 							z.EncFallback(x.TxBytes)
@@ -3458,39 +3586,39 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr296 || yy2arr296 {
-				if yyq296[3] {
+			if yyr310 || yy2arr310 {
+				if yyq310[3] {
 					if x.TxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy309 := *x.TxErrors
-						yym310 := z.EncBinary()
-						_ = yym310
+						yy323 := *x.TxErrors
+						yym324 := z.EncBinary()
+						_ = yym324
 						if false {
 						} else {
-							r.EncodeInt(int64(yy309))
+							r.EncodeInt(int64(yy323))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq296[3] {
+				if yyq310[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("txErrors"))
 					if x.TxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy311 := *x.TxErrors
-						yym312 := z.EncBinary()
-						_ = yym312
+						yy325 := *x.TxErrors
+						yym326 := z.EncBinary()
+						_ = yym326
 						if false {
 						} else {
-							r.EncodeInt(int64(yy311))
+							r.EncodeInt(int64(yy325))
 						}
 					}
 				}
 			}
-			if yysep296 {
+			if yysep310 {
 				r.EncodeEnd()
 			}
 		}
@@ -3501,24 +3629,24 @@ func (x *NetworkMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym313 := z.DecBinary()
-	_ = yym313
+	yym327 := z.DecBinary()
+	_ = yym327
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl314 := r.ReadMapStart()
-			if yyl314 == 0 {
+			yyl328 := r.ReadMapStart()
+			if yyl328 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl314, d)
+				x.codecDecodeSelfFromMap(yyl328, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl314 := r.ReadArrayStart()
-			if yyl314 == 0 {
+			yyl328 := r.ReadArrayStart()
+			if yyl328 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl314, d)
+				x.codecDecodeSelfFromArray(yyl328, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3530,12 +3658,12 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys315Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys315Slc
-	var yyhl315 bool = l >= 0
-	for yyj315 := 0; ; yyj315++ {
-		if yyhl315 {
-			if yyj315 >= l {
+	var yys329Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys329Slc
+	var yyhl329 bool = l >= 0
+	for yyj329 := 0; ; yyj329++ {
+		if yyhl329 {
+			if yyj329 >= l {
 				break
 			}
 		} else {
@@ -3543,9 +3671,9 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys315Slc = r.DecodeBytes(yys315Slc, true, true)
-		yys315 := string(yys315Slc)
-		switch yys315 {
+		yys329Slc = r.DecodeBytes(yys329Slc, true, true)
+		yys329 := string(yys329Slc)
+		switch yys329 {
 		case "rxBytes":
 			if r.TryDecodeAsNil() {
 				if x.RxBytes != nil {
@@ -3555,11 +3683,11 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RxBytes == nil {
 					x.RxBytes = new(pkg2_resource.Quantity)
 				}
-				yym317 := z.DecBinary()
-				_ = yym317
+				yym331 := z.DecBinary()
+				_ = yym331
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
-				} else if !yym317 && z.IsJSONHandle() {
+				} else if !yym331 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.RxBytes)
 				} else {
 					z.DecFallback(x.RxBytes, false)
@@ -3574,8 +3702,8 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RxErrors == nil {
 					x.RxErrors = new(int64)
 				}
-				yym319 := z.DecBinary()
-				_ = yym319
+				yym333 := z.DecBinary()
+				_ = yym333
 				if false {
 				} else {
 					*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
@@ -3590,11 +3718,11 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TxBytes == nil {
 					x.TxBytes = new(pkg2_resource.Quantity)
 				}
-				yym321 := z.DecBinary()
-				_ = yym321
+				yym335 := z.DecBinary()
+				_ = yym335
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
-				} else if !yym321 && z.IsJSONHandle() {
+				} else if !yym335 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TxBytes)
 				} else {
 					z.DecFallback(x.TxBytes, false)
@@ -3609,18 +3737,18 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TxErrors == nil {
 					x.TxErrors = new(int64)
 				}
-				yym323 := z.DecBinary()
-				_ = yym323
+				yym337 := z.DecBinary()
+				_ = yym337
 				if false {
 				} else {
 					*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys315)
-		} // end switch yys315
-	} // end for yyj315
-	if !yyhl315 {
+			z.DecStructFieldNotFound(-1, yys329)
+		} // end switch yys329
+	} // end for yyj329
+	if !yyhl329 {
 		r.ReadEnd()
 	}
 }
@@ -3629,16 +3757,16 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj324 int
-	var yyb324 bool
-	var yyhl324 bool = l >= 0
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	var yyj338 int
+	var yyb338 bool
+	var yyhl338 bool = l >= 0
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb338 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb338 {
 		r.ReadEnd()
 		return
 	}
@@ -3650,23 +3778,23 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RxBytes == nil {
 			x.RxBytes = new(pkg2_resource.Quantity)
 		}
-		yym326 := z.DecBinary()
-		_ = yym326
+		yym340 := z.DecBinary()
+		_ = yym340
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
-		} else if !yym326 && z.IsJSONHandle() {
+		} else if !yym340 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.RxBytes)
 		} else {
 			z.DecFallback(x.RxBytes, false)
 		}
 	}
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb338 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb338 {
 		r.ReadEnd()
 		return
 	}
@@ -3678,20 +3806,20 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RxErrors == nil {
 			x.RxErrors = new(int64)
 		}
-		yym328 := z.DecBinary()
-		_ = yym328
+		yym342 := z.DecBinary()
+		_ = yym342
 		if false {
 		} else {
 			*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb338 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb338 {
 		r.ReadEnd()
 		return
 	}
@@ -3703,23 +3831,23 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TxBytes == nil {
 			x.TxBytes = new(pkg2_resource.Quantity)
 		}
-		yym330 := z.DecBinary()
-		_ = yym330
+		yym344 := z.DecBinary()
+		_ = yym344
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
-		} else if !yym330 && z.IsJSONHandle() {
+		} else if !yym344 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TxBytes)
 		} else {
 			z.DecFallback(x.TxBytes, false)
 		}
 	}
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb338 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb338 {
 		r.ReadEnd()
 		return
 	}
@@ -3731,24 +3859,24 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TxErrors == nil {
 			x.TxErrors = new(int64)
 		}
-		yym332 := z.DecBinary()
-		_ = yym332
+		yym346 := z.DecBinary()
+		_ = yym346
 		if false {
 		} else {
 			*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj324++
-		if yyhl324 {
-			yyb324 = yyj324 > l
+		yyj338++
+		if yyhl338 {
+			yyb338 = yyj338 > l
 		} else {
-			yyb324 = r.CheckBreak()
+			yyb338 = r.CheckBreak()
 		}
-		if yyb324 {
+		if yyb338 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj324-1, "")
+		z.DecStructFieldNotFound(yyj338-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3760,39 +3888,39 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym333 := z.EncBinary()
-		_ = yym333
+		yym347 := z.EncBinary()
+		_ = yym347
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep334 := !z.EncBinary()
-			yy2arr334 := z.EncBasicHandle().StructToArray
-			var yyq334 [2]bool
-			_, _, _ = yysep334, yyq334, yy2arr334
-			const yyr334 bool = false
-			yyq334[0] = x.TotalCores != nil
-			yyq334[1] = x.LoadAverage != nil
-			if yyr334 || yy2arr334 {
+			yysep348 := !z.EncBinary()
+			yy2arr348 := z.EncBasicHandle().StructToArray
+			var yyq348 [2]bool
+			_, _, _ = yysep348, yyq348, yy2arr348
+			const yyr348 bool = false
+			yyq348[0] = x.TotalCores != nil
+			yyq348[1] = x.LoadAverage != nil
+			if yyr348 || yy2arr348 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn334 int = 0
-				for _, b := range yyq334 {
+				var yynn348 int = 0
+				for _, b := range yyq348 {
 					if b {
-						yynn334++
+						yynn348++
 					}
 				}
-				r.EncodeMapStart(yynn334)
+				r.EncodeMapStart(yynn348)
 			}
-			if yyr334 || yy2arr334 {
-				if yyq334[0] {
+			if yyr348 || yy2arr348 {
+				if yyq348[0] {
 					if x.TotalCores == nil {
 						r.EncodeNil()
 					} else {
-						yym336 := z.EncBinary()
-						_ = yym336
+						yym350 := z.EncBinary()
+						_ = yym350
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
-						} else if !yym336 && z.IsJSONHandle() {
+						} else if !yym350 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalCores)
 						} else {
 							z.EncFallback(x.TotalCores)
@@ -3802,16 +3930,16 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq334[0] {
+				if yyq348[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalCores"))
 					if x.TotalCores == nil {
 						r.EncodeNil()
 					} else {
-						yym337 := z.EncBinary()
-						_ = yym337
+						yym351 := z.EncBinary()
+						_ = yym351
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
-						} else if !yym337 && z.IsJSONHandle() {
+						} else if !yym351 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalCores)
 						} else {
 							z.EncFallback(x.TotalCores)
@@ -3819,16 +3947,16 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr334 || yy2arr334 {
-				if yyq334[1] {
+			if yyr348 || yy2arr348 {
+				if yyq348[1] {
 					if x.LoadAverage == nil {
 						r.EncodeNil()
 					} else {
-						yym339 := z.EncBinary()
-						_ = yym339
+						yym353 := z.EncBinary()
+						_ = yym353
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
-						} else if !yym339 && z.IsJSONHandle() {
+						} else if !yym353 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LoadAverage)
 						} else {
 							z.EncFallback(x.LoadAverage)
@@ -3838,16 +3966,16 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq334[1] {
+				if yyq348[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadAverage"))
 					if x.LoadAverage == nil {
 						r.EncodeNil()
 					} else {
-						yym340 := z.EncBinary()
-						_ = yym340
+						yym354 := z.EncBinary()
+						_ = yym354
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
-						} else if !yym340 && z.IsJSONHandle() {
+						} else if !yym354 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LoadAverage)
 						} else {
 							z.EncFallback(x.LoadAverage)
@@ -3855,7 +3983,7 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep334 {
+			if yysep348 {
 				r.EncodeEnd()
 			}
 		}
@@ -3866,24 +3994,24 @@ func (x *CPUMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym341 := z.DecBinary()
-	_ = yym341
+	yym355 := z.DecBinary()
+	_ = yym355
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl342 := r.ReadMapStart()
-			if yyl342 == 0 {
+			yyl356 := r.ReadMapStart()
+			if yyl356 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl342, d)
+				x.codecDecodeSelfFromMap(yyl356, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl342 := r.ReadArrayStart()
-			if yyl342 == 0 {
+			yyl356 := r.ReadArrayStart()
+			if yyl356 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl342, d)
+				x.codecDecodeSelfFromArray(yyl356, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3895,12 +4023,12 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys343Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys343Slc
-	var yyhl343 bool = l >= 0
-	for yyj343 := 0; ; yyj343++ {
-		if yyhl343 {
-			if yyj343 >= l {
+	var yys357Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys357Slc
+	var yyhl357 bool = l >= 0
+	for yyj357 := 0; ; yyj357++ {
+		if yyhl357 {
+			if yyj357 >= l {
 				break
 			}
 		} else {
@@ -3908,9 +4036,9 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
-		yys343 := string(yys343Slc)
-		switch yys343 {
+		yys357Slc = r.DecodeBytes(yys357Slc, true, true)
+		yys357 := string(yys357Slc)
+		switch yys357 {
 		case "totalCores":
 			if r.TryDecodeAsNil() {
 				if x.TotalCores != nil {
@@ -3920,11 +4048,11 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalCores == nil {
 					x.TotalCores = new(pkg2_resource.Quantity)
 				}
-				yym345 := z.DecBinary()
-				_ = yym345
+				yym359 := z.DecBinary()
+				_ = yym359
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-				} else if !yym345 && z.IsJSONHandle() {
+				} else if !yym359 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalCores)
 				} else {
 					z.DecFallback(x.TotalCores, false)
@@ -3939,21 +4067,21 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.LoadAverage == nil {
 					x.LoadAverage = new(pkg2_resource.Quantity)
 				}
-				yym347 := z.DecBinary()
-				_ = yym347
+				yym361 := z.DecBinary()
+				_ = yym361
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
-				} else if !yym347 && z.IsJSONHandle() {
+				} else if !yym361 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LoadAverage)
 				} else {
 					z.DecFallback(x.LoadAverage, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys343)
-		} // end switch yys343
-	} // end for yyj343
-	if !yyhl343 {
+			z.DecStructFieldNotFound(-1, yys357)
+		} // end switch yys357
+	} // end for yyj357
+	if !yyhl357 {
 		r.ReadEnd()
 	}
 }
@@ -3962,16 +4090,16 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj348 int
-	var yyb348 bool
-	var yyhl348 bool = l >= 0
-	yyj348++
-	if yyhl348 {
-		yyb348 = yyj348 > l
+	var yyj362 int
+	var yyb362 bool
+	var yyhl362 bool = l >= 0
+	yyj362++
+	if yyhl362 {
+		yyb362 = yyj362 > l
 	} else {
-		yyb348 = r.CheckBreak()
+		yyb362 = r.CheckBreak()
 	}
-	if yyb348 {
+	if yyb362 {
 		r.ReadEnd()
 		return
 	}
@@ -3983,23 +4111,23 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalCores == nil {
 			x.TotalCores = new(pkg2_resource.Quantity)
 		}
-		yym350 := z.DecBinary()
-		_ = yym350
+		yym364 := z.DecBinary()
+		_ = yym364
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-		} else if !yym350 && z.IsJSONHandle() {
+		} else if !yym364 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalCores)
 		} else {
 			z.DecFallback(x.TotalCores, false)
 		}
 	}
-	yyj348++
-	if yyhl348 {
-		yyb348 = yyj348 > l
+	yyj362++
+	if yyhl362 {
+		yyb362 = yyj362 > l
 	} else {
-		yyb348 = r.CheckBreak()
+		yyb362 = r.CheckBreak()
 	}
-	if yyb348 {
+	if yyb362 {
 		r.ReadEnd()
 		return
 	}
@@ -4011,27 +4139,27 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.LoadAverage == nil {
 			x.LoadAverage = new(pkg2_resource.Quantity)
 		}
-		yym352 := z.DecBinary()
-		_ = yym352
+		yym366 := z.DecBinary()
+		_ = yym366
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
-		} else if !yym352 && z.IsJSONHandle() {
+		} else if !yym366 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LoadAverage)
 		} else {
 			z.DecFallback(x.LoadAverage, false)
 		}
 	}
 	for {
-		yyj348++
-		if yyhl348 {
-			yyb348 = yyj348 > l
+		yyj362++
+		if yyhl362 {
+			yyb362 = yyj362 > l
 		} else {
-			yyb348 = r.CheckBreak()
+			yyb362 = r.CheckBreak()
 		}
-		if yyb348 {
+		if yyb362 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj348-1, "")
+		z.DecStructFieldNotFound(yyj362-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4043,41 +4171,41 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym353 := z.EncBinary()
-		_ = yym353
+		yym367 := z.EncBinary()
+		_ = yym367
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep354 := !z.EncBinary()
-			yy2arr354 := z.EncBasicHandle().StructToArray
-			var yyq354 [4]bool
-			_, _, _ = yysep354, yyq354, yy2arr354
-			const yyr354 bool = false
-			yyq354[0] = x.TotalBytes != nil
-			yyq354[1] = x.UsageBytes != nil
-			yyq354[2] = x.PageFaults != nil
-			yyq354[3] = x.MajorPageFaults != nil
-			if yyr354 || yy2arr354 {
+			yysep368 := !z.EncBinary()
+			yy2arr368 := z.EncBasicHandle().StructToArray
+			var yyq368 [4]bool
+			_, _, _ = yysep368, yyq368, yy2arr368
+			const yyr368 bool = false
+			yyq368[0] = x.TotalBytes != nil
+			yyq368[1] = x.UsageBytes != nil
+			yyq368[2] = x.PageFaults != nil
+			yyq368[3] = x.MajorPageFaults != nil
+			if yyr368 || yy2arr368 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn354 int = 0
-				for _, b := range yyq354 {
+				var yynn368 int = 0
+				for _, b := range yyq368 {
 					if b {
-						yynn354++
+						yynn368++
 					}
 				}
-				r.EncodeMapStart(yynn354)
+				r.EncodeMapStart(yynn368)
 			}
-			if yyr354 || yy2arr354 {
-				if yyq354[0] {
+			if yyr368 || yy2arr368 {
+				if yyq368[0] {
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym356 := z.EncBinary()
-						_ = yym356
+						yym370 := z.EncBinary()
+						_ = yym370
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym356 && z.IsJSONHandle() {
+						} else if !yym370 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4087,16 +4215,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq354[0] {
+				if yyq368[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalBytes"))
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym357 := z.EncBinary()
-						_ = yym357
+						yym371 := z.EncBinary()
+						_ = yym371
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym357 && z.IsJSONHandle() {
+						} else if !yym371 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4104,16 +4232,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr354 || yy2arr354 {
-				if yyq354[1] {
+			if yyr368 || yy2arr368 {
+				if yyq368[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym359 := z.EncBinary()
-						_ = yym359
+						yym373 := z.EncBinary()
+						_ = yym373
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym359 && z.IsJSONHandle() {
+						} else if !yym373 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4123,16 +4251,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq354[1] {
+				if yyq368[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym360 := z.EncBinary()
-						_ = yym360
+						yym374 := z.EncBinary()
+						_ = yym374
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym360 && z.IsJSONHandle() {
+						} else if !yym374 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4140,71 +4268,71 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr354 || yy2arr354 {
-				if yyq354[2] {
+			if yyr368 || yy2arr368 {
+				if yyq368[2] {
 					if x.PageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy362 := *x.PageFaults
-						yym363 := z.EncBinary()
-						_ = yym363
+						yy376 := *x.PageFaults
+						yym377 := z.EncBinary()
+						_ = yym377
 						if false {
 						} else {
-							r.EncodeInt(int64(yy362))
+							r.EncodeInt(int64(yy376))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq354[2] {
+				if yyq368[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
 					if x.PageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy364 := *x.PageFaults
-						yym365 := z.EncBinary()
-						_ = yym365
+						yy378 := *x.PageFaults
+						yym379 := z.EncBinary()
+						_ = yym379
 						if false {
 						} else {
-							r.EncodeInt(int64(yy364))
+							r.EncodeInt(int64(yy378))
 						}
 					}
 				}
 			}
-			if yyr354 || yy2arr354 {
-				if yyq354[3] {
+			if yyr368 || yy2arr368 {
+				if yyq368[3] {
 					if x.MajorPageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy367 := *x.MajorPageFaults
-						yym368 := z.EncBinary()
-						_ = yym368
+						yy381 := *x.MajorPageFaults
+						yym382 := z.EncBinary()
+						_ = yym382
 						if false {
 						} else {
-							r.EncodeInt(int64(yy367))
+							r.EncodeInt(int64(yy381))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq354[3] {
+				if yyq368[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
 					if x.MajorPageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy369 := *x.MajorPageFaults
-						yym370 := z.EncBinary()
-						_ = yym370
+						yy383 := *x.MajorPageFaults
+						yym384 := z.EncBinary()
+						_ = yym384
 						if false {
 						} else {
-							r.EncodeInt(int64(yy369))
+							r.EncodeInt(int64(yy383))
 						}
 					}
 				}
 			}
-			if yysep354 {
+			if yysep368 {
 				r.EncodeEnd()
 			}
 		}
@@ -4215,24 +4343,24 @@ func (x *MemoryMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym371 := z.DecBinary()
-	_ = yym371
+	yym385 := z.DecBinary()
+	_ = yym385
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl372 := r.ReadMapStart()
-			if yyl372 == 0 {
+			yyl386 := r.ReadMapStart()
+			if yyl386 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl372, d)
+				x.codecDecodeSelfFromMap(yyl386, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl372 := r.ReadArrayStart()
-			if yyl372 == 0 {
+			yyl386 := r.ReadArrayStart()
+			if yyl386 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl372, d)
+				x.codecDecodeSelfFromArray(yyl386, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4244,12 +4372,12 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys373Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys373Slc
-	var yyhl373 bool = l >= 0
-	for yyj373 := 0; ; yyj373++ {
-		if yyhl373 {
-			if yyj373 >= l {
+	var yys387Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys387Slc
+	var yyhl387 bool = l >= 0
+	for yyj387 := 0; ; yyj387++ {
+		if yyhl387 {
+			if yyj387 >= l {
 				break
 			}
 		} else {
@@ -4257,9 +4385,9 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys373Slc = r.DecodeBytes(yys373Slc, true, true)
-		yys373 := string(yys373Slc)
-		switch yys373 {
+		yys387Slc = r.DecodeBytes(yys387Slc, true, true)
+		yys387 := string(yys387Slc)
+		switch yys387 {
 		case "totalBytes":
 			if r.TryDecodeAsNil() {
 				if x.TotalBytes != nil {
@@ -4269,11 +4397,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalBytes == nil {
 					x.TotalBytes = new(pkg2_resource.Quantity)
 				}
-				yym375 := z.DecBinary()
-				_ = yym375
+				yym389 := z.DecBinary()
+				_ = yym389
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-				} else if !yym375 && z.IsJSONHandle() {
+				} else if !yym389 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalBytes)
 				} else {
 					z.DecFallback(x.TotalBytes, false)
@@ -4288,11 +4416,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym377 := z.DecBinary()
-				_ = yym377
+				yym391 := z.DecBinary()
+				_ = yym391
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym377 && z.IsJSONHandle() {
+				} else if !yym391 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4307,8 +4435,8 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.PageFaults == nil {
 					x.PageFaults = new(int64)
 				}
-				yym379 := z.DecBinary()
-				_ = yym379
+				yym393 := z.DecBinary()
+				_ = yym393
 				if false {
 				} else {
 					*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
@@ -4323,18 +4451,18 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.MajorPageFaults == nil {
 					x.MajorPageFaults = new(int64)
 				}
-				yym381 := z.DecBinary()
-				_ = yym381
+				yym395 := z.DecBinary()
+				_ = yym395
 				if false {
 				} else {
 					*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys373)
-		} // end switch yys373
-	} // end for yyj373
-	if !yyhl373 {
+			z.DecStructFieldNotFound(-1, yys387)
+		} // end switch yys387
+	} // end for yyj387
+	if !yyhl387 {
 		r.ReadEnd()
 	}
 }
@@ -4343,16 +4471,16 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj382 int
-	var yyb382 bool
-	var yyhl382 bool = l >= 0
-	yyj382++
-	if yyhl382 {
-		yyb382 = yyj382 > l
+	var yyj396 int
+	var yyb396 bool
+	var yyhl396 bool = l >= 0
+	yyj396++
+	if yyhl396 {
+		yyb396 = yyj396 > l
 	} else {
-		yyb382 = r.CheckBreak()
+		yyb396 = r.CheckBreak()
 	}
-	if yyb382 {
+	if yyb396 {
 		r.ReadEnd()
 		return
 	}
@@ -4364,23 +4492,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalBytes == nil {
 			x.TotalBytes = new(pkg2_resource.Quantity)
 		}
-		yym384 := z.DecBinary()
-		_ = yym384
+		yym398 := z.DecBinary()
+		_ = yym398
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-		} else if !yym384 && z.IsJSONHandle() {
+		} else if !yym398 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalBytes)
 		} else {
 			z.DecFallback(x.TotalBytes, false)
 		}
 	}
-	yyj382++
-	if yyhl382 {
-		yyb382 = yyj382 > l
+	yyj396++
+	if yyhl396 {
+		yyb396 = yyj396 > l
 	} else {
-		yyb382 = r.CheckBreak()
+		yyb396 = r.CheckBreak()
 	}
-	if yyb382 {
+	if yyb396 {
 		r.ReadEnd()
 		return
 	}
@@ -4392,23 +4520,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym386 := z.DecBinary()
-		_ = yym386
+		yym400 := z.DecBinary()
+		_ = yym400
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym386 && z.IsJSONHandle() {
+		} else if !yym400 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj382++
-	if yyhl382 {
-		yyb382 = yyj382 > l
+	yyj396++
+	if yyhl396 {
+		yyb396 = yyj396 > l
 	} else {
-		yyb382 = r.CheckBreak()
+		yyb396 = r.CheckBreak()
 	}
-	if yyb382 {
+	if yyb396 {
 		r.ReadEnd()
 		return
 	}
@@ -4420,20 +4548,20 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.PageFaults == nil {
 			x.PageFaults = new(int64)
 		}
-		yym388 := z.DecBinary()
-		_ = yym388
+		yym402 := z.DecBinary()
+		_ = yym402
 		if false {
 		} else {
 			*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj382++
-	if yyhl382 {
-		yyb382 = yyj382 > l
+	yyj396++
+	if yyhl396 {
+		yyb396 = yyj396 > l
 	} else {
-		yyb382 = r.CheckBreak()
+		yyb396 = r.CheckBreak()
 	}
-	if yyb382 {
+	if yyb396 {
 		r.ReadEnd()
 		return
 	}
@@ -4445,24 +4573,344 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.MajorPageFaults == nil {
 			x.MajorPageFaults = new(int64)
 		}
-		yym390 := z.DecBinary()
-		_ = yym390
+		yym404 := z.DecBinary()
+		_ = yym404
 		if false {
 		} else {
 			*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj382++
-		if yyhl382 {
-			yyb382 = yyj382 > l
+		yyj396++
+		if yyhl396 {
+			yyb396 = yyj396 > l
 		} else {
-			yyb382 = r.CheckBreak()
+			yyb396 = r.CheckBreak()
 		}
-		if yyb382 {
+		if yyb396 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj382-1, "")
+		z.DecStructFieldNotFound(yyj396-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym405 := z.EncBinary()
+		_ = yym405
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep406 := !z.EncBinary()
+			yy2arr406 := z.EncBasicHandle().StructToArray
+			var yyq406 [3]bool
+			_, _, _ = yysep406, yyq406, yy2arr406
+			const yyr406 bool = false
+			yyq406[1] = x.UsageBytes != nil
+			yyq406[2] = x.LimitBytes != nil
+			if yyr406 || yy2arr406 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn406 int = 1
+				for _, b := range yyq406 {
+					if b {
+						yynn406++
+					}
+				}
+				r.EncodeMapStart(yynn406)
+			}
+			if yyr406 || yy2arr406 {
+				yym408 := z.EncBinary()
+				_ = yym408
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("device"))
+				yym409 := z.EncBinary()
+				_ = yym409
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
+				}
+			}
+			if yyr406 || yy2arr406 {
+				if yyq406[1] {
+					if x.UsageBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym411 := z.EncBinary()
+						_ = yym411
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
+						} else if !yym411 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UsageBytes)
+						} else {
+							z.EncFallback(x.UsageBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq406[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
+					if x.UsageBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym412 := z.EncBinary()
+						_ = yym412
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
+						} else if !yym412 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UsageBytes)
+						} else {
+							z.EncFallback(x.UsageBytes)
+						}
+					}
+				}
+			}
+			if yyr406 || yy2arr406 {
+				if yyq406[2] {
+					if x.LimitBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym414 := z.EncBinary()
+						_ = yym414
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
+						} else if !yym414 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.LimitBytes)
+						} else {
+							z.EncFallback(x.LimitBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq406[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
+					if x.LimitBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym415 := z.EncBinary()
+						_ = yym415
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
+						} else if !yym415 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.LimitBytes)
+						} else {
+							z.EncFallback(x.LimitBytes)
+						}
+					}
+				}
+			}
+			if yysep406 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *FilesystemMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym416 := z.DecBinary()
+	_ = yym416
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl417 := r.ReadMapStart()
+			if yyl417 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl417, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl417 := r.ReadArrayStart()
+			if yyl417 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl417, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys418Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys418Slc
+	var yyhl418 bool = l >= 0
+	for yyj418 := 0; ; yyj418++ {
+		if yyhl418 {
+			if yyj418 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys418Slc = r.DecodeBytes(yys418Slc, true, true)
+		yys418 := string(yys418Slc)
+		switch yys418 {
+		case "device":
+			if r.TryDecodeAsNil() {
+				x.Device = ""
+			} else {
+				x.Device = string(r.DecodeString())
+			}
+		case "usageBytes":
+			if r.TryDecodeAsNil() {
+				if x.UsageBytes != nil {
+					x.UsageBytes = nil
+				}
+			} else {
+				if x.UsageBytes == nil {
+					x.UsageBytes = new(pkg2_resource.Quantity)
+				}
+				yym421 := z.DecBinary()
+				_ = yym421
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
+				} else if !yym421 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.UsageBytes)
+				} else {
+					z.DecFallback(x.UsageBytes, false)
+				}
+			}
+		case "limitBytes":
+			if r.TryDecodeAsNil() {
+				if x.LimitBytes != nil {
+					x.LimitBytes = nil
+				}
+			} else {
+				if x.LimitBytes == nil {
+					x.LimitBytes = new(pkg2_resource.Quantity)
+				}
+				yym423 := z.DecBinary()
+				_ = yym423
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
+				} else if !yym423 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.LimitBytes)
+				} else {
+					z.DecFallback(x.LimitBytes, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys418)
+		} // end switch yys418
+	} // end for yyj418
+	if !yyhl418 {
+		r.ReadEnd()
+	}
+}
+
+func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj424 int
+	var yyb424 bool
+	var yyhl424 bool = l >= 0
+	yyj424++
+	if yyhl424 {
+		yyb424 = yyj424 > l
+	} else {
+		yyb424 = r.CheckBreak()
+	}
+	if yyb424 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Device = ""
+	} else {
+		x.Device = string(r.DecodeString())
+	}
+	yyj424++
+	if yyhl424 {
+		yyb424 = yyj424 > l
+	} else {
+		yyb424 = r.CheckBreak()
+	}
+	if yyb424 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.UsageBytes != nil {
+			x.UsageBytes = nil
+		}
+	} else {
+		if x.UsageBytes == nil {
+			x.UsageBytes = new(pkg2_resource.Quantity)
+		}
+		yym427 := z.DecBinary()
+		_ = yym427
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
+		} else if !yym427 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.UsageBytes)
+		} else {
+			z.DecFallback(x.UsageBytes, false)
+		}
+	}
+	yyj424++
+	if yyhl424 {
+		yyb424 = yyj424 > l
+	} else {
+		yyb424 = r.CheckBreak()
+	}
+	if yyb424 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.LimitBytes != nil {
+			x.LimitBytes = nil
+		}
+	} else {
+		if x.LimitBytes == nil {
+			x.LimitBytes = new(pkg2_resource.Quantity)
+		}
+		yym429 := z.DecBinary()
+		_ = yym429
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
+		} else if !yym429 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.LimitBytes)
+		} else {
+			z.DecFallback(x.LimitBytes, false)
+		}
+	}
+	for {
+		yyj424++
+		if yyhl424 {
+			yyb424 = yyj424 > l
+		} else {
+			yyb424 = r.CheckBreak()
+		}
+		if yyb424 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj424-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4471,8 +4919,8 @@ func (x CustomMetricType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym391 := z.EncBinary()
-	_ = yym391
+	yym430 := z.EncBinary()
+	_ = yym430
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -4484,8 +4932,8 @@ func (x *CustomMetricType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym392 := z.DecBinary()
-	_ = yym392
+	yym431 := z.DecBinary()
+	_ = yym431
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -4500,73 +4948,73 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym393 := z.EncBinary()
-		_ = yym393
+		yym432 := z.EncBinary()
+		_ = yym432
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep394 := !z.EncBinary()
-			yy2arr394 := z.EncBasicHandle().StructToArray
-			var yyq394 [4]bool
-			_, _, _ = yysep394, yyq394, yy2arr394
-			const yyr394 bool = false
-			yyq394[3] = len(x.Samples) != 0
-			if yyr394 || yy2arr394 {
+			yysep433 := !z.EncBinary()
+			yy2arr433 := z.EncBasicHandle().StructToArray
+			var yyq433 [4]bool
+			_, _, _ = yysep433, yyq433, yy2arr433
+			const yyr433 bool = false
+			yyq433[3] = len(x.Samples) != 0
+			if yyr433 || yy2arr433 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn394 int = 3
-				for _, b := range yyq394 {
+				var yynn433 int = 3
+				for _, b := range yyq433 {
 					if b {
-						yynn394++
+						yynn433++
 					}
 				}
-				r.EncodeMapStart(yynn394)
+				r.EncodeMapStart(yynn433)
 			}
-			if yyr394 || yy2arr394 {
-				yym396 := z.EncBinary()
-				_ = yym396
+			if yyr433 || yy2arr433 {
+				yym435 := z.EncBinary()
+				_ = yym435
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
-				yym397 := z.EncBinary()
-				_ = yym397
+				yym436 := z.EncBinary()
+				_ = yym436
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yyr394 || yy2arr394 {
+			if yyr433 || yy2arr433 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr394 || yy2arr394 {
-				yym400 := z.EncBinary()
-				_ = yym400
+			if yyr433 || yy2arr433 {
+				yym439 := z.EncBinary()
+				_ = yym439
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("unit"))
-				yym401 := z.EncBinary()
-				_ = yym401
+				yym440 := z.EncBinary()
+				_ = yym440
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
 				}
 			}
-			if yyr394 || yy2arr394 {
-				if yyq394[3] {
+			if yyr433 || yy2arr433 {
+				if yyq433[3] {
 					if x.Samples == nil {
 						r.EncodeNil()
 					} else {
-						yym403 := z.EncBinary()
-						_ = yym403
+						yym442 := z.EncBinary()
+						_ = yym442
 						if false {
 						} else {
 							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
@@ -4576,13 +5024,13 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq394[3] {
+				if yyq433[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("samples"))
 					if x.Samples == nil {
 						r.EncodeNil()
 					} else {
-						yym404 := z.EncBinary()
-						_ = yym404
+						yym443 := z.EncBinary()
+						_ = yym443
 						if false {
 						} else {
 							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
@@ -4590,7 +5038,7 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep394 {
+			if yysep433 {
 				r.EncodeEnd()
 			}
 		}
@@ -4601,24 +5049,24 @@ func (x *CustomMetric) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym405 := z.DecBinary()
-	_ = yym405
+	yym444 := z.DecBinary()
+	_ = yym444
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl406 := r.ReadMapStart()
-			if yyl406 == 0 {
+			yyl445 := r.ReadMapStart()
+			if yyl445 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl406, d)
+				x.codecDecodeSelfFromMap(yyl445, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl406 := r.ReadArrayStart()
-			if yyl406 == 0 {
+			yyl445 := r.ReadArrayStart()
+			if yyl445 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl406, d)
+				x.codecDecodeSelfFromArray(yyl445, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4630,12 +5078,12 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys407Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys407Slc
-	var yyhl407 bool = l >= 0
-	for yyj407 := 0; ; yyj407++ {
-		if yyhl407 {
-			if yyj407 >= l {
+	var yys446Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys446Slc
+	var yyhl446 bool = l >= 0
+	for yyj446 := 0; ; yyj446++ {
+		if yyhl446 {
+			if yyj446 >= l {
 				break
 			}
 		} else {
@@ -4643,9 +5091,9 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys407Slc = r.DecodeBytes(yys407Slc, true, true)
-		yys407 := string(yys407Slc)
-		switch yys407 {
+		yys446Slc = r.DecodeBytes(yys446Slc, true, true)
+		yys446 := string(yys446Slc)
+		switch yys446 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -4668,19 +5116,19 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Samples = nil
 			} else {
-				yyv411 := &x.Samples
-				yym412 := z.DecBinary()
-				_ = yym412
+				yyv450 := &x.Samples
+				yym451 := z.DecBinary()
+				_ = yym451
 				if false {
 				} else {
-					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv411), d)
+					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv450), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys407)
-		} // end switch yys407
-	} // end for yyj407
-	if !yyhl407 {
+			z.DecStructFieldNotFound(-1, yys446)
+		} // end switch yys446
+	} // end for yyj446
+	if !yyhl446 {
 		r.ReadEnd()
 	}
 }
@@ -4689,16 +5137,16 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj413 int
-	var yyb413 bool
-	var yyhl413 bool = l >= 0
-	yyj413++
-	if yyhl413 {
-		yyb413 = yyj413 > l
+	var yyj452 int
+	var yyb452 bool
+	var yyhl452 bool = l >= 0
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb413 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb413 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
@@ -4707,13 +5155,13 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj413++
-	if yyhl413 {
-		yyb413 = yyj413 > l
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb413 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb413 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
@@ -4722,13 +5170,13 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = CustomMetricType(r.DecodeString())
 	}
-	yyj413++
-	if yyhl413 {
-		yyb413 = yyj413 > l
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb413 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb413 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
@@ -4737,38 +5185,38 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Unit = string(r.DecodeString())
 	}
-	yyj413++
-	if yyhl413 {
-		yyb413 = yyj413 > l
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb413 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb413 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Samples = nil
 	} else {
-		yyv417 := &x.Samples
-		yym418 := z.DecBinary()
-		_ = yym418
+		yyv456 := &x.Samples
+		yym457 := z.DecBinary()
+		_ = yym457
 		if false {
 		} else {
-			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv417), d)
+			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv456), d)
 		}
 	}
 	for {
-		yyj413++
-		if yyhl413 {
-			yyb413 = yyj413 > l
+		yyj452++
+		if yyhl452 {
+			yyb452 = yyj452 > l
 		} else {
-			yyb413 = r.CheckBreak()
+			yyb452 = r.CheckBreak()
 		}
-		if yyb413 {
+		if yyb452 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj413-1, "")
+		z.DecStructFieldNotFound(yyj452-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4780,113 +5228,113 @@ func (x *CustomMetricSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym419 := z.EncBinary()
-		_ = yym419
+		yym458 := z.EncBinary()
+		_ = yym458
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep420 := !z.EncBinary()
-			yy2arr420 := z.EncBasicHandle().StructToArray
-			var yyq420 [3]bool
-			_, _, _ = yysep420, yyq420, yy2arr420
-			const yyr420 bool = false
-			yyq420[1] = x.Label != nil
-			if yyr420 || yy2arr420 {
+			yysep459 := !z.EncBinary()
+			yy2arr459 := z.EncBasicHandle().StructToArray
+			var yyq459 [3]bool
+			_, _, _ = yysep459, yyq459, yy2arr459
+			const yyr459 bool = false
+			yyq459[1] = x.Label != nil
+			if yyr459 || yy2arr459 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn420 int = 2
-				for _, b := range yyq420 {
+				var yynn459 int = 2
+				for _, b := range yyq459 {
 					if b {
-						yynn420++
+						yynn459++
 					}
 				}
-				r.EncodeMapStart(yynn420)
+				r.EncodeMapStart(yynn459)
 			}
-			if yyr420 || yy2arr420 {
-				yy422 := &x.SampleTime
-				yym423 := z.EncBinary()
-				_ = yym423
+			if yyr459 || yy2arr459 {
+				yy461 := &x.SampleTime
+				yym462 := z.EncBinary()
+				_ = yym462
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy422) {
-				} else if yym423 {
-					z.EncBinaryMarshal(yy422)
-				} else if !yym423 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy422)
+				} else if z.HasExtensions() && z.EncExt(yy461) {
+				} else if yym462 {
+					z.EncBinaryMarshal(yy461)
+				} else if !yym462 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy461)
 				} else {
-					z.EncFallback(yy422)
+					z.EncFallback(yy461)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy424 := &x.SampleTime
-				yym425 := z.EncBinary()
-				_ = yym425
+				yy463 := &x.SampleTime
+				yym464 := z.EncBinary()
+				_ = yym464
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy424) {
-				} else if yym425 {
-					z.EncBinaryMarshal(yy424)
-				} else if !yym425 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy424)
+				} else if z.HasExtensions() && z.EncExt(yy463) {
+				} else if yym464 {
+					z.EncBinaryMarshal(yy463)
+				} else if !yym464 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy463)
 				} else {
-					z.EncFallback(yy424)
+					z.EncFallback(yy463)
 				}
 			}
-			if yyr420 || yy2arr420 {
-				if yyq420[1] {
+			if yyr459 || yy2arr459 {
+				if yyq459[1] {
 					if x.Label == nil {
 						r.EncodeNil()
 					} else {
-						yy427 := *x.Label
-						yym428 := z.EncBinary()
-						_ = yym428
+						yy466 := *x.Label
+						yym467 := z.EncBinary()
+						_ = yym467
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy427))
+							r.EncodeString(codecSelferC_UTF81234, string(yy466))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq420[1] {
+				if yyq459[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("label"))
 					if x.Label == nil {
 						r.EncodeNil()
 					} else {
-						yy429 := *x.Label
-						yym430 := z.EncBinary()
-						_ = yym430
+						yy468 := *x.Label
+						yym469 := z.EncBinary()
+						_ = yym469
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy429))
+							r.EncodeString(codecSelferC_UTF81234, string(yy468))
 						}
 					}
 				}
 			}
-			if yyr420 || yy2arr420 {
-				yy432 := &x.Value
-				yym433 := z.EncBinary()
-				_ = yym433
+			if yyr459 || yy2arr459 {
+				yy471 := &x.Value
+				yym472 := z.EncBinary()
+				_ = yym472
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy432) {
-				} else if !yym433 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy432)
+				} else if z.HasExtensions() && z.EncExt(yy471) {
+				} else if !yym472 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy471)
 				} else {
-					z.EncFallback(yy432)
+					z.EncFallback(yy471)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yy434 := &x.Value
-				yym435 := z.EncBinary()
-				_ = yym435
+				yy473 := &x.Value
+				yym474 := z.EncBinary()
+				_ = yym474
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy434) {
-				} else if !yym435 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy434)
+				} else if z.HasExtensions() && z.EncExt(yy473) {
+				} else if !yym474 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy473)
 				} else {
-					z.EncFallback(yy434)
+					z.EncFallback(yy473)
 				}
 			}
-			if yysep420 {
+			if yysep459 {
 				r.EncodeEnd()
 			}
 		}
@@ -4897,24 +5345,24 @@ func (x *CustomMetricSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym436 := z.DecBinary()
-	_ = yym436
+	yym475 := z.DecBinary()
+	_ = yym475
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl437 := r.ReadMapStart()
-			if yyl437 == 0 {
+			yyl476 := r.ReadMapStart()
+			if yyl476 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl437, d)
+				x.codecDecodeSelfFromMap(yyl476, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl437 := r.ReadArrayStart()
-			if yyl437 == 0 {
+			yyl476 := r.ReadArrayStart()
+			if yyl476 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl437, d)
+				x.codecDecodeSelfFromArray(yyl476, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4926,12 +5374,12 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys438Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys438Slc
-	var yyhl438 bool = l >= 0
-	for yyj438 := 0; ; yyj438++ {
-		if yyhl438 {
-			if yyj438 >= l {
+	var yys477Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys477Slc
+	var yyhl477 bool = l >= 0
+	for yyj477 := 0; ; yyj477++ {
+		if yyhl477 {
+			if yyj477 >= l {
 				break
 			}
 		} else {
@@ -4939,24 +5387,24 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys438Slc = r.DecodeBytes(yys438Slc, true, true)
-		yys438 := string(yys438Slc)
-		switch yys438 {
+		yys477Slc = r.DecodeBytes(yys477Slc, true, true)
+		yys477 := string(yys477Slc)
+		switch yys477 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv439 := &x.SampleTime
-				yym440 := z.DecBinary()
-				_ = yym440
+				yyv478 := &x.SampleTime
+				yym479 := z.DecBinary()
+				_ = yym479
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv439) {
-				} else if yym440 {
-					z.DecBinaryUnmarshal(yyv439)
-				} else if !yym440 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv439)
+				} else if z.HasExtensions() && z.DecExt(yyv478) {
+				} else if yym479 {
+					z.DecBinaryUnmarshal(yyv478)
+				} else if !yym479 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv478)
 				} else {
-					z.DecFallback(yyv439, false)
+					z.DecFallback(yyv478, false)
 				}
 			}
 		case "label":
@@ -4968,8 +5416,8 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.Label == nil {
 					x.Label = new(string)
 				}
-				yym442 := z.DecBinary()
-				_ = yym442
+				yym481 := z.DecBinary()
+				_ = yym481
 				if false {
 				} else {
 					*((*string)(x.Label)) = r.DecodeString()
@@ -4979,22 +5427,22 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Value = pkg2_resource.Quantity{}
 			} else {
-				yyv443 := &x.Value
-				yym444 := z.DecBinary()
-				_ = yym444
+				yyv482 := &x.Value
+				yym483 := z.DecBinary()
+				_ = yym483
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv443) {
-				} else if !yym444 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv443)
+				} else if z.HasExtensions() && z.DecExt(yyv482) {
+				} else if !yym483 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv482)
 				} else {
-					z.DecFallback(yyv443, false)
+					z.DecFallback(yyv482, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys438)
-		} // end switch yys438
-	} // end for yyj438
-	if !yyhl438 {
+			z.DecStructFieldNotFound(-1, yys477)
+		} // end switch yys477
+	} // end for yyj477
+	if !yyhl477 {
 		r.ReadEnd()
 	}
 }
@@ -5003,42 +5451,42 @@ func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj445 int
-	var yyb445 bool
-	var yyhl445 bool = l >= 0
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
+	var yyj484 int
+	var yyb484 bool
+	var yyhl484 bool = l >= 0
+	yyj484++
+	if yyhl484 {
+		yyb484 = yyj484 > l
 	} else {
-		yyb445 = r.CheckBreak()
+		yyb484 = r.CheckBreak()
 	}
-	if yyb445 {
+	if yyb484 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv446 := &x.SampleTime
-		yym447 := z.DecBinary()
-		_ = yym447
+		yyv485 := &x.SampleTime
+		yym486 := z.DecBinary()
+		_ = yym486
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv446) {
-		} else if yym447 {
-			z.DecBinaryUnmarshal(yyv446)
-		} else if !yym447 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv446)
+		} else if z.HasExtensions() && z.DecExt(yyv485) {
+		} else if yym486 {
+			z.DecBinaryUnmarshal(yyv485)
+		} else if !yym486 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv485)
 		} else {
-			z.DecFallback(yyv446, false)
+			z.DecFallback(yyv485, false)
 		}
 	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
+	yyj484++
+	if yyhl484 {
+		yyb484 = yyj484 > l
 	} else {
-		yyb445 = r.CheckBreak()
+		yyb484 = r.CheckBreak()
 	}
-	if yyb445 {
+	if yyb484 {
 		r.ReadEnd()
 		return
 	}
@@ -5050,48 +5498,48 @@ func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.Label == nil {
 			x.Label = new(string)
 		}
-		yym449 := z.DecBinary()
-		_ = yym449
+		yym488 := z.DecBinary()
+		_ = yym488
 		if false {
 		} else {
 			*((*string)(x.Label)) = r.DecodeString()
 		}
 	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
+	yyj484++
+	if yyhl484 {
+		yyb484 = yyj484 > l
 	} else {
-		yyb445 = r.CheckBreak()
+		yyb484 = r.CheckBreak()
 	}
-	if yyb445 {
+	if yyb484 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Value = pkg2_resource.Quantity{}
 	} else {
-		yyv450 := &x.Value
-		yym451 := z.DecBinary()
-		_ = yym451
+		yyv489 := &x.Value
+		yym490 := z.DecBinary()
+		_ = yym490
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv450) {
-		} else if !yym451 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv450)
+		} else if z.HasExtensions() && z.DecExt(yyv489) {
+		} else if !yym490 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv489)
 		} else {
-			z.DecFallback(yyv450, false)
+			z.DecFallback(yyv489, false)
 		}
 	}
 	for {
-		yyj445++
-		if yyhl445 {
-			yyb445 = yyj445 > l
+		yyj484++
+		if yyhl484 {
+			yyb484 = yyj484 > l
 		} else {
-			yyb445 = r.CheckBreak()
+			yyb484 = r.CheckBreak()
 		}
-		if yyb445 {
+		if yyb484 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj445-1, "")
+		z.DecStructFieldNotFound(yyj484-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5103,42 +5551,42 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym452 := z.EncBinary()
-		_ = yym452
+		yym491 := z.EncBinary()
+		_ = yym491
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep453 := !z.EncBinary()
-			yy2arr453 := z.EncBasicHandle().StructToArray
-			var yyq453 [3]bool
-			_, _, _ = yysep453, yyq453, yy2arr453
-			const yyr453 bool = false
-			yyq453[0] = x.SinceTime != nil
-			yyq453[1] = x.UntilTime != nil
-			yyq453[2] = x.MaxSamples != 0
-			if yyr453 || yy2arr453 {
+			yysep492 := !z.EncBinary()
+			yy2arr492 := z.EncBasicHandle().StructToArray
+			var yyq492 [3]bool
+			_, _, _ = yysep492, yyq492, yy2arr492
+			const yyr492 bool = false
+			yyq492[0] = x.SinceTime != nil
+			yyq492[1] = x.UntilTime != nil
+			yyq492[2] = x.MaxSamples != 0
+			if yyr492 || yy2arr492 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn453 int = 0
-				for _, b := range yyq453 {
+				var yynn492 int = 0
+				for _, b := range yyq492 {
 					if b {
-						yynn453++
+						yynn492++
 					}
 				}
-				r.EncodeMapStart(yynn453)
+				r.EncodeMapStart(yynn492)
 			}
-			if yyr453 || yy2arr453 {
-				if yyq453[0] {
+			if yyr492 || yy2arr492 {
+				if yyq492[0] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym455 := z.EncBinary()
-						_ = yym455
+						yym494 := z.EncBinary()
+						_ = yym494
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym455 {
+						} else if yym494 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym455 && z.IsJSONHandle() {
+						} else if !yym494 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5148,18 +5596,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq453[0] {
+				if yyq492[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym456 := z.EncBinary()
-						_ = yym456
+						yym495 := z.EncBinary()
+						_ = yym495
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym456 {
+						} else if yym495 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym456 && z.IsJSONHandle() {
+						} else if !yym495 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5167,18 +5615,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr453 || yy2arr453 {
-				if yyq453[1] {
+			if yyr492 || yy2arr492 {
+				if yyq492[1] {
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym458 := z.EncBinary()
-						_ = yym458
+						yym497 := z.EncBinary()
+						_ = yym497
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym458 {
+						} else if yym497 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym458 && z.IsJSONHandle() {
+						} else if !yym497 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5188,18 +5636,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq453[1] {
+				if yyq492[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym459 := z.EncBinary()
-						_ = yym459
+						yym498 := z.EncBinary()
+						_ = yym498
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym459 {
+						} else if yym498 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym459 && z.IsJSONHandle() {
+						} else if !yym498 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5207,10 +5655,10 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr453 || yy2arr453 {
-				if yyq453[2] {
-					yym461 := z.EncBinary()
-					_ = yym461
+			if yyr492 || yy2arr492 {
+				if yyq492[2] {
+					yym500 := z.EncBinary()
+					_ = yym500
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -5219,17 +5667,17 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq453[2] {
+				if yyq492[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
-					yym462 := z.EncBinary()
-					_ = yym462
+					yym501 := z.EncBinary()
+					_ = yym501
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
 					}
 				}
 			}
-			if yysep453 {
+			if yysep492 {
 				r.EncodeEnd()
 			}
 		}
@@ -5240,24 +5688,24 @@ func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym463 := z.DecBinary()
-	_ = yym463
+	yym502 := z.DecBinary()
+	_ = yym502
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl464 := r.ReadMapStart()
-			if yyl464 == 0 {
+			yyl503 := r.ReadMapStart()
+			if yyl503 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl464, d)
+				x.codecDecodeSelfFromMap(yyl503, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl464 := r.ReadArrayStart()
-			if yyl464 == 0 {
+			yyl503 := r.ReadArrayStart()
+			if yyl503 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl464, d)
+				x.codecDecodeSelfFromArray(yyl503, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5269,12 +5717,12 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys465Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys465Slc
-	var yyhl465 bool = l >= 0
-	for yyj465 := 0; ; yyj465++ {
-		if yyhl465 {
-			if yyj465 >= l {
+	var yys504Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys504Slc
+	var yyhl504 bool = l >= 0
+	for yyj504 := 0; ; yyj504++ {
+		if yyhl504 {
+			if yyj504 >= l {
 				break
 			}
 		} else {
@@ -5282,9 +5730,9 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys465Slc = r.DecodeBytes(yys465Slc, true, true)
-		yys465 := string(yys465Slc)
-		switch yys465 {
+		yys504Slc = r.DecodeBytes(yys504Slc, true, true)
+		yys504 := string(yys504Slc)
+		switch yys504 {
 		case "sinceTime":
 			if r.TryDecodeAsNil() {
 				if x.SinceTime != nil {
@@ -5294,13 +5742,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg1_unversioned.Time)
 				}
-				yym467 := z.DecBinary()
-				_ = yym467
+				yym506 := z.DecBinary()
+				_ = yym506
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym467 {
+				} else if yym506 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym467 && z.IsJSONHandle() {
+				} else if !yym506 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -5315,13 +5763,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UntilTime == nil {
 					x.UntilTime = new(pkg1_unversioned.Time)
 				}
-				yym469 := z.DecBinary()
-				_ = yym469
+				yym508 := z.DecBinary()
+				_ = yym508
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-				} else if yym469 {
+				} else if yym508 {
 					z.DecBinaryUnmarshal(x.UntilTime)
-				} else if !yym469 && z.IsJSONHandle() {
+				} else if !yym508 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UntilTime)
 				} else {
 					z.DecFallback(x.UntilTime, false)
@@ -5334,10 +5782,10 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys465)
-		} // end switch yys465
-	} // end for yyj465
-	if !yyhl465 {
+			z.DecStructFieldNotFound(-1, yys504)
+		} // end switch yys504
+	} // end for yyj504
+	if !yyhl504 {
 		r.ReadEnd()
 	}
 }
@@ -5346,16 +5794,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj471 int
-	var yyb471 bool
-	var yyhl471 bool = l >= 0
-	yyj471++
-	if yyhl471 {
-		yyb471 = yyj471 > l
+	var yyj510 int
+	var yyb510 bool
+	var yyhl510 bool = l >= 0
+	yyj510++
+	if yyhl510 {
+		yyb510 = yyj510 > l
 	} else {
-		yyb471 = r.CheckBreak()
+		yyb510 = r.CheckBreak()
 	}
-	if yyb471 {
+	if yyb510 {
 		r.ReadEnd()
 		return
 	}
@@ -5367,25 +5815,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg1_unversioned.Time)
 		}
-		yym473 := z.DecBinary()
-		_ = yym473
+		yym512 := z.DecBinary()
+		_ = yym512
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym473 {
+		} else if yym512 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym473 && z.IsJSONHandle() {
+		} else if !yym512 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj471++
-	if yyhl471 {
-		yyb471 = yyj471 > l
+	yyj510++
+	if yyhl510 {
+		yyb510 = yyj510 > l
 	} else {
-		yyb471 = r.CheckBreak()
+		yyb510 = r.CheckBreak()
 	}
-	if yyb471 {
+	if yyb510 {
 		r.ReadEnd()
 		return
 	}
@@ -5397,25 +5845,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UntilTime == nil {
 			x.UntilTime = new(pkg1_unversioned.Time)
 		}
-		yym475 := z.DecBinary()
-		_ = yym475
+		yym514 := z.DecBinary()
+		_ = yym514
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-		} else if yym475 {
+		} else if yym514 {
 			z.DecBinaryUnmarshal(x.UntilTime)
-		} else if !yym475 && z.IsJSONHandle() {
+		} else if !yym514 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UntilTime)
 		} else {
 			z.DecFallback(x.UntilTime, false)
 		}
 	}
-	yyj471++
-	if yyhl471 {
-		yyb471 = yyj471 > l
+	yyj510++
+	if yyhl510 {
+		yyb510 = yyj510 > l
 	} else {
-		yyb471 = r.CheckBreak()
+		yyb510 = r.CheckBreak()
 	}
-	if yyb471 {
+	if yyb510 {
 		r.ReadEnd()
 		return
 	}
@@ -5425,16 +5873,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj471++
-		if yyhl471 {
-			yyb471 = yyj471 > l
+		yyj510++
+		if yyhl510 {
+			yyb510 = yyj510 > l
 		} else {
-			yyb471 = r.CheckBreak()
+			yyb510 = r.CheckBreak()
 		}
-		if yyb471 {
+		if yyb510 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj471-1, "")
+		z.DecStructFieldNotFound(yyj510-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5444,9 +5892,9 @@ func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv477 := range v {
-		yy478 := &yyv477
-		yy478.CodecEncodeSelf(e)
+	for _, yyv516 := range v {
+		yy517 := &yyv516
+		yy517.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5456,75 +5904,75 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv479 := *v
-	yyh479, yyl479 := z.DecSliceHelperStart()
+	yyv518 := *v
+	yyh518, yyl518 := z.DecSliceHelperStart()
 
-	var yyrr479, yyrl479 int
-	var yyc479, yyrt479 bool
-	_, _, _ = yyc479, yyrt479, yyrl479
-	yyrr479 = yyl479
+	var yyrr518, yyrl518 int
+	var yyc518, yyrt518 bool
+	_, _, _ = yyc518, yyrt518, yyrl518
+	yyrr518 = yyl518
 
-	if yyv479 == nil {
-		if yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 48); yyrt479 {
-			yyrr479 = yyrl479
+	if yyv518 == nil {
+		if yyrl518, yyrt518 = z.DecInferLen(yyl518, z.DecBasicHandle().MaxInitLen, 72); yyrt518 {
+			yyrr518 = yyrl518
 		}
-		yyv479 = make([]AggregateSample, yyrl479)
-		yyc479 = true
+		yyv518 = make([]AggregateSample, yyrl518)
+		yyc518 = true
 	}
 
-	if yyl479 == 0 {
-		if len(yyv479) != 0 {
-			yyv479 = yyv479[:0]
-			yyc479 = true
+	if yyl518 == 0 {
+		if len(yyv518) != 0 {
+			yyv518 = yyv518[:0]
+			yyc518 = true
 		}
-	} else if yyl479 > 0 {
+	} else if yyl518 > 0 {
 
-		if yyl479 > cap(yyv479) {
-			yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 48)
-			yyv479 = make([]AggregateSample, yyrl479)
-			yyc479 = true
+		if yyl518 > cap(yyv518) {
+			yyrl518, yyrt518 = z.DecInferLen(yyl518, z.DecBasicHandle().MaxInitLen, 72)
+			yyv518 = make([]AggregateSample, yyrl518)
+			yyc518 = true
 
-			yyrr479 = len(yyv479)
-		} else if yyl479 != len(yyv479) {
-			yyv479 = yyv479[:yyl479]
-			yyc479 = true
+			yyrr518 = len(yyv518)
+		} else if yyl518 != len(yyv518) {
+			yyv518 = yyv518[:yyl518]
+			yyc518 = true
 		}
-		yyj479 := 0
-		for ; yyj479 < yyrr479; yyj479++ {
+		yyj518 := 0
+		for ; yyj518 < yyrr518; yyj518++ {
 			if r.TryDecodeAsNil() {
-				yyv479[yyj479] = AggregateSample{}
+				yyv518[yyj518] = AggregateSample{}
 			} else {
-				yyv480 := &yyv479[yyj479]
-				yyv480.CodecDecodeSelf(d)
+				yyv519 := &yyv518[yyj518]
+				yyv519.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt479 {
-			for ; yyj479 < yyl479; yyj479++ {
-				yyv479 = append(yyv479, AggregateSample{})
+		if yyrt518 {
+			for ; yyj518 < yyl518; yyj518++ {
+				yyv518 = append(yyv518, AggregateSample{})
 				if r.TryDecodeAsNil() {
-					yyv479[yyj479] = AggregateSample{}
+					yyv518[yyj518] = AggregateSample{}
 				} else {
-					yyv481 := &yyv479[yyj479]
-					yyv481.CodecDecodeSelf(d)
+					yyv520 := &yyv518[yyj518]
+					yyv520.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj479 := 0; !r.CheckBreak(); yyj479++ {
-			if yyj479 >= len(yyv479) {
-				yyv479 = append(yyv479, AggregateSample{}) // var yyz479 AggregateSample
-				yyc479 = true
+		for yyj518 := 0; !r.CheckBreak(); yyj518++ {
+			if yyj518 >= len(yyv518) {
+				yyv518 = append(yyv518, AggregateSample{}) // var yyz518 AggregateSample
+				yyc518 = true
 			}
 
-			if yyj479 < len(yyv479) {
+			if yyj518 < len(yyv518) {
 				if r.TryDecodeAsNil() {
-					yyv479[yyj479] = AggregateSample{}
+					yyv518[yyj518] = AggregateSample{}
 				} else {
-					yyv482 := &yyv479[yyj479]
-					yyv482.CodecDecodeSelf(d)
+					yyv521 := &yyv518[yyj518]
+					yyv521.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5532,10 +5980,10 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 			}
 
 		}
-		yyh479.End()
+		yyh518.End()
 	}
-	if yyc479 {
-		*v = yyv479
+	if yyc518 {
+		*v = yyv518
 	}
 
 }
@@ -5545,9 +5993,9 @@ func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv483 := range v {
-		yy484 := &yyv483
-		yy484.CodecEncodeSelf(e)
+	for _, yyv522 := range v {
+		yy523 := &yyv522
+		yy523.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5557,75 +6005,75 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv485 := *v
-	yyh485, yyl485 := z.DecSliceHelperStart()
+	yyv524 := *v
+	yyh524, yyl524 := z.DecSliceHelperStart()
 
-	var yyrr485, yyrl485 int
-	var yyc485, yyrt485 bool
-	_, _, _ = yyc485, yyrt485, yyrl485
-	yyrr485 = yyl485
+	var yyrr524, yyrl524 int
+	var yyc524, yyrt524 bool
+	_, _, _ = yyc524, yyrt524, yyrl524
+	yyrr524 = yyl524
 
-	if yyv485 == nil {
-		if yyrl485, yyrt485 = z.DecInferLen(yyl485, z.DecBasicHandle().MaxInitLen, 72); yyrt485 {
-			yyrr485 = yyrl485
+	if yyv524 == nil {
+		if yyrl524, yyrt524 = z.DecInferLen(yyl524, z.DecBasicHandle().MaxInitLen, 72); yyrt524 {
+			yyrr524 = yyrl524
 		}
-		yyv485 = make([]RawContainerMetrics, yyrl485)
-		yyc485 = true
+		yyv524 = make([]RawContainerMetrics, yyrl524)
+		yyc524 = true
 	}
 
-	if yyl485 == 0 {
-		if len(yyv485) != 0 {
-			yyv485 = yyv485[:0]
-			yyc485 = true
+	if yyl524 == 0 {
+		if len(yyv524) != 0 {
+			yyv524 = yyv524[:0]
+			yyc524 = true
 		}
-	} else if yyl485 > 0 {
+	} else if yyl524 > 0 {
 
-		if yyl485 > cap(yyv485) {
-			yyrl485, yyrt485 = z.DecInferLen(yyl485, z.DecBasicHandle().MaxInitLen, 72)
-			yyv485 = make([]RawContainerMetrics, yyrl485)
-			yyc485 = true
+		if yyl524 > cap(yyv524) {
+			yyrl524, yyrt524 = z.DecInferLen(yyl524, z.DecBasicHandle().MaxInitLen, 72)
+			yyv524 = make([]RawContainerMetrics, yyrl524)
+			yyc524 = true
 
-			yyrr485 = len(yyv485)
-		} else if yyl485 != len(yyv485) {
-			yyv485 = yyv485[:yyl485]
-			yyc485 = true
+			yyrr524 = len(yyv524)
+		} else if yyl524 != len(yyv524) {
+			yyv524 = yyv524[:yyl524]
+			yyc524 = true
 		}
-		yyj485 := 0
-		for ; yyj485 < yyrr485; yyj485++ {
+		yyj524 := 0
+		for ; yyj524 < yyrr524; yyj524++ {
 			if r.TryDecodeAsNil() {
-				yyv485[yyj485] = RawContainerMetrics{}
+				yyv524[yyj524] = RawContainerMetrics{}
 			} else {
-				yyv486 := &yyv485[yyj485]
-				yyv486.CodecDecodeSelf(d)
+				yyv525 := &yyv524[yyj524]
+				yyv525.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt485 {
-			for ; yyj485 < yyl485; yyj485++ {
-				yyv485 = append(yyv485, RawContainerMetrics{})
+		if yyrt524 {
+			for ; yyj524 < yyl524; yyj524++ {
+				yyv524 = append(yyv524, RawContainerMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv485[yyj485] = RawContainerMetrics{}
+					yyv524[yyj524] = RawContainerMetrics{}
 				} else {
-					yyv487 := &yyv485[yyj485]
-					yyv487.CodecDecodeSelf(d)
+					yyv526 := &yyv524[yyj524]
+					yyv526.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj485 := 0; !r.CheckBreak(); yyj485++ {
-			if yyj485 >= len(yyv485) {
-				yyv485 = append(yyv485, RawContainerMetrics{}) // var yyz485 RawContainerMetrics
-				yyc485 = true
+		for yyj524 := 0; !r.CheckBreak(); yyj524++ {
+			if yyj524 >= len(yyv524) {
+				yyv524 = append(yyv524, RawContainerMetrics{}) // var yyz524 RawContainerMetrics
+				yyc524 = true
 			}
 
-			if yyj485 < len(yyv485) {
+			if yyj524 < len(yyv524) {
 				if r.TryDecodeAsNil() {
-					yyv485[yyj485] = RawContainerMetrics{}
+					yyv524[yyj524] = RawContainerMetrics{}
 				} else {
-					yyv488 := &yyv485[yyj485]
-					yyv488.CodecDecodeSelf(d)
+					yyv527 := &yyv524[yyj524]
+					yyv527.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5633,10 +6081,10 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 			}
 
 		}
-		yyh485.End()
+		yyh524.End()
 	}
-	if yyc485 {
-		*v = yyv485
+	if yyc524 {
+		*v = yyv524
 	}
 
 }
@@ -5646,9 +6094,9 @@ func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv489 := range v {
-		yy490 := &yyv489
-		yy490.CodecEncodeSelf(e)
+	for _, yyv528 := range v {
+		yy529 := &yyv528
+		yy529.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5658,75 +6106,75 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv491 := *v
-	yyh491, yyl491 := z.DecSliceHelperStart()
+	yyv530 := *v
+	yyh530, yyl530 := z.DecSliceHelperStart()
 
-	var yyrr491, yyrl491 int
-	var yyc491, yyrt491 bool
-	_, _, _ = yyc491, yyrt491, yyrl491
-	yyrr491 = yyl491
+	var yyrr530, yyrl530 int
+	var yyc530, yyrt530 bool
+	_, _, _ = yyc530, yyrt530, yyrl530
+	yyrr530 = yyl530
 
-	if yyv491 == nil {
-		if yyrl491, yyrt491 = z.DecInferLen(yyl491, z.DecBasicHandle().MaxInitLen, 128); yyrt491 {
-			yyrr491 = yyrl491
+	if yyv530 == nil {
+		if yyrl530, yyrt530 = z.DecInferLen(yyl530, z.DecBasicHandle().MaxInitLen, 128); yyrt530 {
+			yyrr530 = yyrl530
 		}
-		yyv491 = make([]RawNodeMetrics, yyrl491)
-		yyc491 = true
+		yyv530 = make([]RawNodeMetrics, yyrl530)
+		yyc530 = true
 	}
 
-	if yyl491 == 0 {
-		if len(yyv491) != 0 {
-			yyv491 = yyv491[:0]
-			yyc491 = true
+	if yyl530 == 0 {
+		if len(yyv530) != 0 {
+			yyv530 = yyv530[:0]
+			yyc530 = true
 		}
-	} else if yyl491 > 0 {
+	} else if yyl530 > 0 {
 
-		if yyl491 > cap(yyv491) {
-			yyrl491, yyrt491 = z.DecInferLen(yyl491, z.DecBasicHandle().MaxInitLen, 128)
-			yyv491 = make([]RawNodeMetrics, yyrl491)
-			yyc491 = true
+		if yyl530 > cap(yyv530) {
+			yyrl530, yyrt530 = z.DecInferLen(yyl530, z.DecBasicHandle().MaxInitLen, 128)
+			yyv530 = make([]RawNodeMetrics, yyrl530)
+			yyc530 = true
 
-			yyrr491 = len(yyv491)
-		} else if yyl491 != len(yyv491) {
-			yyv491 = yyv491[:yyl491]
-			yyc491 = true
+			yyrr530 = len(yyv530)
+		} else if yyl530 != len(yyv530) {
+			yyv530 = yyv530[:yyl530]
+			yyc530 = true
 		}
-		yyj491 := 0
-		for ; yyj491 < yyrr491; yyj491++ {
+		yyj530 := 0
+		for ; yyj530 < yyrr530; yyj530++ {
 			if r.TryDecodeAsNil() {
-				yyv491[yyj491] = RawNodeMetrics{}
+				yyv530[yyj530] = RawNodeMetrics{}
 			} else {
-				yyv492 := &yyv491[yyj491]
-				yyv492.CodecDecodeSelf(d)
+				yyv531 := &yyv530[yyj530]
+				yyv531.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt491 {
-			for ; yyj491 < yyl491; yyj491++ {
-				yyv491 = append(yyv491, RawNodeMetrics{})
+		if yyrt530 {
+			for ; yyj530 < yyl530; yyj530++ {
+				yyv530 = append(yyv530, RawNodeMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv491[yyj491] = RawNodeMetrics{}
+					yyv530[yyj530] = RawNodeMetrics{}
 				} else {
-					yyv493 := &yyv491[yyj491]
-					yyv493.CodecDecodeSelf(d)
+					yyv532 := &yyv530[yyj530]
+					yyv532.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj491 := 0; !r.CheckBreak(); yyj491++ {
-			if yyj491 >= len(yyv491) {
-				yyv491 = append(yyv491, RawNodeMetrics{}) // var yyz491 RawNodeMetrics
-				yyc491 = true
+		for yyj530 := 0; !r.CheckBreak(); yyj530++ {
+			if yyj530 >= len(yyv530) {
+				yyv530 = append(yyv530, RawNodeMetrics{}) // var yyz530 RawNodeMetrics
+				yyc530 = true
 			}
 
-			if yyj491 < len(yyv491) {
+			if yyj530 < len(yyv530) {
 				if r.TryDecodeAsNil() {
-					yyv491[yyj491] = RawNodeMetrics{}
+					yyv530[yyj530] = RawNodeMetrics{}
 				} else {
-					yyv494 := &yyv491[yyj491]
-					yyv494.CodecDecodeSelf(d)
+					yyv533 := &yyv530[yyj530]
+					yyv533.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5734,10 +6182,10 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 			}
 
 		}
-		yyh491.End()
+		yyh530.End()
 	}
-	if yyc491 {
-		*v = yyv491
+	if yyc530 {
+		*v = yyv530
 	}
 
 }
@@ -5747,9 +6195,9 @@ func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv495 := range v {
-		yy496 := &yyv495
-		yy496.CodecEncodeSelf(e)
+	for _, yyv534 := range v {
+		yy535 := &yyv534
+		yy535.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5759,75 +6207,75 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv497 := *v
-	yyh497, yyl497 := z.DecSliceHelperStart()
+	yyv536 := *v
+	yyh536, yyl536 := z.DecSliceHelperStart()
 
-	var yyrr497, yyrl497 int
-	var yyc497, yyrt497 bool
-	_, _, _ = yyc497, yyrt497, yyrl497
-	yyrr497 = yyl497
+	var yyrr536, yyrl536 int
+	var yyc536, yyrt536 bool
+	_, _, _ = yyc536, yyrt536, yyrl536
+	yyrr536 = yyl536
 
-	if yyv497 == nil {
-		if yyrl497, yyrt497 = z.DecInferLen(yyl497, z.DecBasicHandle().MaxInitLen, 32); yyrt497 {
-			yyrr497 = yyrl497
+	if yyv536 == nil {
+		if yyrl536, yyrt536 = z.DecInferLen(yyl536, z.DecBasicHandle().MaxInitLen, 32); yyrt536 {
+			yyrr536 = yyrl536
 		}
-		yyv497 = make([]PodSample, yyrl497)
-		yyc497 = true
+		yyv536 = make([]PodSample, yyrl536)
+		yyc536 = true
 	}
 
-	if yyl497 == 0 {
-		if len(yyv497) != 0 {
-			yyv497 = yyv497[:0]
-			yyc497 = true
+	if yyl536 == 0 {
+		if len(yyv536) != 0 {
+			yyv536 = yyv536[:0]
+			yyc536 = true
 		}
-	} else if yyl497 > 0 {
+	} else if yyl536 > 0 {
 
-		if yyl497 > cap(yyv497) {
-			yyrl497, yyrt497 = z.DecInferLen(yyl497, z.DecBasicHandle().MaxInitLen, 32)
-			yyv497 = make([]PodSample, yyrl497)
-			yyc497 = true
+		if yyl536 > cap(yyv536) {
+			yyrl536, yyrt536 = z.DecInferLen(yyl536, z.DecBasicHandle().MaxInitLen, 32)
+			yyv536 = make([]PodSample, yyrl536)
+			yyc536 = true
 
-			yyrr497 = len(yyv497)
-		} else if yyl497 != len(yyv497) {
-			yyv497 = yyv497[:yyl497]
-			yyc497 = true
+			yyrr536 = len(yyv536)
+		} else if yyl536 != len(yyv536) {
+			yyv536 = yyv536[:yyl536]
+			yyc536 = true
 		}
-		yyj497 := 0
-		for ; yyj497 < yyrr497; yyj497++ {
+		yyj536 := 0
+		for ; yyj536 < yyrr536; yyj536++ {
 			if r.TryDecodeAsNil() {
-				yyv497[yyj497] = PodSample{}
+				yyv536[yyj536] = PodSample{}
 			} else {
-				yyv498 := &yyv497[yyj497]
-				yyv498.CodecDecodeSelf(d)
+				yyv537 := &yyv536[yyj536]
+				yyv537.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt497 {
-			for ; yyj497 < yyl497; yyj497++ {
-				yyv497 = append(yyv497, PodSample{})
+		if yyrt536 {
+			for ; yyj536 < yyl536; yyj536++ {
+				yyv536 = append(yyv536, PodSample{})
 				if r.TryDecodeAsNil() {
-					yyv497[yyj497] = PodSample{}
+					yyv536[yyj536] = PodSample{}
 				} else {
-					yyv499 := &yyv497[yyj497]
-					yyv499.CodecDecodeSelf(d)
+					yyv538 := &yyv536[yyj536]
+					yyv538.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj497 := 0; !r.CheckBreak(); yyj497++ {
-			if yyj497 >= len(yyv497) {
-				yyv497 = append(yyv497, PodSample{}) // var yyz497 PodSample
-				yyc497 = true
+		for yyj536 := 0; !r.CheckBreak(); yyj536++ {
+			if yyj536 >= len(yyv536) {
+				yyv536 = append(yyv536, PodSample{}) // var yyz536 PodSample
+				yyc536 = true
 			}
 
-			if yyj497 < len(yyv497) {
+			if yyj536 < len(yyv536) {
 				if r.TryDecodeAsNil() {
-					yyv497[yyj497] = PodSample{}
+					yyv536[yyj536] = PodSample{}
 				} else {
-					yyv500 := &yyv497[yyj497]
-					yyv500.CodecDecodeSelf(d)
+					yyv539 := &yyv536[yyj536]
+					yyv539.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5835,10 +6283,10 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 			}
 
 		}
-		yyh497.End()
+		yyh536.End()
 	}
-	if yyc497 {
-		*v = yyv497
+	if yyc536 {
+		*v = yyv536
 	}
 
 }
@@ -5848,9 +6296,9 @@ func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv501 := range v {
-		yy502 := &yyv501
-		yy502.CodecEncodeSelf(e)
+	for _, yyv540 := range v {
+		yy541 := &yyv540
+		yy541.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5860,75 +6308,75 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv503 := *v
-	yyh503, yyl503 := z.DecSliceHelperStart()
+	yyv542 := *v
+	yyh542, yyl542 := z.DecSliceHelperStart()
 
-	var yyrr503, yyrl503 int
-	var yyc503, yyrt503 bool
-	_, _, _ = yyc503, yyrt503, yyrl503
-	yyrr503 = yyl503
+	var yyrr542, yyrl542 int
+	var yyc542, yyrt542 bool
+	_, _, _ = yyc542, yyrt542, yyrl542
+	yyrr542 = yyl542
 
-	if yyv503 == nil {
-		if yyrl503, yyrt503 = z.DecInferLen(yyl503, z.DecBasicHandle().MaxInitLen, 160); yyrt503 {
-			yyrr503 = yyrl503
+	if yyv542 == nil {
+		if yyrl542, yyrt542 = z.DecInferLen(yyl542, z.DecBasicHandle().MaxInitLen, 160); yyrt542 {
+			yyrr542 = yyrl542
 		}
-		yyv503 = make([]RawPodMetrics, yyrl503)
-		yyc503 = true
+		yyv542 = make([]RawPodMetrics, yyrl542)
+		yyc542 = true
 	}
 
-	if yyl503 == 0 {
-		if len(yyv503) != 0 {
-			yyv503 = yyv503[:0]
-			yyc503 = true
+	if yyl542 == 0 {
+		if len(yyv542) != 0 {
+			yyv542 = yyv542[:0]
+			yyc542 = true
 		}
-	} else if yyl503 > 0 {
+	} else if yyl542 > 0 {
 
-		if yyl503 > cap(yyv503) {
-			yyrl503, yyrt503 = z.DecInferLen(yyl503, z.DecBasicHandle().MaxInitLen, 160)
-			yyv503 = make([]RawPodMetrics, yyrl503)
-			yyc503 = true
+		if yyl542 > cap(yyv542) {
+			yyrl542, yyrt542 = z.DecInferLen(yyl542, z.DecBasicHandle().MaxInitLen, 160)
+			yyv542 = make([]RawPodMetrics, yyrl542)
+			yyc542 = true
 
-			yyrr503 = len(yyv503)
-		} else if yyl503 != len(yyv503) {
-			yyv503 = yyv503[:yyl503]
-			yyc503 = true
+			yyrr542 = len(yyv542)
+		} else if yyl542 != len(yyv542) {
+			yyv542 = yyv542[:yyl542]
+			yyc542 = true
 		}
-		yyj503 := 0
-		for ; yyj503 < yyrr503; yyj503++ {
+		yyj542 := 0
+		for ; yyj542 < yyrr542; yyj542++ {
 			if r.TryDecodeAsNil() {
-				yyv503[yyj503] = RawPodMetrics{}
+				yyv542[yyj542] = RawPodMetrics{}
 			} else {
-				yyv504 := &yyv503[yyj503]
-				yyv504.CodecDecodeSelf(d)
+				yyv543 := &yyv542[yyj542]
+				yyv543.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt503 {
-			for ; yyj503 < yyl503; yyj503++ {
-				yyv503 = append(yyv503, RawPodMetrics{})
+		if yyrt542 {
+			for ; yyj542 < yyl542; yyj542++ {
+				yyv542 = append(yyv542, RawPodMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv503[yyj503] = RawPodMetrics{}
+					yyv542[yyj542] = RawPodMetrics{}
 				} else {
-					yyv505 := &yyv503[yyj503]
-					yyv505.CodecDecodeSelf(d)
+					yyv544 := &yyv542[yyj542]
+					yyv544.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj503 := 0; !r.CheckBreak(); yyj503++ {
-			if yyj503 >= len(yyv503) {
-				yyv503 = append(yyv503, RawPodMetrics{}) // var yyz503 RawPodMetrics
-				yyc503 = true
+		for yyj542 := 0; !r.CheckBreak(); yyj542++ {
+			if yyj542 >= len(yyv542) {
+				yyv542 = append(yyv542, RawPodMetrics{}) // var yyz542 RawPodMetrics
+				yyc542 = true
 			}
 
-			if yyj503 < len(yyv503) {
+			if yyj542 < len(yyv542) {
 				if r.TryDecodeAsNil() {
-					yyv503[yyj503] = RawPodMetrics{}
+					yyv542[yyj542] = RawPodMetrics{}
 				} else {
-					yyv506 := &yyv503[yyj503]
-					yyv506.CodecDecodeSelf(d)
+					yyv545 := &yyv542[yyj542]
+					yyv545.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5936,10 +6384,10 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 			}
 
 		}
-		yyh503.End()
+		yyh542.End()
 	}
-	if yyc503 {
-		*v = yyv503
+	if yyc542 {
+		*v = yyv542
 	}
 
 }
@@ -5949,9 +6397,9 @@ func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv507 := range v {
-		yy508 := &yyv507
-		yy508.CodecEncodeSelf(e)
+	for _, yyv546 := range v {
+		yy547 := &yyv546
+		yy547.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5961,75 +6409,75 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv509 := *v
-	yyh509, yyl509 := z.DecSliceHelperStart()
+	yyv548 := *v
+	yyh548, yyl548 := z.DecSliceHelperStart()
 
-	var yyrr509, yyrl509 int
-	var yyc509, yyrt509 bool
-	_, _, _ = yyc509, yyrt509, yyrl509
-	yyrr509 = yyl509
+	var yyrr548, yyrl548 int
+	var yyc548, yyrt548 bool
+	_, _, _ = yyc548, yyrt548, yyrl548
+	yyrr548 = yyl548
 
-	if yyv509 == nil {
-		if yyrl509, yyrt509 = z.DecInferLen(yyl509, z.DecBasicHandle().MaxInitLen, 40); yyrt509 {
-			yyrr509 = yyrl509
+	if yyv548 == nil {
+		if yyrl548, yyrt548 = z.DecInferLen(yyl548, z.DecBasicHandle().MaxInitLen, 64); yyrt548 {
+			yyrr548 = yyrl548
 		}
-		yyv509 = make([]ContainerSample, yyrl509)
-		yyc509 = true
+		yyv548 = make([]ContainerSample, yyrl548)
+		yyc548 = true
 	}
 
-	if yyl509 == 0 {
-		if len(yyv509) != 0 {
-			yyv509 = yyv509[:0]
-			yyc509 = true
+	if yyl548 == 0 {
+		if len(yyv548) != 0 {
+			yyv548 = yyv548[:0]
+			yyc548 = true
 		}
-	} else if yyl509 > 0 {
+	} else if yyl548 > 0 {
 
-		if yyl509 > cap(yyv509) {
-			yyrl509, yyrt509 = z.DecInferLen(yyl509, z.DecBasicHandle().MaxInitLen, 40)
-			yyv509 = make([]ContainerSample, yyrl509)
-			yyc509 = true
+		if yyl548 > cap(yyv548) {
+			yyrl548, yyrt548 = z.DecInferLen(yyl548, z.DecBasicHandle().MaxInitLen, 64)
+			yyv548 = make([]ContainerSample, yyrl548)
+			yyc548 = true
 
-			yyrr509 = len(yyv509)
-		} else if yyl509 != len(yyv509) {
-			yyv509 = yyv509[:yyl509]
-			yyc509 = true
+			yyrr548 = len(yyv548)
+		} else if yyl548 != len(yyv548) {
+			yyv548 = yyv548[:yyl548]
+			yyc548 = true
 		}
-		yyj509 := 0
-		for ; yyj509 < yyrr509; yyj509++ {
+		yyj548 := 0
+		for ; yyj548 < yyrr548; yyj548++ {
 			if r.TryDecodeAsNil() {
-				yyv509[yyj509] = ContainerSample{}
+				yyv548[yyj548] = ContainerSample{}
 			} else {
-				yyv510 := &yyv509[yyj509]
-				yyv510.CodecDecodeSelf(d)
+				yyv549 := &yyv548[yyj548]
+				yyv549.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt509 {
-			for ; yyj509 < yyl509; yyj509++ {
-				yyv509 = append(yyv509, ContainerSample{})
+		if yyrt548 {
+			for ; yyj548 < yyl548; yyj548++ {
+				yyv548 = append(yyv548, ContainerSample{})
 				if r.TryDecodeAsNil() {
-					yyv509[yyj509] = ContainerSample{}
+					yyv548[yyj548] = ContainerSample{}
 				} else {
-					yyv511 := &yyv509[yyj509]
-					yyv511.CodecDecodeSelf(d)
+					yyv550 := &yyv548[yyj548]
+					yyv550.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj509 := 0; !r.CheckBreak(); yyj509++ {
-			if yyj509 >= len(yyv509) {
-				yyv509 = append(yyv509, ContainerSample{}) // var yyz509 ContainerSample
-				yyc509 = true
+		for yyj548 := 0; !r.CheckBreak(); yyj548++ {
+			if yyj548 >= len(yyv548) {
+				yyv548 = append(yyv548, ContainerSample{}) // var yyz548 ContainerSample
+				yyc548 = true
 			}
 
-			if yyj509 < len(yyv509) {
+			if yyj548 < len(yyv548) {
 				if r.TryDecodeAsNil() {
-					yyv509[yyj509] = ContainerSample{}
+					yyv548[yyj548] = ContainerSample{}
 				} else {
-					yyv512 := &yyv509[yyj509]
-					yyv512.CodecDecodeSelf(d)
+					yyv551 := &yyv548[yyj548]
+					yyv551.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6037,10 +6485,10 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 			}
 
 		}
-		yyh509.End()
+		yyh548.End()
 	}
-	if yyc509 {
-		*v = yyv509
+	if yyc548 {
+		*v = yyv548
 	}
 
 }
@@ -6050,9 +6498,9 @@ func (x codecSelfer1234) encSliceCustomMetric(v []CustomMetric, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv513 := range v {
-		yy514 := &yyv513
-		yy514.CodecEncodeSelf(e)
+	for _, yyv552 := range v {
+		yy553 := &yyv552
+		yy553.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6062,75 +6510,75 @@ func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv515 := *v
-	yyh515, yyl515 := z.DecSliceHelperStart()
+	yyv554 := *v
+	yyh554, yyl554 := z.DecSliceHelperStart()
 
-	var yyrr515, yyrl515 int
-	var yyc515, yyrt515 bool
-	_, _, _ = yyc515, yyrt515, yyrl515
-	yyrr515 = yyl515
+	var yyrr554, yyrl554 int
+	var yyc554, yyrt554 bool
+	_, _, _ = yyc554, yyrt554, yyrl554
+	yyrr554 = yyl554
 
-	if yyv515 == nil {
-		if yyrl515, yyrt515 = z.DecInferLen(yyl515, z.DecBasicHandle().MaxInitLen, 72); yyrt515 {
-			yyrr515 = yyrl515
+	if yyv554 == nil {
+		if yyrl554, yyrt554 = z.DecInferLen(yyl554, z.DecBasicHandle().MaxInitLen, 72); yyrt554 {
+			yyrr554 = yyrl554
 		}
-		yyv515 = make([]CustomMetric, yyrl515)
-		yyc515 = true
+		yyv554 = make([]CustomMetric, yyrl554)
+		yyc554 = true
 	}
 
-	if yyl515 == 0 {
-		if len(yyv515) != 0 {
-			yyv515 = yyv515[:0]
-			yyc515 = true
+	if yyl554 == 0 {
+		if len(yyv554) != 0 {
+			yyv554 = yyv554[:0]
+			yyc554 = true
 		}
-	} else if yyl515 > 0 {
+	} else if yyl554 > 0 {
 
-		if yyl515 > cap(yyv515) {
-			yyrl515, yyrt515 = z.DecInferLen(yyl515, z.DecBasicHandle().MaxInitLen, 72)
-			yyv515 = make([]CustomMetric, yyrl515)
-			yyc515 = true
+		if yyl554 > cap(yyv554) {
+			yyrl554, yyrt554 = z.DecInferLen(yyl554, z.DecBasicHandle().MaxInitLen, 72)
+			yyv554 = make([]CustomMetric, yyrl554)
+			yyc554 = true
 
-			yyrr515 = len(yyv515)
-		} else if yyl515 != len(yyv515) {
-			yyv515 = yyv515[:yyl515]
-			yyc515 = true
+			yyrr554 = len(yyv554)
+		} else if yyl554 != len(yyv554) {
+			yyv554 = yyv554[:yyl554]
+			yyc554 = true
 		}
-		yyj515 := 0
-		for ; yyj515 < yyrr515; yyj515++ {
+		yyj554 := 0
+		for ; yyj554 < yyrr554; yyj554++ {
 			if r.TryDecodeAsNil() {
-				yyv515[yyj515] = CustomMetric{}
+				yyv554[yyj554] = CustomMetric{}
 			} else {
-				yyv516 := &yyv515[yyj515]
-				yyv516.CodecDecodeSelf(d)
+				yyv555 := &yyv554[yyj554]
+				yyv555.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt515 {
-			for ; yyj515 < yyl515; yyj515++ {
-				yyv515 = append(yyv515, CustomMetric{})
+		if yyrt554 {
+			for ; yyj554 < yyl554; yyj554++ {
+				yyv554 = append(yyv554, CustomMetric{})
 				if r.TryDecodeAsNil() {
-					yyv515[yyj515] = CustomMetric{}
+					yyv554[yyj554] = CustomMetric{}
 				} else {
-					yyv517 := &yyv515[yyj515]
-					yyv517.CodecDecodeSelf(d)
+					yyv556 := &yyv554[yyj554]
+					yyv556.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj515 := 0; !r.CheckBreak(); yyj515++ {
-			if yyj515 >= len(yyv515) {
-				yyv515 = append(yyv515, CustomMetric{}) // var yyz515 CustomMetric
-				yyc515 = true
+		for yyj554 := 0; !r.CheckBreak(); yyj554++ {
+			if yyj554 >= len(yyv554) {
+				yyv554 = append(yyv554, CustomMetric{}) // var yyz554 CustomMetric
+				yyc554 = true
 			}
 
-			if yyj515 < len(yyv515) {
+			if yyj554 < len(yyv554) {
 				if r.TryDecodeAsNil() {
-					yyv515[yyj515] = CustomMetric{}
+					yyv554[yyj554] = CustomMetric{}
 				} else {
-					yyv518 := &yyv515[yyj515]
-					yyv518.CodecDecodeSelf(d)
+					yyv557 := &yyv554[yyj554]
+					yyv557.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6138,10 +6586,111 @@ func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.De
 			}
 
 		}
-		yyh515.End()
+		yyh554.End()
 	}
-	if yyc515 {
-		*v = yyv515
+	if yyc554 {
+		*v = yyv554
+	}
+
+}
+
+func (x codecSelfer1234) encSliceFilesystemMetrics(v []FilesystemMetrics, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv558 := range v {
+		yy559 := &yyv558
+		yy559.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv560 := *v
+	yyh560, yyl560 := z.DecSliceHelperStart()
+
+	var yyrr560, yyrl560 int
+	var yyc560, yyrt560 bool
+	_, _, _ = yyc560, yyrt560, yyrl560
+	yyrr560 = yyl560
+
+	if yyv560 == nil {
+		if yyrl560, yyrt560 = z.DecInferLen(yyl560, z.DecBasicHandle().MaxInitLen, 32); yyrt560 {
+			yyrr560 = yyrl560
+		}
+		yyv560 = make([]FilesystemMetrics, yyrl560)
+		yyc560 = true
+	}
+
+	if yyl560 == 0 {
+		if len(yyv560) != 0 {
+			yyv560 = yyv560[:0]
+			yyc560 = true
+		}
+	} else if yyl560 > 0 {
+
+		if yyl560 > cap(yyv560) {
+			yyrl560, yyrt560 = z.DecInferLen(yyl560, z.DecBasicHandle().MaxInitLen, 32)
+			yyv560 = make([]FilesystemMetrics, yyrl560)
+			yyc560 = true
+
+			yyrr560 = len(yyv560)
+		} else if yyl560 != len(yyv560) {
+			yyv560 = yyv560[:yyl560]
+			yyc560 = true
+		}
+		yyj560 := 0
+		for ; yyj560 < yyrr560; yyj560++ {
+			if r.TryDecodeAsNil() {
+				yyv560[yyj560] = FilesystemMetrics{}
+			} else {
+				yyv561 := &yyv560[yyj560]
+				yyv561.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt560 {
+			for ; yyj560 < yyl560; yyj560++ {
+				yyv560 = append(yyv560, FilesystemMetrics{})
+				if r.TryDecodeAsNil() {
+					yyv560[yyj560] = FilesystemMetrics{}
+				} else {
+					yyv562 := &yyv560[yyj560]
+					yyv562.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj560 := 0; !r.CheckBreak(); yyj560++ {
+			if yyj560 >= len(yyv560) {
+				yyv560 = append(yyv560, FilesystemMetrics{}) // var yyz560 FilesystemMetrics
+				yyc560 = true
+			}
+
+			if yyj560 < len(yyv560) {
+				if r.TryDecodeAsNil() {
+					yyv560[yyj560] = FilesystemMetrics{}
+				} else {
+					yyv563 := &yyv560[yyj560]
+					yyv563.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh560.End()
+	}
+	if yyc560 {
+		*v = yyv560
 	}
 
 }
@@ -6151,9 +6700,9 @@ func (x codecSelfer1234) encSliceCustomMetricSample(v []CustomMetricSample, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv519 := range v {
-		yy520 := &yyv519
-		yy520.CodecEncodeSelf(e)
+	for _, yyv564 := range v {
+		yy565 := &yyv564
+		yy565.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6163,75 +6712,75 @@ func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv521 := *v
-	yyh521, yyl521 := z.DecSliceHelperStart()
+	yyv566 := *v
+	yyh566, yyl566 := z.DecSliceHelperStart()
 
-	var yyrr521, yyrl521 int
-	var yyc521, yyrt521 bool
-	_, _, _ = yyc521, yyrt521, yyrl521
-	yyrr521 = yyl521
+	var yyrr566, yyrl566 int
+	var yyc566, yyrt566 bool
+	_, _, _ = yyc566, yyrt566, yyrl566
+	yyrr566 = yyl566
 
-	if yyv521 == nil {
-		if yyrl521, yyrt521 = z.DecInferLen(yyl521, z.DecBasicHandle().MaxInitLen, 56); yyrt521 {
-			yyrr521 = yyrl521
+	if yyv566 == nil {
+		if yyrl566, yyrt566 = z.DecInferLen(yyl566, z.DecBasicHandle().MaxInitLen, 56); yyrt566 {
+			yyrr566 = yyrl566
 		}
-		yyv521 = make([]CustomMetricSample, yyrl521)
-		yyc521 = true
+		yyv566 = make([]CustomMetricSample, yyrl566)
+		yyc566 = true
 	}
 
-	if yyl521 == 0 {
-		if len(yyv521) != 0 {
-			yyv521 = yyv521[:0]
-			yyc521 = true
+	if yyl566 == 0 {
+		if len(yyv566) != 0 {
+			yyv566 = yyv566[:0]
+			yyc566 = true
 		}
-	} else if yyl521 > 0 {
+	} else if yyl566 > 0 {
 
-		if yyl521 > cap(yyv521) {
-			yyrl521, yyrt521 = z.DecInferLen(yyl521, z.DecBasicHandle().MaxInitLen, 56)
-			yyv521 = make([]CustomMetricSample, yyrl521)
-			yyc521 = true
+		if yyl566 > cap(yyv566) {
+			yyrl566, yyrt566 = z.DecInferLen(yyl566, z.DecBasicHandle().MaxInitLen, 56)
+			yyv566 = make([]CustomMetricSample, yyrl566)
+			yyc566 = true
 
-			yyrr521 = len(yyv521)
-		} else if yyl521 != len(yyv521) {
-			yyv521 = yyv521[:yyl521]
-			yyc521 = true
+			yyrr566 = len(yyv566)
+		} else if yyl566 != len(yyv566) {
+			yyv566 = yyv566[:yyl566]
+			yyc566 = true
 		}
-		yyj521 := 0
-		for ; yyj521 < yyrr521; yyj521++ {
+		yyj566 := 0
+		for ; yyj566 < yyrr566; yyj566++ {
 			if r.TryDecodeAsNil() {
-				yyv521[yyj521] = CustomMetricSample{}
+				yyv566[yyj566] = CustomMetricSample{}
 			} else {
-				yyv522 := &yyv521[yyj521]
-				yyv522.CodecDecodeSelf(d)
+				yyv567 := &yyv566[yyj566]
+				yyv567.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt521 {
-			for ; yyj521 < yyl521; yyj521++ {
-				yyv521 = append(yyv521, CustomMetricSample{})
+		if yyrt566 {
+			for ; yyj566 < yyl566; yyj566++ {
+				yyv566 = append(yyv566, CustomMetricSample{})
 				if r.TryDecodeAsNil() {
-					yyv521[yyj521] = CustomMetricSample{}
+					yyv566[yyj566] = CustomMetricSample{}
 				} else {
-					yyv523 := &yyv521[yyj521]
-					yyv523.CodecDecodeSelf(d)
+					yyv568 := &yyv566[yyj566]
+					yyv568.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj521 := 0; !r.CheckBreak(); yyj521++ {
-			if yyj521 >= len(yyv521) {
-				yyv521 = append(yyv521, CustomMetricSample{}) // var yyz521 CustomMetricSample
-				yyc521 = true
+		for yyj566 := 0; !r.CheckBreak(); yyj566++ {
+			if yyj566 >= len(yyv566) {
+				yyv566 = append(yyv566, CustomMetricSample{}) // var yyz566 CustomMetricSample
+				yyc566 = true
 			}
 
-			if yyj521 < len(yyv521) {
+			if yyj566 < len(yyv566) {
 				if r.TryDecodeAsNil() {
-					yyv521[yyj521] = CustomMetricSample{}
+					yyv566[yyj566] = CustomMetricSample{}
 				} else {
-					yyv524 := &yyv521[yyj521]
-					yyv524.CodecDecodeSelf(d)
+					yyv569 := &yyv566[yyj566]
+					yyv569.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6239,10 +6788,10 @@ func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *
 			}
 
 		}
-		yyh521.End()
+		yyh566.End()
 	}
-	if yyc521 {
-		*v = yyv521
+	if yyc566 {
+		*v = yyv566
 	}
 
 }

--- a/pkg/apis/metrics/types.generated.go
+++ b/pkg/apis/metrics/types.generated.go
@@ -25,9 +25,13 @@ import (
 	"errors"
 	"fmt"
 	codec1978 "github.com/ugorji/go/codec"
+	pkg2_resource "k8s.io/kubernetes/pkg/api/resource"
 	pkg1_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	pkg4_types "k8s.io/kubernetes/pkg/types"
 	"reflect"
 	"runtime"
+	pkg3_inf "speter.net/go/exp/math/dec/inf"
+	time "time"
 )
 
 const (
@@ -52,12 +56,16 @@ func init() {
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
-		var v0 pkg1_unversioned.TypeMeta
-		_ = v0
+		var v0 pkg2_resource.Quantity
+		var v1 pkg1_unversioned.TypeMeta
+		var v2 pkg4_types.UID
+		var v3 pkg3_inf.Dec
+		var v4 time.Time
+		_, _, _, _, _ = v0, v1, v2, v3, v4
 	}
 }
 
-func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *MetricsMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -71,13 +79,12 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2 := !z.EncBinary()
 			yy2arr2 := z.EncBasicHandle().StructToArray
-			var yyq2 [2]bool
+			var yyq2 [1]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
+			yyq2[0] = x.SelfLink != ""
 			if yyr2 || yy2arr2 {
-				r.EncodeArrayStart(2)
+				r.EncodeArrayStart(1)
 			} else {
 				var yynn2 int = 0
 				for _, b := range yyq2 {
@@ -93,41 +100,19 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym4
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.SelfLink))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("selfLink"))
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.SelfLink))
 					}
 				}
 			}
@@ -138,28 +123,28 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *RawNode) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *MetricsMeta) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym9 := z.DecBinary()
-	_ = yym9
+	yym6 := z.DecBinary()
+	_ = yym6
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl10 := r.ReadMapStart()
-			if yyl10 == 0 {
+			yyl7 := r.ReadMapStart()
+			if yyl7 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl10, d)
+				x.codecDecodeSelfFromMap(yyl7, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl10 := r.ReadArrayStart()
-			if yyl10 == 0 {
+			yyl7 := r.ReadArrayStart()
+			if yyl7 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl10, d)
+				x.codecDecodeSelfFromArray(yyl7, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -167,16 +152,16 @@ func (x *RawNode) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *RawNode) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *MetricsMeta) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys11Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys11Slc
-	var yyhl11 bool = l >= 0
-	for yyj11 := 0; ; yyj11++ {
-		if yyhl11 {
-			if yyj11 >= l {
+	var yys8Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys8Slc
+	var yyhl8 bool = l >= 0
+	for yyj8 := 0; ; yyj8++ {
+		if yyhl8 {
+			if yyj8 >= l {
 				break
 			}
 		} else {
@@ -184,116 +169,97 @@ func (x *RawNode) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys11Slc = r.DecodeBytes(yys11Slc, true, true)
-		yys11 := string(yys11Slc)
-		switch yys11 {
-		case "kind":
+		yys8Slc = r.DecodeBytes(yys8Slc, true, true)
+		yys8 := string(yys8Slc)
+		switch yys8 {
+		case "selfLink":
 			if r.TryDecodeAsNil() {
-				x.Kind = ""
+				x.SelfLink = ""
 			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
+				x.SelfLink = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys11)
-		} // end switch yys11
-	} // end for yyj11
-	if !yyhl11 {
+			z.DecStructFieldNotFound(-1, yys8)
+		} // end switch yys8
+	} // end for yyj8
+	if !yyhl8 {
 		r.ReadEnd()
 	}
 }
 
-func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *MetricsMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj14 int
-	var yyb14 bool
-	var yyhl14 bool = l >= 0
-	yyj14++
-	if yyhl14 {
-		yyb14 = yyj14 > l
+	var yyj10 int
+	var yyb10 bool
+	var yyhl10 bool = l >= 0
+	yyj10++
+	if yyhl10 {
+		yyb10 = yyj10 > l
 	} else {
-		yyb14 = r.CheckBreak()
+		yyb10 = r.CheckBreak()
 	}
-	if yyb14 {
+	if yyb10 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
+		x.SelfLink = ""
 	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj14++
-	if yyhl14 {
-		yyb14 = yyj14 > l
-	} else {
-		yyb14 = r.CheckBreak()
-	}
-	if yyb14 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
+		x.SelfLink = string(r.DecodeString())
 	}
 	for {
-		yyj14++
-		if yyhl14 {
-			yyb14 = yyj14 > l
+		yyj10++
+		if yyhl10 {
+			yyb10 = yyj10 > l
 		} else {
-			yyb14 = r.CheckBreak()
+			yyb10 = r.CheckBreak()
 		}
-		if yyb14 {
+		if yyb10 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj14-1, "")
+		z.DecStructFieldNotFound(yyj10-1, "")
 	}
 	r.ReadEnd()
 }
 
-func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *RawNodeMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym17 := z.EncBinary()
-		_ = yym17
+		yym12 := z.EncBinary()
+		_ = yym12
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep18 := !z.EncBinary()
-			yy2arr18 := z.EncBasicHandle().StructToArray
-			var yyq18 [2]bool
-			_, _, _ = yysep18, yyq18, yy2arr18
-			const yyr18 bool = false
-			yyq18[0] = x.Kind != ""
-			yyq18[1] = x.APIVersion != ""
-			if yyr18 || yy2arr18 {
-				r.EncodeArrayStart(2)
+			yysep13 := !z.EncBinary()
+			yy2arr13 := z.EncBasicHandle().StructToArray
+			var yyq13 [6]bool
+			_, _, _ = yysep13, yyq13, yy2arr13
+			const yyr13 bool = false
+			yyq13[0] = x.Kind != ""
+			yyq13[1] = x.APIVersion != ""
+			yyq13[4] = len(x.Total) != 0
+			yyq13[5] = len(x.SystemContainers) != 0
+			if yyr13 || yy2arr13 {
+				r.EncodeArrayStart(6)
 			} else {
-				var yynn18 int = 0
-				for _, b := range yyq18 {
+				var yynn13 int = 2
+				for _, b := range yyq13 {
 					if b {
-						yynn18++
+						yynn13++
 					}
 				}
-				r.EncodeMapStart(yynn18)
+				r.EncodeMapStart(yynn13)
 			}
-			if yyr18 || yy2arr18 {
-				if yyq18[0] {
-					yym20 := z.EncBinary()
-					_ = yym20
+			if yyr13 || yy2arr13 {
+				if yyq13[0] {
+					yym15 := z.EncBinary()
+					_ = yym15
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -302,20 +268,20 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq18[0] {
+				if yyq13[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym21 := z.EncBinary()
-					_ = yym21
+					yym16 := z.EncBinary()
+					_ = yym16
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr18 || yy2arr18 {
-				if yyq18[1] {
-					yym23 := z.EncBinary()
-					_ = yym23
+			if yyr13 || yy2arr13 {
+				if yyq13[1] {
+					yym18 := z.EncBinary()
+					_ = yym18
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -324,45 +290,141 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq18[1] {
+				if yyq13[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym24 := z.EncBinary()
-					_ = yym24
+					yym19 := z.EncBinary()
+					_ = yym19
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yysep18 {
+			if yyr13 || yy2arr13 {
+				yy21 := &x.ListMeta
+				yym22 := z.EncBinary()
+				_ = yym22
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy21) {
+				} else {
+					z.EncFallback(yy21)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				yy23 := &x.ListMeta
+				yym24 := z.EncBinary()
+				_ = yym24
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy23) {
+				} else {
+					z.EncFallback(yy23)
+				}
+			}
+			if yyr13 || yy2arr13 {
+				yym26 := z.EncBinary()
+				_ = yym26
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.NodeName))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("nodeName"))
+				yym27 := z.EncBinary()
+				_ = yym27
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.NodeName))
+				}
+			}
+			if yyr13 || yy2arr13 {
+				if yyq13[4] {
+					if x.Total == nil {
+						r.EncodeNil()
+					} else {
+						yym29 := z.EncBinary()
+						_ = yym29
+						if false {
+						} else {
+							h.encSliceAggregateSample(([]AggregateSample)(x.Total), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq13[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("total"))
+					if x.Total == nil {
+						r.EncodeNil()
+					} else {
+						yym30 := z.EncBinary()
+						_ = yym30
+						if false {
+						} else {
+							h.encSliceAggregateSample(([]AggregateSample)(x.Total), e)
+						}
+					}
+				}
+			}
+			if yyr13 || yy2arr13 {
+				if yyq13[5] {
+					if x.SystemContainers == nil {
+						r.EncodeNil()
+					} else {
+						yym32 := z.EncBinary()
+						_ = yym32
+						if false {
+						} else {
+							h.encSliceRawContainerMetrics(([]RawContainerMetrics)(x.SystemContainers), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq13[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("systemContainers"))
+					if x.SystemContainers == nil {
+						r.EncodeNil()
+					} else {
+						yym33 := z.EncBinary()
+						_ = yym33
+						if false {
+						} else {
+							h.encSliceRawContainerMetrics(([]RawContainerMetrics)(x.SystemContainers), e)
+						}
+					}
+				}
+			}
+			if yysep13 {
 				r.EncodeEnd()
 			}
 		}
 	}
 }
 
-func (x *RawPod) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *RawNodeMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym25 := z.DecBinary()
-	_ = yym25
+	yym34 := z.DecBinary()
+	_ = yym34
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl26 := r.ReadMapStart()
-			if yyl26 == 0 {
+			yyl35 := r.ReadMapStart()
+			if yyl35 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl26, d)
+				x.codecDecodeSelfFromMap(yyl35, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl26 := r.ReadArrayStart()
-			if yyl26 == 0 {
+			yyl35 := r.ReadArrayStart()
+			if yyl35 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl26, d)
+				x.codecDecodeSelfFromArray(yyl35, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -370,16 +432,16 @@ func (x *RawPod) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *RawNodeMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys27Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys27Slc
-	var yyhl27 bool = l >= 0
-	for yyj27 := 0; ; yyj27++ {
-		if yyhl27 {
-			if yyj27 >= l {
+	var yys36Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys36Slc
+	var yyhl36 bool = l >= 0
+	for yyj36 := 0; ; yyj36++ {
+		if yyhl36 {
+			if yyj36 >= l {
 				break
 			}
 		} else {
@@ -387,9 +449,9 @@ func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys27Slc = r.DecodeBytes(yys27Slc, true, true)
-		yys27 := string(yys27Slc)
-		switch yys27 {
+		yys36Slc = r.DecodeBytes(yys36Slc, true, true)
+		yys36 := string(yys36Slc)
+		switch yys36 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -402,29 +464,72 @@ func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.APIVersion = string(r.DecodeString())
 			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv39 := &x.ListMeta
+				yym40 := z.DecBinary()
+				_ = yym40
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv39) {
+				} else {
+					z.DecFallback(yyv39, false)
+				}
+			}
+		case "nodeName":
+			if r.TryDecodeAsNil() {
+				x.NodeName = ""
+			} else {
+				x.NodeName = string(r.DecodeString())
+			}
+		case "total":
+			if r.TryDecodeAsNil() {
+				x.Total = nil
+			} else {
+				yyv42 := &x.Total
+				yym43 := z.DecBinary()
+				_ = yym43
+				if false {
+				} else {
+					h.decSliceAggregateSample((*[]AggregateSample)(yyv42), d)
+				}
+			}
+		case "systemContainers":
+			if r.TryDecodeAsNil() {
+				x.SystemContainers = nil
+			} else {
+				yyv44 := &x.SystemContainers
+				yym45 := z.DecBinary()
+				_ = yym45
+				if false {
+				} else {
+					h.decSliceRawContainerMetrics((*[]RawContainerMetrics)(yyv44), d)
+				}
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys27)
-		} // end switch yys27
-	} // end for yyj27
-	if !yyhl27 {
+			z.DecStructFieldNotFound(-1, yys36)
+		} // end switch yys36
+	} // end for yyj36
+	if !yyhl36 {
 		r.ReadEnd()
 	}
 }
 
-func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *RawNodeMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj30 int
-	var yyb30 bool
-	var yyhl30 bool = l >= 0
-	yyj30++
-	if yyhl30 {
-		yyb30 = yyj30 > l
+	var yyj46 int
+	var yyb46 bool
+	var yyhl46 bool = l >= 0
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
 	} else {
-		yyb30 = r.CheckBreak()
+		yyb46 = r.CheckBreak()
 	}
-	if yyb30 {
+	if yyb46 {
 		r.ReadEnd()
 		return
 	}
@@ -433,13 +538,13 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj30++
-	if yyhl30 {
-		yyb30 = yyj30 > l
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
 	} else {
-		yyb30 = r.CheckBreak()
+		yyb46 = r.CheckBreak()
 	}
-	if yyb30 {
+	if yyb46 {
 		r.ReadEnd()
 		return
 	}
@@ -448,17 +553,5696 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	for {
-		yyj30++
-		if yyhl30 {
-			yyb30 = yyj30 > l
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
+	} else {
+		yyb46 = r.CheckBreak()
+	}
+	if yyb46 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv49 := &x.ListMeta
+		yym50 := z.DecBinary()
+		_ = yym50
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv49) {
 		} else {
-			yyb30 = r.CheckBreak()
+			z.DecFallback(yyv49, false)
 		}
-		if yyb30 {
+	}
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
+	} else {
+		yyb46 = r.CheckBreak()
+	}
+	if yyb46 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.NodeName = ""
+	} else {
+		x.NodeName = string(r.DecodeString())
+	}
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
+	} else {
+		yyb46 = r.CheckBreak()
+	}
+	if yyb46 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Total = nil
+	} else {
+		yyv52 := &x.Total
+		yym53 := z.DecBinary()
+		_ = yym53
+		if false {
+		} else {
+			h.decSliceAggregateSample((*[]AggregateSample)(yyv52), d)
+		}
+	}
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
+	} else {
+		yyb46 = r.CheckBreak()
+	}
+	if yyb46 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SystemContainers = nil
+	} else {
+		yyv54 := &x.SystemContainers
+		yym55 := z.DecBinary()
+		_ = yym55
+		if false {
+		} else {
+			h.decSliceRawContainerMetrics((*[]RawContainerMetrics)(yyv54), d)
+		}
+	}
+	for {
+		yyj46++
+		if yyhl46 {
+			yyb46 = yyj46 > l
+		} else {
+			yyb46 = r.CheckBreak()
+		}
+		if yyb46 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj30-1, "")
+		z.DecStructFieldNotFound(yyj46-1, "")
 	}
 	r.ReadEnd()
+}
+
+func (x *RawNodeMetricsList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym56 := z.EncBinary()
+		_ = yym56
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep57 := !z.EncBinary()
+			yy2arr57 := z.EncBasicHandle().StructToArray
+			var yyq57 [4]bool
+			_, _, _ = yysep57, yyq57, yy2arr57
+			const yyr57 bool = false
+			yyq57[0] = x.Kind != ""
+			yyq57[1] = x.APIVersion != ""
+			yyq57[2] = true
+			if yyr57 || yy2arr57 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn57 int = 1
+				for _, b := range yyq57 {
+					if b {
+						yynn57++
+					}
+				}
+				r.EncodeMapStart(yynn57)
+			}
+			if yyr57 || yy2arr57 {
+				if yyq57[0] {
+					yym59 := z.EncBinary()
+					_ = yym59
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq57[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym60 := z.EncBinary()
+					_ = yym60
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr57 || yy2arr57 {
+				if yyq57[1] {
+					yym62 := z.EncBinary()
+					_ = yym62
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq57[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym63 := z.EncBinary()
+					_ = yym63
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr57 || yy2arr57 {
+				if yyq57[2] {
+					yy65 := &x.ListMeta
+					yym66 := z.EncBinary()
+					_ = yym66
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy65) {
+					} else {
+						z.EncFallback(yy65)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq57[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy67 := &x.ListMeta
+					yym68 := z.EncBinary()
+					_ = yym68
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy67) {
+					} else {
+						z.EncFallback(yy67)
+					}
+				}
+			}
+			if yyr57 || yy2arr57 {
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym70 := z.EncBinary()
+					_ = yym70
+					if false {
+					} else {
+						h.encSliceRawNodeMetrics(([]RawNodeMetrics)(x.Items), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym71 := z.EncBinary()
+					_ = yym71
+					if false {
+					} else {
+						h.encSliceRawNodeMetrics(([]RawNodeMetrics)(x.Items), e)
+					}
+				}
+			}
+			if yysep57 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawNodeMetricsList) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym72 := z.DecBinary()
+	_ = yym72
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl73 := r.ReadMapStart()
+			if yyl73 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl73, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl73 := r.ReadArrayStart()
+			if yyl73 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl73, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawNodeMetricsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys74Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys74Slc
+	var yyhl74 bool = l >= 0
+	for yyj74 := 0; ; yyj74++ {
+		if yyhl74 {
+			if yyj74 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys74Slc = r.DecodeBytes(yys74Slc, true, true)
+		yys74 := string(yys74Slc)
+		switch yys74 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv77 := &x.ListMeta
+				yym78 := z.DecBinary()
+				_ = yym78
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv77) {
+				} else {
+					z.DecFallback(yyv77, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv79 := &x.Items
+				yym80 := z.DecBinary()
+				_ = yym80
+				if false {
+				} else {
+					h.decSliceRawNodeMetrics((*[]RawNodeMetrics)(yyv79), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys74)
+		} // end switch yys74
+	} // end for yyj74
+	if !yyhl74 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawNodeMetricsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj81 int
+	var yyb81 bool
+	var yyhl81 bool = l >= 0
+	yyj81++
+	if yyhl81 {
+		yyb81 = yyj81 > l
+	} else {
+		yyb81 = r.CheckBreak()
+	}
+	if yyb81 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj81++
+	if yyhl81 {
+		yyb81 = yyj81 > l
+	} else {
+		yyb81 = r.CheckBreak()
+	}
+	if yyb81 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj81++
+	if yyhl81 {
+		yyb81 = yyj81 > l
+	} else {
+		yyb81 = r.CheckBreak()
+	}
+	if yyb81 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv84 := &x.ListMeta
+		yym85 := z.DecBinary()
+		_ = yym85
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv84) {
+		} else {
+			z.DecFallback(yyv84, false)
+		}
+	}
+	yyj81++
+	if yyhl81 {
+		yyb81 = yyj81 > l
+	} else {
+		yyb81 = r.CheckBreak()
+	}
+	if yyb81 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv86 := &x.Items
+		yym87 := z.DecBinary()
+		_ = yym87
+		if false {
+		} else {
+			h.decSliceRawNodeMetrics((*[]RawNodeMetrics)(yyv86), d)
+		}
+	}
+	for {
+		yyj81++
+		if yyhl81 {
+			yyb81 = yyj81 > l
+		} else {
+			yyb81 = r.CheckBreak()
+		}
+		if yyb81 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj81-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *RawPodMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym88 := z.EncBinary()
+		_ = yym88
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep89 := !z.EncBinary()
+			yy2arr89 := z.EncBasicHandle().StructToArray
+			var yyq89 [6]bool
+			_, _, _ = yysep89, yyq89, yy2arr89
+			const yyr89 bool = false
+			yyq89[0] = x.Kind != ""
+			yyq89[1] = x.APIVersion != ""
+			if yyr89 || yy2arr89 {
+				r.EncodeArrayStart(6)
+			} else {
+				var yynn89 int = 4
+				for _, b := range yyq89 {
+					if b {
+						yynn89++
+					}
+				}
+				r.EncodeMapStart(yynn89)
+			}
+			if yyr89 || yy2arr89 {
+				if yyq89[0] {
+					yym91 := z.EncBinary()
+					_ = yym91
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq89[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym92 := z.EncBinary()
+					_ = yym92
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr89 || yy2arr89 {
+				if yyq89[1] {
+					yym94 := z.EncBinary()
+					_ = yym94
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq89[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym95 := z.EncBinary()
+					_ = yym95
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr89 || yy2arr89 {
+				yy97 := &x.ListMeta
+				yym98 := z.EncBinary()
+				_ = yym98
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy97) {
+				} else {
+					z.EncFallback(yy97)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				yy99 := &x.ListMeta
+				yym100 := z.EncBinary()
+				_ = yym100
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy99) {
+				} else {
+					z.EncFallback(yy99)
+				}
+			}
+			if yyr89 || yy2arr89 {
+				yy102 := &x.PodRef
+				yy102.CodecEncodeSelf(e)
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("podRef"))
+				yy103 := &x.PodRef
+				yy103.CodecEncodeSelf(e)
+			}
+			if yyr89 || yy2arr89 {
+				if x.Containers == nil {
+					r.EncodeNil()
+				} else {
+					yym105 := z.EncBinary()
+					_ = yym105
+					if false {
+					} else {
+						h.encSliceRawContainerMetrics(([]RawContainerMetrics)(x.Containers), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("containers"))
+				if x.Containers == nil {
+					r.EncodeNil()
+				} else {
+					yym106 := z.EncBinary()
+					_ = yym106
+					if false {
+					} else {
+						h.encSliceRawContainerMetrics(([]RawContainerMetrics)(x.Containers), e)
+					}
+				}
+			}
+			if yyr89 || yy2arr89 {
+				if x.Samples == nil {
+					r.EncodeNil()
+				} else {
+					yym108 := z.EncBinary()
+					_ = yym108
+					if false {
+					} else {
+						h.encSlicePodSample(([]PodSample)(x.Samples), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("samples"))
+				if x.Samples == nil {
+					r.EncodeNil()
+				} else {
+					yym109 := z.EncBinary()
+					_ = yym109
+					if false {
+					} else {
+						h.encSlicePodSample(([]PodSample)(x.Samples), e)
+					}
+				}
+			}
+			if yysep89 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawPodMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym110 := z.DecBinary()
+	_ = yym110
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl111 := r.ReadMapStart()
+			if yyl111 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl111, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl111 := r.ReadArrayStart()
+			if yyl111 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl111, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawPodMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys112Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys112Slc
+	var yyhl112 bool = l >= 0
+	for yyj112 := 0; ; yyj112++ {
+		if yyhl112 {
+			if yyj112 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys112Slc = r.DecodeBytes(yys112Slc, true, true)
+		yys112 := string(yys112Slc)
+		switch yys112 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv115 := &x.ListMeta
+				yym116 := z.DecBinary()
+				_ = yym116
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv115) {
+				} else {
+					z.DecFallback(yyv115, false)
+				}
+			}
+		case "podRef":
+			if r.TryDecodeAsNil() {
+				x.PodRef = NonLocalObjectReference{}
+			} else {
+				yyv117 := &x.PodRef
+				yyv117.CodecDecodeSelf(d)
+			}
+		case "containers":
+			if r.TryDecodeAsNil() {
+				x.Containers = nil
+			} else {
+				yyv118 := &x.Containers
+				yym119 := z.DecBinary()
+				_ = yym119
+				if false {
+				} else {
+					h.decSliceRawContainerMetrics((*[]RawContainerMetrics)(yyv118), d)
+				}
+			}
+		case "samples":
+			if r.TryDecodeAsNil() {
+				x.Samples = nil
+			} else {
+				yyv120 := &x.Samples
+				yym121 := z.DecBinary()
+				_ = yym121
+				if false {
+				} else {
+					h.decSlicePodSample((*[]PodSample)(yyv120), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys112)
+		} // end switch yys112
+	} // end for yyj112
+	if !yyhl112 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawPodMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj122 int
+	var yyb122 bool
+	var yyhl122 bool = l >= 0
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv125 := &x.ListMeta
+		yym126 := z.DecBinary()
+		_ = yym126
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv125) {
+		} else {
+			z.DecFallback(yyv125, false)
+		}
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.PodRef = NonLocalObjectReference{}
+	} else {
+		yyv127 := &x.PodRef
+		yyv127.CodecDecodeSelf(d)
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Containers = nil
+	} else {
+		yyv128 := &x.Containers
+		yym129 := z.DecBinary()
+		_ = yym129
+		if false {
+		} else {
+			h.decSliceRawContainerMetrics((*[]RawContainerMetrics)(yyv128), d)
+		}
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Samples = nil
+	} else {
+		yyv130 := &x.Samples
+		yym131 := z.DecBinary()
+		_ = yym131
+		if false {
+		} else {
+			h.decSlicePodSample((*[]PodSample)(yyv130), d)
+		}
+	}
+	for {
+		yyj122++
+		if yyhl122 {
+			yyb122 = yyj122 > l
+		} else {
+			yyb122 = r.CheckBreak()
+		}
+		if yyb122 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj122-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *RawPodMetricsList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym132 := z.EncBinary()
+		_ = yym132
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep133 := !z.EncBinary()
+			yy2arr133 := z.EncBasicHandle().StructToArray
+			var yyq133 [4]bool
+			_, _, _ = yysep133, yyq133, yy2arr133
+			const yyr133 bool = false
+			yyq133[0] = x.Kind != ""
+			yyq133[1] = x.APIVersion != ""
+			yyq133[2] = true
+			if yyr133 || yy2arr133 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn133 int = 1
+				for _, b := range yyq133 {
+					if b {
+						yynn133++
+					}
+				}
+				r.EncodeMapStart(yynn133)
+			}
+			if yyr133 || yy2arr133 {
+				if yyq133[0] {
+					yym135 := z.EncBinary()
+					_ = yym135
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq133[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym136 := z.EncBinary()
+					_ = yym136
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr133 || yy2arr133 {
+				if yyq133[1] {
+					yym138 := z.EncBinary()
+					_ = yym138
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq133[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym139 := z.EncBinary()
+					_ = yym139
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr133 || yy2arr133 {
+				if yyq133[2] {
+					yy141 := &x.ListMeta
+					yym142 := z.EncBinary()
+					_ = yym142
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy141) {
+					} else {
+						z.EncFallback(yy141)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq133[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy143 := &x.ListMeta
+					yym144 := z.EncBinary()
+					_ = yym144
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy143) {
+					} else {
+						z.EncFallback(yy143)
+					}
+				}
+			}
+			if yyr133 || yy2arr133 {
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym146 := z.EncBinary()
+					_ = yym146
+					if false {
+					} else {
+						h.encSliceRawPodMetrics(([]RawPodMetrics)(x.Items), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym147 := z.EncBinary()
+					_ = yym147
+					if false {
+					} else {
+						h.encSliceRawPodMetrics(([]RawPodMetrics)(x.Items), e)
+					}
+				}
+			}
+			if yysep133 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawPodMetricsList) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym148 := z.DecBinary()
+	_ = yym148
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl149 := r.ReadMapStart()
+			if yyl149 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl149, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl149 := r.ReadArrayStart()
+			if yyl149 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl149, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawPodMetricsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys150Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys150Slc
+	var yyhl150 bool = l >= 0
+	for yyj150 := 0; ; yyj150++ {
+		if yyhl150 {
+			if yyj150 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys150Slc = r.DecodeBytes(yys150Slc, true, true)
+		yys150 := string(yys150Slc)
+		switch yys150 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv153 := &x.ListMeta
+				yym154 := z.DecBinary()
+				_ = yym154
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv153) {
+				} else {
+					z.DecFallback(yyv153, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv155 := &x.Items
+				yym156 := z.DecBinary()
+				_ = yym156
+				if false {
+				} else {
+					h.decSliceRawPodMetrics((*[]RawPodMetrics)(yyv155), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys150)
+		} // end switch yys150
+	} // end for yyj150
+	if !yyhl150 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawPodMetricsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj157 int
+	var yyb157 bool
+	var yyhl157 bool = l >= 0
+	yyj157++
+	if yyhl157 {
+		yyb157 = yyj157 > l
+	} else {
+		yyb157 = r.CheckBreak()
+	}
+	if yyb157 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj157++
+	if yyhl157 {
+		yyb157 = yyj157 > l
+	} else {
+		yyb157 = r.CheckBreak()
+	}
+	if yyb157 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj157++
+	if yyhl157 {
+		yyb157 = yyj157 > l
+	} else {
+		yyb157 = r.CheckBreak()
+	}
+	if yyb157 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv160 := &x.ListMeta
+		yym161 := z.DecBinary()
+		_ = yym161
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv160) {
+		} else {
+			z.DecFallback(yyv160, false)
+		}
+	}
+	yyj157++
+	if yyhl157 {
+		yyb157 = yyj157 > l
+	} else {
+		yyb157 = r.CheckBreak()
+	}
+	if yyb157 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv162 := &x.Items
+		yym163 := z.DecBinary()
+		_ = yym163
+		if false {
+		} else {
+			h.decSliceRawPodMetrics((*[]RawPodMetrics)(yyv162), d)
+		}
+	}
+	for {
+		yyj157++
+		if yyhl157 {
+			yyb157 = yyj157 > l
+		} else {
+			yyb157 = r.CheckBreak()
+		}
+		if yyb157 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj157-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *RawContainerMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym164 := z.EncBinary()
+		_ = yym164
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep165 := !z.EncBinary()
+			yy2arr165 := z.EncBasicHandle().StructToArray
+			var yyq165 [4]bool
+			_, _, _ = yysep165, yyq165, yy2arr165
+			const yyr165 bool = false
+			yyq165[1] = len(x.Labels) != 0
+			yyq165[3] = len(x.CustomMetrics) != 0
+			if yyr165 || yy2arr165 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn165 int = 2
+				for _, b := range yyq165 {
+					if b {
+						yynn165++
+					}
+				}
+				r.EncodeMapStart(yynn165)
+			}
+			if yyr165 || yy2arr165 {
+				yym167 := z.EncBinary()
+				_ = yym167
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				yym168 := z.EncBinary()
+				_ = yym168
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			}
+			if yyr165 || yy2arr165 {
+				if yyq165[1] {
+					if x.Labels == nil {
+						r.EncodeNil()
+					} else {
+						yym170 := z.EncBinary()
+						_ = yym170
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.Labels, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq165[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("labels"))
+					if x.Labels == nil {
+						r.EncodeNil()
+					} else {
+						yym171 := z.EncBinary()
+						_ = yym171
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.Labels, false, e)
+						}
+					}
+				}
+			}
+			if yyr165 || yy2arr165 {
+				if x.Samples == nil {
+					r.EncodeNil()
+				} else {
+					yym173 := z.EncBinary()
+					_ = yym173
+					if false {
+					} else {
+						h.encSliceContainerSample(([]ContainerSample)(x.Samples), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("samples"))
+				if x.Samples == nil {
+					r.EncodeNil()
+				} else {
+					yym174 := z.EncBinary()
+					_ = yym174
+					if false {
+					} else {
+						h.encSliceContainerSample(([]ContainerSample)(x.Samples), e)
+					}
+				}
+			}
+			if yyr165 || yy2arr165 {
+				if yyq165[3] {
+					if x.CustomMetrics == nil {
+						r.EncodeNil()
+					} else {
+						yym176 := z.EncBinary()
+						_ = yym176
+						if false {
+						} else {
+							h.encSliceCustomMetric(([]CustomMetric)(x.CustomMetrics), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq165[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("customMetrics"))
+					if x.CustomMetrics == nil {
+						r.EncodeNil()
+					} else {
+						yym177 := z.EncBinary()
+						_ = yym177
+						if false {
+						} else {
+							h.encSliceCustomMetric(([]CustomMetric)(x.CustomMetrics), e)
+						}
+					}
+				}
+			}
+			if yysep165 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawContainerMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym178 := z.DecBinary()
+	_ = yym178
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl179 := r.ReadMapStart()
+			if yyl179 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl179, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl179 := r.ReadArrayStart()
+			if yyl179 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl179, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawContainerMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys180Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys180Slc
+	var yyhl180 bool = l >= 0
+	for yyj180 := 0; ; yyj180++ {
+		if yyhl180 {
+			if yyj180 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys180Slc = r.DecodeBytes(yys180Slc, true, true)
+		yys180 := string(yys180Slc)
+		switch yys180 {
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "labels":
+			if r.TryDecodeAsNil() {
+				x.Labels = nil
+			} else {
+				yyv182 := &x.Labels
+				yym183 := z.DecBinary()
+				_ = yym183
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv182, false, d)
+				}
+			}
+		case "samples":
+			if r.TryDecodeAsNil() {
+				x.Samples = nil
+			} else {
+				yyv184 := &x.Samples
+				yym185 := z.DecBinary()
+				_ = yym185
+				if false {
+				} else {
+					h.decSliceContainerSample((*[]ContainerSample)(yyv184), d)
+				}
+			}
+		case "customMetrics":
+			if r.TryDecodeAsNil() {
+				x.CustomMetrics = nil
+			} else {
+				yyv186 := &x.CustomMetrics
+				yym187 := z.DecBinary()
+				_ = yym187
+				if false {
+				} else {
+					h.decSliceCustomMetric((*[]CustomMetric)(yyv186), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys180)
+		} // end switch yys180
+	} // end for yyj180
+	if !yyhl180 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawContainerMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj188 int
+	var yyb188 bool
+	var yyhl188 bool = l >= 0
+	yyj188++
+	if yyhl188 {
+		yyb188 = yyj188 > l
+	} else {
+		yyb188 = r.CheckBreak()
+	}
+	if yyb188 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj188++
+	if yyhl188 {
+		yyb188 = yyj188 > l
+	} else {
+		yyb188 = r.CheckBreak()
+	}
+	if yyb188 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Labels = nil
+	} else {
+		yyv190 := &x.Labels
+		yym191 := z.DecBinary()
+		_ = yym191
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv190, false, d)
+		}
+	}
+	yyj188++
+	if yyhl188 {
+		yyb188 = yyj188 > l
+	} else {
+		yyb188 = r.CheckBreak()
+	}
+	if yyb188 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Samples = nil
+	} else {
+		yyv192 := &x.Samples
+		yym193 := z.DecBinary()
+		_ = yym193
+		if false {
+		} else {
+			h.decSliceContainerSample((*[]ContainerSample)(yyv192), d)
+		}
+	}
+	yyj188++
+	if yyhl188 {
+		yyb188 = yyj188 > l
+	} else {
+		yyb188 = r.CheckBreak()
+	}
+	if yyb188 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.CustomMetrics = nil
+	} else {
+		yyv194 := &x.CustomMetrics
+		yym195 := z.DecBinary()
+		_ = yym195
+		if false {
+		} else {
+			h.decSliceCustomMetric((*[]CustomMetric)(yyv194), d)
+		}
+	}
+	for {
+		yyj188++
+		if yyhl188 {
+			yyb188 = yyj188 > l
+		} else {
+			yyb188 = r.CheckBreak()
+		}
+		if yyb188 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj188-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *NonLocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym196 := z.EncBinary()
+		_ = yym196
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep197 := !z.EncBinary()
+			yy2arr197 := z.EncBasicHandle().StructToArray
+			var yyq197 [3]bool
+			_, _, _ = yysep197, yyq197, yy2arr197
+			const yyr197 bool = false
+			yyq197[2] = x.UID != ""
+			if yyr197 || yy2arr197 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn197 int = 2
+				for _, b := range yyq197 {
+					if b {
+						yynn197++
+					}
+				}
+				r.EncodeMapStart(yynn197)
+			}
+			if yyr197 || yy2arr197 {
+				yym199 := z.EncBinary()
+				_ = yym199
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				yym200 := z.EncBinary()
+				_ = yym200
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			}
+			if yyr197 || yy2arr197 {
+				yym202 := z.EncBinary()
+				_ = yym202
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+				yym203 := z.EncBinary()
+				_ = yym203
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+				}
+			}
+			if yyr197 || yy2arr197 {
+				if yyq197[2] {
+					yym205 := z.EncBinary()
+					_ = yym205
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq197[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("uid"))
+					yym206 := z.EncBinary()
+					_ = yym206
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+					}
+				}
+			}
+			if yysep197 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *NonLocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym207 := z.DecBinary()
+	_ = yym207
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl208 := r.ReadMapStart()
+			if yyl208 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl208, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl208 := r.ReadArrayStart()
+			if yyl208 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl208, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *NonLocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys209Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys209Slc
+	var yyhl209 bool = l >= 0
+	for yyj209 := 0; ; yyj209++ {
+		if yyhl209 {
+			if yyj209 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys209Slc = r.DecodeBytes(yys209Slc, true, true)
+		yys209 := string(yys209Slc)
+		switch yys209 {
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "namespace":
+			if r.TryDecodeAsNil() {
+				x.Namespace = ""
+			} else {
+				x.Namespace = string(r.DecodeString())
+			}
+		case "uid":
+			if r.TryDecodeAsNil() {
+				x.UID = ""
+			} else {
+				x.UID = pkg4_types.UID(r.DecodeString())
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys209)
+		} // end switch yys209
+	} // end for yyj209
+	if !yyhl209 {
+		r.ReadEnd()
+	}
+}
+
+func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj213 int
+	var yyb213 bool
+	var yyhl213 bool = l >= 0
+	yyj213++
+	if yyhl213 {
+		yyb213 = yyj213 > l
+	} else {
+		yyb213 = r.CheckBreak()
+	}
+	if yyb213 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj213++
+	if yyhl213 {
+		yyb213 = yyj213 > l
+	} else {
+		yyb213 = r.CheckBreak()
+	}
+	if yyb213 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Namespace = ""
+	} else {
+		x.Namespace = string(r.DecodeString())
+	}
+	yyj213++
+	if yyhl213 {
+		yyb213 = yyj213 > l
+	} else {
+		yyb213 = r.CheckBreak()
+	}
+	if yyb213 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.UID = ""
+	} else {
+		x.UID = pkg4_types.UID(r.DecodeString())
+	}
+	for {
+		yyj213++
+		if yyhl213 {
+			yyb213 = yyj213 > l
+		} else {
+			yyb213 = r.CheckBreak()
+		}
+		if yyb213 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj213-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *Sample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym217 := z.EncBinary()
+		_ = yym217
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep218 := !z.EncBinary()
+			yy2arr218 := z.EncBasicHandle().StructToArray
+			var yyq218 [1]bool
+			_, _, _ = yysep218, yyq218, yy2arr218
+			const yyr218 bool = false
+			if yyr218 || yy2arr218 {
+				r.EncodeArrayStart(1)
+			} else {
+				var yynn218 int = 1
+				for _, b := range yyq218 {
+					if b {
+						yynn218++
+					}
+				}
+				r.EncodeMapStart(yynn218)
+			}
+			if yyr218 || yy2arr218 {
+				yy220 := &x.SampleTime
+				yym221 := z.EncBinary()
+				_ = yym221
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy220) {
+				} else if yym221 {
+					z.EncBinaryMarshal(yy220)
+				} else if !yym221 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy220)
+				} else {
+					z.EncFallback(yy220)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy222 := &x.SampleTime
+				yym223 := z.EncBinary()
+				_ = yym223
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy222) {
+				} else if yym223 {
+					z.EncBinaryMarshal(yy222)
+				} else if !yym223 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy222)
+				} else {
+					z.EncFallback(yy222)
+				}
+			}
+			if yysep218 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *Sample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym224 := z.DecBinary()
+	_ = yym224
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl225 := r.ReadMapStart()
+			if yyl225 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl225, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl225 := r.ReadArrayStart()
+			if yyl225 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl225, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Sample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys226Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys226Slc
+	var yyhl226 bool = l >= 0
+	for yyj226 := 0; ; yyj226++ {
+		if yyhl226 {
+			if yyj226 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys226Slc = r.DecodeBytes(yys226Slc, true, true)
+		yys226 := string(yys226Slc)
+		switch yys226 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv227 := &x.SampleTime
+				yym228 := z.DecBinary()
+				_ = yym228
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv227) {
+				} else if yym228 {
+					z.DecBinaryUnmarshal(yyv227)
+				} else if !yym228 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv227)
+				} else {
+					z.DecFallback(yyv227, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys226)
+		} // end switch yys226
+	} // end for yyj226
+	if !yyhl226 {
+		r.ReadEnd()
+	}
+}
+
+func (x *Sample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj229 int
+	var yyb229 bool
+	var yyhl229 bool = l >= 0
+	yyj229++
+	if yyhl229 {
+		yyb229 = yyj229 > l
+	} else {
+		yyb229 = r.CheckBreak()
+	}
+	if yyb229 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv230 := &x.SampleTime
+		yym231 := z.DecBinary()
+		_ = yym231
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv230) {
+		} else if yym231 {
+			z.DecBinaryUnmarshal(yyv230)
+		} else if !yym231 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv230)
+		} else {
+			z.DecFallback(yyv230, false)
+		}
+	}
+	for {
+		yyj229++
+		if yyhl229 {
+			yyb229 = yyj229 > l
+		} else {
+			yyb229 = r.CheckBreak()
+		}
+		if yyb229 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj229-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym232 := z.EncBinary()
+		_ = yym232
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep233 := !z.EncBinary()
+			yy2arr233 := z.EncBasicHandle().StructToArray
+			var yyq233 [4]bool
+			_, _, _ = yysep233, yyq233, yy2arr233
+			const yyr233 bool = false
+			yyq233[1] = x.CPU != nil
+			yyq233[2] = x.Memory != nil
+			yyq233[3] = x.Network != nil
+			if yyr233 || yy2arr233 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn233 int = 1
+				for _, b := range yyq233 {
+					if b {
+						yynn233++
+					}
+				}
+				r.EncodeMapStart(yynn233)
+			}
+			if yyr233 || yy2arr233 {
+				yy235 := &x.SampleTime
+				yym236 := z.EncBinary()
+				_ = yym236
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy235) {
+				} else if yym236 {
+					z.EncBinaryMarshal(yy235)
+				} else if !yym236 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy235)
+				} else {
+					z.EncFallback(yy235)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy237 := &x.SampleTime
+				yym238 := z.EncBinary()
+				_ = yym238
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy237) {
+				} else if yym238 {
+					z.EncBinaryMarshal(yy237)
+				} else if !yym238 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy237)
+				} else {
+					z.EncFallback(yy237)
+				}
+			}
+			if yyr233 || yy2arr233 {
+				if yyq233[1] {
+					if x.CPU == nil {
+						r.EncodeNil()
+					} else {
+						x.CPU.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq233[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
+					if x.CPU == nil {
+						r.EncodeNil()
+					} else {
+						x.CPU.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr233 || yy2arr233 {
+				if yyq233[2] {
+					if x.Memory == nil {
+						r.EncodeNil()
+					} else {
+						x.Memory.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq233[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("memory"))
+					if x.Memory == nil {
+						r.EncodeNil()
+					} else {
+						x.Memory.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr233 || yy2arr233 {
+				if yyq233[3] {
+					if x.Network == nil {
+						r.EncodeNil()
+					} else {
+						x.Network.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq233[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("network"))
+					if x.Network == nil {
+						r.EncodeNil()
+					} else {
+						x.Network.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yysep233 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *AggregateSample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym242 := z.DecBinary()
+	_ = yym242
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl243 := r.ReadMapStart()
+			if yyl243 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl243, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl243 := r.ReadArrayStart()
+			if yyl243 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl243, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys244Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys244Slc
+	var yyhl244 bool = l >= 0
+	for yyj244 := 0; ; yyj244++ {
+		if yyhl244 {
+			if yyj244 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys244Slc = r.DecodeBytes(yys244Slc, true, true)
+		yys244 := string(yys244Slc)
+		switch yys244 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv245 := &x.SampleTime
+				yym246 := z.DecBinary()
+				_ = yym246
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv245) {
+				} else if yym246 {
+					z.DecBinaryUnmarshal(yyv245)
+				} else if !yym246 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv245)
+				} else {
+					z.DecFallback(yyv245, false)
+				}
+			}
+		case "cpu":
+			if r.TryDecodeAsNil() {
+				if x.CPU != nil {
+					x.CPU = nil
+				}
+			} else {
+				if x.CPU == nil {
+					x.CPU = new(CPUMetrics)
+				}
+				x.CPU.CodecDecodeSelf(d)
+			}
+		case "memory":
+			if r.TryDecodeAsNil() {
+				if x.Memory != nil {
+					x.Memory = nil
+				}
+			} else {
+				if x.Memory == nil {
+					x.Memory = new(MemoryMetrics)
+				}
+				x.Memory.CodecDecodeSelf(d)
+			}
+		case "network":
+			if r.TryDecodeAsNil() {
+				if x.Network != nil {
+					x.Network = nil
+				}
+			} else {
+				if x.Network == nil {
+					x.Network = new(NetworkMetrics)
+				}
+				x.Network.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys244)
+		} // end switch yys244
+	} // end for yyj244
+	if !yyhl244 {
+		r.ReadEnd()
+	}
+}
+
+func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj250 int
+	var yyb250 bool
+	var yyhl250 bool = l >= 0
+	yyj250++
+	if yyhl250 {
+		yyb250 = yyj250 > l
+	} else {
+		yyb250 = r.CheckBreak()
+	}
+	if yyb250 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv251 := &x.SampleTime
+		yym252 := z.DecBinary()
+		_ = yym252
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv251) {
+		} else if yym252 {
+			z.DecBinaryUnmarshal(yyv251)
+		} else if !yym252 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv251)
+		} else {
+			z.DecFallback(yyv251, false)
+		}
+	}
+	yyj250++
+	if yyhl250 {
+		yyb250 = yyj250 > l
+	} else {
+		yyb250 = r.CheckBreak()
+	}
+	if yyb250 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.CPU != nil {
+			x.CPU = nil
+		}
+	} else {
+		if x.CPU == nil {
+			x.CPU = new(CPUMetrics)
+		}
+		x.CPU.CodecDecodeSelf(d)
+	}
+	yyj250++
+	if yyhl250 {
+		yyb250 = yyj250 > l
+	} else {
+		yyb250 = r.CheckBreak()
+	}
+	if yyb250 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Memory != nil {
+			x.Memory = nil
+		}
+	} else {
+		if x.Memory == nil {
+			x.Memory = new(MemoryMetrics)
+		}
+		x.Memory.CodecDecodeSelf(d)
+	}
+	yyj250++
+	if yyhl250 {
+		yyb250 = yyj250 > l
+	} else {
+		yyb250 = r.CheckBreak()
+	}
+	if yyb250 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Network != nil {
+			x.Network = nil
+		}
+	} else {
+		if x.Network == nil {
+			x.Network = new(NetworkMetrics)
+		}
+		x.Network.CodecDecodeSelf(d)
+	}
+	for {
+		yyj250++
+		if yyhl250 {
+			yyb250 = yyj250 > l
+		} else {
+			yyb250 = r.CheckBreak()
+		}
+		if yyb250 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj250-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym256 := z.EncBinary()
+		_ = yym256
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep257 := !z.EncBinary()
+			yy2arr257 := z.EncBasicHandle().StructToArray
+			var yyq257 [2]bool
+			_, _, _ = yysep257, yyq257, yy2arr257
+			const yyr257 bool = false
+			yyq257[1] = x.Network != nil
+			if yyr257 || yy2arr257 {
+				r.EncodeArrayStart(2)
+			} else {
+				var yynn257 int = 1
+				for _, b := range yyq257 {
+					if b {
+						yynn257++
+					}
+				}
+				r.EncodeMapStart(yynn257)
+			}
+			if yyr257 || yy2arr257 {
+				yy259 := &x.SampleTime
+				yym260 := z.EncBinary()
+				_ = yym260
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy259) {
+				} else if yym260 {
+					z.EncBinaryMarshal(yy259)
+				} else if !yym260 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy259)
+				} else {
+					z.EncFallback(yy259)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy261 := &x.SampleTime
+				yym262 := z.EncBinary()
+				_ = yym262
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy261) {
+				} else if yym262 {
+					z.EncBinaryMarshal(yy261)
+				} else if !yym262 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy261)
+				} else {
+					z.EncFallback(yy261)
+				}
+			}
+			if yyr257 || yy2arr257 {
+				if yyq257[1] {
+					if x.Network == nil {
+						r.EncodeNil()
+					} else {
+						x.Network.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq257[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("network"))
+					if x.Network == nil {
+						r.EncodeNil()
+					} else {
+						x.Network.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yysep257 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *PodSample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym264 := z.DecBinary()
+	_ = yym264
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl265 := r.ReadMapStart()
+			if yyl265 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl265, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl265 := r.ReadArrayStart()
+			if yyl265 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl265, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys266Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys266Slc
+	var yyhl266 bool = l >= 0
+	for yyj266 := 0; ; yyj266++ {
+		if yyhl266 {
+			if yyj266 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys266Slc = r.DecodeBytes(yys266Slc, true, true)
+		yys266 := string(yys266Slc)
+		switch yys266 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv267 := &x.SampleTime
+				yym268 := z.DecBinary()
+				_ = yym268
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv267) {
+				} else if yym268 {
+					z.DecBinaryUnmarshal(yyv267)
+				} else if !yym268 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv267)
+				} else {
+					z.DecFallback(yyv267, false)
+				}
+			}
+		case "network":
+			if r.TryDecodeAsNil() {
+				if x.Network != nil {
+					x.Network = nil
+				}
+			} else {
+				if x.Network == nil {
+					x.Network = new(NetworkMetrics)
+				}
+				x.Network.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys266)
+		} // end switch yys266
+	} // end for yyj266
+	if !yyhl266 {
+		r.ReadEnd()
+	}
+}
+
+func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj270 int
+	var yyb270 bool
+	var yyhl270 bool = l >= 0
+	yyj270++
+	if yyhl270 {
+		yyb270 = yyj270 > l
+	} else {
+		yyb270 = r.CheckBreak()
+	}
+	if yyb270 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv271 := &x.SampleTime
+		yym272 := z.DecBinary()
+		_ = yym272
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv271) {
+		} else if yym272 {
+			z.DecBinaryUnmarshal(yyv271)
+		} else if !yym272 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv271)
+		} else {
+			z.DecFallback(yyv271, false)
+		}
+	}
+	yyj270++
+	if yyhl270 {
+		yyb270 = yyj270 > l
+	} else {
+		yyb270 = r.CheckBreak()
+	}
+	if yyb270 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Network != nil {
+			x.Network = nil
+		}
+	} else {
+		if x.Network == nil {
+			x.Network = new(NetworkMetrics)
+		}
+		x.Network.CodecDecodeSelf(d)
+	}
+	for {
+		yyj270++
+		if yyhl270 {
+			yyb270 = yyj270 > l
+		} else {
+			yyb270 = r.CheckBreak()
+		}
+		if yyb270 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj270-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym274 := z.EncBinary()
+		_ = yym274
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep275 := !z.EncBinary()
+			yy2arr275 := z.EncBasicHandle().StructToArray
+			var yyq275 [3]bool
+			_, _, _ = yysep275, yyq275, yy2arr275
+			const yyr275 bool = false
+			yyq275[1] = x.CPU != nil
+			yyq275[2] = x.Memory != nil
+			if yyr275 || yy2arr275 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn275 int = 1
+				for _, b := range yyq275 {
+					if b {
+						yynn275++
+					}
+				}
+				r.EncodeMapStart(yynn275)
+			}
+			if yyr275 || yy2arr275 {
+				yy277 := &x.SampleTime
+				yym278 := z.EncBinary()
+				_ = yym278
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy277) {
+				} else if yym278 {
+					z.EncBinaryMarshal(yy277)
+				} else if !yym278 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy277)
+				} else {
+					z.EncFallback(yy277)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy279 := &x.SampleTime
+				yym280 := z.EncBinary()
+				_ = yym280
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy279) {
+				} else if yym280 {
+					z.EncBinaryMarshal(yy279)
+				} else if !yym280 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy279)
+				} else {
+					z.EncFallback(yy279)
+				}
+			}
+			if yyr275 || yy2arr275 {
+				if yyq275[1] {
+					if x.CPU == nil {
+						r.EncodeNil()
+					} else {
+						x.CPU.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq275[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
+					if x.CPU == nil {
+						r.EncodeNil()
+					} else {
+						x.CPU.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr275 || yy2arr275 {
+				if yyq275[2] {
+					if x.Memory == nil {
+						r.EncodeNil()
+					} else {
+						x.Memory.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq275[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("memory"))
+					if x.Memory == nil {
+						r.EncodeNil()
+					} else {
+						x.Memory.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yysep275 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *ContainerSample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym283 := z.DecBinary()
+	_ = yym283
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl284 := r.ReadMapStart()
+			if yyl284 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl284, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl284 := r.ReadArrayStart()
+			if yyl284 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl284, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys285Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys285Slc
+	var yyhl285 bool = l >= 0
+	for yyj285 := 0; ; yyj285++ {
+		if yyhl285 {
+			if yyj285 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys285Slc = r.DecodeBytes(yys285Slc, true, true)
+		yys285 := string(yys285Slc)
+		switch yys285 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv286 := &x.SampleTime
+				yym287 := z.DecBinary()
+				_ = yym287
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv286) {
+				} else if yym287 {
+					z.DecBinaryUnmarshal(yyv286)
+				} else if !yym287 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv286)
+				} else {
+					z.DecFallback(yyv286, false)
+				}
+			}
+		case "cpu":
+			if r.TryDecodeAsNil() {
+				if x.CPU != nil {
+					x.CPU = nil
+				}
+			} else {
+				if x.CPU == nil {
+					x.CPU = new(CPUMetrics)
+				}
+				x.CPU.CodecDecodeSelf(d)
+			}
+		case "memory":
+			if r.TryDecodeAsNil() {
+				if x.Memory != nil {
+					x.Memory = nil
+				}
+			} else {
+				if x.Memory == nil {
+					x.Memory = new(MemoryMetrics)
+				}
+				x.Memory.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys285)
+		} // end switch yys285
+	} // end for yyj285
+	if !yyhl285 {
+		r.ReadEnd()
+	}
+}
+
+func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj290 int
+	var yyb290 bool
+	var yyhl290 bool = l >= 0
+	yyj290++
+	if yyhl290 {
+		yyb290 = yyj290 > l
+	} else {
+		yyb290 = r.CheckBreak()
+	}
+	if yyb290 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv291 := &x.SampleTime
+		yym292 := z.DecBinary()
+		_ = yym292
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv291) {
+		} else if yym292 {
+			z.DecBinaryUnmarshal(yyv291)
+		} else if !yym292 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv291)
+		} else {
+			z.DecFallback(yyv291, false)
+		}
+	}
+	yyj290++
+	if yyhl290 {
+		yyb290 = yyj290 > l
+	} else {
+		yyb290 = r.CheckBreak()
+	}
+	if yyb290 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.CPU != nil {
+			x.CPU = nil
+		}
+	} else {
+		if x.CPU == nil {
+			x.CPU = new(CPUMetrics)
+		}
+		x.CPU.CodecDecodeSelf(d)
+	}
+	yyj290++
+	if yyhl290 {
+		yyb290 = yyj290 > l
+	} else {
+		yyb290 = r.CheckBreak()
+	}
+	if yyb290 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Memory != nil {
+			x.Memory = nil
+		}
+	} else {
+		if x.Memory == nil {
+			x.Memory = new(MemoryMetrics)
+		}
+		x.Memory.CodecDecodeSelf(d)
+	}
+	for {
+		yyj290++
+		if yyhl290 {
+			yyb290 = yyj290 > l
+		} else {
+			yyb290 = r.CheckBreak()
+		}
+		if yyb290 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj290-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym295 := z.EncBinary()
+		_ = yym295
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep296 := !z.EncBinary()
+			yy2arr296 := z.EncBasicHandle().StructToArray
+			var yyq296 [4]bool
+			_, _, _ = yysep296, yyq296, yy2arr296
+			const yyr296 bool = false
+			yyq296[0] = x.RxBytes != nil
+			yyq296[1] = x.RxErrors != nil
+			yyq296[2] = x.TxBytes != nil
+			yyq296[3] = x.TxErrors != nil
+			if yyr296 || yy2arr296 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn296 int = 0
+				for _, b := range yyq296 {
+					if b {
+						yynn296++
+					}
+				}
+				r.EncodeMapStart(yynn296)
+			}
+			if yyr296 || yy2arr296 {
+				if yyq296[0] {
+					if x.RxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym298 := z.EncBinary()
+						_ = yym298
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
+						} else if !yym298 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.RxBytes)
+						} else {
+							z.EncFallback(x.RxBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq296[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("rxBytes"))
+					if x.RxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym299 := z.EncBinary()
+						_ = yym299
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
+						} else if !yym299 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.RxBytes)
+						} else {
+							z.EncFallback(x.RxBytes)
+						}
+					}
+				}
+			}
+			if yyr296 || yy2arr296 {
+				if yyq296[1] {
+					if x.RxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy301 := *x.RxErrors
+						yym302 := z.EncBinary()
+						_ = yym302
+						if false {
+						} else {
+							r.EncodeInt(int64(yy301))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq296[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("rxErrors"))
+					if x.RxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy303 := *x.RxErrors
+						yym304 := z.EncBinary()
+						_ = yym304
+						if false {
+						} else {
+							r.EncodeInt(int64(yy303))
+						}
+					}
+				}
+			}
+			if yyr296 || yy2arr296 {
+				if yyq296[2] {
+					if x.TxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym306 := z.EncBinary()
+						_ = yym306
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
+						} else if !yym306 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TxBytes)
+						} else {
+							z.EncFallback(x.TxBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq296[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("txBytes"))
+					if x.TxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym307 := z.EncBinary()
+						_ = yym307
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
+						} else if !yym307 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TxBytes)
+						} else {
+							z.EncFallback(x.TxBytes)
+						}
+					}
+				}
+			}
+			if yyr296 || yy2arr296 {
+				if yyq296[3] {
+					if x.TxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy309 := *x.TxErrors
+						yym310 := z.EncBinary()
+						_ = yym310
+						if false {
+						} else {
+							r.EncodeInt(int64(yy309))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq296[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("txErrors"))
+					if x.TxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy311 := *x.TxErrors
+						yym312 := z.EncBinary()
+						_ = yym312
+						if false {
+						} else {
+							r.EncodeInt(int64(yy311))
+						}
+					}
+				}
+			}
+			if yysep296 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *NetworkMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym313 := z.DecBinary()
+	_ = yym313
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl314 := r.ReadMapStart()
+			if yyl314 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl314, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl314 := r.ReadArrayStart()
+			if yyl314 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl314, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys315Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys315Slc
+	var yyhl315 bool = l >= 0
+	for yyj315 := 0; ; yyj315++ {
+		if yyhl315 {
+			if yyj315 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys315Slc = r.DecodeBytes(yys315Slc, true, true)
+		yys315 := string(yys315Slc)
+		switch yys315 {
+		case "rxBytes":
+			if r.TryDecodeAsNil() {
+				if x.RxBytes != nil {
+					x.RxBytes = nil
+				}
+			} else {
+				if x.RxBytes == nil {
+					x.RxBytes = new(pkg2_resource.Quantity)
+				}
+				yym317 := z.DecBinary()
+				_ = yym317
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
+				} else if !yym317 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.RxBytes)
+				} else {
+					z.DecFallback(x.RxBytes, false)
+				}
+			}
+		case "rxErrors":
+			if r.TryDecodeAsNil() {
+				if x.RxErrors != nil {
+					x.RxErrors = nil
+				}
+			} else {
+				if x.RxErrors == nil {
+					x.RxErrors = new(int64)
+				}
+				yym319 := z.DecBinary()
+				_ = yym319
+				if false {
+				} else {
+					*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
+				}
+			}
+		case "txBytes":
+			if r.TryDecodeAsNil() {
+				if x.TxBytes != nil {
+					x.TxBytes = nil
+				}
+			} else {
+				if x.TxBytes == nil {
+					x.TxBytes = new(pkg2_resource.Quantity)
+				}
+				yym321 := z.DecBinary()
+				_ = yym321
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
+				} else if !yym321 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.TxBytes)
+				} else {
+					z.DecFallback(x.TxBytes, false)
+				}
+			}
+		case "txErrors":
+			if r.TryDecodeAsNil() {
+				if x.TxErrors != nil {
+					x.TxErrors = nil
+				}
+			} else {
+				if x.TxErrors == nil {
+					x.TxErrors = new(int64)
+				}
+				yym323 := z.DecBinary()
+				_ = yym323
+				if false {
+				} else {
+					*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys315)
+		} // end switch yys315
+	} // end for yyj315
+	if !yyhl315 {
+		r.ReadEnd()
+	}
+}
+
+func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj324 int
+	var yyb324 bool
+	var yyhl324 bool = l >= 0
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
+	} else {
+		yyb324 = r.CheckBreak()
+	}
+	if yyb324 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.RxBytes != nil {
+			x.RxBytes = nil
+		}
+	} else {
+		if x.RxBytes == nil {
+			x.RxBytes = new(pkg2_resource.Quantity)
+		}
+		yym326 := z.DecBinary()
+		_ = yym326
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
+		} else if !yym326 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.RxBytes)
+		} else {
+			z.DecFallback(x.RxBytes, false)
+		}
+	}
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
+	} else {
+		yyb324 = r.CheckBreak()
+	}
+	if yyb324 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.RxErrors != nil {
+			x.RxErrors = nil
+		}
+	} else {
+		if x.RxErrors == nil {
+			x.RxErrors = new(int64)
+		}
+		yym328 := z.DecBinary()
+		_ = yym328
+		if false {
+		} else {
+			*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
+		}
+	}
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
+	} else {
+		yyb324 = r.CheckBreak()
+	}
+	if yyb324 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.TxBytes != nil {
+			x.TxBytes = nil
+		}
+	} else {
+		if x.TxBytes == nil {
+			x.TxBytes = new(pkg2_resource.Quantity)
+		}
+		yym330 := z.DecBinary()
+		_ = yym330
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
+		} else if !yym330 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.TxBytes)
+		} else {
+			z.DecFallback(x.TxBytes, false)
+		}
+	}
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
+	} else {
+		yyb324 = r.CheckBreak()
+	}
+	if yyb324 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.TxErrors != nil {
+			x.TxErrors = nil
+		}
+	} else {
+		if x.TxErrors == nil {
+			x.TxErrors = new(int64)
+		}
+		yym332 := z.DecBinary()
+		_ = yym332
+		if false {
+		} else {
+			*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
+		}
+	}
+	for {
+		yyj324++
+		if yyhl324 {
+			yyb324 = yyj324 > l
+		} else {
+			yyb324 = r.CheckBreak()
+		}
+		if yyb324 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj324-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym333 := z.EncBinary()
+		_ = yym333
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep334 := !z.EncBinary()
+			yy2arr334 := z.EncBasicHandle().StructToArray
+			var yyq334 [2]bool
+			_, _, _ = yysep334, yyq334, yy2arr334
+			const yyr334 bool = false
+			yyq334[0] = x.TotalCores != nil
+			yyq334[1] = x.LoadAverage != nil
+			if yyr334 || yy2arr334 {
+				r.EncodeArrayStart(2)
+			} else {
+				var yynn334 int = 0
+				for _, b := range yyq334 {
+					if b {
+						yynn334++
+					}
+				}
+				r.EncodeMapStart(yynn334)
+			}
+			if yyr334 || yy2arr334 {
+				if yyq334[0] {
+					if x.TotalCores == nil {
+						r.EncodeNil()
+					} else {
+						yym336 := z.EncBinary()
+						_ = yym336
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
+						} else if !yym336 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TotalCores)
+						} else {
+							z.EncFallback(x.TotalCores)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq334[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("totalCores"))
+					if x.TotalCores == nil {
+						r.EncodeNil()
+					} else {
+						yym337 := z.EncBinary()
+						_ = yym337
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
+						} else if !yym337 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TotalCores)
+						} else {
+							z.EncFallback(x.TotalCores)
+						}
+					}
+				}
+			}
+			if yyr334 || yy2arr334 {
+				if yyq334[1] {
+					if x.LoadAverage == nil {
+						r.EncodeNil()
+					} else {
+						yym339 := z.EncBinary()
+						_ = yym339
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
+						} else if !yym339 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.LoadAverage)
+						} else {
+							z.EncFallback(x.LoadAverage)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq334[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("loadAverage"))
+					if x.LoadAverage == nil {
+						r.EncodeNil()
+					} else {
+						yym340 := z.EncBinary()
+						_ = yym340
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
+						} else if !yym340 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.LoadAverage)
+						} else {
+							z.EncFallback(x.LoadAverage)
+						}
+					}
+				}
+			}
+			if yysep334 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *CPUMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym341 := z.DecBinary()
+	_ = yym341
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl342 := r.ReadMapStart()
+			if yyl342 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl342, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl342 := r.ReadArrayStart()
+			if yyl342 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl342, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys343Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys343Slc
+	var yyhl343 bool = l >= 0
+	for yyj343 := 0; ; yyj343++ {
+		if yyhl343 {
+			if yyj343 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
+		yys343 := string(yys343Slc)
+		switch yys343 {
+		case "totalCores":
+			if r.TryDecodeAsNil() {
+				if x.TotalCores != nil {
+					x.TotalCores = nil
+				}
+			} else {
+				if x.TotalCores == nil {
+					x.TotalCores = new(pkg2_resource.Quantity)
+				}
+				yym345 := z.DecBinary()
+				_ = yym345
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
+				} else if !yym345 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.TotalCores)
+				} else {
+					z.DecFallback(x.TotalCores, false)
+				}
+			}
+		case "loadAverage":
+			if r.TryDecodeAsNil() {
+				if x.LoadAverage != nil {
+					x.LoadAverage = nil
+				}
+			} else {
+				if x.LoadAverage == nil {
+					x.LoadAverage = new(pkg2_resource.Quantity)
+				}
+				yym347 := z.DecBinary()
+				_ = yym347
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
+				} else if !yym347 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.LoadAverage)
+				} else {
+					z.DecFallback(x.LoadAverage, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys343)
+		} // end switch yys343
+	} // end for yyj343
+	if !yyhl343 {
+		r.ReadEnd()
+	}
+}
+
+func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj348 int
+	var yyb348 bool
+	var yyhl348 bool = l >= 0
+	yyj348++
+	if yyhl348 {
+		yyb348 = yyj348 > l
+	} else {
+		yyb348 = r.CheckBreak()
+	}
+	if yyb348 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.TotalCores != nil {
+			x.TotalCores = nil
+		}
+	} else {
+		if x.TotalCores == nil {
+			x.TotalCores = new(pkg2_resource.Quantity)
+		}
+		yym350 := z.DecBinary()
+		_ = yym350
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
+		} else if !yym350 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.TotalCores)
+		} else {
+			z.DecFallback(x.TotalCores, false)
+		}
+	}
+	yyj348++
+	if yyhl348 {
+		yyb348 = yyj348 > l
+	} else {
+		yyb348 = r.CheckBreak()
+	}
+	if yyb348 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.LoadAverage != nil {
+			x.LoadAverage = nil
+		}
+	} else {
+		if x.LoadAverage == nil {
+			x.LoadAverage = new(pkg2_resource.Quantity)
+		}
+		yym352 := z.DecBinary()
+		_ = yym352
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
+		} else if !yym352 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.LoadAverage)
+		} else {
+			z.DecFallback(x.LoadAverage, false)
+		}
+	}
+	for {
+		yyj348++
+		if yyhl348 {
+			yyb348 = yyj348 > l
+		} else {
+			yyb348 = r.CheckBreak()
+		}
+		if yyb348 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj348-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym353 := z.EncBinary()
+		_ = yym353
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep354 := !z.EncBinary()
+			yy2arr354 := z.EncBasicHandle().StructToArray
+			var yyq354 [4]bool
+			_, _, _ = yysep354, yyq354, yy2arr354
+			const yyr354 bool = false
+			yyq354[0] = x.TotalBytes != nil
+			yyq354[1] = x.UsageBytes != nil
+			yyq354[2] = x.PageFaults != nil
+			yyq354[3] = x.MajorPageFaults != nil
+			if yyr354 || yy2arr354 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn354 int = 0
+				for _, b := range yyq354 {
+					if b {
+						yynn354++
+					}
+				}
+				r.EncodeMapStart(yynn354)
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[0] {
+					if x.TotalBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym356 := z.EncBinary()
+						_ = yym356
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
+						} else if !yym356 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TotalBytes)
+						} else {
+							z.EncFallback(x.TotalBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("totalBytes"))
+					if x.TotalBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym357 := z.EncBinary()
+						_ = yym357
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
+						} else if !yym357 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TotalBytes)
+						} else {
+							z.EncFallback(x.TotalBytes)
+						}
+					}
+				}
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[1] {
+					if x.UsageBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym359 := z.EncBinary()
+						_ = yym359
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
+						} else if !yym359 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UsageBytes)
+						} else {
+							z.EncFallback(x.UsageBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
+					if x.UsageBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym360 := z.EncBinary()
+						_ = yym360
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
+						} else if !yym360 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UsageBytes)
+						} else {
+							z.EncFallback(x.UsageBytes)
+						}
+					}
+				}
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[2] {
+					if x.PageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy362 := *x.PageFaults
+						yym363 := z.EncBinary()
+						_ = yym363
+						if false {
+						} else {
+							r.EncodeInt(int64(yy362))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
+					if x.PageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy364 := *x.PageFaults
+						yym365 := z.EncBinary()
+						_ = yym365
+						if false {
+						} else {
+							r.EncodeInt(int64(yy364))
+						}
+					}
+				}
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[3] {
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy367 := *x.MajorPageFaults
+						yym368 := z.EncBinary()
+						_ = yym368
+						if false {
+						} else {
+							r.EncodeInt(int64(yy367))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy369 := *x.MajorPageFaults
+						yym370 := z.EncBinary()
+						_ = yym370
+						if false {
+						} else {
+							r.EncodeInt(int64(yy369))
+						}
+					}
+				}
+			}
+			if yysep354 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *MemoryMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym371 := z.DecBinary()
+	_ = yym371
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl372 := r.ReadMapStart()
+			if yyl372 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl372, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl372 := r.ReadArrayStart()
+			if yyl372 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl372, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys373Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys373Slc
+	var yyhl373 bool = l >= 0
+	for yyj373 := 0; ; yyj373++ {
+		if yyhl373 {
+			if yyj373 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys373Slc = r.DecodeBytes(yys373Slc, true, true)
+		yys373 := string(yys373Slc)
+		switch yys373 {
+		case "totalBytes":
+			if r.TryDecodeAsNil() {
+				if x.TotalBytes != nil {
+					x.TotalBytes = nil
+				}
+			} else {
+				if x.TotalBytes == nil {
+					x.TotalBytes = new(pkg2_resource.Quantity)
+				}
+				yym375 := z.DecBinary()
+				_ = yym375
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
+				} else if !yym375 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.TotalBytes)
+				} else {
+					z.DecFallback(x.TotalBytes, false)
+				}
+			}
+		case "usageBytes":
+			if r.TryDecodeAsNil() {
+				if x.UsageBytes != nil {
+					x.UsageBytes = nil
+				}
+			} else {
+				if x.UsageBytes == nil {
+					x.UsageBytes = new(pkg2_resource.Quantity)
+				}
+				yym377 := z.DecBinary()
+				_ = yym377
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
+				} else if !yym377 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.UsageBytes)
+				} else {
+					z.DecFallback(x.UsageBytes, false)
+				}
+			}
+		case "pageFaults":
+			if r.TryDecodeAsNil() {
+				if x.PageFaults != nil {
+					x.PageFaults = nil
+				}
+			} else {
+				if x.PageFaults == nil {
+					x.PageFaults = new(int64)
+				}
+				yym379 := z.DecBinary()
+				_ = yym379
+				if false {
+				} else {
+					*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
+				}
+			}
+		case "majorPageFaults":
+			if r.TryDecodeAsNil() {
+				if x.MajorPageFaults != nil {
+					x.MajorPageFaults = nil
+				}
+			} else {
+				if x.MajorPageFaults == nil {
+					x.MajorPageFaults = new(int64)
+				}
+				yym381 := z.DecBinary()
+				_ = yym381
+				if false {
+				} else {
+					*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys373)
+		} // end switch yys373
+	} // end for yyj373
+	if !yyhl373 {
+		r.ReadEnd()
+	}
+}
+
+func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj382 int
+	var yyb382 bool
+	var yyhl382 bool = l >= 0
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
+	} else {
+		yyb382 = r.CheckBreak()
+	}
+	if yyb382 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.TotalBytes != nil {
+			x.TotalBytes = nil
+		}
+	} else {
+		if x.TotalBytes == nil {
+			x.TotalBytes = new(pkg2_resource.Quantity)
+		}
+		yym384 := z.DecBinary()
+		_ = yym384
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
+		} else if !yym384 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.TotalBytes)
+		} else {
+			z.DecFallback(x.TotalBytes, false)
+		}
+	}
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
+	} else {
+		yyb382 = r.CheckBreak()
+	}
+	if yyb382 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.UsageBytes != nil {
+			x.UsageBytes = nil
+		}
+	} else {
+		if x.UsageBytes == nil {
+			x.UsageBytes = new(pkg2_resource.Quantity)
+		}
+		yym386 := z.DecBinary()
+		_ = yym386
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
+		} else if !yym386 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.UsageBytes)
+		} else {
+			z.DecFallback(x.UsageBytes, false)
+		}
+	}
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
+	} else {
+		yyb382 = r.CheckBreak()
+	}
+	if yyb382 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.PageFaults != nil {
+			x.PageFaults = nil
+		}
+	} else {
+		if x.PageFaults == nil {
+			x.PageFaults = new(int64)
+		}
+		yym388 := z.DecBinary()
+		_ = yym388
+		if false {
+		} else {
+			*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
+		}
+	}
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
+	} else {
+		yyb382 = r.CheckBreak()
+	}
+	if yyb382 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.MajorPageFaults != nil {
+			x.MajorPageFaults = nil
+		}
+	} else {
+		if x.MajorPageFaults == nil {
+			x.MajorPageFaults = new(int64)
+		}
+		yym390 := z.DecBinary()
+		_ = yym390
+		if false {
+		} else {
+			*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
+		}
+	}
+	for {
+		yyj382++
+		if yyhl382 {
+			yyb382 = yyj382 > l
+		} else {
+			yyb382 = r.CheckBreak()
+		}
+		if yyb382 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj382-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x CustomMetricType) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	yym391 := z.EncBinary()
+	_ = yym391
+	if false {
+	} else if z.HasExtensions() && z.EncExt(x) {
+	} else {
+		r.EncodeString(codecSelferC_UTF81234, string(x))
+	}
+}
+
+func (x *CustomMetricType) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym392 := z.DecBinary()
+	_ = yym392
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		*((*string)(x)) = r.DecodeString()
+	}
+}
+
+func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym393 := z.EncBinary()
+		_ = yym393
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep394 := !z.EncBinary()
+			yy2arr394 := z.EncBasicHandle().StructToArray
+			var yyq394 [4]bool
+			_, _, _ = yysep394, yyq394, yy2arr394
+			const yyr394 bool = false
+			yyq394[3] = len(x.Samples) != 0
+			if yyr394 || yy2arr394 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn394 int = 3
+				for _, b := range yyq394 {
+					if b {
+						yynn394++
+					}
+				}
+				r.EncodeMapStart(yynn394)
+			}
+			if yyr394 || yy2arr394 {
+				yym396 := z.EncBinary()
+				_ = yym396
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				yym397 := z.EncBinary()
+				_ = yym397
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			}
+			if yyr394 || yy2arr394 {
+				x.Type.CodecEncodeSelf(e)
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				x.Type.CodecEncodeSelf(e)
+			}
+			if yyr394 || yy2arr394 {
+				yym400 := z.EncBinary()
+				_ = yym400
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("unit"))
+				yym401 := z.EncBinary()
+				_ = yym401
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
+				}
+			}
+			if yyr394 || yy2arr394 {
+				if yyq394[3] {
+					if x.Samples == nil {
+						r.EncodeNil()
+					} else {
+						yym403 := z.EncBinary()
+						_ = yym403
+						if false {
+						} else {
+							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq394[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("samples"))
+					if x.Samples == nil {
+						r.EncodeNil()
+					} else {
+						yym404 := z.EncBinary()
+						_ = yym404
+						if false {
+						} else {
+							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
+						}
+					}
+				}
+			}
+			if yysep394 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *CustomMetric) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym405 := z.DecBinary()
+	_ = yym405
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl406 := r.ReadMapStart()
+			if yyl406 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl406, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl406 := r.ReadArrayStart()
+			if yyl406 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl406, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys407Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys407Slc
+	var yyhl407 bool = l >= 0
+	for yyj407 := 0; ; yyj407++ {
+		if yyhl407 {
+			if yyj407 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys407Slc = r.DecodeBytes(yys407Slc, true, true)
+		yys407 := string(yys407Slc)
+		switch yys407 {
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "type":
+			if r.TryDecodeAsNil() {
+				x.Type = ""
+			} else {
+				x.Type = CustomMetricType(r.DecodeString())
+			}
+		case "unit":
+			if r.TryDecodeAsNil() {
+				x.Unit = ""
+			} else {
+				x.Unit = string(r.DecodeString())
+			}
+		case "samples":
+			if r.TryDecodeAsNil() {
+				x.Samples = nil
+			} else {
+				yyv411 := &x.Samples
+				yym412 := z.DecBinary()
+				_ = yym412
+				if false {
+				} else {
+					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv411), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys407)
+		} // end switch yys407
+	} // end for yyj407
+	if !yyhl407 {
+		r.ReadEnd()
+	}
+}
+
+func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj413 int
+	var yyb413 bool
+	var yyhl413 bool = l >= 0
+	yyj413++
+	if yyhl413 {
+		yyb413 = yyj413 > l
+	} else {
+		yyb413 = r.CheckBreak()
+	}
+	if yyb413 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj413++
+	if yyhl413 {
+		yyb413 = yyj413 > l
+	} else {
+		yyb413 = r.CheckBreak()
+	}
+	if yyb413 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Type = ""
+	} else {
+		x.Type = CustomMetricType(r.DecodeString())
+	}
+	yyj413++
+	if yyhl413 {
+		yyb413 = yyj413 > l
+	} else {
+		yyb413 = r.CheckBreak()
+	}
+	if yyb413 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Unit = ""
+	} else {
+		x.Unit = string(r.DecodeString())
+	}
+	yyj413++
+	if yyhl413 {
+		yyb413 = yyj413 > l
+	} else {
+		yyb413 = r.CheckBreak()
+	}
+	if yyb413 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Samples = nil
+	} else {
+		yyv417 := &x.Samples
+		yym418 := z.DecBinary()
+		_ = yym418
+		if false {
+		} else {
+			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv417), d)
+		}
+	}
+	for {
+		yyj413++
+		if yyhl413 {
+			yyb413 = yyj413 > l
+		} else {
+			yyb413 = r.CheckBreak()
+		}
+		if yyb413 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj413-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *CustomMetricSample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym419 := z.EncBinary()
+		_ = yym419
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep420 := !z.EncBinary()
+			yy2arr420 := z.EncBasicHandle().StructToArray
+			var yyq420 [3]bool
+			_, _, _ = yysep420, yyq420, yy2arr420
+			const yyr420 bool = false
+			yyq420[1] = x.Label != nil
+			if yyr420 || yy2arr420 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn420 int = 2
+				for _, b := range yyq420 {
+					if b {
+						yynn420++
+					}
+				}
+				r.EncodeMapStart(yynn420)
+			}
+			if yyr420 || yy2arr420 {
+				yy422 := &x.SampleTime
+				yym423 := z.EncBinary()
+				_ = yym423
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy422) {
+				} else if yym423 {
+					z.EncBinaryMarshal(yy422)
+				} else if !yym423 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy422)
+				} else {
+					z.EncFallback(yy422)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy424 := &x.SampleTime
+				yym425 := z.EncBinary()
+				_ = yym425
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy424) {
+				} else if yym425 {
+					z.EncBinaryMarshal(yy424)
+				} else if !yym425 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy424)
+				} else {
+					z.EncFallback(yy424)
+				}
+			}
+			if yyr420 || yy2arr420 {
+				if yyq420[1] {
+					if x.Label == nil {
+						r.EncodeNil()
+					} else {
+						yy427 := *x.Label
+						yym428 := z.EncBinary()
+						_ = yym428
+						if false {
+						} else {
+							r.EncodeString(codecSelferC_UTF81234, string(yy427))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq420[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("label"))
+					if x.Label == nil {
+						r.EncodeNil()
+					} else {
+						yy429 := *x.Label
+						yym430 := z.EncBinary()
+						_ = yym430
+						if false {
+						} else {
+							r.EncodeString(codecSelferC_UTF81234, string(yy429))
+						}
+					}
+				}
+			}
+			if yyr420 || yy2arr420 {
+				yy432 := &x.Value
+				yym433 := z.EncBinary()
+				_ = yym433
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy432) {
+				} else if !yym433 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy432)
+				} else {
+					z.EncFallback(yy432)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("value"))
+				yy434 := &x.Value
+				yym435 := z.EncBinary()
+				_ = yym435
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy434) {
+				} else if !yym435 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy434)
+				} else {
+					z.EncFallback(yy434)
+				}
+			}
+			if yysep420 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *CustomMetricSample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym436 := z.DecBinary()
+	_ = yym436
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl437 := r.ReadMapStart()
+			if yyl437 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl437, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl437 := r.ReadArrayStart()
+			if yyl437 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl437, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys438Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys438Slc
+	var yyhl438 bool = l >= 0
+	for yyj438 := 0; ; yyj438++ {
+		if yyhl438 {
+			if yyj438 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys438Slc = r.DecodeBytes(yys438Slc, true, true)
+		yys438 := string(yys438Slc)
+		switch yys438 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv439 := &x.SampleTime
+				yym440 := z.DecBinary()
+				_ = yym440
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv439) {
+				} else if yym440 {
+					z.DecBinaryUnmarshal(yyv439)
+				} else if !yym440 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv439)
+				} else {
+					z.DecFallback(yyv439, false)
+				}
+			}
+		case "label":
+			if r.TryDecodeAsNil() {
+				if x.Label != nil {
+					x.Label = nil
+				}
+			} else {
+				if x.Label == nil {
+					x.Label = new(string)
+				}
+				yym442 := z.DecBinary()
+				_ = yym442
+				if false {
+				} else {
+					*((*string)(x.Label)) = r.DecodeString()
+				}
+			}
+		case "value":
+			if r.TryDecodeAsNil() {
+				x.Value = pkg2_resource.Quantity{}
+			} else {
+				yyv443 := &x.Value
+				yym444 := z.DecBinary()
+				_ = yym444
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv443) {
+				} else if !yym444 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv443)
+				} else {
+					z.DecFallback(yyv443, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys438)
+		} // end switch yys438
+	} // end for yyj438
+	if !yyhl438 {
+		r.ReadEnd()
+	}
+}
+
+func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj445 int
+	var yyb445 bool
+	var yyhl445 bool = l >= 0
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
+	} else {
+		yyb445 = r.CheckBreak()
+	}
+	if yyb445 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv446 := &x.SampleTime
+		yym447 := z.DecBinary()
+		_ = yym447
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv446) {
+		} else if yym447 {
+			z.DecBinaryUnmarshal(yyv446)
+		} else if !yym447 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv446)
+		} else {
+			z.DecFallback(yyv446, false)
+		}
+	}
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
+	} else {
+		yyb445 = r.CheckBreak()
+	}
+	if yyb445 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Label != nil {
+			x.Label = nil
+		}
+	} else {
+		if x.Label == nil {
+			x.Label = new(string)
+		}
+		yym449 := z.DecBinary()
+		_ = yym449
+		if false {
+		} else {
+			*((*string)(x.Label)) = r.DecodeString()
+		}
+	}
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
+	} else {
+		yyb445 = r.CheckBreak()
+	}
+	if yyb445 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Value = pkg2_resource.Quantity{}
+	} else {
+		yyv450 := &x.Value
+		yym451 := z.DecBinary()
+		_ = yym451
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv450) {
+		} else if !yym451 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv450)
+		} else {
+			z.DecFallback(yyv450, false)
+		}
+	}
+	for {
+		yyj445++
+		if yyhl445 {
+			yyb445 = yyj445 > l
+		} else {
+			yyb445 = r.CheckBreak()
+		}
+		if yyb445 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj445-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym452 := z.EncBinary()
+		_ = yym452
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep453 := !z.EncBinary()
+			yy2arr453 := z.EncBasicHandle().StructToArray
+			var yyq453 [3]bool
+			_, _, _ = yysep453, yyq453, yy2arr453
+			const yyr453 bool = false
+			yyq453[0] = x.SinceTime != nil
+			yyq453[1] = x.UntilTime != nil
+			yyq453[2] = x.MaxSamples != 0
+			if yyr453 || yy2arr453 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn453 int = 0
+				for _, b := range yyq453 {
+					if b {
+						yynn453++
+					}
+				}
+				r.EncodeMapStart(yynn453)
+			}
+			if yyr453 || yy2arr453 {
+				if yyq453[0] {
+					if x.SinceTime == nil {
+						r.EncodeNil()
+					} else {
+						yym455 := z.EncBinary()
+						_ = yym455
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
+						} else if yym455 {
+							z.EncBinaryMarshal(x.SinceTime)
+						} else if !yym455 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.SinceTime)
+						} else {
+							z.EncFallback(x.SinceTime)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq453[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
+					if x.SinceTime == nil {
+						r.EncodeNil()
+					} else {
+						yym456 := z.EncBinary()
+						_ = yym456
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
+						} else if yym456 {
+							z.EncBinaryMarshal(x.SinceTime)
+						} else if !yym456 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.SinceTime)
+						} else {
+							z.EncFallback(x.SinceTime)
+						}
+					}
+				}
+			}
+			if yyr453 || yy2arr453 {
+				if yyq453[1] {
+					if x.UntilTime == nil {
+						r.EncodeNil()
+					} else {
+						yym458 := z.EncBinary()
+						_ = yym458
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
+						} else if yym458 {
+							z.EncBinaryMarshal(x.UntilTime)
+						} else if !yym458 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UntilTime)
+						} else {
+							z.EncFallback(x.UntilTime)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq453[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
+					if x.UntilTime == nil {
+						r.EncodeNil()
+					} else {
+						yym459 := z.EncBinary()
+						_ = yym459
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
+						} else if yym459 {
+							z.EncBinaryMarshal(x.UntilTime)
+						} else if !yym459 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UntilTime)
+						} else {
+							z.EncFallback(x.UntilTime)
+						}
+					}
+				}
+			}
+			if yyr453 || yy2arr453 {
+				if yyq453[2] {
+					yym461 := z.EncBinary()
+					_ = yym461
+					if false {
+					} else {
+						r.EncodeInt(int64(x.MaxSamples))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq453[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
+					yym462 := z.EncBinary()
+					_ = yym462
+					if false {
+					} else {
+						r.EncodeInt(int64(x.MaxSamples))
+					}
+				}
+			}
+			if yysep453 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym463 := z.DecBinary()
+	_ = yym463
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl464 := r.ReadMapStart()
+			if yyl464 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl464, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl464 := r.ReadArrayStart()
+			if yyl464 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl464, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys465Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys465Slc
+	var yyhl465 bool = l >= 0
+	for yyj465 := 0; ; yyj465++ {
+		if yyhl465 {
+			if yyj465 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys465Slc = r.DecodeBytes(yys465Slc, true, true)
+		yys465 := string(yys465Slc)
+		switch yys465 {
+		case "sinceTime":
+			if r.TryDecodeAsNil() {
+				if x.SinceTime != nil {
+					x.SinceTime = nil
+				}
+			} else {
+				if x.SinceTime == nil {
+					x.SinceTime = new(pkg1_unversioned.Time)
+				}
+				yym467 := z.DecBinary()
+				_ = yym467
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
+				} else if yym467 {
+					z.DecBinaryUnmarshal(x.SinceTime)
+				} else if !yym467 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.SinceTime)
+				} else {
+					z.DecFallback(x.SinceTime, false)
+				}
+			}
+		case "untilTime":
+			if r.TryDecodeAsNil() {
+				if x.UntilTime != nil {
+					x.UntilTime = nil
+				}
+			} else {
+				if x.UntilTime == nil {
+					x.UntilTime = new(pkg1_unversioned.Time)
+				}
+				yym469 := z.DecBinary()
+				_ = yym469
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
+				} else if yym469 {
+					z.DecBinaryUnmarshal(x.UntilTime)
+				} else if !yym469 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.UntilTime)
+				} else {
+					z.DecFallback(x.UntilTime, false)
+				}
+			}
+		case "maxSamples":
+			if r.TryDecodeAsNil() {
+				x.MaxSamples = 0
+			} else {
+				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys465)
+		} // end switch yys465
+	} // end for yyj465
+	if !yyhl465 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj471 int
+	var yyb471 bool
+	var yyhl471 bool = l >= 0
+	yyj471++
+	if yyhl471 {
+		yyb471 = yyj471 > l
+	} else {
+		yyb471 = r.CheckBreak()
+	}
+	if yyb471 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.SinceTime != nil {
+			x.SinceTime = nil
+		}
+	} else {
+		if x.SinceTime == nil {
+			x.SinceTime = new(pkg1_unversioned.Time)
+		}
+		yym473 := z.DecBinary()
+		_ = yym473
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
+		} else if yym473 {
+			z.DecBinaryUnmarshal(x.SinceTime)
+		} else if !yym473 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.SinceTime)
+		} else {
+			z.DecFallback(x.SinceTime, false)
+		}
+	}
+	yyj471++
+	if yyhl471 {
+		yyb471 = yyj471 > l
+	} else {
+		yyb471 = r.CheckBreak()
+	}
+	if yyb471 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.UntilTime != nil {
+			x.UntilTime = nil
+		}
+	} else {
+		if x.UntilTime == nil {
+			x.UntilTime = new(pkg1_unversioned.Time)
+		}
+		yym475 := z.DecBinary()
+		_ = yym475
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
+		} else if yym475 {
+			z.DecBinaryUnmarshal(x.UntilTime)
+		} else if !yym475 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.UntilTime)
+		} else {
+			z.DecFallback(x.UntilTime, false)
+		}
+	}
+	yyj471++
+	if yyhl471 {
+		yyb471 = yyj471 > l
+	} else {
+		yyb471 = r.CheckBreak()
+	}
+	if yyb471 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.MaxSamples = 0
+	} else {
+		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
+	}
+	for {
+		yyj471++
+		if yyhl471 {
+			yyb471 = yyj471 > l
+		} else {
+			yyb471 = r.CheckBreak()
+		}
+		if yyb471 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj471-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv477 := range v {
+		yy478 := &yyv477
+		yy478.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv479 := *v
+	yyh479, yyl479 := z.DecSliceHelperStart()
+
+	var yyrr479, yyrl479 int
+	var yyc479, yyrt479 bool
+	_, _, _ = yyc479, yyrt479, yyrl479
+	yyrr479 = yyl479
+
+	if yyv479 == nil {
+		if yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 48); yyrt479 {
+			yyrr479 = yyrl479
+		}
+		yyv479 = make([]AggregateSample, yyrl479)
+		yyc479 = true
+	}
+
+	if yyl479 == 0 {
+		if len(yyv479) != 0 {
+			yyv479 = yyv479[:0]
+			yyc479 = true
+		}
+	} else if yyl479 > 0 {
+
+		if yyl479 > cap(yyv479) {
+			yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 48)
+			yyv479 = make([]AggregateSample, yyrl479)
+			yyc479 = true
+
+			yyrr479 = len(yyv479)
+		} else if yyl479 != len(yyv479) {
+			yyv479 = yyv479[:yyl479]
+			yyc479 = true
+		}
+		yyj479 := 0
+		for ; yyj479 < yyrr479; yyj479++ {
+			if r.TryDecodeAsNil() {
+				yyv479[yyj479] = AggregateSample{}
+			} else {
+				yyv480 := &yyv479[yyj479]
+				yyv480.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt479 {
+			for ; yyj479 < yyl479; yyj479++ {
+				yyv479 = append(yyv479, AggregateSample{})
+				if r.TryDecodeAsNil() {
+					yyv479[yyj479] = AggregateSample{}
+				} else {
+					yyv481 := &yyv479[yyj479]
+					yyv481.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj479 := 0; !r.CheckBreak(); yyj479++ {
+			if yyj479 >= len(yyv479) {
+				yyv479 = append(yyv479, AggregateSample{}) // var yyz479 AggregateSample
+				yyc479 = true
+			}
+
+			if yyj479 < len(yyv479) {
+				if r.TryDecodeAsNil() {
+					yyv479[yyj479] = AggregateSample{}
+				} else {
+					yyv482 := &yyv479[yyj479]
+					yyv482.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh479.End()
+	}
+	if yyc479 {
+		*v = yyv479
+	}
+
+}
+
+func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv483 := range v {
+		yy484 := &yyv483
+		yy484.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv485 := *v
+	yyh485, yyl485 := z.DecSliceHelperStart()
+
+	var yyrr485, yyrl485 int
+	var yyc485, yyrt485 bool
+	_, _, _ = yyc485, yyrt485, yyrl485
+	yyrr485 = yyl485
+
+	if yyv485 == nil {
+		if yyrl485, yyrt485 = z.DecInferLen(yyl485, z.DecBasicHandle().MaxInitLen, 72); yyrt485 {
+			yyrr485 = yyrl485
+		}
+		yyv485 = make([]RawContainerMetrics, yyrl485)
+		yyc485 = true
+	}
+
+	if yyl485 == 0 {
+		if len(yyv485) != 0 {
+			yyv485 = yyv485[:0]
+			yyc485 = true
+		}
+	} else if yyl485 > 0 {
+
+		if yyl485 > cap(yyv485) {
+			yyrl485, yyrt485 = z.DecInferLen(yyl485, z.DecBasicHandle().MaxInitLen, 72)
+			yyv485 = make([]RawContainerMetrics, yyrl485)
+			yyc485 = true
+
+			yyrr485 = len(yyv485)
+		} else if yyl485 != len(yyv485) {
+			yyv485 = yyv485[:yyl485]
+			yyc485 = true
+		}
+		yyj485 := 0
+		for ; yyj485 < yyrr485; yyj485++ {
+			if r.TryDecodeAsNil() {
+				yyv485[yyj485] = RawContainerMetrics{}
+			} else {
+				yyv486 := &yyv485[yyj485]
+				yyv486.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt485 {
+			for ; yyj485 < yyl485; yyj485++ {
+				yyv485 = append(yyv485, RawContainerMetrics{})
+				if r.TryDecodeAsNil() {
+					yyv485[yyj485] = RawContainerMetrics{}
+				} else {
+					yyv487 := &yyv485[yyj485]
+					yyv487.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj485 := 0; !r.CheckBreak(); yyj485++ {
+			if yyj485 >= len(yyv485) {
+				yyv485 = append(yyv485, RawContainerMetrics{}) // var yyz485 RawContainerMetrics
+				yyc485 = true
+			}
+
+			if yyj485 < len(yyv485) {
+				if r.TryDecodeAsNil() {
+					yyv485[yyj485] = RawContainerMetrics{}
+				} else {
+					yyv488 := &yyv485[yyj485]
+					yyv488.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh485.End()
+	}
+	if yyc485 {
+		*v = yyv485
+	}
+
+}
+
+func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv489 := range v {
+		yy490 := &yyv489
+		yy490.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv491 := *v
+	yyh491, yyl491 := z.DecSliceHelperStart()
+
+	var yyrr491, yyrl491 int
+	var yyc491, yyrt491 bool
+	_, _, _ = yyc491, yyrt491, yyrl491
+	yyrr491 = yyl491
+
+	if yyv491 == nil {
+		if yyrl491, yyrt491 = z.DecInferLen(yyl491, z.DecBasicHandle().MaxInitLen, 128); yyrt491 {
+			yyrr491 = yyrl491
+		}
+		yyv491 = make([]RawNodeMetrics, yyrl491)
+		yyc491 = true
+	}
+
+	if yyl491 == 0 {
+		if len(yyv491) != 0 {
+			yyv491 = yyv491[:0]
+			yyc491 = true
+		}
+	} else if yyl491 > 0 {
+
+		if yyl491 > cap(yyv491) {
+			yyrl491, yyrt491 = z.DecInferLen(yyl491, z.DecBasicHandle().MaxInitLen, 128)
+			yyv491 = make([]RawNodeMetrics, yyrl491)
+			yyc491 = true
+
+			yyrr491 = len(yyv491)
+		} else if yyl491 != len(yyv491) {
+			yyv491 = yyv491[:yyl491]
+			yyc491 = true
+		}
+		yyj491 := 0
+		for ; yyj491 < yyrr491; yyj491++ {
+			if r.TryDecodeAsNil() {
+				yyv491[yyj491] = RawNodeMetrics{}
+			} else {
+				yyv492 := &yyv491[yyj491]
+				yyv492.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt491 {
+			for ; yyj491 < yyl491; yyj491++ {
+				yyv491 = append(yyv491, RawNodeMetrics{})
+				if r.TryDecodeAsNil() {
+					yyv491[yyj491] = RawNodeMetrics{}
+				} else {
+					yyv493 := &yyv491[yyj491]
+					yyv493.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj491 := 0; !r.CheckBreak(); yyj491++ {
+			if yyj491 >= len(yyv491) {
+				yyv491 = append(yyv491, RawNodeMetrics{}) // var yyz491 RawNodeMetrics
+				yyc491 = true
+			}
+
+			if yyj491 < len(yyv491) {
+				if r.TryDecodeAsNil() {
+					yyv491[yyj491] = RawNodeMetrics{}
+				} else {
+					yyv494 := &yyv491[yyj491]
+					yyv494.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh491.End()
+	}
+	if yyc491 {
+		*v = yyv491
+	}
+
+}
+
+func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv495 := range v {
+		yy496 := &yyv495
+		yy496.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv497 := *v
+	yyh497, yyl497 := z.DecSliceHelperStart()
+
+	var yyrr497, yyrl497 int
+	var yyc497, yyrt497 bool
+	_, _, _ = yyc497, yyrt497, yyrl497
+	yyrr497 = yyl497
+
+	if yyv497 == nil {
+		if yyrl497, yyrt497 = z.DecInferLen(yyl497, z.DecBasicHandle().MaxInitLen, 32); yyrt497 {
+			yyrr497 = yyrl497
+		}
+		yyv497 = make([]PodSample, yyrl497)
+		yyc497 = true
+	}
+
+	if yyl497 == 0 {
+		if len(yyv497) != 0 {
+			yyv497 = yyv497[:0]
+			yyc497 = true
+		}
+	} else if yyl497 > 0 {
+
+		if yyl497 > cap(yyv497) {
+			yyrl497, yyrt497 = z.DecInferLen(yyl497, z.DecBasicHandle().MaxInitLen, 32)
+			yyv497 = make([]PodSample, yyrl497)
+			yyc497 = true
+
+			yyrr497 = len(yyv497)
+		} else if yyl497 != len(yyv497) {
+			yyv497 = yyv497[:yyl497]
+			yyc497 = true
+		}
+		yyj497 := 0
+		for ; yyj497 < yyrr497; yyj497++ {
+			if r.TryDecodeAsNil() {
+				yyv497[yyj497] = PodSample{}
+			} else {
+				yyv498 := &yyv497[yyj497]
+				yyv498.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt497 {
+			for ; yyj497 < yyl497; yyj497++ {
+				yyv497 = append(yyv497, PodSample{})
+				if r.TryDecodeAsNil() {
+					yyv497[yyj497] = PodSample{}
+				} else {
+					yyv499 := &yyv497[yyj497]
+					yyv499.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj497 := 0; !r.CheckBreak(); yyj497++ {
+			if yyj497 >= len(yyv497) {
+				yyv497 = append(yyv497, PodSample{}) // var yyz497 PodSample
+				yyc497 = true
+			}
+
+			if yyj497 < len(yyv497) {
+				if r.TryDecodeAsNil() {
+					yyv497[yyj497] = PodSample{}
+				} else {
+					yyv500 := &yyv497[yyj497]
+					yyv500.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh497.End()
+	}
+	if yyc497 {
+		*v = yyv497
+	}
+
+}
+
+func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv501 := range v {
+		yy502 := &yyv501
+		yy502.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv503 := *v
+	yyh503, yyl503 := z.DecSliceHelperStart()
+
+	var yyrr503, yyrl503 int
+	var yyc503, yyrt503 bool
+	_, _, _ = yyc503, yyrt503, yyrl503
+	yyrr503 = yyl503
+
+	if yyv503 == nil {
+		if yyrl503, yyrt503 = z.DecInferLen(yyl503, z.DecBasicHandle().MaxInitLen, 160); yyrt503 {
+			yyrr503 = yyrl503
+		}
+		yyv503 = make([]RawPodMetrics, yyrl503)
+		yyc503 = true
+	}
+
+	if yyl503 == 0 {
+		if len(yyv503) != 0 {
+			yyv503 = yyv503[:0]
+			yyc503 = true
+		}
+	} else if yyl503 > 0 {
+
+		if yyl503 > cap(yyv503) {
+			yyrl503, yyrt503 = z.DecInferLen(yyl503, z.DecBasicHandle().MaxInitLen, 160)
+			yyv503 = make([]RawPodMetrics, yyrl503)
+			yyc503 = true
+
+			yyrr503 = len(yyv503)
+		} else if yyl503 != len(yyv503) {
+			yyv503 = yyv503[:yyl503]
+			yyc503 = true
+		}
+		yyj503 := 0
+		for ; yyj503 < yyrr503; yyj503++ {
+			if r.TryDecodeAsNil() {
+				yyv503[yyj503] = RawPodMetrics{}
+			} else {
+				yyv504 := &yyv503[yyj503]
+				yyv504.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt503 {
+			for ; yyj503 < yyl503; yyj503++ {
+				yyv503 = append(yyv503, RawPodMetrics{})
+				if r.TryDecodeAsNil() {
+					yyv503[yyj503] = RawPodMetrics{}
+				} else {
+					yyv505 := &yyv503[yyj503]
+					yyv505.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj503 := 0; !r.CheckBreak(); yyj503++ {
+			if yyj503 >= len(yyv503) {
+				yyv503 = append(yyv503, RawPodMetrics{}) // var yyz503 RawPodMetrics
+				yyc503 = true
+			}
+
+			if yyj503 < len(yyv503) {
+				if r.TryDecodeAsNil() {
+					yyv503[yyj503] = RawPodMetrics{}
+				} else {
+					yyv506 := &yyv503[yyj503]
+					yyv506.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh503.End()
+	}
+	if yyc503 {
+		*v = yyv503
+	}
+
+}
+
+func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv507 := range v {
+		yy508 := &yyv507
+		yy508.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv509 := *v
+	yyh509, yyl509 := z.DecSliceHelperStart()
+
+	var yyrr509, yyrl509 int
+	var yyc509, yyrt509 bool
+	_, _, _ = yyc509, yyrt509, yyrl509
+	yyrr509 = yyl509
+
+	if yyv509 == nil {
+		if yyrl509, yyrt509 = z.DecInferLen(yyl509, z.DecBasicHandle().MaxInitLen, 40); yyrt509 {
+			yyrr509 = yyrl509
+		}
+		yyv509 = make([]ContainerSample, yyrl509)
+		yyc509 = true
+	}
+
+	if yyl509 == 0 {
+		if len(yyv509) != 0 {
+			yyv509 = yyv509[:0]
+			yyc509 = true
+		}
+	} else if yyl509 > 0 {
+
+		if yyl509 > cap(yyv509) {
+			yyrl509, yyrt509 = z.DecInferLen(yyl509, z.DecBasicHandle().MaxInitLen, 40)
+			yyv509 = make([]ContainerSample, yyrl509)
+			yyc509 = true
+
+			yyrr509 = len(yyv509)
+		} else if yyl509 != len(yyv509) {
+			yyv509 = yyv509[:yyl509]
+			yyc509 = true
+		}
+		yyj509 := 0
+		for ; yyj509 < yyrr509; yyj509++ {
+			if r.TryDecodeAsNil() {
+				yyv509[yyj509] = ContainerSample{}
+			} else {
+				yyv510 := &yyv509[yyj509]
+				yyv510.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt509 {
+			for ; yyj509 < yyl509; yyj509++ {
+				yyv509 = append(yyv509, ContainerSample{})
+				if r.TryDecodeAsNil() {
+					yyv509[yyj509] = ContainerSample{}
+				} else {
+					yyv511 := &yyv509[yyj509]
+					yyv511.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj509 := 0; !r.CheckBreak(); yyj509++ {
+			if yyj509 >= len(yyv509) {
+				yyv509 = append(yyv509, ContainerSample{}) // var yyz509 ContainerSample
+				yyc509 = true
+			}
+
+			if yyj509 < len(yyv509) {
+				if r.TryDecodeAsNil() {
+					yyv509[yyj509] = ContainerSample{}
+				} else {
+					yyv512 := &yyv509[yyj509]
+					yyv512.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh509.End()
+	}
+	if yyc509 {
+		*v = yyv509
+	}
+
+}
+
+func (x codecSelfer1234) encSliceCustomMetric(v []CustomMetric, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv513 := range v {
+		yy514 := &yyv513
+		yy514.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv515 := *v
+	yyh515, yyl515 := z.DecSliceHelperStart()
+
+	var yyrr515, yyrl515 int
+	var yyc515, yyrt515 bool
+	_, _, _ = yyc515, yyrt515, yyrl515
+	yyrr515 = yyl515
+
+	if yyv515 == nil {
+		if yyrl515, yyrt515 = z.DecInferLen(yyl515, z.DecBasicHandle().MaxInitLen, 72); yyrt515 {
+			yyrr515 = yyrl515
+		}
+		yyv515 = make([]CustomMetric, yyrl515)
+		yyc515 = true
+	}
+
+	if yyl515 == 0 {
+		if len(yyv515) != 0 {
+			yyv515 = yyv515[:0]
+			yyc515 = true
+		}
+	} else if yyl515 > 0 {
+
+		if yyl515 > cap(yyv515) {
+			yyrl515, yyrt515 = z.DecInferLen(yyl515, z.DecBasicHandle().MaxInitLen, 72)
+			yyv515 = make([]CustomMetric, yyrl515)
+			yyc515 = true
+
+			yyrr515 = len(yyv515)
+		} else if yyl515 != len(yyv515) {
+			yyv515 = yyv515[:yyl515]
+			yyc515 = true
+		}
+		yyj515 := 0
+		for ; yyj515 < yyrr515; yyj515++ {
+			if r.TryDecodeAsNil() {
+				yyv515[yyj515] = CustomMetric{}
+			} else {
+				yyv516 := &yyv515[yyj515]
+				yyv516.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt515 {
+			for ; yyj515 < yyl515; yyj515++ {
+				yyv515 = append(yyv515, CustomMetric{})
+				if r.TryDecodeAsNil() {
+					yyv515[yyj515] = CustomMetric{}
+				} else {
+					yyv517 := &yyv515[yyj515]
+					yyv517.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj515 := 0; !r.CheckBreak(); yyj515++ {
+			if yyj515 >= len(yyv515) {
+				yyv515 = append(yyv515, CustomMetric{}) // var yyz515 CustomMetric
+				yyc515 = true
+			}
+
+			if yyj515 < len(yyv515) {
+				if r.TryDecodeAsNil() {
+					yyv515[yyj515] = CustomMetric{}
+				} else {
+					yyv518 := &yyv515[yyj515]
+					yyv518.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh515.End()
+	}
+	if yyc515 {
+		*v = yyv515
+	}
+
+}
+
+func (x codecSelfer1234) encSliceCustomMetricSample(v []CustomMetricSample, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv519 := range v {
+		yy520 := &yyv519
+		yy520.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv521 := *v
+	yyh521, yyl521 := z.DecSliceHelperStart()
+
+	var yyrr521, yyrl521 int
+	var yyc521, yyrt521 bool
+	_, _, _ = yyc521, yyrt521, yyrl521
+	yyrr521 = yyl521
+
+	if yyv521 == nil {
+		if yyrl521, yyrt521 = z.DecInferLen(yyl521, z.DecBasicHandle().MaxInitLen, 56); yyrt521 {
+			yyrr521 = yyrl521
+		}
+		yyv521 = make([]CustomMetricSample, yyrl521)
+		yyc521 = true
+	}
+
+	if yyl521 == 0 {
+		if len(yyv521) != 0 {
+			yyv521 = yyv521[:0]
+			yyc521 = true
+		}
+	} else if yyl521 > 0 {
+
+		if yyl521 > cap(yyv521) {
+			yyrl521, yyrt521 = z.DecInferLen(yyl521, z.DecBasicHandle().MaxInitLen, 56)
+			yyv521 = make([]CustomMetricSample, yyrl521)
+			yyc521 = true
+
+			yyrr521 = len(yyv521)
+		} else if yyl521 != len(yyv521) {
+			yyv521 = yyv521[:yyl521]
+			yyc521 = true
+		}
+		yyj521 := 0
+		for ; yyj521 < yyrr521; yyj521++ {
+			if r.TryDecodeAsNil() {
+				yyv521[yyj521] = CustomMetricSample{}
+			} else {
+				yyv522 := &yyv521[yyj521]
+				yyv522.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt521 {
+			for ; yyj521 < yyl521; yyj521++ {
+				yyv521 = append(yyv521, CustomMetricSample{})
+				if r.TryDecodeAsNil() {
+					yyv521[yyj521] = CustomMetricSample{}
+				} else {
+					yyv523 := &yyv521[yyj521]
+					yyv523.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj521 := 0; !r.CheckBreak(); yyj521++ {
+			if yyj521 >= len(yyv521) {
+				yyv521 = append(yyv521, CustomMetricSample{}) // var yyz521 CustomMetricSample
+				yyc521 = true
+			}
+
+			if yyj521 < len(yyv521) {
+				if r.TryDecodeAsNil() {
+					yyv521[yyj521] = CustomMetricSample{}
+				} else {
+					yyv524 := &yyv521[yyj521]
+					yyv524.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh521.End()
+	}
+	if yyc521 {
+		*v = yyv521
+	}
+
 }

--- a/pkg/apis/metrics/types.go
+++ b/pkg/apis/metrics/types.go
@@ -158,9 +158,6 @@ type CPUMetrics struct {
 	// Total CPU usage (sum of all cores) averaged over the sample window.
 	// The "core" unit can be interpreted as CPU core-seconds per second.
 	TotalCores *resource.Quantity `json:"totalCores,omitempty"`
-	// CPU load that the container is experiencing, represented as a smoothed average of number of
-	// runnable threads.  Load is averaged over the sampling window.
-	LoadAverage *resource.Quantity `json:"loadAverage,omitempty"`
 }
 
 // MemoryMetrics contains data about memory usage.

--- a/pkg/apis/metrics/types.go
+++ b/pkg/apis/metrics/types.go
@@ -183,11 +183,6 @@ type FilesystemMetrics struct {
 
 // RawMetricsOptions are the query options for raw metrics endpoints.
 type RawMetricsOptions struct {
-	// Only include samples with sampleTime equal to or more recent than this time.
-	// This does not affect cumulative values, which are cumulative from object creation.
-	SinceTime *unversioned.Time `json:"sinceTime,omitempty"`
-	// Only include samples with sampleTime equal to or less recent than this time.
-	UntilTime *unversioned.Time `json:"untilTime,omitempty"`
 	// Specifies the maximum number of elements in any list of samples.
 	// When the total number of samples exceeds the maximum the most recent samples are returned.
 	MaxSamples int `json:"maxSamples,omitempty"`

--- a/pkg/apis/metrics/types.go
+++ b/pkg/apis/metrics/types.go
@@ -16,14 +16,205 @@ limitations under the License.
 
 package metrics
 
-import "k8s.io/kubernetes/pkg/api/unversioned"
+import (
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/types"
+)
 
-// Placeholder top-level node resource metrics.
-type RawNode struct {
-	unversioned.TypeMeta `json:",inline"`
+// MetricsMeta describes metadata that top-level metrics resources must have.
+// Metrics data is a synthetic collection of Samples, and thus does not use ObjectMeta.
+// All metrics data is read-only.
+type MetricsMeta struct {
+	// SelfLink is a URL representing this object.
+	// Populated by the system.
+	SelfLink string `json:"selfLink,omitempty"`
 }
 
-// Placeholder top-level pod resource metrics.
-type RawPod struct {
+// RawNode holds node-level unprocessed sample metrics.
+type RawNodeMetrics struct {
 	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata, since this is a synthetic resource.
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+	unversioned.ListMeta `json:"metadata"`
+	// Reference to the measured Node.
+	NodeName string `json:"nodeName"`
+	// Overall node metrics.
+	Total []AggregateSample `json:"total,omitempty" patchStrategy:"merge" patchMergeKey:"sampleTime"`
+	// Metrics of system daemons tracked as raw containers, which may include:
+	//   "/kubelet", "/docker-daemon", "kube-proxy" - Tracks respective component metrics
+	//   "/system" - Tracks metrics of non-kubernetes and non-kernel processes (grouped together)
+	SystemContainers []RawContainerMetrics `json:"systemContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+}
+
+// RawNodeMetricsList holds a list of RawNodeMetrics.
+// Endpoints which return this type respect unversioned.ListOptions
+type RawNodeMetricsList struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata.
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+	unversioned.ListMeta `json:"metadata,omitempty"`
+	// List of raw node metrics.
+	Items []RawNodeMetrics `json:"items"`
+}
+
+// RawPod holds pod-level unprocessed sample metrics.
+type RawPodMetrics struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata, since this is a synthetic resource.
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+	unversioned.ListMeta `json:"metadata"`
+	// Reference to the measured Pod.
+	PodRef NonLocalObjectReference `json:"podRef"`
+	// Metrics of containers in the measured pod.
+	Containers []RawContainerMetrics `json:"containers" patchStrategy:"merge" patchMergeKey:"name"`
+	// Historical metric samples of pod-level resources.
+	Samples []PodSample `json:"samples" patchStrategy:"merge" patchMergeKey:"sampleTime"`
+}
+
+// RawPodMetricsList holds a list of RawPodMetrics.
+// Endpoints which return this type respect unversioned.ListOptions
+type RawPodMetricsList struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata.
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+	unversioned.ListMeta `json:"metadata,omitempty"`
+	// List of raw pod metrics.
+	Items []RawPodMetrics `json:"items"`
+}
+
+// RawContainerMetrics holds container-level unprocessed sample metrics.
+type RawContainerMetrics struct {
+	// Reference to the measured container.
+	Name string `json:"name"`
+	// Metadata labels associated with this container (not Kubernetes labels).
+	// For example, docker labels.
+	Labels map[string]string `json:"labels,omitempty"`
+	// Historical metric samples gathered from the container.
+	Samples []ContainerSample `json:"samples" patchStrategy:"merge" patchMergeKey:"sampleTime"`
+	// Application-specific metrics.
+	CustomMetrics []CustomMetric `json:"customMetrics,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+}
+
+// NonLocalObjectReference contains enough information to locate the referenced object.
+type NonLocalObjectReference struct {
+	Name      string    `json:"name"`
+	Namespace string    `json:"namespace"`
+	UID       types.UID `json:"uid,omitempty"`
+}
+
+// Sample defines metadata common to all sample types.
+// Samples may not be nested within other samples.
+type Sample struct {
+	// The time this data point was collected at.
+	SampleTime unversioned.Time `json:"sampleTime"`
+}
+
+// AggregateSample contains a metric sample point of data aggregated across containers.
+type AggregateSample struct {
+	Sample `json:",inline"`
+	// Metrics pertaining to CPU resources.
+	CPU *CPUMetrics `json:"cpu,omitempty"`
+	// Metrics pertaining to memory (RAM) resources.
+	Memory *MemoryMetrics `json:"memory,omitempty"`
+	// Metrics pertaining to network resources.
+	Network *NetworkMetrics `json:"network,omitempty"`
+}
+
+// PodSample contains a metric sample point of pod-level resources.
+type PodSample struct {
+	Sample `json:",inline"`
+	// Metrics pertaining to network resources.
+	Network *NetworkMetrics `json:"network,omitempty"`
+}
+
+// ContainerSample contains a metric sample point of container-level resources.
+type ContainerSample struct {
+	Sample `json:",inline"`
+	// Metrics pertaining to CPU resources.
+	CPU *CPUMetrics `json:"cpu,omitempty"`
+	// Metrics pertaining to memory (RAM) resources.
+	Memory *MemoryMetrics `json:"memory,omitempty"`
+}
+
+// NetworkMetrics contains data about network resources.
+type NetworkMetrics struct {
+	// Cumulative count of bytes received.
+	RxBytes *resource.Quantity `json:"rxBytes,omitempty"`
+	// Cumulative count of receive errors encountered.
+	RxErrors *int64 `json:"rxErrors,omitempty"`
+	// Cumulative count of bytes transmitted.
+	TxBytes *resource.Quantity `json:"txBytes,omitempty"`
+	// Cumulative count of transmit errors encountered.
+	TxErrors *int64 `json:"txErrors,omitempty"`
+}
+
+// CPUMetrics contains data about CPU usage.
+type CPUMetrics struct {
+	// Total CPU usage (sum of all cores) averaged over the sample window.
+	// The "core" unit can be interpreted as CPU core-seconds per second.
+	TotalCores *resource.Quantity `json:"totalCores,omitempty"`
+	// CPU load that the container is experiencing, represented as a smoothed average of number of
+	// runnable threads.  Load is averaged over the sampling window.
+	LoadAverage *resource.Quantity `json:"loadAverage,omitempty"`
+}
+
+// MemoryMetrics contains data about memory usage.
+type MemoryMetrics struct {
+	// Total memory in use. This includes all memory regardless of when it was accessed.
+	TotalBytes *resource.Quantity `json:"totalBytes,omitempty"`
+	// The amount of working set memory. This includes recently accessed memory,
+	// dirty memory, and kernel memory. UsageBytes is <= TotalBytes.
+	UsageBytes *resource.Quantity `json:"usageBytes,omitempty"`
+	// Cumulative number of minor page faults.
+	PageFaults *int64 `json:"pageFaults,omitempty"`
+	// Cumulative number of major page faults.
+	MajorPageFaults *int64 `json:"majorPageFaults,omitempty"`
+}
+
+// CustomMetricType specifies the type of metric being exported.
+type CustomMetricType string
+
+const (
+	// Instantaneous value. May increase or decrease.
+	CustomMetricGauge CustomMetricType = "Gauge"
+	// A counter-like value that increases monotonically.
+	CustomMetricCumulative CustomMetricType = "Cumulative"
+	// Rate over a time period.
+	CustomMetricDelta CustomMetricType = "Delta"
+)
+
+// CustomMetric provides custom application metric data.
+// See https://github.com/google/cadvisor/blob/master/docs/application_metrics.md
+type CustomMetric struct {
+	// The name of the metric.
+	Name string `json:"name"`
+	// Type of the metric.
+	Type CustomMetricType `json:"type"`
+	// Display Unit for the sample values.
+	Unit string `json:"unit"`
+	// Historical custom metric samples.
+	Samples []CustomMetricSample `json:"samples,omitempty" patchStrategy:"merge" patchMergeKey:"sampleTime"`
+}
+
+// CustomMetric contains a single sample point for a custom metric.
+type CustomMetricSample struct {
+	Sample `json:",inline"`
+	// Label associated with a metric
+	Label *string `json:"label,omitempty"`
+	// The value of the metric at this point.
+	// The unit is defined by the CustomMetric this sample belongs to.
+	Value resource.Quantity `json:"value"`
+}
+
+// RawMetricsOptions are the query options for raw metrics endpoints.
+type RawMetricsOptions struct {
+	// Only include samples with sampleTime equal to or more recent than this time.
+	// This does not affect cumulative values, which are cumulative from object creation.
+	SinceTime *unversioned.Time `json:"sinceTime,omitempty"`
+	// Only include samples with sampleTime equal to or less recent than this time.
+	UntilTime *unversioned.Time `json:"untilTime,omitempty"`
+	// Specifies the maximum number of elements in any list of samples.
+	// When the total number of samples exceeds the maximum the most recent samples are returned.
+	MaxSamples int `json:"maxSamples,omitempty"`
 }

--- a/pkg/apis/metrics/types.go
+++ b/pkg/apis/metrics/types.go
@@ -92,8 +92,6 @@ type RawContainerMetrics struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// Historical metric samples gathered from the container.
 	Samples []ContainerSample `json:"samples" patchStrategy:"merge" patchMergeKey:"sampleTime"`
-	// Application-specific metrics.
-	CustomMetrics []CustomMetric `json:"customMetrics,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // NonLocalObjectReference contains enough information to locate the referenced object.
@@ -181,41 +179,6 @@ type FilesystemMetrics struct {
 	UsageBytes *resource.Quantity `json:"usageBytes,omitempty"`
 	// Number of bytes that can be consumed by the container on this filesystem.
 	LimitBytes *resource.Quantity `json:"limitBytes,omitempty"`
-}
-
-// CustomMetricType specifies the type of metric being exported.
-type CustomMetricType string
-
-const (
-	// Instantaneous value. May increase or decrease.
-	CustomMetricGauge CustomMetricType = "Gauge"
-	// A counter-like value that increases monotonically.
-	CustomMetricCumulative CustomMetricType = "Cumulative"
-	// Rate over a time period.
-	CustomMetricDelta CustomMetricType = "Delta"
-)
-
-// CustomMetric provides custom application metric data.
-// See https://github.com/google/cadvisor/blob/master/docs/application_metrics.md
-type CustomMetric struct {
-	// The name of the metric.
-	Name string `json:"name"`
-	// Type of the metric.
-	Type CustomMetricType `json:"type"`
-	// Display Unit for the sample values.
-	Unit string `json:"unit"`
-	// Historical custom metric samples.
-	Samples []CustomMetricSample `json:"samples,omitempty" patchStrategy:"merge" patchMergeKey:"sampleTime"`
-}
-
-// CustomMetric contains a single sample point for a custom metric.
-type CustomMetricSample struct {
-	Sample `json:",inline"`
-	// Label associated with a metric
-	Label *string `json:"label,omitempty"`
-	// The value of the metric at this point.
-	// The unit is defined by the CustomMetric this sample belongs to.
-	Value resource.Quantity `json:"value"`
 }
 
 // RawMetricsOptions are the query options for raw metrics endpoints.

--- a/pkg/apis/metrics/types.go
+++ b/pkg/apis/metrics/types.go
@@ -119,6 +119,8 @@ type AggregateSample struct {
 	Memory *MemoryMetrics `json:"memory,omitempty"`
 	// Metrics pertaining to network resources.
 	Network *NetworkMetrics `json:"network,omitempty"`
+	// Metrics pertaining to filesystem resources. Reported per-device.
+	Filesystem []FilesystemMetrics `json:"filesystem,omitempty" patchStrategy:"merge" patchMergeKey:"device"`
 }
 
 // PodSample contains a metric sample point of pod-level resources.
@@ -135,6 +137,8 @@ type ContainerSample struct {
 	CPU *CPUMetrics `json:"cpu,omitempty"`
 	// Metrics pertaining to memory (RAM) resources.
 	Memory *MemoryMetrics `json:"memory,omitempty"`
+	// Metrics pertaining to filesystem resources. Reported per-device.
+	Filesystem []FilesystemMetrics `json:"filesystem,omitempty" patchStrategy:"merge" patchMergeKey:"device"`
 }
 
 // NetworkMetrics contains data about network resources.
@@ -170,6 +174,16 @@ type MemoryMetrics struct {
 	PageFaults *int64 `json:"pageFaults,omitempty"`
 	// Cumulative number of major page faults.
 	MajorPageFaults *int64 `json:"majorPageFaults,omitempty"`
+}
+
+// FilesystemMetrics contains data about filesystem usage.
+type FilesystemMetrics struct {
+	// The block device name associated with the filesystem.
+	Device string `json:"device"`
+	// Number of bytes that is consumed by the container on this filesystem.
+	UsageBytes *resource.Quantity `json:"usageBytes,omitempty"`
+	// Number of bytes that can be consumed by the container on this filesystem.
+	LimitBytes *resource.Quantity `json:"limitBytes,omitempty"`
 }
 
 // CustomMetricType specifies the type of metric being exported.

--- a/pkg/apis/metrics/v1alpha1/conversion_generated.go
+++ b/pkg/apis/metrics/v1alpha1/conversion_generated.go
@@ -18,77 +18,10 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	reflect "reflect"
-
-	api "k8s.io/kubernetes/pkg/api"
-	metrics "k8s.io/kubernetes/pkg/apis/metrics"
-	conversion "k8s.io/kubernetes/pkg/conversion"
-)
-
-func autoconvert_metrics_RawNode_To_v1alpha1_RawNode(in *metrics.RawNode, out *RawNode, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*metrics.RawNode))(in)
-	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_metrics_RawNode_To_v1alpha1_RawNode(in *metrics.RawNode, out *RawNode, s conversion.Scope) error {
-	return autoconvert_metrics_RawNode_To_v1alpha1_RawNode(in, out, s)
-}
-
-func autoconvert_metrics_RawPod_To_v1alpha1_RawPod(in *metrics.RawPod, out *RawPod, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*metrics.RawPod))(in)
-	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_metrics_RawPod_To_v1alpha1_RawPod(in *metrics.RawPod, out *RawPod, s conversion.Scope) error {
-	return autoconvert_metrics_RawPod_To_v1alpha1_RawPod(in, out, s)
-}
-
-func autoconvert_v1alpha1_RawNode_To_metrics_RawNode(in *RawNode, out *metrics.RawNode, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*RawNode))(in)
-	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_v1alpha1_RawNode_To_metrics_RawNode(in *RawNode, out *metrics.RawNode, s conversion.Scope) error {
-	return autoconvert_v1alpha1_RawNode_To_metrics_RawNode(in, out, s)
-}
-
-func autoconvert_v1alpha1_RawPod_To_metrics_RawPod(in *RawPod, out *metrics.RawPod, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*RawPod))(in)
-	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_v1alpha1_RawPod_To_metrics_RawPod(in *RawPod, out *metrics.RawPod, s conversion.Scope) error {
-	return autoconvert_v1alpha1_RawPod_To_metrics_RawPod(in, out, s)
-}
+import api "k8s.io/kubernetes/pkg/api"
 
 func init() {
-	err := api.Scheme.AddGeneratedConversionFuncs(
-		autoconvert_metrics_RawNode_To_v1alpha1_RawNode,
-		autoconvert_metrics_RawPod_To_v1alpha1_RawPod,
-		autoconvert_v1alpha1_RawNode_To_metrics_RawNode,
-		autoconvert_v1alpha1_RawPod_To_metrics_RawPod,
-	)
+	err := api.Scheme.AddGeneratedConversionFuncs()
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)

--- a/pkg/apis/metrics/v1alpha1/conversion_generated.go
+++ b/pkg/apis/metrics/v1alpha1/conversion_generated.go
@@ -18,10 +18,933 @@ limitations under the License.
 
 package v1alpha1
 
-import api "k8s.io/kubernetes/pkg/api"
+import (
+	reflect "reflect"
+
+	api "k8s.io/kubernetes/pkg/api"
+	metrics "k8s.io/kubernetes/pkg/apis/metrics"
+	conversion "k8s.io/kubernetes/pkg/conversion"
+)
+
+func autoconvert_metrics_AggregateSample_To_v1alpha1_AggregateSample(in *metrics.AggregateSample, out *AggregateSample, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.AggregateSample))(in)
+	}
+	if err := convert_metrics_Sample_To_v1alpha1_Sample(&in.Sample, &out.Sample, s); err != nil {
+		return err
+	}
+	if in.CPU != nil {
+		out.CPU = new(CPUMetrics)
+		if err := convert_metrics_CPUMetrics_To_v1alpha1_CPUMetrics(in.CPU, out.CPU, s); err != nil {
+			return err
+		}
+	} else {
+		out.CPU = nil
+	}
+	if in.Memory != nil {
+		out.Memory = new(MemoryMetrics)
+		if err := convert_metrics_MemoryMetrics_To_v1alpha1_MemoryMetrics(in.Memory, out.Memory, s); err != nil {
+			return err
+		}
+	} else {
+		out.Memory = nil
+	}
+	if in.Network != nil {
+		out.Network = new(NetworkMetrics)
+		if err := convert_metrics_NetworkMetrics_To_v1alpha1_NetworkMetrics(in.Network, out.Network, s); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	if in.Filesystem != nil {
+		out.Filesystem = make([]FilesystemMetrics, len(in.Filesystem))
+		for i := range in.Filesystem {
+			if err := convert_metrics_FilesystemMetrics_To_v1alpha1_FilesystemMetrics(&in.Filesystem[i], &out.Filesystem[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Filesystem = nil
+	}
+	return nil
+}
+
+func convert_metrics_AggregateSample_To_v1alpha1_AggregateSample(in *metrics.AggregateSample, out *AggregateSample, s conversion.Scope) error {
+	return autoconvert_metrics_AggregateSample_To_v1alpha1_AggregateSample(in, out, s)
+}
+
+func autoconvert_metrics_CPUMetrics_To_v1alpha1_CPUMetrics(in *metrics.CPUMetrics, out *CPUMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.CPUMetrics))(in)
+	}
+	if in.TotalCores != nil {
+		if err := s.Convert(&in.TotalCores, &out.TotalCores, 0); err != nil {
+			return err
+		}
+	} else {
+		out.TotalCores = nil
+	}
+	return nil
+}
+
+func convert_metrics_CPUMetrics_To_v1alpha1_CPUMetrics(in *metrics.CPUMetrics, out *CPUMetrics, s conversion.Scope) error {
+	return autoconvert_metrics_CPUMetrics_To_v1alpha1_CPUMetrics(in, out, s)
+}
+
+func autoconvert_metrics_ContainerSample_To_v1alpha1_ContainerSample(in *metrics.ContainerSample, out *ContainerSample, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.ContainerSample))(in)
+	}
+	if err := convert_metrics_Sample_To_v1alpha1_Sample(&in.Sample, &out.Sample, s); err != nil {
+		return err
+	}
+	if in.CPU != nil {
+		out.CPU = new(CPUMetrics)
+		if err := convert_metrics_CPUMetrics_To_v1alpha1_CPUMetrics(in.CPU, out.CPU, s); err != nil {
+			return err
+		}
+	} else {
+		out.CPU = nil
+	}
+	if in.Memory != nil {
+		out.Memory = new(MemoryMetrics)
+		if err := convert_metrics_MemoryMetrics_To_v1alpha1_MemoryMetrics(in.Memory, out.Memory, s); err != nil {
+			return err
+		}
+	} else {
+		out.Memory = nil
+	}
+	if in.Filesystem != nil {
+		out.Filesystem = make([]FilesystemMetrics, len(in.Filesystem))
+		for i := range in.Filesystem {
+			if err := convert_metrics_FilesystemMetrics_To_v1alpha1_FilesystemMetrics(&in.Filesystem[i], &out.Filesystem[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Filesystem = nil
+	}
+	return nil
+}
+
+func convert_metrics_ContainerSample_To_v1alpha1_ContainerSample(in *metrics.ContainerSample, out *ContainerSample, s conversion.Scope) error {
+	return autoconvert_metrics_ContainerSample_To_v1alpha1_ContainerSample(in, out, s)
+}
+
+func autoconvert_metrics_FilesystemMetrics_To_v1alpha1_FilesystemMetrics(in *metrics.FilesystemMetrics, out *FilesystemMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.FilesystemMetrics))(in)
+	}
+	out.Device = in.Device
+	if in.UsageBytes != nil {
+		if err := s.Convert(&in.UsageBytes, &out.UsageBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.UsageBytes = nil
+	}
+	if in.LimitBytes != nil {
+		if err := s.Convert(&in.LimitBytes, &out.LimitBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.LimitBytes = nil
+	}
+	return nil
+}
+
+func convert_metrics_FilesystemMetrics_To_v1alpha1_FilesystemMetrics(in *metrics.FilesystemMetrics, out *FilesystemMetrics, s conversion.Scope) error {
+	return autoconvert_metrics_FilesystemMetrics_To_v1alpha1_FilesystemMetrics(in, out, s)
+}
+
+func autoconvert_metrics_MemoryMetrics_To_v1alpha1_MemoryMetrics(in *metrics.MemoryMetrics, out *MemoryMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.MemoryMetrics))(in)
+	}
+	if in.TotalBytes != nil {
+		if err := s.Convert(&in.TotalBytes, &out.TotalBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.TotalBytes = nil
+	}
+	if in.UsageBytes != nil {
+		if err := s.Convert(&in.UsageBytes, &out.UsageBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.UsageBytes = nil
+	}
+	if in.PageFaults != nil {
+		out.PageFaults = new(int64)
+		*out.PageFaults = *in.PageFaults
+	} else {
+		out.PageFaults = nil
+	}
+	if in.MajorPageFaults != nil {
+		out.MajorPageFaults = new(int64)
+		*out.MajorPageFaults = *in.MajorPageFaults
+	} else {
+		out.MajorPageFaults = nil
+	}
+	return nil
+}
+
+func convert_metrics_MemoryMetrics_To_v1alpha1_MemoryMetrics(in *metrics.MemoryMetrics, out *MemoryMetrics, s conversion.Scope) error {
+	return autoconvert_metrics_MemoryMetrics_To_v1alpha1_MemoryMetrics(in, out, s)
+}
+
+func autoconvert_metrics_MetricsMeta_To_v1alpha1_MetricsMeta(in *metrics.MetricsMeta, out *MetricsMeta, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.MetricsMeta))(in)
+	}
+	out.SelfLink = in.SelfLink
+	return nil
+}
+
+func convert_metrics_MetricsMeta_To_v1alpha1_MetricsMeta(in *metrics.MetricsMeta, out *MetricsMeta, s conversion.Scope) error {
+	return autoconvert_metrics_MetricsMeta_To_v1alpha1_MetricsMeta(in, out, s)
+}
+
+func autoconvert_metrics_NetworkMetrics_To_v1alpha1_NetworkMetrics(in *metrics.NetworkMetrics, out *NetworkMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.NetworkMetrics))(in)
+	}
+	if in.RxBytes != nil {
+		if err := s.Convert(&in.RxBytes, &out.RxBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RxBytes = nil
+	}
+	if in.RxErrors != nil {
+		out.RxErrors = new(int64)
+		*out.RxErrors = *in.RxErrors
+	} else {
+		out.RxErrors = nil
+	}
+	if in.TxBytes != nil {
+		if err := s.Convert(&in.TxBytes, &out.TxBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.TxBytes = nil
+	}
+	if in.TxErrors != nil {
+		out.TxErrors = new(int64)
+		*out.TxErrors = *in.TxErrors
+	} else {
+		out.TxErrors = nil
+	}
+	return nil
+}
+
+func convert_metrics_NetworkMetrics_To_v1alpha1_NetworkMetrics(in *metrics.NetworkMetrics, out *NetworkMetrics, s conversion.Scope) error {
+	return autoconvert_metrics_NetworkMetrics_To_v1alpha1_NetworkMetrics(in, out, s)
+}
+
+func autoconvert_metrics_NonLocalObjectReference_To_v1alpha1_NonLocalObjectReference(in *metrics.NonLocalObjectReference, out *NonLocalObjectReference, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.NonLocalObjectReference))(in)
+	}
+	out.Name = in.Name
+	out.Namespace = in.Namespace
+	out.UID = in.UID
+	return nil
+}
+
+func convert_metrics_NonLocalObjectReference_To_v1alpha1_NonLocalObjectReference(in *metrics.NonLocalObjectReference, out *NonLocalObjectReference, s conversion.Scope) error {
+	return autoconvert_metrics_NonLocalObjectReference_To_v1alpha1_NonLocalObjectReference(in, out, s)
+}
+
+func autoconvert_metrics_PodSample_To_v1alpha1_PodSample(in *metrics.PodSample, out *PodSample, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.PodSample))(in)
+	}
+	if err := convert_metrics_Sample_To_v1alpha1_Sample(&in.Sample, &out.Sample, s); err != nil {
+		return err
+	}
+	if in.Network != nil {
+		out.Network = new(NetworkMetrics)
+		if err := convert_metrics_NetworkMetrics_To_v1alpha1_NetworkMetrics(in.Network, out.Network, s); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	return nil
+}
+
+func convert_metrics_PodSample_To_v1alpha1_PodSample(in *metrics.PodSample, out *PodSample, s conversion.Scope) error {
+	return autoconvert_metrics_PodSample_To_v1alpha1_PodSample(in, out, s)
+}
+
+func autoconvert_metrics_RawContainerMetrics_To_v1alpha1_RawContainerMetrics(in *metrics.RawContainerMetrics, out *RawContainerMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.RawContainerMetrics))(in)
+	}
+	out.Name = in.Name
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Samples != nil {
+		out.Samples = make([]ContainerSample, len(in.Samples))
+		for i := range in.Samples {
+			if err := convert_metrics_ContainerSample_To_v1alpha1_ContainerSample(&in.Samples[i], &out.Samples[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Samples = nil
+	}
+	return nil
+}
+
+func convert_metrics_RawContainerMetrics_To_v1alpha1_RawContainerMetrics(in *metrics.RawContainerMetrics, out *RawContainerMetrics, s conversion.Scope) error {
+	return autoconvert_metrics_RawContainerMetrics_To_v1alpha1_RawContainerMetrics(in, out, s)
+}
+
+func autoconvert_metrics_RawMetricsOptions_To_v1alpha1_RawMetricsOptions(in *metrics.RawMetricsOptions, out *RawMetricsOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.RawMetricsOptions))(in)
+	}
+	out.MaxSamples = in.MaxSamples
+	return nil
+}
+
+func convert_metrics_RawMetricsOptions_To_v1alpha1_RawMetricsOptions(in *metrics.RawMetricsOptions, out *RawMetricsOptions, s conversion.Scope) error {
+	return autoconvert_metrics_RawMetricsOptions_To_v1alpha1_RawMetricsOptions(in, out, s)
+}
+
+func autoconvert_metrics_RawNodeMetrics_To_v1alpha1_RawNodeMetrics(in *metrics.RawNodeMetrics, out *RawNodeMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.RawNodeMetrics))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	out.NodeName = in.NodeName
+	if in.Total != nil {
+		out.Total = make([]AggregateSample, len(in.Total))
+		for i := range in.Total {
+			if err := convert_metrics_AggregateSample_To_v1alpha1_AggregateSample(&in.Total[i], &out.Total[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Total = nil
+	}
+	if in.SystemContainers != nil {
+		out.SystemContainers = make([]RawContainerMetrics, len(in.SystemContainers))
+		for i := range in.SystemContainers {
+			if err := convert_metrics_RawContainerMetrics_To_v1alpha1_RawContainerMetrics(&in.SystemContainers[i], &out.SystemContainers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.SystemContainers = nil
+	}
+	return nil
+}
+
+func convert_metrics_RawNodeMetrics_To_v1alpha1_RawNodeMetrics(in *metrics.RawNodeMetrics, out *RawNodeMetrics, s conversion.Scope) error {
+	return autoconvert_metrics_RawNodeMetrics_To_v1alpha1_RawNodeMetrics(in, out, s)
+}
+
+func autoconvert_metrics_RawNodeMetricsList_To_v1alpha1_RawNodeMetricsList(in *metrics.RawNodeMetricsList, out *RawNodeMetricsList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.RawNodeMetricsList))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]RawNodeMetrics, len(in.Items))
+		for i := range in.Items {
+			if err := convert_metrics_RawNodeMetrics_To_v1alpha1_RawNodeMetrics(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_metrics_RawNodeMetricsList_To_v1alpha1_RawNodeMetricsList(in *metrics.RawNodeMetricsList, out *RawNodeMetricsList, s conversion.Scope) error {
+	return autoconvert_metrics_RawNodeMetricsList_To_v1alpha1_RawNodeMetricsList(in, out, s)
+}
+
+func autoconvert_metrics_RawPodMetrics_To_v1alpha1_RawPodMetrics(in *metrics.RawPodMetrics, out *RawPodMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.RawPodMetrics))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	if err := convert_metrics_NonLocalObjectReference_To_v1alpha1_NonLocalObjectReference(&in.PodRef, &out.PodRef, s); err != nil {
+		return err
+	}
+	if in.Containers != nil {
+		out.Containers = make([]RawContainerMetrics, len(in.Containers))
+		for i := range in.Containers {
+			if err := convert_metrics_RawContainerMetrics_To_v1alpha1_RawContainerMetrics(&in.Containers[i], &out.Containers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Containers = nil
+	}
+	if in.Samples != nil {
+		out.Samples = make([]PodSample, len(in.Samples))
+		for i := range in.Samples {
+			if err := convert_metrics_PodSample_To_v1alpha1_PodSample(&in.Samples[i], &out.Samples[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Samples = nil
+	}
+	return nil
+}
+
+func convert_metrics_RawPodMetrics_To_v1alpha1_RawPodMetrics(in *metrics.RawPodMetrics, out *RawPodMetrics, s conversion.Scope) error {
+	return autoconvert_metrics_RawPodMetrics_To_v1alpha1_RawPodMetrics(in, out, s)
+}
+
+func autoconvert_metrics_RawPodMetricsList_To_v1alpha1_RawPodMetricsList(in *metrics.RawPodMetricsList, out *RawPodMetricsList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.RawPodMetricsList))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]RawPodMetrics, len(in.Items))
+		for i := range in.Items {
+			if err := convert_metrics_RawPodMetrics_To_v1alpha1_RawPodMetrics(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_metrics_RawPodMetricsList_To_v1alpha1_RawPodMetricsList(in *metrics.RawPodMetricsList, out *RawPodMetricsList, s conversion.Scope) error {
+	return autoconvert_metrics_RawPodMetricsList_To_v1alpha1_RawPodMetricsList(in, out, s)
+}
+
+func autoconvert_metrics_Sample_To_v1alpha1_Sample(in *metrics.Sample, out *Sample, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.Sample))(in)
+	}
+	if err := s.Convert(&in.SampleTime, &out.SampleTime, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_metrics_Sample_To_v1alpha1_Sample(in *metrics.Sample, out *Sample, s conversion.Scope) error {
+	return autoconvert_metrics_Sample_To_v1alpha1_Sample(in, out, s)
+}
+
+func autoconvert_v1alpha1_AggregateSample_To_metrics_AggregateSample(in *AggregateSample, out *metrics.AggregateSample, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*AggregateSample))(in)
+	}
+	if err := convert_v1alpha1_Sample_To_metrics_Sample(&in.Sample, &out.Sample, s); err != nil {
+		return err
+	}
+	if in.CPU != nil {
+		out.CPU = new(metrics.CPUMetrics)
+		if err := convert_v1alpha1_CPUMetrics_To_metrics_CPUMetrics(in.CPU, out.CPU, s); err != nil {
+			return err
+		}
+	} else {
+		out.CPU = nil
+	}
+	if in.Memory != nil {
+		out.Memory = new(metrics.MemoryMetrics)
+		if err := convert_v1alpha1_MemoryMetrics_To_metrics_MemoryMetrics(in.Memory, out.Memory, s); err != nil {
+			return err
+		}
+	} else {
+		out.Memory = nil
+	}
+	if in.Network != nil {
+		out.Network = new(metrics.NetworkMetrics)
+		if err := convert_v1alpha1_NetworkMetrics_To_metrics_NetworkMetrics(in.Network, out.Network, s); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	if in.Filesystem != nil {
+		out.Filesystem = make([]metrics.FilesystemMetrics, len(in.Filesystem))
+		for i := range in.Filesystem {
+			if err := convert_v1alpha1_FilesystemMetrics_To_metrics_FilesystemMetrics(&in.Filesystem[i], &out.Filesystem[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Filesystem = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_AggregateSample_To_metrics_AggregateSample(in *AggregateSample, out *metrics.AggregateSample, s conversion.Scope) error {
+	return autoconvert_v1alpha1_AggregateSample_To_metrics_AggregateSample(in, out, s)
+}
+
+func autoconvert_v1alpha1_CPUMetrics_To_metrics_CPUMetrics(in *CPUMetrics, out *metrics.CPUMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*CPUMetrics))(in)
+	}
+	if in.TotalCores != nil {
+		if err := s.Convert(&in.TotalCores, &out.TotalCores, 0); err != nil {
+			return err
+		}
+	} else {
+		out.TotalCores = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_CPUMetrics_To_metrics_CPUMetrics(in *CPUMetrics, out *metrics.CPUMetrics, s conversion.Scope) error {
+	return autoconvert_v1alpha1_CPUMetrics_To_metrics_CPUMetrics(in, out, s)
+}
+
+func autoconvert_v1alpha1_ContainerSample_To_metrics_ContainerSample(in *ContainerSample, out *metrics.ContainerSample, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ContainerSample))(in)
+	}
+	if err := convert_v1alpha1_Sample_To_metrics_Sample(&in.Sample, &out.Sample, s); err != nil {
+		return err
+	}
+	if in.CPU != nil {
+		out.CPU = new(metrics.CPUMetrics)
+		if err := convert_v1alpha1_CPUMetrics_To_metrics_CPUMetrics(in.CPU, out.CPU, s); err != nil {
+			return err
+		}
+	} else {
+		out.CPU = nil
+	}
+	if in.Memory != nil {
+		out.Memory = new(metrics.MemoryMetrics)
+		if err := convert_v1alpha1_MemoryMetrics_To_metrics_MemoryMetrics(in.Memory, out.Memory, s); err != nil {
+			return err
+		}
+	} else {
+		out.Memory = nil
+	}
+	if in.Filesystem != nil {
+		out.Filesystem = make([]metrics.FilesystemMetrics, len(in.Filesystem))
+		for i := range in.Filesystem {
+			if err := convert_v1alpha1_FilesystemMetrics_To_metrics_FilesystemMetrics(&in.Filesystem[i], &out.Filesystem[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Filesystem = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_ContainerSample_To_metrics_ContainerSample(in *ContainerSample, out *metrics.ContainerSample, s conversion.Scope) error {
+	return autoconvert_v1alpha1_ContainerSample_To_metrics_ContainerSample(in, out, s)
+}
+
+func autoconvert_v1alpha1_FilesystemMetrics_To_metrics_FilesystemMetrics(in *FilesystemMetrics, out *metrics.FilesystemMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*FilesystemMetrics))(in)
+	}
+	out.Device = in.Device
+	if in.UsageBytes != nil {
+		if err := s.Convert(&in.UsageBytes, &out.UsageBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.UsageBytes = nil
+	}
+	if in.LimitBytes != nil {
+		if err := s.Convert(&in.LimitBytes, &out.LimitBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.LimitBytes = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_FilesystemMetrics_To_metrics_FilesystemMetrics(in *FilesystemMetrics, out *metrics.FilesystemMetrics, s conversion.Scope) error {
+	return autoconvert_v1alpha1_FilesystemMetrics_To_metrics_FilesystemMetrics(in, out, s)
+}
+
+func autoconvert_v1alpha1_MemoryMetrics_To_metrics_MemoryMetrics(in *MemoryMetrics, out *metrics.MemoryMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*MemoryMetrics))(in)
+	}
+	if in.TotalBytes != nil {
+		if err := s.Convert(&in.TotalBytes, &out.TotalBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.TotalBytes = nil
+	}
+	if in.UsageBytes != nil {
+		if err := s.Convert(&in.UsageBytes, &out.UsageBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.UsageBytes = nil
+	}
+	if in.PageFaults != nil {
+		out.PageFaults = new(int64)
+		*out.PageFaults = *in.PageFaults
+	} else {
+		out.PageFaults = nil
+	}
+	if in.MajorPageFaults != nil {
+		out.MajorPageFaults = new(int64)
+		*out.MajorPageFaults = *in.MajorPageFaults
+	} else {
+		out.MajorPageFaults = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_MemoryMetrics_To_metrics_MemoryMetrics(in *MemoryMetrics, out *metrics.MemoryMetrics, s conversion.Scope) error {
+	return autoconvert_v1alpha1_MemoryMetrics_To_metrics_MemoryMetrics(in, out, s)
+}
+
+func autoconvert_v1alpha1_MetricsMeta_To_metrics_MetricsMeta(in *MetricsMeta, out *metrics.MetricsMeta, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*MetricsMeta))(in)
+	}
+	out.SelfLink = in.SelfLink
+	return nil
+}
+
+func convert_v1alpha1_MetricsMeta_To_metrics_MetricsMeta(in *MetricsMeta, out *metrics.MetricsMeta, s conversion.Scope) error {
+	return autoconvert_v1alpha1_MetricsMeta_To_metrics_MetricsMeta(in, out, s)
+}
+
+func autoconvert_v1alpha1_NetworkMetrics_To_metrics_NetworkMetrics(in *NetworkMetrics, out *metrics.NetworkMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*NetworkMetrics))(in)
+	}
+	if in.RxBytes != nil {
+		if err := s.Convert(&in.RxBytes, &out.RxBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RxBytes = nil
+	}
+	if in.RxErrors != nil {
+		out.RxErrors = new(int64)
+		*out.RxErrors = *in.RxErrors
+	} else {
+		out.RxErrors = nil
+	}
+	if in.TxBytes != nil {
+		if err := s.Convert(&in.TxBytes, &out.TxBytes, 0); err != nil {
+			return err
+		}
+	} else {
+		out.TxBytes = nil
+	}
+	if in.TxErrors != nil {
+		out.TxErrors = new(int64)
+		*out.TxErrors = *in.TxErrors
+	} else {
+		out.TxErrors = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_NetworkMetrics_To_metrics_NetworkMetrics(in *NetworkMetrics, out *metrics.NetworkMetrics, s conversion.Scope) error {
+	return autoconvert_v1alpha1_NetworkMetrics_To_metrics_NetworkMetrics(in, out, s)
+}
+
+func autoconvert_v1alpha1_NonLocalObjectReference_To_metrics_NonLocalObjectReference(in *NonLocalObjectReference, out *metrics.NonLocalObjectReference, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*NonLocalObjectReference))(in)
+	}
+	out.Name = in.Name
+	out.Namespace = in.Namespace
+	out.UID = in.UID
+	return nil
+}
+
+func convert_v1alpha1_NonLocalObjectReference_To_metrics_NonLocalObjectReference(in *NonLocalObjectReference, out *metrics.NonLocalObjectReference, s conversion.Scope) error {
+	return autoconvert_v1alpha1_NonLocalObjectReference_To_metrics_NonLocalObjectReference(in, out, s)
+}
+
+func autoconvert_v1alpha1_PodSample_To_metrics_PodSample(in *PodSample, out *metrics.PodSample, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*PodSample))(in)
+	}
+	if err := convert_v1alpha1_Sample_To_metrics_Sample(&in.Sample, &out.Sample, s); err != nil {
+		return err
+	}
+	if in.Network != nil {
+		out.Network = new(metrics.NetworkMetrics)
+		if err := convert_v1alpha1_NetworkMetrics_To_metrics_NetworkMetrics(in.Network, out.Network, s); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_PodSample_To_metrics_PodSample(in *PodSample, out *metrics.PodSample, s conversion.Scope) error {
+	return autoconvert_v1alpha1_PodSample_To_metrics_PodSample(in, out, s)
+}
+
+func autoconvert_v1alpha1_RawContainerMetrics_To_metrics_RawContainerMetrics(in *RawContainerMetrics, out *metrics.RawContainerMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*RawContainerMetrics))(in)
+	}
+	out.Name = in.Name
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Samples != nil {
+		out.Samples = make([]metrics.ContainerSample, len(in.Samples))
+		for i := range in.Samples {
+			if err := convert_v1alpha1_ContainerSample_To_metrics_ContainerSample(&in.Samples[i], &out.Samples[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Samples = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_RawContainerMetrics_To_metrics_RawContainerMetrics(in *RawContainerMetrics, out *metrics.RawContainerMetrics, s conversion.Scope) error {
+	return autoconvert_v1alpha1_RawContainerMetrics_To_metrics_RawContainerMetrics(in, out, s)
+}
+
+func autoconvert_v1alpha1_RawMetricsOptions_To_metrics_RawMetricsOptions(in *RawMetricsOptions, out *metrics.RawMetricsOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*RawMetricsOptions))(in)
+	}
+	out.MaxSamples = in.MaxSamples
+	return nil
+}
+
+func convert_v1alpha1_RawMetricsOptions_To_metrics_RawMetricsOptions(in *RawMetricsOptions, out *metrics.RawMetricsOptions, s conversion.Scope) error {
+	return autoconvert_v1alpha1_RawMetricsOptions_To_metrics_RawMetricsOptions(in, out, s)
+}
+
+func autoconvert_v1alpha1_RawNodeMetrics_To_metrics_RawNodeMetrics(in *RawNodeMetrics, out *metrics.RawNodeMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*RawNodeMetrics))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	out.NodeName = in.NodeName
+	if in.Total != nil {
+		out.Total = make([]metrics.AggregateSample, len(in.Total))
+		for i := range in.Total {
+			if err := convert_v1alpha1_AggregateSample_To_metrics_AggregateSample(&in.Total[i], &out.Total[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Total = nil
+	}
+	if in.SystemContainers != nil {
+		out.SystemContainers = make([]metrics.RawContainerMetrics, len(in.SystemContainers))
+		for i := range in.SystemContainers {
+			if err := convert_v1alpha1_RawContainerMetrics_To_metrics_RawContainerMetrics(&in.SystemContainers[i], &out.SystemContainers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.SystemContainers = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_RawNodeMetrics_To_metrics_RawNodeMetrics(in *RawNodeMetrics, out *metrics.RawNodeMetrics, s conversion.Scope) error {
+	return autoconvert_v1alpha1_RawNodeMetrics_To_metrics_RawNodeMetrics(in, out, s)
+}
+
+func autoconvert_v1alpha1_RawNodeMetricsList_To_metrics_RawNodeMetricsList(in *RawNodeMetricsList, out *metrics.RawNodeMetricsList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*RawNodeMetricsList))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]metrics.RawNodeMetrics, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1alpha1_RawNodeMetrics_To_metrics_RawNodeMetrics(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_RawNodeMetricsList_To_metrics_RawNodeMetricsList(in *RawNodeMetricsList, out *metrics.RawNodeMetricsList, s conversion.Scope) error {
+	return autoconvert_v1alpha1_RawNodeMetricsList_To_metrics_RawNodeMetricsList(in, out, s)
+}
+
+func autoconvert_v1alpha1_RawPodMetrics_To_metrics_RawPodMetrics(in *RawPodMetrics, out *metrics.RawPodMetrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*RawPodMetrics))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	if err := convert_v1alpha1_NonLocalObjectReference_To_metrics_NonLocalObjectReference(&in.PodRef, &out.PodRef, s); err != nil {
+		return err
+	}
+	if in.Containers != nil {
+		out.Containers = make([]metrics.RawContainerMetrics, len(in.Containers))
+		for i := range in.Containers {
+			if err := convert_v1alpha1_RawContainerMetrics_To_metrics_RawContainerMetrics(&in.Containers[i], &out.Containers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Containers = nil
+	}
+	if in.Samples != nil {
+		out.Samples = make([]metrics.PodSample, len(in.Samples))
+		for i := range in.Samples {
+			if err := convert_v1alpha1_PodSample_To_metrics_PodSample(&in.Samples[i], &out.Samples[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Samples = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_RawPodMetrics_To_metrics_RawPodMetrics(in *RawPodMetrics, out *metrics.RawPodMetrics, s conversion.Scope) error {
+	return autoconvert_v1alpha1_RawPodMetrics_To_metrics_RawPodMetrics(in, out, s)
+}
+
+func autoconvert_v1alpha1_RawPodMetricsList_To_metrics_RawPodMetricsList(in *RawPodMetricsList, out *metrics.RawPodMetricsList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*RawPodMetricsList))(in)
+	}
+	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]metrics.RawPodMetrics, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1alpha1_RawPodMetrics_To_metrics_RawPodMetrics(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1alpha1_RawPodMetricsList_To_metrics_RawPodMetricsList(in *RawPodMetricsList, out *metrics.RawPodMetricsList, s conversion.Scope) error {
+	return autoconvert_v1alpha1_RawPodMetricsList_To_metrics_RawPodMetricsList(in, out, s)
+}
+
+func autoconvert_v1alpha1_Sample_To_metrics_Sample(in *Sample, out *metrics.Sample, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*Sample))(in)
+	}
+	if err := s.Convert(&in.SampleTime, &out.SampleTime, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1alpha1_Sample_To_metrics_Sample(in *Sample, out *metrics.Sample, s conversion.Scope) error {
+	return autoconvert_v1alpha1_Sample_To_metrics_Sample(in, out, s)
+}
 
 func init() {
-	err := api.Scheme.AddGeneratedConversionFuncs()
+	err := api.Scheme.AddGeneratedConversionFuncs(
+		autoconvert_metrics_AggregateSample_To_v1alpha1_AggregateSample,
+		autoconvert_metrics_CPUMetrics_To_v1alpha1_CPUMetrics,
+		autoconvert_metrics_ContainerSample_To_v1alpha1_ContainerSample,
+		autoconvert_metrics_FilesystemMetrics_To_v1alpha1_FilesystemMetrics,
+		autoconvert_metrics_MemoryMetrics_To_v1alpha1_MemoryMetrics,
+		autoconvert_metrics_MetricsMeta_To_v1alpha1_MetricsMeta,
+		autoconvert_metrics_NetworkMetrics_To_v1alpha1_NetworkMetrics,
+		autoconvert_metrics_NonLocalObjectReference_To_v1alpha1_NonLocalObjectReference,
+		autoconvert_metrics_PodSample_To_v1alpha1_PodSample,
+		autoconvert_metrics_RawContainerMetrics_To_v1alpha1_RawContainerMetrics,
+		autoconvert_metrics_RawMetricsOptions_To_v1alpha1_RawMetricsOptions,
+		autoconvert_metrics_RawNodeMetricsList_To_v1alpha1_RawNodeMetricsList,
+		autoconvert_metrics_RawNodeMetrics_To_v1alpha1_RawNodeMetrics,
+		autoconvert_metrics_RawPodMetricsList_To_v1alpha1_RawPodMetricsList,
+		autoconvert_metrics_RawPodMetrics_To_v1alpha1_RawPodMetrics,
+		autoconvert_metrics_Sample_To_v1alpha1_Sample,
+		autoconvert_v1alpha1_AggregateSample_To_metrics_AggregateSample,
+		autoconvert_v1alpha1_CPUMetrics_To_metrics_CPUMetrics,
+		autoconvert_v1alpha1_ContainerSample_To_metrics_ContainerSample,
+		autoconvert_v1alpha1_FilesystemMetrics_To_metrics_FilesystemMetrics,
+		autoconvert_v1alpha1_MemoryMetrics_To_metrics_MemoryMetrics,
+		autoconvert_v1alpha1_MetricsMeta_To_metrics_MetricsMeta,
+		autoconvert_v1alpha1_NetworkMetrics_To_metrics_NetworkMetrics,
+		autoconvert_v1alpha1_NonLocalObjectReference_To_metrics_NonLocalObjectReference,
+		autoconvert_v1alpha1_PodSample_To_metrics_PodSample,
+		autoconvert_v1alpha1_RawContainerMetrics_To_metrics_RawContainerMetrics,
+		autoconvert_v1alpha1_RawMetricsOptions_To_metrics_RawMetricsOptions,
+		autoconvert_v1alpha1_RawNodeMetricsList_To_metrics_RawNodeMetricsList,
+		autoconvert_v1alpha1_RawNodeMetrics_To_metrics_RawNodeMetrics,
+		autoconvert_v1alpha1_RawPodMetricsList_To_metrics_RawPodMetricsList,
+		autoconvert_v1alpha1_RawPodMetrics_To_metrics_RawPodMetrics,
+		autoconvert_v1alpha1_Sample_To_metrics_Sample,
+	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)

--- a/pkg/apis/metrics/v1alpha1/deep_copy_generated.go
+++ b/pkg/apis/metrics/v1alpha1/deep_copy_generated.go
@@ -18,38 +18,10 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	api "k8s.io/kubernetes/pkg/api"
-	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
-	conversion "k8s.io/kubernetes/pkg/conversion"
-)
-
-func deepCopy_unversioned_TypeMeta(in unversioned.TypeMeta, out *unversioned.TypeMeta, c *conversion.Cloner) error {
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
-	return nil
-}
-
-func deepCopy_v1alpha1_RawNode(in RawNode, out *RawNode, c *conversion.Cloner) error {
-	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
-		return err
-	}
-	return nil
-}
-
-func deepCopy_v1alpha1_RawPod(in RawPod, out *RawPod, c *conversion.Cloner) error {
-	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
-		return err
-	}
-	return nil
-}
+import api "k8s.io/kubernetes/pkg/api"
 
 func init() {
-	err := api.Scheme.AddGeneratedDeepCopyFuncs(
-		deepCopy_unversioned_TypeMeta,
-		deepCopy_v1alpha1_RawNode,
-		deepCopy_v1alpha1_RawPod,
-	)
+	err := api.Scheme.AddGeneratedDeepCopyFuncs()
 	if err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.
 		panic(err)

--- a/pkg/apis/metrics/v1alpha1/deep_copy_generated.go
+++ b/pkg/apis/metrics/v1alpha1/deep_copy_generated.go
@@ -18,10 +18,411 @@ limitations under the License.
 
 package v1alpha1
 
-import api "k8s.io/kubernetes/pkg/api"
+import (
+	time "time"
+
+	api "k8s.io/kubernetes/pkg/api"
+	resource "k8s.io/kubernetes/pkg/api/resource"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	conversion "k8s.io/kubernetes/pkg/conversion"
+	inf "speter.net/go/exp/math/dec/inf"
+)
+
+func deepCopy_resource_Quantity(in resource.Quantity, out *resource.Quantity, c *conversion.Cloner) error {
+	if in.Amount != nil {
+		if newVal, err := c.DeepCopy(in.Amount); err != nil {
+			return err
+		} else {
+			out.Amount = newVal.(*inf.Dec)
+		}
+	} else {
+		out.Amount = nil
+	}
+	out.Format = in.Format
+	return nil
+}
+
+func deepCopy_unversioned_ListMeta(in unversioned.ListMeta, out *unversioned.ListMeta, c *conversion.Cloner) error {
+	out.SelfLink = in.SelfLink
+	out.ResourceVersion = in.ResourceVersion
+	return nil
+}
+
+func deepCopy_unversioned_Time(in unversioned.Time, out *unversioned.Time, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Time); err != nil {
+		return err
+	} else {
+		out.Time = newVal.(time.Time)
+	}
+	return nil
+}
+
+func deepCopy_unversioned_TypeMeta(in unversioned.TypeMeta, out *unversioned.TypeMeta, c *conversion.Cloner) error {
+	out.Kind = in.Kind
+	out.APIVersion = in.APIVersion
+	return nil
+}
+
+func deepCopy_v1alpha1_AggregateSample(in AggregateSample, out *AggregateSample, c *conversion.Cloner) error {
+	if err := deepCopy_v1alpha1_Sample(in.Sample, &out.Sample, c); err != nil {
+		return err
+	}
+	if in.CPU != nil {
+		out.CPU = new(CPUMetrics)
+		if err := deepCopy_v1alpha1_CPUMetrics(*in.CPU, out.CPU, c); err != nil {
+			return err
+		}
+	} else {
+		out.CPU = nil
+	}
+	if in.Memory != nil {
+		out.Memory = new(MemoryMetrics)
+		if err := deepCopy_v1alpha1_MemoryMetrics(*in.Memory, out.Memory, c); err != nil {
+			return err
+		}
+	} else {
+		out.Memory = nil
+	}
+	if in.Network != nil {
+		out.Network = new(NetworkMetrics)
+		if err := deepCopy_v1alpha1_NetworkMetrics(*in.Network, out.Network, c); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	if in.Filesystem != nil {
+		out.Filesystem = make([]FilesystemMetrics, len(in.Filesystem))
+		for i := range in.Filesystem {
+			if err := deepCopy_v1alpha1_FilesystemMetrics(in.Filesystem[i], &out.Filesystem[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Filesystem = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_CPUMetrics(in CPUMetrics, out *CPUMetrics, c *conversion.Cloner) error {
+	if in.TotalCores != nil {
+		out.TotalCores = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.TotalCores, out.TotalCores, c); err != nil {
+			return err
+		}
+	} else {
+		out.TotalCores = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_ContainerSample(in ContainerSample, out *ContainerSample, c *conversion.Cloner) error {
+	if err := deepCopy_v1alpha1_Sample(in.Sample, &out.Sample, c); err != nil {
+		return err
+	}
+	if in.CPU != nil {
+		out.CPU = new(CPUMetrics)
+		if err := deepCopy_v1alpha1_CPUMetrics(*in.CPU, out.CPU, c); err != nil {
+			return err
+		}
+	} else {
+		out.CPU = nil
+	}
+	if in.Memory != nil {
+		out.Memory = new(MemoryMetrics)
+		if err := deepCopy_v1alpha1_MemoryMetrics(*in.Memory, out.Memory, c); err != nil {
+			return err
+		}
+	} else {
+		out.Memory = nil
+	}
+	if in.Filesystem != nil {
+		out.Filesystem = make([]FilesystemMetrics, len(in.Filesystem))
+		for i := range in.Filesystem {
+			if err := deepCopy_v1alpha1_FilesystemMetrics(in.Filesystem[i], &out.Filesystem[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Filesystem = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_FilesystemMetrics(in FilesystemMetrics, out *FilesystemMetrics, c *conversion.Cloner) error {
+	out.Device = in.Device
+	if in.UsageBytes != nil {
+		out.UsageBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.UsageBytes, out.UsageBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.UsageBytes = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.LimitBytes, out.LimitBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.LimitBytes = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_MemoryMetrics(in MemoryMetrics, out *MemoryMetrics, c *conversion.Cloner) error {
+	if in.TotalBytes != nil {
+		out.TotalBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.TotalBytes, out.TotalBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.TotalBytes = nil
+	}
+	if in.UsageBytes != nil {
+		out.UsageBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.UsageBytes, out.UsageBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.UsageBytes = nil
+	}
+	if in.PageFaults != nil {
+		out.PageFaults = new(int64)
+		*out.PageFaults = *in.PageFaults
+	} else {
+		out.PageFaults = nil
+	}
+	if in.MajorPageFaults != nil {
+		out.MajorPageFaults = new(int64)
+		*out.MajorPageFaults = *in.MajorPageFaults
+	} else {
+		out.MajorPageFaults = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_MetricsMeta(in MetricsMeta, out *MetricsMeta, c *conversion.Cloner) error {
+	out.SelfLink = in.SelfLink
+	return nil
+}
+
+func deepCopy_v1alpha1_NetworkMetrics(in NetworkMetrics, out *NetworkMetrics, c *conversion.Cloner) error {
+	if in.RxBytes != nil {
+		out.RxBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.RxBytes, out.RxBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.RxBytes = nil
+	}
+	if in.RxErrors != nil {
+		out.RxErrors = new(int64)
+		*out.RxErrors = *in.RxErrors
+	} else {
+		out.RxErrors = nil
+	}
+	if in.TxBytes != nil {
+		out.TxBytes = new(resource.Quantity)
+		if err := deepCopy_resource_Quantity(*in.TxBytes, out.TxBytes, c); err != nil {
+			return err
+		}
+	} else {
+		out.TxBytes = nil
+	}
+	if in.TxErrors != nil {
+		out.TxErrors = new(int64)
+		*out.TxErrors = *in.TxErrors
+	} else {
+		out.TxErrors = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_NonLocalObjectReference(in NonLocalObjectReference, out *NonLocalObjectReference, c *conversion.Cloner) error {
+	out.Name = in.Name
+	out.Namespace = in.Namespace
+	out.UID = in.UID
+	return nil
+}
+
+func deepCopy_v1alpha1_PodSample(in PodSample, out *PodSample, c *conversion.Cloner) error {
+	if err := deepCopy_v1alpha1_Sample(in.Sample, &out.Sample, c); err != nil {
+		return err
+	}
+	if in.Network != nil {
+		out.Network = new(NetworkMetrics)
+		if err := deepCopy_v1alpha1_NetworkMetrics(*in.Network, out.Network, c); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_RawContainerMetrics(in RawContainerMetrics, out *RawContainerMetrics, c *conversion.Cloner) error {
+	out.Name = in.Name
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Samples != nil {
+		out.Samples = make([]ContainerSample, len(in.Samples))
+		for i := range in.Samples {
+			if err := deepCopy_v1alpha1_ContainerSample(in.Samples[i], &out.Samples[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Samples = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_RawMetricsOptions(in RawMetricsOptions, out *RawMetricsOptions, c *conversion.Cloner) error {
+	out.MaxSamples = in.MaxSamples
+	return nil
+}
+
+func deepCopy_v1alpha1_RawNodeMetrics(in RawNodeMetrics, out *RawNodeMetrics, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	out.NodeName = in.NodeName
+	if in.Total != nil {
+		out.Total = make([]AggregateSample, len(in.Total))
+		for i := range in.Total {
+			if err := deepCopy_v1alpha1_AggregateSample(in.Total[i], &out.Total[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Total = nil
+	}
+	if in.SystemContainers != nil {
+		out.SystemContainers = make([]RawContainerMetrics, len(in.SystemContainers))
+		for i := range in.SystemContainers {
+			if err := deepCopy_v1alpha1_RawContainerMetrics(in.SystemContainers[i], &out.SystemContainers[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.SystemContainers = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_RawNodeMetricsList(in RawNodeMetricsList, out *RawNodeMetricsList, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]RawNodeMetrics, len(in.Items))
+		for i := range in.Items {
+			if err := deepCopy_v1alpha1_RawNodeMetrics(in.Items[i], &out.Items[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_RawPodMetrics(in RawPodMetrics, out *RawPodMetrics, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1alpha1_NonLocalObjectReference(in.PodRef, &out.PodRef, c); err != nil {
+		return err
+	}
+	if in.Containers != nil {
+		out.Containers = make([]RawContainerMetrics, len(in.Containers))
+		for i := range in.Containers {
+			if err := deepCopy_v1alpha1_RawContainerMetrics(in.Containers[i], &out.Containers[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Containers = nil
+	}
+	if in.Samples != nil {
+		out.Samples = make([]PodSample, len(in.Samples))
+		for i := range in.Samples {
+			if err := deepCopy_v1alpha1_PodSample(in.Samples[i], &out.Samples[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Samples = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_RawPodMetricsList(in RawPodMetricsList, out *RawPodMetricsList, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]RawPodMetrics, len(in.Items))
+		for i := range in.Items {
+			if err := deepCopy_v1alpha1_RawPodMetrics(in.Items[i], &out.Items[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func deepCopy_v1alpha1_Sample(in Sample, out *Sample, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_Time(in.SampleTime, &out.SampleTime, c); err != nil {
+		return err
+	}
+	return nil
+}
 
 func init() {
-	err := api.Scheme.AddGeneratedDeepCopyFuncs()
+	err := api.Scheme.AddGeneratedDeepCopyFuncs(
+		deepCopy_resource_Quantity,
+		deepCopy_unversioned_ListMeta,
+		deepCopy_unversioned_Time,
+		deepCopy_unversioned_TypeMeta,
+		deepCopy_v1alpha1_AggregateSample,
+		deepCopy_v1alpha1_CPUMetrics,
+		deepCopy_v1alpha1_ContainerSample,
+		deepCopy_v1alpha1_FilesystemMetrics,
+		deepCopy_v1alpha1_MemoryMetrics,
+		deepCopy_v1alpha1_MetricsMeta,
+		deepCopy_v1alpha1_NetworkMetrics,
+		deepCopy_v1alpha1_NonLocalObjectReference,
+		deepCopy_v1alpha1_PodSample,
+		deepCopy_v1alpha1_RawContainerMetrics,
+		deepCopy_v1alpha1_RawMetricsOptions,
+		deepCopy_v1alpha1_RawNodeMetrics,
+		deepCopy_v1alpha1_RawNodeMetricsList,
+		deepCopy_v1alpha1_RawPodMetrics,
+		deepCopy_v1alpha1_RawPodMetricsList,
+		deepCopy_v1alpha1_Sample,
+	)
 	if err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.
 		panic(err)

--- a/pkg/apis/metrics/v1alpha1/register.go
+++ b/pkg/apis/metrics/v1alpha1/register.go
@@ -30,11 +30,41 @@ func init() {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes() {
-	api.Scheme.AddKnownTypes("metrics/v1alpha1",
-		&RawNode{},
-		&RawPod{},
+	api.Scheme.AddKnownTypes("",
+		&MetricsMeta{},
+		&RawNodeMetrics{},
+		&RawNodeMetricsList{},
+		&RawPodMetrics{},
+		&RawPodMetricsList{},
+		&RawContainerMetrics{},
+		&NonLocalObjectReference{},
+		&Sample{},
+		&AggregateSample{},
+		&PodSample{},
+		&ContainerSample{},
+		&NetworkMetrics{},
+		&CPUMetrics{},
+		&MemoryMetrics{},
+		&CustomMetric{},
+		&CustomMetricSample{},
+		&RawMetricsOptions{},
 	)
 }
 
-func (*RawNode) IsAnAPIObject() {}
-func (*RawPod) IsAnAPIObject()  {}
+func (*MetricsMeta) IsAnAPIObject()             {}
+func (*RawNodeMetrics) IsAnAPIObject()          {}
+func (*RawNodeMetricsList) IsAnAPIObject()      {}
+func (*RawPodMetrics) IsAnAPIObject()           {}
+func (*RawPodMetricsList) IsAnAPIObject()       {}
+func (*RawContainerMetrics) IsAnAPIObject()     {}
+func (*NonLocalObjectReference) IsAnAPIObject() {}
+func (*Sample) IsAnAPIObject()                  {}
+func (*AggregateSample) IsAnAPIObject()         {}
+func (*PodSample) IsAnAPIObject()               {}
+func (*ContainerSample) IsAnAPIObject()         {}
+func (*NetworkMetrics) IsAnAPIObject()          {}
+func (*CPUMetrics) IsAnAPIObject()              {}
+func (*MemoryMetrics) IsAnAPIObject()           {}
+func (*CustomMetric) IsAnAPIObject()            {}
+func (*CustomMetricSample) IsAnAPIObject()      {}
+func (*RawMetricsOptions) IsAnAPIObject()       {}

--- a/pkg/apis/metrics/v1alpha1/register.go
+++ b/pkg/apis/metrics/v1alpha1/register.go
@@ -30,7 +30,7 @@ func init() {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes() {
-	api.Scheme.AddKnownTypes("",
+	api.Scheme.AddKnownTypes("metrics/v1alpha1",
 		&MetricsMeta{},
 		&RawNodeMetrics{},
 		&RawNodeMetricsList{},

--- a/pkg/apis/metrics/v1alpha1/register.go
+++ b/pkg/apis/metrics/v1alpha1/register.go
@@ -45,8 +45,6 @@ func addKnownTypes() {
 		&NetworkMetrics{},
 		&CPUMetrics{},
 		&MemoryMetrics{},
-		&CustomMetric{},
-		&CustomMetricSample{},
 		&RawMetricsOptions{},
 	)
 }
@@ -65,6 +63,4 @@ func (*ContainerSample) IsAnAPIObject()         {}
 func (*NetworkMetrics) IsAnAPIObject()          {}
 func (*CPUMetrics) IsAnAPIObject()              {}
 func (*MemoryMetrics) IsAnAPIObject()           {}
-func (*CustomMetric) IsAnAPIObject()            {}
-func (*CustomMetricSample) IsAnAPIObject()      {}
 func (*RawMetricsOptions) IsAnAPIObject()       {}

--- a/pkg/apis/metrics/v1alpha1/types.generated.go
+++ b/pkg/apis/metrics/v1alpha1/types.generated.go
@@ -3895,13 +3895,12 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep348 := !z.EncBinary()
 			yy2arr348 := z.EncBasicHandle().StructToArray
-			var yyq348 [2]bool
+			var yyq348 [1]bool
 			_, _, _ = yysep348, yyq348, yy2arr348
 			const yyr348 bool = false
 			yyq348[0] = x.TotalCores != nil
-			yyq348[1] = x.LoadAverage != nil
 			if yyr348 || yy2arr348 {
-				r.EncodeArrayStart(2)
+				r.EncodeArrayStart(1)
 			} else {
 				var yynn348 int = 0
 				for _, b := range yyq348 {
@@ -3947,42 +3946,6 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr348 || yy2arr348 {
-				if yyq348[1] {
-					if x.LoadAverage == nil {
-						r.EncodeNil()
-					} else {
-						yym353 := z.EncBinary()
-						_ = yym353
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
-						} else if !yym353 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.LoadAverage)
-						} else {
-							z.EncFallback(x.LoadAverage)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq348[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("loadAverage"))
-					if x.LoadAverage == nil {
-						r.EncodeNil()
-					} else {
-						yym354 := z.EncBinary()
-						_ = yym354
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
-						} else if !yym354 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.LoadAverage)
-						} else {
-							z.EncFallback(x.LoadAverage)
-						}
-					}
-				}
-			}
 			if yysep348 {
 				r.EncodeEnd()
 			}
@@ -3994,24 +3957,24 @@ func (x *CPUMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym355 := z.DecBinary()
-	_ = yym355
+	yym352 := z.DecBinary()
+	_ = yym352
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl356 := r.ReadMapStart()
-			if yyl356 == 0 {
+			yyl353 := r.ReadMapStart()
+			if yyl353 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl356, d)
+				x.codecDecodeSelfFromMap(yyl353, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl356 := r.ReadArrayStart()
-			if yyl356 == 0 {
+			yyl353 := r.ReadArrayStart()
+			if yyl353 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl356, d)
+				x.codecDecodeSelfFromArray(yyl353, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4023,12 +3986,12 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys357Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys357Slc
-	var yyhl357 bool = l >= 0
-	for yyj357 := 0; ; yyj357++ {
-		if yyhl357 {
-			if yyj357 >= l {
+	var yys354Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys354Slc
+	var yyhl354 bool = l >= 0
+	for yyj354 := 0; ; yyj354++ {
+		if yyhl354 {
+			if yyj354 >= l {
 				break
 			}
 		} else {
@@ -4036,9 +3999,9 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys357Slc = r.DecodeBytes(yys357Slc, true, true)
-		yys357 := string(yys357Slc)
-		switch yys357 {
+		yys354Slc = r.DecodeBytes(yys354Slc, true, true)
+		yys354 := string(yys354Slc)
+		switch yys354 {
 		case "totalCores":
 			if r.TryDecodeAsNil() {
 				if x.TotalCores != nil {
@@ -4048,40 +4011,21 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalCores == nil {
 					x.TotalCores = new(pkg2_resource.Quantity)
 				}
-				yym359 := z.DecBinary()
-				_ = yym359
+				yym356 := z.DecBinary()
+				_ = yym356
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-				} else if !yym359 && z.IsJSONHandle() {
+				} else if !yym356 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalCores)
 				} else {
 					z.DecFallback(x.TotalCores, false)
 				}
 			}
-		case "loadAverage":
-			if r.TryDecodeAsNil() {
-				if x.LoadAverage != nil {
-					x.LoadAverage = nil
-				}
-			} else {
-				if x.LoadAverage == nil {
-					x.LoadAverage = new(pkg2_resource.Quantity)
-				}
-				yym361 := z.DecBinary()
-				_ = yym361
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
-				} else if !yym361 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.LoadAverage)
-				} else {
-					z.DecFallback(x.LoadAverage, false)
-				}
-			}
 		default:
-			z.DecStructFieldNotFound(-1, yys357)
-		} // end switch yys357
-	} // end for yyj357
-	if !yyhl357 {
+			z.DecStructFieldNotFound(-1, yys354)
+		} // end switch yys354
+	} // end for yyj354
+	if !yyhl354 {
 		r.ReadEnd()
 	}
 }
@@ -4090,16 +4034,16 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj362 int
-	var yyb362 bool
-	var yyhl362 bool = l >= 0
-	yyj362++
-	if yyhl362 {
-		yyb362 = yyj362 > l
+	var yyj357 int
+	var yyb357 bool
+	var yyhl357 bool = l >= 0
+	yyj357++
+	if yyhl357 {
+		yyb357 = yyj357 > l
 	} else {
-		yyb362 = r.CheckBreak()
+		yyb357 = r.CheckBreak()
 	}
-	if yyb362 {
+	if yyb357 {
 		r.ReadEnd()
 		return
 	}
@@ -4111,55 +4055,27 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalCores == nil {
 			x.TotalCores = new(pkg2_resource.Quantity)
 		}
-		yym364 := z.DecBinary()
-		_ = yym364
+		yym359 := z.DecBinary()
+		_ = yym359
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-		} else if !yym364 && z.IsJSONHandle() {
+		} else if !yym359 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalCores)
 		} else {
 			z.DecFallback(x.TotalCores, false)
 		}
 	}
-	yyj362++
-	if yyhl362 {
-		yyb362 = yyj362 > l
-	} else {
-		yyb362 = r.CheckBreak()
-	}
-	if yyb362 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		if x.LoadAverage != nil {
-			x.LoadAverage = nil
-		}
-	} else {
-		if x.LoadAverage == nil {
-			x.LoadAverage = new(pkg2_resource.Quantity)
-		}
-		yym366 := z.DecBinary()
-		_ = yym366
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
-		} else if !yym366 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.LoadAverage)
-		} else {
-			z.DecFallback(x.LoadAverage, false)
-		}
-	}
 	for {
-		yyj362++
-		if yyhl362 {
-			yyb362 = yyj362 > l
+		yyj357++
+		if yyhl357 {
+			yyb357 = yyj357 > l
 		} else {
-			yyb362 = r.CheckBreak()
+			yyb357 = r.CheckBreak()
 		}
-		if yyb362 {
+		if yyb357 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj362-1, "")
+		z.DecStructFieldNotFound(yyj357-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4171,41 +4087,41 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym367 := z.EncBinary()
-		_ = yym367
+		yym360 := z.EncBinary()
+		_ = yym360
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep368 := !z.EncBinary()
-			yy2arr368 := z.EncBasicHandle().StructToArray
-			var yyq368 [4]bool
-			_, _, _ = yysep368, yyq368, yy2arr368
-			const yyr368 bool = false
-			yyq368[0] = x.TotalBytes != nil
-			yyq368[1] = x.UsageBytes != nil
-			yyq368[2] = x.PageFaults != nil
-			yyq368[3] = x.MajorPageFaults != nil
-			if yyr368 || yy2arr368 {
+			yysep361 := !z.EncBinary()
+			yy2arr361 := z.EncBasicHandle().StructToArray
+			var yyq361 [4]bool
+			_, _, _ = yysep361, yyq361, yy2arr361
+			const yyr361 bool = false
+			yyq361[0] = x.TotalBytes != nil
+			yyq361[1] = x.UsageBytes != nil
+			yyq361[2] = x.PageFaults != nil
+			yyq361[3] = x.MajorPageFaults != nil
+			if yyr361 || yy2arr361 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn368 int = 0
-				for _, b := range yyq368 {
+				var yynn361 int = 0
+				for _, b := range yyq361 {
 					if b {
-						yynn368++
+						yynn361++
 					}
 				}
-				r.EncodeMapStart(yynn368)
+				r.EncodeMapStart(yynn361)
 			}
-			if yyr368 || yy2arr368 {
-				if yyq368[0] {
+			if yyr361 || yy2arr361 {
+				if yyq361[0] {
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym370 := z.EncBinary()
-						_ = yym370
+						yym363 := z.EncBinary()
+						_ = yym363
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym370 && z.IsJSONHandle() {
+						} else if !yym363 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4215,16 +4131,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq368[0] {
+				if yyq361[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalBytes"))
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym371 := z.EncBinary()
-						_ = yym371
+						yym364 := z.EncBinary()
+						_ = yym364
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym371 && z.IsJSONHandle() {
+						} else if !yym364 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4232,16 +4148,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr368 || yy2arr368 {
-				if yyq368[1] {
+			if yyr361 || yy2arr361 {
+				if yyq361[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym373 := z.EncBinary()
-						_ = yym373
+						yym366 := z.EncBinary()
+						_ = yym366
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym373 && z.IsJSONHandle() {
+						} else if !yym366 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4251,16 +4167,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq368[1] {
+				if yyq361[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym374 := z.EncBinary()
-						_ = yym374
+						yym367 := z.EncBinary()
+						_ = yym367
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym374 && z.IsJSONHandle() {
+						} else if !yym367 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4268,12 +4184,61 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr368 || yy2arr368 {
-				if yyq368[2] {
+			if yyr361 || yy2arr361 {
+				if yyq361[2] {
 					if x.PageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy376 := *x.PageFaults
+						yy369 := *x.PageFaults
+						yym370 := z.EncBinary()
+						_ = yym370
+						if false {
+						} else {
+							r.EncodeInt(int64(yy369))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq361[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
+					if x.PageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy371 := *x.PageFaults
+						yym372 := z.EncBinary()
+						_ = yym372
+						if false {
+						} else {
+							r.EncodeInt(int64(yy371))
+						}
+					}
+				}
+			}
+			if yyr361 || yy2arr361 {
+				if yyq361[3] {
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy374 := *x.MajorPageFaults
+						yym375 := z.EncBinary()
+						_ = yym375
+						if false {
+						} else {
+							r.EncodeInt(int64(yy374))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq361[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy376 := *x.MajorPageFaults
 						yym377 := z.EncBinary()
 						_ = yym377
 						if false {
@@ -4281,58 +4246,9 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 							r.EncodeInt(int64(yy376))
 						}
 					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq368[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
-					if x.PageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy378 := *x.PageFaults
-						yym379 := z.EncBinary()
-						_ = yym379
-						if false {
-						} else {
-							r.EncodeInt(int64(yy378))
-						}
-					}
 				}
 			}
-			if yyr368 || yy2arr368 {
-				if yyq368[3] {
-					if x.MajorPageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy381 := *x.MajorPageFaults
-						yym382 := z.EncBinary()
-						_ = yym382
-						if false {
-						} else {
-							r.EncodeInt(int64(yy381))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq368[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
-					if x.MajorPageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy383 := *x.MajorPageFaults
-						yym384 := z.EncBinary()
-						_ = yym384
-						if false {
-						} else {
-							r.EncodeInt(int64(yy383))
-						}
-					}
-				}
-			}
-			if yysep368 {
+			if yysep361 {
 				r.EncodeEnd()
 			}
 		}
@@ -4343,24 +4259,24 @@ func (x *MemoryMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym385 := z.DecBinary()
-	_ = yym385
+	yym378 := z.DecBinary()
+	_ = yym378
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl386 := r.ReadMapStart()
-			if yyl386 == 0 {
+			yyl379 := r.ReadMapStart()
+			if yyl379 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl386, d)
+				x.codecDecodeSelfFromMap(yyl379, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl386 := r.ReadArrayStart()
-			if yyl386 == 0 {
+			yyl379 := r.ReadArrayStart()
+			if yyl379 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl386, d)
+				x.codecDecodeSelfFromArray(yyl379, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4372,12 +4288,12 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys387Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys387Slc
-	var yyhl387 bool = l >= 0
-	for yyj387 := 0; ; yyj387++ {
-		if yyhl387 {
-			if yyj387 >= l {
+	var yys380Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys380Slc
+	var yyhl380 bool = l >= 0
+	for yyj380 := 0; ; yyj380++ {
+		if yyhl380 {
+			if yyj380 >= l {
 				break
 			}
 		} else {
@@ -4385,9 +4301,9 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys387Slc = r.DecodeBytes(yys387Slc, true, true)
-		yys387 := string(yys387Slc)
-		switch yys387 {
+		yys380Slc = r.DecodeBytes(yys380Slc, true, true)
+		yys380 := string(yys380Slc)
+		switch yys380 {
 		case "totalBytes":
 			if r.TryDecodeAsNil() {
 				if x.TotalBytes != nil {
@@ -4397,11 +4313,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalBytes == nil {
 					x.TotalBytes = new(pkg2_resource.Quantity)
 				}
-				yym389 := z.DecBinary()
-				_ = yym389
+				yym382 := z.DecBinary()
+				_ = yym382
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-				} else if !yym389 && z.IsJSONHandle() {
+				} else if !yym382 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalBytes)
 				} else {
 					z.DecFallback(x.TotalBytes, false)
@@ -4416,11 +4332,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym391 := z.DecBinary()
-				_ = yym391
+				yym384 := z.DecBinary()
+				_ = yym384
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym391 && z.IsJSONHandle() {
+				} else if !yym384 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4435,8 +4351,8 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.PageFaults == nil {
 					x.PageFaults = new(int64)
 				}
-				yym393 := z.DecBinary()
-				_ = yym393
+				yym386 := z.DecBinary()
+				_ = yym386
 				if false {
 				} else {
 					*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
@@ -4451,18 +4367,18 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.MajorPageFaults == nil {
 					x.MajorPageFaults = new(int64)
 				}
-				yym395 := z.DecBinary()
-				_ = yym395
+				yym388 := z.DecBinary()
+				_ = yym388
 				if false {
 				} else {
 					*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys387)
-		} // end switch yys387
-	} // end for yyj387
-	if !yyhl387 {
+			z.DecStructFieldNotFound(-1, yys380)
+		} // end switch yys380
+	} // end for yyj380
+	if !yyhl380 {
 		r.ReadEnd()
 	}
 }
@@ -4471,16 +4387,16 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj396 int
-	var yyb396 bool
-	var yyhl396 bool = l >= 0
-	yyj396++
-	if yyhl396 {
-		yyb396 = yyj396 > l
+	var yyj389 int
+	var yyb389 bool
+	var yyhl389 bool = l >= 0
+	yyj389++
+	if yyhl389 {
+		yyb389 = yyj389 > l
 	} else {
-		yyb396 = r.CheckBreak()
+		yyb389 = r.CheckBreak()
 	}
-	if yyb396 {
+	if yyb389 {
 		r.ReadEnd()
 		return
 	}
@@ -4492,23 +4408,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalBytes == nil {
 			x.TotalBytes = new(pkg2_resource.Quantity)
 		}
-		yym398 := z.DecBinary()
-		_ = yym398
+		yym391 := z.DecBinary()
+		_ = yym391
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-		} else if !yym398 && z.IsJSONHandle() {
+		} else if !yym391 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalBytes)
 		} else {
 			z.DecFallback(x.TotalBytes, false)
 		}
 	}
-	yyj396++
-	if yyhl396 {
-		yyb396 = yyj396 > l
+	yyj389++
+	if yyhl389 {
+		yyb389 = yyj389 > l
 	} else {
-		yyb396 = r.CheckBreak()
+		yyb389 = r.CheckBreak()
 	}
-	if yyb396 {
+	if yyb389 {
 		r.ReadEnd()
 		return
 	}
@@ -4520,23 +4436,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym400 := z.DecBinary()
-		_ = yym400
+		yym393 := z.DecBinary()
+		_ = yym393
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym400 && z.IsJSONHandle() {
+		} else if !yym393 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj396++
-	if yyhl396 {
-		yyb396 = yyj396 > l
+	yyj389++
+	if yyhl389 {
+		yyb389 = yyj389 > l
 	} else {
-		yyb396 = r.CheckBreak()
+		yyb389 = r.CheckBreak()
 	}
-	if yyb396 {
+	if yyb389 {
 		r.ReadEnd()
 		return
 	}
@@ -4548,20 +4464,20 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.PageFaults == nil {
 			x.PageFaults = new(int64)
 		}
-		yym402 := z.DecBinary()
-		_ = yym402
+		yym395 := z.DecBinary()
+		_ = yym395
 		if false {
 		} else {
 			*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj396++
-	if yyhl396 {
-		yyb396 = yyj396 > l
+	yyj389++
+	if yyhl389 {
+		yyb389 = yyj389 > l
 	} else {
-		yyb396 = r.CheckBreak()
+		yyb389 = r.CheckBreak()
 	}
-	if yyb396 {
+	if yyb389 {
 		r.ReadEnd()
 		return
 	}
@@ -4573,24 +4489,24 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.MajorPageFaults == nil {
 			x.MajorPageFaults = new(int64)
 		}
-		yym404 := z.DecBinary()
-		_ = yym404
+		yym397 := z.DecBinary()
+		_ = yym397
 		if false {
 		} else {
 			*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj396++
-		if yyhl396 {
-			yyb396 = yyj396 > l
+		yyj389++
+		if yyhl389 {
+			yyb389 = yyj389 > l
 		} else {
-			yyb396 = r.CheckBreak()
+			yyb389 = r.CheckBreak()
 		}
-		if yyb396 {
+		if yyb389 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj396-1, "")
+		z.DecStructFieldNotFound(yyj389-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4602,55 +4518,55 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym405 := z.EncBinary()
-		_ = yym405
+		yym398 := z.EncBinary()
+		_ = yym398
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep406 := !z.EncBinary()
-			yy2arr406 := z.EncBasicHandle().StructToArray
-			var yyq406 [3]bool
-			_, _, _ = yysep406, yyq406, yy2arr406
-			const yyr406 bool = false
-			yyq406[1] = x.UsageBytes != nil
-			yyq406[2] = x.LimitBytes != nil
-			if yyr406 || yy2arr406 {
+			yysep399 := !z.EncBinary()
+			yy2arr399 := z.EncBasicHandle().StructToArray
+			var yyq399 [3]bool
+			_, _, _ = yysep399, yyq399, yy2arr399
+			const yyr399 bool = false
+			yyq399[1] = x.UsageBytes != nil
+			yyq399[2] = x.LimitBytes != nil
+			if yyr399 || yy2arr399 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn406 int = 1
-				for _, b := range yyq406 {
+				var yynn399 int = 1
+				for _, b := range yyq399 {
 					if b {
-						yynn406++
+						yynn399++
 					}
 				}
-				r.EncodeMapStart(yynn406)
+				r.EncodeMapStart(yynn399)
 			}
-			if yyr406 || yy2arr406 {
-				yym408 := z.EncBinary()
-				_ = yym408
+			if yyr399 || yy2arr399 {
+				yym401 := z.EncBinary()
+				_ = yym401
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("device"))
-				yym409 := z.EncBinary()
-				_ = yym409
+				yym402 := z.EncBinary()
+				_ = yym402
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
 				}
 			}
-			if yyr406 || yy2arr406 {
-				if yyq406[1] {
+			if yyr399 || yy2arr399 {
+				if yyq399[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym411 := z.EncBinary()
-						_ = yym411
+						yym404 := z.EncBinary()
+						_ = yym404
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym411 && z.IsJSONHandle() {
+						} else if !yym404 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4660,16 +4576,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq406[1] {
+				if yyq399[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym412 := z.EncBinary()
-						_ = yym412
+						yym405 := z.EncBinary()
+						_ = yym405
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym412 && z.IsJSONHandle() {
+						} else if !yym405 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4677,16 +4593,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr406 || yy2arr406 {
-				if yyq406[2] {
+			if yyr399 || yy2arr399 {
+				if yyq399[2] {
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym414 := z.EncBinary()
-						_ = yym414
+						yym407 := z.EncBinary()
+						_ = yym407
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
-						} else if !yym414 && z.IsJSONHandle() {
+						} else if !yym407 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LimitBytes)
 						} else {
 							z.EncFallback(x.LimitBytes)
@@ -4696,16 +4612,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq406[2] {
+				if yyq399[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym415 := z.EncBinary()
-						_ = yym415
+						yym408 := z.EncBinary()
+						_ = yym408
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
-						} else if !yym415 && z.IsJSONHandle() {
+						} else if !yym408 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LimitBytes)
 						} else {
 							z.EncFallback(x.LimitBytes)
@@ -4713,7 +4629,7 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep406 {
+			if yysep399 {
 				r.EncodeEnd()
 			}
 		}
@@ -4724,24 +4640,24 @@ func (x *FilesystemMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym416 := z.DecBinary()
-	_ = yym416
+	yym409 := z.DecBinary()
+	_ = yym409
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl417 := r.ReadMapStart()
-			if yyl417 == 0 {
+			yyl410 := r.ReadMapStart()
+			if yyl410 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl417, d)
+				x.codecDecodeSelfFromMap(yyl410, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl417 := r.ReadArrayStart()
-			if yyl417 == 0 {
+			yyl410 := r.ReadArrayStart()
+			if yyl410 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl417, d)
+				x.codecDecodeSelfFromArray(yyl410, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4753,12 +4669,12 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys418Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys418Slc
-	var yyhl418 bool = l >= 0
-	for yyj418 := 0; ; yyj418++ {
-		if yyhl418 {
-			if yyj418 >= l {
+	var yys411Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys411Slc
+	var yyhl411 bool = l >= 0
+	for yyj411 := 0; ; yyj411++ {
+		if yyhl411 {
+			if yyj411 >= l {
 				break
 			}
 		} else {
@@ -4766,9 +4682,9 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys418Slc = r.DecodeBytes(yys418Slc, true, true)
-		yys418 := string(yys418Slc)
-		switch yys418 {
+		yys411Slc = r.DecodeBytes(yys411Slc, true, true)
+		yys411 := string(yys411Slc)
+		switch yys411 {
 		case "device":
 			if r.TryDecodeAsNil() {
 				x.Device = ""
@@ -4784,11 +4700,11 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym421 := z.DecBinary()
-				_ = yym421
+				yym414 := z.DecBinary()
+				_ = yym414
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym421 && z.IsJSONHandle() {
+				} else if !yym414 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4803,21 +4719,21 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(pkg2_resource.Quantity)
 				}
-				yym423 := z.DecBinary()
-				_ = yym423
+				yym416 := z.DecBinary()
+				_ = yym416
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
-				} else if !yym423 && z.IsJSONHandle() {
+				} else if !yym416 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LimitBytes)
 				} else {
 					z.DecFallback(x.LimitBytes, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys418)
-		} // end switch yys418
-	} // end for yyj418
-	if !yyhl418 {
+			z.DecStructFieldNotFound(-1, yys411)
+		} // end switch yys411
+	} // end for yyj411
+	if !yyhl411 {
 		r.ReadEnd()
 	}
 }
@@ -4826,16 +4742,16 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj424 int
-	var yyb424 bool
-	var yyhl424 bool = l >= 0
-	yyj424++
-	if yyhl424 {
-		yyb424 = yyj424 > l
+	var yyj417 int
+	var yyb417 bool
+	var yyhl417 bool = l >= 0
+	yyj417++
+	if yyhl417 {
+		yyb417 = yyj417 > l
 	} else {
-		yyb424 = r.CheckBreak()
+		yyb417 = r.CheckBreak()
 	}
-	if yyb424 {
+	if yyb417 {
 		r.ReadEnd()
 		return
 	}
@@ -4844,13 +4760,13 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Device = string(r.DecodeString())
 	}
-	yyj424++
-	if yyhl424 {
-		yyb424 = yyj424 > l
+	yyj417++
+	if yyhl417 {
+		yyb417 = yyj417 > l
 	} else {
-		yyb424 = r.CheckBreak()
+		yyb417 = r.CheckBreak()
 	}
-	if yyb424 {
+	if yyb417 {
 		r.ReadEnd()
 		return
 	}
@@ -4862,23 +4778,23 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym427 := z.DecBinary()
-		_ = yym427
+		yym420 := z.DecBinary()
+		_ = yym420
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym427 && z.IsJSONHandle() {
+		} else if !yym420 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj424++
-	if yyhl424 {
-		yyb424 = yyj424 > l
+	yyj417++
+	if yyhl417 {
+		yyb417 = yyj417 > l
 	} else {
-		yyb424 = r.CheckBreak()
+		yyb417 = r.CheckBreak()
 	}
-	if yyb424 {
+	if yyb417 {
 		r.ReadEnd()
 		return
 	}
@@ -4890,27 +4806,27 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(pkg2_resource.Quantity)
 		}
-		yym429 := z.DecBinary()
-		_ = yym429
+		yym422 := z.DecBinary()
+		_ = yym422
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
-		} else if !yym429 && z.IsJSONHandle() {
+		} else if !yym422 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LimitBytes)
 		} else {
 			z.DecFallback(x.LimitBytes, false)
 		}
 	}
 	for {
-		yyj424++
-		if yyhl424 {
-			yyb424 = yyj424 > l
+		yyj417++
+		if yyhl417 {
+			yyb417 = yyj417 > l
 		} else {
-			yyb424 = r.CheckBreak()
+			yyb417 = r.CheckBreak()
 		}
-		if yyb424 {
+		if yyb417 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj424-1, "")
+		z.DecStructFieldNotFound(yyj417-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4919,8 +4835,8 @@ func (x CustomMetricType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym430 := z.EncBinary()
-	_ = yym430
+	yym423 := z.EncBinary()
+	_ = yym423
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -4932,8 +4848,8 @@ func (x *CustomMetricType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym431 := z.DecBinary()
-	_ = yym431
+	yym424 := z.DecBinary()
+	_ = yym424
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -4948,73 +4864,73 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym432 := z.EncBinary()
-		_ = yym432
+		yym425 := z.EncBinary()
+		_ = yym425
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep433 := !z.EncBinary()
-			yy2arr433 := z.EncBasicHandle().StructToArray
-			var yyq433 [4]bool
-			_, _, _ = yysep433, yyq433, yy2arr433
-			const yyr433 bool = false
-			yyq433[3] = len(x.Samples) != 0
-			if yyr433 || yy2arr433 {
+			yysep426 := !z.EncBinary()
+			yy2arr426 := z.EncBasicHandle().StructToArray
+			var yyq426 [4]bool
+			_, _, _ = yysep426, yyq426, yy2arr426
+			const yyr426 bool = false
+			yyq426[3] = len(x.Samples) != 0
+			if yyr426 || yy2arr426 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn433 int = 3
-				for _, b := range yyq433 {
+				var yynn426 int = 3
+				for _, b := range yyq426 {
 					if b {
-						yynn433++
+						yynn426++
 					}
 				}
-				r.EncodeMapStart(yynn433)
+				r.EncodeMapStart(yynn426)
 			}
-			if yyr433 || yy2arr433 {
-				yym435 := z.EncBinary()
-				_ = yym435
+			if yyr426 || yy2arr426 {
+				yym428 := z.EncBinary()
+				_ = yym428
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
-				yym436 := z.EncBinary()
-				_ = yym436
+				yym429 := z.EncBinary()
+				_ = yym429
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yyr433 || yy2arr433 {
+			if yyr426 || yy2arr426 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr433 || yy2arr433 {
-				yym439 := z.EncBinary()
-				_ = yym439
+			if yyr426 || yy2arr426 {
+				yym432 := z.EncBinary()
+				_ = yym432
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("unit"))
-				yym440 := z.EncBinary()
-				_ = yym440
+				yym433 := z.EncBinary()
+				_ = yym433
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
 				}
 			}
-			if yyr433 || yy2arr433 {
-				if yyq433[3] {
+			if yyr426 || yy2arr426 {
+				if yyq426[3] {
 					if x.Samples == nil {
 						r.EncodeNil()
 					} else {
-						yym442 := z.EncBinary()
-						_ = yym442
+						yym435 := z.EncBinary()
+						_ = yym435
 						if false {
 						} else {
 							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
@@ -5024,13 +4940,13 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq433[3] {
+				if yyq426[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("samples"))
 					if x.Samples == nil {
 						r.EncodeNil()
 					} else {
-						yym443 := z.EncBinary()
-						_ = yym443
+						yym436 := z.EncBinary()
+						_ = yym436
 						if false {
 						} else {
 							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
@@ -5038,7 +4954,7 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep433 {
+			if yysep426 {
 				r.EncodeEnd()
 			}
 		}
@@ -5049,24 +4965,24 @@ func (x *CustomMetric) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym444 := z.DecBinary()
-	_ = yym444
+	yym437 := z.DecBinary()
+	_ = yym437
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl445 := r.ReadMapStart()
-			if yyl445 == 0 {
+			yyl438 := r.ReadMapStart()
+			if yyl438 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl445, d)
+				x.codecDecodeSelfFromMap(yyl438, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl445 := r.ReadArrayStart()
-			if yyl445 == 0 {
+			yyl438 := r.ReadArrayStart()
+			if yyl438 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl445, d)
+				x.codecDecodeSelfFromArray(yyl438, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5078,12 +4994,12 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys446Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys446Slc
-	var yyhl446 bool = l >= 0
-	for yyj446 := 0; ; yyj446++ {
-		if yyhl446 {
-			if yyj446 >= l {
+	var yys439Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys439Slc
+	var yyhl439 bool = l >= 0
+	for yyj439 := 0; ; yyj439++ {
+		if yyhl439 {
+			if yyj439 >= l {
 				break
 			}
 		} else {
@@ -5091,9 +5007,9 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys446Slc = r.DecodeBytes(yys446Slc, true, true)
-		yys446 := string(yys446Slc)
-		switch yys446 {
+		yys439Slc = r.DecodeBytes(yys439Slc, true, true)
+		yys439 := string(yys439Slc)
+		switch yys439 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -5116,19 +5032,19 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Samples = nil
 			} else {
-				yyv450 := &x.Samples
-				yym451 := z.DecBinary()
-				_ = yym451
+				yyv443 := &x.Samples
+				yym444 := z.DecBinary()
+				_ = yym444
 				if false {
 				} else {
-					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv450), d)
+					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv443), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys446)
-		} // end switch yys446
-	} // end for yyj446
-	if !yyhl446 {
+			z.DecStructFieldNotFound(-1, yys439)
+		} // end switch yys439
+	} // end for yyj439
+	if !yyhl439 {
 		r.ReadEnd()
 	}
 }
@@ -5137,16 +5053,16 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj452 int
-	var yyb452 bool
-	var yyhl452 bool = l >= 0
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	var yyj445 int
+	var yyb445 bool
+	var yyhl445 bool = l >= 0
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb445 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb445 {
 		r.ReadEnd()
 		return
 	}
@@ -5155,13 +5071,13 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb445 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb445 {
 		r.ReadEnd()
 		return
 	}
@@ -5170,13 +5086,13 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = CustomMetricType(r.DecodeString())
 	}
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb445 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb445 {
 		r.ReadEnd()
 		return
 	}
@@ -5185,38 +5101,38 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Unit = string(r.DecodeString())
 	}
-	yyj452++
-	if yyhl452 {
-		yyb452 = yyj452 > l
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
 	} else {
-		yyb452 = r.CheckBreak()
+		yyb445 = r.CheckBreak()
 	}
-	if yyb452 {
+	if yyb445 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Samples = nil
 	} else {
-		yyv456 := &x.Samples
-		yym457 := z.DecBinary()
-		_ = yym457
+		yyv449 := &x.Samples
+		yym450 := z.DecBinary()
+		_ = yym450
 		if false {
 		} else {
-			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv456), d)
+			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv449), d)
 		}
 	}
 	for {
-		yyj452++
-		if yyhl452 {
-			yyb452 = yyj452 > l
+		yyj445++
+		if yyhl445 {
+			yyb445 = yyj445 > l
 		} else {
-			yyb452 = r.CheckBreak()
+			yyb445 = r.CheckBreak()
 		}
-		if yyb452 {
+		if yyb445 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj452-1, "")
+		z.DecStructFieldNotFound(yyj445-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5228,113 +5144,113 @@ func (x *CustomMetricSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym458 := z.EncBinary()
-		_ = yym458
+		yym451 := z.EncBinary()
+		_ = yym451
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep459 := !z.EncBinary()
-			yy2arr459 := z.EncBasicHandle().StructToArray
-			var yyq459 [3]bool
-			_, _, _ = yysep459, yyq459, yy2arr459
-			const yyr459 bool = false
-			yyq459[1] = x.Label != nil
-			if yyr459 || yy2arr459 {
+			yysep452 := !z.EncBinary()
+			yy2arr452 := z.EncBasicHandle().StructToArray
+			var yyq452 [3]bool
+			_, _, _ = yysep452, yyq452, yy2arr452
+			const yyr452 bool = false
+			yyq452[1] = x.Label != nil
+			if yyr452 || yy2arr452 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn459 int = 2
-				for _, b := range yyq459 {
+				var yynn452 int = 2
+				for _, b := range yyq452 {
 					if b {
-						yynn459++
+						yynn452++
 					}
 				}
-				r.EncodeMapStart(yynn459)
+				r.EncodeMapStart(yynn452)
 			}
-			if yyr459 || yy2arr459 {
-				yy461 := &x.SampleTime
-				yym462 := z.EncBinary()
-				_ = yym462
+			if yyr452 || yy2arr452 {
+				yy454 := &x.SampleTime
+				yym455 := z.EncBinary()
+				_ = yym455
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy461) {
-				} else if yym462 {
-					z.EncBinaryMarshal(yy461)
-				} else if !yym462 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy461)
+				} else if z.HasExtensions() && z.EncExt(yy454) {
+				} else if yym455 {
+					z.EncBinaryMarshal(yy454)
+				} else if !yym455 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy454)
 				} else {
-					z.EncFallback(yy461)
+					z.EncFallback(yy454)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy463 := &x.SampleTime
-				yym464 := z.EncBinary()
-				_ = yym464
+				yy456 := &x.SampleTime
+				yym457 := z.EncBinary()
+				_ = yym457
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy463) {
-				} else if yym464 {
-					z.EncBinaryMarshal(yy463)
-				} else if !yym464 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy463)
+				} else if z.HasExtensions() && z.EncExt(yy456) {
+				} else if yym457 {
+					z.EncBinaryMarshal(yy456)
+				} else if !yym457 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy456)
 				} else {
-					z.EncFallback(yy463)
+					z.EncFallback(yy456)
 				}
 			}
-			if yyr459 || yy2arr459 {
-				if yyq459[1] {
+			if yyr452 || yy2arr452 {
+				if yyq452[1] {
 					if x.Label == nil {
 						r.EncodeNil()
 					} else {
-						yy466 := *x.Label
-						yym467 := z.EncBinary()
-						_ = yym467
+						yy459 := *x.Label
+						yym460 := z.EncBinary()
+						_ = yym460
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy466))
+							r.EncodeString(codecSelferC_UTF81234, string(yy459))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq459[1] {
+				if yyq452[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("label"))
 					if x.Label == nil {
 						r.EncodeNil()
 					} else {
-						yy468 := *x.Label
-						yym469 := z.EncBinary()
-						_ = yym469
+						yy461 := *x.Label
+						yym462 := z.EncBinary()
+						_ = yym462
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy468))
+							r.EncodeString(codecSelferC_UTF81234, string(yy461))
 						}
 					}
 				}
 			}
-			if yyr459 || yy2arr459 {
-				yy471 := &x.Value
-				yym472 := z.EncBinary()
-				_ = yym472
+			if yyr452 || yy2arr452 {
+				yy464 := &x.Value
+				yym465 := z.EncBinary()
+				_ = yym465
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy471) {
-				} else if !yym472 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy471)
+				} else if z.HasExtensions() && z.EncExt(yy464) {
+				} else if !yym465 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy464)
 				} else {
-					z.EncFallback(yy471)
+					z.EncFallback(yy464)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yy473 := &x.Value
-				yym474 := z.EncBinary()
-				_ = yym474
+				yy466 := &x.Value
+				yym467 := z.EncBinary()
+				_ = yym467
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy473) {
-				} else if !yym474 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy473)
+				} else if z.HasExtensions() && z.EncExt(yy466) {
+				} else if !yym467 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy466)
 				} else {
-					z.EncFallback(yy473)
+					z.EncFallback(yy466)
 				}
 			}
-			if yysep459 {
+			if yysep452 {
 				r.EncodeEnd()
 			}
 		}
@@ -5345,24 +5261,24 @@ func (x *CustomMetricSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym475 := z.DecBinary()
-	_ = yym475
+	yym468 := z.DecBinary()
+	_ = yym468
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl476 := r.ReadMapStart()
-			if yyl476 == 0 {
+			yyl469 := r.ReadMapStart()
+			if yyl469 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl476, d)
+				x.codecDecodeSelfFromMap(yyl469, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl476 := r.ReadArrayStart()
-			if yyl476 == 0 {
+			yyl469 := r.ReadArrayStart()
+			if yyl469 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl476, d)
+				x.codecDecodeSelfFromArray(yyl469, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5374,12 +5290,12 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys477Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys477Slc
-	var yyhl477 bool = l >= 0
-	for yyj477 := 0; ; yyj477++ {
-		if yyhl477 {
-			if yyj477 >= l {
+	var yys470Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys470Slc
+	var yyhl470 bool = l >= 0
+	for yyj470 := 0; ; yyj470++ {
+		if yyhl470 {
+			if yyj470 >= l {
 				break
 			}
 		} else {
@@ -5387,24 +5303,24 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys477Slc = r.DecodeBytes(yys477Slc, true, true)
-		yys477 := string(yys477Slc)
-		switch yys477 {
+		yys470Slc = r.DecodeBytes(yys470Slc, true, true)
+		yys470 := string(yys470Slc)
+		switch yys470 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv478 := &x.SampleTime
-				yym479 := z.DecBinary()
-				_ = yym479
+				yyv471 := &x.SampleTime
+				yym472 := z.DecBinary()
+				_ = yym472
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv478) {
-				} else if yym479 {
-					z.DecBinaryUnmarshal(yyv478)
-				} else if !yym479 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv478)
+				} else if z.HasExtensions() && z.DecExt(yyv471) {
+				} else if yym472 {
+					z.DecBinaryUnmarshal(yyv471)
+				} else if !yym472 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv471)
 				} else {
-					z.DecFallback(yyv478, false)
+					z.DecFallback(yyv471, false)
 				}
 			}
 		case "label":
@@ -5416,8 +5332,8 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.Label == nil {
 					x.Label = new(string)
 				}
-				yym481 := z.DecBinary()
-				_ = yym481
+				yym474 := z.DecBinary()
+				_ = yym474
 				if false {
 				} else {
 					*((*string)(x.Label)) = r.DecodeString()
@@ -5427,22 +5343,22 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Value = pkg2_resource.Quantity{}
 			} else {
-				yyv482 := &x.Value
-				yym483 := z.DecBinary()
-				_ = yym483
+				yyv475 := &x.Value
+				yym476 := z.DecBinary()
+				_ = yym476
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv482) {
-				} else if !yym483 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv482)
+				} else if z.HasExtensions() && z.DecExt(yyv475) {
+				} else if !yym476 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv475)
 				} else {
-					z.DecFallback(yyv482, false)
+					z.DecFallback(yyv475, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys477)
-		} // end switch yys477
-	} // end for yyj477
-	if !yyhl477 {
+			z.DecStructFieldNotFound(-1, yys470)
+		} // end switch yys470
+	} // end for yyj470
+	if !yyhl470 {
 		r.ReadEnd()
 	}
 }
@@ -5451,42 +5367,42 @@ func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj484 int
-	var yyb484 bool
-	var yyhl484 bool = l >= 0
-	yyj484++
-	if yyhl484 {
-		yyb484 = yyj484 > l
+	var yyj477 int
+	var yyb477 bool
+	var yyhl477 bool = l >= 0
+	yyj477++
+	if yyhl477 {
+		yyb477 = yyj477 > l
 	} else {
-		yyb484 = r.CheckBreak()
+		yyb477 = r.CheckBreak()
 	}
-	if yyb484 {
+	if yyb477 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv485 := &x.SampleTime
-		yym486 := z.DecBinary()
-		_ = yym486
+		yyv478 := &x.SampleTime
+		yym479 := z.DecBinary()
+		_ = yym479
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv485) {
-		} else if yym486 {
-			z.DecBinaryUnmarshal(yyv485)
-		} else if !yym486 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv485)
+		} else if z.HasExtensions() && z.DecExt(yyv478) {
+		} else if yym479 {
+			z.DecBinaryUnmarshal(yyv478)
+		} else if !yym479 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv478)
 		} else {
-			z.DecFallback(yyv485, false)
+			z.DecFallback(yyv478, false)
 		}
 	}
-	yyj484++
-	if yyhl484 {
-		yyb484 = yyj484 > l
+	yyj477++
+	if yyhl477 {
+		yyb477 = yyj477 > l
 	} else {
-		yyb484 = r.CheckBreak()
+		yyb477 = r.CheckBreak()
 	}
-	if yyb484 {
+	if yyb477 {
 		r.ReadEnd()
 		return
 	}
@@ -5498,48 +5414,48 @@ func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.Label == nil {
 			x.Label = new(string)
 		}
-		yym488 := z.DecBinary()
-		_ = yym488
+		yym481 := z.DecBinary()
+		_ = yym481
 		if false {
 		} else {
 			*((*string)(x.Label)) = r.DecodeString()
 		}
 	}
-	yyj484++
-	if yyhl484 {
-		yyb484 = yyj484 > l
+	yyj477++
+	if yyhl477 {
+		yyb477 = yyj477 > l
 	} else {
-		yyb484 = r.CheckBreak()
+		yyb477 = r.CheckBreak()
 	}
-	if yyb484 {
+	if yyb477 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Value = pkg2_resource.Quantity{}
 	} else {
-		yyv489 := &x.Value
-		yym490 := z.DecBinary()
-		_ = yym490
+		yyv482 := &x.Value
+		yym483 := z.DecBinary()
+		_ = yym483
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv489) {
-		} else if !yym490 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv489)
+		} else if z.HasExtensions() && z.DecExt(yyv482) {
+		} else if !yym483 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv482)
 		} else {
-			z.DecFallback(yyv489, false)
+			z.DecFallback(yyv482, false)
 		}
 	}
 	for {
-		yyj484++
-		if yyhl484 {
-			yyb484 = yyj484 > l
+		yyj477++
+		if yyhl477 {
+			yyb477 = yyj477 > l
 		} else {
-			yyb484 = r.CheckBreak()
+			yyb477 = r.CheckBreak()
 		}
-		if yyb484 {
+		if yyb477 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj484-1, "")
+		z.DecStructFieldNotFound(yyj477-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5551,42 +5467,42 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym491 := z.EncBinary()
-		_ = yym491
+		yym484 := z.EncBinary()
+		_ = yym484
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep492 := !z.EncBinary()
-			yy2arr492 := z.EncBasicHandle().StructToArray
-			var yyq492 [3]bool
-			_, _, _ = yysep492, yyq492, yy2arr492
-			const yyr492 bool = false
-			yyq492[0] = x.SinceTime != nil
-			yyq492[1] = x.UntilTime != nil
-			yyq492[2] = x.MaxSamples != 0
-			if yyr492 || yy2arr492 {
+			yysep485 := !z.EncBinary()
+			yy2arr485 := z.EncBasicHandle().StructToArray
+			var yyq485 [3]bool
+			_, _, _ = yysep485, yyq485, yy2arr485
+			const yyr485 bool = false
+			yyq485[0] = x.SinceTime != nil
+			yyq485[1] = x.UntilTime != nil
+			yyq485[2] = x.MaxSamples != 0
+			if yyr485 || yy2arr485 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn492 int = 0
-				for _, b := range yyq492 {
+				var yynn485 int = 0
+				for _, b := range yyq485 {
 					if b {
-						yynn492++
+						yynn485++
 					}
 				}
-				r.EncodeMapStart(yynn492)
+				r.EncodeMapStart(yynn485)
 			}
-			if yyr492 || yy2arr492 {
-				if yyq492[0] {
+			if yyr485 || yy2arr485 {
+				if yyq485[0] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym494 := z.EncBinary()
-						_ = yym494
+						yym487 := z.EncBinary()
+						_ = yym487
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym494 {
+						} else if yym487 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym494 && z.IsJSONHandle() {
+						} else if !yym487 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5596,18 +5512,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq492[0] {
+				if yyq485[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym495 := z.EncBinary()
-						_ = yym495
+						yym488 := z.EncBinary()
+						_ = yym488
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym495 {
+						} else if yym488 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym495 && z.IsJSONHandle() {
+						} else if !yym488 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5615,18 +5531,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr492 || yy2arr492 {
-				if yyq492[1] {
+			if yyr485 || yy2arr485 {
+				if yyq485[1] {
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym497 := z.EncBinary()
-						_ = yym497
+						yym490 := z.EncBinary()
+						_ = yym490
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym497 {
+						} else if yym490 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym497 && z.IsJSONHandle() {
+						} else if !yym490 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5636,18 +5552,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq492[1] {
+				if yyq485[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym498 := z.EncBinary()
-						_ = yym498
+						yym491 := z.EncBinary()
+						_ = yym491
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym498 {
+						} else if yym491 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym498 && z.IsJSONHandle() {
+						} else if !yym491 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5655,10 +5571,10 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr492 || yy2arr492 {
-				if yyq492[2] {
-					yym500 := z.EncBinary()
-					_ = yym500
+			if yyr485 || yy2arr485 {
+				if yyq485[2] {
+					yym493 := z.EncBinary()
+					_ = yym493
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -5667,17 +5583,17 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq492[2] {
+				if yyq485[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
-					yym501 := z.EncBinary()
-					_ = yym501
+					yym494 := z.EncBinary()
+					_ = yym494
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
 					}
 				}
 			}
-			if yysep492 {
+			if yysep485 {
 				r.EncodeEnd()
 			}
 		}
@@ -5688,24 +5604,24 @@ func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym502 := z.DecBinary()
-	_ = yym502
+	yym495 := z.DecBinary()
+	_ = yym495
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl503 := r.ReadMapStart()
-			if yyl503 == 0 {
+			yyl496 := r.ReadMapStart()
+			if yyl496 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl503, d)
+				x.codecDecodeSelfFromMap(yyl496, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl503 := r.ReadArrayStart()
-			if yyl503 == 0 {
+			yyl496 := r.ReadArrayStart()
+			if yyl496 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl503, d)
+				x.codecDecodeSelfFromArray(yyl496, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5717,12 +5633,12 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys504Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys504Slc
-	var yyhl504 bool = l >= 0
-	for yyj504 := 0; ; yyj504++ {
-		if yyhl504 {
-			if yyj504 >= l {
+	var yys497Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys497Slc
+	var yyhl497 bool = l >= 0
+	for yyj497 := 0; ; yyj497++ {
+		if yyhl497 {
+			if yyj497 >= l {
 				break
 			}
 		} else {
@@ -5730,9 +5646,9 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys504Slc = r.DecodeBytes(yys504Slc, true, true)
-		yys504 := string(yys504Slc)
-		switch yys504 {
+		yys497Slc = r.DecodeBytes(yys497Slc, true, true)
+		yys497 := string(yys497Slc)
+		switch yys497 {
 		case "sinceTime":
 			if r.TryDecodeAsNil() {
 				if x.SinceTime != nil {
@@ -5742,13 +5658,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg1_unversioned.Time)
 				}
-				yym506 := z.DecBinary()
-				_ = yym506
+				yym499 := z.DecBinary()
+				_ = yym499
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym506 {
+				} else if yym499 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym506 && z.IsJSONHandle() {
+				} else if !yym499 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -5763,13 +5679,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UntilTime == nil {
 					x.UntilTime = new(pkg1_unversioned.Time)
 				}
-				yym508 := z.DecBinary()
-				_ = yym508
+				yym501 := z.DecBinary()
+				_ = yym501
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-				} else if yym508 {
+				} else if yym501 {
 					z.DecBinaryUnmarshal(x.UntilTime)
-				} else if !yym508 && z.IsJSONHandle() {
+				} else if !yym501 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UntilTime)
 				} else {
 					z.DecFallback(x.UntilTime, false)
@@ -5782,10 +5698,10 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys504)
-		} // end switch yys504
-	} // end for yyj504
-	if !yyhl504 {
+			z.DecStructFieldNotFound(-1, yys497)
+		} // end switch yys497
+	} // end for yyj497
+	if !yyhl497 {
 		r.ReadEnd()
 	}
 }
@@ -5794,16 +5710,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj510 int
-	var yyb510 bool
-	var yyhl510 bool = l >= 0
-	yyj510++
-	if yyhl510 {
-		yyb510 = yyj510 > l
+	var yyj503 int
+	var yyb503 bool
+	var yyhl503 bool = l >= 0
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb510 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb510 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5815,25 +5731,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg1_unversioned.Time)
 		}
-		yym512 := z.DecBinary()
-		_ = yym512
+		yym505 := z.DecBinary()
+		_ = yym505
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym512 {
+		} else if yym505 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym512 && z.IsJSONHandle() {
+		} else if !yym505 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj510++
-	if yyhl510 {
-		yyb510 = yyj510 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb510 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb510 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5845,25 +5761,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UntilTime == nil {
 			x.UntilTime = new(pkg1_unversioned.Time)
 		}
-		yym514 := z.DecBinary()
-		_ = yym514
+		yym507 := z.DecBinary()
+		_ = yym507
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-		} else if yym514 {
+		} else if yym507 {
 			z.DecBinaryUnmarshal(x.UntilTime)
-		} else if !yym514 && z.IsJSONHandle() {
+		} else if !yym507 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UntilTime)
 		} else {
 			z.DecFallback(x.UntilTime, false)
 		}
 	}
-	yyj510++
-	if yyhl510 {
-		yyb510 = yyj510 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb510 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb510 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5873,16 +5789,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj510++
-		if yyhl510 {
-			yyb510 = yyj510 > l
+		yyj503++
+		if yyhl503 {
+			yyb503 = yyj503 > l
 		} else {
-			yyb510 = r.CheckBreak()
+			yyb503 = r.CheckBreak()
 		}
-		if yyb510 {
+		if yyb503 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj510-1, "")
+		z.DecStructFieldNotFound(yyj503-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5892,9 +5808,9 @@ func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv516 := range v {
-		yy517 := &yyv516
-		yy517.CodecEncodeSelf(e)
+	for _, yyv509 := range v {
+		yy510 := &yyv509
+		yy510.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5904,75 +5820,75 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv518 := *v
-	yyh518, yyl518 := z.DecSliceHelperStart()
+	yyv511 := *v
+	yyh511, yyl511 := z.DecSliceHelperStart()
 
-	var yyrr518, yyrl518 int
-	var yyc518, yyrt518 bool
-	_, _, _ = yyc518, yyrt518, yyrl518
-	yyrr518 = yyl518
+	var yyrr511, yyrl511 int
+	var yyc511, yyrt511 bool
+	_, _, _ = yyc511, yyrt511, yyrl511
+	yyrr511 = yyl511
 
-	if yyv518 == nil {
-		if yyrl518, yyrt518 = z.DecInferLen(yyl518, z.DecBasicHandle().MaxInitLen, 72); yyrt518 {
-			yyrr518 = yyrl518
+	if yyv511 == nil {
+		if yyrl511, yyrt511 = z.DecInferLen(yyl511, z.DecBasicHandle().MaxInitLen, 72); yyrt511 {
+			yyrr511 = yyrl511
 		}
-		yyv518 = make([]AggregateSample, yyrl518)
-		yyc518 = true
+		yyv511 = make([]AggregateSample, yyrl511)
+		yyc511 = true
 	}
 
-	if yyl518 == 0 {
-		if len(yyv518) != 0 {
-			yyv518 = yyv518[:0]
-			yyc518 = true
+	if yyl511 == 0 {
+		if len(yyv511) != 0 {
+			yyv511 = yyv511[:0]
+			yyc511 = true
 		}
-	} else if yyl518 > 0 {
+	} else if yyl511 > 0 {
 
-		if yyl518 > cap(yyv518) {
-			yyrl518, yyrt518 = z.DecInferLen(yyl518, z.DecBasicHandle().MaxInitLen, 72)
-			yyv518 = make([]AggregateSample, yyrl518)
-			yyc518 = true
+		if yyl511 > cap(yyv511) {
+			yyrl511, yyrt511 = z.DecInferLen(yyl511, z.DecBasicHandle().MaxInitLen, 72)
+			yyv511 = make([]AggregateSample, yyrl511)
+			yyc511 = true
 
-			yyrr518 = len(yyv518)
-		} else if yyl518 != len(yyv518) {
-			yyv518 = yyv518[:yyl518]
-			yyc518 = true
+			yyrr511 = len(yyv511)
+		} else if yyl511 != len(yyv511) {
+			yyv511 = yyv511[:yyl511]
+			yyc511 = true
 		}
-		yyj518 := 0
-		for ; yyj518 < yyrr518; yyj518++ {
+		yyj511 := 0
+		for ; yyj511 < yyrr511; yyj511++ {
 			if r.TryDecodeAsNil() {
-				yyv518[yyj518] = AggregateSample{}
+				yyv511[yyj511] = AggregateSample{}
 			} else {
-				yyv519 := &yyv518[yyj518]
-				yyv519.CodecDecodeSelf(d)
+				yyv512 := &yyv511[yyj511]
+				yyv512.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt518 {
-			for ; yyj518 < yyl518; yyj518++ {
-				yyv518 = append(yyv518, AggregateSample{})
+		if yyrt511 {
+			for ; yyj511 < yyl511; yyj511++ {
+				yyv511 = append(yyv511, AggregateSample{})
 				if r.TryDecodeAsNil() {
-					yyv518[yyj518] = AggregateSample{}
+					yyv511[yyj511] = AggregateSample{}
 				} else {
-					yyv520 := &yyv518[yyj518]
-					yyv520.CodecDecodeSelf(d)
+					yyv513 := &yyv511[yyj511]
+					yyv513.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj518 := 0; !r.CheckBreak(); yyj518++ {
-			if yyj518 >= len(yyv518) {
-				yyv518 = append(yyv518, AggregateSample{}) // var yyz518 AggregateSample
-				yyc518 = true
+		for yyj511 := 0; !r.CheckBreak(); yyj511++ {
+			if yyj511 >= len(yyv511) {
+				yyv511 = append(yyv511, AggregateSample{}) // var yyz511 AggregateSample
+				yyc511 = true
 			}
 
-			if yyj518 < len(yyv518) {
+			if yyj511 < len(yyv511) {
 				if r.TryDecodeAsNil() {
-					yyv518[yyj518] = AggregateSample{}
+					yyv511[yyj511] = AggregateSample{}
 				} else {
-					yyv521 := &yyv518[yyj518]
-					yyv521.CodecDecodeSelf(d)
+					yyv514 := &yyv511[yyj511]
+					yyv514.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5980,10 +5896,10 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 			}
 
 		}
-		yyh518.End()
+		yyh511.End()
 	}
-	if yyc518 {
-		*v = yyv518
+	if yyc511 {
+		*v = yyv511
 	}
 
 }
@@ -5993,9 +5909,9 @@ func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv522 := range v {
-		yy523 := &yyv522
-		yy523.CodecEncodeSelf(e)
+	for _, yyv515 := range v {
+		yy516 := &yyv515
+		yy516.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6005,75 +5921,75 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv524 := *v
-	yyh524, yyl524 := z.DecSliceHelperStart()
+	yyv517 := *v
+	yyh517, yyl517 := z.DecSliceHelperStart()
 
-	var yyrr524, yyrl524 int
-	var yyc524, yyrt524 bool
-	_, _, _ = yyc524, yyrt524, yyrl524
-	yyrr524 = yyl524
+	var yyrr517, yyrl517 int
+	var yyc517, yyrt517 bool
+	_, _, _ = yyc517, yyrt517, yyrl517
+	yyrr517 = yyl517
 
-	if yyv524 == nil {
-		if yyrl524, yyrt524 = z.DecInferLen(yyl524, z.DecBasicHandle().MaxInitLen, 72); yyrt524 {
-			yyrr524 = yyrl524
+	if yyv517 == nil {
+		if yyrl517, yyrt517 = z.DecInferLen(yyl517, z.DecBasicHandle().MaxInitLen, 72); yyrt517 {
+			yyrr517 = yyrl517
 		}
-		yyv524 = make([]RawContainerMetrics, yyrl524)
-		yyc524 = true
+		yyv517 = make([]RawContainerMetrics, yyrl517)
+		yyc517 = true
 	}
 
-	if yyl524 == 0 {
-		if len(yyv524) != 0 {
-			yyv524 = yyv524[:0]
-			yyc524 = true
+	if yyl517 == 0 {
+		if len(yyv517) != 0 {
+			yyv517 = yyv517[:0]
+			yyc517 = true
 		}
-	} else if yyl524 > 0 {
+	} else if yyl517 > 0 {
 
-		if yyl524 > cap(yyv524) {
-			yyrl524, yyrt524 = z.DecInferLen(yyl524, z.DecBasicHandle().MaxInitLen, 72)
-			yyv524 = make([]RawContainerMetrics, yyrl524)
-			yyc524 = true
+		if yyl517 > cap(yyv517) {
+			yyrl517, yyrt517 = z.DecInferLen(yyl517, z.DecBasicHandle().MaxInitLen, 72)
+			yyv517 = make([]RawContainerMetrics, yyrl517)
+			yyc517 = true
 
-			yyrr524 = len(yyv524)
-		} else if yyl524 != len(yyv524) {
-			yyv524 = yyv524[:yyl524]
-			yyc524 = true
+			yyrr517 = len(yyv517)
+		} else if yyl517 != len(yyv517) {
+			yyv517 = yyv517[:yyl517]
+			yyc517 = true
 		}
-		yyj524 := 0
-		for ; yyj524 < yyrr524; yyj524++ {
+		yyj517 := 0
+		for ; yyj517 < yyrr517; yyj517++ {
 			if r.TryDecodeAsNil() {
-				yyv524[yyj524] = RawContainerMetrics{}
+				yyv517[yyj517] = RawContainerMetrics{}
 			} else {
-				yyv525 := &yyv524[yyj524]
-				yyv525.CodecDecodeSelf(d)
+				yyv518 := &yyv517[yyj517]
+				yyv518.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt524 {
-			for ; yyj524 < yyl524; yyj524++ {
-				yyv524 = append(yyv524, RawContainerMetrics{})
+		if yyrt517 {
+			for ; yyj517 < yyl517; yyj517++ {
+				yyv517 = append(yyv517, RawContainerMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv524[yyj524] = RawContainerMetrics{}
+					yyv517[yyj517] = RawContainerMetrics{}
 				} else {
-					yyv526 := &yyv524[yyj524]
-					yyv526.CodecDecodeSelf(d)
+					yyv519 := &yyv517[yyj517]
+					yyv519.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj524 := 0; !r.CheckBreak(); yyj524++ {
-			if yyj524 >= len(yyv524) {
-				yyv524 = append(yyv524, RawContainerMetrics{}) // var yyz524 RawContainerMetrics
-				yyc524 = true
+		for yyj517 := 0; !r.CheckBreak(); yyj517++ {
+			if yyj517 >= len(yyv517) {
+				yyv517 = append(yyv517, RawContainerMetrics{}) // var yyz517 RawContainerMetrics
+				yyc517 = true
 			}
 
-			if yyj524 < len(yyv524) {
+			if yyj517 < len(yyv517) {
 				if r.TryDecodeAsNil() {
-					yyv524[yyj524] = RawContainerMetrics{}
+					yyv517[yyj517] = RawContainerMetrics{}
 				} else {
-					yyv527 := &yyv524[yyj524]
-					yyv527.CodecDecodeSelf(d)
+					yyv520 := &yyv517[yyj517]
+					yyv520.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6081,10 +5997,10 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 			}
 
 		}
-		yyh524.End()
+		yyh517.End()
 	}
-	if yyc524 {
-		*v = yyv524
+	if yyc517 {
+		*v = yyv517
 	}
 
 }
@@ -6094,9 +6010,9 @@ func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv528 := range v {
-		yy529 := &yyv528
-		yy529.CodecEncodeSelf(e)
+	for _, yyv521 := range v {
+		yy522 := &yyv521
+		yy522.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6106,75 +6022,75 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv530 := *v
-	yyh530, yyl530 := z.DecSliceHelperStart()
+	yyv523 := *v
+	yyh523, yyl523 := z.DecSliceHelperStart()
 
-	var yyrr530, yyrl530 int
-	var yyc530, yyrt530 bool
-	_, _, _ = yyc530, yyrt530, yyrl530
-	yyrr530 = yyl530
+	var yyrr523, yyrl523 int
+	var yyc523, yyrt523 bool
+	_, _, _ = yyc523, yyrt523, yyrl523
+	yyrr523 = yyl523
 
-	if yyv530 == nil {
-		if yyrl530, yyrt530 = z.DecInferLen(yyl530, z.DecBasicHandle().MaxInitLen, 128); yyrt530 {
-			yyrr530 = yyrl530
+	if yyv523 == nil {
+		if yyrl523, yyrt523 = z.DecInferLen(yyl523, z.DecBasicHandle().MaxInitLen, 128); yyrt523 {
+			yyrr523 = yyrl523
 		}
-		yyv530 = make([]RawNodeMetrics, yyrl530)
-		yyc530 = true
+		yyv523 = make([]RawNodeMetrics, yyrl523)
+		yyc523 = true
 	}
 
-	if yyl530 == 0 {
-		if len(yyv530) != 0 {
-			yyv530 = yyv530[:0]
-			yyc530 = true
+	if yyl523 == 0 {
+		if len(yyv523) != 0 {
+			yyv523 = yyv523[:0]
+			yyc523 = true
 		}
-	} else if yyl530 > 0 {
+	} else if yyl523 > 0 {
 
-		if yyl530 > cap(yyv530) {
-			yyrl530, yyrt530 = z.DecInferLen(yyl530, z.DecBasicHandle().MaxInitLen, 128)
-			yyv530 = make([]RawNodeMetrics, yyrl530)
-			yyc530 = true
+		if yyl523 > cap(yyv523) {
+			yyrl523, yyrt523 = z.DecInferLen(yyl523, z.DecBasicHandle().MaxInitLen, 128)
+			yyv523 = make([]RawNodeMetrics, yyrl523)
+			yyc523 = true
 
-			yyrr530 = len(yyv530)
-		} else if yyl530 != len(yyv530) {
-			yyv530 = yyv530[:yyl530]
-			yyc530 = true
+			yyrr523 = len(yyv523)
+		} else if yyl523 != len(yyv523) {
+			yyv523 = yyv523[:yyl523]
+			yyc523 = true
 		}
-		yyj530 := 0
-		for ; yyj530 < yyrr530; yyj530++ {
+		yyj523 := 0
+		for ; yyj523 < yyrr523; yyj523++ {
 			if r.TryDecodeAsNil() {
-				yyv530[yyj530] = RawNodeMetrics{}
+				yyv523[yyj523] = RawNodeMetrics{}
 			} else {
-				yyv531 := &yyv530[yyj530]
-				yyv531.CodecDecodeSelf(d)
+				yyv524 := &yyv523[yyj523]
+				yyv524.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt530 {
-			for ; yyj530 < yyl530; yyj530++ {
-				yyv530 = append(yyv530, RawNodeMetrics{})
+		if yyrt523 {
+			for ; yyj523 < yyl523; yyj523++ {
+				yyv523 = append(yyv523, RawNodeMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv530[yyj530] = RawNodeMetrics{}
+					yyv523[yyj523] = RawNodeMetrics{}
 				} else {
-					yyv532 := &yyv530[yyj530]
-					yyv532.CodecDecodeSelf(d)
+					yyv525 := &yyv523[yyj523]
+					yyv525.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj530 := 0; !r.CheckBreak(); yyj530++ {
-			if yyj530 >= len(yyv530) {
-				yyv530 = append(yyv530, RawNodeMetrics{}) // var yyz530 RawNodeMetrics
-				yyc530 = true
+		for yyj523 := 0; !r.CheckBreak(); yyj523++ {
+			if yyj523 >= len(yyv523) {
+				yyv523 = append(yyv523, RawNodeMetrics{}) // var yyz523 RawNodeMetrics
+				yyc523 = true
 			}
 
-			if yyj530 < len(yyv530) {
+			if yyj523 < len(yyv523) {
 				if r.TryDecodeAsNil() {
-					yyv530[yyj530] = RawNodeMetrics{}
+					yyv523[yyj523] = RawNodeMetrics{}
 				} else {
-					yyv533 := &yyv530[yyj530]
-					yyv533.CodecDecodeSelf(d)
+					yyv526 := &yyv523[yyj523]
+					yyv526.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6182,10 +6098,10 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 			}
 
 		}
-		yyh530.End()
+		yyh523.End()
 	}
-	if yyc530 {
-		*v = yyv530
+	if yyc523 {
+		*v = yyv523
 	}
 
 }
@@ -6195,9 +6111,9 @@ func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv534 := range v {
-		yy535 := &yyv534
-		yy535.CodecEncodeSelf(e)
+	for _, yyv527 := range v {
+		yy528 := &yyv527
+		yy528.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6207,75 +6123,75 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv536 := *v
-	yyh536, yyl536 := z.DecSliceHelperStart()
+	yyv529 := *v
+	yyh529, yyl529 := z.DecSliceHelperStart()
 
-	var yyrr536, yyrl536 int
-	var yyc536, yyrt536 bool
-	_, _, _ = yyc536, yyrt536, yyrl536
-	yyrr536 = yyl536
+	var yyrr529, yyrl529 int
+	var yyc529, yyrt529 bool
+	_, _, _ = yyc529, yyrt529, yyrl529
+	yyrr529 = yyl529
 
-	if yyv536 == nil {
-		if yyrl536, yyrt536 = z.DecInferLen(yyl536, z.DecBasicHandle().MaxInitLen, 32); yyrt536 {
-			yyrr536 = yyrl536
+	if yyv529 == nil {
+		if yyrl529, yyrt529 = z.DecInferLen(yyl529, z.DecBasicHandle().MaxInitLen, 32); yyrt529 {
+			yyrr529 = yyrl529
 		}
-		yyv536 = make([]PodSample, yyrl536)
-		yyc536 = true
+		yyv529 = make([]PodSample, yyrl529)
+		yyc529 = true
 	}
 
-	if yyl536 == 0 {
-		if len(yyv536) != 0 {
-			yyv536 = yyv536[:0]
-			yyc536 = true
+	if yyl529 == 0 {
+		if len(yyv529) != 0 {
+			yyv529 = yyv529[:0]
+			yyc529 = true
 		}
-	} else if yyl536 > 0 {
+	} else if yyl529 > 0 {
 
-		if yyl536 > cap(yyv536) {
-			yyrl536, yyrt536 = z.DecInferLen(yyl536, z.DecBasicHandle().MaxInitLen, 32)
-			yyv536 = make([]PodSample, yyrl536)
-			yyc536 = true
+		if yyl529 > cap(yyv529) {
+			yyrl529, yyrt529 = z.DecInferLen(yyl529, z.DecBasicHandle().MaxInitLen, 32)
+			yyv529 = make([]PodSample, yyrl529)
+			yyc529 = true
 
-			yyrr536 = len(yyv536)
-		} else if yyl536 != len(yyv536) {
-			yyv536 = yyv536[:yyl536]
-			yyc536 = true
+			yyrr529 = len(yyv529)
+		} else if yyl529 != len(yyv529) {
+			yyv529 = yyv529[:yyl529]
+			yyc529 = true
 		}
-		yyj536 := 0
-		for ; yyj536 < yyrr536; yyj536++ {
+		yyj529 := 0
+		for ; yyj529 < yyrr529; yyj529++ {
 			if r.TryDecodeAsNil() {
-				yyv536[yyj536] = PodSample{}
+				yyv529[yyj529] = PodSample{}
 			} else {
-				yyv537 := &yyv536[yyj536]
-				yyv537.CodecDecodeSelf(d)
+				yyv530 := &yyv529[yyj529]
+				yyv530.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt536 {
-			for ; yyj536 < yyl536; yyj536++ {
-				yyv536 = append(yyv536, PodSample{})
+		if yyrt529 {
+			for ; yyj529 < yyl529; yyj529++ {
+				yyv529 = append(yyv529, PodSample{})
 				if r.TryDecodeAsNil() {
-					yyv536[yyj536] = PodSample{}
+					yyv529[yyj529] = PodSample{}
 				} else {
-					yyv538 := &yyv536[yyj536]
-					yyv538.CodecDecodeSelf(d)
+					yyv531 := &yyv529[yyj529]
+					yyv531.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj536 := 0; !r.CheckBreak(); yyj536++ {
-			if yyj536 >= len(yyv536) {
-				yyv536 = append(yyv536, PodSample{}) // var yyz536 PodSample
-				yyc536 = true
+		for yyj529 := 0; !r.CheckBreak(); yyj529++ {
+			if yyj529 >= len(yyv529) {
+				yyv529 = append(yyv529, PodSample{}) // var yyz529 PodSample
+				yyc529 = true
 			}
 
-			if yyj536 < len(yyv536) {
+			if yyj529 < len(yyv529) {
 				if r.TryDecodeAsNil() {
-					yyv536[yyj536] = PodSample{}
+					yyv529[yyj529] = PodSample{}
 				} else {
-					yyv539 := &yyv536[yyj536]
-					yyv539.CodecDecodeSelf(d)
+					yyv532 := &yyv529[yyj529]
+					yyv532.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6283,10 +6199,10 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 			}
 
 		}
-		yyh536.End()
+		yyh529.End()
 	}
-	if yyc536 {
-		*v = yyv536
+	if yyc529 {
+		*v = yyv529
 	}
 
 }
@@ -6296,9 +6212,9 @@ func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv540 := range v {
-		yy541 := &yyv540
-		yy541.CodecEncodeSelf(e)
+	for _, yyv533 := range v {
+		yy534 := &yyv533
+		yy534.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6308,75 +6224,75 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv542 := *v
-	yyh542, yyl542 := z.DecSliceHelperStart()
+	yyv535 := *v
+	yyh535, yyl535 := z.DecSliceHelperStart()
 
-	var yyrr542, yyrl542 int
-	var yyc542, yyrt542 bool
-	_, _, _ = yyc542, yyrt542, yyrl542
-	yyrr542 = yyl542
+	var yyrr535, yyrl535 int
+	var yyc535, yyrt535 bool
+	_, _, _ = yyc535, yyrt535, yyrl535
+	yyrr535 = yyl535
 
-	if yyv542 == nil {
-		if yyrl542, yyrt542 = z.DecInferLen(yyl542, z.DecBasicHandle().MaxInitLen, 160); yyrt542 {
-			yyrr542 = yyrl542
+	if yyv535 == nil {
+		if yyrl535, yyrt535 = z.DecInferLen(yyl535, z.DecBasicHandle().MaxInitLen, 160); yyrt535 {
+			yyrr535 = yyrl535
 		}
-		yyv542 = make([]RawPodMetrics, yyrl542)
-		yyc542 = true
+		yyv535 = make([]RawPodMetrics, yyrl535)
+		yyc535 = true
 	}
 
-	if yyl542 == 0 {
-		if len(yyv542) != 0 {
-			yyv542 = yyv542[:0]
-			yyc542 = true
+	if yyl535 == 0 {
+		if len(yyv535) != 0 {
+			yyv535 = yyv535[:0]
+			yyc535 = true
 		}
-	} else if yyl542 > 0 {
+	} else if yyl535 > 0 {
 
-		if yyl542 > cap(yyv542) {
-			yyrl542, yyrt542 = z.DecInferLen(yyl542, z.DecBasicHandle().MaxInitLen, 160)
-			yyv542 = make([]RawPodMetrics, yyrl542)
-			yyc542 = true
+		if yyl535 > cap(yyv535) {
+			yyrl535, yyrt535 = z.DecInferLen(yyl535, z.DecBasicHandle().MaxInitLen, 160)
+			yyv535 = make([]RawPodMetrics, yyrl535)
+			yyc535 = true
 
-			yyrr542 = len(yyv542)
-		} else if yyl542 != len(yyv542) {
-			yyv542 = yyv542[:yyl542]
-			yyc542 = true
+			yyrr535 = len(yyv535)
+		} else if yyl535 != len(yyv535) {
+			yyv535 = yyv535[:yyl535]
+			yyc535 = true
 		}
-		yyj542 := 0
-		for ; yyj542 < yyrr542; yyj542++ {
+		yyj535 := 0
+		for ; yyj535 < yyrr535; yyj535++ {
 			if r.TryDecodeAsNil() {
-				yyv542[yyj542] = RawPodMetrics{}
+				yyv535[yyj535] = RawPodMetrics{}
 			} else {
-				yyv543 := &yyv542[yyj542]
-				yyv543.CodecDecodeSelf(d)
+				yyv536 := &yyv535[yyj535]
+				yyv536.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt542 {
-			for ; yyj542 < yyl542; yyj542++ {
-				yyv542 = append(yyv542, RawPodMetrics{})
+		if yyrt535 {
+			for ; yyj535 < yyl535; yyj535++ {
+				yyv535 = append(yyv535, RawPodMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv542[yyj542] = RawPodMetrics{}
+					yyv535[yyj535] = RawPodMetrics{}
 				} else {
-					yyv544 := &yyv542[yyj542]
-					yyv544.CodecDecodeSelf(d)
+					yyv537 := &yyv535[yyj535]
+					yyv537.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj542 := 0; !r.CheckBreak(); yyj542++ {
-			if yyj542 >= len(yyv542) {
-				yyv542 = append(yyv542, RawPodMetrics{}) // var yyz542 RawPodMetrics
-				yyc542 = true
+		for yyj535 := 0; !r.CheckBreak(); yyj535++ {
+			if yyj535 >= len(yyv535) {
+				yyv535 = append(yyv535, RawPodMetrics{}) // var yyz535 RawPodMetrics
+				yyc535 = true
 			}
 
-			if yyj542 < len(yyv542) {
+			if yyj535 < len(yyv535) {
 				if r.TryDecodeAsNil() {
-					yyv542[yyj542] = RawPodMetrics{}
+					yyv535[yyj535] = RawPodMetrics{}
 				} else {
-					yyv545 := &yyv542[yyj542]
-					yyv545.CodecDecodeSelf(d)
+					yyv538 := &yyv535[yyj535]
+					yyv538.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6384,10 +6300,10 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 			}
 
 		}
-		yyh542.End()
+		yyh535.End()
 	}
-	if yyc542 {
-		*v = yyv542
+	if yyc535 {
+		*v = yyv535
 	}
 
 }
@@ -6397,9 +6313,9 @@ func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv546 := range v {
-		yy547 := &yyv546
-		yy547.CodecEncodeSelf(e)
+	for _, yyv539 := range v {
+		yy540 := &yyv539
+		yy540.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6409,75 +6325,75 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv548 := *v
-	yyh548, yyl548 := z.DecSliceHelperStart()
+	yyv541 := *v
+	yyh541, yyl541 := z.DecSliceHelperStart()
 
-	var yyrr548, yyrl548 int
-	var yyc548, yyrt548 bool
-	_, _, _ = yyc548, yyrt548, yyrl548
-	yyrr548 = yyl548
+	var yyrr541, yyrl541 int
+	var yyc541, yyrt541 bool
+	_, _, _ = yyc541, yyrt541, yyrl541
+	yyrr541 = yyl541
 
-	if yyv548 == nil {
-		if yyrl548, yyrt548 = z.DecInferLen(yyl548, z.DecBasicHandle().MaxInitLen, 64); yyrt548 {
-			yyrr548 = yyrl548
+	if yyv541 == nil {
+		if yyrl541, yyrt541 = z.DecInferLen(yyl541, z.DecBasicHandle().MaxInitLen, 64); yyrt541 {
+			yyrr541 = yyrl541
 		}
-		yyv548 = make([]ContainerSample, yyrl548)
-		yyc548 = true
+		yyv541 = make([]ContainerSample, yyrl541)
+		yyc541 = true
 	}
 
-	if yyl548 == 0 {
-		if len(yyv548) != 0 {
-			yyv548 = yyv548[:0]
-			yyc548 = true
+	if yyl541 == 0 {
+		if len(yyv541) != 0 {
+			yyv541 = yyv541[:0]
+			yyc541 = true
 		}
-	} else if yyl548 > 0 {
+	} else if yyl541 > 0 {
 
-		if yyl548 > cap(yyv548) {
-			yyrl548, yyrt548 = z.DecInferLen(yyl548, z.DecBasicHandle().MaxInitLen, 64)
-			yyv548 = make([]ContainerSample, yyrl548)
-			yyc548 = true
+		if yyl541 > cap(yyv541) {
+			yyrl541, yyrt541 = z.DecInferLen(yyl541, z.DecBasicHandle().MaxInitLen, 64)
+			yyv541 = make([]ContainerSample, yyrl541)
+			yyc541 = true
 
-			yyrr548 = len(yyv548)
-		} else if yyl548 != len(yyv548) {
-			yyv548 = yyv548[:yyl548]
-			yyc548 = true
+			yyrr541 = len(yyv541)
+		} else if yyl541 != len(yyv541) {
+			yyv541 = yyv541[:yyl541]
+			yyc541 = true
 		}
-		yyj548 := 0
-		for ; yyj548 < yyrr548; yyj548++ {
+		yyj541 := 0
+		for ; yyj541 < yyrr541; yyj541++ {
 			if r.TryDecodeAsNil() {
-				yyv548[yyj548] = ContainerSample{}
+				yyv541[yyj541] = ContainerSample{}
 			} else {
-				yyv549 := &yyv548[yyj548]
-				yyv549.CodecDecodeSelf(d)
+				yyv542 := &yyv541[yyj541]
+				yyv542.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt548 {
-			for ; yyj548 < yyl548; yyj548++ {
-				yyv548 = append(yyv548, ContainerSample{})
+		if yyrt541 {
+			for ; yyj541 < yyl541; yyj541++ {
+				yyv541 = append(yyv541, ContainerSample{})
 				if r.TryDecodeAsNil() {
-					yyv548[yyj548] = ContainerSample{}
+					yyv541[yyj541] = ContainerSample{}
 				} else {
-					yyv550 := &yyv548[yyj548]
-					yyv550.CodecDecodeSelf(d)
+					yyv543 := &yyv541[yyj541]
+					yyv543.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj548 := 0; !r.CheckBreak(); yyj548++ {
-			if yyj548 >= len(yyv548) {
-				yyv548 = append(yyv548, ContainerSample{}) // var yyz548 ContainerSample
-				yyc548 = true
+		for yyj541 := 0; !r.CheckBreak(); yyj541++ {
+			if yyj541 >= len(yyv541) {
+				yyv541 = append(yyv541, ContainerSample{}) // var yyz541 ContainerSample
+				yyc541 = true
 			}
 
-			if yyj548 < len(yyv548) {
+			if yyj541 < len(yyv541) {
 				if r.TryDecodeAsNil() {
-					yyv548[yyj548] = ContainerSample{}
+					yyv541[yyj541] = ContainerSample{}
 				} else {
-					yyv551 := &yyv548[yyj548]
-					yyv551.CodecDecodeSelf(d)
+					yyv544 := &yyv541[yyj541]
+					yyv544.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6485,10 +6401,10 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 			}
 
 		}
-		yyh548.End()
+		yyh541.End()
 	}
-	if yyc548 {
-		*v = yyv548
+	if yyc541 {
+		*v = yyv541
 	}
 
 }
@@ -6498,9 +6414,9 @@ func (x codecSelfer1234) encSliceCustomMetric(v []CustomMetric, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv552 := range v {
-		yy553 := &yyv552
-		yy553.CodecEncodeSelf(e)
+	for _, yyv545 := range v {
+		yy546 := &yyv545
+		yy546.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6510,75 +6426,75 @@ func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv554 := *v
-	yyh554, yyl554 := z.DecSliceHelperStart()
+	yyv547 := *v
+	yyh547, yyl547 := z.DecSliceHelperStart()
 
-	var yyrr554, yyrl554 int
-	var yyc554, yyrt554 bool
-	_, _, _ = yyc554, yyrt554, yyrl554
-	yyrr554 = yyl554
+	var yyrr547, yyrl547 int
+	var yyc547, yyrt547 bool
+	_, _, _ = yyc547, yyrt547, yyrl547
+	yyrr547 = yyl547
 
-	if yyv554 == nil {
-		if yyrl554, yyrt554 = z.DecInferLen(yyl554, z.DecBasicHandle().MaxInitLen, 72); yyrt554 {
-			yyrr554 = yyrl554
+	if yyv547 == nil {
+		if yyrl547, yyrt547 = z.DecInferLen(yyl547, z.DecBasicHandle().MaxInitLen, 72); yyrt547 {
+			yyrr547 = yyrl547
 		}
-		yyv554 = make([]CustomMetric, yyrl554)
-		yyc554 = true
+		yyv547 = make([]CustomMetric, yyrl547)
+		yyc547 = true
 	}
 
-	if yyl554 == 0 {
-		if len(yyv554) != 0 {
-			yyv554 = yyv554[:0]
-			yyc554 = true
+	if yyl547 == 0 {
+		if len(yyv547) != 0 {
+			yyv547 = yyv547[:0]
+			yyc547 = true
 		}
-	} else if yyl554 > 0 {
+	} else if yyl547 > 0 {
 
-		if yyl554 > cap(yyv554) {
-			yyrl554, yyrt554 = z.DecInferLen(yyl554, z.DecBasicHandle().MaxInitLen, 72)
-			yyv554 = make([]CustomMetric, yyrl554)
-			yyc554 = true
+		if yyl547 > cap(yyv547) {
+			yyrl547, yyrt547 = z.DecInferLen(yyl547, z.DecBasicHandle().MaxInitLen, 72)
+			yyv547 = make([]CustomMetric, yyrl547)
+			yyc547 = true
 
-			yyrr554 = len(yyv554)
-		} else if yyl554 != len(yyv554) {
-			yyv554 = yyv554[:yyl554]
-			yyc554 = true
+			yyrr547 = len(yyv547)
+		} else if yyl547 != len(yyv547) {
+			yyv547 = yyv547[:yyl547]
+			yyc547 = true
 		}
-		yyj554 := 0
-		for ; yyj554 < yyrr554; yyj554++ {
+		yyj547 := 0
+		for ; yyj547 < yyrr547; yyj547++ {
 			if r.TryDecodeAsNil() {
-				yyv554[yyj554] = CustomMetric{}
+				yyv547[yyj547] = CustomMetric{}
 			} else {
-				yyv555 := &yyv554[yyj554]
-				yyv555.CodecDecodeSelf(d)
+				yyv548 := &yyv547[yyj547]
+				yyv548.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt554 {
-			for ; yyj554 < yyl554; yyj554++ {
-				yyv554 = append(yyv554, CustomMetric{})
+		if yyrt547 {
+			for ; yyj547 < yyl547; yyj547++ {
+				yyv547 = append(yyv547, CustomMetric{})
 				if r.TryDecodeAsNil() {
-					yyv554[yyj554] = CustomMetric{}
+					yyv547[yyj547] = CustomMetric{}
 				} else {
-					yyv556 := &yyv554[yyj554]
-					yyv556.CodecDecodeSelf(d)
+					yyv549 := &yyv547[yyj547]
+					yyv549.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj554 := 0; !r.CheckBreak(); yyj554++ {
-			if yyj554 >= len(yyv554) {
-				yyv554 = append(yyv554, CustomMetric{}) // var yyz554 CustomMetric
-				yyc554 = true
+		for yyj547 := 0; !r.CheckBreak(); yyj547++ {
+			if yyj547 >= len(yyv547) {
+				yyv547 = append(yyv547, CustomMetric{}) // var yyz547 CustomMetric
+				yyc547 = true
 			}
 
-			if yyj554 < len(yyv554) {
+			if yyj547 < len(yyv547) {
 				if r.TryDecodeAsNil() {
-					yyv554[yyj554] = CustomMetric{}
+					yyv547[yyj547] = CustomMetric{}
 				} else {
-					yyv557 := &yyv554[yyj554]
-					yyv557.CodecDecodeSelf(d)
+					yyv550 := &yyv547[yyj547]
+					yyv550.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6586,10 +6502,10 @@ func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.De
 			}
 
 		}
-		yyh554.End()
+		yyh547.End()
 	}
-	if yyc554 {
-		*v = yyv554
+	if yyc547 {
+		*v = yyv547
 	}
 
 }
@@ -6599,9 +6515,9 @@ func (x codecSelfer1234) encSliceFilesystemMetrics(v []FilesystemMetrics, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv558 := range v {
-		yy559 := &yyv558
-		yy559.CodecEncodeSelf(e)
+	for _, yyv551 := range v {
+		yy552 := &yyv551
+		yy552.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6611,75 +6527,75 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv560 := *v
-	yyh560, yyl560 := z.DecSliceHelperStart()
+	yyv553 := *v
+	yyh553, yyl553 := z.DecSliceHelperStart()
 
-	var yyrr560, yyrl560 int
-	var yyc560, yyrt560 bool
-	_, _, _ = yyc560, yyrt560, yyrl560
-	yyrr560 = yyl560
+	var yyrr553, yyrl553 int
+	var yyc553, yyrt553 bool
+	_, _, _ = yyc553, yyrt553, yyrl553
+	yyrr553 = yyl553
 
-	if yyv560 == nil {
-		if yyrl560, yyrt560 = z.DecInferLen(yyl560, z.DecBasicHandle().MaxInitLen, 32); yyrt560 {
-			yyrr560 = yyrl560
+	if yyv553 == nil {
+		if yyrl553, yyrt553 = z.DecInferLen(yyl553, z.DecBasicHandle().MaxInitLen, 32); yyrt553 {
+			yyrr553 = yyrl553
 		}
-		yyv560 = make([]FilesystemMetrics, yyrl560)
-		yyc560 = true
+		yyv553 = make([]FilesystemMetrics, yyrl553)
+		yyc553 = true
 	}
 
-	if yyl560 == 0 {
-		if len(yyv560) != 0 {
-			yyv560 = yyv560[:0]
-			yyc560 = true
+	if yyl553 == 0 {
+		if len(yyv553) != 0 {
+			yyv553 = yyv553[:0]
+			yyc553 = true
 		}
-	} else if yyl560 > 0 {
+	} else if yyl553 > 0 {
 
-		if yyl560 > cap(yyv560) {
-			yyrl560, yyrt560 = z.DecInferLen(yyl560, z.DecBasicHandle().MaxInitLen, 32)
-			yyv560 = make([]FilesystemMetrics, yyrl560)
-			yyc560 = true
+		if yyl553 > cap(yyv553) {
+			yyrl553, yyrt553 = z.DecInferLen(yyl553, z.DecBasicHandle().MaxInitLen, 32)
+			yyv553 = make([]FilesystemMetrics, yyrl553)
+			yyc553 = true
 
-			yyrr560 = len(yyv560)
-		} else if yyl560 != len(yyv560) {
-			yyv560 = yyv560[:yyl560]
-			yyc560 = true
+			yyrr553 = len(yyv553)
+		} else if yyl553 != len(yyv553) {
+			yyv553 = yyv553[:yyl553]
+			yyc553 = true
 		}
-		yyj560 := 0
-		for ; yyj560 < yyrr560; yyj560++ {
+		yyj553 := 0
+		for ; yyj553 < yyrr553; yyj553++ {
 			if r.TryDecodeAsNil() {
-				yyv560[yyj560] = FilesystemMetrics{}
+				yyv553[yyj553] = FilesystemMetrics{}
 			} else {
-				yyv561 := &yyv560[yyj560]
-				yyv561.CodecDecodeSelf(d)
+				yyv554 := &yyv553[yyj553]
+				yyv554.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt560 {
-			for ; yyj560 < yyl560; yyj560++ {
-				yyv560 = append(yyv560, FilesystemMetrics{})
+		if yyrt553 {
+			for ; yyj553 < yyl553; yyj553++ {
+				yyv553 = append(yyv553, FilesystemMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv560[yyj560] = FilesystemMetrics{}
+					yyv553[yyj553] = FilesystemMetrics{}
 				} else {
-					yyv562 := &yyv560[yyj560]
-					yyv562.CodecDecodeSelf(d)
+					yyv555 := &yyv553[yyj553]
+					yyv555.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj560 := 0; !r.CheckBreak(); yyj560++ {
-			if yyj560 >= len(yyv560) {
-				yyv560 = append(yyv560, FilesystemMetrics{}) // var yyz560 FilesystemMetrics
-				yyc560 = true
+		for yyj553 := 0; !r.CheckBreak(); yyj553++ {
+			if yyj553 >= len(yyv553) {
+				yyv553 = append(yyv553, FilesystemMetrics{}) // var yyz553 FilesystemMetrics
+				yyc553 = true
 			}
 
-			if yyj560 < len(yyv560) {
+			if yyj553 < len(yyv553) {
 				if r.TryDecodeAsNil() {
-					yyv560[yyj560] = FilesystemMetrics{}
+					yyv553[yyj553] = FilesystemMetrics{}
 				} else {
-					yyv563 := &yyv560[yyj560]
-					yyv563.CodecDecodeSelf(d)
+					yyv556 := &yyv553[yyj553]
+					yyv556.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6687,10 +6603,10 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 			}
 
 		}
-		yyh560.End()
+		yyh553.End()
 	}
-	if yyc560 {
-		*v = yyv560
+	if yyc553 {
+		*v = yyv553
 	}
 
 }
@@ -6700,9 +6616,9 @@ func (x codecSelfer1234) encSliceCustomMetricSample(v []CustomMetricSample, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv564 := range v {
-		yy565 := &yyv564
-		yy565.CodecEncodeSelf(e)
+	for _, yyv557 := range v {
+		yy558 := &yyv557
+		yy558.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6712,75 +6628,75 @@ func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv566 := *v
-	yyh566, yyl566 := z.DecSliceHelperStart()
+	yyv559 := *v
+	yyh559, yyl559 := z.DecSliceHelperStart()
 
-	var yyrr566, yyrl566 int
-	var yyc566, yyrt566 bool
-	_, _, _ = yyc566, yyrt566, yyrl566
-	yyrr566 = yyl566
+	var yyrr559, yyrl559 int
+	var yyc559, yyrt559 bool
+	_, _, _ = yyc559, yyrt559, yyrl559
+	yyrr559 = yyl559
 
-	if yyv566 == nil {
-		if yyrl566, yyrt566 = z.DecInferLen(yyl566, z.DecBasicHandle().MaxInitLen, 56); yyrt566 {
-			yyrr566 = yyrl566
+	if yyv559 == nil {
+		if yyrl559, yyrt559 = z.DecInferLen(yyl559, z.DecBasicHandle().MaxInitLen, 56); yyrt559 {
+			yyrr559 = yyrl559
 		}
-		yyv566 = make([]CustomMetricSample, yyrl566)
-		yyc566 = true
+		yyv559 = make([]CustomMetricSample, yyrl559)
+		yyc559 = true
 	}
 
-	if yyl566 == 0 {
-		if len(yyv566) != 0 {
-			yyv566 = yyv566[:0]
-			yyc566 = true
+	if yyl559 == 0 {
+		if len(yyv559) != 0 {
+			yyv559 = yyv559[:0]
+			yyc559 = true
 		}
-	} else if yyl566 > 0 {
+	} else if yyl559 > 0 {
 
-		if yyl566 > cap(yyv566) {
-			yyrl566, yyrt566 = z.DecInferLen(yyl566, z.DecBasicHandle().MaxInitLen, 56)
-			yyv566 = make([]CustomMetricSample, yyrl566)
-			yyc566 = true
+		if yyl559 > cap(yyv559) {
+			yyrl559, yyrt559 = z.DecInferLen(yyl559, z.DecBasicHandle().MaxInitLen, 56)
+			yyv559 = make([]CustomMetricSample, yyrl559)
+			yyc559 = true
 
-			yyrr566 = len(yyv566)
-		} else if yyl566 != len(yyv566) {
-			yyv566 = yyv566[:yyl566]
-			yyc566 = true
+			yyrr559 = len(yyv559)
+		} else if yyl559 != len(yyv559) {
+			yyv559 = yyv559[:yyl559]
+			yyc559 = true
 		}
-		yyj566 := 0
-		for ; yyj566 < yyrr566; yyj566++ {
+		yyj559 := 0
+		for ; yyj559 < yyrr559; yyj559++ {
 			if r.TryDecodeAsNil() {
-				yyv566[yyj566] = CustomMetricSample{}
+				yyv559[yyj559] = CustomMetricSample{}
 			} else {
-				yyv567 := &yyv566[yyj566]
-				yyv567.CodecDecodeSelf(d)
+				yyv560 := &yyv559[yyj559]
+				yyv560.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt566 {
-			for ; yyj566 < yyl566; yyj566++ {
-				yyv566 = append(yyv566, CustomMetricSample{})
+		if yyrt559 {
+			for ; yyj559 < yyl559; yyj559++ {
+				yyv559 = append(yyv559, CustomMetricSample{})
 				if r.TryDecodeAsNil() {
-					yyv566[yyj566] = CustomMetricSample{}
+					yyv559[yyj559] = CustomMetricSample{}
 				} else {
-					yyv568 := &yyv566[yyj566]
-					yyv568.CodecDecodeSelf(d)
+					yyv561 := &yyv559[yyj559]
+					yyv561.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj566 := 0; !r.CheckBreak(); yyj566++ {
-			if yyj566 >= len(yyv566) {
-				yyv566 = append(yyv566, CustomMetricSample{}) // var yyz566 CustomMetricSample
-				yyc566 = true
+		for yyj559 := 0; !r.CheckBreak(); yyj559++ {
+			if yyj559 >= len(yyv559) {
+				yyv559 = append(yyv559, CustomMetricSample{}) // var yyz559 CustomMetricSample
+				yyc559 = true
 			}
 
-			if yyj566 < len(yyv566) {
+			if yyj559 < len(yyv559) {
 				if r.TryDecodeAsNil() {
-					yyv566[yyj566] = CustomMetricSample{}
+					yyv559[yyj559] = CustomMetricSample{}
 				} else {
-					yyv569 := &yyv566[yyj566]
-					yyv569.CodecDecodeSelf(d)
+					yyv562 := &yyv559[yyj559]
+					yyv562.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6788,10 +6704,10 @@ func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *
 			}
 
 		}
-		yyh566.End()
+		yyh559.End()
 	}
-	if yyc566 {
-		*v = yyv566
+	if yyc559 {
+		*v = yyv559
 	}
 
 }

--- a/pkg/apis/metrics/v1alpha1/types.generated.go
+++ b/pkg/apis/metrics/v1alpha1/types.generated.go
@@ -1708,13 +1708,12 @@ func (x *RawContainerMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep165 := !z.EncBinary()
 			yy2arr165 := z.EncBasicHandle().StructToArray
-			var yyq165 [4]bool
+			var yyq165 [3]bool
 			_, _, _ = yysep165, yyq165, yy2arr165
 			const yyr165 bool = false
 			yyq165[1] = len(x.Labels) != 0
-			yyq165[3] = len(x.CustomMetrics) != 0
 			if yyr165 || yy2arr165 {
-				r.EncodeArrayStart(4)
+				r.EncodeArrayStart(3)
 			} else {
 				var yynn165 int = 2
 				for _, b := range yyq165 {
@@ -1794,36 +1793,6 @@ func (x *RawContainerMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr165 || yy2arr165 {
-				if yyq165[3] {
-					if x.CustomMetrics == nil {
-						r.EncodeNil()
-					} else {
-						yym176 := z.EncBinary()
-						_ = yym176
-						if false {
-						} else {
-							h.encSliceCustomMetric(([]CustomMetric)(x.CustomMetrics), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq165[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("customMetrics"))
-					if x.CustomMetrics == nil {
-						r.EncodeNil()
-					} else {
-						yym177 := z.EncBinary()
-						_ = yym177
-						if false {
-						} else {
-							h.encSliceCustomMetric(([]CustomMetric)(x.CustomMetrics), e)
-						}
-					}
-				}
-			}
 			if yysep165 {
 				r.EncodeEnd()
 			}
@@ -1835,24 +1804,24 @@ func (x *RawContainerMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym178 := z.DecBinary()
-	_ = yym178
+	yym175 := z.DecBinary()
+	_ = yym175
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl179 := r.ReadMapStart()
-			if yyl179 == 0 {
+			yyl176 := r.ReadMapStart()
+			if yyl176 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl179, d)
+				x.codecDecodeSelfFromMap(yyl176, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl179 := r.ReadArrayStart()
-			if yyl179 == 0 {
+			yyl176 := r.ReadArrayStart()
+			if yyl176 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl179, d)
+				x.codecDecodeSelfFromArray(yyl176, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1864,12 +1833,12 @@ func (x *RawContainerMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys180Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys180Slc
-	var yyhl180 bool = l >= 0
-	for yyj180 := 0; ; yyj180++ {
-		if yyhl180 {
-			if yyj180 >= l {
+	var yys177Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys177Slc
+	var yyhl177 bool = l >= 0
+	for yyj177 := 0; ; yyj177++ {
+		if yyhl177 {
+			if yyj177 >= l {
 				break
 			}
 		} else {
@@ -1877,9 +1846,9 @@ func (x *RawContainerMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys180Slc = r.DecodeBytes(yys180Slc, true, true)
-		yys180 := string(yys180Slc)
-		switch yys180 {
+		yys177Slc = r.DecodeBytes(yys177Slc, true, true)
+		yys177 := string(yys177Slc)
+		switch yys177 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -1890,43 +1859,31 @@ func (x *RawContainerMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.Labels = nil
 			} else {
-				yyv182 := &x.Labels
-				yym183 := z.DecBinary()
-				_ = yym183
+				yyv179 := &x.Labels
+				yym180 := z.DecBinary()
+				_ = yym180
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv182, false, d)
+					z.F.DecMapStringStringX(yyv179, false, d)
 				}
 			}
 		case "samples":
 			if r.TryDecodeAsNil() {
 				x.Samples = nil
 			} else {
-				yyv184 := &x.Samples
-				yym185 := z.DecBinary()
-				_ = yym185
+				yyv181 := &x.Samples
+				yym182 := z.DecBinary()
+				_ = yym182
 				if false {
 				} else {
-					h.decSliceContainerSample((*[]ContainerSample)(yyv184), d)
-				}
-			}
-		case "customMetrics":
-			if r.TryDecodeAsNil() {
-				x.CustomMetrics = nil
-			} else {
-				yyv186 := &x.CustomMetrics
-				yym187 := z.DecBinary()
-				_ = yym187
-				if false {
-				} else {
-					h.decSliceCustomMetric((*[]CustomMetric)(yyv186), d)
+					h.decSliceContainerSample((*[]ContainerSample)(yyv181), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys180)
-		} // end switch yys180
-	} // end for yyj180
-	if !yyhl180 {
+			z.DecStructFieldNotFound(-1, yys177)
+		} // end switch yys177
+	} // end for yyj177
+	if !yyhl177 {
 		r.ReadEnd()
 	}
 }
@@ -1935,16 +1892,16 @@ func (x *RawContainerMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj188 int
-	var yyb188 bool
-	var yyhl188 bool = l >= 0
-	yyj188++
-	if yyhl188 {
-		yyb188 = yyj188 > l
+	var yyj183 int
+	var yyb183 bool
+	var yyhl183 bool = l >= 0
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb188 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb188 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
@@ -1953,80 +1910,59 @@ func (x *RawContainerMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj188++
-	if yyhl188 {
-		yyb188 = yyj188 > l
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb188 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb188 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
-		yyv190 := &x.Labels
-		yym191 := z.DecBinary()
-		_ = yym191
+		yyv185 := &x.Labels
+		yym186 := z.DecBinary()
+		_ = yym186
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv190, false, d)
+			z.F.DecMapStringStringX(yyv185, false, d)
 		}
 	}
-	yyj188++
-	if yyhl188 {
-		yyb188 = yyj188 > l
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb188 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb188 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Samples = nil
 	} else {
-		yyv192 := &x.Samples
-		yym193 := z.DecBinary()
-		_ = yym193
+		yyv187 := &x.Samples
+		yym188 := z.DecBinary()
+		_ = yym188
 		if false {
 		} else {
-			h.decSliceContainerSample((*[]ContainerSample)(yyv192), d)
-		}
-	}
-	yyj188++
-	if yyhl188 {
-		yyb188 = yyj188 > l
-	} else {
-		yyb188 = r.CheckBreak()
-	}
-	if yyb188 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.CustomMetrics = nil
-	} else {
-		yyv194 := &x.CustomMetrics
-		yym195 := z.DecBinary()
-		_ = yym195
-		if false {
-		} else {
-			h.decSliceCustomMetric((*[]CustomMetric)(yyv194), d)
+			h.decSliceContainerSample((*[]ContainerSample)(yyv187), d)
 		}
 	}
 	for {
-		yyj188++
-		if yyhl188 {
-			yyb188 = yyj188 > l
+		yyj183++
+		if yyhl183 {
+			yyb183 = yyj183 > l
 		} else {
-			yyb188 = r.CheckBreak()
+			yyb183 = r.CheckBreak()
 		}
-		if yyb188 {
+		if yyb183 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj188-1, "")
+		z.DecStructFieldNotFound(yyj183-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2038,64 +1974,64 @@ func (x *NonLocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym196 := z.EncBinary()
-		_ = yym196
+		yym189 := z.EncBinary()
+		_ = yym189
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep197 := !z.EncBinary()
-			yy2arr197 := z.EncBasicHandle().StructToArray
-			var yyq197 [3]bool
-			_, _, _ = yysep197, yyq197, yy2arr197
-			const yyr197 bool = false
-			yyq197[2] = x.UID != ""
-			if yyr197 || yy2arr197 {
+			yysep190 := !z.EncBinary()
+			yy2arr190 := z.EncBasicHandle().StructToArray
+			var yyq190 [3]bool
+			_, _, _ = yysep190, yyq190, yy2arr190
+			const yyr190 bool = false
+			yyq190[2] = x.UID != ""
+			if yyr190 || yy2arr190 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn197 int = 2
-				for _, b := range yyq197 {
+				var yynn190 int = 2
+				for _, b := range yyq190 {
 					if b {
-						yynn197++
+						yynn190++
 					}
 				}
-				r.EncodeMapStart(yynn197)
+				r.EncodeMapStart(yynn190)
 			}
-			if yyr197 || yy2arr197 {
-				yym199 := z.EncBinary()
-				_ = yym199
+			if yyr190 || yy2arr190 {
+				yym192 := z.EncBinary()
+				_ = yym192
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
-				yym200 := z.EncBinary()
-				_ = yym200
+				yym193 := z.EncBinary()
+				_ = yym193
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yyr197 || yy2arr197 {
-				yym202 := z.EncBinary()
-				_ = yym202
+			if yyr190 || yy2arr190 {
+				yym195 := z.EncBinary()
+				_ = yym195
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("namespace"))
-				yym203 := z.EncBinary()
-				_ = yym203
+				yym196 := z.EncBinary()
+				_ = yym196
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
 				}
 			}
-			if yyr197 || yy2arr197 {
-				if yyq197[2] {
-					yym205 := z.EncBinary()
-					_ = yym205
+			if yyr190 || yy2arr190 {
+				if yyq190[2] {
+					yym198 := z.EncBinary()
+					_ = yym198
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
@@ -2105,10 +2041,10 @@ func (x *NonLocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq197[2] {
+				if yyq190[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("uid"))
-					yym206 := z.EncBinary()
-					_ = yym206
+					yym199 := z.EncBinary()
+					_ = yym199
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
@@ -2116,7 +2052,7 @@ func (x *NonLocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep197 {
+			if yysep190 {
 				r.EncodeEnd()
 			}
 		}
@@ -2127,24 +2063,24 @@ func (x *NonLocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym207 := z.DecBinary()
-	_ = yym207
+	yym200 := z.DecBinary()
+	_ = yym200
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl208 := r.ReadMapStart()
-			if yyl208 == 0 {
+			yyl201 := r.ReadMapStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl208, d)
+				x.codecDecodeSelfFromMap(yyl201, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl208 := r.ReadArrayStart()
-			if yyl208 == 0 {
+			yyl201 := r.ReadArrayStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl208, d)
+				x.codecDecodeSelfFromArray(yyl201, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2156,12 +2092,12 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys209Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys209Slc
-	var yyhl209 bool = l >= 0
-	for yyj209 := 0; ; yyj209++ {
-		if yyhl209 {
-			if yyj209 >= l {
+	var yys202Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys202Slc
+	var yyhl202 bool = l >= 0
+	for yyj202 := 0; ; yyj202++ {
+		if yyhl202 {
+			if yyj202 >= l {
 				break
 			}
 		} else {
@@ -2169,9 +2105,9 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys209Slc = r.DecodeBytes(yys209Slc, true, true)
-		yys209 := string(yys209Slc)
-		switch yys209 {
+		yys202Slc = r.DecodeBytes(yys202Slc, true, true)
+		yys202 := string(yys202Slc)
+		switch yys202 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -2191,10 +2127,10 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.UID = pkg4_types.UID(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys209)
-		} // end switch yys209
-	} // end for yyj209
-	if !yyhl209 {
+			z.DecStructFieldNotFound(-1, yys202)
+		} // end switch yys202
+	} // end for yyj202
+	if !yyhl202 {
 		r.ReadEnd()
 	}
 }
@@ -2203,16 +2139,16 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj213 int
-	var yyb213 bool
-	var yyhl213 bool = l >= 0
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	var yyj206 int
+	var yyb206 bool
+	var yyhl206 bool = l >= 0
+	yyj206++
+	if yyhl206 {
+		yyb206 = yyj206 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb206 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb206 {
 		r.ReadEnd()
 		return
 	}
@@ -2221,13 +2157,13 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj206++
+	if yyhl206 {
+		yyb206 = yyj206 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb206 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb206 {
 		r.ReadEnd()
 		return
 	}
@@ -2236,13 +2172,13 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Namespace = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj206++
+	if yyhl206 {
+		yyb206 = yyj206 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb206 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb206 {
 		r.ReadEnd()
 		return
 	}
@@ -2252,16 +2188,16 @@ func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.UID = pkg4_types.UID(r.DecodeString())
 	}
 	for {
-		yyj213++
-		if yyhl213 {
-			yyb213 = yyj213 > l
+		yyj206++
+		if yyhl206 {
+			yyb206 = yyj206 > l
 		} else {
-			yyb213 = r.CheckBreak()
+			yyb206 = r.CheckBreak()
 		}
-		if yyb213 {
+		if yyb206 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj213-1, "")
+		z.DecStructFieldNotFound(yyj206-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2273,56 +2209,56 @@ func (x *Sample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym217 := z.EncBinary()
-		_ = yym217
+		yym210 := z.EncBinary()
+		_ = yym210
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep218 := !z.EncBinary()
-			yy2arr218 := z.EncBasicHandle().StructToArray
-			var yyq218 [1]bool
-			_, _, _ = yysep218, yyq218, yy2arr218
-			const yyr218 bool = false
-			if yyr218 || yy2arr218 {
+			yysep211 := !z.EncBinary()
+			yy2arr211 := z.EncBasicHandle().StructToArray
+			var yyq211 [1]bool
+			_, _, _ = yysep211, yyq211, yy2arr211
+			const yyr211 bool = false
+			if yyr211 || yy2arr211 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn218 int = 1
-				for _, b := range yyq218 {
+				var yynn211 int = 1
+				for _, b := range yyq211 {
 					if b {
-						yynn218++
+						yynn211++
 					}
 				}
-				r.EncodeMapStart(yynn218)
+				r.EncodeMapStart(yynn211)
 			}
-			if yyr218 || yy2arr218 {
-				yy220 := &x.SampleTime
-				yym221 := z.EncBinary()
-				_ = yym221
+			if yyr211 || yy2arr211 {
+				yy213 := &x.SampleTime
+				yym214 := z.EncBinary()
+				_ = yym214
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy220) {
-				} else if yym221 {
-					z.EncBinaryMarshal(yy220)
-				} else if !yym221 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy220)
+				} else if z.HasExtensions() && z.EncExt(yy213) {
+				} else if yym214 {
+					z.EncBinaryMarshal(yy213)
+				} else if !yym214 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy213)
 				} else {
-					z.EncFallback(yy220)
+					z.EncFallback(yy213)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy222 := &x.SampleTime
-				yym223 := z.EncBinary()
-				_ = yym223
+				yy215 := &x.SampleTime
+				yym216 := z.EncBinary()
+				_ = yym216
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy222) {
-				} else if yym223 {
-					z.EncBinaryMarshal(yy222)
-				} else if !yym223 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy222)
+				} else if z.HasExtensions() && z.EncExt(yy215) {
+				} else if yym216 {
+					z.EncBinaryMarshal(yy215)
+				} else if !yym216 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy215)
 				} else {
-					z.EncFallback(yy222)
+					z.EncFallback(yy215)
 				}
 			}
-			if yysep218 {
+			if yysep211 {
 				r.EncodeEnd()
 			}
 		}
@@ -2333,24 +2269,24 @@ func (x *Sample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym224 := z.DecBinary()
-	_ = yym224
+	yym217 := z.DecBinary()
+	_ = yym217
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl225 := r.ReadMapStart()
-			if yyl225 == 0 {
+			yyl218 := r.ReadMapStart()
+			if yyl218 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl225, d)
+				x.codecDecodeSelfFromMap(yyl218, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl225 := r.ReadArrayStart()
-			if yyl225 == 0 {
+			yyl218 := r.ReadArrayStart()
+			if yyl218 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl225, d)
+				x.codecDecodeSelfFromArray(yyl218, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2362,12 +2298,12 @@ func (x *Sample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys226Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys226Slc
-	var yyhl226 bool = l >= 0
-	for yyj226 := 0; ; yyj226++ {
-		if yyhl226 {
-			if yyj226 >= l {
+	var yys219Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys219Slc
+	var yyhl219 bool = l >= 0
+	for yyj219 := 0; ; yyj219++ {
+		if yyhl219 {
+			if yyj219 >= l {
 				break
 			}
 		} else {
@@ -2375,31 +2311,31 @@ func (x *Sample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys226Slc = r.DecodeBytes(yys226Slc, true, true)
-		yys226 := string(yys226Slc)
-		switch yys226 {
+		yys219Slc = r.DecodeBytes(yys219Slc, true, true)
+		yys219 := string(yys219Slc)
+		switch yys219 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv227 := &x.SampleTime
-				yym228 := z.DecBinary()
-				_ = yym228
+				yyv220 := &x.SampleTime
+				yym221 := z.DecBinary()
+				_ = yym221
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv227) {
-				} else if yym228 {
-					z.DecBinaryUnmarshal(yyv227)
-				} else if !yym228 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv227)
+				} else if z.HasExtensions() && z.DecExt(yyv220) {
+				} else if yym221 {
+					z.DecBinaryUnmarshal(yyv220)
+				} else if !yym221 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv220)
 				} else {
-					z.DecFallback(yyv227, false)
+					z.DecFallback(yyv220, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys226)
-		} // end switch yys226
-	} // end for yyj226
-	if !yyhl226 {
+			z.DecStructFieldNotFound(-1, yys219)
+		} // end switch yys219
+	} // end for yyj219
+	if !yyhl219 {
 		r.ReadEnd()
 	}
 }
@@ -2408,46 +2344,46 @@ func (x *Sample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj229 int
-	var yyb229 bool
-	var yyhl229 bool = l >= 0
-	yyj229++
-	if yyhl229 {
-		yyb229 = yyj229 > l
+	var yyj222 int
+	var yyb222 bool
+	var yyhl222 bool = l >= 0
+	yyj222++
+	if yyhl222 {
+		yyb222 = yyj222 > l
 	} else {
-		yyb229 = r.CheckBreak()
+		yyb222 = r.CheckBreak()
 	}
-	if yyb229 {
+	if yyb222 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv230 := &x.SampleTime
-		yym231 := z.DecBinary()
-		_ = yym231
+		yyv223 := &x.SampleTime
+		yym224 := z.DecBinary()
+		_ = yym224
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv230) {
-		} else if yym231 {
-			z.DecBinaryUnmarshal(yyv230)
-		} else if !yym231 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv230)
+		} else if z.HasExtensions() && z.DecExt(yyv223) {
+		} else if yym224 {
+			z.DecBinaryUnmarshal(yyv223)
+		} else if !yym224 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv223)
 		} else {
-			z.DecFallback(yyv230, false)
+			z.DecFallback(yyv223, false)
 		}
 	}
 	for {
-		yyj229++
-		if yyhl229 {
-			yyb229 = yyj229 > l
+		yyj222++
+		if yyhl222 {
+			yyb222 = yyj222 > l
 		} else {
-			yyb229 = r.CheckBreak()
+			yyb222 = r.CheckBreak()
 		}
-		if yyb229 {
+		if yyb222 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj229-1, "")
+		z.DecStructFieldNotFound(yyj222-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2459,61 +2395,61 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym232 := z.EncBinary()
-		_ = yym232
+		yym225 := z.EncBinary()
+		_ = yym225
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep233 := !z.EncBinary()
-			yy2arr233 := z.EncBasicHandle().StructToArray
-			var yyq233 [5]bool
-			_, _, _ = yysep233, yyq233, yy2arr233
-			const yyr233 bool = false
-			yyq233[1] = x.CPU != nil
-			yyq233[2] = x.Memory != nil
-			yyq233[3] = x.Network != nil
-			yyq233[4] = len(x.Filesystem) != 0
-			if yyr233 || yy2arr233 {
+			yysep226 := !z.EncBinary()
+			yy2arr226 := z.EncBasicHandle().StructToArray
+			var yyq226 [5]bool
+			_, _, _ = yysep226, yyq226, yy2arr226
+			const yyr226 bool = false
+			yyq226[1] = x.CPU != nil
+			yyq226[2] = x.Memory != nil
+			yyq226[3] = x.Network != nil
+			yyq226[4] = len(x.Filesystem) != 0
+			if yyr226 || yy2arr226 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn233 int = 1
-				for _, b := range yyq233 {
+				var yynn226 int = 1
+				for _, b := range yyq226 {
 					if b {
-						yynn233++
+						yynn226++
 					}
 				}
-				r.EncodeMapStart(yynn233)
+				r.EncodeMapStart(yynn226)
 			}
-			if yyr233 || yy2arr233 {
-				yy235 := &x.SampleTime
-				yym236 := z.EncBinary()
-				_ = yym236
+			if yyr226 || yy2arr226 {
+				yy228 := &x.SampleTime
+				yym229 := z.EncBinary()
+				_ = yym229
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy235) {
-				} else if yym236 {
-					z.EncBinaryMarshal(yy235)
-				} else if !yym236 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy235)
+				} else if z.HasExtensions() && z.EncExt(yy228) {
+				} else if yym229 {
+					z.EncBinaryMarshal(yy228)
+				} else if !yym229 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy228)
 				} else {
-					z.EncFallback(yy235)
+					z.EncFallback(yy228)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy237 := &x.SampleTime
-				yym238 := z.EncBinary()
-				_ = yym238
+				yy230 := &x.SampleTime
+				yym231 := z.EncBinary()
+				_ = yym231
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy237) {
-				} else if yym238 {
-					z.EncBinaryMarshal(yy237)
-				} else if !yym238 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy237)
+				} else if z.HasExtensions() && z.EncExt(yy230) {
+				} else if yym231 {
+					z.EncBinaryMarshal(yy230)
+				} else if !yym231 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy230)
 				} else {
-					z.EncFallback(yy237)
+					z.EncFallback(yy230)
 				}
 			}
-			if yyr233 || yy2arr233 {
-				if yyq233[1] {
+			if yyr226 || yy2arr226 {
+				if yyq226[1] {
 					if x.CPU == nil {
 						r.EncodeNil()
 					} else {
@@ -2523,7 +2459,7 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq233[1] {
+				if yyq226[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
 					if x.CPU == nil {
 						r.EncodeNil()
@@ -2532,8 +2468,8 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr233 || yy2arr233 {
-				if yyq233[2] {
+			if yyr226 || yy2arr226 {
+				if yyq226[2] {
 					if x.Memory == nil {
 						r.EncodeNil()
 					} else {
@@ -2543,7 +2479,7 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq233[2] {
+				if yyq226[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("memory"))
 					if x.Memory == nil {
 						r.EncodeNil()
@@ -2552,8 +2488,8 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr233 || yy2arr233 {
-				if yyq233[3] {
+			if yyr226 || yy2arr226 {
+				if yyq226[3] {
 					if x.Network == nil {
 						r.EncodeNil()
 					} else {
@@ -2563,7 +2499,7 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq233[3] {
+				if yyq226[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("network"))
 					if x.Network == nil {
 						r.EncodeNil()
@@ -2572,13 +2508,13 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr233 || yy2arr233 {
-				if yyq233[4] {
+			if yyr226 || yy2arr226 {
+				if yyq226[4] {
 					if x.Filesystem == nil {
 						r.EncodeNil()
 					} else {
-						yym243 := z.EncBinary()
-						_ = yym243
+						yym236 := z.EncBinary()
+						_ = yym236
 						if false {
 						} else {
 							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
@@ -2588,13 +2524,13 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq233[4] {
+				if yyq226[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("filesystem"))
 					if x.Filesystem == nil {
 						r.EncodeNil()
 					} else {
-						yym244 := z.EncBinary()
-						_ = yym244
+						yym237 := z.EncBinary()
+						_ = yym237
 						if false {
 						} else {
 							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
@@ -2602,7 +2538,7 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep233 {
+			if yysep226 {
 				r.EncodeEnd()
 			}
 		}
@@ -2613,24 +2549,24 @@ func (x *AggregateSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym245 := z.DecBinary()
-	_ = yym245
+	yym238 := z.DecBinary()
+	_ = yym238
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl246 := r.ReadMapStart()
-			if yyl246 == 0 {
+			yyl239 := r.ReadMapStart()
+			if yyl239 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl246, d)
+				x.codecDecodeSelfFromMap(yyl239, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl246 := r.ReadArrayStart()
-			if yyl246 == 0 {
+			yyl239 := r.ReadArrayStart()
+			if yyl239 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl246, d)
+				x.codecDecodeSelfFromArray(yyl239, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2642,12 +2578,12 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys247Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys247Slc
-	var yyhl247 bool = l >= 0
-	for yyj247 := 0; ; yyj247++ {
-		if yyhl247 {
-			if yyj247 >= l {
+	var yys240Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys240Slc
+	var yyhl240 bool = l >= 0
+	for yyj240 := 0; ; yyj240++ {
+		if yyhl240 {
+			if yyj240 >= l {
 				break
 			}
 		} else {
@@ -2655,24 +2591,24 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys247Slc = r.DecodeBytes(yys247Slc, true, true)
-		yys247 := string(yys247Slc)
-		switch yys247 {
+		yys240Slc = r.DecodeBytes(yys240Slc, true, true)
+		yys240 := string(yys240Slc)
+		switch yys240 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv248 := &x.SampleTime
-				yym249 := z.DecBinary()
-				_ = yym249
+				yyv241 := &x.SampleTime
+				yym242 := z.DecBinary()
+				_ = yym242
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv248) {
-				} else if yym249 {
-					z.DecBinaryUnmarshal(yyv248)
-				} else if !yym249 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv248)
+				} else if z.HasExtensions() && z.DecExt(yyv241) {
+				} else if yym242 {
+					z.DecBinaryUnmarshal(yyv241)
+				} else if !yym242 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv241)
 				} else {
-					z.DecFallback(yyv248, false)
+					z.DecFallback(yyv241, false)
 				}
 			}
 		case "cpu":
@@ -2712,19 +2648,19 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Filesystem = nil
 			} else {
-				yyv253 := &x.Filesystem
-				yym254 := z.DecBinary()
-				_ = yym254
+				yyv246 := &x.Filesystem
+				yym247 := z.DecBinary()
+				_ = yym247
 				if false {
 				} else {
-					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv253), d)
+					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv246), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys247)
-		} // end switch yys247
-	} // end for yyj247
-	if !yyhl247 {
+			z.DecStructFieldNotFound(-1, yys240)
+		} // end switch yys240
+	} // end for yyj240
+	if !yyhl240 {
 		r.ReadEnd()
 	}
 }
@@ -2733,42 +2669,42 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj255 int
-	var yyb255 bool
-	var yyhl255 bool = l >= 0
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	var yyj248 int
+	var yyb248 bool
+	var yyhl248 bool = l >= 0
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv256 := &x.SampleTime
-		yym257 := z.DecBinary()
-		_ = yym257
+		yyv249 := &x.SampleTime
+		yym250 := z.DecBinary()
+		_ = yym250
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv256) {
-		} else if yym257 {
-			z.DecBinaryUnmarshal(yyv256)
-		} else if !yym257 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv256)
+		} else if z.HasExtensions() && z.DecExt(yyv249) {
+		} else if yym250 {
+			z.DecBinaryUnmarshal(yyv249)
+		} else if !yym250 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv249)
 		} else {
-			z.DecFallback(yyv256, false)
+			z.DecFallback(yyv249, false)
 		}
 	}
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
@@ -2782,13 +2718,13 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.CPU.CodecDecodeSelf(d)
 	}
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
@@ -2802,13 +2738,13 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Memory.CodecDecodeSelf(d)
 	}
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
@@ -2822,38 +2758,38 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Network.CodecDecodeSelf(d)
 	}
-	yyj255++
-	if yyhl255 {
-		yyb255 = yyj255 > l
+	yyj248++
+	if yyhl248 {
+		yyb248 = yyj248 > l
 	} else {
-		yyb255 = r.CheckBreak()
+		yyb248 = r.CheckBreak()
 	}
-	if yyb255 {
+	if yyb248 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Filesystem = nil
 	} else {
-		yyv261 := &x.Filesystem
-		yym262 := z.DecBinary()
-		_ = yym262
+		yyv254 := &x.Filesystem
+		yym255 := z.DecBinary()
+		_ = yym255
 		if false {
 		} else {
-			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv261), d)
+			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv254), d)
 		}
 	}
 	for {
-		yyj255++
-		if yyhl255 {
-			yyb255 = yyj255 > l
+		yyj248++
+		if yyhl248 {
+			yyb248 = yyj248 > l
 		} else {
-			yyb255 = r.CheckBreak()
+			yyb248 = r.CheckBreak()
 		}
-		if yyb255 {
+		if yyb248 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj255-1, "")
+		z.DecStructFieldNotFound(yyj248-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2865,58 +2801,58 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym263 := z.EncBinary()
-		_ = yym263
+		yym256 := z.EncBinary()
+		_ = yym256
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep264 := !z.EncBinary()
-			yy2arr264 := z.EncBasicHandle().StructToArray
-			var yyq264 [2]bool
-			_, _, _ = yysep264, yyq264, yy2arr264
-			const yyr264 bool = false
-			yyq264[1] = x.Network != nil
-			if yyr264 || yy2arr264 {
+			yysep257 := !z.EncBinary()
+			yy2arr257 := z.EncBasicHandle().StructToArray
+			var yyq257 [2]bool
+			_, _, _ = yysep257, yyq257, yy2arr257
+			const yyr257 bool = false
+			yyq257[1] = x.Network != nil
+			if yyr257 || yy2arr257 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn264 int = 1
-				for _, b := range yyq264 {
+				var yynn257 int = 1
+				for _, b := range yyq257 {
 					if b {
-						yynn264++
+						yynn257++
 					}
 				}
-				r.EncodeMapStart(yynn264)
+				r.EncodeMapStart(yynn257)
 			}
-			if yyr264 || yy2arr264 {
-				yy266 := &x.SampleTime
-				yym267 := z.EncBinary()
-				_ = yym267
+			if yyr257 || yy2arr257 {
+				yy259 := &x.SampleTime
+				yym260 := z.EncBinary()
+				_ = yym260
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy266) {
-				} else if yym267 {
-					z.EncBinaryMarshal(yy266)
-				} else if !yym267 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy266)
+				} else if z.HasExtensions() && z.EncExt(yy259) {
+				} else if yym260 {
+					z.EncBinaryMarshal(yy259)
+				} else if !yym260 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy259)
 				} else {
-					z.EncFallback(yy266)
+					z.EncFallback(yy259)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy268 := &x.SampleTime
-				yym269 := z.EncBinary()
-				_ = yym269
+				yy261 := &x.SampleTime
+				yym262 := z.EncBinary()
+				_ = yym262
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy268) {
-				} else if yym269 {
-					z.EncBinaryMarshal(yy268)
-				} else if !yym269 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy268)
+				} else if z.HasExtensions() && z.EncExt(yy261) {
+				} else if yym262 {
+					z.EncBinaryMarshal(yy261)
+				} else if !yym262 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy261)
 				} else {
-					z.EncFallback(yy268)
+					z.EncFallback(yy261)
 				}
 			}
-			if yyr264 || yy2arr264 {
-				if yyq264[1] {
+			if yyr257 || yy2arr257 {
+				if yyq257[1] {
 					if x.Network == nil {
 						r.EncodeNil()
 					} else {
@@ -2926,7 +2862,7 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq264[1] {
+				if yyq257[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("network"))
 					if x.Network == nil {
 						r.EncodeNil()
@@ -2935,7 +2871,7 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep264 {
+			if yysep257 {
 				r.EncodeEnd()
 			}
 		}
@@ -2946,24 +2882,24 @@ func (x *PodSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym271 := z.DecBinary()
-	_ = yym271
+	yym264 := z.DecBinary()
+	_ = yym264
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl272 := r.ReadMapStart()
-			if yyl272 == 0 {
+			yyl265 := r.ReadMapStart()
+			if yyl265 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl272, d)
+				x.codecDecodeSelfFromMap(yyl265, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl272 := r.ReadArrayStart()
-			if yyl272 == 0 {
+			yyl265 := r.ReadArrayStart()
+			if yyl265 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl272, d)
+				x.codecDecodeSelfFromArray(yyl265, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2975,12 +2911,12 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys273Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys273Slc
-	var yyhl273 bool = l >= 0
-	for yyj273 := 0; ; yyj273++ {
-		if yyhl273 {
-			if yyj273 >= l {
+	var yys266Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys266Slc
+	var yyhl266 bool = l >= 0
+	for yyj266 := 0; ; yyj266++ {
+		if yyhl266 {
+			if yyj266 >= l {
 				break
 			}
 		} else {
@@ -2988,24 +2924,24 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys273Slc = r.DecodeBytes(yys273Slc, true, true)
-		yys273 := string(yys273Slc)
-		switch yys273 {
+		yys266Slc = r.DecodeBytes(yys266Slc, true, true)
+		yys266 := string(yys266Slc)
+		switch yys266 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv274 := &x.SampleTime
-				yym275 := z.DecBinary()
-				_ = yym275
+				yyv267 := &x.SampleTime
+				yym268 := z.DecBinary()
+				_ = yym268
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv274) {
-				} else if yym275 {
-					z.DecBinaryUnmarshal(yyv274)
-				} else if !yym275 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv274)
+				} else if z.HasExtensions() && z.DecExt(yyv267) {
+				} else if yym268 {
+					z.DecBinaryUnmarshal(yyv267)
+				} else if !yym268 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv267)
 				} else {
-					z.DecFallback(yyv274, false)
+					z.DecFallback(yyv267, false)
 				}
 			}
 		case "network":
@@ -3020,10 +2956,10 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Network.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys273)
-		} // end switch yys273
-	} // end for yyj273
-	if !yyhl273 {
+			z.DecStructFieldNotFound(-1, yys266)
+		} // end switch yys266
+	} // end for yyj266
+	if !yyhl266 {
 		r.ReadEnd()
 	}
 }
@@ -3032,42 +2968,42 @@ func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj277 int
-	var yyb277 bool
-	var yyhl277 bool = l >= 0
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	var yyj270 int
+	var yyb270 bool
+	var yyhl270 bool = l >= 0
+	yyj270++
+	if yyhl270 {
+		yyb270 = yyj270 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb270 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb270 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv278 := &x.SampleTime
-		yym279 := z.DecBinary()
-		_ = yym279
+		yyv271 := &x.SampleTime
+		yym272 := z.DecBinary()
+		_ = yym272
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv278) {
-		} else if yym279 {
-			z.DecBinaryUnmarshal(yyv278)
-		} else if !yym279 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv278)
+		} else if z.HasExtensions() && z.DecExt(yyv271) {
+		} else if yym272 {
+			z.DecBinaryUnmarshal(yyv271)
+		} else if !yym272 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv271)
 		} else {
-			z.DecFallback(yyv278, false)
+			z.DecFallback(yyv271, false)
 		}
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj270++
+	if yyhl270 {
+		yyb270 = yyj270 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb270 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb270 {
 		r.ReadEnd()
 		return
 	}
@@ -3082,16 +3018,16 @@ func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Network.CodecDecodeSelf(d)
 	}
 	for {
-		yyj277++
-		if yyhl277 {
-			yyb277 = yyj277 > l
+		yyj270++
+		if yyhl270 {
+			yyb270 = yyj270 > l
 		} else {
-			yyb277 = r.CheckBreak()
+			yyb270 = r.CheckBreak()
 		}
-		if yyb277 {
+		if yyb270 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj277-1, "")
+		z.DecStructFieldNotFound(yyj270-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3103,60 +3039,60 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym281 := z.EncBinary()
-		_ = yym281
+		yym274 := z.EncBinary()
+		_ = yym274
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep282 := !z.EncBinary()
-			yy2arr282 := z.EncBasicHandle().StructToArray
-			var yyq282 [4]bool
-			_, _, _ = yysep282, yyq282, yy2arr282
-			const yyr282 bool = false
-			yyq282[1] = x.CPU != nil
-			yyq282[2] = x.Memory != nil
-			yyq282[3] = len(x.Filesystem) != 0
-			if yyr282 || yy2arr282 {
+			yysep275 := !z.EncBinary()
+			yy2arr275 := z.EncBasicHandle().StructToArray
+			var yyq275 [4]bool
+			_, _, _ = yysep275, yyq275, yy2arr275
+			const yyr275 bool = false
+			yyq275[1] = x.CPU != nil
+			yyq275[2] = x.Memory != nil
+			yyq275[3] = len(x.Filesystem) != 0
+			if yyr275 || yy2arr275 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn282 int = 1
-				for _, b := range yyq282 {
+				var yynn275 int = 1
+				for _, b := range yyq275 {
 					if b {
-						yynn282++
+						yynn275++
 					}
 				}
-				r.EncodeMapStart(yynn282)
+				r.EncodeMapStart(yynn275)
 			}
-			if yyr282 || yy2arr282 {
-				yy284 := &x.SampleTime
-				yym285 := z.EncBinary()
-				_ = yym285
+			if yyr275 || yy2arr275 {
+				yy277 := &x.SampleTime
+				yym278 := z.EncBinary()
+				_ = yym278
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy284) {
-				} else if yym285 {
-					z.EncBinaryMarshal(yy284)
-				} else if !yym285 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy284)
+				} else if z.HasExtensions() && z.EncExt(yy277) {
+				} else if yym278 {
+					z.EncBinaryMarshal(yy277)
+				} else if !yym278 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy277)
 				} else {
-					z.EncFallback(yy284)
+					z.EncFallback(yy277)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy286 := &x.SampleTime
-				yym287 := z.EncBinary()
-				_ = yym287
+				yy279 := &x.SampleTime
+				yym280 := z.EncBinary()
+				_ = yym280
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy286) {
-				} else if yym287 {
-					z.EncBinaryMarshal(yy286)
-				} else if !yym287 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy286)
+				} else if z.HasExtensions() && z.EncExt(yy279) {
+				} else if yym280 {
+					z.EncBinaryMarshal(yy279)
+				} else if !yym280 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy279)
 				} else {
-					z.EncFallback(yy286)
+					z.EncFallback(yy279)
 				}
 			}
-			if yyr282 || yy2arr282 {
-				if yyq282[1] {
+			if yyr275 || yy2arr275 {
+				if yyq275[1] {
 					if x.CPU == nil {
 						r.EncodeNil()
 					} else {
@@ -3166,7 +3102,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq282[1] {
+				if yyq275[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
 					if x.CPU == nil {
 						r.EncodeNil()
@@ -3175,8 +3111,8 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr282 || yy2arr282 {
-				if yyq282[2] {
+			if yyr275 || yy2arr275 {
+				if yyq275[2] {
 					if x.Memory == nil {
 						r.EncodeNil()
 					} else {
@@ -3186,7 +3122,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq282[2] {
+				if yyq275[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("memory"))
 					if x.Memory == nil {
 						r.EncodeNil()
@@ -3195,13 +3131,13 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr282 || yy2arr282 {
-				if yyq282[3] {
+			if yyr275 || yy2arr275 {
+				if yyq275[3] {
 					if x.Filesystem == nil {
 						r.EncodeNil()
 					} else {
-						yym291 := z.EncBinary()
-						_ = yym291
+						yym284 := z.EncBinary()
+						_ = yym284
 						if false {
 						} else {
 							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
@@ -3211,13 +3147,13 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq282[3] {
+				if yyq275[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("filesystem"))
 					if x.Filesystem == nil {
 						r.EncodeNil()
 					} else {
-						yym292 := z.EncBinary()
-						_ = yym292
+						yym285 := z.EncBinary()
+						_ = yym285
 						if false {
 						} else {
 							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
@@ -3225,7 +3161,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep282 {
+			if yysep275 {
 				r.EncodeEnd()
 			}
 		}
@@ -3236,24 +3172,24 @@ func (x *ContainerSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym293 := z.DecBinary()
-	_ = yym293
+	yym286 := z.DecBinary()
+	_ = yym286
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl294 := r.ReadMapStart()
-			if yyl294 == 0 {
+			yyl287 := r.ReadMapStart()
+			if yyl287 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl294, d)
+				x.codecDecodeSelfFromMap(yyl287, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl294 := r.ReadArrayStart()
-			if yyl294 == 0 {
+			yyl287 := r.ReadArrayStart()
+			if yyl287 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl294, d)
+				x.codecDecodeSelfFromArray(yyl287, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3265,12 +3201,12 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys295Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys295Slc
-	var yyhl295 bool = l >= 0
-	for yyj295 := 0; ; yyj295++ {
-		if yyhl295 {
-			if yyj295 >= l {
+	var yys288Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys288Slc
+	var yyhl288 bool = l >= 0
+	for yyj288 := 0; ; yyj288++ {
+		if yyhl288 {
+			if yyj288 >= l {
 				break
 			}
 		} else {
@@ -3278,24 +3214,24 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys295Slc = r.DecodeBytes(yys295Slc, true, true)
-		yys295 := string(yys295Slc)
-		switch yys295 {
+		yys288Slc = r.DecodeBytes(yys288Slc, true, true)
+		yys288 := string(yys288Slc)
+		switch yys288 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv296 := &x.SampleTime
-				yym297 := z.DecBinary()
-				_ = yym297
+				yyv289 := &x.SampleTime
+				yym290 := z.DecBinary()
+				_ = yym290
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv296) {
-				} else if yym297 {
-					z.DecBinaryUnmarshal(yyv296)
-				} else if !yym297 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv296)
+				} else if z.HasExtensions() && z.DecExt(yyv289) {
+				} else if yym290 {
+					z.DecBinaryUnmarshal(yyv289)
+				} else if !yym290 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv289)
 				} else {
-					z.DecFallback(yyv296, false)
+					z.DecFallback(yyv289, false)
 				}
 			}
 		case "cpu":
@@ -3324,19 +3260,19 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Filesystem = nil
 			} else {
-				yyv300 := &x.Filesystem
-				yym301 := z.DecBinary()
-				_ = yym301
+				yyv293 := &x.Filesystem
+				yym294 := z.DecBinary()
+				_ = yym294
 				if false {
 				} else {
-					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv300), d)
+					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv293), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys295)
-		} // end switch yys295
-	} // end for yyj295
-	if !yyhl295 {
+			z.DecStructFieldNotFound(-1, yys288)
+		} // end switch yys288
+	} // end for yyj288
+	if !yyhl288 {
 		r.ReadEnd()
 	}
 }
@@ -3345,42 +3281,42 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj302 int
-	var yyb302 bool
-	var yyhl302 bool = l >= 0
-	yyj302++
-	if yyhl302 {
-		yyb302 = yyj302 > l
+	var yyj295 int
+	var yyb295 bool
+	var yyhl295 bool = l >= 0
+	yyj295++
+	if yyhl295 {
+		yyb295 = yyj295 > l
 	} else {
-		yyb302 = r.CheckBreak()
+		yyb295 = r.CheckBreak()
 	}
-	if yyb302 {
+	if yyb295 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv303 := &x.SampleTime
-		yym304 := z.DecBinary()
-		_ = yym304
+		yyv296 := &x.SampleTime
+		yym297 := z.DecBinary()
+		_ = yym297
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv303) {
-		} else if yym304 {
-			z.DecBinaryUnmarshal(yyv303)
-		} else if !yym304 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv303)
+		} else if z.HasExtensions() && z.DecExt(yyv296) {
+		} else if yym297 {
+			z.DecBinaryUnmarshal(yyv296)
+		} else if !yym297 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv296)
 		} else {
-			z.DecFallback(yyv303, false)
+			z.DecFallback(yyv296, false)
 		}
 	}
-	yyj302++
-	if yyhl302 {
-		yyb302 = yyj302 > l
+	yyj295++
+	if yyhl295 {
+		yyb295 = yyj295 > l
 	} else {
-		yyb302 = r.CheckBreak()
+		yyb295 = r.CheckBreak()
 	}
-	if yyb302 {
+	if yyb295 {
 		r.ReadEnd()
 		return
 	}
@@ -3394,13 +3330,13 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.CPU.CodecDecodeSelf(d)
 	}
-	yyj302++
-	if yyhl302 {
-		yyb302 = yyj302 > l
+	yyj295++
+	if yyhl295 {
+		yyb295 = yyj295 > l
 	} else {
-		yyb302 = r.CheckBreak()
+		yyb295 = r.CheckBreak()
 	}
-	if yyb302 {
+	if yyb295 {
 		r.ReadEnd()
 		return
 	}
@@ -3414,38 +3350,38 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Memory.CodecDecodeSelf(d)
 	}
-	yyj302++
-	if yyhl302 {
-		yyb302 = yyj302 > l
+	yyj295++
+	if yyhl295 {
+		yyb295 = yyj295 > l
 	} else {
-		yyb302 = r.CheckBreak()
+		yyb295 = r.CheckBreak()
 	}
-	if yyb302 {
+	if yyb295 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Filesystem = nil
 	} else {
-		yyv307 := &x.Filesystem
-		yym308 := z.DecBinary()
-		_ = yym308
+		yyv300 := &x.Filesystem
+		yym301 := z.DecBinary()
+		_ = yym301
 		if false {
 		} else {
-			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv307), d)
+			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv300), d)
 		}
 	}
 	for {
-		yyj302++
-		if yyhl302 {
-			yyb302 = yyj302 > l
+		yyj295++
+		if yyhl295 {
+			yyb295 = yyj295 > l
 		} else {
-			yyb302 = r.CheckBreak()
+			yyb295 = r.CheckBreak()
 		}
-		if yyb302 {
+		if yyb295 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj302-1, "")
+		z.DecStructFieldNotFound(yyj295-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3457,41 +3393,41 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym309 := z.EncBinary()
-		_ = yym309
+		yym302 := z.EncBinary()
+		_ = yym302
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep310 := !z.EncBinary()
-			yy2arr310 := z.EncBasicHandle().StructToArray
-			var yyq310 [4]bool
-			_, _, _ = yysep310, yyq310, yy2arr310
-			const yyr310 bool = false
-			yyq310[0] = x.RxBytes != nil
-			yyq310[1] = x.RxErrors != nil
-			yyq310[2] = x.TxBytes != nil
-			yyq310[3] = x.TxErrors != nil
-			if yyr310 || yy2arr310 {
+			yysep303 := !z.EncBinary()
+			yy2arr303 := z.EncBasicHandle().StructToArray
+			var yyq303 [4]bool
+			_, _, _ = yysep303, yyq303, yy2arr303
+			const yyr303 bool = false
+			yyq303[0] = x.RxBytes != nil
+			yyq303[1] = x.RxErrors != nil
+			yyq303[2] = x.TxBytes != nil
+			yyq303[3] = x.TxErrors != nil
+			if yyr303 || yy2arr303 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn310 int = 0
-				for _, b := range yyq310 {
+				var yynn303 int = 0
+				for _, b := range yyq303 {
 					if b {
-						yynn310++
+						yynn303++
 					}
 				}
-				r.EncodeMapStart(yynn310)
+				r.EncodeMapStart(yynn303)
 			}
-			if yyr310 || yy2arr310 {
-				if yyq310[0] {
+			if yyr303 || yy2arr303 {
+				if yyq303[0] {
 					if x.RxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym312 := z.EncBinary()
-						_ = yym312
+						yym305 := z.EncBinary()
+						_ = yym305
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
-						} else if !yym312 && z.IsJSONHandle() {
+						} else if !yym305 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.RxBytes)
 						} else {
 							z.EncFallback(x.RxBytes)
@@ -3501,65 +3437,65 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq310[0] {
+				if yyq303[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("rxBytes"))
 					if x.RxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym306 := z.EncBinary()
+						_ = yym306
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
+						} else if !yym306 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.RxBytes)
+						} else {
+							z.EncFallback(x.RxBytes)
+						}
+					}
+				}
+			}
+			if yyr303 || yy2arr303 {
+				if yyq303[1] {
+					if x.RxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy308 := *x.RxErrors
+						yym309 := z.EncBinary()
+						_ = yym309
+						if false {
+						} else {
+							r.EncodeInt(int64(yy308))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq303[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("rxErrors"))
+					if x.RxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy310 := *x.RxErrors
+						yym311 := z.EncBinary()
+						_ = yym311
+						if false {
+						} else {
+							r.EncodeInt(int64(yy310))
+						}
+					}
+				}
+			}
+			if yyr303 || yy2arr303 {
+				if yyq303[2] {
+					if x.TxBytes == nil {
 						r.EncodeNil()
 					} else {
 						yym313 := z.EncBinary()
 						_ = yym313
 						if false {
-						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
-						} else if !yym313 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.RxBytes)
-						} else {
-							z.EncFallback(x.RxBytes)
-						}
-					}
-				}
-			}
-			if yyr310 || yy2arr310 {
-				if yyq310[1] {
-					if x.RxErrors == nil {
-						r.EncodeNil()
-					} else {
-						yy315 := *x.RxErrors
-						yym316 := z.EncBinary()
-						_ = yym316
-						if false {
-						} else {
-							r.EncodeInt(int64(yy315))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq310[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("rxErrors"))
-					if x.RxErrors == nil {
-						r.EncodeNil()
-					} else {
-						yy317 := *x.RxErrors
-						yym318 := z.EncBinary()
-						_ = yym318
-						if false {
-						} else {
-							r.EncodeInt(int64(yy317))
-						}
-					}
-				}
-			}
-			if yyr310 || yy2arr310 {
-				if yyq310[2] {
-					if x.TxBytes == nil {
-						r.EncodeNil()
-					} else {
-						yym320 := z.EncBinary()
-						_ = yym320
-						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
-						} else if !yym320 && z.IsJSONHandle() {
+						} else if !yym313 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TxBytes)
 						} else {
 							z.EncFallback(x.TxBytes)
@@ -3569,16 +3505,16 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq310[2] {
+				if yyq303[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("txBytes"))
 					if x.TxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym321 := z.EncBinary()
-						_ = yym321
+						yym314 := z.EncBinary()
+						_ = yym314
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
-						} else if !yym321 && z.IsJSONHandle() {
+						} else if !yym314 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TxBytes)
 						} else {
 							z.EncFallback(x.TxBytes)
@@ -3586,39 +3522,39 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr310 || yy2arr310 {
-				if yyq310[3] {
+			if yyr303 || yy2arr303 {
+				if yyq303[3] {
 					if x.TxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy323 := *x.TxErrors
-						yym324 := z.EncBinary()
-						_ = yym324
+						yy316 := *x.TxErrors
+						yym317 := z.EncBinary()
+						_ = yym317
 						if false {
 						} else {
-							r.EncodeInt(int64(yy323))
+							r.EncodeInt(int64(yy316))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq310[3] {
+				if yyq303[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("txErrors"))
 					if x.TxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy325 := *x.TxErrors
-						yym326 := z.EncBinary()
-						_ = yym326
+						yy318 := *x.TxErrors
+						yym319 := z.EncBinary()
+						_ = yym319
 						if false {
 						} else {
-							r.EncodeInt(int64(yy325))
+							r.EncodeInt(int64(yy318))
 						}
 					}
 				}
 			}
-			if yysep310 {
+			if yysep303 {
 				r.EncodeEnd()
 			}
 		}
@@ -3629,24 +3565,24 @@ func (x *NetworkMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym327 := z.DecBinary()
-	_ = yym327
+	yym320 := z.DecBinary()
+	_ = yym320
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl328 := r.ReadMapStart()
-			if yyl328 == 0 {
+			yyl321 := r.ReadMapStart()
+			if yyl321 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl328, d)
+				x.codecDecodeSelfFromMap(yyl321, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl328 := r.ReadArrayStart()
-			if yyl328 == 0 {
+			yyl321 := r.ReadArrayStart()
+			if yyl321 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl328, d)
+				x.codecDecodeSelfFromArray(yyl321, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3658,12 +3594,12 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys329Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys329Slc
-	var yyhl329 bool = l >= 0
-	for yyj329 := 0; ; yyj329++ {
-		if yyhl329 {
-			if yyj329 >= l {
+	var yys322Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys322Slc
+	var yyhl322 bool = l >= 0
+	for yyj322 := 0; ; yyj322++ {
+		if yyhl322 {
+			if yyj322 >= l {
 				break
 			}
 		} else {
@@ -3671,9 +3607,9 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys329Slc = r.DecodeBytes(yys329Slc, true, true)
-		yys329 := string(yys329Slc)
-		switch yys329 {
+		yys322Slc = r.DecodeBytes(yys322Slc, true, true)
+		yys322 := string(yys322Slc)
+		switch yys322 {
 		case "rxBytes":
 			if r.TryDecodeAsNil() {
 				if x.RxBytes != nil {
@@ -3683,11 +3619,11 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RxBytes == nil {
 					x.RxBytes = new(pkg2_resource.Quantity)
 				}
-				yym331 := z.DecBinary()
-				_ = yym331
+				yym324 := z.DecBinary()
+				_ = yym324
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
-				} else if !yym331 && z.IsJSONHandle() {
+				} else if !yym324 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.RxBytes)
 				} else {
 					z.DecFallback(x.RxBytes, false)
@@ -3702,8 +3638,8 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RxErrors == nil {
 					x.RxErrors = new(int64)
 				}
-				yym333 := z.DecBinary()
-				_ = yym333
+				yym326 := z.DecBinary()
+				_ = yym326
 				if false {
 				} else {
 					*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
@@ -3718,11 +3654,11 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TxBytes == nil {
 					x.TxBytes = new(pkg2_resource.Quantity)
 				}
-				yym335 := z.DecBinary()
-				_ = yym335
+				yym328 := z.DecBinary()
+				_ = yym328
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
-				} else if !yym335 && z.IsJSONHandle() {
+				} else if !yym328 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TxBytes)
 				} else {
 					z.DecFallback(x.TxBytes, false)
@@ -3737,18 +3673,18 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TxErrors == nil {
 					x.TxErrors = new(int64)
 				}
-				yym337 := z.DecBinary()
-				_ = yym337
+				yym330 := z.DecBinary()
+				_ = yym330
 				if false {
 				} else {
 					*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys329)
-		} // end switch yys329
-	} // end for yyj329
-	if !yyhl329 {
+			z.DecStructFieldNotFound(-1, yys322)
+		} // end switch yys322
+	} // end for yyj322
+	if !yyhl322 {
 		r.ReadEnd()
 	}
 }
@@ -3757,16 +3693,16 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj338 int
-	var yyb338 bool
-	var yyhl338 bool = l >= 0
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
+	var yyj331 int
+	var yyb331 bool
+	var yyhl331 bool = l >= 0
+	yyj331++
+	if yyhl331 {
+		yyb331 = yyj331 > l
 	} else {
-		yyb338 = r.CheckBreak()
+		yyb331 = r.CheckBreak()
 	}
-	if yyb338 {
+	if yyb331 {
 		r.ReadEnd()
 		return
 	}
@@ -3778,23 +3714,23 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RxBytes == nil {
 			x.RxBytes = new(pkg2_resource.Quantity)
 		}
-		yym340 := z.DecBinary()
-		_ = yym340
+		yym333 := z.DecBinary()
+		_ = yym333
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
-		} else if !yym340 && z.IsJSONHandle() {
+		} else if !yym333 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.RxBytes)
 		} else {
 			z.DecFallback(x.RxBytes, false)
 		}
 	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
+	yyj331++
+	if yyhl331 {
+		yyb331 = yyj331 > l
 	} else {
-		yyb338 = r.CheckBreak()
+		yyb331 = r.CheckBreak()
 	}
-	if yyb338 {
+	if yyb331 {
 		r.ReadEnd()
 		return
 	}
@@ -3806,20 +3742,20 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RxErrors == nil {
 			x.RxErrors = new(int64)
 		}
-		yym342 := z.DecBinary()
-		_ = yym342
+		yym335 := z.DecBinary()
+		_ = yym335
 		if false {
 		} else {
 			*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
+	yyj331++
+	if yyhl331 {
+		yyb331 = yyj331 > l
 	} else {
-		yyb338 = r.CheckBreak()
+		yyb331 = r.CheckBreak()
 	}
-	if yyb338 {
+	if yyb331 {
 		r.ReadEnd()
 		return
 	}
@@ -3831,23 +3767,23 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TxBytes == nil {
 			x.TxBytes = new(pkg2_resource.Quantity)
 		}
-		yym344 := z.DecBinary()
-		_ = yym344
+		yym337 := z.DecBinary()
+		_ = yym337
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
-		} else if !yym344 && z.IsJSONHandle() {
+		} else if !yym337 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TxBytes)
 		} else {
 			z.DecFallback(x.TxBytes, false)
 		}
 	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
+	yyj331++
+	if yyhl331 {
+		yyb331 = yyj331 > l
 	} else {
-		yyb338 = r.CheckBreak()
+		yyb331 = r.CheckBreak()
 	}
-	if yyb338 {
+	if yyb331 {
 		r.ReadEnd()
 		return
 	}
@@ -3859,24 +3795,24 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TxErrors == nil {
 			x.TxErrors = new(int64)
 		}
-		yym346 := z.DecBinary()
-		_ = yym346
+		yym339 := z.DecBinary()
+		_ = yym339
 		if false {
 		} else {
 			*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj338++
-		if yyhl338 {
-			yyb338 = yyj338 > l
+		yyj331++
+		if yyhl331 {
+			yyb331 = yyj331 > l
 		} else {
-			yyb338 = r.CheckBreak()
+			yyb331 = r.CheckBreak()
 		}
-		if yyb338 {
+		if yyb331 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj338-1, "")
+		z.DecStructFieldNotFound(yyj331-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3888,38 +3824,38 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym347 := z.EncBinary()
-		_ = yym347
+		yym340 := z.EncBinary()
+		_ = yym340
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep348 := !z.EncBinary()
-			yy2arr348 := z.EncBasicHandle().StructToArray
-			var yyq348 [1]bool
-			_, _, _ = yysep348, yyq348, yy2arr348
-			const yyr348 bool = false
-			yyq348[0] = x.TotalCores != nil
-			if yyr348 || yy2arr348 {
+			yysep341 := !z.EncBinary()
+			yy2arr341 := z.EncBasicHandle().StructToArray
+			var yyq341 [1]bool
+			_, _, _ = yysep341, yyq341, yy2arr341
+			const yyr341 bool = false
+			yyq341[0] = x.TotalCores != nil
+			if yyr341 || yy2arr341 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn348 int = 0
-				for _, b := range yyq348 {
+				var yynn341 int = 0
+				for _, b := range yyq341 {
 					if b {
-						yynn348++
+						yynn341++
 					}
 				}
-				r.EncodeMapStart(yynn348)
+				r.EncodeMapStart(yynn341)
 			}
-			if yyr348 || yy2arr348 {
-				if yyq348[0] {
+			if yyr341 || yy2arr341 {
+				if yyq341[0] {
 					if x.TotalCores == nil {
 						r.EncodeNil()
 					} else {
-						yym350 := z.EncBinary()
-						_ = yym350
+						yym343 := z.EncBinary()
+						_ = yym343
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
-						} else if !yym350 && z.IsJSONHandle() {
+						} else if !yym343 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalCores)
 						} else {
 							z.EncFallback(x.TotalCores)
@@ -3929,16 +3865,16 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq348[0] {
+				if yyq341[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalCores"))
 					if x.TotalCores == nil {
 						r.EncodeNil()
 					} else {
-						yym351 := z.EncBinary()
-						_ = yym351
+						yym344 := z.EncBinary()
+						_ = yym344
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
-						} else if !yym351 && z.IsJSONHandle() {
+						} else if !yym344 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalCores)
 						} else {
 							z.EncFallback(x.TotalCores)
@@ -3946,7 +3882,7 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep348 {
+			if yysep341 {
 				r.EncodeEnd()
 			}
 		}
@@ -3957,24 +3893,24 @@ func (x *CPUMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym352 := z.DecBinary()
-	_ = yym352
+	yym345 := z.DecBinary()
+	_ = yym345
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl353 := r.ReadMapStart()
-			if yyl353 == 0 {
+			yyl346 := r.ReadMapStart()
+			if yyl346 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl353, d)
+				x.codecDecodeSelfFromMap(yyl346, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl353 := r.ReadArrayStart()
-			if yyl353 == 0 {
+			yyl346 := r.ReadArrayStart()
+			if yyl346 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl353, d)
+				x.codecDecodeSelfFromArray(yyl346, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3986,12 +3922,12 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys354Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys354Slc
-	var yyhl354 bool = l >= 0
-	for yyj354 := 0; ; yyj354++ {
-		if yyhl354 {
-			if yyj354 >= l {
+	var yys347Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys347Slc
+	var yyhl347 bool = l >= 0
+	for yyj347 := 0; ; yyj347++ {
+		if yyhl347 {
+			if yyj347 >= l {
 				break
 			}
 		} else {
@@ -3999,9 +3935,9 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys354Slc = r.DecodeBytes(yys354Slc, true, true)
-		yys354 := string(yys354Slc)
-		switch yys354 {
+		yys347Slc = r.DecodeBytes(yys347Slc, true, true)
+		yys347 := string(yys347Slc)
+		switch yys347 {
 		case "totalCores":
 			if r.TryDecodeAsNil() {
 				if x.TotalCores != nil {
@@ -4011,21 +3947,21 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalCores == nil {
 					x.TotalCores = new(pkg2_resource.Quantity)
 				}
-				yym356 := z.DecBinary()
-				_ = yym356
+				yym349 := z.DecBinary()
+				_ = yym349
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-				} else if !yym356 && z.IsJSONHandle() {
+				} else if !yym349 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalCores)
 				} else {
 					z.DecFallback(x.TotalCores, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys354)
-		} // end switch yys354
-	} // end for yyj354
-	if !yyhl354 {
+			z.DecStructFieldNotFound(-1, yys347)
+		} // end switch yys347
+	} // end for yyj347
+	if !yyhl347 {
 		r.ReadEnd()
 	}
 }
@@ -4034,16 +3970,16 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj357 int
-	var yyb357 bool
-	var yyhl357 bool = l >= 0
-	yyj357++
-	if yyhl357 {
-		yyb357 = yyj357 > l
+	var yyj350 int
+	var yyb350 bool
+	var yyhl350 bool = l >= 0
+	yyj350++
+	if yyhl350 {
+		yyb350 = yyj350 > l
 	} else {
-		yyb357 = r.CheckBreak()
+		yyb350 = r.CheckBreak()
 	}
-	if yyb357 {
+	if yyb350 {
 		r.ReadEnd()
 		return
 	}
@@ -4055,27 +3991,27 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalCores == nil {
 			x.TotalCores = new(pkg2_resource.Quantity)
 		}
-		yym359 := z.DecBinary()
-		_ = yym359
+		yym352 := z.DecBinary()
+		_ = yym352
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-		} else if !yym359 && z.IsJSONHandle() {
+		} else if !yym352 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalCores)
 		} else {
 			z.DecFallback(x.TotalCores, false)
 		}
 	}
 	for {
-		yyj357++
-		if yyhl357 {
-			yyb357 = yyj357 > l
+		yyj350++
+		if yyhl350 {
+			yyb350 = yyj350 > l
 		} else {
-			yyb357 = r.CheckBreak()
+			yyb350 = r.CheckBreak()
 		}
-		if yyb357 {
+		if yyb350 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj357-1, "")
+		z.DecStructFieldNotFound(yyj350-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4087,41 +4023,41 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym360 := z.EncBinary()
-		_ = yym360
+		yym353 := z.EncBinary()
+		_ = yym353
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep361 := !z.EncBinary()
-			yy2arr361 := z.EncBasicHandle().StructToArray
-			var yyq361 [4]bool
-			_, _, _ = yysep361, yyq361, yy2arr361
-			const yyr361 bool = false
-			yyq361[0] = x.TotalBytes != nil
-			yyq361[1] = x.UsageBytes != nil
-			yyq361[2] = x.PageFaults != nil
-			yyq361[3] = x.MajorPageFaults != nil
-			if yyr361 || yy2arr361 {
+			yysep354 := !z.EncBinary()
+			yy2arr354 := z.EncBasicHandle().StructToArray
+			var yyq354 [4]bool
+			_, _, _ = yysep354, yyq354, yy2arr354
+			const yyr354 bool = false
+			yyq354[0] = x.TotalBytes != nil
+			yyq354[1] = x.UsageBytes != nil
+			yyq354[2] = x.PageFaults != nil
+			yyq354[3] = x.MajorPageFaults != nil
+			if yyr354 || yy2arr354 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn361 int = 0
-				for _, b := range yyq361 {
+				var yynn354 int = 0
+				for _, b := range yyq354 {
 					if b {
-						yynn361++
+						yynn354++
 					}
 				}
-				r.EncodeMapStart(yynn361)
+				r.EncodeMapStart(yynn354)
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[0] {
+			if yyr354 || yy2arr354 {
+				if yyq354[0] {
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym363 := z.EncBinary()
-						_ = yym363
+						yym356 := z.EncBinary()
+						_ = yym356
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym363 && z.IsJSONHandle() {
+						} else if !yym356 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4131,16 +4067,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[0] {
+				if yyq354[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalBytes"))
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym364 := z.EncBinary()
-						_ = yym364
+						yym357 := z.EncBinary()
+						_ = yym357
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym364 && z.IsJSONHandle() {
+						} else if !yym357 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4148,16 +4084,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[1] {
+			if yyr354 || yy2arr354 {
+				if yyq354[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym366 := z.EncBinary()
-						_ = yym366
+						yym359 := z.EncBinary()
+						_ = yym359
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym366 && z.IsJSONHandle() {
+						} else if !yym359 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4167,16 +4103,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[1] {
+				if yyq354[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym367 := z.EncBinary()
-						_ = yym367
+						yym360 := z.EncBinary()
+						_ = yym360
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym367 && z.IsJSONHandle() {
+						} else if !yym360 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4184,12 +4120,61 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[2] {
+			if yyr354 || yy2arr354 {
+				if yyq354[2] {
 					if x.PageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy369 := *x.PageFaults
+						yy362 := *x.PageFaults
+						yym363 := z.EncBinary()
+						_ = yym363
+						if false {
+						} else {
+							r.EncodeInt(int64(yy362))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
+					if x.PageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy364 := *x.PageFaults
+						yym365 := z.EncBinary()
+						_ = yym365
+						if false {
+						} else {
+							r.EncodeInt(int64(yy364))
+						}
+					}
+				}
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[3] {
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy367 := *x.MajorPageFaults
+						yym368 := z.EncBinary()
+						_ = yym368
+						if false {
+						} else {
+							r.EncodeInt(int64(yy367))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy369 := *x.MajorPageFaults
 						yym370 := z.EncBinary()
 						_ = yym370
 						if false {
@@ -4197,58 +4182,9 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 							r.EncodeInt(int64(yy369))
 						}
 					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq361[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
-					if x.PageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy371 := *x.PageFaults
-						yym372 := z.EncBinary()
-						_ = yym372
-						if false {
-						} else {
-							r.EncodeInt(int64(yy371))
-						}
-					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[3] {
-					if x.MajorPageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy374 := *x.MajorPageFaults
-						yym375 := z.EncBinary()
-						_ = yym375
-						if false {
-						} else {
-							r.EncodeInt(int64(yy374))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq361[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
-					if x.MajorPageFaults == nil {
-						r.EncodeNil()
-					} else {
-						yy376 := *x.MajorPageFaults
-						yym377 := z.EncBinary()
-						_ = yym377
-						if false {
-						} else {
-							r.EncodeInt(int64(yy376))
-						}
-					}
-				}
-			}
-			if yysep361 {
+			if yysep354 {
 				r.EncodeEnd()
 			}
 		}
@@ -4259,24 +4195,24 @@ func (x *MemoryMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym378 := z.DecBinary()
-	_ = yym378
+	yym371 := z.DecBinary()
+	_ = yym371
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl379 := r.ReadMapStart()
-			if yyl379 == 0 {
+			yyl372 := r.ReadMapStart()
+			if yyl372 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl379, d)
+				x.codecDecodeSelfFromMap(yyl372, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl379 := r.ReadArrayStart()
-			if yyl379 == 0 {
+			yyl372 := r.ReadArrayStart()
+			if yyl372 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl379, d)
+				x.codecDecodeSelfFromArray(yyl372, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4288,12 +4224,12 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys380Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys380Slc
-	var yyhl380 bool = l >= 0
-	for yyj380 := 0; ; yyj380++ {
-		if yyhl380 {
-			if yyj380 >= l {
+	var yys373Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys373Slc
+	var yyhl373 bool = l >= 0
+	for yyj373 := 0; ; yyj373++ {
+		if yyhl373 {
+			if yyj373 >= l {
 				break
 			}
 		} else {
@@ -4301,9 +4237,9 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys380Slc = r.DecodeBytes(yys380Slc, true, true)
-		yys380 := string(yys380Slc)
-		switch yys380 {
+		yys373Slc = r.DecodeBytes(yys373Slc, true, true)
+		yys373 := string(yys373Slc)
+		switch yys373 {
 		case "totalBytes":
 			if r.TryDecodeAsNil() {
 				if x.TotalBytes != nil {
@@ -4313,11 +4249,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalBytes == nil {
 					x.TotalBytes = new(pkg2_resource.Quantity)
 				}
-				yym382 := z.DecBinary()
-				_ = yym382
+				yym375 := z.DecBinary()
+				_ = yym375
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-				} else if !yym382 && z.IsJSONHandle() {
+				} else if !yym375 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalBytes)
 				} else {
 					z.DecFallback(x.TotalBytes, false)
@@ -4332,11 +4268,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym384 := z.DecBinary()
-				_ = yym384
+				yym377 := z.DecBinary()
+				_ = yym377
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym384 && z.IsJSONHandle() {
+				} else if !yym377 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4351,8 +4287,8 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.PageFaults == nil {
 					x.PageFaults = new(int64)
 				}
-				yym386 := z.DecBinary()
-				_ = yym386
+				yym379 := z.DecBinary()
+				_ = yym379
 				if false {
 				} else {
 					*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
@@ -4367,18 +4303,18 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.MajorPageFaults == nil {
 					x.MajorPageFaults = new(int64)
 				}
-				yym388 := z.DecBinary()
-				_ = yym388
+				yym381 := z.DecBinary()
+				_ = yym381
 				if false {
 				} else {
 					*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys380)
-		} // end switch yys380
-	} // end for yyj380
-	if !yyhl380 {
+			z.DecStructFieldNotFound(-1, yys373)
+		} // end switch yys373
+	} // end for yyj373
+	if !yyhl373 {
 		r.ReadEnd()
 	}
 }
@@ -4387,16 +4323,16 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj389 int
-	var yyb389 bool
-	var yyhl389 bool = l >= 0
-	yyj389++
-	if yyhl389 {
-		yyb389 = yyj389 > l
+	var yyj382 int
+	var yyb382 bool
+	var yyhl382 bool = l >= 0
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
 	} else {
-		yyb389 = r.CheckBreak()
+		yyb382 = r.CheckBreak()
 	}
-	if yyb389 {
+	if yyb382 {
 		r.ReadEnd()
 		return
 	}
@@ -4408,23 +4344,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalBytes == nil {
 			x.TotalBytes = new(pkg2_resource.Quantity)
 		}
-		yym391 := z.DecBinary()
-		_ = yym391
+		yym384 := z.DecBinary()
+		_ = yym384
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-		} else if !yym391 && z.IsJSONHandle() {
+		} else if !yym384 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalBytes)
 		} else {
 			z.DecFallback(x.TotalBytes, false)
 		}
 	}
-	yyj389++
-	if yyhl389 {
-		yyb389 = yyj389 > l
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
 	} else {
-		yyb389 = r.CheckBreak()
+		yyb382 = r.CheckBreak()
 	}
-	if yyb389 {
+	if yyb382 {
 		r.ReadEnd()
 		return
 	}
@@ -4436,23 +4372,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym393 := z.DecBinary()
-		_ = yym393
+		yym386 := z.DecBinary()
+		_ = yym386
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym393 && z.IsJSONHandle() {
+		} else if !yym386 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj389++
-	if yyhl389 {
-		yyb389 = yyj389 > l
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
 	} else {
-		yyb389 = r.CheckBreak()
+		yyb382 = r.CheckBreak()
 	}
-	if yyb389 {
+	if yyb382 {
 		r.ReadEnd()
 		return
 	}
@@ -4464,20 +4400,20 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.PageFaults == nil {
 			x.PageFaults = new(int64)
 		}
-		yym395 := z.DecBinary()
-		_ = yym395
+		yym388 := z.DecBinary()
+		_ = yym388
 		if false {
 		} else {
 			*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj389++
-	if yyhl389 {
-		yyb389 = yyj389 > l
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
 	} else {
-		yyb389 = r.CheckBreak()
+		yyb382 = r.CheckBreak()
 	}
-	if yyb389 {
+	if yyb382 {
 		r.ReadEnd()
 		return
 	}
@@ -4489,24 +4425,24 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.MajorPageFaults == nil {
 			x.MajorPageFaults = new(int64)
 		}
-		yym397 := z.DecBinary()
-		_ = yym397
+		yym390 := z.DecBinary()
+		_ = yym390
 		if false {
 		} else {
 			*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj389++
-		if yyhl389 {
-			yyb389 = yyj389 > l
+		yyj382++
+		if yyhl382 {
+			yyb382 = yyj382 > l
 		} else {
-			yyb389 = r.CheckBreak()
+			yyb382 = r.CheckBreak()
 		}
-		if yyb389 {
+		if yyb382 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj389-1, "")
+		z.DecStructFieldNotFound(yyj382-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4518,55 +4454,55 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym398 := z.EncBinary()
-		_ = yym398
+		yym391 := z.EncBinary()
+		_ = yym391
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep399 := !z.EncBinary()
-			yy2arr399 := z.EncBasicHandle().StructToArray
-			var yyq399 [3]bool
-			_, _, _ = yysep399, yyq399, yy2arr399
-			const yyr399 bool = false
-			yyq399[1] = x.UsageBytes != nil
-			yyq399[2] = x.LimitBytes != nil
-			if yyr399 || yy2arr399 {
+			yysep392 := !z.EncBinary()
+			yy2arr392 := z.EncBasicHandle().StructToArray
+			var yyq392 [3]bool
+			_, _, _ = yysep392, yyq392, yy2arr392
+			const yyr392 bool = false
+			yyq392[1] = x.UsageBytes != nil
+			yyq392[2] = x.LimitBytes != nil
+			if yyr392 || yy2arr392 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn399 int = 1
-				for _, b := range yyq399 {
+				var yynn392 int = 1
+				for _, b := range yyq392 {
 					if b {
-						yynn399++
+						yynn392++
 					}
 				}
-				r.EncodeMapStart(yynn399)
+				r.EncodeMapStart(yynn392)
 			}
-			if yyr399 || yy2arr399 {
-				yym401 := z.EncBinary()
-				_ = yym401
+			if yyr392 || yy2arr392 {
+				yym394 := z.EncBinary()
+				_ = yym394
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("device"))
-				yym402 := z.EncBinary()
-				_ = yym402
+				yym395 := z.EncBinary()
+				_ = yym395
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
 				}
 			}
-			if yyr399 || yy2arr399 {
-				if yyq399[1] {
+			if yyr392 || yy2arr392 {
+				if yyq392[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym404 := z.EncBinary()
-						_ = yym404
+						yym397 := z.EncBinary()
+						_ = yym397
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym404 && z.IsJSONHandle() {
+						} else if !yym397 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4576,16 +4512,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq399[1] {
+				if yyq392[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym405 := z.EncBinary()
-						_ = yym405
+						yym398 := z.EncBinary()
+						_ = yym398
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym405 && z.IsJSONHandle() {
+						} else if !yym398 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4593,16 +4529,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr399 || yy2arr399 {
-				if yyq399[2] {
+			if yyr392 || yy2arr392 {
+				if yyq392[2] {
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym407 := z.EncBinary()
-						_ = yym407
+						yym400 := z.EncBinary()
+						_ = yym400
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
-						} else if !yym407 && z.IsJSONHandle() {
+						} else if !yym400 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LimitBytes)
 						} else {
 							z.EncFallback(x.LimitBytes)
@@ -4612,16 +4548,16 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq399[2] {
+				if yyq392[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym408 := z.EncBinary()
-						_ = yym408
+						yym401 := z.EncBinary()
+						_ = yym401
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
-						} else if !yym408 && z.IsJSONHandle() {
+						} else if !yym401 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LimitBytes)
 						} else {
 							z.EncFallback(x.LimitBytes)
@@ -4629,7 +4565,7 @@ func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep399 {
+			if yysep392 {
 				r.EncodeEnd()
 			}
 		}
@@ -4640,24 +4576,24 @@ func (x *FilesystemMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym409 := z.DecBinary()
-	_ = yym409
+	yym402 := z.DecBinary()
+	_ = yym402
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl410 := r.ReadMapStart()
-			if yyl410 == 0 {
+			yyl403 := r.ReadMapStart()
+			if yyl403 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl410, d)
+				x.codecDecodeSelfFromMap(yyl403, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl410 := r.ReadArrayStart()
-			if yyl410 == 0 {
+			yyl403 := r.ReadArrayStart()
+			if yyl403 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl410, d)
+				x.codecDecodeSelfFromArray(yyl403, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4669,12 +4605,12 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys411Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys411Slc
-	var yyhl411 bool = l >= 0
-	for yyj411 := 0; ; yyj411++ {
-		if yyhl411 {
-			if yyj411 >= l {
+	var yys404Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys404Slc
+	var yyhl404 bool = l >= 0
+	for yyj404 := 0; ; yyj404++ {
+		if yyhl404 {
+			if yyj404 >= l {
 				break
 			}
 		} else {
@@ -4682,9 +4618,9 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys411Slc = r.DecodeBytes(yys411Slc, true, true)
-		yys411 := string(yys411Slc)
-		switch yys411 {
+		yys404Slc = r.DecodeBytes(yys404Slc, true, true)
+		yys404 := string(yys404Slc)
+		switch yys404 {
 		case "device":
 			if r.TryDecodeAsNil() {
 				x.Device = ""
@@ -4700,11 +4636,11 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym414 := z.DecBinary()
-				_ = yym414
+				yym407 := z.DecBinary()
+				_ = yym407
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym414 && z.IsJSONHandle() {
+				} else if !yym407 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4719,21 +4655,21 @@ func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(pkg2_resource.Quantity)
 				}
-				yym416 := z.DecBinary()
-				_ = yym416
+				yym409 := z.DecBinary()
+				_ = yym409
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
-				} else if !yym416 && z.IsJSONHandle() {
+				} else if !yym409 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LimitBytes)
 				} else {
 					z.DecFallback(x.LimitBytes, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys411)
-		} // end switch yys411
-	} // end for yyj411
-	if !yyhl411 {
+			z.DecStructFieldNotFound(-1, yys404)
+		} // end switch yys404
+	} // end for yyj404
+	if !yyhl404 {
 		r.ReadEnd()
 	}
 }
@@ -4742,16 +4678,16 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj417 int
-	var yyb417 bool
-	var yyhl417 bool = l >= 0
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	var yyj410 int
+	var yyb410 bool
+	var yyhl410 bool = l >= 0
+	yyj410++
+	if yyhl410 {
+		yyb410 = yyj410 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb410 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb410 {
 		r.ReadEnd()
 		return
 	}
@@ -4760,13 +4696,13 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Device = string(r.DecodeString())
 	}
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	yyj410++
+	if yyhl410 {
+		yyb410 = yyj410 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb410 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb410 {
 		r.ReadEnd()
 		return
 	}
@@ -4778,23 +4714,23 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym420 := z.DecBinary()
-		_ = yym420
+		yym413 := z.DecBinary()
+		_ = yym413
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym420 && z.IsJSONHandle() {
+		} else if !yym413 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	yyj410++
+	if yyhl410 {
+		yyb410 = yyj410 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb410 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb410 {
 		r.ReadEnd()
 		return
 	}
@@ -4806,656 +4742,27 @@ func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(pkg2_resource.Quantity)
 		}
-		yym422 := z.DecBinary()
-		_ = yym422
+		yym415 := z.DecBinary()
+		_ = yym415
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
-		} else if !yym422 && z.IsJSONHandle() {
+		} else if !yym415 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LimitBytes)
 		} else {
 			z.DecFallback(x.LimitBytes, false)
 		}
 	}
 	for {
-		yyj417++
-		if yyhl417 {
-			yyb417 = yyj417 > l
+		yyj410++
+		if yyhl410 {
+			yyb410 = yyj410 > l
 		} else {
-			yyb417 = r.CheckBreak()
+			yyb410 = r.CheckBreak()
 		}
-		if yyb417 {
+		if yyb410 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj417-1, "")
-	}
-	r.ReadEnd()
-}
-
-func (x CustomMetricType) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	yym423 := z.EncBinary()
-	_ = yym423
-	if false {
-	} else if z.HasExtensions() && z.EncExt(x) {
-	} else {
-		r.EncodeString(codecSelferC_UTF81234, string(x))
-	}
-}
-
-func (x *CustomMetricType) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym424 := z.DecBinary()
-	_ = yym424
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		*((*string)(x)) = r.DecodeString()
-	}
-}
-
-func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym425 := z.EncBinary()
-		_ = yym425
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep426 := !z.EncBinary()
-			yy2arr426 := z.EncBasicHandle().StructToArray
-			var yyq426 [4]bool
-			_, _, _ = yysep426, yyq426, yy2arr426
-			const yyr426 bool = false
-			yyq426[3] = len(x.Samples) != 0
-			if yyr426 || yy2arr426 {
-				r.EncodeArrayStart(4)
-			} else {
-				var yynn426 int = 3
-				for _, b := range yyq426 {
-					if b {
-						yynn426++
-					}
-				}
-				r.EncodeMapStart(yynn426)
-			}
-			if yyr426 || yy2arr426 {
-				yym428 := z.EncBinary()
-				_ = yym428
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("name"))
-				yym429 := z.EncBinary()
-				_ = yym429
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-				}
-			}
-			if yyr426 || yy2arr426 {
-				x.Type.CodecEncodeSelf(e)
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("type"))
-				x.Type.CodecEncodeSelf(e)
-			}
-			if yyr426 || yy2arr426 {
-				yym432 := z.EncBinary()
-				_ = yym432
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("unit"))
-				yym433 := z.EncBinary()
-				_ = yym433
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
-				}
-			}
-			if yyr426 || yy2arr426 {
-				if yyq426[3] {
-					if x.Samples == nil {
-						r.EncodeNil()
-					} else {
-						yym435 := z.EncBinary()
-						_ = yym435
-						if false {
-						} else {
-							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq426[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("samples"))
-					if x.Samples == nil {
-						r.EncodeNil()
-					} else {
-						yym436 := z.EncBinary()
-						_ = yym436
-						if false {
-						} else {
-							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
-						}
-					}
-				}
-			}
-			if yysep426 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *CustomMetric) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym437 := z.DecBinary()
-	_ = yym437
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl438 := r.ReadMapStart()
-			if yyl438 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl438, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl438 := r.ReadArrayStart()
-			if yyl438 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl438, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys439Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys439Slc
-	var yyhl439 bool = l >= 0
-	for yyj439 := 0; ; yyj439++ {
-		if yyhl439 {
-			if yyj439 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys439Slc = r.DecodeBytes(yys439Slc, true, true)
-		yys439 := string(yys439Slc)
-		switch yys439 {
-		case "name":
-			if r.TryDecodeAsNil() {
-				x.Name = ""
-			} else {
-				x.Name = string(r.DecodeString())
-			}
-		case "type":
-			if r.TryDecodeAsNil() {
-				x.Type = ""
-			} else {
-				x.Type = CustomMetricType(r.DecodeString())
-			}
-		case "unit":
-			if r.TryDecodeAsNil() {
-				x.Unit = ""
-			} else {
-				x.Unit = string(r.DecodeString())
-			}
-		case "samples":
-			if r.TryDecodeAsNil() {
-				x.Samples = nil
-			} else {
-				yyv443 := &x.Samples
-				yym444 := z.DecBinary()
-				_ = yym444
-				if false {
-				} else {
-					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv443), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys439)
-		} // end switch yys439
-	} // end for yyj439
-	if !yyhl439 {
-		r.ReadEnd()
-	}
-}
-
-func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj445 int
-	var yyb445 bool
-	var yyhl445 bool = l >= 0
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
-	} else {
-		yyb445 = r.CheckBreak()
-	}
-	if yyb445 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Name = ""
-	} else {
-		x.Name = string(r.DecodeString())
-	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
-	} else {
-		yyb445 = r.CheckBreak()
-	}
-	if yyb445 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Type = ""
-	} else {
-		x.Type = CustomMetricType(r.DecodeString())
-	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
-	} else {
-		yyb445 = r.CheckBreak()
-	}
-	if yyb445 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Unit = ""
-	} else {
-		x.Unit = string(r.DecodeString())
-	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
-	} else {
-		yyb445 = r.CheckBreak()
-	}
-	if yyb445 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Samples = nil
-	} else {
-		yyv449 := &x.Samples
-		yym450 := z.DecBinary()
-		_ = yym450
-		if false {
-		} else {
-			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv449), d)
-		}
-	}
-	for {
-		yyj445++
-		if yyhl445 {
-			yyb445 = yyj445 > l
-		} else {
-			yyb445 = r.CheckBreak()
-		}
-		if yyb445 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj445-1, "")
-	}
-	r.ReadEnd()
-}
-
-func (x *CustomMetricSample) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym451 := z.EncBinary()
-		_ = yym451
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep452 := !z.EncBinary()
-			yy2arr452 := z.EncBasicHandle().StructToArray
-			var yyq452 [3]bool
-			_, _, _ = yysep452, yyq452, yy2arr452
-			const yyr452 bool = false
-			yyq452[1] = x.Label != nil
-			if yyr452 || yy2arr452 {
-				r.EncodeArrayStart(3)
-			} else {
-				var yynn452 int = 2
-				for _, b := range yyq452 {
-					if b {
-						yynn452++
-					}
-				}
-				r.EncodeMapStart(yynn452)
-			}
-			if yyr452 || yy2arr452 {
-				yy454 := &x.SampleTime
-				yym455 := z.EncBinary()
-				_ = yym455
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy454) {
-				} else if yym455 {
-					z.EncBinaryMarshal(yy454)
-				} else if !yym455 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy454)
-				} else {
-					z.EncFallback(yy454)
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy456 := &x.SampleTime
-				yym457 := z.EncBinary()
-				_ = yym457
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy456) {
-				} else if yym457 {
-					z.EncBinaryMarshal(yy456)
-				} else if !yym457 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy456)
-				} else {
-					z.EncFallback(yy456)
-				}
-			}
-			if yyr452 || yy2arr452 {
-				if yyq452[1] {
-					if x.Label == nil {
-						r.EncodeNil()
-					} else {
-						yy459 := *x.Label
-						yym460 := z.EncBinary()
-						_ = yym460
-						if false {
-						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy459))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq452[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("label"))
-					if x.Label == nil {
-						r.EncodeNil()
-					} else {
-						yy461 := *x.Label
-						yym462 := z.EncBinary()
-						_ = yym462
-						if false {
-						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy461))
-						}
-					}
-				}
-			}
-			if yyr452 || yy2arr452 {
-				yy464 := &x.Value
-				yym465 := z.EncBinary()
-				_ = yym465
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy464) {
-				} else if !yym465 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy464)
-				} else {
-					z.EncFallback(yy464)
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yy466 := &x.Value
-				yym467 := z.EncBinary()
-				_ = yym467
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy466) {
-				} else if !yym467 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy466)
-				} else {
-					z.EncFallback(yy466)
-				}
-			}
-			if yysep452 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *CustomMetricSample) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym468 := z.DecBinary()
-	_ = yym468
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl469 := r.ReadMapStart()
-			if yyl469 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl469, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl469 := r.ReadArrayStart()
-			if yyl469 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl469, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys470Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys470Slc
-	var yyhl470 bool = l >= 0
-	for yyj470 := 0; ; yyj470++ {
-		if yyhl470 {
-			if yyj470 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys470Slc = r.DecodeBytes(yys470Slc, true, true)
-		yys470 := string(yys470Slc)
-		switch yys470 {
-		case "sampleTime":
-			if r.TryDecodeAsNil() {
-				x.SampleTime = pkg1_unversioned.Time{}
-			} else {
-				yyv471 := &x.SampleTime
-				yym472 := z.DecBinary()
-				_ = yym472
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv471) {
-				} else if yym472 {
-					z.DecBinaryUnmarshal(yyv471)
-				} else if !yym472 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv471)
-				} else {
-					z.DecFallback(yyv471, false)
-				}
-			}
-		case "label":
-			if r.TryDecodeAsNil() {
-				if x.Label != nil {
-					x.Label = nil
-				}
-			} else {
-				if x.Label == nil {
-					x.Label = new(string)
-				}
-				yym474 := z.DecBinary()
-				_ = yym474
-				if false {
-				} else {
-					*((*string)(x.Label)) = r.DecodeString()
-				}
-			}
-		case "value":
-			if r.TryDecodeAsNil() {
-				x.Value = pkg2_resource.Quantity{}
-			} else {
-				yyv475 := &x.Value
-				yym476 := z.DecBinary()
-				_ = yym476
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv475) {
-				} else if !yym476 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv475)
-				} else {
-					z.DecFallback(yyv475, false)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys470)
-		} // end switch yys470
-	} // end for yyj470
-	if !yyhl470 {
-		r.ReadEnd()
-	}
-}
-
-func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj477 int
-	var yyb477 bool
-	var yyhl477 bool = l >= 0
-	yyj477++
-	if yyhl477 {
-		yyb477 = yyj477 > l
-	} else {
-		yyb477 = r.CheckBreak()
-	}
-	if yyb477 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.SampleTime = pkg1_unversioned.Time{}
-	} else {
-		yyv478 := &x.SampleTime
-		yym479 := z.DecBinary()
-		_ = yym479
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv478) {
-		} else if yym479 {
-			z.DecBinaryUnmarshal(yyv478)
-		} else if !yym479 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv478)
-		} else {
-			z.DecFallback(yyv478, false)
-		}
-	}
-	yyj477++
-	if yyhl477 {
-		yyb477 = yyj477 > l
-	} else {
-		yyb477 = r.CheckBreak()
-	}
-	if yyb477 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		if x.Label != nil {
-			x.Label = nil
-		}
-	} else {
-		if x.Label == nil {
-			x.Label = new(string)
-		}
-		yym481 := z.DecBinary()
-		_ = yym481
-		if false {
-		} else {
-			*((*string)(x.Label)) = r.DecodeString()
-		}
-	}
-	yyj477++
-	if yyhl477 {
-		yyb477 = yyj477 > l
-	} else {
-		yyb477 = r.CheckBreak()
-	}
-	if yyb477 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Value = pkg2_resource.Quantity{}
-	} else {
-		yyv482 := &x.Value
-		yym483 := z.DecBinary()
-		_ = yym483
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv482) {
-		} else if !yym483 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv482)
-		} else {
-			z.DecFallback(yyv482, false)
-		}
-	}
-	for {
-		yyj477++
-		if yyhl477 {
-			yyb477 = yyj477 > l
-		} else {
-			yyb477 = r.CheckBreak()
-		}
-		if yyb477 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj477-1, "")
+		z.DecStructFieldNotFound(yyj410-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5467,42 +4774,42 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym484 := z.EncBinary()
-		_ = yym484
+		yym416 := z.EncBinary()
+		_ = yym416
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep485 := !z.EncBinary()
-			yy2arr485 := z.EncBasicHandle().StructToArray
-			var yyq485 [3]bool
-			_, _, _ = yysep485, yyq485, yy2arr485
-			const yyr485 bool = false
-			yyq485[0] = x.SinceTime != nil
-			yyq485[1] = x.UntilTime != nil
-			yyq485[2] = x.MaxSamples != 0
-			if yyr485 || yy2arr485 {
+			yysep417 := !z.EncBinary()
+			yy2arr417 := z.EncBasicHandle().StructToArray
+			var yyq417 [3]bool
+			_, _, _ = yysep417, yyq417, yy2arr417
+			const yyr417 bool = false
+			yyq417[0] = x.SinceTime != nil
+			yyq417[1] = x.UntilTime != nil
+			yyq417[2] = x.MaxSamples != 0
+			if yyr417 || yy2arr417 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn485 int = 0
-				for _, b := range yyq485 {
+				var yynn417 int = 0
+				for _, b := range yyq417 {
 					if b {
-						yynn485++
+						yynn417++
 					}
 				}
-				r.EncodeMapStart(yynn485)
+				r.EncodeMapStart(yynn417)
 			}
-			if yyr485 || yy2arr485 {
-				if yyq485[0] {
+			if yyr417 || yy2arr417 {
+				if yyq417[0] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym487 := z.EncBinary()
-						_ = yym487
+						yym419 := z.EncBinary()
+						_ = yym419
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym487 {
+						} else if yym419 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym487 && z.IsJSONHandle() {
+						} else if !yym419 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5512,18 +4819,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq485[0] {
+				if yyq417[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym488 := z.EncBinary()
-						_ = yym488
+						yym420 := z.EncBinary()
+						_ = yym420
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym488 {
+						} else if yym420 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym488 && z.IsJSONHandle() {
+						} else if !yym420 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5531,18 +4838,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr485 || yy2arr485 {
-				if yyq485[1] {
+			if yyr417 || yy2arr417 {
+				if yyq417[1] {
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym490 := z.EncBinary()
-						_ = yym490
+						yym422 := z.EncBinary()
+						_ = yym422
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym490 {
+						} else if yym422 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym490 && z.IsJSONHandle() {
+						} else if !yym422 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5552,18 +4859,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq485[1] {
+				if yyq417[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym491 := z.EncBinary()
-						_ = yym491
+						yym423 := z.EncBinary()
+						_ = yym423
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym491 {
+						} else if yym423 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym491 && z.IsJSONHandle() {
+						} else if !yym423 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5571,10 +4878,10 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr485 || yy2arr485 {
-				if yyq485[2] {
-					yym493 := z.EncBinary()
-					_ = yym493
+			if yyr417 || yy2arr417 {
+				if yyq417[2] {
+					yym425 := z.EncBinary()
+					_ = yym425
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -5583,17 +4890,17 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq485[2] {
+				if yyq417[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
-					yym494 := z.EncBinary()
-					_ = yym494
+					yym426 := z.EncBinary()
+					_ = yym426
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
 					}
 				}
 			}
-			if yysep485 {
+			if yysep417 {
 				r.EncodeEnd()
 			}
 		}
@@ -5604,24 +4911,24 @@ func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym495 := z.DecBinary()
-	_ = yym495
+	yym427 := z.DecBinary()
+	_ = yym427
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl496 := r.ReadMapStart()
-			if yyl496 == 0 {
+			yyl428 := r.ReadMapStart()
+			if yyl428 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl496, d)
+				x.codecDecodeSelfFromMap(yyl428, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl496 := r.ReadArrayStart()
-			if yyl496 == 0 {
+			yyl428 := r.ReadArrayStart()
+			if yyl428 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl496, d)
+				x.codecDecodeSelfFromArray(yyl428, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5633,12 +4940,12 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys497Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys497Slc
-	var yyhl497 bool = l >= 0
-	for yyj497 := 0; ; yyj497++ {
-		if yyhl497 {
-			if yyj497 >= l {
+	var yys429Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys429Slc
+	var yyhl429 bool = l >= 0
+	for yyj429 := 0; ; yyj429++ {
+		if yyhl429 {
+			if yyj429 >= l {
 				break
 			}
 		} else {
@@ -5646,9 +4953,9 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys497Slc = r.DecodeBytes(yys497Slc, true, true)
-		yys497 := string(yys497Slc)
-		switch yys497 {
+		yys429Slc = r.DecodeBytes(yys429Slc, true, true)
+		yys429 := string(yys429Slc)
+		switch yys429 {
 		case "sinceTime":
 			if r.TryDecodeAsNil() {
 				if x.SinceTime != nil {
@@ -5658,13 +4965,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg1_unversioned.Time)
 				}
-				yym499 := z.DecBinary()
-				_ = yym499
+				yym431 := z.DecBinary()
+				_ = yym431
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym499 {
+				} else if yym431 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym499 && z.IsJSONHandle() {
+				} else if !yym431 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -5679,13 +4986,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UntilTime == nil {
 					x.UntilTime = new(pkg1_unversioned.Time)
 				}
-				yym501 := z.DecBinary()
-				_ = yym501
+				yym433 := z.DecBinary()
+				_ = yym433
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-				} else if yym501 {
+				} else if yym433 {
 					z.DecBinaryUnmarshal(x.UntilTime)
-				} else if !yym501 && z.IsJSONHandle() {
+				} else if !yym433 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UntilTime)
 				} else {
 					z.DecFallback(x.UntilTime, false)
@@ -5698,10 +5005,10 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys497)
-		} // end switch yys497
-	} // end for yyj497
-	if !yyhl497 {
+			z.DecStructFieldNotFound(-1, yys429)
+		} // end switch yys429
+	} // end for yyj429
+	if !yyhl429 {
 		r.ReadEnd()
 	}
 }
@@ -5710,16 +5017,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj503 int
-	var yyb503 bool
-	var yyhl503 bool = l >= 0
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	var yyj435 int
+	var yyb435 bool
+	var yyhl435 bool = l >= 0
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
@@ -5731,25 +5038,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg1_unversioned.Time)
 		}
-		yym505 := z.DecBinary()
-		_ = yym505
+		yym437 := z.DecBinary()
+		_ = yym437
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym505 {
+		} else if yym437 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym505 && z.IsJSONHandle() {
+		} else if !yym437 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
@@ -5761,25 +5068,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UntilTime == nil {
 			x.UntilTime = new(pkg1_unversioned.Time)
 		}
-		yym507 := z.DecBinary()
-		_ = yym507
+		yym439 := z.DecBinary()
+		_ = yym439
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-		} else if yym507 {
+		} else if yym439 {
 			z.DecBinaryUnmarshal(x.UntilTime)
-		} else if !yym507 && z.IsJSONHandle() {
+		} else if !yym439 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UntilTime)
 		} else {
 			z.DecFallback(x.UntilTime, false)
 		}
 	}
-	yyj503++
-	if yyhl503 {
-		yyb503 = yyj503 > l
+	yyj435++
+	if yyhl435 {
+		yyb435 = yyj435 > l
 	} else {
-		yyb503 = r.CheckBreak()
+		yyb435 = r.CheckBreak()
 	}
-	if yyb503 {
+	if yyb435 {
 		r.ReadEnd()
 		return
 	}
@@ -5789,16 +5096,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj503++
-		if yyhl503 {
-			yyb503 = yyj503 > l
+		yyj435++
+		if yyhl435 {
+			yyb435 = yyj435 > l
 		} else {
-			yyb503 = r.CheckBreak()
+			yyb435 = r.CheckBreak()
 		}
-		if yyb503 {
+		if yyb435 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj503-1, "")
+		z.DecStructFieldNotFound(yyj435-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5808,9 +5115,9 @@ func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv509 := range v {
-		yy510 := &yyv509
-		yy510.CodecEncodeSelf(e)
+	for _, yyv441 := range v {
+		yy442 := &yyv441
+		yy442.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5820,75 +5127,75 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv511 := *v
-	yyh511, yyl511 := z.DecSliceHelperStart()
+	yyv443 := *v
+	yyh443, yyl443 := z.DecSliceHelperStart()
 
-	var yyrr511, yyrl511 int
-	var yyc511, yyrt511 bool
-	_, _, _ = yyc511, yyrt511, yyrl511
-	yyrr511 = yyl511
+	var yyrr443, yyrl443 int
+	var yyc443, yyrt443 bool
+	_, _, _ = yyc443, yyrt443, yyrl443
+	yyrr443 = yyl443
 
-	if yyv511 == nil {
-		if yyrl511, yyrt511 = z.DecInferLen(yyl511, z.DecBasicHandle().MaxInitLen, 72); yyrt511 {
-			yyrr511 = yyrl511
+	if yyv443 == nil {
+		if yyrl443, yyrt443 = z.DecInferLen(yyl443, z.DecBasicHandle().MaxInitLen, 72); yyrt443 {
+			yyrr443 = yyrl443
 		}
-		yyv511 = make([]AggregateSample, yyrl511)
-		yyc511 = true
+		yyv443 = make([]AggregateSample, yyrl443)
+		yyc443 = true
 	}
 
-	if yyl511 == 0 {
-		if len(yyv511) != 0 {
-			yyv511 = yyv511[:0]
-			yyc511 = true
+	if yyl443 == 0 {
+		if len(yyv443) != 0 {
+			yyv443 = yyv443[:0]
+			yyc443 = true
 		}
-	} else if yyl511 > 0 {
+	} else if yyl443 > 0 {
 
-		if yyl511 > cap(yyv511) {
-			yyrl511, yyrt511 = z.DecInferLen(yyl511, z.DecBasicHandle().MaxInitLen, 72)
-			yyv511 = make([]AggregateSample, yyrl511)
-			yyc511 = true
+		if yyl443 > cap(yyv443) {
+			yyrl443, yyrt443 = z.DecInferLen(yyl443, z.DecBasicHandle().MaxInitLen, 72)
+			yyv443 = make([]AggregateSample, yyrl443)
+			yyc443 = true
 
-			yyrr511 = len(yyv511)
-		} else if yyl511 != len(yyv511) {
-			yyv511 = yyv511[:yyl511]
-			yyc511 = true
+			yyrr443 = len(yyv443)
+		} else if yyl443 != len(yyv443) {
+			yyv443 = yyv443[:yyl443]
+			yyc443 = true
 		}
-		yyj511 := 0
-		for ; yyj511 < yyrr511; yyj511++ {
+		yyj443 := 0
+		for ; yyj443 < yyrr443; yyj443++ {
 			if r.TryDecodeAsNil() {
-				yyv511[yyj511] = AggregateSample{}
+				yyv443[yyj443] = AggregateSample{}
 			} else {
-				yyv512 := &yyv511[yyj511]
-				yyv512.CodecDecodeSelf(d)
+				yyv444 := &yyv443[yyj443]
+				yyv444.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt511 {
-			for ; yyj511 < yyl511; yyj511++ {
-				yyv511 = append(yyv511, AggregateSample{})
+		if yyrt443 {
+			for ; yyj443 < yyl443; yyj443++ {
+				yyv443 = append(yyv443, AggregateSample{})
 				if r.TryDecodeAsNil() {
-					yyv511[yyj511] = AggregateSample{}
+					yyv443[yyj443] = AggregateSample{}
 				} else {
-					yyv513 := &yyv511[yyj511]
-					yyv513.CodecDecodeSelf(d)
+					yyv445 := &yyv443[yyj443]
+					yyv445.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj511 := 0; !r.CheckBreak(); yyj511++ {
-			if yyj511 >= len(yyv511) {
-				yyv511 = append(yyv511, AggregateSample{}) // var yyz511 AggregateSample
-				yyc511 = true
+		for yyj443 := 0; !r.CheckBreak(); yyj443++ {
+			if yyj443 >= len(yyv443) {
+				yyv443 = append(yyv443, AggregateSample{}) // var yyz443 AggregateSample
+				yyc443 = true
 			}
 
-			if yyj511 < len(yyv511) {
+			if yyj443 < len(yyv443) {
 				if r.TryDecodeAsNil() {
-					yyv511[yyj511] = AggregateSample{}
+					yyv443[yyj443] = AggregateSample{}
 				} else {
-					yyv514 := &yyv511[yyj511]
-					yyv514.CodecDecodeSelf(d)
+					yyv446 := &yyv443[yyj443]
+					yyv446.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5896,10 +5203,10 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 			}
 
 		}
-		yyh511.End()
+		yyh443.End()
 	}
-	if yyc511 {
-		*v = yyv511
+	if yyc443 {
+		*v = yyv443
 	}
 
 }
@@ -5909,9 +5216,9 @@ func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv515 := range v {
-		yy516 := &yyv515
-		yy516.CodecEncodeSelf(e)
+	for _, yyv447 := range v {
+		yy448 := &yyv447
+		yy448.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5921,75 +5228,75 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv517 := *v
-	yyh517, yyl517 := z.DecSliceHelperStart()
+	yyv449 := *v
+	yyh449, yyl449 := z.DecSliceHelperStart()
 
-	var yyrr517, yyrl517 int
-	var yyc517, yyrt517 bool
-	_, _, _ = yyc517, yyrt517, yyrl517
-	yyrr517 = yyl517
+	var yyrr449, yyrl449 int
+	var yyc449, yyrt449 bool
+	_, _, _ = yyc449, yyrt449, yyrl449
+	yyrr449 = yyl449
 
-	if yyv517 == nil {
-		if yyrl517, yyrt517 = z.DecInferLen(yyl517, z.DecBasicHandle().MaxInitLen, 72); yyrt517 {
-			yyrr517 = yyrl517
+	if yyv449 == nil {
+		if yyrl449, yyrt449 = z.DecInferLen(yyl449, z.DecBasicHandle().MaxInitLen, 48); yyrt449 {
+			yyrr449 = yyrl449
 		}
-		yyv517 = make([]RawContainerMetrics, yyrl517)
-		yyc517 = true
+		yyv449 = make([]RawContainerMetrics, yyrl449)
+		yyc449 = true
 	}
 
-	if yyl517 == 0 {
-		if len(yyv517) != 0 {
-			yyv517 = yyv517[:0]
-			yyc517 = true
+	if yyl449 == 0 {
+		if len(yyv449) != 0 {
+			yyv449 = yyv449[:0]
+			yyc449 = true
 		}
-	} else if yyl517 > 0 {
+	} else if yyl449 > 0 {
 
-		if yyl517 > cap(yyv517) {
-			yyrl517, yyrt517 = z.DecInferLen(yyl517, z.DecBasicHandle().MaxInitLen, 72)
-			yyv517 = make([]RawContainerMetrics, yyrl517)
-			yyc517 = true
+		if yyl449 > cap(yyv449) {
+			yyrl449, yyrt449 = z.DecInferLen(yyl449, z.DecBasicHandle().MaxInitLen, 48)
+			yyv449 = make([]RawContainerMetrics, yyrl449)
+			yyc449 = true
 
-			yyrr517 = len(yyv517)
-		} else if yyl517 != len(yyv517) {
-			yyv517 = yyv517[:yyl517]
-			yyc517 = true
+			yyrr449 = len(yyv449)
+		} else if yyl449 != len(yyv449) {
+			yyv449 = yyv449[:yyl449]
+			yyc449 = true
 		}
-		yyj517 := 0
-		for ; yyj517 < yyrr517; yyj517++ {
+		yyj449 := 0
+		for ; yyj449 < yyrr449; yyj449++ {
 			if r.TryDecodeAsNil() {
-				yyv517[yyj517] = RawContainerMetrics{}
+				yyv449[yyj449] = RawContainerMetrics{}
 			} else {
-				yyv518 := &yyv517[yyj517]
-				yyv518.CodecDecodeSelf(d)
+				yyv450 := &yyv449[yyj449]
+				yyv450.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt517 {
-			for ; yyj517 < yyl517; yyj517++ {
-				yyv517 = append(yyv517, RawContainerMetrics{})
+		if yyrt449 {
+			for ; yyj449 < yyl449; yyj449++ {
+				yyv449 = append(yyv449, RawContainerMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv517[yyj517] = RawContainerMetrics{}
+					yyv449[yyj449] = RawContainerMetrics{}
 				} else {
-					yyv519 := &yyv517[yyj517]
-					yyv519.CodecDecodeSelf(d)
+					yyv451 := &yyv449[yyj449]
+					yyv451.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj517 := 0; !r.CheckBreak(); yyj517++ {
-			if yyj517 >= len(yyv517) {
-				yyv517 = append(yyv517, RawContainerMetrics{}) // var yyz517 RawContainerMetrics
-				yyc517 = true
+		for yyj449 := 0; !r.CheckBreak(); yyj449++ {
+			if yyj449 >= len(yyv449) {
+				yyv449 = append(yyv449, RawContainerMetrics{}) // var yyz449 RawContainerMetrics
+				yyc449 = true
 			}
 
-			if yyj517 < len(yyv517) {
+			if yyj449 < len(yyv449) {
 				if r.TryDecodeAsNil() {
-					yyv517[yyj517] = RawContainerMetrics{}
+					yyv449[yyj449] = RawContainerMetrics{}
 				} else {
-					yyv520 := &yyv517[yyj517]
-					yyv520.CodecDecodeSelf(d)
+					yyv452 := &yyv449[yyj449]
+					yyv452.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5997,10 +5304,10 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 			}
 
 		}
-		yyh517.End()
+		yyh449.End()
 	}
-	if yyc517 {
-		*v = yyv517
+	if yyc449 {
+		*v = yyv449
 	}
 
 }
@@ -6010,9 +5317,9 @@ func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv521 := range v {
-		yy522 := &yyv521
-		yy522.CodecEncodeSelf(e)
+	for _, yyv453 := range v {
+		yy454 := &yyv453
+		yy454.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6022,75 +5329,75 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv523 := *v
-	yyh523, yyl523 := z.DecSliceHelperStart()
+	yyv455 := *v
+	yyh455, yyl455 := z.DecSliceHelperStart()
 
-	var yyrr523, yyrl523 int
-	var yyc523, yyrt523 bool
-	_, _, _ = yyc523, yyrt523, yyrl523
-	yyrr523 = yyl523
+	var yyrr455, yyrl455 int
+	var yyc455, yyrt455 bool
+	_, _, _ = yyc455, yyrt455, yyrl455
+	yyrr455 = yyl455
 
-	if yyv523 == nil {
-		if yyrl523, yyrt523 = z.DecInferLen(yyl523, z.DecBasicHandle().MaxInitLen, 128); yyrt523 {
-			yyrr523 = yyrl523
+	if yyv455 == nil {
+		if yyrl455, yyrt455 = z.DecInferLen(yyl455, z.DecBasicHandle().MaxInitLen, 128); yyrt455 {
+			yyrr455 = yyrl455
 		}
-		yyv523 = make([]RawNodeMetrics, yyrl523)
-		yyc523 = true
+		yyv455 = make([]RawNodeMetrics, yyrl455)
+		yyc455 = true
 	}
 
-	if yyl523 == 0 {
-		if len(yyv523) != 0 {
-			yyv523 = yyv523[:0]
-			yyc523 = true
+	if yyl455 == 0 {
+		if len(yyv455) != 0 {
+			yyv455 = yyv455[:0]
+			yyc455 = true
 		}
-	} else if yyl523 > 0 {
+	} else if yyl455 > 0 {
 
-		if yyl523 > cap(yyv523) {
-			yyrl523, yyrt523 = z.DecInferLen(yyl523, z.DecBasicHandle().MaxInitLen, 128)
-			yyv523 = make([]RawNodeMetrics, yyrl523)
-			yyc523 = true
+		if yyl455 > cap(yyv455) {
+			yyrl455, yyrt455 = z.DecInferLen(yyl455, z.DecBasicHandle().MaxInitLen, 128)
+			yyv455 = make([]RawNodeMetrics, yyrl455)
+			yyc455 = true
 
-			yyrr523 = len(yyv523)
-		} else if yyl523 != len(yyv523) {
-			yyv523 = yyv523[:yyl523]
-			yyc523 = true
+			yyrr455 = len(yyv455)
+		} else if yyl455 != len(yyv455) {
+			yyv455 = yyv455[:yyl455]
+			yyc455 = true
 		}
-		yyj523 := 0
-		for ; yyj523 < yyrr523; yyj523++ {
+		yyj455 := 0
+		for ; yyj455 < yyrr455; yyj455++ {
 			if r.TryDecodeAsNil() {
-				yyv523[yyj523] = RawNodeMetrics{}
+				yyv455[yyj455] = RawNodeMetrics{}
 			} else {
-				yyv524 := &yyv523[yyj523]
-				yyv524.CodecDecodeSelf(d)
+				yyv456 := &yyv455[yyj455]
+				yyv456.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt523 {
-			for ; yyj523 < yyl523; yyj523++ {
-				yyv523 = append(yyv523, RawNodeMetrics{})
+		if yyrt455 {
+			for ; yyj455 < yyl455; yyj455++ {
+				yyv455 = append(yyv455, RawNodeMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv523[yyj523] = RawNodeMetrics{}
+					yyv455[yyj455] = RawNodeMetrics{}
 				} else {
-					yyv525 := &yyv523[yyj523]
-					yyv525.CodecDecodeSelf(d)
+					yyv457 := &yyv455[yyj455]
+					yyv457.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj523 := 0; !r.CheckBreak(); yyj523++ {
-			if yyj523 >= len(yyv523) {
-				yyv523 = append(yyv523, RawNodeMetrics{}) // var yyz523 RawNodeMetrics
-				yyc523 = true
+		for yyj455 := 0; !r.CheckBreak(); yyj455++ {
+			if yyj455 >= len(yyv455) {
+				yyv455 = append(yyv455, RawNodeMetrics{}) // var yyz455 RawNodeMetrics
+				yyc455 = true
 			}
 
-			if yyj523 < len(yyv523) {
+			if yyj455 < len(yyv455) {
 				if r.TryDecodeAsNil() {
-					yyv523[yyj523] = RawNodeMetrics{}
+					yyv455[yyj455] = RawNodeMetrics{}
 				} else {
-					yyv526 := &yyv523[yyj523]
-					yyv526.CodecDecodeSelf(d)
+					yyv458 := &yyv455[yyj455]
+					yyv458.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6098,10 +5405,10 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 			}
 
 		}
-		yyh523.End()
+		yyh455.End()
 	}
-	if yyc523 {
-		*v = yyv523
+	if yyc455 {
+		*v = yyv455
 	}
 
 }
@@ -6111,9 +5418,9 @@ func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv527 := range v {
-		yy528 := &yyv527
-		yy528.CodecEncodeSelf(e)
+	for _, yyv459 := range v {
+		yy460 := &yyv459
+		yy460.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6123,75 +5430,75 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv529 := *v
-	yyh529, yyl529 := z.DecSliceHelperStart()
+	yyv461 := *v
+	yyh461, yyl461 := z.DecSliceHelperStart()
 
-	var yyrr529, yyrl529 int
-	var yyc529, yyrt529 bool
-	_, _, _ = yyc529, yyrt529, yyrl529
-	yyrr529 = yyl529
+	var yyrr461, yyrl461 int
+	var yyc461, yyrt461 bool
+	_, _, _ = yyc461, yyrt461, yyrl461
+	yyrr461 = yyl461
 
-	if yyv529 == nil {
-		if yyrl529, yyrt529 = z.DecInferLen(yyl529, z.DecBasicHandle().MaxInitLen, 32); yyrt529 {
-			yyrr529 = yyrl529
+	if yyv461 == nil {
+		if yyrl461, yyrt461 = z.DecInferLen(yyl461, z.DecBasicHandle().MaxInitLen, 32); yyrt461 {
+			yyrr461 = yyrl461
 		}
-		yyv529 = make([]PodSample, yyrl529)
-		yyc529 = true
+		yyv461 = make([]PodSample, yyrl461)
+		yyc461 = true
 	}
 
-	if yyl529 == 0 {
-		if len(yyv529) != 0 {
-			yyv529 = yyv529[:0]
-			yyc529 = true
+	if yyl461 == 0 {
+		if len(yyv461) != 0 {
+			yyv461 = yyv461[:0]
+			yyc461 = true
 		}
-	} else if yyl529 > 0 {
+	} else if yyl461 > 0 {
 
-		if yyl529 > cap(yyv529) {
-			yyrl529, yyrt529 = z.DecInferLen(yyl529, z.DecBasicHandle().MaxInitLen, 32)
-			yyv529 = make([]PodSample, yyrl529)
-			yyc529 = true
+		if yyl461 > cap(yyv461) {
+			yyrl461, yyrt461 = z.DecInferLen(yyl461, z.DecBasicHandle().MaxInitLen, 32)
+			yyv461 = make([]PodSample, yyrl461)
+			yyc461 = true
 
-			yyrr529 = len(yyv529)
-		} else if yyl529 != len(yyv529) {
-			yyv529 = yyv529[:yyl529]
-			yyc529 = true
+			yyrr461 = len(yyv461)
+		} else if yyl461 != len(yyv461) {
+			yyv461 = yyv461[:yyl461]
+			yyc461 = true
 		}
-		yyj529 := 0
-		for ; yyj529 < yyrr529; yyj529++ {
+		yyj461 := 0
+		for ; yyj461 < yyrr461; yyj461++ {
 			if r.TryDecodeAsNil() {
-				yyv529[yyj529] = PodSample{}
+				yyv461[yyj461] = PodSample{}
 			} else {
-				yyv530 := &yyv529[yyj529]
-				yyv530.CodecDecodeSelf(d)
+				yyv462 := &yyv461[yyj461]
+				yyv462.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt529 {
-			for ; yyj529 < yyl529; yyj529++ {
-				yyv529 = append(yyv529, PodSample{})
+		if yyrt461 {
+			for ; yyj461 < yyl461; yyj461++ {
+				yyv461 = append(yyv461, PodSample{})
 				if r.TryDecodeAsNil() {
-					yyv529[yyj529] = PodSample{}
+					yyv461[yyj461] = PodSample{}
 				} else {
-					yyv531 := &yyv529[yyj529]
-					yyv531.CodecDecodeSelf(d)
+					yyv463 := &yyv461[yyj461]
+					yyv463.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj529 := 0; !r.CheckBreak(); yyj529++ {
-			if yyj529 >= len(yyv529) {
-				yyv529 = append(yyv529, PodSample{}) // var yyz529 PodSample
-				yyc529 = true
+		for yyj461 := 0; !r.CheckBreak(); yyj461++ {
+			if yyj461 >= len(yyv461) {
+				yyv461 = append(yyv461, PodSample{}) // var yyz461 PodSample
+				yyc461 = true
 			}
 
-			if yyj529 < len(yyv529) {
+			if yyj461 < len(yyv461) {
 				if r.TryDecodeAsNil() {
-					yyv529[yyj529] = PodSample{}
+					yyv461[yyj461] = PodSample{}
 				} else {
-					yyv532 := &yyv529[yyj529]
-					yyv532.CodecDecodeSelf(d)
+					yyv464 := &yyv461[yyj461]
+					yyv464.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6199,10 +5506,10 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 			}
 
 		}
-		yyh529.End()
+		yyh461.End()
 	}
-	if yyc529 {
-		*v = yyv529
+	if yyc461 {
+		*v = yyv461
 	}
 
 }
@@ -6212,9 +5519,9 @@ func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv533 := range v {
-		yy534 := &yyv533
-		yy534.CodecEncodeSelf(e)
+	for _, yyv465 := range v {
+		yy466 := &yyv465
+		yy466.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6224,75 +5531,75 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv535 := *v
-	yyh535, yyl535 := z.DecSliceHelperStart()
+	yyv467 := *v
+	yyh467, yyl467 := z.DecSliceHelperStart()
 
-	var yyrr535, yyrl535 int
-	var yyc535, yyrt535 bool
-	_, _, _ = yyc535, yyrt535, yyrl535
-	yyrr535 = yyl535
+	var yyrr467, yyrl467 int
+	var yyc467, yyrt467 bool
+	_, _, _ = yyc467, yyrt467, yyrl467
+	yyrr467 = yyl467
 
-	if yyv535 == nil {
-		if yyrl535, yyrt535 = z.DecInferLen(yyl535, z.DecBasicHandle().MaxInitLen, 160); yyrt535 {
-			yyrr535 = yyrl535
+	if yyv467 == nil {
+		if yyrl467, yyrt467 = z.DecInferLen(yyl467, z.DecBasicHandle().MaxInitLen, 160); yyrt467 {
+			yyrr467 = yyrl467
 		}
-		yyv535 = make([]RawPodMetrics, yyrl535)
-		yyc535 = true
+		yyv467 = make([]RawPodMetrics, yyrl467)
+		yyc467 = true
 	}
 
-	if yyl535 == 0 {
-		if len(yyv535) != 0 {
-			yyv535 = yyv535[:0]
-			yyc535 = true
+	if yyl467 == 0 {
+		if len(yyv467) != 0 {
+			yyv467 = yyv467[:0]
+			yyc467 = true
 		}
-	} else if yyl535 > 0 {
+	} else if yyl467 > 0 {
 
-		if yyl535 > cap(yyv535) {
-			yyrl535, yyrt535 = z.DecInferLen(yyl535, z.DecBasicHandle().MaxInitLen, 160)
-			yyv535 = make([]RawPodMetrics, yyrl535)
-			yyc535 = true
+		if yyl467 > cap(yyv467) {
+			yyrl467, yyrt467 = z.DecInferLen(yyl467, z.DecBasicHandle().MaxInitLen, 160)
+			yyv467 = make([]RawPodMetrics, yyrl467)
+			yyc467 = true
 
-			yyrr535 = len(yyv535)
-		} else if yyl535 != len(yyv535) {
-			yyv535 = yyv535[:yyl535]
-			yyc535 = true
+			yyrr467 = len(yyv467)
+		} else if yyl467 != len(yyv467) {
+			yyv467 = yyv467[:yyl467]
+			yyc467 = true
 		}
-		yyj535 := 0
-		for ; yyj535 < yyrr535; yyj535++ {
+		yyj467 := 0
+		for ; yyj467 < yyrr467; yyj467++ {
 			if r.TryDecodeAsNil() {
-				yyv535[yyj535] = RawPodMetrics{}
+				yyv467[yyj467] = RawPodMetrics{}
 			} else {
-				yyv536 := &yyv535[yyj535]
-				yyv536.CodecDecodeSelf(d)
+				yyv468 := &yyv467[yyj467]
+				yyv468.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt535 {
-			for ; yyj535 < yyl535; yyj535++ {
-				yyv535 = append(yyv535, RawPodMetrics{})
+		if yyrt467 {
+			for ; yyj467 < yyl467; yyj467++ {
+				yyv467 = append(yyv467, RawPodMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv535[yyj535] = RawPodMetrics{}
+					yyv467[yyj467] = RawPodMetrics{}
 				} else {
-					yyv537 := &yyv535[yyj535]
-					yyv537.CodecDecodeSelf(d)
+					yyv469 := &yyv467[yyj467]
+					yyv469.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj535 := 0; !r.CheckBreak(); yyj535++ {
-			if yyj535 >= len(yyv535) {
-				yyv535 = append(yyv535, RawPodMetrics{}) // var yyz535 RawPodMetrics
-				yyc535 = true
+		for yyj467 := 0; !r.CheckBreak(); yyj467++ {
+			if yyj467 >= len(yyv467) {
+				yyv467 = append(yyv467, RawPodMetrics{}) // var yyz467 RawPodMetrics
+				yyc467 = true
 			}
 
-			if yyj535 < len(yyv535) {
+			if yyj467 < len(yyv467) {
 				if r.TryDecodeAsNil() {
-					yyv535[yyj535] = RawPodMetrics{}
+					yyv467[yyj467] = RawPodMetrics{}
 				} else {
-					yyv538 := &yyv535[yyj535]
-					yyv538.CodecDecodeSelf(d)
+					yyv470 := &yyv467[yyj467]
+					yyv470.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6300,10 +5607,10 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 			}
 
 		}
-		yyh535.End()
+		yyh467.End()
 	}
-	if yyc535 {
-		*v = yyv535
+	if yyc467 {
+		*v = yyv467
 	}
 
 }
@@ -6313,9 +5620,9 @@ func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv539 := range v {
-		yy540 := &yyv539
-		yy540.CodecEncodeSelf(e)
+	for _, yyv471 := range v {
+		yy472 := &yyv471
+		yy472.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6325,75 +5632,75 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv541 := *v
-	yyh541, yyl541 := z.DecSliceHelperStart()
+	yyv473 := *v
+	yyh473, yyl473 := z.DecSliceHelperStart()
 
-	var yyrr541, yyrl541 int
-	var yyc541, yyrt541 bool
-	_, _, _ = yyc541, yyrt541, yyrl541
-	yyrr541 = yyl541
+	var yyrr473, yyrl473 int
+	var yyc473, yyrt473 bool
+	_, _, _ = yyc473, yyrt473, yyrl473
+	yyrr473 = yyl473
 
-	if yyv541 == nil {
-		if yyrl541, yyrt541 = z.DecInferLen(yyl541, z.DecBasicHandle().MaxInitLen, 64); yyrt541 {
-			yyrr541 = yyrl541
+	if yyv473 == nil {
+		if yyrl473, yyrt473 = z.DecInferLen(yyl473, z.DecBasicHandle().MaxInitLen, 64); yyrt473 {
+			yyrr473 = yyrl473
 		}
-		yyv541 = make([]ContainerSample, yyrl541)
-		yyc541 = true
+		yyv473 = make([]ContainerSample, yyrl473)
+		yyc473 = true
 	}
 
-	if yyl541 == 0 {
-		if len(yyv541) != 0 {
-			yyv541 = yyv541[:0]
-			yyc541 = true
+	if yyl473 == 0 {
+		if len(yyv473) != 0 {
+			yyv473 = yyv473[:0]
+			yyc473 = true
 		}
-	} else if yyl541 > 0 {
+	} else if yyl473 > 0 {
 
-		if yyl541 > cap(yyv541) {
-			yyrl541, yyrt541 = z.DecInferLen(yyl541, z.DecBasicHandle().MaxInitLen, 64)
-			yyv541 = make([]ContainerSample, yyrl541)
-			yyc541 = true
+		if yyl473 > cap(yyv473) {
+			yyrl473, yyrt473 = z.DecInferLen(yyl473, z.DecBasicHandle().MaxInitLen, 64)
+			yyv473 = make([]ContainerSample, yyrl473)
+			yyc473 = true
 
-			yyrr541 = len(yyv541)
-		} else if yyl541 != len(yyv541) {
-			yyv541 = yyv541[:yyl541]
-			yyc541 = true
+			yyrr473 = len(yyv473)
+		} else if yyl473 != len(yyv473) {
+			yyv473 = yyv473[:yyl473]
+			yyc473 = true
 		}
-		yyj541 := 0
-		for ; yyj541 < yyrr541; yyj541++ {
+		yyj473 := 0
+		for ; yyj473 < yyrr473; yyj473++ {
 			if r.TryDecodeAsNil() {
-				yyv541[yyj541] = ContainerSample{}
+				yyv473[yyj473] = ContainerSample{}
 			} else {
-				yyv542 := &yyv541[yyj541]
-				yyv542.CodecDecodeSelf(d)
+				yyv474 := &yyv473[yyj473]
+				yyv474.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt541 {
-			for ; yyj541 < yyl541; yyj541++ {
-				yyv541 = append(yyv541, ContainerSample{})
+		if yyrt473 {
+			for ; yyj473 < yyl473; yyj473++ {
+				yyv473 = append(yyv473, ContainerSample{})
 				if r.TryDecodeAsNil() {
-					yyv541[yyj541] = ContainerSample{}
+					yyv473[yyj473] = ContainerSample{}
 				} else {
-					yyv543 := &yyv541[yyj541]
-					yyv543.CodecDecodeSelf(d)
+					yyv475 := &yyv473[yyj473]
+					yyv475.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj541 := 0; !r.CheckBreak(); yyj541++ {
-			if yyj541 >= len(yyv541) {
-				yyv541 = append(yyv541, ContainerSample{}) // var yyz541 ContainerSample
-				yyc541 = true
+		for yyj473 := 0; !r.CheckBreak(); yyj473++ {
+			if yyj473 >= len(yyv473) {
+				yyv473 = append(yyv473, ContainerSample{}) // var yyz473 ContainerSample
+				yyc473 = true
 			}
 
-			if yyj541 < len(yyv541) {
+			if yyj473 < len(yyv473) {
 				if r.TryDecodeAsNil() {
-					yyv541[yyj541] = ContainerSample{}
+					yyv473[yyj473] = ContainerSample{}
 				} else {
-					yyv544 := &yyv541[yyj541]
-					yyv544.CodecDecodeSelf(d)
+					yyv476 := &yyv473[yyj473]
+					yyv476.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6401,111 +5708,10 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 			}
 
 		}
-		yyh541.End()
+		yyh473.End()
 	}
-	if yyc541 {
-		*v = yyv541
-	}
-
-}
-
-func (x codecSelfer1234) encSliceCustomMetric(v []CustomMetric, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv545 := range v {
-		yy546 := &yyv545
-		yy546.CodecEncodeSelf(e)
-	}
-	r.EncodeEnd()
-}
-
-func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv547 := *v
-	yyh547, yyl547 := z.DecSliceHelperStart()
-
-	var yyrr547, yyrl547 int
-	var yyc547, yyrt547 bool
-	_, _, _ = yyc547, yyrt547, yyrl547
-	yyrr547 = yyl547
-
-	if yyv547 == nil {
-		if yyrl547, yyrt547 = z.DecInferLen(yyl547, z.DecBasicHandle().MaxInitLen, 72); yyrt547 {
-			yyrr547 = yyrl547
-		}
-		yyv547 = make([]CustomMetric, yyrl547)
-		yyc547 = true
-	}
-
-	if yyl547 == 0 {
-		if len(yyv547) != 0 {
-			yyv547 = yyv547[:0]
-			yyc547 = true
-		}
-	} else if yyl547 > 0 {
-
-		if yyl547 > cap(yyv547) {
-			yyrl547, yyrt547 = z.DecInferLen(yyl547, z.DecBasicHandle().MaxInitLen, 72)
-			yyv547 = make([]CustomMetric, yyrl547)
-			yyc547 = true
-
-			yyrr547 = len(yyv547)
-		} else if yyl547 != len(yyv547) {
-			yyv547 = yyv547[:yyl547]
-			yyc547 = true
-		}
-		yyj547 := 0
-		for ; yyj547 < yyrr547; yyj547++ {
-			if r.TryDecodeAsNil() {
-				yyv547[yyj547] = CustomMetric{}
-			} else {
-				yyv548 := &yyv547[yyj547]
-				yyv548.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt547 {
-			for ; yyj547 < yyl547; yyj547++ {
-				yyv547 = append(yyv547, CustomMetric{})
-				if r.TryDecodeAsNil() {
-					yyv547[yyj547] = CustomMetric{}
-				} else {
-					yyv549 := &yyv547[yyj547]
-					yyv549.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		for yyj547 := 0; !r.CheckBreak(); yyj547++ {
-			if yyj547 >= len(yyv547) {
-				yyv547 = append(yyv547, CustomMetric{}) // var yyz547 CustomMetric
-				yyc547 = true
-			}
-
-			if yyj547 < len(yyv547) {
-				if r.TryDecodeAsNil() {
-					yyv547[yyj547] = CustomMetric{}
-				} else {
-					yyv550 := &yyv547[yyj547]
-					yyv550.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		yyh547.End()
-	}
-	if yyc547 {
-		*v = yyv547
+	if yyc473 {
+		*v = yyv473
 	}
 
 }
@@ -6515,9 +5721,9 @@ func (x codecSelfer1234) encSliceFilesystemMetrics(v []FilesystemMetrics, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv551 := range v {
-		yy552 := &yyv551
-		yy552.CodecEncodeSelf(e)
+	for _, yyv477 := range v {
+		yy478 := &yyv477
+		yy478.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6527,75 +5733,75 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv553 := *v
-	yyh553, yyl553 := z.DecSliceHelperStart()
+	yyv479 := *v
+	yyh479, yyl479 := z.DecSliceHelperStart()
 
-	var yyrr553, yyrl553 int
-	var yyc553, yyrt553 bool
-	_, _, _ = yyc553, yyrt553, yyrl553
-	yyrr553 = yyl553
+	var yyrr479, yyrl479 int
+	var yyc479, yyrt479 bool
+	_, _, _ = yyc479, yyrt479, yyrl479
+	yyrr479 = yyl479
 
-	if yyv553 == nil {
-		if yyrl553, yyrt553 = z.DecInferLen(yyl553, z.DecBasicHandle().MaxInitLen, 32); yyrt553 {
-			yyrr553 = yyrl553
+	if yyv479 == nil {
+		if yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 32); yyrt479 {
+			yyrr479 = yyrl479
 		}
-		yyv553 = make([]FilesystemMetrics, yyrl553)
-		yyc553 = true
+		yyv479 = make([]FilesystemMetrics, yyrl479)
+		yyc479 = true
 	}
 
-	if yyl553 == 0 {
-		if len(yyv553) != 0 {
-			yyv553 = yyv553[:0]
-			yyc553 = true
+	if yyl479 == 0 {
+		if len(yyv479) != 0 {
+			yyv479 = yyv479[:0]
+			yyc479 = true
 		}
-	} else if yyl553 > 0 {
+	} else if yyl479 > 0 {
 
-		if yyl553 > cap(yyv553) {
-			yyrl553, yyrt553 = z.DecInferLen(yyl553, z.DecBasicHandle().MaxInitLen, 32)
-			yyv553 = make([]FilesystemMetrics, yyrl553)
-			yyc553 = true
+		if yyl479 > cap(yyv479) {
+			yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 32)
+			yyv479 = make([]FilesystemMetrics, yyrl479)
+			yyc479 = true
 
-			yyrr553 = len(yyv553)
-		} else if yyl553 != len(yyv553) {
-			yyv553 = yyv553[:yyl553]
-			yyc553 = true
+			yyrr479 = len(yyv479)
+		} else if yyl479 != len(yyv479) {
+			yyv479 = yyv479[:yyl479]
+			yyc479 = true
 		}
-		yyj553 := 0
-		for ; yyj553 < yyrr553; yyj553++ {
+		yyj479 := 0
+		for ; yyj479 < yyrr479; yyj479++ {
 			if r.TryDecodeAsNil() {
-				yyv553[yyj553] = FilesystemMetrics{}
+				yyv479[yyj479] = FilesystemMetrics{}
 			} else {
-				yyv554 := &yyv553[yyj553]
-				yyv554.CodecDecodeSelf(d)
+				yyv480 := &yyv479[yyj479]
+				yyv480.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt553 {
-			for ; yyj553 < yyl553; yyj553++ {
-				yyv553 = append(yyv553, FilesystemMetrics{})
+		if yyrt479 {
+			for ; yyj479 < yyl479; yyj479++ {
+				yyv479 = append(yyv479, FilesystemMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv553[yyj553] = FilesystemMetrics{}
+					yyv479[yyj479] = FilesystemMetrics{}
 				} else {
-					yyv555 := &yyv553[yyj553]
-					yyv555.CodecDecodeSelf(d)
+					yyv481 := &yyv479[yyj479]
+					yyv481.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj553 := 0; !r.CheckBreak(); yyj553++ {
-			if yyj553 >= len(yyv553) {
-				yyv553 = append(yyv553, FilesystemMetrics{}) // var yyz553 FilesystemMetrics
-				yyc553 = true
+		for yyj479 := 0; !r.CheckBreak(); yyj479++ {
+			if yyj479 >= len(yyv479) {
+				yyv479 = append(yyv479, FilesystemMetrics{}) // var yyz479 FilesystemMetrics
+				yyc479 = true
 			}
 
-			if yyj553 < len(yyv553) {
+			if yyj479 < len(yyv479) {
 				if r.TryDecodeAsNil() {
-					yyv553[yyj553] = FilesystemMetrics{}
+					yyv479[yyj479] = FilesystemMetrics{}
 				} else {
-					yyv556 := &yyv553[yyj553]
-					yyv556.CodecDecodeSelf(d)
+					yyv482 := &yyv479[yyj479]
+					yyv482.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6603,111 +5809,10 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 			}
 
 		}
-		yyh553.End()
+		yyh479.End()
 	}
-	if yyc553 {
-		*v = yyv553
-	}
-
-}
-
-func (x codecSelfer1234) encSliceCustomMetricSample(v []CustomMetricSample, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv557 := range v {
-		yy558 := &yyv557
-		yy558.CodecEncodeSelf(e)
-	}
-	r.EncodeEnd()
-}
-
-func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv559 := *v
-	yyh559, yyl559 := z.DecSliceHelperStart()
-
-	var yyrr559, yyrl559 int
-	var yyc559, yyrt559 bool
-	_, _, _ = yyc559, yyrt559, yyrl559
-	yyrr559 = yyl559
-
-	if yyv559 == nil {
-		if yyrl559, yyrt559 = z.DecInferLen(yyl559, z.DecBasicHandle().MaxInitLen, 56); yyrt559 {
-			yyrr559 = yyrl559
-		}
-		yyv559 = make([]CustomMetricSample, yyrl559)
-		yyc559 = true
-	}
-
-	if yyl559 == 0 {
-		if len(yyv559) != 0 {
-			yyv559 = yyv559[:0]
-			yyc559 = true
-		}
-	} else if yyl559 > 0 {
-
-		if yyl559 > cap(yyv559) {
-			yyrl559, yyrt559 = z.DecInferLen(yyl559, z.DecBasicHandle().MaxInitLen, 56)
-			yyv559 = make([]CustomMetricSample, yyrl559)
-			yyc559 = true
-
-			yyrr559 = len(yyv559)
-		} else if yyl559 != len(yyv559) {
-			yyv559 = yyv559[:yyl559]
-			yyc559 = true
-		}
-		yyj559 := 0
-		for ; yyj559 < yyrr559; yyj559++ {
-			if r.TryDecodeAsNil() {
-				yyv559[yyj559] = CustomMetricSample{}
-			} else {
-				yyv560 := &yyv559[yyj559]
-				yyv560.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt559 {
-			for ; yyj559 < yyl559; yyj559++ {
-				yyv559 = append(yyv559, CustomMetricSample{})
-				if r.TryDecodeAsNil() {
-					yyv559[yyj559] = CustomMetricSample{}
-				} else {
-					yyv561 := &yyv559[yyj559]
-					yyv561.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		for yyj559 := 0; !r.CheckBreak(); yyj559++ {
-			if yyj559 >= len(yyv559) {
-				yyv559 = append(yyv559, CustomMetricSample{}) // var yyz559 CustomMetricSample
-				yyc559 = true
-			}
-
-			if yyj559 < len(yyv559) {
-				if r.TryDecodeAsNil() {
-					yyv559[yyj559] = CustomMetricSample{}
-				} else {
-					yyv562 := &yyv559[yyj559]
-					yyv562.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		yyh559.End()
-	}
-	if yyc559 {
-		*v = yyv559
+	if yyc479 {
+		*v = yyv479
 	}
 
 }

--- a/pkg/apis/metrics/v1alpha1/types.generated.go
+++ b/pkg/apis/metrics/v1alpha1/types.generated.go
@@ -4781,14 +4781,12 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep417 := !z.EncBinary()
 			yy2arr417 := z.EncBasicHandle().StructToArray
-			var yyq417 [3]bool
+			var yyq417 [1]bool
 			_, _, _ = yysep417, yyq417, yy2arr417
 			const yyr417 bool = false
-			yyq417[0] = x.SinceTime != nil
-			yyq417[1] = x.UntilTime != nil
-			yyq417[2] = x.MaxSamples != 0
+			yyq417[0] = x.MaxSamples != 0
 			if yyr417 || yy2arr417 {
-				r.EncodeArrayStart(3)
+				r.EncodeArrayStart(1)
 			} else {
 				var yynn417 int = 0
 				for _, b := range yyq417 {
@@ -4800,88 +4798,8 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr417 || yy2arr417 {
 				if yyq417[0] {
-					if x.SinceTime == nil {
-						r.EncodeNil()
-					} else {
-						yym419 := z.EncBinary()
-						_ = yym419
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym419 {
-							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym419 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.SinceTime)
-						} else {
-							z.EncFallback(x.SinceTime)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq417[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
-					if x.SinceTime == nil {
-						r.EncodeNil()
-					} else {
-						yym420 := z.EncBinary()
-						_ = yym420
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym420 {
-							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym420 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.SinceTime)
-						} else {
-							z.EncFallback(x.SinceTime)
-						}
-					}
-				}
-			}
-			if yyr417 || yy2arr417 {
-				if yyq417[1] {
-					if x.UntilTime == nil {
-						r.EncodeNil()
-					} else {
-						yym422 := z.EncBinary()
-						_ = yym422
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym422 {
-							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym422 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.UntilTime)
-						} else {
-							z.EncFallback(x.UntilTime)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq417[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
-					if x.UntilTime == nil {
-						r.EncodeNil()
-					} else {
-						yym423 := z.EncBinary()
-						_ = yym423
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym423 {
-							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym423 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.UntilTime)
-						} else {
-							z.EncFallback(x.UntilTime)
-						}
-					}
-				}
-			}
-			if yyr417 || yy2arr417 {
-				if yyq417[2] {
-					yym425 := z.EncBinary()
-					_ = yym425
+					yym419 := z.EncBinary()
+					_ = yym419
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -4890,10 +4808,10 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq417[2] {
+				if yyq417[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
-					yym426 := z.EncBinary()
-					_ = yym426
+					yym420 := z.EncBinary()
+					_ = yym420
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -4911,24 +4829,24 @@ func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym427 := z.DecBinary()
-	_ = yym427
+	yym421 := z.DecBinary()
+	_ = yym421
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl428 := r.ReadMapStart()
-			if yyl428 == 0 {
+			yyl422 := r.ReadMapStart()
+			if yyl422 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl428, d)
+				x.codecDecodeSelfFromMap(yyl422, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl428 := r.ReadArrayStart()
-			if yyl428 == 0 {
+			yyl422 := r.ReadArrayStart()
+			if yyl422 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl428, d)
+				x.codecDecodeSelfFromArray(yyl422, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4940,12 +4858,12 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys429Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys429Slc
-	var yyhl429 bool = l >= 0
-	for yyj429 := 0; ; yyj429++ {
-		if yyhl429 {
-			if yyj429 >= l {
+	var yys423Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys423Slc
+	var yyhl423 bool = l >= 0
+	for yyj423 := 0; ; yyj423++ {
+		if yyhl423 {
+			if yyj423 >= l {
 				break
 			}
 		} else {
@@ -4953,51 +4871,9 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys429Slc = r.DecodeBytes(yys429Slc, true, true)
-		yys429 := string(yys429Slc)
-		switch yys429 {
-		case "sinceTime":
-			if r.TryDecodeAsNil() {
-				if x.SinceTime != nil {
-					x.SinceTime = nil
-				}
-			} else {
-				if x.SinceTime == nil {
-					x.SinceTime = new(pkg1_unversioned.Time)
-				}
-				yym431 := z.DecBinary()
-				_ = yym431
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym431 {
-					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym431 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.SinceTime)
-				} else {
-					z.DecFallback(x.SinceTime, false)
-				}
-			}
-		case "untilTime":
-			if r.TryDecodeAsNil() {
-				if x.UntilTime != nil {
-					x.UntilTime = nil
-				}
-			} else {
-				if x.UntilTime == nil {
-					x.UntilTime = new(pkg1_unversioned.Time)
-				}
-				yym433 := z.DecBinary()
-				_ = yym433
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-				} else if yym433 {
-					z.DecBinaryUnmarshal(x.UntilTime)
-				} else if !yym433 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.UntilTime)
-				} else {
-					z.DecFallback(x.UntilTime, false)
-				}
-			}
+		yys423Slc = r.DecodeBytes(yys423Slc, true, true)
+		yys423 := string(yys423Slc)
+		switch yys423 {
 		case "maxSamples":
 			if r.TryDecodeAsNil() {
 				x.MaxSamples = 0
@@ -5005,10 +4881,10 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys429)
-		} // end switch yys429
-	} // end for yyj429
-	if !yyhl429 {
+			z.DecStructFieldNotFound(-1, yys423)
+		} // end switch yys423
+	} // end for yyj423
+	if !yyhl423 {
 		r.ReadEnd()
 	}
 }
@@ -5017,76 +4893,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj435 int
-	var yyb435 bool
-	var yyhl435 bool = l >= 0
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
+	var yyj425 int
+	var yyb425 bool
+	var yyhl425 bool = l >= 0
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
 	} else {
-		yyb435 = r.CheckBreak()
+		yyb425 = r.CheckBreak()
 	}
-	if yyb435 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		if x.SinceTime != nil {
-			x.SinceTime = nil
-		}
-	} else {
-		if x.SinceTime == nil {
-			x.SinceTime = new(pkg1_unversioned.Time)
-		}
-		yym437 := z.DecBinary()
-		_ = yym437
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym437 {
-			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym437 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.SinceTime)
-		} else {
-			z.DecFallback(x.SinceTime, false)
-		}
-	}
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
-	} else {
-		yyb435 = r.CheckBreak()
-	}
-	if yyb435 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		if x.UntilTime != nil {
-			x.UntilTime = nil
-		}
-	} else {
-		if x.UntilTime == nil {
-			x.UntilTime = new(pkg1_unversioned.Time)
-		}
-		yym439 := z.DecBinary()
-		_ = yym439
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-		} else if yym439 {
-			z.DecBinaryUnmarshal(x.UntilTime)
-		} else if !yym439 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.UntilTime)
-		} else {
-			z.DecFallback(x.UntilTime, false)
-		}
-	}
-	yyj435++
-	if yyhl435 {
-		yyb435 = yyj435 > l
-	} else {
-		yyb435 = r.CheckBreak()
-	}
-	if yyb435 {
+	if yyb425 {
 		r.ReadEnd()
 		return
 	}
@@ -5096,16 +4912,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj435++
-		if yyhl435 {
-			yyb435 = yyj435 > l
+		yyj425++
+		if yyhl425 {
+			yyb425 = yyj425 > l
 		} else {
-			yyb435 = r.CheckBreak()
+			yyb425 = r.CheckBreak()
 		}
-		if yyb435 {
+		if yyb425 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj435-1, "")
+		z.DecStructFieldNotFound(yyj425-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5115,9 +4931,9 @@ func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv441 := range v {
-		yy442 := &yyv441
-		yy442.CodecEncodeSelf(e)
+	for _, yyv427 := range v {
+		yy428 := &yyv427
+		yy428.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5127,75 +4943,75 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv443 := *v
-	yyh443, yyl443 := z.DecSliceHelperStart()
+	yyv429 := *v
+	yyh429, yyl429 := z.DecSliceHelperStart()
 
-	var yyrr443, yyrl443 int
-	var yyc443, yyrt443 bool
-	_, _, _ = yyc443, yyrt443, yyrl443
-	yyrr443 = yyl443
+	var yyrr429, yyrl429 int
+	var yyc429, yyrt429 bool
+	_, _, _ = yyc429, yyrt429, yyrl429
+	yyrr429 = yyl429
 
-	if yyv443 == nil {
-		if yyrl443, yyrt443 = z.DecInferLen(yyl443, z.DecBasicHandle().MaxInitLen, 72); yyrt443 {
-			yyrr443 = yyrl443
+	if yyv429 == nil {
+		if yyrl429, yyrt429 = z.DecInferLen(yyl429, z.DecBasicHandle().MaxInitLen, 72); yyrt429 {
+			yyrr429 = yyrl429
 		}
-		yyv443 = make([]AggregateSample, yyrl443)
-		yyc443 = true
+		yyv429 = make([]AggregateSample, yyrl429)
+		yyc429 = true
 	}
 
-	if yyl443 == 0 {
-		if len(yyv443) != 0 {
-			yyv443 = yyv443[:0]
-			yyc443 = true
+	if yyl429 == 0 {
+		if len(yyv429) != 0 {
+			yyv429 = yyv429[:0]
+			yyc429 = true
 		}
-	} else if yyl443 > 0 {
+	} else if yyl429 > 0 {
 
-		if yyl443 > cap(yyv443) {
-			yyrl443, yyrt443 = z.DecInferLen(yyl443, z.DecBasicHandle().MaxInitLen, 72)
-			yyv443 = make([]AggregateSample, yyrl443)
-			yyc443 = true
+		if yyl429 > cap(yyv429) {
+			yyrl429, yyrt429 = z.DecInferLen(yyl429, z.DecBasicHandle().MaxInitLen, 72)
+			yyv429 = make([]AggregateSample, yyrl429)
+			yyc429 = true
 
-			yyrr443 = len(yyv443)
-		} else if yyl443 != len(yyv443) {
-			yyv443 = yyv443[:yyl443]
-			yyc443 = true
+			yyrr429 = len(yyv429)
+		} else if yyl429 != len(yyv429) {
+			yyv429 = yyv429[:yyl429]
+			yyc429 = true
 		}
-		yyj443 := 0
-		for ; yyj443 < yyrr443; yyj443++ {
+		yyj429 := 0
+		for ; yyj429 < yyrr429; yyj429++ {
 			if r.TryDecodeAsNil() {
-				yyv443[yyj443] = AggregateSample{}
+				yyv429[yyj429] = AggregateSample{}
 			} else {
-				yyv444 := &yyv443[yyj443]
-				yyv444.CodecDecodeSelf(d)
+				yyv430 := &yyv429[yyj429]
+				yyv430.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt443 {
-			for ; yyj443 < yyl443; yyj443++ {
-				yyv443 = append(yyv443, AggregateSample{})
+		if yyrt429 {
+			for ; yyj429 < yyl429; yyj429++ {
+				yyv429 = append(yyv429, AggregateSample{})
 				if r.TryDecodeAsNil() {
-					yyv443[yyj443] = AggregateSample{}
+					yyv429[yyj429] = AggregateSample{}
 				} else {
-					yyv445 := &yyv443[yyj443]
-					yyv445.CodecDecodeSelf(d)
+					yyv431 := &yyv429[yyj429]
+					yyv431.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj443 := 0; !r.CheckBreak(); yyj443++ {
-			if yyj443 >= len(yyv443) {
-				yyv443 = append(yyv443, AggregateSample{}) // var yyz443 AggregateSample
-				yyc443 = true
+		for yyj429 := 0; !r.CheckBreak(); yyj429++ {
+			if yyj429 >= len(yyv429) {
+				yyv429 = append(yyv429, AggregateSample{}) // var yyz429 AggregateSample
+				yyc429 = true
 			}
 
-			if yyj443 < len(yyv443) {
+			if yyj429 < len(yyv429) {
 				if r.TryDecodeAsNil() {
-					yyv443[yyj443] = AggregateSample{}
+					yyv429[yyj429] = AggregateSample{}
 				} else {
-					yyv446 := &yyv443[yyj443]
-					yyv446.CodecDecodeSelf(d)
+					yyv432 := &yyv429[yyj429]
+					yyv432.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5203,10 +5019,10 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 			}
 
 		}
-		yyh443.End()
+		yyh429.End()
 	}
-	if yyc443 {
-		*v = yyv443
+	if yyc429 {
+		*v = yyv429
 	}
 
 }
@@ -5216,9 +5032,9 @@ func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv447 := range v {
-		yy448 := &yyv447
-		yy448.CodecEncodeSelf(e)
+	for _, yyv433 := range v {
+		yy434 := &yyv433
+		yy434.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5228,75 +5044,75 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv449 := *v
-	yyh449, yyl449 := z.DecSliceHelperStart()
+	yyv435 := *v
+	yyh435, yyl435 := z.DecSliceHelperStart()
 
-	var yyrr449, yyrl449 int
-	var yyc449, yyrt449 bool
-	_, _, _ = yyc449, yyrt449, yyrl449
-	yyrr449 = yyl449
+	var yyrr435, yyrl435 int
+	var yyc435, yyrt435 bool
+	_, _, _ = yyc435, yyrt435, yyrl435
+	yyrr435 = yyl435
 
-	if yyv449 == nil {
-		if yyrl449, yyrt449 = z.DecInferLen(yyl449, z.DecBasicHandle().MaxInitLen, 48); yyrt449 {
-			yyrr449 = yyrl449
+	if yyv435 == nil {
+		if yyrl435, yyrt435 = z.DecInferLen(yyl435, z.DecBasicHandle().MaxInitLen, 48); yyrt435 {
+			yyrr435 = yyrl435
 		}
-		yyv449 = make([]RawContainerMetrics, yyrl449)
-		yyc449 = true
+		yyv435 = make([]RawContainerMetrics, yyrl435)
+		yyc435 = true
 	}
 
-	if yyl449 == 0 {
-		if len(yyv449) != 0 {
-			yyv449 = yyv449[:0]
-			yyc449 = true
+	if yyl435 == 0 {
+		if len(yyv435) != 0 {
+			yyv435 = yyv435[:0]
+			yyc435 = true
 		}
-	} else if yyl449 > 0 {
+	} else if yyl435 > 0 {
 
-		if yyl449 > cap(yyv449) {
-			yyrl449, yyrt449 = z.DecInferLen(yyl449, z.DecBasicHandle().MaxInitLen, 48)
-			yyv449 = make([]RawContainerMetrics, yyrl449)
-			yyc449 = true
+		if yyl435 > cap(yyv435) {
+			yyrl435, yyrt435 = z.DecInferLen(yyl435, z.DecBasicHandle().MaxInitLen, 48)
+			yyv435 = make([]RawContainerMetrics, yyrl435)
+			yyc435 = true
 
-			yyrr449 = len(yyv449)
-		} else if yyl449 != len(yyv449) {
-			yyv449 = yyv449[:yyl449]
-			yyc449 = true
+			yyrr435 = len(yyv435)
+		} else if yyl435 != len(yyv435) {
+			yyv435 = yyv435[:yyl435]
+			yyc435 = true
 		}
-		yyj449 := 0
-		for ; yyj449 < yyrr449; yyj449++ {
+		yyj435 := 0
+		for ; yyj435 < yyrr435; yyj435++ {
 			if r.TryDecodeAsNil() {
-				yyv449[yyj449] = RawContainerMetrics{}
+				yyv435[yyj435] = RawContainerMetrics{}
 			} else {
-				yyv450 := &yyv449[yyj449]
-				yyv450.CodecDecodeSelf(d)
+				yyv436 := &yyv435[yyj435]
+				yyv436.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt449 {
-			for ; yyj449 < yyl449; yyj449++ {
-				yyv449 = append(yyv449, RawContainerMetrics{})
+		if yyrt435 {
+			for ; yyj435 < yyl435; yyj435++ {
+				yyv435 = append(yyv435, RawContainerMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv449[yyj449] = RawContainerMetrics{}
+					yyv435[yyj435] = RawContainerMetrics{}
 				} else {
-					yyv451 := &yyv449[yyj449]
-					yyv451.CodecDecodeSelf(d)
+					yyv437 := &yyv435[yyj435]
+					yyv437.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj449 := 0; !r.CheckBreak(); yyj449++ {
-			if yyj449 >= len(yyv449) {
-				yyv449 = append(yyv449, RawContainerMetrics{}) // var yyz449 RawContainerMetrics
-				yyc449 = true
+		for yyj435 := 0; !r.CheckBreak(); yyj435++ {
+			if yyj435 >= len(yyv435) {
+				yyv435 = append(yyv435, RawContainerMetrics{}) // var yyz435 RawContainerMetrics
+				yyc435 = true
 			}
 
-			if yyj449 < len(yyv449) {
+			if yyj435 < len(yyv435) {
 				if r.TryDecodeAsNil() {
-					yyv449[yyj449] = RawContainerMetrics{}
+					yyv435[yyj435] = RawContainerMetrics{}
 				} else {
-					yyv452 := &yyv449[yyj449]
-					yyv452.CodecDecodeSelf(d)
+					yyv438 := &yyv435[yyj435]
+					yyv438.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5304,10 +5120,10 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 			}
 
 		}
-		yyh449.End()
+		yyh435.End()
 	}
-	if yyc449 {
-		*v = yyv449
+	if yyc435 {
+		*v = yyv435
 	}
 
 }
@@ -5317,9 +5133,9 @@ func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv453 := range v {
-		yy454 := &yyv453
-		yy454.CodecEncodeSelf(e)
+	for _, yyv439 := range v {
+		yy440 := &yyv439
+		yy440.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5329,75 +5145,75 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv455 := *v
-	yyh455, yyl455 := z.DecSliceHelperStart()
+	yyv441 := *v
+	yyh441, yyl441 := z.DecSliceHelperStart()
 
-	var yyrr455, yyrl455 int
-	var yyc455, yyrt455 bool
-	_, _, _ = yyc455, yyrt455, yyrl455
-	yyrr455 = yyl455
+	var yyrr441, yyrl441 int
+	var yyc441, yyrt441 bool
+	_, _, _ = yyc441, yyrt441, yyrl441
+	yyrr441 = yyl441
 
-	if yyv455 == nil {
-		if yyrl455, yyrt455 = z.DecInferLen(yyl455, z.DecBasicHandle().MaxInitLen, 128); yyrt455 {
-			yyrr455 = yyrl455
+	if yyv441 == nil {
+		if yyrl441, yyrt441 = z.DecInferLen(yyl441, z.DecBasicHandle().MaxInitLen, 128); yyrt441 {
+			yyrr441 = yyrl441
 		}
-		yyv455 = make([]RawNodeMetrics, yyrl455)
-		yyc455 = true
+		yyv441 = make([]RawNodeMetrics, yyrl441)
+		yyc441 = true
 	}
 
-	if yyl455 == 0 {
-		if len(yyv455) != 0 {
-			yyv455 = yyv455[:0]
-			yyc455 = true
+	if yyl441 == 0 {
+		if len(yyv441) != 0 {
+			yyv441 = yyv441[:0]
+			yyc441 = true
 		}
-	} else if yyl455 > 0 {
+	} else if yyl441 > 0 {
 
-		if yyl455 > cap(yyv455) {
-			yyrl455, yyrt455 = z.DecInferLen(yyl455, z.DecBasicHandle().MaxInitLen, 128)
-			yyv455 = make([]RawNodeMetrics, yyrl455)
-			yyc455 = true
+		if yyl441 > cap(yyv441) {
+			yyrl441, yyrt441 = z.DecInferLen(yyl441, z.DecBasicHandle().MaxInitLen, 128)
+			yyv441 = make([]RawNodeMetrics, yyrl441)
+			yyc441 = true
 
-			yyrr455 = len(yyv455)
-		} else if yyl455 != len(yyv455) {
-			yyv455 = yyv455[:yyl455]
-			yyc455 = true
+			yyrr441 = len(yyv441)
+		} else if yyl441 != len(yyv441) {
+			yyv441 = yyv441[:yyl441]
+			yyc441 = true
 		}
-		yyj455 := 0
-		for ; yyj455 < yyrr455; yyj455++ {
+		yyj441 := 0
+		for ; yyj441 < yyrr441; yyj441++ {
 			if r.TryDecodeAsNil() {
-				yyv455[yyj455] = RawNodeMetrics{}
+				yyv441[yyj441] = RawNodeMetrics{}
 			} else {
-				yyv456 := &yyv455[yyj455]
-				yyv456.CodecDecodeSelf(d)
+				yyv442 := &yyv441[yyj441]
+				yyv442.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt455 {
-			for ; yyj455 < yyl455; yyj455++ {
-				yyv455 = append(yyv455, RawNodeMetrics{})
+		if yyrt441 {
+			for ; yyj441 < yyl441; yyj441++ {
+				yyv441 = append(yyv441, RawNodeMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv455[yyj455] = RawNodeMetrics{}
+					yyv441[yyj441] = RawNodeMetrics{}
 				} else {
-					yyv457 := &yyv455[yyj455]
-					yyv457.CodecDecodeSelf(d)
+					yyv443 := &yyv441[yyj441]
+					yyv443.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj455 := 0; !r.CheckBreak(); yyj455++ {
-			if yyj455 >= len(yyv455) {
-				yyv455 = append(yyv455, RawNodeMetrics{}) // var yyz455 RawNodeMetrics
-				yyc455 = true
+		for yyj441 := 0; !r.CheckBreak(); yyj441++ {
+			if yyj441 >= len(yyv441) {
+				yyv441 = append(yyv441, RawNodeMetrics{}) // var yyz441 RawNodeMetrics
+				yyc441 = true
 			}
 
-			if yyj455 < len(yyv455) {
+			if yyj441 < len(yyv441) {
 				if r.TryDecodeAsNil() {
-					yyv455[yyj455] = RawNodeMetrics{}
+					yyv441[yyj441] = RawNodeMetrics{}
 				} else {
-					yyv458 := &yyv455[yyj455]
-					yyv458.CodecDecodeSelf(d)
+					yyv444 := &yyv441[yyj441]
+					yyv444.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5405,10 +5221,10 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 			}
 
 		}
-		yyh455.End()
+		yyh441.End()
 	}
-	if yyc455 {
-		*v = yyv455
+	if yyc441 {
+		*v = yyv441
 	}
 
 }
@@ -5418,9 +5234,9 @@ func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv459 := range v {
-		yy460 := &yyv459
-		yy460.CodecEncodeSelf(e)
+	for _, yyv445 := range v {
+		yy446 := &yyv445
+		yy446.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5430,75 +5246,75 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv461 := *v
-	yyh461, yyl461 := z.DecSliceHelperStart()
+	yyv447 := *v
+	yyh447, yyl447 := z.DecSliceHelperStart()
 
-	var yyrr461, yyrl461 int
-	var yyc461, yyrt461 bool
-	_, _, _ = yyc461, yyrt461, yyrl461
-	yyrr461 = yyl461
+	var yyrr447, yyrl447 int
+	var yyc447, yyrt447 bool
+	_, _, _ = yyc447, yyrt447, yyrl447
+	yyrr447 = yyl447
 
-	if yyv461 == nil {
-		if yyrl461, yyrt461 = z.DecInferLen(yyl461, z.DecBasicHandle().MaxInitLen, 32); yyrt461 {
-			yyrr461 = yyrl461
+	if yyv447 == nil {
+		if yyrl447, yyrt447 = z.DecInferLen(yyl447, z.DecBasicHandle().MaxInitLen, 32); yyrt447 {
+			yyrr447 = yyrl447
 		}
-		yyv461 = make([]PodSample, yyrl461)
-		yyc461 = true
+		yyv447 = make([]PodSample, yyrl447)
+		yyc447 = true
 	}
 
-	if yyl461 == 0 {
-		if len(yyv461) != 0 {
-			yyv461 = yyv461[:0]
-			yyc461 = true
+	if yyl447 == 0 {
+		if len(yyv447) != 0 {
+			yyv447 = yyv447[:0]
+			yyc447 = true
 		}
-	} else if yyl461 > 0 {
+	} else if yyl447 > 0 {
 
-		if yyl461 > cap(yyv461) {
-			yyrl461, yyrt461 = z.DecInferLen(yyl461, z.DecBasicHandle().MaxInitLen, 32)
-			yyv461 = make([]PodSample, yyrl461)
-			yyc461 = true
+		if yyl447 > cap(yyv447) {
+			yyrl447, yyrt447 = z.DecInferLen(yyl447, z.DecBasicHandle().MaxInitLen, 32)
+			yyv447 = make([]PodSample, yyrl447)
+			yyc447 = true
 
-			yyrr461 = len(yyv461)
-		} else if yyl461 != len(yyv461) {
-			yyv461 = yyv461[:yyl461]
-			yyc461 = true
+			yyrr447 = len(yyv447)
+		} else if yyl447 != len(yyv447) {
+			yyv447 = yyv447[:yyl447]
+			yyc447 = true
 		}
-		yyj461 := 0
-		for ; yyj461 < yyrr461; yyj461++ {
+		yyj447 := 0
+		for ; yyj447 < yyrr447; yyj447++ {
 			if r.TryDecodeAsNil() {
-				yyv461[yyj461] = PodSample{}
+				yyv447[yyj447] = PodSample{}
 			} else {
-				yyv462 := &yyv461[yyj461]
-				yyv462.CodecDecodeSelf(d)
+				yyv448 := &yyv447[yyj447]
+				yyv448.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt461 {
-			for ; yyj461 < yyl461; yyj461++ {
-				yyv461 = append(yyv461, PodSample{})
+		if yyrt447 {
+			for ; yyj447 < yyl447; yyj447++ {
+				yyv447 = append(yyv447, PodSample{})
 				if r.TryDecodeAsNil() {
-					yyv461[yyj461] = PodSample{}
+					yyv447[yyj447] = PodSample{}
 				} else {
-					yyv463 := &yyv461[yyj461]
-					yyv463.CodecDecodeSelf(d)
+					yyv449 := &yyv447[yyj447]
+					yyv449.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj461 := 0; !r.CheckBreak(); yyj461++ {
-			if yyj461 >= len(yyv461) {
-				yyv461 = append(yyv461, PodSample{}) // var yyz461 PodSample
-				yyc461 = true
+		for yyj447 := 0; !r.CheckBreak(); yyj447++ {
+			if yyj447 >= len(yyv447) {
+				yyv447 = append(yyv447, PodSample{}) // var yyz447 PodSample
+				yyc447 = true
 			}
 
-			if yyj461 < len(yyv461) {
+			if yyj447 < len(yyv447) {
 				if r.TryDecodeAsNil() {
-					yyv461[yyj461] = PodSample{}
+					yyv447[yyj447] = PodSample{}
 				} else {
-					yyv464 := &yyv461[yyj461]
-					yyv464.CodecDecodeSelf(d)
+					yyv450 := &yyv447[yyj447]
+					yyv450.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5506,10 +5322,10 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 			}
 
 		}
-		yyh461.End()
+		yyh447.End()
 	}
-	if yyc461 {
-		*v = yyv461
+	if yyc447 {
+		*v = yyv447
 	}
 
 }
@@ -5519,9 +5335,9 @@ func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv465 := range v {
-		yy466 := &yyv465
-		yy466.CodecEncodeSelf(e)
+	for _, yyv451 := range v {
+		yy452 := &yyv451
+		yy452.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5531,75 +5347,75 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv467 := *v
-	yyh467, yyl467 := z.DecSliceHelperStart()
+	yyv453 := *v
+	yyh453, yyl453 := z.DecSliceHelperStart()
 
-	var yyrr467, yyrl467 int
-	var yyc467, yyrt467 bool
-	_, _, _ = yyc467, yyrt467, yyrl467
-	yyrr467 = yyl467
+	var yyrr453, yyrl453 int
+	var yyc453, yyrt453 bool
+	_, _, _ = yyc453, yyrt453, yyrl453
+	yyrr453 = yyl453
 
-	if yyv467 == nil {
-		if yyrl467, yyrt467 = z.DecInferLen(yyl467, z.DecBasicHandle().MaxInitLen, 160); yyrt467 {
-			yyrr467 = yyrl467
+	if yyv453 == nil {
+		if yyrl453, yyrt453 = z.DecInferLen(yyl453, z.DecBasicHandle().MaxInitLen, 160); yyrt453 {
+			yyrr453 = yyrl453
 		}
-		yyv467 = make([]RawPodMetrics, yyrl467)
-		yyc467 = true
+		yyv453 = make([]RawPodMetrics, yyrl453)
+		yyc453 = true
 	}
 
-	if yyl467 == 0 {
-		if len(yyv467) != 0 {
-			yyv467 = yyv467[:0]
-			yyc467 = true
+	if yyl453 == 0 {
+		if len(yyv453) != 0 {
+			yyv453 = yyv453[:0]
+			yyc453 = true
 		}
-	} else if yyl467 > 0 {
+	} else if yyl453 > 0 {
 
-		if yyl467 > cap(yyv467) {
-			yyrl467, yyrt467 = z.DecInferLen(yyl467, z.DecBasicHandle().MaxInitLen, 160)
-			yyv467 = make([]RawPodMetrics, yyrl467)
-			yyc467 = true
+		if yyl453 > cap(yyv453) {
+			yyrl453, yyrt453 = z.DecInferLen(yyl453, z.DecBasicHandle().MaxInitLen, 160)
+			yyv453 = make([]RawPodMetrics, yyrl453)
+			yyc453 = true
 
-			yyrr467 = len(yyv467)
-		} else if yyl467 != len(yyv467) {
-			yyv467 = yyv467[:yyl467]
-			yyc467 = true
+			yyrr453 = len(yyv453)
+		} else if yyl453 != len(yyv453) {
+			yyv453 = yyv453[:yyl453]
+			yyc453 = true
 		}
-		yyj467 := 0
-		for ; yyj467 < yyrr467; yyj467++ {
+		yyj453 := 0
+		for ; yyj453 < yyrr453; yyj453++ {
 			if r.TryDecodeAsNil() {
-				yyv467[yyj467] = RawPodMetrics{}
+				yyv453[yyj453] = RawPodMetrics{}
 			} else {
-				yyv468 := &yyv467[yyj467]
-				yyv468.CodecDecodeSelf(d)
+				yyv454 := &yyv453[yyj453]
+				yyv454.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt467 {
-			for ; yyj467 < yyl467; yyj467++ {
-				yyv467 = append(yyv467, RawPodMetrics{})
+		if yyrt453 {
+			for ; yyj453 < yyl453; yyj453++ {
+				yyv453 = append(yyv453, RawPodMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv467[yyj467] = RawPodMetrics{}
+					yyv453[yyj453] = RawPodMetrics{}
 				} else {
-					yyv469 := &yyv467[yyj467]
-					yyv469.CodecDecodeSelf(d)
+					yyv455 := &yyv453[yyj453]
+					yyv455.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj467 := 0; !r.CheckBreak(); yyj467++ {
-			if yyj467 >= len(yyv467) {
-				yyv467 = append(yyv467, RawPodMetrics{}) // var yyz467 RawPodMetrics
-				yyc467 = true
+		for yyj453 := 0; !r.CheckBreak(); yyj453++ {
+			if yyj453 >= len(yyv453) {
+				yyv453 = append(yyv453, RawPodMetrics{}) // var yyz453 RawPodMetrics
+				yyc453 = true
 			}
 
-			if yyj467 < len(yyv467) {
+			if yyj453 < len(yyv453) {
 				if r.TryDecodeAsNil() {
-					yyv467[yyj467] = RawPodMetrics{}
+					yyv453[yyj453] = RawPodMetrics{}
 				} else {
-					yyv470 := &yyv467[yyj467]
-					yyv470.CodecDecodeSelf(d)
+					yyv456 := &yyv453[yyj453]
+					yyv456.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5607,10 +5423,10 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 			}
 
 		}
-		yyh467.End()
+		yyh453.End()
 	}
-	if yyc467 {
-		*v = yyv467
+	if yyc453 {
+		*v = yyv453
 	}
 
 }
@@ -5620,9 +5436,9 @@ func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv471 := range v {
-		yy472 := &yyv471
-		yy472.CodecEncodeSelf(e)
+	for _, yyv457 := range v {
+		yy458 := &yyv457
+		yy458.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5632,75 +5448,75 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv473 := *v
-	yyh473, yyl473 := z.DecSliceHelperStart()
+	yyv459 := *v
+	yyh459, yyl459 := z.DecSliceHelperStart()
 
-	var yyrr473, yyrl473 int
-	var yyc473, yyrt473 bool
-	_, _, _ = yyc473, yyrt473, yyrl473
-	yyrr473 = yyl473
+	var yyrr459, yyrl459 int
+	var yyc459, yyrt459 bool
+	_, _, _ = yyc459, yyrt459, yyrl459
+	yyrr459 = yyl459
 
-	if yyv473 == nil {
-		if yyrl473, yyrt473 = z.DecInferLen(yyl473, z.DecBasicHandle().MaxInitLen, 64); yyrt473 {
-			yyrr473 = yyrl473
+	if yyv459 == nil {
+		if yyrl459, yyrt459 = z.DecInferLen(yyl459, z.DecBasicHandle().MaxInitLen, 64); yyrt459 {
+			yyrr459 = yyrl459
 		}
-		yyv473 = make([]ContainerSample, yyrl473)
-		yyc473 = true
+		yyv459 = make([]ContainerSample, yyrl459)
+		yyc459 = true
 	}
 
-	if yyl473 == 0 {
-		if len(yyv473) != 0 {
-			yyv473 = yyv473[:0]
-			yyc473 = true
+	if yyl459 == 0 {
+		if len(yyv459) != 0 {
+			yyv459 = yyv459[:0]
+			yyc459 = true
 		}
-	} else if yyl473 > 0 {
+	} else if yyl459 > 0 {
 
-		if yyl473 > cap(yyv473) {
-			yyrl473, yyrt473 = z.DecInferLen(yyl473, z.DecBasicHandle().MaxInitLen, 64)
-			yyv473 = make([]ContainerSample, yyrl473)
-			yyc473 = true
+		if yyl459 > cap(yyv459) {
+			yyrl459, yyrt459 = z.DecInferLen(yyl459, z.DecBasicHandle().MaxInitLen, 64)
+			yyv459 = make([]ContainerSample, yyrl459)
+			yyc459 = true
 
-			yyrr473 = len(yyv473)
-		} else if yyl473 != len(yyv473) {
-			yyv473 = yyv473[:yyl473]
-			yyc473 = true
+			yyrr459 = len(yyv459)
+		} else if yyl459 != len(yyv459) {
+			yyv459 = yyv459[:yyl459]
+			yyc459 = true
 		}
-		yyj473 := 0
-		for ; yyj473 < yyrr473; yyj473++ {
+		yyj459 := 0
+		for ; yyj459 < yyrr459; yyj459++ {
 			if r.TryDecodeAsNil() {
-				yyv473[yyj473] = ContainerSample{}
+				yyv459[yyj459] = ContainerSample{}
 			} else {
-				yyv474 := &yyv473[yyj473]
-				yyv474.CodecDecodeSelf(d)
+				yyv460 := &yyv459[yyj459]
+				yyv460.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt473 {
-			for ; yyj473 < yyl473; yyj473++ {
-				yyv473 = append(yyv473, ContainerSample{})
+		if yyrt459 {
+			for ; yyj459 < yyl459; yyj459++ {
+				yyv459 = append(yyv459, ContainerSample{})
 				if r.TryDecodeAsNil() {
-					yyv473[yyj473] = ContainerSample{}
+					yyv459[yyj459] = ContainerSample{}
 				} else {
-					yyv475 := &yyv473[yyj473]
-					yyv475.CodecDecodeSelf(d)
+					yyv461 := &yyv459[yyj459]
+					yyv461.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj473 := 0; !r.CheckBreak(); yyj473++ {
-			if yyj473 >= len(yyv473) {
-				yyv473 = append(yyv473, ContainerSample{}) // var yyz473 ContainerSample
-				yyc473 = true
+		for yyj459 := 0; !r.CheckBreak(); yyj459++ {
+			if yyj459 >= len(yyv459) {
+				yyv459 = append(yyv459, ContainerSample{}) // var yyz459 ContainerSample
+				yyc459 = true
 			}
 
-			if yyj473 < len(yyv473) {
+			if yyj459 < len(yyv459) {
 				if r.TryDecodeAsNil() {
-					yyv473[yyj473] = ContainerSample{}
+					yyv459[yyj459] = ContainerSample{}
 				} else {
-					yyv476 := &yyv473[yyj473]
-					yyv476.CodecDecodeSelf(d)
+					yyv462 := &yyv459[yyj459]
+					yyv462.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5708,10 +5524,10 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 			}
 
 		}
-		yyh473.End()
+		yyh459.End()
 	}
-	if yyc473 {
-		*v = yyv473
+	if yyc459 {
+		*v = yyv459
 	}
 
 }
@@ -5721,9 +5537,9 @@ func (x codecSelfer1234) encSliceFilesystemMetrics(v []FilesystemMetrics, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv477 := range v {
-		yy478 := &yyv477
-		yy478.CodecEncodeSelf(e)
+	for _, yyv463 := range v {
+		yy464 := &yyv463
+		yy464.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5733,75 +5549,75 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv479 := *v
-	yyh479, yyl479 := z.DecSliceHelperStart()
+	yyv465 := *v
+	yyh465, yyl465 := z.DecSliceHelperStart()
 
-	var yyrr479, yyrl479 int
-	var yyc479, yyrt479 bool
-	_, _, _ = yyc479, yyrt479, yyrl479
-	yyrr479 = yyl479
+	var yyrr465, yyrl465 int
+	var yyc465, yyrt465 bool
+	_, _, _ = yyc465, yyrt465, yyrl465
+	yyrr465 = yyl465
 
-	if yyv479 == nil {
-		if yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 32); yyrt479 {
-			yyrr479 = yyrl479
+	if yyv465 == nil {
+		if yyrl465, yyrt465 = z.DecInferLen(yyl465, z.DecBasicHandle().MaxInitLen, 32); yyrt465 {
+			yyrr465 = yyrl465
 		}
-		yyv479 = make([]FilesystemMetrics, yyrl479)
-		yyc479 = true
+		yyv465 = make([]FilesystemMetrics, yyrl465)
+		yyc465 = true
 	}
 
-	if yyl479 == 0 {
-		if len(yyv479) != 0 {
-			yyv479 = yyv479[:0]
-			yyc479 = true
+	if yyl465 == 0 {
+		if len(yyv465) != 0 {
+			yyv465 = yyv465[:0]
+			yyc465 = true
 		}
-	} else if yyl479 > 0 {
+	} else if yyl465 > 0 {
 
-		if yyl479 > cap(yyv479) {
-			yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 32)
-			yyv479 = make([]FilesystemMetrics, yyrl479)
-			yyc479 = true
+		if yyl465 > cap(yyv465) {
+			yyrl465, yyrt465 = z.DecInferLen(yyl465, z.DecBasicHandle().MaxInitLen, 32)
+			yyv465 = make([]FilesystemMetrics, yyrl465)
+			yyc465 = true
 
-			yyrr479 = len(yyv479)
-		} else if yyl479 != len(yyv479) {
-			yyv479 = yyv479[:yyl479]
-			yyc479 = true
+			yyrr465 = len(yyv465)
+		} else if yyl465 != len(yyv465) {
+			yyv465 = yyv465[:yyl465]
+			yyc465 = true
 		}
-		yyj479 := 0
-		for ; yyj479 < yyrr479; yyj479++ {
+		yyj465 := 0
+		for ; yyj465 < yyrr465; yyj465++ {
 			if r.TryDecodeAsNil() {
-				yyv479[yyj479] = FilesystemMetrics{}
+				yyv465[yyj465] = FilesystemMetrics{}
 			} else {
-				yyv480 := &yyv479[yyj479]
-				yyv480.CodecDecodeSelf(d)
+				yyv466 := &yyv465[yyj465]
+				yyv466.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt479 {
-			for ; yyj479 < yyl479; yyj479++ {
-				yyv479 = append(yyv479, FilesystemMetrics{})
+		if yyrt465 {
+			for ; yyj465 < yyl465; yyj465++ {
+				yyv465 = append(yyv465, FilesystemMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv479[yyj479] = FilesystemMetrics{}
+					yyv465[yyj465] = FilesystemMetrics{}
 				} else {
-					yyv481 := &yyv479[yyj479]
-					yyv481.CodecDecodeSelf(d)
+					yyv467 := &yyv465[yyj465]
+					yyv467.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj479 := 0; !r.CheckBreak(); yyj479++ {
-			if yyj479 >= len(yyv479) {
-				yyv479 = append(yyv479, FilesystemMetrics{}) // var yyz479 FilesystemMetrics
-				yyc479 = true
+		for yyj465 := 0; !r.CheckBreak(); yyj465++ {
+			if yyj465 >= len(yyv465) {
+				yyv465 = append(yyv465, FilesystemMetrics{}) // var yyz465 FilesystemMetrics
+				yyc465 = true
 			}
 
-			if yyj479 < len(yyv479) {
+			if yyj465 < len(yyv465) {
 				if r.TryDecodeAsNil() {
-					yyv479[yyj479] = FilesystemMetrics{}
+					yyv465[yyj465] = FilesystemMetrics{}
 				} else {
-					yyv482 := &yyv479[yyj479]
-					yyv482.CodecDecodeSelf(d)
+					yyv468 := &yyv465[yyj465]
+					yyv468.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5809,10 +5625,10 @@ func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *co
 			}
 
 		}
-		yyh479.End()
+		yyh465.End()
 	}
-	if yyc479 {
-		*v = yyv479
+	if yyc465 {
+		*v = yyv465
 	}
 
 }

--- a/pkg/apis/metrics/v1alpha1/types.generated.go
+++ b/pkg/apis/metrics/v1alpha1/types.generated.go
@@ -2466,14 +2466,15 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep233 := !z.EncBinary()
 			yy2arr233 := z.EncBasicHandle().StructToArray
-			var yyq233 [4]bool
+			var yyq233 [5]bool
 			_, _, _ = yysep233, yyq233, yy2arr233
 			const yyr233 bool = false
 			yyq233[1] = x.CPU != nil
 			yyq233[2] = x.Memory != nil
 			yyq233[3] = x.Network != nil
+			yyq233[4] = len(x.Filesystem) != 0
 			if yyr233 || yy2arr233 {
-				r.EncodeArrayStart(4)
+				r.EncodeArrayStart(5)
 			} else {
 				var yynn233 int = 1
 				for _, b := range yyq233 {
@@ -2571,6 +2572,36 @@ func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
+			if yyr233 || yy2arr233 {
+				if yyq233[4] {
+					if x.Filesystem == nil {
+						r.EncodeNil()
+					} else {
+						yym243 := z.EncBinary()
+						_ = yym243
+						if false {
+						} else {
+							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq233[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("filesystem"))
+					if x.Filesystem == nil {
+						r.EncodeNil()
+					} else {
+						yym244 := z.EncBinary()
+						_ = yym244
+						if false {
+						} else {
+							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
+						}
+					}
+				}
+			}
 			if yysep233 {
 				r.EncodeEnd()
 			}
@@ -2582,24 +2613,24 @@ func (x *AggregateSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym242 := z.DecBinary()
-	_ = yym242
+	yym245 := z.DecBinary()
+	_ = yym245
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl243 := r.ReadMapStart()
-			if yyl243 == 0 {
+			yyl246 := r.ReadMapStart()
+			if yyl246 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl243, d)
+				x.codecDecodeSelfFromMap(yyl246, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl243 := r.ReadArrayStart()
-			if yyl243 == 0 {
+			yyl246 := r.ReadArrayStart()
+			if yyl246 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl243, d)
+				x.codecDecodeSelfFromArray(yyl246, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2611,12 +2642,12 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys244Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys244Slc
-	var yyhl244 bool = l >= 0
-	for yyj244 := 0; ; yyj244++ {
-		if yyhl244 {
-			if yyj244 >= l {
+	var yys247Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys247Slc
+	var yyhl247 bool = l >= 0
+	for yyj247 := 0; ; yyj247++ {
+		if yyhl247 {
+			if yyj247 >= l {
 				break
 			}
 		} else {
@@ -2624,24 +2655,24 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys244Slc = r.DecodeBytes(yys244Slc, true, true)
-		yys244 := string(yys244Slc)
-		switch yys244 {
+		yys247Slc = r.DecodeBytes(yys247Slc, true, true)
+		yys247 := string(yys247Slc)
+		switch yys247 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv245 := &x.SampleTime
-				yym246 := z.DecBinary()
-				_ = yym246
+				yyv248 := &x.SampleTime
+				yym249 := z.DecBinary()
+				_ = yym249
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv245) {
-				} else if yym246 {
-					z.DecBinaryUnmarshal(yyv245)
-				} else if !yym246 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv245)
+				} else if z.HasExtensions() && z.DecExt(yyv248) {
+				} else if yym249 {
+					z.DecBinaryUnmarshal(yyv248)
+				} else if !yym249 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv248)
 				} else {
-					z.DecFallback(yyv245, false)
+					z.DecFallback(yyv248, false)
 				}
 			}
 		case "cpu":
@@ -2677,11 +2708,23 @@ func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 				x.Network.CodecDecodeSelf(d)
 			}
+		case "filesystem":
+			if r.TryDecodeAsNil() {
+				x.Filesystem = nil
+			} else {
+				yyv253 := &x.Filesystem
+				yym254 := z.DecBinary()
+				_ = yym254
+				if false {
+				} else {
+					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv253), d)
+				}
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys244)
-		} // end switch yys244
-	} // end for yyj244
-	if !yyhl244 {
+			z.DecStructFieldNotFound(-1, yys247)
+		} // end switch yys247
+	} // end for yyj247
+	if !yyhl247 {
 		r.ReadEnd()
 	}
 }
@@ -2690,42 +2733,42 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj250 int
-	var yyb250 bool
-	var yyhl250 bool = l >= 0
-	yyj250++
-	if yyhl250 {
-		yyb250 = yyj250 > l
+	var yyj255 int
+	var yyb255 bool
+	var yyhl255 bool = l >= 0
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
 	} else {
-		yyb250 = r.CheckBreak()
+		yyb255 = r.CheckBreak()
 	}
-	if yyb250 {
+	if yyb255 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv251 := &x.SampleTime
-		yym252 := z.DecBinary()
-		_ = yym252
+		yyv256 := &x.SampleTime
+		yym257 := z.DecBinary()
+		_ = yym257
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv251) {
-		} else if yym252 {
-			z.DecBinaryUnmarshal(yyv251)
-		} else if !yym252 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv251)
+		} else if z.HasExtensions() && z.DecExt(yyv256) {
+		} else if yym257 {
+			z.DecBinaryUnmarshal(yyv256)
+		} else if !yym257 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv256)
 		} else {
-			z.DecFallback(yyv251, false)
+			z.DecFallback(yyv256, false)
 		}
 	}
-	yyj250++
-	if yyhl250 {
-		yyb250 = yyj250 > l
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
 	} else {
-		yyb250 = r.CheckBreak()
+		yyb255 = r.CheckBreak()
 	}
-	if yyb250 {
+	if yyb255 {
 		r.ReadEnd()
 		return
 	}
@@ -2739,13 +2782,13 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.CPU.CodecDecodeSelf(d)
 	}
-	yyj250++
-	if yyhl250 {
-		yyb250 = yyj250 > l
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
 	} else {
-		yyb250 = r.CheckBreak()
+		yyb255 = r.CheckBreak()
 	}
-	if yyb250 {
+	if yyb255 {
 		r.ReadEnd()
 		return
 	}
@@ -2759,13 +2802,13 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Memory.CodecDecodeSelf(d)
 	}
-	yyj250++
-	if yyhl250 {
-		yyb250 = yyj250 > l
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
 	} else {
-		yyb250 = r.CheckBreak()
+		yyb255 = r.CheckBreak()
 	}
-	if yyb250 {
+	if yyb255 {
 		r.ReadEnd()
 		return
 	}
@@ -2779,17 +2822,38 @@ func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Network.CodecDecodeSelf(d)
 	}
-	for {
-		yyj250++
-		if yyhl250 {
-			yyb250 = yyj250 > l
+	yyj255++
+	if yyhl255 {
+		yyb255 = yyj255 > l
+	} else {
+		yyb255 = r.CheckBreak()
+	}
+	if yyb255 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Filesystem = nil
+	} else {
+		yyv261 := &x.Filesystem
+		yym262 := z.DecBinary()
+		_ = yym262
+		if false {
 		} else {
-			yyb250 = r.CheckBreak()
+			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv261), d)
 		}
-		if yyb250 {
+	}
+	for {
+		yyj255++
+		if yyhl255 {
+			yyb255 = yyj255 > l
+		} else {
+			yyb255 = r.CheckBreak()
+		}
+		if yyb255 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj250-1, "")
+		z.DecStructFieldNotFound(yyj255-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2801,58 +2865,58 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym256 := z.EncBinary()
-		_ = yym256
+		yym263 := z.EncBinary()
+		_ = yym263
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep257 := !z.EncBinary()
-			yy2arr257 := z.EncBasicHandle().StructToArray
-			var yyq257 [2]bool
-			_, _, _ = yysep257, yyq257, yy2arr257
-			const yyr257 bool = false
-			yyq257[1] = x.Network != nil
-			if yyr257 || yy2arr257 {
+			yysep264 := !z.EncBinary()
+			yy2arr264 := z.EncBasicHandle().StructToArray
+			var yyq264 [2]bool
+			_, _, _ = yysep264, yyq264, yy2arr264
+			const yyr264 bool = false
+			yyq264[1] = x.Network != nil
+			if yyr264 || yy2arr264 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn257 int = 1
-				for _, b := range yyq257 {
+				var yynn264 int = 1
+				for _, b := range yyq264 {
 					if b {
-						yynn257++
+						yynn264++
 					}
 				}
-				r.EncodeMapStart(yynn257)
+				r.EncodeMapStart(yynn264)
 			}
-			if yyr257 || yy2arr257 {
-				yy259 := &x.SampleTime
-				yym260 := z.EncBinary()
-				_ = yym260
+			if yyr264 || yy2arr264 {
+				yy266 := &x.SampleTime
+				yym267 := z.EncBinary()
+				_ = yym267
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy259) {
-				} else if yym260 {
-					z.EncBinaryMarshal(yy259)
-				} else if !yym260 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy259)
+				} else if z.HasExtensions() && z.EncExt(yy266) {
+				} else if yym267 {
+					z.EncBinaryMarshal(yy266)
+				} else if !yym267 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy266)
 				} else {
-					z.EncFallback(yy259)
+					z.EncFallback(yy266)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy261 := &x.SampleTime
-				yym262 := z.EncBinary()
-				_ = yym262
+				yy268 := &x.SampleTime
+				yym269 := z.EncBinary()
+				_ = yym269
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy261) {
-				} else if yym262 {
-					z.EncBinaryMarshal(yy261)
-				} else if !yym262 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy261)
+				} else if z.HasExtensions() && z.EncExt(yy268) {
+				} else if yym269 {
+					z.EncBinaryMarshal(yy268)
+				} else if !yym269 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy268)
 				} else {
-					z.EncFallback(yy261)
+					z.EncFallback(yy268)
 				}
 			}
-			if yyr257 || yy2arr257 {
-				if yyq257[1] {
+			if yyr264 || yy2arr264 {
+				if yyq264[1] {
 					if x.Network == nil {
 						r.EncodeNil()
 					} else {
@@ -2862,7 +2926,7 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq257[1] {
+				if yyq264[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("network"))
 					if x.Network == nil {
 						r.EncodeNil()
@@ -2871,7 +2935,7 @@ func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep257 {
+			if yysep264 {
 				r.EncodeEnd()
 			}
 		}
@@ -2882,24 +2946,24 @@ func (x *PodSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym264 := z.DecBinary()
-	_ = yym264
+	yym271 := z.DecBinary()
+	_ = yym271
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl265 := r.ReadMapStart()
-			if yyl265 == 0 {
+			yyl272 := r.ReadMapStart()
+			if yyl272 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl265, d)
+				x.codecDecodeSelfFromMap(yyl272, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl265 := r.ReadArrayStart()
-			if yyl265 == 0 {
+			yyl272 := r.ReadArrayStart()
+			if yyl272 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl265, d)
+				x.codecDecodeSelfFromArray(yyl272, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2911,12 +2975,12 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys266Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys266Slc
-	var yyhl266 bool = l >= 0
-	for yyj266 := 0; ; yyj266++ {
-		if yyhl266 {
-			if yyj266 >= l {
+	var yys273Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys273Slc
+	var yyhl273 bool = l >= 0
+	for yyj273 := 0; ; yyj273++ {
+		if yyhl273 {
+			if yyj273 >= l {
 				break
 			}
 		} else {
@@ -2924,24 +2988,24 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys266Slc = r.DecodeBytes(yys266Slc, true, true)
-		yys266 := string(yys266Slc)
-		switch yys266 {
+		yys273Slc = r.DecodeBytes(yys273Slc, true, true)
+		yys273 := string(yys273Slc)
+		switch yys273 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv267 := &x.SampleTime
-				yym268 := z.DecBinary()
-				_ = yym268
+				yyv274 := &x.SampleTime
+				yym275 := z.DecBinary()
+				_ = yym275
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv267) {
-				} else if yym268 {
-					z.DecBinaryUnmarshal(yyv267)
-				} else if !yym268 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv267)
+				} else if z.HasExtensions() && z.DecExt(yyv274) {
+				} else if yym275 {
+					z.DecBinaryUnmarshal(yyv274)
+				} else if !yym275 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv274)
 				} else {
-					z.DecFallback(yyv267, false)
+					z.DecFallback(yyv274, false)
 				}
 			}
 		case "network":
@@ -2956,10 +3020,10 @@ func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Network.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys266)
-		} // end switch yys266
-	} // end for yyj266
-	if !yyhl266 {
+			z.DecStructFieldNotFound(-1, yys273)
+		} // end switch yys273
+	} // end for yyj273
+	if !yyhl273 {
 		r.ReadEnd()
 	}
 }
@@ -2968,42 +3032,42 @@ func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj270 int
-	var yyb270 bool
-	var yyhl270 bool = l >= 0
-	yyj270++
-	if yyhl270 {
-		yyb270 = yyj270 > l
+	var yyj277 int
+	var yyb277 bool
+	var yyhl277 bool = l >= 0
+	yyj277++
+	if yyhl277 {
+		yyb277 = yyj277 > l
 	} else {
-		yyb270 = r.CheckBreak()
+		yyb277 = r.CheckBreak()
 	}
-	if yyb270 {
+	if yyb277 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv271 := &x.SampleTime
-		yym272 := z.DecBinary()
-		_ = yym272
+		yyv278 := &x.SampleTime
+		yym279 := z.DecBinary()
+		_ = yym279
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv271) {
-		} else if yym272 {
-			z.DecBinaryUnmarshal(yyv271)
-		} else if !yym272 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv271)
+		} else if z.HasExtensions() && z.DecExt(yyv278) {
+		} else if yym279 {
+			z.DecBinaryUnmarshal(yyv278)
+		} else if !yym279 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv278)
 		} else {
-			z.DecFallback(yyv271, false)
+			z.DecFallback(yyv278, false)
 		}
 	}
-	yyj270++
-	if yyhl270 {
-		yyb270 = yyj270 > l
+	yyj277++
+	if yyhl277 {
+		yyb277 = yyj277 > l
 	} else {
-		yyb270 = r.CheckBreak()
+		yyb277 = r.CheckBreak()
 	}
-	if yyb270 {
+	if yyb277 {
 		r.ReadEnd()
 		return
 	}
@@ -3018,16 +3082,16 @@ func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Network.CodecDecodeSelf(d)
 	}
 	for {
-		yyj270++
-		if yyhl270 {
-			yyb270 = yyj270 > l
+		yyj277++
+		if yyhl277 {
+			yyb277 = yyj277 > l
 		} else {
-			yyb270 = r.CheckBreak()
+			yyb277 = r.CheckBreak()
 		}
-		if yyb270 {
+		if yyb277 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj270-1, "")
+		z.DecStructFieldNotFound(yyj277-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3039,59 +3103,60 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym274 := z.EncBinary()
-		_ = yym274
+		yym281 := z.EncBinary()
+		_ = yym281
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep275 := !z.EncBinary()
-			yy2arr275 := z.EncBasicHandle().StructToArray
-			var yyq275 [3]bool
-			_, _, _ = yysep275, yyq275, yy2arr275
-			const yyr275 bool = false
-			yyq275[1] = x.CPU != nil
-			yyq275[2] = x.Memory != nil
-			if yyr275 || yy2arr275 {
-				r.EncodeArrayStart(3)
+			yysep282 := !z.EncBinary()
+			yy2arr282 := z.EncBasicHandle().StructToArray
+			var yyq282 [4]bool
+			_, _, _ = yysep282, yyq282, yy2arr282
+			const yyr282 bool = false
+			yyq282[1] = x.CPU != nil
+			yyq282[2] = x.Memory != nil
+			yyq282[3] = len(x.Filesystem) != 0
+			if yyr282 || yy2arr282 {
+				r.EncodeArrayStart(4)
 			} else {
-				var yynn275 int = 1
-				for _, b := range yyq275 {
+				var yynn282 int = 1
+				for _, b := range yyq282 {
 					if b {
-						yynn275++
+						yynn282++
 					}
 				}
-				r.EncodeMapStart(yynn275)
+				r.EncodeMapStart(yynn282)
 			}
-			if yyr275 || yy2arr275 {
-				yy277 := &x.SampleTime
-				yym278 := z.EncBinary()
-				_ = yym278
+			if yyr282 || yy2arr282 {
+				yy284 := &x.SampleTime
+				yym285 := z.EncBinary()
+				_ = yym285
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy277) {
-				} else if yym278 {
-					z.EncBinaryMarshal(yy277)
-				} else if !yym278 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy277)
+				} else if z.HasExtensions() && z.EncExt(yy284) {
+				} else if yym285 {
+					z.EncBinaryMarshal(yy284)
+				} else if !yym285 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy284)
 				} else {
-					z.EncFallback(yy277)
+					z.EncFallback(yy284)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy279 := &x.SampleTime
-				yym280 := z.EncBinary()
-				_ = yym280
+				yy286 := &x.SampleTime
+				yym287 := z.EncBinary()
+				_ = yym287
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy279) {
-				} else if yym280 {
-					z.EncBinaryMarshal(yy279)
-				} else if !yym280 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy279)
+				} else if z.HasExtensions() && z.EncExt(yy286) {
+				} else if yym287 {
+					z.EncBinaryMarshal(yy286)
+				} else if !yym287 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy286)
 				} else {
-					z.EncFallback(yy279)
+					z.EncFallback(yy286)
 				}
 			}
-			if yyr275 || yy2arr275 {
-				if yyq275[1] {
+			if yyr282 || yy2arr282 {
+				if yyq282[1] {
 					if x.CPU == nil {
 						r.EncodeNil()
 					} else {
@@ -3101,7 +3166,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq275[1] {
+				if yyq282[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
 					if x.CPU == nil {
 						r.EncodeNil()
@@ -3110,8 +3175,8 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr275 || yy2arr275 {
-				if yyq275[2] {
+			if yyr282 || yy2arr282 {
+				if yyq282[2] {
 					if x.Memory == nil {
 						r.EncodeNil()
 					} else {
@@ -3121,7 +3186,7 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq275[2] {
+				if yyq282[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("memory"))
 					if x.Memory == nil {
 						r.EncodeNil()
@@ -3130,7 +3195,37 @@ func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep275 {
+			if yyr282 || yy2arr282 {
+				if yyq282[3] {
+					if x.Filesystem == nil {
+						r.EncodeNil()
+					} else {
+						yym291 := z.EncBinary()
+						_ = yym291
+						if false {
+						} else {
+							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq282[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("filesystem"))
+					if x.Filesystem == nil {
+						r.EncodeNil()
+					} else {
+						yym292 := z.EncBinary()
+						_ = yym292
+						if false {
+						} else {
+							h.encSliceFilesystemMetrics(([]FilesystemMetrics)(x.Filesystem), e)
+						}
+					}
+				}
+			}
+			if yysep282 {
 				r.EncodeEnd()
 			}
 		}
@@ -3141,24 +3236,24 @@ func (x *ContainerSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym283 := z.DecBinary()
-	_ = yym283
+	yym293 := z.DecBinary()
+	_ = yym293
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl284 := r.ReadMapStart()
-			if yyl284 == 0 {
+			yyl294 := r.ReadMapStart()
+			if yyl294 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl284, d)
+				x.codecDecodeSelfFromMap(yyl294, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl284 := r.ReadArrayStart()
-			if yyl284 == 0 {
+			yyl294 := r.ReadArrayStart()
+			if yyl294 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl284, d)
+				x.codecDecodeSelfFromArray(yyl294, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3170,12 +3265,12 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys285Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys285Slc
-	var yyhl285 bool = l >= 0
-	for yyj285 := 0; ; yyj285++ {
-		if yyhl285 {
-			if yyj285 >= l {
+	var yys295Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys295Slc
+	var yyhl295 bool = l >= 0
+	for yyj295 := 0; ; yyj295++ {
+		if yyhl295 {
+			if yyj295 >= l {
 				break
 			}
 		} else {
@@ -3183,24 +3278,24 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys285Slc = r.DecodeBytes(yys285Slc, true, true)
-		yys285 := string(yys285Slc)
-		switch yys285 {
+		yys295Slc = r.DecodeBytes(yys295Slc, true, true)
+		yys295 := string(yys295Slc)
+		switch yys295 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv286 := &x.SampleTime
-				yym287 := z.DecBinary()
-				_ = yym287
+				yyv296 := &x.SampleTime
+				yym297 := z.DecBinary()
+				_ = yym297
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv286) {
-				} else if yym287 {
-					z.DecBinaryUnmarshal(yyv286)
-				} else if !yym287 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv286)
+				} else if z.HasExtensions() && z.DecExt(yyv296) {
+				} else if yym297 {
+					z.DecBinaryUnmarshal(yyv296)
+				} else if !yym297 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv296)
 				} else {
-					z.DecFallback(yyv286, false)
+					z.DecFallback(yyv296, false)
 				}
 			}
 		case "cpu":
@@ -3225,11 +3320,23 @@ func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 				x.Memory.CodecDecodeSelf(d)
 			}
+		case "filesystem":
+			if r.TryDecodeAsNil() {
+				x.Filesystem = nil
+			} else {
+				yyv300 := &x.Filesystem
+				yym301 := z.DecBinary()
+				_ = yym301
+				if false {
+				} else {
+					h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv300), d)
+				}
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys285)
-		} // end switch yys285
-	} // end for yyj285
-	if !yyhl285 {
+			z.DecStructFieldNotFound(-1, yys295)
+		} // end switch yys295
+	} // end for yyj295
+	if !yyhl295 {
 		r.ReadEnd()
 	}
 }
@@ -3238,42 +3345,42 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj290 int
-	var yyb290 bool
-	var yyhl290 bool = l >= 0
-	yyj290++
-	if yyhl290 {
-		yyb290 = yyj290 > l
+	var yyj302 int
+	var yyb302 bool
+	var yyhl302 bool = l >= 0
+	yyj302++
+	if yyhl302 {
+		yyb302 = yyj302 > l
 	} else {
-		yyb290 = r.CheckBreak()
+		yyb302 = r.CheckBreak()
 	}
-	if yyb290 {
+	if yyb302 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv291 := &x.SampleTime
-		yym292 := z.DecBinary()
-		_ = yym292
+		yyv303 := &x.SampleTime
+		yym304 := z.DecBinary()
+		_ = yym304
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv291) {
-		} else if yym292 {
-			z.DecBinaryUnmarshal(yyv291)
-		} else if !yym292 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv291)
+		} else if z.HasExtensions() && z.DecExt(yyv303) {
+		} else if yym304 {
+			z.DecBinaryUnmarshal(yyv303)
+		} else if !yym304 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv303)
 		} else {
-			z.DecFallback(yyv291, false)
+			z.DecFallback(yyv303, false)
 		}
 	}
-	yyj290++
-	if yyhl290 {
-		yyb290 = yyj290 > l
+	yyj302++
+	if yyhl302 {
+		yyb302 = yyj302 > l
 	} else {
-		yyb290 = r.CheckBreak()
+		yyb302 = r.CheckBreak()
 	}
-	if yyb290 {
+	if yyb302 {
 		r.ReadEnd()
 		return
 	}
@@ -3287,13 +3394,13 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.CPU.CodecDecodeSelf(d)
 	}
-	yyj290++
-	if yyhl290 {
-		yyb290 = yyj290 > l
+	yyj302++
+	if yyhl302 {
+		yyb302 = yyj302 > l
 	} else {
-		yyb290 = r.CheckBreak()
+		yyb302 = r.CheckBreak()
 	}
-	if yyb290 {
+	if yyb302 {
 		r.ReadEnd()
 		return
 	}
@@ -3307,17 +3414,38 @@ func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Memory.CodecDecodeSelf(d)
 	}
-	for {
-		yyj290++
-		if yyhl290 {
-			yyb290 = yyj290 > l
+	yyj302++
+	if yyhl302 {
+		yyb302 = yyj302 > l
+	} else {
+		yyb302 = r.CheckBreak()
+	}
+	if yyb302 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Filesystem = nil
+	} else {
+		yyv307 := &x.Filesystem
+		yym308 := z.DecBinary()
+		_ = yym308
+		if false {
 		} else {
-			yyb290 = r.CheckBreak()
+			h.decSliceFilesystemMetrics((*[]FilesystemMetrics)(yyv307), d)
 		}
-		if yyb290 {
+	}
+	for {
+		yyj302++
+		if yyhl302 {
+			yyb302 = yyj302 > l
+		} else {
+			yyb302 = r.CheckBreak()
+		}
+		if yyb302 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj290-1, "")
+		z.DecStructFieldNotFound(yyj302-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3329,41 +3457,41 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym295 := z.EncBinary()
-		_ = yym295
+		yym309 := z.EncBinary()
+		_ = yym309
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep296 := !z.EncBinary()
-			yy2arr296 := z.EncBasicHandle().StructToArray
-			var yyq296 [4]bool
-			_, _, _ = yysep296, yyq296, yy2arr296
-			const yyr296 bool = false
-			yyq296[0] = x.RxBytes != nil
-			yyq296[1] = x.RxErrors != nil
-			yyq296[2] = x.TxBytes != nil
-			yyq296[3] = x.TxErrors != nil
-			if yyr296 || yy2arr296 {
+			yysep310 := !z.EncBinary()
+			yy2arr310 := z.EncBasicHandle().StructToArray
+			var yyq310 [4]bool
+			_, _, _ = yysep310, yyq310, yy2arr310
+			const yyr310 bool = false
+			yyq310[0] = x.RxBytes != nil
+			yyq310[1] = x.RxErrors != nil
+			yyq310[2] = x.TxBytes != nil
+			yyq310[3] = x.TxErrors != nil
+			if yyr310 || yy2arr310 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn296 int = 0
-				for _, b := range yyq296 {
+				var yynn310 int = 0
+				for _, b := range yyq310 {
 					if b {
-						yynn296++
+						yynn310++
 					}
 				}
-				r.EncodeMapStart(yynn296)
+				r.EncodeMapStart(yynn310)
 			}
-			if yyr296 || yy2arr296 {
-				if yyq296[0] {
+			if yyr310 || yy2arr310 {
+				if yyq310[0] {
 					if x.RxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym298 := z.EncBinary()
-						_ = yym298
+						yym312 := z.EncBinary()
+						_ = yym312
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
-						} else if !yym298 && z.IsJSONHandle() {
+						} else if !yym312 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.RxBytes)
 						} else {
 							z.EncFallback(x.RxBytes)
@@ -3373,16 +3501,16 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq296[0] {
+				if yyq310[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("rxBytes"))
 					if x.RxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym299 := z.EncBinary()
-						_ = yym299
+						yym313 := z.EncBinary()
+						_ = yym313
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
-						} else if !yym299 && z.IsJSONHandle() {
+						} else if !yym313 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.RxBytes)
 						} else {
 							z.EncFallback(x.RxBytes)
@@ -3390,48 +3518,48 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr296 || yy2arr296 {
-				if yyq296[1] {
+			if yyr310 || yy2arr310 {
+				if yyq310[1] {
 					if x.RxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy301 := *x.RxErrors
-						yym302 := z.EncBinary()
-						_ = yym302
+						yy315 := *x.RxErrors
+						yym316 := z.EncBinary()
+						_ = yym316
 						if false {
 						} else {
-							r.EncodeInt(int64(yy301))
+							r.EncodeInt(int64(yy315))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq296[1] {
+				if yyq310[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rxErrors"))
 					if x.RxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy303 := *x.RxErrors
-						yym304 := z.EncBinary()
-						_ = yym304
+						yy317 := *x.RxErrors
+						yym318 := z.EncBinary()
+						_ = yym318
 						if false {
 						} else {
-							r.EncodeInt(int64(yy303))
+							r.EncodeInt(int64(yy317))
 						}
 					}
 				}
 			}
-			if yyr296 || yy2arr296 {
-				if yyq296[2] {
+			if yyr310 || yy2arr310 {
+				if yyq310[2] {
 					if x.TxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym306 := z.EncBinary()
-						_ = yym306
+						yym320 := z.EncBinary()
+						_ = yym320
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
-						} else if !yym306 && z.IsJSONHandle() {
+						} else if !yym320 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TxBytes)
 						} else {
 							z.EncFallback(x.TxBytes)
@@ -3441,16 +3569,16 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq296[2] {
+				if yyq310[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("txBytes"))
 					if x.TxBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym307 := z.EncBinary()
-						_ = yym307
+						yym321 := z.EncBinary()
+						_ = yym321
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
-						} else if !yym307 && z.IsJSONHandle() {
+						} else if !yym321 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TxBytes)
 						} else {
 							z.EncFallback(x.TxBytes)
@@ -3458,39 +3586,39 @@ func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr296 || yy2arr296 {
-				if yyq296[3] {
+			if yyr310 || yy2arr310 {
+				if yyq310[3] {
 					if x.TxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy309 := *x.TxErrors
-						yym310 := z.EncBinary()
-						_ = yym310
+						yy323 := *x.TxErrors
+						yym324 := z.EncBinary()
+						_ = yym324
 						if false {
 						} else {
-							r.EncodeInt(int64(yy309))
+							r.EncodeInt(int64(yy323))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq296[3] {
+				if yyq310[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("txErrors"))
 					if x.TxErrors == nil {
 						r.EncodeNil()
 					} else {
-						yy311 := *x.TxErrors
-						yym312 := z.EncBinary()
-						_ = yym312
+						yy325 := *x.TxErrors
+						yym326 := z.EncBinary()
+						_ = yym326
 						if false {
 						} else {
-							r.EncodeInt(int64(yy311))
+							r.EncodeInt(int64(yy325))
 						}
 					}
 				}
 			}
-			if yysep296 {
+			if yysep310 {
 				r.EncodeEnd()
 			}
 		}
@@ -3501,24 +3629,24 @@ func (x *NetworkMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym313 := z.DecBinary()
-	_ = yym313
+	yym327 := z.DecBinary()
+	_ = yym327
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl314 := r.ReadMapStart()
-			if yyl314 == 0 {
+			yyl328 := r.ReadMapStart()
+			if yyl328 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl314, d)
+				x.codecDecodeSelfFromMap(yyl328, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl314 := r.ReadArrayStart()
-			if yyl314 == 0 {
+			yyl328 := r.ReadArrayStart()
+			if yyl328 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl314, d)
+				x.codecDecodeSelfFromArray(yyl328, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3530,12 +3658,12 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys315Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys315Slc
-	var yyhl315 bool = l >= 0
-	for yyj315 := 0; ; yyj315++ {
-		if yyhl315 {
-			if yyj315 >= l {
+	var yys329Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys329Slc
+	var yyhl329 bool = l >= 0
+	for yyj329 := 0; ; yyj329++ {
+		if yyhl329 {
+			if yyj329 >= l {
 				break
 			}
 		} else {
@@ -3543,9 +3671,9 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys315Slc = r.DecodeBytes(yys315Slc, true, true)
-		yys315 := string(yys315Slc)
-		switch yys315 {
+		yys329Slc = r.DecodeBytes(yys329Slc, true, true)
+		yys329 := string(yys329Slc)
+		switch yys329 {
 		case "rxBytes":
 			if r.TryDecodeAsNil() {
 				if x.RxBytes != nil {
@@ -3555,11 +3683,11 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RxBytes == nil {
 					x.RxBytes = new(pkg2_resource.Quantity)
 				}
-				yym317 := z.DecBinary()
-				_ = yym317
+				yym331 := z.DecBinary()
+				_ = yym331
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
-				} else if !yym317 && z.IsJSONHandle() {
+				} else if !yym331 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.RxBytes)
 				} else {
 					z.DecFallback(x.RxBytes, false)
@@ -3574,8 +3702,8 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RxErrors == nil {
 					x.RxErrors = new(int64)
 				}
-				yym319 := z.DecBinary()
-				_ = yym319
+				yym333 := z.DecBinary()
+				_ = yym333
 				if false {
 				} else {
 					*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
@@ -3590,11 +3718,11 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TxBytes == nil {
 					x.TxBytes = new(pkg2_resource.Quantity)
 				}
-				yym321 := z.DecBinary()
-				_ = yym321
+				yym335 := z.DecBinary()
+				_ = yym335
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
-				} else if !yym321 && z.IsJSONHandle() {
+				} else if !yym335 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TxBytes)
 				} else {
 					z.DecFallback(x.TxBytes, false)
@@ -3609,18 +3737,18 @@ func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TxErrors == nil {
 					x.TxErrors = new(int64)
 				}
-				yym323 := z.DecBinary()
-				_ = yym323
+				yym337 := z.DecBinary()
+				_ = yym337
 				if false {
 				} else {
 					*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys315)
-		} // end switch yys315
-	} // end for yyj315
-	if !yyhl315 {
+			z.DecStructFieldNotFound(-1, yys329)
+		} // end switch yys329
+	} // end for yyj329
+	if !yyhl329 {
 		r.ReadEnd()
 	}
 }
@@ -3629,16 +3757,16 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj324 int
-	var yyb324 bool
-	var yyhl324 bool = l >= 0
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	var yyj338 int
+	var yyb338 bool
+	var yyhl338 bool = l >= 0
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb338 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb338 {
 		r.ReadEnd()
 		return
 	}
@@ -3650,23 +3778,23 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RxBytes == nil {
 			x.RxBytes = new(pkg2_resource.Quantity)
 		}
-		yym326 := z.DecBinary()
-		_ = yym326
+		yym340 := z.DecBinary()
+		_ = yym340
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
-		} else if !yym326 && z.IsJSONHandle() {
+		} else if !yym340 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.RxBytes)
 		} else {
 			z.DecFallback(x.RxBytes, false)
 		}
 	}
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb338 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb338 {
 		r.ReadEnd()
 		return
 	}
@@ -3678,20 +3806,20 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RxErrors == nil {
 			x.RxErrors = new(int64)
 		}
-		yym328 := z.DecBinary()
-		_ = yym328
+		yym342 := z.DecBinary()
+		_ = yym342
 		if false {
 		} else {
 			*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb338 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb338 {
 		r.ReadEnd()
 		return
 	}
@@ -3703,23 +3831,23 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TxBytes == nil {
 			x.TxBytes = new(pkg2_resource.Quantity)
 		}
-		yym330 := z.DecBinary()
-		_ = yym330
+		yym344 := z.DecBinary()
+		_ = yym344
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
-		} else if !yym330 && z.IsJSONHandle() {
+		} else if !yym344 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TxBytes)
 		} else {
 			z.DecFallback(x.TxBytes, false)
 		}
 	}
-	yyj324++
-	if yyhl324 {
-		yyb324 = yyj324 > l
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
 	} else {
-		yyb324 = r.CheckBreak()
+		yyb338 = r.CheckBreak()
 	}
-	if yyb324 {
+	if yyb338 {
 		r.ReadEnd()
 		return
 	}
@@ -3731,24 +3859,24 @@ func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TxErrors == nil {
 			x.TxErrors = new(int64)
 		}
-		yym332 := z.DecBinary()
-		_ = yym332
+		yym346 := z.DecBinary()
+		_ = yym346
 		if false {
 		} else {
 			*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj324++
-		if yyhl324 {
-			yyb324 = yyj324 > l
+		yyj338++
+		if yyhl338 {
+			yyb338 = yyj338 > l
 		} else {
-			yyb324 = r.CheckBreak()
+			yyb338 = r.CheckBreak()
 		}
-		if yyb324 {
+		if yyb338 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj324-1, "")
+		z.DecStructFieldNotFound(yyj338-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3760,39 +3888,39 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym333 := z.EncBinary()
-		_ = yym333
+		yym347 := z.EncBinary()
+		_ = yym347
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep334 := !z.EncBinary()
-			yy2arr334 := z.EncBasicHandle().StructToArray
-			var yyq334 [2]bool
-			_, _, _ = yysep334, yyq334, yy2arr334
-			const yyr334 bool = false
-			yyq334[0] = x.TotalCores != nil
-			yyq334[1] = x.LoadAverage != nil
-			if yyr334 || yy2arr334 {
+			yysep348 := !z.EncBinary()
+			yy2arr348 := z.EncBasicHandle().StructToArray
+			var yyq348 [2]bool
+			_, _, _ = yysep348, yyq348, yy2arr348
+			const yyr348 bool = false
+			yyq348[0] = x.TotalCores != nil
+			yyq348[1] = x.LoadAverage != nil
+			if yyr348 || yy2arr348 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn334 int = 0
-				for _, b := range yyq334 {
+				var yynn348 int = 0
+				for _, b := range yyq348 {
 					if b {
-						yynn334++
+						yynn348++
 					}
 				}
-				r.EncodeMapStart(yynn334)
+				r.EncodeMapStart(yynn348)
 			}
-			if yyr334 || yy2arr334 {
-				if yyq334[0] {
+			if yyr348 || yy2arr348 {
+				if yyq348[0] {
 					if x.TotalCores == nil {
 						r.EncodeNil()
 					} else {
-						yym336 := z.EncBinary()
-						_ = yym336
+						yym350 := z.EncBinary()
+						_ = yym350
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
-						} else if !yym336 && z.IsJSONHandle() {
+						} else if !yym350 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalCores)
 						} else {
 							z.EncFallback(x.TotalCores)
@@ -3802,16 +3930,16 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq334[0] {
+				if yyq348[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalCores"))
 					if x.TotalCores == nil {
 						r.EncodeNil()
 					} else {
-						yym337 := z.EncBinary()
-						_ = yym337
+						yym351 := z.EncBinary()
+						_ = yym351
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
-						} else if !yym337 && z.IsJSONHandle() {
+						} else if !yym351 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalCores)
 						} else {
 							z.EncFallback(x.TotalCores)
@@ -3819,16 +3947,16 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr334 || yy2arr334 {
-				if yyq334[1] {
+			if yyr348 || yy2arr348 {
+				if yyq348[1] {
 					if x.LoadAverage == nil {
 						r.EncodeNil()
 					} else {
-						yym339 := z.EncBinary()
-						_ = yym339
+						yym353 := z.EncBinary()
+						_ = yym353
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
-						} else if !yym339 && z.IsJSONHandle() {
+						} else if !yym353 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LoadAverage)
 						} else {
 							z.EncFallback(x.LoadAverage)
@@ -3838,16 +3966,16 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq334[1] {
+				if yyq348[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadAverage"))
 					if x.LoadAverage == nil {
 						r.EncodeNil()
 					} else {
-						yym340 := z.EncBinary()
-						_ = yym340
+						yym354 := z.EncBinary()
+						_ = yym354
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
-						} else if !yym340 && z.IsJSONHandle() {
+						} else if !yym354 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LoadAverage)
 						} else {
 							z.EncFallback(x.LoadAverage)
@@ -3855,7 +3983,7 @@ func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep334 {
+			if yysep348 {
 				r.EncodeEnd()
 			}
 		}
@@ -3866,24 +3994,24 @@ func (x *CPUMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym341 := z.DecBinary()
-	_ = yym341
+	yym355 := z.DecBinary()
+	_ = yym355
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl342 := r.ReadMapStart()
-			if yyl342 == 0 {
+			yyl356 := r.ReadMapStart()
+			if yyl356 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl342, d)
+				x.codecDecodeSelfFromMap(yyl356, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl342 := r.ReadArrayStart()
-			if yyl342 == 0 {
+			yyl356 := r.ReadArrayStart()
+			if yyl356 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl342, d)
+				x.codecDecodeSelfFromArray(yyl356, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3895,12 +4023,12 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys343Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys343Slc
-	var yyhl343 bool = l >= 0
-	for yyj343 := 0; ; yyj343++ {
-		if yyhl343 {
-			if yyj343 >= l {
+	var yys357Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys357Slc
+	var yyhl357 bool = l >= 0
+	for yyj357 := 0; ; yyj357++ {
+		if yyhl357 {
+			if yyj357 >= l {
 				break
 			}
 		} else {
@@ -3908,9 +4036,9 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
-		yys343 := string(yys343Slc)
-		switch yys343 {
+		yys357Slc = r.DecodeBytes(yys357Slc, true, true)
+		yys357 := string(yys357Slc)
+		switch yys357 {
 		case "totalCores":
 			if r.TryDecodeAsNil() {
 				if x.TotalCores != nil {
@@ -3920,11 +4048,11 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalCores == nil {
 					x.TotalCores = new(pkg2_resource.Quantity)
 				}
-				yym345 := z.DecBinary()
-				_ = yym345
+				yym359 := z.DecBinary()
+				_ = yym359
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-				} else if !yym345 && z.IsJSONHandle() {
+				} else if !yym359 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalCores)
 				} else {
 					z.DecFallback(x.TotalCores, false)
@@ -3939,21 +4067,21 @@ func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.LoadAverage == nil {
 					x.LoadAverage = new(pkg2_resource.Quantity)
 				}
-				yym347 := z.DecBinary()
-				_ = yym347
+				yym361 := z.DecBinary()
+				_ = yym361
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
-				} else if !yym347 && z.IsJSONHandle() {
+				} else if !yym361 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LoadAverage)
 				} else {
 					z.DecFallback(x.LoadAverage, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys343)
-		} // end switch yys343
-	} // end for yyj343
-	if !yyhl343 {
+			z.DecStructFieldNotFound(-1, yys357)
+		} // end switch yys357
+	} // end for yyj357
+	if !yyhl357 {
 		r.ReadEnd()
 	}
 }
@@ -3962,16 +4090,16 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj348 int
-	var yyb348 bool
-	var yyhl348 bool = l >= 0
-	yyj348++
-	if yyhl348 {
-		yyb348 = yyj348 > l
+	var yyj362 int
+	var yyb362 bool
+	var yyhl362 bool = l >= 0
+	yyj362++
+	if yyhl362 {
+		yyb362 = yyj362 > l
 	} else {
-		yyb348 = r.CheckBreak()
+		yyb362 = r.CheckBreak()
 	}
-	if yyb348 {
+	if yyb362 {
 		r.ReadEnd()
 		return
 	}
@@ -3983,23 +4111,23 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalCores == nil {
 			x.TotalCores = new(pkg2_resource.Quantity)
 		}
-		yym350 := z.DecBinary()
-		_ = yym350
+		yym364 := z.DecBinary()
+		_ = yym364
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
-		} else if !yym350 && z.IsJSONHandle() {
+		} else if !yym364 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalCores)
 		} else {
 			z.DecFallback(x.TotalCores, false)
 		}
 	}
-	yyj348++
-	if yyhl348 {
-		yyb348 = yyj348 > l
+	yyj362++
+	if yyhl362 {
+		yyb362 = yyj362 > l
 	} else {
-		yyb348 = r.CheckBreak()
+		yyb362 = r.CheckBreak()
 	}
-	if yyb348 {
+	if yyb362 {
 		r.ReadEnd()
 		return
 	}
@@ -4011,27 +4139,27 @@ func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.LoadAverage == nil {
 			x.LoadAverage = new(pkg2_resource.Quantity)
 		}
-		yym352 := z.DecBinary()
-		_ = yym352
+		yym366 := z.DecBinary()
+		_ = yym366
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
-		} else if !yym352 && z.IsJSONHandle() {
+		} else if !yym366 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LoadAverage)
 		} else {
 			z.DecFallback(x.LoadAverage, false)
 		}
 	}
 	for {
-		yyj348++
-		if yyhl348 {
-			yyb348 = yyj348 > l
+		yyj362++
+		if yyhl362 {
+			yyb362 = yyj362 > l
 		} else {
-			yyb348 = r.CheckBreak()
+			yyb362 = r.CheckBreak()
 		}
-		if yyb348 {
+		if yyb362 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj348-1, "")
+		z.DecStructFieldNotFound(yyj362-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4043,41 +4171,41 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym353 := z.EncBinary()
-		_ = yym353
+		yym367 := z.EncBinary()
+		_ = yym367
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep354 := !z.EncBinary()
-			yy2arr354 := z.EncBasicHandle().StructToArray
-			var yyq354 [4]bool
-			_, _, _ = yysep354, yyq354, yy2arr354
-			const yyr354 bool = false
-			yyq354[0] = x.TotalBytes != nil
-			yyq354[1] = x.UsageBytes != nil
-			yyq354[2] = x.PageFaults != nil
-			yyq354[3] = x.MajorPageFaults != nil
-			if yyr354 || yy2arr354 {
+			yysep368 := !z.EncBinary()
+			yy2arr368 := z.EncBasicHandle().StructToArray
+			var yyq368 [4]bool
+			_, _, _ = yysep368, yyq368, yy2arr368
+			const yyr368 bool = false
+			yyq368[0] = x.TotalBytes != nil
+			yyq368[1] = x.UsageBytes != nil
+			yyq368[2] = x.PageFaults != nil
+			yyq368[3] = x.MajorPageFaults != nil
+			if yyr368 || yy2arr368 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn354 int = 0
-				for _, b := range yyq354 {
+				var yynn368 int = 0
+				for _, b := range yyq368 {
 					if b {
-						yynn354++
+						yynn368++
 					}
 				}
-				r.EncodeMapStart(yynn354)
+				r.EncodeMapStart(yynn368)
 			}
-			if yyr354 || yy2arr354 {
-				if yyq354[0] {
+			if yyr368 || yy2arr368 {
+				if yyq368[0] {
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym356 := z.EncBinary()
-						_ = yym356
+						yym370 := z.EncBinary()
+						_ = yym370
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym356 && z.IsJSONHandle() {
+						} else if !yym370 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4087,16 +4215,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq354[0] {
+				if yyq368[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("totalBytes"))
 					if x.TotalBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym357 := z.EncBinary()
-						_ = yym357
+						yym371 := z.EncBinary()
+						_ = yym371
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
-						} else if !yym357 && z.IsJSONHandle() {
+						} else if !yym371 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.TotalBytes)
 						} else {
 							z.EncFallback(x.TotalBytes)
@@ -4104,16 +4232,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr354 || yy2arr354 {
-				if yyq354[1] {
+			if yyr368 || yy2arr368 {
+				if yyq368[1] {
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym359 := z.EncBinary()
-						_ = yym359
+						yym373 := z.EncBinary()
+						_ = yym373
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym359 && z.IsJSONHandle() {
+						} else if !yym373 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4123,16 +4251,16 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq354[1] {
+				if yyq368[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
 					if x.UsageBytes == nil {
 						r.EncodeNil()
 					} else {
-						yym360 := z.EncBinary()
-						_ = yym360
+						yym374 := z.EncBinary()
+						_ = yym374
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
-						} else if !yym360 && z.IsJSONHandle() {
+						} else if !yym374 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UsageBytes)
 						} else {
 							z.EncFallback(x.UsageBytes)
@@ -4140,71 +4268,71 @@ func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr354 || yy2arr354 {
-				if yyq354[2] {
+			if yyr368 || yy2arr368 {
+				if yyq368[2] {
 					if x.PageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy362 := *x.PageFaults
-						yym363 := z.EncBinary()
-						_ = yym363
+						yy376 := *x.PageFaults
+						yym377 := z.EncBinary()
+						_ = yym377
 						if false {
 						} else {
-							r.EncodeInt(int64(yy362))
+							r.EncodeInt(int64(yy376))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq354[2] {
+				if yyq368[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
 					if x.PageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy364 := *x.PageFaults
-						yym365 := z.EncBinary()
-						_ = yym365
+						yy378 := *x.PageFaults
+						yym379 := z.EncBinary()
+						_ = yym379
 						if false {
 						} else {
-							r.EncodeInt(int64(yy364))
+							r.EncodeInt(int64(yy378))
 						}
 					}
 				}
 			}
-			if yyr354 || yy2arr354 {
-				if yyq354[3] {
+			if yyr368 || yy2arr368 {
+				if yyq368[3] {
 					if x.MajorPageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy367 := *x.MajorPageFaults
-						yym368 := z.EncBinary()
-						_ = yym368
+						yy381 := *x.MajorPageFaults
+						yym382 := z.EncBinary()
+						_ = yym382
 						if false {
 						} else {
-							r.EncodeInt(int64(yy367))
+							r.EncodeInt(int64(yy381))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq354[3] {
+				if yyq368[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
 					if x.MajorPageFaults == nil {
 						r.EncodeNil()
 					} else {
-						yy369 := *x.MajorPageFaults
-						yym370 := z.EncBinary()
-						_ = yym370
+						yy383 := *x.MajorPageFaults
+						yym384 := z.EncBinary()
+						_ = yym384
 						if false {
 						} else {
-							r.EncodeInt(int64(yy369))
+							r.EncodeInt(int64(yy383))
 						}
 					}
 				}
 			}
-			if yysep354 {
+			if yysep368 {
 				r.EncodeEnd()
 			}
 		}
@@ -4215,24 +4343,24 @@ func (x *MemoryMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym371 := z.DecBinary()
-	_ = yym371
+	yym385 := z.DecBinary()
+	_ = yym385
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl372 := r.ReadMapStart()
-			if yyl372 == 0 {
+			yyl386 := r.ReadMapStart()
+			if yyl386 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl372, d)
+				x.codecDecodeSelfFromMap(yyl386, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl372 := r.ReadArrayStart()
-			if yyl372 == 0 {
+			yyl386 := r.ReadArrayStart()
+			if yyl386 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl372, d)
+				x.codecDecodeSelfFromArray(yyl386, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4244,12 +4372,12 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys373Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys373Slc
-	var yyhl373 bool = l >= 0
-	for yyj373 := 0; ; yyj373++ {
-		if yyhl373 {
-			if yyj373 >= l {
+	var yys387Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys387Slc
+	var yyhl387 bool = l >= 0
+	for yyj387 := 0; ; yyj387++ {
+		if yyhl387 {
+			if yyj387 >= l {
 				break
 			}
 		} else {
@@ -4257,9 +4385,9 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys373Slc = r.DecodeBytes(yys373Slc, true, true)
-		yys373 := string(yys373Slc)
-		switch yys373 {
+		yys387Slc = r.DecodeBytes(yys387Slc, true, true)
+		yys387 := string(yys387Slc)
+		switch yys387 {
 		case "totalBytes":
 			if r.TryDecodeAsNil() {
 				if x.TotalBytes != nil {
@@ -4269,11 +4397,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TotalBytes == nil {
 					x.TotalBytes = new(pkg2_resource.Quantity)
 				}
-				yym375 := z.DecBinary()
-				_ = yym375
+				yym389 := z.DecBinary()
+				_ = yym389
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-				} else if !yym375 && z.IsJSONHandle() {
+				} else if !yym389 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.TotalBytes)
 				} else {
 					z.DecFallback(x.TotalBytes, false)
@@ -4288,11 +4416,11 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.UsageBytes == nil {
 					x.UsageBytes = new(pkg2_resource.Quantity)
 				}
-				yym377 := z.DecBinary()
-				_ = yym377
+				yym391 := z.DecBinary()
+				_ = yym391
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-				} else if !yym377 && z.IsJSONHandle() {
+				} else if !yym391 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UsageBytes)
 				} else {
 					z.DecFallback(x.UsageBytes, false)
@@ -4307,8 +4435,8 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.PageFaults == nil {
 					x.PageFaults = new(int64)
 				}
-				yym379 := z.DecBinary()
-				_ = yym379
+				yym393 := z.DecBinary()
+				_ = yym393
 				if false {
 				} else {
 					*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
@@ -4323,18 +4451,18 @@ func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.MajorPageFaults == nil {
 					x.MajorPageFaults = new(int64)
 				}
-				yym381 := z.DecBinary()
-				_ = yym381
+				yym395 := z.DecBinary()
+				_ = yym395
 				if false {
 				} else {
 					*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys373)
-		} // end switch yys373
-	} // end for yyj373
-	if !yyhl373 {
+			z.DecStructFieldNotFound(-1, yys387)
+		} // end switch yys387
+	} // end for yyj387
+	if !yyhl387 {
 		r.ReadEnd()
 	}
 }
@@ -4343,16 +4471,16 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj382 int
-	var yyb382 bool
-	var yyhl382 bool = l >= 0
-	yyj382++
-	if yyhl382 {
-		yyb382 = yyj382 > l
+	var yyj396 int
+	var yyb396 bool
+	var yyhl396 bool = l >= 0
+	yyj396++
+	if yyhl396 {
+		yyb396 = yyj396 > l
 	} else {
-		yyb382 = r.CheckBreak()
+		yyb396 = r.CheckBreak()
 	}
-	if yyb382 {
+	if yyb396 {
 		r.ReadEnd()
 		return
 	}
@@ -4364,23 +4492,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TotalBytes == nil {
 			x.TotalBytes = new(pkg2_resource.Quantity)
 		}
-		yym384 := z.DecBinary()
-		_ = yym384
+		yym398 := z.DecBinary()
+		_ = yym398
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
-		} else if !yym384 && z.IsJSONHandle() {
+		} else if !yym398 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.TotalBytes)
 		} else {
 			z.DecFallback(x.TotalBytes, false)
 		}
 	}
-	yyj382++
-	if yyhl382 {
-		yyb382 = yyj382 > l
+	yyj396++
+	if yyhl396 {
+		yyb396 = yyj396 > l
 	} else {
-		yyb382 = r.CheckBreak()
+		yyb396 = r.CheckBreak()
 	}
-	if yyb382 {
+	if yyb396 {
 		r.ReadEnd()
 		return
 	}
@@ -4392,23 +4520,23 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.UsageBytes == nil {
 			x.UsageBytes = new(pkg2_resource.Quantity)
 		}
-		yym386 := z.DecBinary()
-		_ = yym386
+		yym400 := z.DecBinary()
+		_ = yym400
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
-		} else if !yym386 && z.IsJSONHandle() {
+		} else if !yym400 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UsageBytes)
 		} else {
 			z.DecFallback(x.UsageBytes, false)
 		}
 	}
-	yyj382++
-	if yyhl382 {
-		yyb382 = yyj382 > l
+	yyj396++
+	if yyhl396 {
+		yyb396 = yyj396 > l
 	} else {
-		yyb382 = r.CheckBreak()
+		yyb396 = r.CheckBreak()
 	}
-	if yyb382 {
+	if yyb396 {
 		r.ReadEnd()
 		return
 	}
@@ -4420,20 +4548,20 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.PageFaults == nil {
 			x.PageFaults = new(int64)
 		}
-		yym388 := z.DecBinary()
-		_ = yym388
+		yym402 := z.DecBinary()
+		_ = yym402
 		if false {
 		} else {
 			*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj382++
-	if yyhl382 {
-		yyb382 = yyj382 > l
+	yyj396++
+	if yyhl396 {
+		yyb396 = yyj396 > l
 	} else {
-		yyb382 = r.CheckBreak()
+		yyb396 = r.CheckBreak()
 	}
-	if yyb382 {
+	if yyb396 {
 		r.ReadEnd()
 		return
 	}
@@ -4445,24 +4573,344 @@ func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.MajorPageFaults == nil {
 			x.MajorPageFaults = new(int64)
 		}
-		yym390 := z.DecBinary()
-		_ = yym390
+		yym404 := z.DecBinary()
+		_ = yym404
 		if false {
 		} else {
 			*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj382++
-		if yyhl382 {
-			yyb382 = yyj382 > l
+		yyj396++
+		if yyhl396 {
+			yyb396 = yyj396 > l
 		} else {
-			yyb382 = r.CheckBreak()
+			yyb396 = r.CheckBreak()
 		}
-		if yyb382 {
+		if yyb396 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj382-1, "")
+		z.DecStructFieldNotFound(yyj396-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *FilesystemMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym405 := z.EncBinary()
+		_ = yym405
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep406 := !z.EncBinary()
+			yy2arr406 := z.EncBasicHandle().StructToArray
+			var yyq406 [3]bool
+			_, _, _ = yysep406, yyq406, yy2arr406
+			const yyr406 bool = false
+			yyq406[1] = x.UsageBytes != nil
+			yyq406[2] = x.LimitBytes != nil
+			if yyr406 || yy2arr406 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn406 int = 1
+				for _, b := range yyq406 {
+					if b {
+						yynn406++
+					}
+				}
+				r.EncodeMapStart(yynn406)
+			}
+			if yyr406 || yy2arr406 {
+				yym408 := z.EncBinary()
+				_ = yym408
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("device"))
+				yym409 := z.EncBinary()
+				_ = yym409
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Device))
+				}
+			}
+			if yyr406 || yy2arr406 {
+				if yyq406[1] {
+					if x.UsageBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym411 := z.EncBinary()
+						_ = yym411
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
+						} else if !yym411 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UsageBytes)
+						} else {
+							z.EncFallback(x.UsageBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq406[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
+					if x.UsageBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym412 := z.EncBinary()
+						_ = yym412
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
+						} else if !yym412 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UsageBytes)
+						} else {
+							z.EncFallback(x.UsageBytes)
+						}
+					}
+				}
+			}
+			if yyr406 || yy2arr406 {
+				if yyq406[2] {
+					if x.LimitBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym414 := z.EncBinary()
+						_ = yym414
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
+						} else if !yym414 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.LimitBytes)
+						} else {
+							z.EncFallback(x.LimitBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq406[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
+					if x.LimitBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym415 := z.EncBinary()
+						_ = yym415
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.LimitBytes) {
+						} else if !yym415 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.LimitBytes)
+						} else {
+							z.EncFallback(x.LimitBytes)
+						}
+					}
+				}
+			}
+			if yysep406 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *FilesystemMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym416 := z.DecBinary()
+	_ = yym416
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl417 := r.ReadMapStart()
+			if yyl417 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl417, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl417 := r.ReadArrayStart()
+			if yyl417 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl417, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *FilesystemMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys418Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys418Slc
+	var yyhl418 bool = l >= 0
+	for yyj418 := 0; ; yyj418++ {
+		if yyhl418 {
+			if yyj418 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys418Slc = r.DecodeBytes(yys418Slc, true, true)
+		yys418 := string(yys418Slc)
+		switch yys418 {
+		case "device":
+			if r.TryDecodeAsNil() {
+				x.Device = ""
+			} else {
+				x.Device = string(r.DecodeString())
+			}
+		case "usageBytes":
+			if r.TryDecodeAsNil() {
+				if x.UsageBytes != nil {
+					x.UsageBytes = nil
+				}
+			} else {
+				if x.UsageBytes == nil {
+					x.UsageBytes = new(pkg2_resource.Quantity)
+				}
+				yym421 := z.DecBinary()
+				_ = yym421
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
+				} else if !yym421 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.UsageBytes)
+				} else {
+					z.DecFallback(x.UsageBytes, false)
+				}
+			}
+		case "limitBytes":
+			if r.TryDecodeAsNil() {
+				if x.LimitBytes != nil {
+					x.LimitBytes = nil
+				}
+			} else {
+				if x.LimitBytes == nil {
+					x.LimitBytes = new(pkg2_resource.Quantity)
+				}
+				yym423 := z.DecBinary()
+				_ = yym423
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
+				} else if !yym423 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.LimitBytes)
+				} else {
+					z.DecFallback(x.LimitBytes, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys418)
+		} // end switch yys418
+	} // end for yyj418
+	if !yyhl418 {
+		r.ReadEnd()
+	}
+}
+
+func (x *FilesystemMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj424 int
+	var yyb424 bool
+	var yyhl424 bool = l >= 0
+	yyj424++
+	if yyhl424 {
+		yyb424 = yyj424 > l
+	} else {
+		yyb424 = r.CheckBreak()
+	}
+	if yyb424 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Device = ""
+	} else {
+		x.Device = string(r.DecodeString())
+	}
+	yyj424++
+	if yyhl424 {
+		yyb424 = yyj424 > l
+	} else {
+		yyb424 = r.CheckBreak()
+	}
+	if yyb424 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.UsageBytes != nil {
+			x.UsageBytes = nil
+		}
+	} else {
+		if x.UsageBytes == nil {
+			x.UsageBytes = new(pkg2_resource.Quantity)
+		}
+		yym427 := z.DecBinary()
+		_ = yym427
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
+		} else if !yym427 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.UsageBytes)
+		} else {
+			z.DecFallback(x.UsageBytes, false)
+		}
+	}
+	yyj424++
+	if yyhl424 {
+		yyb424 = yyj424 > l
+	} else {
+		yyb424 = r.CheckBreak()
+	}
+	if yyb424 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.LimitBytes != nil {
+			x.LimitBytes = nil
+		}
+	} else {
+		if x.LimitBytes == nil {
+			x.LimitBytes = new(pkg2_resource.Quantity)
+		}
+		yym429 := z.DecBinary()
+		_ = yym429
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.LimitBytes) {
+		} else if !yym429 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.LimitBytes)
+		} else {
+			z.DecFallback(x.LimitBytes, false)
+		}
+	}
+	for {
+		yyj424++
+		if yyhl424 {
+			yyb424 = yyj424 > l
+		} else {
+			yyb424 = r.CheckBreak()
+		}
+		if yyb424 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj424-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4471,8 +4919,8 @@ func (x CustomMetricType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym391 := z.EncBinary()
-	_ = yym391
+	yym430 := z.EncBinary()
+	_ = yym430
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -4484,8 +4932,8 @@ func (x *CustomMetricType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym392 := z.DecBinary()
-	_ = yym392
+	yym431 := z.DecBinary()
+	_ = yym431
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -4500,73 +4948,73 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym393 := z.EncBinary()
-		_ = yym393
+		yym432 := z.EncBinary()
+		_ = yym432
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep394 := !z.EncBinary()
-			yy2arr394 := z.EncBasicHandle().StructToArray
-			var yyq394 [4]bool
-			_, _, _ = yysep394, yyq394, yy2arr394
-			const yyr394 bool = false
-			yyq394[3] = len(x.Samples) != 0
-			if yyr394 || yy2arr394 {
+			yysep433 := !z.EncBinary()
+			yy2arr433 := z.EncBasicHandle().StructToArray
+			var yyq433 [4]bool
+			_, _, _ = yysep433, yyq433, yy2arr433
+			const yyr433 bool = false
+			yyq433[3] = len(x.Samples) != 0
+			if yyr433 || yy2arr433 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn394 int = 3
-				for _, b := range yyq394 {
+				var yynn433 int = 3
+				for _, b := range yyq433 {
 					if b {
-						yynn394++
+						yynn433++
 					}
 				}
-				r.EncodeMapStart(yynn394)
+				r.EncodeMapStart(yynn433)
 			}
-			if yyr394 || yy2arr394 {
-				yym396 := z.EncBinary()
-				_ = yym396
+			if yyr433 || yy2arr433 {
+				yym435 := z.EncBinary()
+				_ = yym435
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
-				yym397 := z.EncBinary()
-				_ = yym397
+				yym436 := z.EncBinary()
+				_ = yym436
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yyr394 || yy2arr394 {
+			if yyr433 || yy2arr433 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr394 || yy2arr394 {
-				yym400 := z.EncBinary()
-				_ = yym400
+			if yyr433 || yy2arr433 {
+				yym439 := z.EncBinary()
+				_ = yym439
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("unit"))
-				yym401 := z.EncBinary()
-				_ = yym401
+				yym440 := z.EncBinary()
+				_ = yym440
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
 				}
 			}
-			if yyr394 || yy2arr394 {
-				if yyq394[3] {
+			if yyr433 || yy2arr433 {
+				if yyq433[3] {
 					if x.Samples == nil {
 						r.EncodeNil()
 					} else {
-						yym403 := z.EncBinary()
-						_ = yym403
+						yym442 := z.EncBinary()
+						_ = yym442
 						if false {
 						} else {
 							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
@@ -4576,13 +5024,13 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq394[3] {
+				if yyq433[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("samples"))
 					if x.Samples == nil {
 						r.EncodeNil()
 					} else {
-						yym404 := z.EncBinary()
-						_ = yym404
+						yym443 := z.EncBinary()
+						_ = yym443
 						if false {
 						} else {
 							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
@@ -4590,7 +5038,7 @@ func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep394 {
+			if yysep433 {
 				r.EncodeEnd()
 			}
 		}
@@ -4601,24 +5049,24 @@ func (x *CustomMetric) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym405 := z.DecBinary()
-	_ = yym405
+	yym444 := z.DecBinary()
+	_ = yym444
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl406 := r.ReadMapStart()
-			if yyl406 == 0 {
+			yyl445 := r.ReadMapStart()
+			if yyl445 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl406, d)
+				x.codecDecodeSelfFromMap(yyl445, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl406 := r.ReadArrayStart()
-			if yyl406 == 0 {
+			yyl445 := r.ReadArrayStart()
+			if yyl445 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl406, d)
+				x.codecDecodeSelfFromArray(yyl445, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4630,12 +5078,12 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys407Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys407Slc
-	var yyhl407 bool = l >= 0
-	for yyj407 := 0; ; yyj407++ {
-		if yyhl407 {
-			if yyj407 >= l {
+	var yys446Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys446Slc
+	var yyhl446 bool = l >= 0
+	for yyj446 := 0; ; yyj446++ {
+		if yyhl446 {
+			if yyj446 >= l {
 				break
 			}
 		} else {
@@ -4643,9 +5091,9 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys407Slc = r.DecodeBytes(yys407Slc, true, true)
-		yys407 := string(yys407Slc)
-		switch yys407 {
+		yys446Slc = r.DecodeBytes(yys446Slc, true, true)
+		yys446 := string(yys446Slc)
+		switch yys446 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -4668,19 +5116,19 @@ func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Samples = nil
 			} else {
-				yyv411 := &x.Samples
-				yym412 := z.DecBinary()
-				_ = yym412
+				yyv450 := &x.Samples
+				yym451 := z.DecBinary()
+				_ = yym451
 				if false {
 				} else {
-					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv411), d)
+					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv450), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys407)
-		} // end switch yys407
-	} // end for yyj407
-	if !yyhl407 {
+			z.DecStructFieldNotFound(-1, yys446)
+		} // end switch yys446
+	} // end for yyj446
+	if !yyhl446 {
 		r.ReadEnd()
 	}
 }
@@ -4689,16 +5137,16 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj413 int
-	var yyb413 bool
-	var yyhl413 bool = l >= 0
-	yyj413++
-	if yyhl413 {
-		yyb413 = yyj413 > l
+	var yyj452 int
+	var yyb452 bool
+	var yyhl452 bool = l >= 0
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb413 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb413 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
@@ -4707,13 +5155,13 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj413++
-	if yyhl413 {
-		yyb413 = yyj413 > l
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb413 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb413 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
@@ -4722,13 +5170,13 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = CustomMetricType(r.DecodeString())
 	}
-	yyj413++
-	if yyhl413 {
-		yyb413 = yyj413 > l
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb413 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb413 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
@@ -4737,38 +5185,38 @@ func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Unit = string(r.DecodeString())
 	}
-	yyj413++
-	if yyhl413 {
-		yyb413 = yyj413 > l
+	yyj452++
+	if yyhl452 {
+		yyb452 = yyj452 > l
 	} else {
-		yyb413 = r.CheckBreak()
+		yyb452 = r.CheckBreak()
 	}
-	if yyb413 {
+	if yyb452 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Samples = nil
 	} else {
-		yyv417 := &x.Samples
-		yym418 := z.DecBinary()
-		_ = yym418
+		yyv456 := &x.Samples
+		yym457 := z.DecBinary()
+		_ = yym457
 		if false {
 		} else {
-			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv417), d)
+			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv456), d)
 		}
 	}
 	for {
-		yyj413++
-		if yyhl413 {
-			yyb413 = yyj413 > l
+		yyj452++
+		if yyhl452 {
+			yyb452 = yyj452 > l
 		} else {
-			yyb413 = r.CheckBreak()
+			yyb452 = r.CheckBreak()
 		}
-		if yyb413 {
+		if yyb452 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj413-1, "")
+		z.DecStructFieldNotFound(yyj452-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4780,113 +5228,113 @@ func (x *CustomMetricSample) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym419 := z.EncBinary()
-		_ = yym419
+		yym458 := z.EncBinary()
+		_ = yym458
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep420 := !z.EncBinary()
-			yy2arr420 := z.EncBasicHandle().StructToArray
-			var yyq420 [3]bool
-			_, _, _ = yysep420, yyq420, yy2arr420
-			const yyr420 bool = false
-			yyq420[1] = x.Label != nil
-			if yyr420 || yy2arr420 {
+			yysep459 := !z.EncBinary()
+			yy2arr459 := z.EncBasicHandle().StructToArray
+			var yyq459 [3]bool
+			_, _, _ = yysep459, yyq459, yy2arr459
+			const yyr459 bool = false
+			yyq459[1] = x.Label != nil
+			if yyr459 || yy2arr459 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn420 int = 2
-				for _, b := range yyq420 {
+				var yynn459 int = 2
+				for _, b := range yyq459 {
 					if b {
-						yynn420++
+						yynn459++
 					}
 				}
-				r.EncodeMapStart(yynn420)
+				r.EncodeMapStart(yynn459)
 			}
-			if yyr420 || yy2arr420 {
-				yy422 := &x.SampleTime
-				yym423 := z.EncBinary()
-				_ = yym423
+			if yyr459 || yy2arr459 {
+				yy461 := &x.SampleTime
+				yym462 := z.EncBinary()
+				_ = yym462
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy422) {
-				} else if yym423 {
-					z.EncBinaryMarshal(yy422)
-				} else if !yym423 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy422)
+				} else if z.HasExtensions() && z.EncExt(yy461) {
+				} else if yym462 {
+					z.EncBinaryMarshal(yy461)
+				} else if !yym462 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy461)
 				} else {
-					z.EncFallback(yy422)
+					z.EncFallback(yy461)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
-				yy424 := &x.SampleTime
-				yym425 := z.EncBinary()
-				_ = yym425
+				yy463 := &x.SampleTime
+				yym464 := z.EncBinary()
+				_ = yym464
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy424) {
-				} else if yym425 {
-					z.EncBinaryMarshal(yy424)
-				} else if !yym425 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy424)
+				} else if z.HasExtensions() && z.EncExt(yy463) {
+				} else if yym464 {
+					z.EncBinaryMarshal(yy463)
+				} else if !yym464 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy463)
 				} else {
-					z.EncFallback(yy424)
+					z.EncFallback(yy463)
 				}
 			}
-			if yyr420 || yy2arr420 {
-				if yyq420[1] {
+			if yyr459 || yy2arr459 {
+				if yyq459[1] {
 					if x.Label == nil {
 						r.EncodeNil()
 					} else {
-						yy427 := *x.Label
-						yym428 := z.EncBinary()
-						_ = yym428
+						yy466 := *x.Label
+						yym467 := z.EncBinary()
+						_ = yym467
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy427))
+							r.EncodeString(codecSelferC_UTF81234, string(yy466))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq420[1] {
+				if yyq459[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("label"))
 					if x.Label == nil {
 						r.EncodeNil()
 					} else {
-						yy429 := *x.Label
-						yym430 := z.EncBinary()
-						_ = yym430
+						yy468 := *x.Label
+						yym469 := z.EncBinary()
+						_ = yym469
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy429))
+							r.EncodeString(codecSelferC_UTF81234, string(yy468))
 						}
 					}
 				}
 			}
-			if yyr420 || yy2arr420 {
-				yy432 := &x.Value
-				yym433 := z.EncBinary()
-				_ = yym433
+			if yyr459 || yy2arr459 {
+				yy471 := &x.Value
+				yym472 := z.EncBinary()
+				_ = yym472
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy432) {
-				} else if !yym433 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy432)
+				} else if z.HasExtensions() && z.EncExt(yy471) {
+				} else if !yym472 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy471)
 				} else {
-					z.EncFallback(yy432)
+					z.EncFallback(yy471)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yy434 := &x.Value
-				yym435 := z.EncBinary()
-				_ = yym435
+				yy473 := &x.Value
+				yym474 := z.EncBinary()
+				_ = yym474
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy434) {
-				} else if !yym435 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy434)
+				} else if z.HasExtensions() && z.EncExt(yy473) {
+				} else if !yym474 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy473)
 				} else {
-					z.EncFallback(yy434)
+					z.EncFallback(yy473)
 				}
 			}
-			if yysep420 {
+			if yysep459 {
 				r.EncodeEnd()
 			}
 		}
@@ -4897,24 +5345,24 @@ func (x *CustomMetricSample) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym436 := z.DecBinary()
-	_ = yym436
+	yym475 := z.DecBinary()
+	_ = yym475
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl437 := r.ReadMapStart()
-			if yyl437 == 0 {
+			yyl476 := r.ReadMapStart()
+			if yyl476 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl437, d)
+				x.codecDecodeSelfFromMap(yyl476, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl437 := r.ReadArrayStart()
-			if yyl437 == 0 {
+			yyl476 := r.ReadArrayStart()
+			if yyl476 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl437, d)
+				x.codecDecodeSelfFromArray(yyl476, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4926,12 +5374,12 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys438Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys438Slc
-	var yyhl438 bool = l >= 0
-	for yyj438 := 0; ; yyj438++ {
-		if yyhl438 {
-			if yyj438 >= l {
+	var yys477Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys477Slc
+	var yyhl477 bool = l >= 0
+	for yyj477 := 0; ; yyj477++ {
+		if yyhl477 {
+			if yyj477 >= l {
 				break
 			}
 		} else {
@@ -4939,24 +5387,24 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys438Slc = r.DecodeBytes(yys438Slc, true, true)
-		yys438 := string(yys438Slc)
-		switch yys438 {
+		yys477Slc = r.DecodeBytes(yys477Slc, true, true)
+		yys477 := string(yys477Slc)
+		switch yys477 {
 		case "sampleTime":
 			if r.TryDecodeAsNil() {
 				x.SampleTime = pkg1_unversioned.Time{}
 			} else {
-				yyv439 := &x.SampleTime
-				yym440 := z.DecBinary()
-				_ = yym440
+				yyv478 := &x.SampleTime
+				yym479 := z.DecBinary()
+				_ = yym479
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv439) {
-				} else if yym440 {
-					z.DecBinaryUnmarshal(yyv439)
-				} else if !yym440 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv439)
+				} else if z.HasExtensions() && z.DecExt(yyv478) {
+				} else if yym479 {
+					z.DecBinaryUnmarshal(yyv478)
+				} else if !yym479 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv478)
 				} else {
-					z.DecFallback(yyv439, false)
+					z.DecFallback(yyv478, false)
 				}
 			}
 		case "label":
@@ -4968,8 +5416,8 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				if x.Label == nil {
 					x.Label = new(string)
 				}
-				yym442 := z.DecBinary()
-				_ = yym442
+				yym481 := z.DecBinary()
+				_ = yym481
 				if false {
 				} else {
 					*((*string)(x.Label)) = r.DecodeString()
@@ -4979,22 +5427,22 @@ func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Value = pkg2_resource.Quantity{}
 			} else {
-				yyv443 := &x.Value
-				yym444 := z.DecBinary()
-				_ = yym444
+				yyv482 := &x.Value
+				yym483 := z.DecBinary()
+				_ = yym483
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv443) {
-				} else if !yym444 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv443)
+				} else if z.HasExtensions() && z.DecExt(yyv482) {
+				} else if !yym483 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv482)
 				} else {
-					z.DecFallback(yyv443, false)
+					z.DecFallback(yyv482, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys438)
-		} // end switch yys438
-	} // end for yyj438
-	if !yyhl438 {
+			z.DecStructFieldNotFound(-1, yys477)
+		} // end switch yys477
+	} // end for yyj477
+	if !yyhl477 {
 		r.ReadEnd()
 	}
 }
@@ -5003,42 +5451,42 @@ func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj445 int
-	var yyb445 bool
-	var yyhl445 bool = l >= 0
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
+	var yyj484 int
+	var yyb484 bool
+	var yyhl484 bool = l >= 0
+	yyj484++
+	if yyhl484 {
+		yyb484 = yyj484 > l
 	} else {
-		yyb445 = r.CheckBreak()
+		yyb484 = r.CheckBreak()
 	}
-	if yyb445 {
+	if yyb484 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.SampleTime = pkg1_unversioned.Time{}
 	} else {
-		yyv446 := &x.SampleTime
-		yym447 := z.DecBinary()
-		_ = yym447
+		yyv485 := &x.SampleTime
+		yym486 := z.DecBinary()
+		_ = yym486
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv446) {
-		} else if yym447 {
-			z.DecBinaryUnmarshal(yyv446)
-		} else if !yym447 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv446)
+		} else if z.HasExtensions() && z.DecExt(yyv485) {
+		} else if yym486 {
+			z.DecBinaryUnmarshal(yyv485)
+		} else if !yym486 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv485)
 		} else {
-			z.DecFallback(yyv446, false)
+			z.DecFallback(yyv485, false)
 		}
 	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
+	yyj484++
+	if yyhl484 {
+		yyb484 = yyj484 > l
 	} else {
-		yyb445 = r.CheckBreak()
+		yyb484 = r.CheckBreak()
 	}
-	if yyb445 {
+	if yyb484 {
 		r.ReadEnd()
 		return
 	}
@@ -5050,48 +5498,48 @@ func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		if x.Label == nil {
 			x.Label = new(string)
 		}
-		yym449 := z.DecBinary()
-		_ = yym449
+		yym488 := z.DecBinary()
+		_ = yym488
 		if false {
 		} else {
 			*((*string)(x.Label)) = r.DecodeString()
 		}
 	}
-	yyj445++
-	if yyhl445 {
-		yyb445 = yyj445 > l
+	yyj484++
+	if yyhl484 {
+		yyb484 = yyj484 > l
 	} else {
-		yyb445 = r.CheckBreak()
+		yyb484 = r.CheckBreak()
 	}
-	if yyb445 {
+	if yyb484 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Value = pkg2_resource.Quantity{}
 	} else {
-		yyv450 := &x.Value
-		yym451 := z.DecBinary()
-		_ = yym451
+		yyv489 := &x.Value
+		yym490 := z.DecBinary()
+		_ = yym490
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv450) {
-		} else if !yym451 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv450)
+		} else if z.HasExtensions() && z.DecExt(yyv489) {
+		} else if !yym490 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv489)
 		} else {
-			z.DecFallback(yyv450, false)
+			z.DecFallback(yyv489, false)
 		}
 	}
 	for {
-		yyj445++
-		if yyhl445 {
-			yyb445 = yyj445 > l
+		yyj484++
+		if yyhl484 {
+			yyb484 = yyj484 > l
 		} else {
-			yyb445 = r.CheckBreak()
+			yyb484 = r.CheckBreak()
 		}
-		if yyb445 {
+		if yyb484 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj445-1, "")
+		z.DecStructFieldNotFound(yyj484-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5103,42 +5551,42 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym452 := z.EncBinary()
-		_ = yym452
+		yym491 := z.EncBinary()
+		_ = yym491
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep453 := !z.EncBinary()
-			yy2arr453 := z.EncBasicHandle().StructToArray
-			var yyq453 [3]bool
-			_, _, _ = yysep453, yyq453, yy2arr453
-			const yyr453 bool = false
-			yyq453[0] = x.SinceTime != nil
-			yyq453[1] = x.UntilTime != nil
-			yyq453[2] = x.MaxSamples != 0
-			if yyr453 || yy2arr453 {
+			yysep492 := !z.EncBinary()
+			yy2arr492 := z.EncBasicHandle().StructToArray
+			var yyq492 [3]bool
+			_, _, _ = yysep492, yyq492, yy2arr492
+			const yyr492 bool = false
+			yyq492[0] = x.SinceTime != nil
+			yyq492[1] = x.UntilTime != nil
+			yyq492[2] = x.MaxSamples != 0
+			if yyr492 || yy2arr492 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn453 int = 0
-				for _, b := range yyq453 {
+				var yynn492 int = 0
+				for _, b := range yyq492 {
 					if b {
-						yynn453++
+						yynn492++
 					}
 				}
-				r.EncodeMapStart(yynn453)
+				r.EncodeMapStart(yynn492)
 			}
-			if yyr453 || yy2arr453 {
-				if yyq453[0] {
+			if yyr492 || yy2arr492 {
+				if yyq492[0] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym455 := z.EncBinary()
-						_ = yym455
+						yym494 := z.EncBinary()
+						_ = yym494
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym455 {
+						} else if yym494 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym455 && z.IsJSONHandle() {
+						} else if !yym494 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5148,18 +5596,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq453[0] {
+				if yyq492[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym456 := z.EncBinary()
-						_ = yym456
+						yym495 := z.EncBinary()
+						_ = yym495
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym456 {
+						} else if yym495 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym456 && z.IsJSONHandle() {
+						} else if !yym495 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -5167,18 +5615,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr453 || yy2arr453 {
-				if yyq453[1] {
+			if yyr492 || yy2arr492 {
+				if yyq492[1] {
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym458 := z.EncBinary()
-						_ = yym458
+						yym497 := z.EncBinary()
+						_ = yym497
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym458 {
+						} else if yym497 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym458 && z.IsJSONHandle() {
+						} else if !yym497 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5188,18 +5636,18 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq453[1] {
+				if yyq492[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
 					if x.UntilTime == nil {
 						r.EncodeNil()
 					} else {
-						yym459 := z.EncBinary()
-						_ = yym459
+						yym498 := z.EncBinary()
+						_ = yym498
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
-						} else if yym459 {
+						} else if yym498 {
 							z.EncBinaryMarshal(x.UntilTime)
-						} else if !yym459 && z.IsJSONHandle() {
+						} else if !yym498 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.UntilTime)
 						} else {
 							z.EncFallback(x.UntilTime)
@@ -5207,10 +5655,10 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr453 || yy2arr453 {
-				if yyq453[2] {
-					yym461 := z.EncBinary()
-					_ = yym461
+			if yyr492 || yy2arr492 {
+				if yyq492[2] {
+					yym500 := z.EncBinary()
+					_ = yym500
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
@@ -5219,17 +5667,17 @@ func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq453[2] {
+				if yyq492[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
-					yym462 := z.EncBinary()
-					_ = yym462
+					yym501 := z.EncBinary()
+					_ = yym501
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MaxSamples))
 					}
 				}
 			}
-			if yysep453 {
+			if yysep492 {
 				r.EncodeEnd()
 			}
 		}
@@ -5240,24 +5688,24 @@ func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym463 := z.DecBinary()
-	_ = yym463
+	yym502 := z.DecBinary()
+	_ = yym502
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl464 := r.ReadMapStart()
-			if yyl464 == 0 {
+			yyl503 := r.ReadMapStart()
+			if yyl503 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl464, d)
+				x.codecDecodeSelfFromMap(yyl503, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl464 := r.ReadArrayStart()
-			if yyl464 == 0 {
+			yyl503 := r.ReadArrayStart()
+			if yyl503 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl464, d)
+				x.codecDecodeSelfFromArray(yyl503, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5269,12 +5717,12 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys465Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys465Slc
-	var yyhl465 bool = l >= 0
-	for yyj465 := 0; ; yyj465++ {
-		if yyhl465 {
-			if yyj465 >= l {
+	var yys504Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys504Slc
+	var yyhl504 bool = l >= 0
+	for yyj504 := 0; ; yyj504++ {
+		if yyhl504 {
+			if yyj504 >= l {
 				break
 			}
 		} else {
@@ -5282,9 +5730,9 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys465Slc = r.DecodeBytes(yys465Slc, true, true)
-		yys465 := string(yys465Slc)
-		switch yys465 {
+		yys504Slc = r.DecodeBytes(yys504Slc, true, true)
+		yys504 := string(yys504Slc)
+		switch yys504 {
 		case "sinceTime":
 			if r.TryDecodeAsNil() {
 				if x.SinceTime != nil {
@@ -5294,13 +5742,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg1_unversioned.Time)
 				}
-				yym467 := z.DecBinary()
-				_ = yym467
+				yym506 := z.DecBinary()
+				_ = yym506
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym467 {
+				} else if yym506 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym467 && z.IsJSONHandle() {
+				} else if !yym506 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -5315,13 +5763,13 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				if x.UntilTime == nil {
 					x.UntilTime = new(pkg1_unversioned.Time)
 				}
-				yym469 := z.DecBinary()
-				_ = yym469
+				yym508 := z.DecBinary()
+				_ = yym508
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-				} else if yym469 {
+				} else if yym508 {
 					z.DecBinaryUnmarshal(x.UntilTime)
-				} else if !yym469 && z.IsJSONHandle() {
+				} else if !yym508 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.UntilTime)
 				} else {
 					z.DecFallback(x.UntilTime, false)
@@ -5334,10 +5782,10 @@ func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys465)
-		} // end switch yys465
-	} // end for yyj465
-	if !yyhl465 {
+			z.DecStructFieldNotFound(-1, yys504)
+		} // end switch yys504
+	} // end for yyj504
+	if !yyhl504 {
 		r.ReadEnd()
 	}
 }
@@ -5346,16 +5794,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj471 int
-	var yyb471 bool
-	var yyhl471 bool = l >= 0
-	yyj471++
-	if yyhl471 {
-		yyb471 = yyj471 > l
+	var yyj510 int
+	var yyb510 bool
+	var yyhl510 bool = l >= 0
+	yyj510++
+	if yyhl510 {
+		yyb510 = yyj510 > l
 	} else {
-		yyb471 = r.CheckBreak()
+		yyb510 = r.CheckBreak()
 	}
-	if yyb471 {
+	if yyb510 {
 		r.ReadEnd()
 		return
 	}
@@ -5367,25 +5815,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg1_unversioned.Time)
 		}
-		yym473 := z.DecBinary()
-		_ = yym473
+		yym512 := z.DecBinary()
+		_ = yym512
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym473 {
+		} else if yym512 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym473 && z.IsJSONHandle() {
+		} else if !yym512 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj471++
-	if yyhl471 {
-		yyb471 = yyj471 > l
+	yyj510++
+	if yyhl510 {
+		yyb510 = yyj510 > l
 	} else {
-		yyb471 = r.CheckBreak()
+		yyb510 = r.CheckBreak()
 	}
-	if yyb471 {
+	if yyb510 {
 		r.ReadEnd()
 		return
 	}
@@ -5397,25 +5845,25 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		if x.UntilTime == nil {
 			x.UntilTime = new(pkg1_unversioned.Time)
 		}
-		yym475 := z.DecBinary()
-		_ = yym475
+		yym514 := z.DecBinary()
+		_ = yym514
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
-		} else if yym475 {
+		} else if yym514 {
 			z.DecBinaryUnmarshal(x.UntilTime)
-		} else if !yym475 && z.IsJSONHandle() {
+		} else if !yym514 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.UntilTime)
 		} else {
 			z.DecFallback(x.UntilTime, false)
 		}
 	}
-	yyj471++
-	if yyhl471 {
-		yyb471 = yyj471 > l
+	yyj510++
+	if yyhl510 {
+		yyb510 = yyj510 > l
 	} else {
-		yyb471 = r.CheckBreak()
+		yyb510 = r.CheckBreak()
 	}
-	if yyb471 {
+	if yyb510 {
 		r.ReadEnd()
 		return
 	}
@@ -5425,16 +5873,16 @@ func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj471++
-		if yyhl471 {
-			yyb471 = yyj471 > l
+		yyj510++
+		if yyhl510 {
+			yyb510 = yyj510 > l
 		} else {
-			yyb471 = r.CheckBreak()
+			yyb510 = r.CheckBreak()
 		}
-		if yyb471 {
+		if yyb510 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj471-1, "")
+		z.DecStructFieldNotFound(yyj510-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5444,9 +5892,9 @@ func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv477 := range v {
-		yy478 := &yyv477
-		yy478.CodecEncodeSelf(e)
+	for _, yyv516 := range v {
+		yy517 := &yyv516
+		yy517.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5456,75 +5904,75 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv479 := *v
-	yyh479, yyl479 := z.DecSliceHelperStart()
+	yyv518 := *v
+	yyh518, yyl518 := z.DecSliceHelperStart()
 
-	var yyrr479, yyrl479 int
-	var yyc479, yyrt479 bool
-	_, _, _ = yyc479, yyrt479, yyrl479
-	yyrr479 = yyl479
+	var yyrr518, yyrl518 int
+	var yyc518, yyrt518 bool
+	_, _, _ = yyc518, yyrt518, yyrl518
+	yyrr518 = yyl518
 
-	if yyv479 == nil {
-		if yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 48); yyrt479 {
-			yyrr479 = yyrl479
+	if yyv518 == nil {
+		if yyrl518, yyrt518 = z.DecInferLen(yyl518, z.DecBasicHandle().MaxInitLen, 72); yyrt518 {
+			yyrr518 = yyrl518
 		}
-		yyv479 = make([]AggregateSample, yyrl479)
-		yyc479 = true
+		yyv518 = make([]AggregateSample, yyrl518)
+		yyc518 = true
 	}
 
-	if yyl479 == 0 {
-		if len(yyv479) != 0 {
-			yyv479 = yyv479[:0]
-			yyc479 = true
+	if yyl518 == 0 {
+		if len(yyv518) != 0 {
+			yyv518 = yyv518[:0]
+			yyc518 = true
 		}
-	} else if yyl479 > 0 {
+	} else if yyl518 > 0 {
 
-		if yyl479 > cap(yyv479) {
-			yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 48)
-			yyv479 = make([]AggregateSample, yyrl479)
-			yyc479 = true
+		if yyl518 > cap(yyv518) {
+			yyrl518, yyrt518 = z.DecInferLen(yyl518, z.DecBasicHandle().MaxInitLen, 72)
+			yyv518 = make([]AggregateSample, yyrl518)
+			yyc518 = true
 
-			yyrr479 = len(yyv479)
-		} else if yyl479 != len(yyv479) {
-			yyv479 = yyv479[:yyl479]
-			yyc479 = true
+			yyrr518 = len(yyv518)
+		} else if yyl518 != len(yyv518) {
+			yyv518 = yyv518[:yyl518]
+			yyc518 = true
 		}
-		yyj479 := 0
-		for ; yyj479 < yyrr479; yyj479++ {
+		yyj518 := 0
+		for ; yyj518 < yyrr518; yyj518++ {
 			if r.TryDecodeAsNil() {
-				yyv479[yyj479] = AggregateSample{}
+				yyv518[yyj518] = AggregateSample{}
 			} else {
-				yyv480 := &yyv479[yyj479]
-				yyv480.CodecDecodeSelf(d)
+				yyv519 := &yyv518[yyj518]
+				yyv519.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt479 {
-			for ; yyj479 < yyl479; yyj479++ {
-				yyv479 = append(yyv479, AggregateSample{})
+		if yyrt518 {
+			for ; yyj518 < yyl518; yyj518++ {
+				yyv518 = append(yyv518, AggregateSample{})
 				if r.TryDecodeAsNil() {
-					yyv479[yyj479] = AggregateSample{}
+					yyv518[yyj518] = AggregateSample{}
 				} else {
-					yyv481 := &yyv479[yyj479]
-					yyv481.CodecDecodeSelf(d)
+					yyv520 := &yyv518[yyj518]
+					yyv520.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj479 := 0; !r.CheckBreak(); yyj479++ {
-			if yyj479 >= len(yyv479) {
-				yyv479 = append(yyv479, AggregateSample{}) // var yyz479 AggregateSample
-				yyc479 = true
+		for yyj518 := 0; !r.CheckBreak(); yyj518++ {
+			if yyj518 >= len(yyv518) {
+				yyv518 = append(yyv518, AggregateSample{}) // var yyz518 AggregateSample
+				yyc518 = true
 			}
 
-			if yyj479 < len(yyv479) {
+			if yyj518 < len(yyv518) {
 				if r.TryDecodeAsNil() {
-					yyv479[yyj479] = AggregateSample{}
+					yyv518[yyj518] = AggregateSample{}
 				} else {
-					yyv482 := &yyv479[yyj479]
-					yyv482.CodecDecodeSelf(d)
+					yyv521 := &yyv518[yyj518]
+					yyv521.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5532,10 +5980,10 @@ func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1
 			}
 
 		}
-		yyh479.End()
+		yyh518.End()
 	}
-	if yyc479 {
-		*v = yyv479
+	if yyc518 {
+		*v = yyv518
 	}
 
 }
@@ -5545,9 +5993,9 @@ func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv483 := range v {
-		yy484 := &yyv483
-		yy484.CodecEncodeSelf(e)
+	for _, yyv522 := range v {
+		yy523 := &yyv522
+		yy523.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5557,75 +6005,75 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv485 := *v
-	yyh485, yyl485 := z.DecSliceHelperStart()
+	yyv524 := *v
+	yyh524, yyl524 := z.DecSliceHelperStart()
 
-	var yyrr485, yyrl485 int
-	var yyc485, yyrt485 bool
-	_, _, _ = yyc485, yyrt485, yyrl485
-	yyrr485 = yyl485
+	var yyrr524, yyrl524 int
+	var yyc524, yyrt524 bool
+	_, _, _ = yyc524, yyrt524, yyrl524
+	yyrr524 = yyl524
 
-	if yyv485 == nil {
-		if yyrl485, yyrt485 = z.DecInferLen(yyl485, z.DecBasicHandle().MaxInitLen, 72); yyrt485 {
-			yyrr485 = yyrl485
+	if yyv524 == nil {
+		if yyrl524, yyrt524 = z.DecInferLen(yyl524, z.DecBasicHandle().MaxInitLen, 72); yyrt524 {
+			yyrr524 = yyrl524
 		}
-		yyv485 = make([]RawContainerMetrics, yyrl485)
-		yyc485 = true
+		yyv524 = make([]RawContainerMetrics, yyrl524)
+		yyc524 = true
 	}
 
-	if yyl485 == 0 {
-		if len(yyv485) != 0 {
-			yyv485 = yyv485[:0]
-			yyc485 = true
+	if yyl524 == 0 {
+		if len(yyv524) != 0 {
+			yyv524 = yyv524[:0]
+			yyc524 = true
 		}
-	} else if yyl485 > 0 {
+	} else if yyl524 > 0 {
 
-		if yyl485 > cap(yyv485) {
-			yyrl485, yyrt485 = z.DecInferLen(yyl485, z.DecBasicHandle().MaxInitLen, 72)
-			yyv485 = make([]RawContainerMetrics, yyrl485)
-			yyc485 = true
+		if yyl524 > cap(yyv524) {
+			yyrl524, yyrt524 = z.DecInferLen(yyl524, z.DecBasicHandle().MaxInitLen, 72)
+			yyv524 = make([]RawContainerMetrics, yyrl524)
+			yyc524 = true
 
-			yyrr485 = len(yyv485)
-		} else if yyl485 != len(yyv485) {
-			yyv485 = yyv485[:yyl485]
-			yyc485 = true
+			yyrr524 = len(yyv524)
+		} else if yyl524 != len(yyv524) {
+			yyv524 = yyv524[:yyl524]
+			yyc524 = true
 		}
-		yyj485 := 0
-		for ; yyj485 < yyrr485; yyj485++ {
+		yyj524 := 0
+		for ; yyj524 < yyrr524; yyj524++ {
 			if r.TryDecodeAsNil() {
-				yyv485[yyj485] = RawContainerMetrics{}
+				yyv524[yyj524] = RawContainerMetrics{}
 			} else {
-				yyv486 := &yyv485[yyj485]
-				yyv486.CodecDecodeSelf(d)
+				yyv525 := &yyv524[yyj524]
+				yyv525.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt485 {
-			for ; yyj485 < yyl485; yyj485++ {
-				yyv485 = append(yyv485, RawContainerMetrics{})
+		if yyrt524 {
+			for ; yyj524 < yyl524; yyj524++ {
+				yyv524 = append(yyv524, RawContainerMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv485[yyj485] = RawContainerMetrics{}
+					yyv524[yyj524] = RawContainerMetrics{}
 				} else {
-					yyv487 := &yyv485[yyj485]
-					yyv487.CodecDecodeSelf(d)
+					yyv526 := &yyv524[yyj524]
+					yyv526.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj485 := 0; !r.CheckBreak(); yyj485++ {
-			if yyj485 >= len(yyv485) {
-				yyv485 = append(yyv485, RawContainerMetrics{}) // var yyz485 RawContainerMetrics
-				yyc485 = true
+		for yyj524 := 0; !r.CheckBreak(); yyj524++ {
+			if yyj524 >= len(yyv524) {
+				yyv524 = append(yyv524, RawContainerMetrics{}) // var yyz524 RawContainerMetrics
+				yyc524 = true
 			}
 
-			if yyj485 < len(yyv485) {
+			if yyj524 < len(yyv524) {
 				if r.TryDecodeAsNil() {
-					yyv485[yyj485] = RawContainerMetrics{}
+					yyv524[yyj524] = RawContainerMetrics{}
 				} else {
-					yyv488 := &yyv485[yyj485]
-					yyv488.CodecDecodeSelf(d)
+					yyv527 := &yyv524[yyj524]
+					yyv527.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5633,10 +6081,10 @@ func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d
 			}
 
 		}
-		yyh485.End()
+		yyh524.End()
 	}
-	if yyc485 {
-		*v = yyv485
+	if yyc524 {
+		*v = yyv524
 	}
 
 }
@@ -5646,9 +6094,9 @@ func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv489 := range v {
-		yy490 := &yyv489
-		yy490.CodecEncodeSelf(e)
+	for _, yyv528 := range v {
+		yy529 := &yyv528
+		yy529.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5658,75 +6106,75 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv491 := *v
-	yyh491, yyl491 := z.DecSliceHelperStart()
+	yyv530 := *v
+	yyh530, yyl530 := z.DecSliceHelperStart()
 
-	var yyrr491, yyrl491 int
-	var yyc491, yyrt491 bool
-	_, _, _ = yyc491, yyrt491, yyrl491
-	yyrr491 = yyl491
+	var yyrr530, yyrl530 int
+	var yyc530, yyrt530 bool
+	_, _, _ = yyc530, yyrt530, yyrl530
+	yyrr530 = yyl530
 
-	if yyv491 == nil {
-		if yyrl491, yyrt491 = z.DecInferLen(yyl491, z.DecBasicHandle().MaxInitLen, 128); yyrt491 {
-			yyrr491 = yyrl491
+	if yyv530 == nil {
+		if yyrl530, yyrt530 = z.DecInferLen(yyl530, z.DecBasicHandle().MaxInitLen, 128); yyrt530 {
+			yyrr530 = yyrl530
 		}
-		yyv491 = make([]RawNodeMetrics, yyrl491)
-		yyc491 = true
+		yyv530 = make([]RawNodeMetrics, yyrl530)
+		yyc530 = true
 	}
 
-	if yyl491 == 0 {
-		if len(yyv491) != 0 {
-			yyv491 = yyv491[:0]
-			yyc491 = true
+	if yyl530 == 0 {
+		if len(yyv530) != 0 {
+			yyv530 = yyv530[:0]
+			yyc530 = true
 		}
-	} else if yyl491 > 0 {
+	} else if yyl530 > 0 {
 
-		if yyl491 > cap(yyv491) {
-			yyrl491, yyrt491 = z.DecInferLen(yyl491, z.DecBasicHandle().MaxInitLen, 128)
-			yyv491 = make([]RawNodeMetrics, yyrl491)
-			yyc491 = true
+		if yyl530 > cap(yyv530) {
+			yyrl530, yyrt530 = z.DecInferLen(yyl530, z.DecBasicHandle().MaxInitLen, 128)
+			yyv530 = make([]RawNodeMetrics, yyrl530)
+			yyc530 = true
 
-			yyrr491 = len(yyv491)
-		} else if yyl491 != len(yyv491) {
-			yyv491 = yyv491[:yyl491]
-			yyc491 = true
+			yyrr530 = len(yyv530)
+		} else if yyl530 != len(yyv530) {
+			yyv530 = yyv530[:yyl530]
+			yyc530 = true
 		}
-		yyj491 := 0
-		for ; yyj491 < yyrr491; yyj491++ {
+		yyj530 := 0
+		for ; yyj530 < yyrr530; yyj530++ {
 			if r.TryDecodeAsNil() {
-				yyv491[yyj491] = RawNodeMetrics{}
+				yyv530[yyj530] = RawNodeMetrics{}
 			} else {
-				yyv492 := &yyv491[yyj491]
-				yyv492.CodecDecodeSelf(d)
+				yyv531 := &yyv530[yyj530]
+				yyv531.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt491 {
-			for ; yyj491 < yyl491; yyj491++ {
-				yyv491 = append(yyv491, RawNodeMetrics{})
+		if yyrt530 {
+			for ; yyj530 < yyl530; yyj530++ {
+				yyv530 = append(yyv530, RawNodeMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv491[yyj491] = RawNodeMetrics{}
+					yyv530[yyj530] = RawNodeMetrics{}
 				} else {
-					yyv493 := &yyv491[yyj491]
-					yyv493.CodecDecodeSelf(d)
+					yyv532 := &yyv530[yyj530]
+					yyv532.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj491 := 0; !r.CheckBreak(); yyj491++ {
-			if yyj491 >= len(yyv491) {
-				yyv491 = append(yyv491, RawNodeMetrics{}) // var yyz491 RawNodeMetrics
-				yyc491 = true
+		for yyj530 := 0; !r.CheckBreak(); yyj530++ {
+			if yyj530 >= len(yyv530) {
+				yyv530 = append(yyv530, RawNodeMetrics{}) // var yyz530 RawNodeMetrics
+				yyc530 = true
 			}
 
-			if yyj491 < len(yyv491) {
+			if yyj530 < len(yyv530) {
 				if r.TryDecodeAsNil() {
-					yyv491[yyj491] = RawNodeMetrics{}
+					yyv530[yyj530] = RawNodeMetrics{}
 				} else {
-					yyv494 := &yyv491[yyj491]
-					yyv494.CodecDecodeSelf(d)
+					yyv533 := &yyv530[yyj530]
+					yyv533.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5734,10 +6182,10 @@ func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec197
 			}
 
 		}
-		yyh491.End()
+		yyh530.End()
 	}
-	if yyc491 {
-		*v = yyv491
+	if yyc530 {
+		*v = yyv530
 	}
 
 }
@@ -5747,9 +6195,9 @@ func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv495 := range v {
-		yy496 := &yyv495
-		yy496.CodecEncodeSelf(e)
+	for _, yyv534 := range v {
+		yy535 := &yyv534
+		yy535.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5759,75 +6207,75 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv497 := *v
-	yyh497, yyl497 := z.DecSliceHelperStart()
+	yyv536 := *v
+	yyh536, yyl536 := z.DecSliceHelperStart()
 
-	var yyrr497, yyrl497 int
-	var yyc497, yyrt497 bool
-	_, _, _ = yyc497, yyrt497, yyrl497
-	yyrr497 = yyl497
+	var yyrr536, yyrl536 int
+	var yyc536, yyrt536 bool
+	_, _, _ = yyc536, yyrt536, yyrl536
+	yyrr536 = yyl536
 
-	if yyv497 == nil {
-		if yyrl497, yyrt497 = z.DecInferLen(yyl497, z.DecBasicHandle().MaxInitLen, 32); yyrt497 {
-			yyrr497 = yyrl497
+	if yyv536 == nil {
+		if yyrl536, yyrt536 = z.DecInferLen(yyl536, z.DecBasicHandle().MaxInitLen, 32); yyrt536 {
+			yyrr536 = yyrl536
 		}
-		yyv497 = make([]PodSample, yyrl497)
-		yyc497 = true
+		yyv536 = make([]PodSample, yyrl536)
+		yyc536 = true
 	}
 
-	if yyl497 == 0 {
-		if len(yyv497) != 0 {
-			yyv497 = yyv497[:0]
-			yyc497 = true
+	if yyl536 == 0 {
+		if len(yyv536) != 0 {
+			yyv536 = yyv536[:0]
+			yyc536 = true
 		}
-	} else if yyl497 > 0 {
+	} else if yyl536 > 0 {
 
-		if yyl497 > cap(yyv497) {
-			yyrl497, yyrt497 = z.DecInferLen(yyl497, z.DecBasicHandle().MaxInitLen, 32)
-			yyv497 = make([]PodSample, yyrl497)
-			yyc497 = true
+		if yyl536 > cap(yyv536) {
+			yyrl536, yyrt536 = z.DecInferLen(yyl536, z.DecBasicHandle().MaxInitLen, 32)
+			yyv536 = make([]PodSample, yyrl536)
+			yyc536 = true
 
-			yyrr497 = len(yyv497)
-		} else if yyl497 != len(yyv497) {
-			yyv497 = yyv497[:yyl497]
-			yyc497 = true
+			yyrr536 = len(yyv536)
+		} else if yyl536 != len(yyv536) {
+			yyv536 = yyv536[:yyl536]
+			yyc536 = true
 		}
-		yyj497 := 0
-		for ; yyj497 < yyrr497; yyj497++ {
+		yyj536 := 0
+		for ; yyj536 < yyrr536; yyj536++ {
 			if r.TryDecodeAsNil() {
-				yyv497[yyj497] = PodSample{}
+				yyv536[yyj536] = PodSample{}
 			} else {
-				yyv498 := &yyv497[yyj497]
-				yyv498.CodecDecodeSelf(d)
+				yyv537 := &yyv536[yyj536]
+				yyv537.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt497 {
-			for ; yyj497 < yyl497; yyj497++ {
-				yyv497 = append(yyv497, PodSample{})
+		if yyrt536 {
+			for ; yyj536 < yyl536; yyj536++ {
+				yyv536 = append(yyv536, PodSample{})
 				if r.TryDecodeAsNil() {
-					yyv497[yyj497] = PodSample{}
+					yyv536[yyj536] = PodSample{}
 				} else {
-					yyv499 := &yyv497[yyj497]
-					yyv499.CodecDecodeSelf(d)
+					yyv538 := &yyv536[yyj536]
+					yyv538.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj497 := 0; !r.CheckBreak(); yyj497++ {
-			if yyj497 >= len(yyv497) {
-				yyv497 = append(yyv497, PodSample{}) // var yyz497 PodSample
-				yyc497 = true
+		for yyj536 := 0; !r.CheckBreak(); yyj536++ {
+			if yyj536 >= len(yyv536) {
+				yyv536 = append(yyv536, PodSample{}) // var yyz536 PodSample
+				yyc536 = true
 			}
 
-			if yyj497 < len(yyv497) {
+			if yyj536 < len(yyv536) {
 				if r.TryDecodeAsNil() {
-					yyv497[yyj497] = PodSample{}
+					yyv536[yyj536] = PodSample{}
 				} else {
-					yyv500 := &yyv497[yyj497]
-					yyv500.CodecDecodeSelf(d)
+					yyv539 := &yyv536[yyj536]
+					yyv539.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5835,10 +6283,10 @@ func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder)
 			}
 
 		}
-		yyh497.End()
+		yyh536.End()
 	}
-	if yyc497 {
-		*v = yyv497
+	if yyc536 {
+		*v = yyv536
 	}
 
 }
@@ -5848,9 +6296,9 @@ func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv501 := range v {
-		yy502 := &yyv501
-		yy502.CodecEncodeSelf(e)
+	for _, yyv540 := range v {
+		yy541 := &yyv540
+		yy541.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5860,75 +6308,75 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv503 := *v
-	yyh503, yyl503 := z.DecSliceHelperStart()
+	yyv542 := *v
+	yyh542, yyl542 := z.DecSliceHelperStart()
 
-	var yyrr503, yyrl503 int
-	var yyc503, yyrt503 bool
-	_, _, _ = yyc503, yyrt503, yyrl503
-	yyrr503 = yyl503
+	var yyrr542, yyrl542 int
+	var yyc542, yyrt542 bool
+	_, _, _ = yyc542, yyrt542, yyrl542
+	yyrr542 = yyl542
 
-	if yyv503 == nil {
-		if yyrl503, yyrt503 = z.DecInferLen(yyl503, z.DecBasicHandle().MaxInitLen, 160); yyrt503 {
-			yyrr503 = yyrl503
+	if yyv542 == nil {
+		if yyrl542, yyrt542 = z.DecInferLen(yyl542, z.DecBasicHandle().MaxInitLen, 160); yyrt542 {
+			yyrr542 = yyrl542
 		}
-		yyv503 = make([]RawPodMetrics, yyrl503)
-		yyc503 = true
+		yyv542 = make([]RawPodMetrics, yyrl542)
+		yyc542 = true
 	}
 
-	if yyl503 == 0 {
-		if len(yyv503) != 0 {
-			yyv503 = yyv503[:0]
-			yyc503 = true
+	if yyl542 == 0 {
+		if len(yyv542) != 0 {
+			yyv542 = yyv542[:0]
+			yyc542 = true
 		}
-	} else if yyl503 > 0 {
+	} else if yyl542 > 0 {
 
-		if yyl503 > cap(yyv503) {
-			yyrl503, yyrt503 = z.DecInferLen(yyl503, z.DecBasicHandle().MaxInitLen, 160)
-			yyv503 = make([]RawPodMetrics, yyrl503)
-			yyc503 = true
+		if yyl542 > cap(yyv542) {
+			yyrl542, yyrt542 = z.DecInferLen(yyl542, z.DecBasicHandle().MaxInitLen, 160)
+			yyv542 = make([]RawPodMetrics, yyrl542)
+			yyc542 = true
 
-			yyrr503 = len(yyv503)
-		} else if yyl503 != len(yyv503) {
-			yyv503 = yyv503[:yyl503]
-			yyc503 = true
+			yyrr542 = len(yyv542)
+		} else if yyl542 != len(yyv542) {
+			yyv542 = yyv542[:yyl542]
+			yyc542 = true
 		}
-		yyj503 := 0
-		for ; yyj503 < yyrr503; yyj503++ {
+		yyj542 := 0
+		for ; yyj542 < yyrr542; yyj542++ {
 			if r.TryDecodeAsNil() {
-				yyv503[yyj503] = RawPodMetrics{}
+				yyv542[yyj542] = RawPodMetrics{}
 			} else {
-				yyv504 := &yyv503[yyj503]
-				yyv504.CodecDecodeSelf(d)
+				yyv543 := &yyv542[yyj542]
+				yyv543.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt503 {
-			for ; yyj503 < yyl503; yyj503++ {
-				yyv503 = append(yyv503, RawPodMetrics{})
+		if yyrt542 {
+			for ; yyj542 < yyl542; yyj542++ {
+				yyv542 = append(yyv542, RawPodMetrics{})
 				if r.TryDecodeAsNil() {
-					yyv503[yyj503] = RawPodMetrics{}
+					yyv542[yyj542] = RawPodMetrics{}
 				} else {
-					yyv505 := &yyv503[yyj503]
-					yyv505.CodecDecodeSelf(d)
+					yyv544 := &yyv542[yyj542]
+					yyv544.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj503 := 0; !r.CheckBreak(); yyj503++ {
-			if yyj503 >= len(yyv503) {
-				yyv503 = append(yyv503, RawPodMetrics{}) // var yyz503 RawPodMetrics
-				yyc503 = true
+		for yyj542 := 0; !r.CheckBreak(); yyj542++ {
+			if yyj542 >= len(yyv542) {
+				yyv542 = append(yyv542, RawPodMetrics{}) // var yyz542 RawPodMetrics
+				yyc542 = true
 			}
 
-			if yyj503 < len(yyv503) {
+			if yyj542 < len(yyv542) {
 				if r.TryDecodeAsNil() {
-					yyv503[yyj503] = RawPodMetrics{}
+					yyv542[yyj542] = RawPodMetrics{}
 				} else {
-					yyv506 := &yyv503[yyj503]
-					yyv506.CodecDecodeSelf(d)
+					yyv545 := &yyv542[yyj542]
+					yyv545.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -5936,10 +6384,10 @@ func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.
 			}
 
 		}
-		yyh503.End()
+		yyh542.End()
 	}
-	if yyc503 {
-		*v = yyv503
+	if yyc542 {
+		*v = yyv542
 	}
 
 }
@@ -5949,9 +6397,9 @@ func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv507 := range v {
-		yy508 := &yyv507
-		yy508.CodecEncodeSelf(e)
+	for _, yyv546 := range v {
+		yy547 := &yyv546
+		yy547.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -5961,75 +6409,75 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv509 := *v
-	yyh509, yyl509 := z.DecSliceHelperStart()
+	yyv548 := *v
+	yyh548, yyl548 := z.DecSliceHelperStart()
 
-	var yyrr509, yyrl509 int
-	var yyc509, yyrt509 bool
-	_, _, _ = yyc509, yyrt509, yyrl509
-	yyrr509 = yyl509
+	var yyrr548, yyrl548 int
+	var yyc548, yyrt548 bool
+	_, _, _ = yyc548, yyrt548, yyrl548
+	yyrr548 = yyl548
 
-	if yyv509 == nil {
-		if yyrl509, yyrt509 = z.DecInferLen(yyl509, z.DecBasicHandle().MaxInitLen, 40); yyrt509 {
-			yyrr509 = yyrl509
+	if yyv548 == nil {
+		if yyrl548, yyrt548 = z.DecInferLen(yyl548, z.DecBasicHandle().MaxInitLen, 64); yyrt548 {
+			yyrr548 = yyrl548
 		}
-		yyv509 = make([]ContainerSample, yyrl509)
-		yyc509 = true
+		yyv548 = make([]ContainerSample, yyrl548)
+		yyc548 = true
 	}
 
-	if yyl509 == 0 {
-		if len(yyv509) != 0 {
-			yyv509 = yyv509[:0]
-			yyc509 = true
+	if yyl548 == 0 {
+		if len(yyv548) != 0 {
+			yyv548 = yyv548[:0]
+			yyc548 = true
 		}
-	} else if yyl509 > 0 {
+	} else if yyl548 > 0 {
 
-		if yyl509 > cap(yyv509) {
-			yyrl509, yyrt509 = z.DecInferLen(yyl509, z.DecBasicHandle().MaxInitLen, 40)
-			yyv509 = make([]ContainerSample, yyrl509)
-			yyc509 = true
+		if yyl548 > cap(yyv548) {
+			yyrl548, yyrt548 = z.DecInferLen(yyl548, z.DecBasicHandle().MaxInitLen, 64)
+			yyv548 = make([]ContainerSample, yyrl548)
+			yyc548 = true
 
-			yyrr509 = len(yyv509)
-		} else if yyl509 != len(yyv509) {
-			yyv509 = yyv509[:yyl509]
-			yyc509 = true
+			yyrr548 = len(yyv548)
+		} else if yyl548 != len(yyv548) {
+			yyv548 = yyv548[:yyl548]
+			yyc548 = true
 		}
-		yyj509 := 0
-		for ; yyj509 < yyrr509; yyj509++ {
+		yyj548 := 0
+		for ; yyj548 < yyrr548; yyj548++ {
 			if r.TryDecodeAsNil() {
-				yyv509[yyj509] = ContainerSample{}
+				yyv548[yyj548] = ContainerSample{}
 			} else {
-				yyv510 := &yyv509[yyj509]
-				yyv510.CodecDecodeSelf(d)
+				yyv549 := &yyv548[yyj548]
+				yyv549.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt509 {
-			for ; yyj509 < yyl509; yyj509++ {
-				yyv509 = append(yyv509, ContainerSample{})
+		if yyrt548 {
+			for ; yyj548 < yyl548; yyj548++ {
+				yyv548 = append(yyv548, ContainerSample{})
 				if r.TryDecodeAsNil() {
-					yyv509[yyj509] = ContainerSample{}
+					yyv548[yyj548] = ContainerSample{}
 				} else {
-					yyv511 := &yyv509[yyj509]
-					yyv511.CodecDecodeSelf(d)
+					yyv550 := &yyv548[yyj548]
+					yyv550.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj509 := 0; !r.CheckBreak(); yyj509++ {
-			if yyj509 >= len(yyv509) {
-				yyv509 = append(yyv509, ContainerSample{}) // var yyz509 ContainerSample
-				yyc509 = true
+		for yyj548 := 0; !r.CheckBreak(); yyj548++ {
+			if yyj548 >= len(yyv548) {
+				yyv548 = append(yyv548, ContainerSample{}) // var yyz548 ContainerSample
+				yyc548 = true
 			}
 
-			if yyj509 < len(yyv509) {
+			if yyj548 < len(yyv548) {
 				if r.TryDecodeAsNil() {
-					yyv509[yyj509] = ContainerSample{}
+					yyv548[yyj548] = ContainerSample{}
 				} else {
-					yyv512 := &yyv509[yyj509]
-					yyv512.CodecDecodeSelf(d)
+					yyv551 := &yyv548[yyj548]
+					yyv551.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6037,10 +6485,10 @@ func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1
 			}
 
 		}
-		yyh509.End()
+		yyh548.End()
 	}
-	if yyc509 {
-		*v = yyv509
+	if yyc548 {
+		*v = yyv548
 	}
 
 }
@@ -6050,9 +6498,9 @@ func (x codecSelfer1234) encSliceCustomMetric(v []CustomMetric, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv513 := range v {
-		yy514 := &yyv513
-		yy514.CodecEncodeSelf(e)
+	for _, yyv552 := range v {
+		yy553 := &yyv552
+		yy553.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6062,75 +6510,75 @@ func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv515 := *v
-	yyh515, yyl515 := z.DecSliceHelperStart()
+	yyv554 := *v
+	yyh554, yyl554 := z.DecSliceHelperStart()
 
-	var yyrr515, yyrl515 int
-	var yyc515, yyrt515 bool
-	_, _, _ = yyc515, yyrt515, yyrl515
-	yyrr515 = yyl515
+	var yyrr554, yyrl554 int
+	var yyc554, yyrt554 bool
+	_, _, _ = yyc554, yyrt554, yyrl554
+	yyrr554 = yyl554
 
-	if yyv515 == nil {
-		if yyrl515, yyrt515 = z.DecInferLen(yyl515, z.DecBasicHandle().MaxInitLen, 72); yyrt515 {
-			yyrr515 = yyrl515
+	if yyv554 == nil {
+		if yyrl554, yyrt554 = z.DecInferLen(yyl554, z.DecBasicHandle().MaxInitLen, 72); yyrt554 {
+			yyrr554 = yyrl554
 		}
-		yyv515 = make([]CustomMetric, yyrl515)
-		yyc515 = true
+		yyv554 = make([]CustomMetric, yyrl554)
+		yyc554 = true
 	}
 
-	if yyl515 == 0 {
-		if len(yyv515) != 0 {
-			yyv515 = yyv515[:0]
-			yyc515 = true
+	if yyl554 == 0 {
+		if len(yyv554) != 0 {
+			yyv554 = yyv554[:0]
+			yyc554 = true
 		}
-	} else if yyl515 > 0 {
+	} else if yyl554 > 0 {
 
-		if yyl515 > cap(yyv515) {
-			yyrl515, yyrt515 = z.DecInferLen(yyl515, z.DecBasicHandle().MaxInitLen, 72)
-			yyv515 = make([]CustomMetric, yyrl515)
-			yyc515 = true
+		if yyl554 > cap(yyv554) {
+			yyrl554, yyrt554 = z.DecInferLen(yyl554, z.DecBasicHandle().MaxInitLen, 72)
+			yyv554 = make([]CustomMetric, yyrl554)
+			yyc554 = true
 
-			yyrr515 = len(yyv515)
-		} else if yyl515 != len(yyv515) {
-			yyv515 = yyv515[:yyl515]
-			yyc515 = true
+			yyrr554 = len(yyv554)
+		} else if yyl554 != len(yyv554) {
+			yyv554 = yyv554[:yyl554]
+			yyc554 = true
 		}
-		yyj515 := 0
-		for ; yyj515 < yyrr515; yyj515++ {
+		yyj554 := 0
+		for ; yyj554 < yyrr554; yyj554++ {
 			if r.TryDecodeAsNil() {
-				yyv515[yyj515] = CustomMetric{}
+				yyv554[yyj554] = CustomMetric{}
 			} else {
-				yyv516 := &yyv515[yyj515]
-				yyv516.CodecDecodeSelf(d)
+				yyv555 := &yyv554[yyj554]
+				yyv555.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt515 {
-			for ; yyj515 < yyl515; yyj515++ {
-				yyv515 = append(yyv515, CustomMetric{})
+		if yyrt554 {
+			for ; yyj554 < yyl554; yyj554++ {
+				yyv554 = append(yyv554, CustomMetric{})
 				if r.TryDecodeAsNil() {
-					yyv515[yyj515] = CustomMetric{}
+					yyv554[yyj554] = CustomMetric{}
 				} else {
-					yyv517 := &yyv515[yyj515]
-					yyv517.CodecDecodeSelf(d)
+					yyv556 := &yyv554[yyj554]
+					yyv556.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj515 := 0; !r.CheckBreak(); yyj515++ {
-			if yyj515 >= len(yyv515) {
-				yyv515 = append(yyv515, CustomMetric{}) // var yyz515 CustomMetric
-				yyc515 = true
+		for yyj554 := 0; !r.CheckBreak(); yyj554++ {
+			if yyj554 >= len(yyv554) {
+				yyv554 = append(yyv554, CustomMetric{}) // var yyz554 CustomMetric
+				yyc554 = true
 			}
 
-			if yyj515 < len(yyv515) {
+			if yyj554 < len(yyv554) {
 				if r.TryDecodeAsNil() {
-					yyv515[yyj515] = CustomMetric{}
+					yyv554[yyj554] = CustomMetric{}
 				} else {
-					yyv518 := &yyv515[yyj515]
-					yyv518.CodecDecodeSelf(d)
+					yyv557 := &yyv554[yyj554]
+					yyv557.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6138,10 +6586,111 @@ func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.De
 			}
 
 		}
-		yyh515.End()
+		yyh554.End()
 	}
-	if yyc515 {
-		*v = yyv515
+	if yyc554 {
+		*v = yyv554
+	}
+
+}
+
+func (x codecSelfer1234) encSliceFilesystemMetrics(v []FilesystemMetrics, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv558 := range v {
+		yy559 := &yyv558
+		yy559.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceFilesystemMetrics(v *[]FilesystemMetrics, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv560 := *v
+	yyh560, yyl560 := z.DecSliceHelperStart()
+
+	var yyrr560, yyrl560 int
+	var yyc560, yyrt560 bool
+	_, _, _ = yyc560, yyrt560, yyrl560
+	yyrr560 = yyl560
+
+	if yyv560 == nil {
+		if yyrl560, yyrt560 = z.DecInferLen(yyl560, z.DecBasicHandle().MaxInitLen, 32); yyrt560 {
+			yyrr560 = yyrl560
+		}
+		yyv560 = make([]FilesystemMetrics, yyrl560)
+		yyc560 = true
+	}
+
+	if yyl560 == 0 {
+		if len(yyv560) != 0 {
+			yyv560 = yyv560[:0]
+			yyc560 = true
+		}
+	} else if yyl560 > 0 {
+
+		if yyl560 > cap(yyv560) {
+			yyrl560, yyrt560 = z.DecInferLen(yyl560, z.DecBasicHandle().MaxInitLen, 32)
+			yyv560 = make([]FilesystemMetrics, yyrl560)
+			yyc560 = true
+
+			yyrr560 = len(yyv560)
+		} else if yyl560 != len(yyv560) {
+			yyv560 = yyv560[:yyl560]
+			yyc560 = true
+		}
+		yyj560 := 0
+		for ; yyj560 < yyrr560; yyj560++ {
+			if r.TryDecodeAsNil() {
+				yyv560[yyj560] = FilesystemMetrics{}
+			} else {
+				yyv561 := &yyv560[yyj560]
+				yyv561.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt560 {
+			for ; yyj560 < yyl560; yyj560++ {
+				yyv560 = append(yyv560, FilesystemMetrics{})
+				if r.TryDecodeAsNil() {
+					yyv560[yyj560] = FilesystemMetrics{}
+				} else {
+					yyv562 := &yyv560[yyj560]
+					yyv562.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj560 := 0; !r.CheckBreak(); yyj560++ {
+			if yyj560 >= len(yyv560) {
+				yyv560 = append(yyv560, FilesystemMetrics{}) // var yyz560 FilesystemMetrics
+				yyc560 = true
+			}
+
+			if yyj560 < len(yyv560) {
+				if r.TryDecodeAsNil() {
+					yyv560[yyj560] = FilesystemMetrics{}
+				} else {
+					yyv563 := &yyv560[yyj560]
+					yyv563.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh560.End()
+	}
+	if yyc560 {
+		*v = yyv560
 	}
 
 }
@@ -6151,9 +6700,9 @@ func (x codecSelfer1234) encSliceCustomMetricSample(v []CustomMetricSample, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv519 := range v {
-		yy520 := &yyv519
-		yy520.CodecEncodeSelf(e)
+	for _, yyv564 := range v {
+		yy565 := &yyv564
+		yy565.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -6163,75 +6712,75 @@ func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv521 := *v
-	yyh521, yyl521 := z.DecSliceHelperStart()
+	yyv566 := *v
+	yyh566, yyl566 := z.DecSliceHelperStart()
 
-	var yyrr521, yyrl521 int
-	var yyc521, yyrt521 bool
-	_, _, _ = yyc521, yyrt521, yyrl521
-	yyrr521 = yyl521
+	var yyrr566, yyrl566 int
+	var yyc566, yyrt566 bool
+	_, _, _ = yyc566, yyrt566, yyrl566
+	yyrr566 = yyl566
 
-	if yyv521 == nil {
-		if yyrl521, yyrt521 = z.DecInferLen(yyl521, z.DecBasicHandle().MaxInitLen, 56); yyrt521 {
-			yyrr521 = yyrl521
+	if yyv566 == nil {
+		if yyrl566, yyrt566 = z.DecInferLen(yyl566, z.DecBasicHandle().MaxInitLen, 56); yyrt566 {
+			yyrr566 = yyrl566
 		}
-		yyv521 = make([]CustomMetricSample, yyrl521)
-		yyc521 = true
+		yyv566 = make([]CustomMetricSample, yyrl566)
+		yyc566 = true
 	}
 
-	if yyl521 == 0 {
-		if len(yyv521) != 0 {
-			yyv521 = yyv521[:0]
-			yyc521 = true
+	if yyl566 == 0 {
+		if len(yyv566) != 0 {
+			yyv566 = yyv566[:0]
+			yyc566 = true
 		}
-	} else if yyl521 > 0 {
+	} else if yyl566 > 0 {
 
-		if yyl521 > cap(yyv521) {
-			yyrl521, yyrt521 = z.DecInferLen(yyl521, z.DecBasicHandle().MaxInitLen, 56)
-			yyv521 = make([]CustomMetricSample, yyrl521)
-			yyc521 = true
+		if yyl566 > cap(yyv566) {
+			yyrl566, yyrt566 = z.DecInferLen(yyl566, z.DecBasicHandle().MaxInitLen, 56)
+			yyv566 = make([]CustomMetricSample, yyrl566)
+			yyc566 = true
 
-			yyrr521 = len(yyv521)
-		} else if yyl521 != len(yyv521) {
-			yyv521 = yyv521[:yyl521]
-			yyc521 = true
+			yyrr566 = len(yyv566)
+		} else if yyl566 != len(yyv566) {
+			yyv566 = yyv566[:yyl566]
+			yyc566 = true
 		}
-		yyj521 := 0
-		for ; yyj521 < yyrr521; yyj521++ {
+		yyj566 := 0
+		for ; yyj566 < yyrr566; yyj566++ {
 			if r.TryDecodeAsNil() {
-				yyv521[yyj521] = CustomMetricSample{}
+				yyv566[yyj566] = CustomMetricSample{}
 			} else {
-				yyv522 := &yyv521[yyj521]
-				yyv522.CodecDecodeSelf(d)
+				yyv567 := &yyv566[yyj566]
+				yyv567.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt521 {
-			for ; yyj521 < yyl521; yyj521++ {
-				yyv521 = append(yyv521, CustomMetricSample{})
+		if yyrt566 {
+			for ; yyj566 < yyl566; yyj566++ {
+				yyv566 = append(yyv566, CustomMetricSample{})
 				if r.TryDecodeAsNil() {
-					yyv521[yyj521] = CustomMetricSample{}
+					yyv566[yyj566] = CustomMetricSample{}
 				} else {
-					yyv523 := &yyv521[yyj521]
-					yyv523.CodecDecodeSelf(d)
+					yyv568 := &yyv566[yyj566]
+					yyv568.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj521 := 0; !r.CheckBreak(); yyj521++ {
-			if yyj521 >= len(yyv521) {
-				yyv521 = append(yyv521, CustomMetricSample{}) // var yyz521 CustomMetricSample
-				yyc521 = true
+		for yyj566 := 0; !r.CheckBreak(); yyj566++ {
+			if yyj566 >= len(yyv566) {
+				yyv566 = append(yyv566, CustomMetricSample{}) // var yyz566 CustomMetricSample
+				yyc566 = true
 			}
 
-			if yyj521 < len(yyv521) {
+			if yyj566 < len(yyv566) {
 				if r.TryDecodeAsNil() {
-					yyv521[yyj521] = CustomMetricSample{}
+					yyv566[yyj566] = CustomMetricSample{}
 				} else {
-					yyv524 := &yyv521[yyj521]
-					yyv524.CodecDecodeSelf(d)
+					yyv569 := &yyv566[yyj566]
+					yyv569.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -6239,10 +6788,10 @@ func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *
 			}
 
 		}
-		yyh521.End()
+		yyh566.End()
 	}
-	if yyc521 {
-		*v = yyv521
+	if yyc566 {
+		*v = yyv566
 	}
 
 }

--- a/pkg/apis/metrics/v1alpha1/types.generated.go
+++ b/pkg/apis/metrics/v1alpha1/types.generated.go
@@ -25,9 +25,13 @@ import (
 	"errors"
 	"fmt"
 	codec1978 "github.com/ugorji/go/codec"
+	pkg2_resource "k8s.io/kubernetes/pkg/api/resource"
 	pkg1_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	pkg4_types "k8s.io/kubernetes/pkg/types"
 	"reflect"
 	"runtime"
+	pkg3_inf "speter.net/go/exp/math/dec/inf"
+	time "time"
 )
 
 const (
@@ -52,12 +56,16 @@ func init() {
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
-		var v0 pkg1_unversioned.TypeMeta
-		_ = v0
+		var v0 pkg2_resource.Quantity
+		var v1 pkg1_unversioned.TypeMeta
+		var v2 pkg4_types.UID
+		var v3 pkg3_inf.Dec
+		var v4 time.Time
+		_, _, _, _, _ = v0, v1, v2, v3, v4
 	}
 }
 
-func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *MetricsMeta) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -71,13 +79,12 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2 := !z.EncBinary()
 			yy2arr2 := z.EncBasicHandle().StructToArray
-			var yyq2 [2]bool
+			var yyq2 [1]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
+			yyq2[0] = x.SelfLink != ""
 			if yyr2 || yy2arr2 {
-				r.EncodeArrayStart(2)
+				r.EncodeArrayStart(1)
 			} else {
 				var yynn2 int = 0
 				for _, b := range yyq2 {
@@ -93,41 +100,19 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym4
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.SelfLink))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("selfLink"))
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.SelfLink))
 					}
 				}
 			}
@@ -138,28 +123,28 @@ func (x *RawNode) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *RawNode) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *MetricsMeta) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym9 := z.DecBinary()
-	_ = yym9
+	yym6 := z.DecBinary()
+	_ = yym6
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl10 := r.ReadMapStart()
-			if yyl10 == 0 {
+			yyl7 := r.ReadMapStart()
+			if yyl7 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl10, d)
+				x.codecDecodeSelfFromMap(yyl7, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl10 := r.ReadArrayStart()
-			if yyl10 == 0 {
+			yyl7 := r.ReadArrayStart()
+			if yyl7 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl10, d)
+				x.codecDecodeSelfFromArray(yyl7, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -167,16 +152,16 @@ func (x *RawNode) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *RawNode) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *MetricsMeta) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys11Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys11Slc
-	var yyhl11 bool = l >= 0
-	for yyj11 := 0; ; yyj11++ {
-		if yyhl11 {
-			if yyj11 >= l {
+	var yys8Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys8Slc
+	var yyhl8 bool = l >= 0
+	for yyj8 := 0; ; yyj8++ {
+		if yyhl8 {
+			if yyj8 >= l {
 				break
 			}
 		} else {
@@ -184,116 +169,97 @@ func (x *RawNode) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys11Slc = r.DecodeBytes(yys11Slc, true, true)
-		yys11 := string(yys11Slc)
-		switch yys11 {
-		case "kind":
+		yys8Slc = r.DecodeBytes(yys8Slc, true, true)
+		yys8 := string(yys8Slc)
+		switch yys8 {
+		case "selfLink":
 			if r.TryDecodeAsNil() {
-				x.Kind = ""
+				x.SelfLink = ""
 			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
+				x.SelfLink = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys11)
-		} // end switch yys11
-	} // end for yyj11
-	if !yyhl11 {
+			z.DecStructFieldNotFound(-1, yys8)
+		} // end switch yys8
+	} // end for yyj8
+	if !yyhl8 {
 		r.ReadEnd()
 	}
 }
 
-func (x *RawNode) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *MetricsMeta) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj14 int
-	var yyb14 bool
-	var yyhl14 bool = l >= 0
-	yyj14++
-	if yyhl14 {
-		yyb14 = yyj14 > l
+	var yyj10 int
+	var yyb10 bool
+	var yyhl10 bool = l >= 0
+	yyj10++
+	if yyhl10 {
+		yyb10 = yyj10 > l
 	} else {
-		yyb14 = r.CheckBreak()
+		yyb10 = r.CheckBreak()
 	}
-	if yyb14 {
+	if yyb10 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
+		x.SelfLink = ""
 	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj14++
-	if yyhl14 {
-		yyb14 = yyj14 > l
-	} else {
-		yyb14 = r.CheckBreak()
-	}
-	if yyb14 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
+		x.SelfLink = string(r.DecodeString())
 	}
 	for {
-		yyj14++
-		if yyhl14 {
-			yyb14 = yyj14 > l
+		yyj10++
+		if yyhl10 {
+			yyb10 = yyj10 > l
 		} else {
-			yyb14 = r.CheckBreak()
+			yyb10 = r.CheckBreak()
 		}
-		if yyb14 {
+		if yyb10 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj14-1, "")
+		z.DecStructFieldNotFound(yyj10-1, "")
 	}
 	r.ReadEnd()
 }
 
-func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *RawNodeMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym17 := z.EncBinary()
-		_ = yym17
+		yym12 := z.EncBinary()
+		_ = yym12
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep18 := !z.EncBinary()
-			yy2arr18 := z.EncBasicHandle().StructToArray
-			var yyq18 [2]bool
-			_, _, _ = yysep18, yyq18, yy2arr18
-			const yyr18 bool = false
-			yyq18[0] = x.Kind != ""
-			yyq18[1] = x.APIVersion != ""
-			if yyr18 || yy2arr18 {
-				r.EncodeArrayStart(2)
+			yysep13 := !z.EncBinary()
+			yy2arr13 := z.EncBasicHandle().StructToArray
+			var yyq13 [6]bool
+			_, _, _ = yysep13, yyq13, yy2arr13
+			const yyr13 bool = false
+			yyq13[0] = x.Kind != ""
+			yyq13[1] = x.APIVersion != ""
+			yyq13[4] = len(x.Total) != 0
+			yyq13[5] = len(x.SystemContainers) != 0
+			if yyr13 || yy2arr13 {
+				r.EncodeArrayStart(6)
 			} else {
-				var yynn18 int = 0
-				for _, b := range yyq18 {
+				var yynn13 int = 2
+				for _, b := range yyq13 {
 					if b {
-						yynn18++
+						yynn13++
 					}
 				}
-				r.EncodeMapStart(yynn18)
+				r.EncodeMapStart(yynn13)
 			}
-			if yyr18 || yy2arr18 {
-				if yyq18[0] {
-					yym20 := z.EncBinary()
-					_ = yym20
+			if yyr13 || yy2arr13 {
+				if yyq13[0] {
+					yym15 := z.EncBinary()
+					_ = yym15
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -302,20 +268,20 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq18[0] {
+				if yyq13[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym21 := z.EncBinary()
-					_ = yym21
+					yym16 := z.EncBinary()
+					_ = yym16
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr18 || yy2arr18 {
-				if yyq18[1] {
-					yym23 := z.EncBinary()
-					_ = yym23
+			if yyr13 || yy2arr13 {
+				if yyq13[1] {
+					yym18 := z.EncBinary()
+					_ = yym18
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -324,45 +290,141 @@ func (x *RawPod) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq18[1] {
+				if yyq13[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym24 := z.EncBinary()
-					_ = yym24
+					yym19 := z.EncBinary()
+					_ = yym19
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yysep18 {
+			if yyr13 || yy2arr13 {
+				yy21 := &x.ListMeta
+				yym22 := z.EncBinary()
+				_ = yym22
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy21) {
+				} else {
+					z.EncFallback(yy21)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				yy23 := &x.ListMeta
+				yym24 := z.EncBinary()
+				_ = yym24
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy23) {
+				} else {
+					z.EncFallback(yy23)
+				}
+			}
+			if yyr13 || yy2arr13 {
+				yym26 := z.EncBinary()
+				_ = yym26
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.NodeName))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("nodeName"))
+				yym27 := z.EncBinary()
+				_ = yym27
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.NodeName))
+				}
+			}
+			if yyr13 || yy2arr13 {
+				if yyq13[4] {
+					if x.Total == nil {
+						r.EncodeNil()
+					} else {
+						yym29 := z.EncBinary()
+						_ = yym29
+						if false {
+						} else {
+							h.encSliceAggregateSample(([]AggregateSample)(x.Total), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq13[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("total"))
+					if x.Total == nil {
+						r.EncodeNil()
+					} else {
+						yym30 := z.EncBinary()
+						_ = yym30
+						if false {
+						} else {
+							h.encSliceAggregateSample(([]AggregateSample)(x.Total), e)
+						}
+					}
+				}
+			}
+			if yyr13 || yy2arr13 {
+				if yyq13[5] {
+					if x.SystemContainers == nil {
+						r.EncodeNil()
+					} else {
+						yym32 := z.EncBinary()
+						_ = yym32
+						if false {
+						} else {
+							h.encSliceRawContainerMetrics(([]RawContainerMetrics)(x.SystemContainers), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq13[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("systemContainers"))
+					if x.SystemContainers == nil {
+						r.EncodeNil()
+					} else {
+						yym33 := z.EncBinary()
+						_ = yym33
+						if false {
+						} else {
+							h.encSliceRawContainerMetrics(([]RawContainerMetrics)(x.SystemContainers), e)
+						}
+					}
+				}
+			}
+			if yysep13 {
 				r.EncodeEnd()
 			}
 		}
 	}
 }
 
-func (x *RawPod) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *RawNodeMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym25 := z.DecBinary()
-	_ = yym25
+	yym34 := z.DecBinary()
+	_ = yym34
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl26 := r.ReadMapStart()
-			if yyl26 == 0 {
+			yyl35 := r.ReadMapStart()
+			if yyl35 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl26, d)
+				x.codecDecodeSelfFromMap(yyl35, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl26 := r.ReadArrayStart()
-			if yyl26 == 0 {
+			yyl35 := r.ReadArrayStart()
+			if yyl35 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl26, d)
+				x.codecDecodeSelfFromArray(yyl35, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -370,16 +432,16 @@ func (x *RawPod) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *RawNodeMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys27Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys27Slc
-	var yyhl27 bool = l >= 0
-	for yyj27 := 0; ; yyj27++ {
-		if yyhl27 {
-			if yyj27 >= l {
+	var yys36Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys36Slc
+	var yyhl36 bool = l >= 0
+	for yyj36 := 0; ; yyj36++ {
+		if yyhl36 {
+			if yyj36 >= l {
 				break
 			}
 		} else {
@@ -387,9 +449,9 @@ func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys27Slc = r.DecodeBytes(yys27Slc, true, true)
-		yys27 := string(yys27Slc)
-		switch yys27 {
+		yys36Slc = r.DecodeBytes(yys36Slc, true, true)
+		yys36 := string(yys36Slc)
+		switch yys36 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -402,29 +464,72 @@ func (x *RawPod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.APIVersion = string(r.DecodeString())
 			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv39 := &x.ListMeta
+				yym40 := z.DecBinary()
+				_ = yym40
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv39) {
+				} else {
+					z.DecFallback(yyv39, false)
+				}
+			}
+		case "nodeName":
+			if r.TryDecodeAsNil() {
+				x.NodeName = ""
+			} else {
+				x.NodeName = string(r.DecodeString())
+			}
+		case "total":
+			if r.TryDecodeAsNil() {
+				x.Total = nil
+			} else {
+				yyv42 := &x.Total
+				yym43 := z.DecBinary()
+				_ = yym43
+				if false {
+				} else {
+					h.decSliceAggregateSample((*[]AggregateSample)(yyv42), d)
+				}
+			}
+		case "systemContainers":
+			if r.TryDecodeAsNil() {
+				x.SystemContainers = nil
+			} else {
+				yyv44 := &x.SystemContainers
+				yym45 := z.DecBinary()
+				_ = yym45
+				if false {
+				} else {
+					h.decSliceRawContainerMetrics((*[]RawContainerMetrics)(yyv44), d)
+				}
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys27)
-		} // end switch yys27
-	} // end for yyj27
-	if !yyhl27 {
+			z.DecStructFieldNotFound(-1, yys36)
+		} // end switch yys36
+	} // end for yyj36
+	if !yyhl36 {
 		r.ReadEnd()
 	}
 }
 
-func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *RawNodeMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj30 int
-	var yyb30 bool
-	var yyhl30 bool = l >= 0
-	yyj30++
-	if yyhl30 {
-		yyb30 = yyj30 > l
+	var yyj46 int
+	var yyb46 bool
+	var yyhl46 bool = l >= 0
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
 	} else {
-		yyb30 = r.CheckBreak()
+		yyb46 = r.CheckBreak()
 	}
-	if yyb30 {
+	if yyb46 {
 		r.ReadEnd()
 		return
 	}
@@ -433,13 +538,13 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj30++
-	if yyhl30 {
-		yyb30 = yyj30 > l
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
 	} else {
-		yyb30 = r.CheckBreak()
+		yyb46 = r.CheckBreak()
 	}
-	if yyb30 {
+	if yyb46 {
 		r.ReadEnd()
 		return
 	}
@@ -448,17 +553,5696 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	for {
-		yyj30++
-		if yyhl30 {
-			yyb30 = yyj30 > l
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
+	} else {
+		yyb46 = r.CheckBreak()
+	}
+	if yyb46 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv49 := &x.ListMeta
+		yym50 := z.DecBinary()
+		_ = yym50
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv49) {
 		} else {
-			yyb30 = r.CheckBreak()
+			z.DecFallback(yyv49, false)
 		}
-		if yyb30 {
+	}
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
+	} else {
+		yyb46 = r.CheckBreak()
+	}
+	if yyb46 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.NodeName = ""
+	} else {
+		x.NodeName = string(r.DecodeString())
+	}
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
+	} else {
+		yyb46 = r.CheckBreak()
+	}
+	if yyb46 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Total = nil
+	} else {
+		yyv52 := &x.Total
+		yym53 := z.DecBinary()
+		_ = yym53
+		if false {
+		} else {
+			h.decSliceAggregateSample((*[]AggregateSample)(yyv52), d)
+		}
+	}
+	yyj46++
+	if yyhl46 {
+		yyb46 = yyj46 > l
+	} else {
+		yyb46 = r.CheckBreak()
+	}
+	if yyb46 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SystemContainers = nil
+	} else {
+		yyv54 := &x.SystemContainers
+		yym55 := z.DecBinary()
+		_ = yym55
+		if false {
+		} else {
+			h.decSliceRawContainerMetrics((*[]RawContainerMetrics)(yyv54), d)
+		}
+	}
+	for {
+		yyj46++
+		if yyhl46 {
+			yyb46 = yyj46 > l
+		} else {
+			yyb46 = r.CheckBreak()
+		}
+		if yyb46 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj30-1, "")
+		z.DecStructFieldNotFound(yyj46-1, "")
 	}
 	r.ReadEnd()
+}
+
+func (x *RawNodeMetricsList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym56 := z.EncBinary()
+		_ = yym56
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep57 := !z.EncBinary()
+			yy2arr57 := z.EncBasicHandle().StructToArray
+			var yyq57 [4]bool
+			_, _, _ = yysep57, yyq57, yy2arr57
+			const yyr57 bool = false
+			yyq57[0] = x.Kind != ""
+			yyq57[1] = x.APIVersion != ""
+			yyq57[2] = true
+			if yyr57 || yy2arr57 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn57 int = 1
+				for _, b := range yyq57 {
+					if b {
+						yynn57++
+					}
+				}
+				r.EncodeMapStart(yynn57)
+			}
+			if yyr57 || yy2arr57 {
+				if yyq57[0] {
+					yym59 := z.EncBinary()
+					_ = yym59
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq57[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym60 := z.EncBinary()
+					_ = yym60
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr57 || yy2arr57 {
+				if yyq57[1] {
+					yym62 := z.EncBinary()
+					_ = yym62
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq57[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym63 := z.EncBinary()
+					_ = yym63
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr57 || yy2arr57 {
+				if yyq57[2] {
+					yy65 := &x.ListMeta
+					yym66 := z.EncBinary()
+					_ = yym66
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy65) {
+					} else {
+						z.EncFallback(yy65)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq57[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy67 := &x.ListMeta
+					yym68 := z.EncBinary()
+					_ = yym68
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy67) {
+					} else {
+						z.EncFallback(yy67)
+					}
+				}
+			}
+			if yyr57 || yy2arr57 {
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym70 := z.EncBinary()
+					_ = yym70
+					if false {
+					} else {
+						h.encSliceRawNodeMetrics(([]RawNodeMetrics)(x.Items), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym71 := z.EncBinary()
+					_ = yym71
+					if false {
+					} else {
+						h.encSliceRawNodeMetrics(([]RawNodeMetrics)(x.Items), e)
+					}
+				}
+			}
+			if yysep57 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawNodeMetricsList) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym72 := z.DecBinary()
+	_ = yym72
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl73 := r.ReadMapStart()
+			if yyl73 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl73, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl73 := r.ReadArrayStart()
+			if yyl73 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl73, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawNodeMetricsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys74Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys74Slc
+	var yyhl74 bool = l >= 0
+	for yyj74 := 0; ; yyj74++ {
+		if yyhl74 {
+			if yyj74 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys74Slc = r.DecodeBytes(yys74Slc, true, true)
+		yys74 := string(yys74Slc)
+		switch yys74 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv77 := &x.ListMeta
+				yym78 := z.DecBinary()
+				_ = yym78
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv77) {
+				} else {
+					z.DecFallback(yyv77, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv79 := &x.Items
+				yym80 := z.DecBinary()
+				_ = yym80
+				if false {
+				} else {
+					h.decSliceRawNodeMetrics((*[]RawNodeMetrics)(yyv79), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys74)
+		} // end switch yys74
+	} // end for yyj74
+	if !yyhl74 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawNodeMetricsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj81 int
+	var yyb81 bool
+	var yyhl81 bool = l >= 0
+	yyj81++
+	if yyhl81 {
+		yyb81 = yyj81 > l
+	} else {
+		yyb81 = r.CheckBreak()
+	}
+	if yyb81 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj81++
+	if yyhl81 {
+		yyb81 = yyj81 > l
+	} else {
+		yyb81 = r.CheckBreak()
+	}
+	if yyb81 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj81++
+	if yyhl81 {
+		yyb81 = yyj81 > l
+	} else {
+		yyb81 = r.CheckBreak()
+	}
+	if yyb81 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv84 := &x.ListMeta
+		yym85 := z.DecBinary()
+		_ = yym85
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv84) {
+		} else {
+			z.DecFallback(yyv84, false)
+		}
+	}
+	yyj81++
+	if yyhl81 {
+		yyb81 = yyj81 > l
+	} else {
+		yyb81 = r.CheckBreak()
+	}
+	if yyb81 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv86 := &x.Items
+		yym87 := z.DecBinary()
+		_ = yym87
+		if false {
+		} else {
+			h.decSliceRawNodeMetrics((*[]RawNodeMetrics)(yyv86), d)
+		}
+	}
+	for {
+		yyj81++
+		if yyhl81 {
+			yyb81 = yyj81 > l
+		} else {
+			yyb81 = r.CheckBreak()
+		}
+		if yyb81 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj81-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *RawPodMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym88 := z.EncBinary()
+		_ = yym88
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep89 := !z.EncBinary()
+			yy2arr89 := z.EncBasicHandle().StructToArray
+			var yyq89 [6]bool
+			_, _, _ = yysep89, yyq89, yy2arr89
+			const yyr89 bool = false
+			yyq89[0] = x.Kind != ""
+			yyq89[1] = x.APIVersion != ""
+			if yyr89 || yy2arr89 {
+				r.EncodeArrayStart(6)
+			} else {
+				var yynn89 int = 4
+				for _, b := range yyq89 {
+					if b {
+						yynn89++
+					}
+				}
+				r.EncodeMapStart(yynn89)
+			}
+			if yyr89 || yy2arr89 {
+				if yyq89[0] {
+					yym91 := z.EncBinary()
+					_ = yym91
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq89[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym92 := z.EncBinary()
+					_ = yym92
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr89 || yy2arr89 {
+				if yyq89[1] {
+					yym94 := z.EncBinary()
+					_ = yym94
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq89[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym95 := z.EncBinary()
+					_ = yym95
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr89 || yy2arr89 {
+				yy97 := &x.ListMeta
+				yym98 := z.EncBinary()
+				_ = yym98
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy97) {
+				} else {
+					z.EncFallback(yy97)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				yy99 := &x.ListMeta
+				yym100 := z.EncBinary()
+				_ = yym100
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy99) {
+				} else {
+					z.EncFallback(yy99)
+				}
+			}
+			if yyr89 || yy2arr89 {
+				yy102 := &x.PodRef
+				yy102.CodecEncodeSelf(e)
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("podRef"))
+				yy103 := &x.PodRef
+				yy103.CodecEncodeSelf(e)
+			}
+			if yyr89 || yy2arr89 {
+				if x.Containers == nil {
+					r.EncodeNil()
+				} else {
+					yym105 := z.EncBinary()
+					_ = yym105
+					if false {
+					} else {
+						h.encSliceRawContainerMetrics(([]RawContainerMetrics)(x.Containers), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("containers"))
+				if x.Containers == nil {
+					r.EncodeNil()
+				} else {
+					yym106 := z.EncBinary()
+					_ = yym106
+					if false {
+					} else {
+						h.encSliceRawContainerMetrics(([]RawContainerMetrics)(x.Containers), e)
+					}
+				}
+			}
+			if yyr89 || yy2arr89 {
+				if x.Samples == nil {
+					r.EncodeNil()
+				} else {
+					yym108 := z.EncBinary()
+					_ = yym108
+					if false {
+					} else {
+						h.encSlicePodSample(([]PodSample)(x.Samples), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("samples"))
+				if x.Samples == nil {
+					r.EncodeNil()
+				} else {
+					yym109 := z.EncBinary()
+					_ = yym109
+					if false {
+					} else {
+						h.encSlicePodSample(([]PodSample)(x.Samples), e)
+					}
+				}
+			}
+			if yysep89 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawPodMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym110 := z.DecBinary()
+	_ = yym110
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl111 := r.ReadMapStart()
+			if yyl111 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl111, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl111 := r.ReadArrayStart()
+			if yyl111 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl111, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawPodMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys112Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys112Slc
+	var yyhl112 bool = l >= 0
+	for yyj112 := 0; ; yyj112++ {
+		if yyhl112 {
+			if yyj112 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys112Slc = r.DecodeBytes(yys112Slc, true, true)
+		yys112 := string(yys112Slc)
+		switch yys112 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv115 := &x.ListMeta
+				yym116 := z.DecBinary()
+				_ = yym116
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv115) {
+				} else {
+					z.DecFallback(yyv115, false)
+				}
+			}
+		case "podRef":
+			if r.TryDecodeAsNil() {
+				x.PodRef = NonLocalObjectReference{}
+			} else {
+				yyv117 := &x.PodRef
+				yyv117.CodecDecodeSelf(d)
+			}
+		case "containers":
+			if r.TryDecodeAsNil() {
+				x.Containers = nil
+			} else {
+				yyv118 := &x.Containers
+				yym119 := z.DecBinary()
+				_ = yym119
+				if false {
+				} else {
+					h.decSliceRawContainerMetrics((*[]RawContainerMetrics)(yyv118), d)
+				}
+			}
+		case "samples":
+			if r.TryDecodeAsNil() {
+				x.Samples = nil
+			} else {
+				yyv120 := &x.Samples
+				yym121 := z.DecBinary()
+				_ = yym121
+				if false {
+				} else {
+					h.decSlicePodSample((*[]PodSample)(yyv120), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys112)
+		} // end switch yys112
+	} // end for yyj112
+	if !yyhl112 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawPodMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj122 int
+	var yyb122 bool
+	var yyhl122 bool = l >= 0
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv125 := &x.ListMeta
+		yym126 := z.DecBinary()
+		_ = yym126
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv125) {
+		} else {
+			z.DecFallback(yyv125, false)
+		}
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.PodRef = NonLocalObjectReference{}
+	} else {
+		yyv127 := &x.PodRef
+		yyv127.CodecDecodeSelf(d)
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Containers = nil
+	} else {
+		yyv128 := &x.Containers
+		yym129 := z.DecBinary()
+		_ = yym129
+		if false {
+		} else {
+			h.decSliceRawContainerMetrics((*[]RawContainerMetrics)(yyv128), d)
+		}
+	}
+	yyj122++
+	if yyhl122 {
+		yyb122 = yyj122 > l
+	} else {
+		yyb122 = r.CheckBreak()
+	}
+	if yyb122 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Samples = nil
+	} else {
+		yyv130 := &x.Samples
+		yym131 := z.DecBinary()
+		_ = yym131
+		if false {
+		} else {
+			h.decSlicePodSample((*[]PodSample)(yyv130), d)
+		}
+	}
+	for {
+		yyj122++
+		if yyhl122 {
+			yyb122 = yyj122 > l
+		} else {
+			yyb122 = r.CheckBreak()
+		}
+		if yyb122 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj122-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *RawPodMetricsList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym132 := z.EncBinary()
+		_ = yym132
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep133 := !z.EncBinary()
+			yy2arr133 := z.EncBasicHandle().StructToArray
+			var yyq133 [4]bool
+			_, _, _ = yysep133, yyq133, yy2arr133
+			const yyr133 bool = false
+			yyq133[0] = x.Kind != ""
+			yyq133[1] = x.APIVersion != ""
+			yyq133[2] = true
+			if yyr133 || yy2arr133 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn133 int = 1
+				for _, b := range yyq133 {
+					if b {
+						yynn133++
+					}
+				}
+				r.EncodeMapStart(yynn133)
+			}
+			if yyr133 || yy2arr133 {
+				if yyq133[0] {
+					yym135 := z.EncBinary()
+					_ = yym135
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq133[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym136 := z.EncBinary()
+					_ = yym136
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr133 || yy2arr133 {
+				if yyq133[1] {
+					yym138 := z.EncBinary()
+					_ = yym138
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq133[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym139 := z.EncBinary()
+					_ = yym139
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr133 || yy2arr133 {
+				if yyq133[2] {
+					yy141 := &x.ListMeta
+					yym142 := z.EncBinary()
+					_ = yym142
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy141) {
+					} else {
+						z.EncFallback(yy141)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq133[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy143 := &x.ListMeta
+					yym144 := z.EncBinary()
+					_ = yym144
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy143) {
+					} else {
+						z.EncFallback(yy143)
+					}
+				}
+			}
+			if yyr133 || yy2arr133 {
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym146 := z.EncBinary()
+					_ = yym146
+					if false {
+					} else {
+						h.encSliceRawPodMetrics(([]RawPodMetrics)(x.Items), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym147 := z.EncBinary()
+					_ = yym147
+					if false {
+					} else {
+						h.encSliceRawPodMetrics(([]RawPodMetrics)(x.Items), e)
+					}
+				}
+			}
+			if yysep133 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawPodMetricsList) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym148 := z.DecBinary()
+	_ = yym148
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl149 := r.ReadMapStart()
+			if yyl149 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl149, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl149 := r.ReadArrayStart()
+			if yyl149 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl149, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawPodMetricsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys150Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys150Slc
+	var yyhl150 bool = l >= 0
+	for yyj150 := 0; ; yyj150++ {
+		if yyhl150 {
+			if yyj150 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys150Slc = r.DecodeBytes(yys150Slc, true, true)
+		yys150 := string(yys150Slc)
+		switch yys150 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv153 := &x.ListMeta
+				yym154 := z.DecBinary()
+				_ = yym154
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv153) {
+				} else {
+					z.DecFallback(yyv153, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv155 := &x.Items
+				yym156 := z.DecBinary()
+				_ = yym156
+				if false {
+				} else {
+					h.decSliceRawPodMetrics((*[]RawPodMetrics)(yyv155), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys150)
+		} // end switch yys150
+	} // end for yyj150
+	if !yyhl150 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawPodMetricsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj157 int
+	var yyb157 bool
+	var yyhl157 bool = l >= 0
+	yyj157++
+	if yyhl157 {
+		yyb157 = yyj157 > l
+	} else {
+		yyb157 = r.CheckBreak()
+	}
+	if yyb157 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj157++
+	if yyhl157 {
+		yyb157 = yyj157 > l
+	} else {
+		yyb157 = r.CheckBreak()
+	}
+	if yyb157 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj157++
+	if yyhl157 {
+		yyb157 = yyj157 > l
+	} else {
+		yyb157 = r.CheckBreak()
+	}
+	if yyb157 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv160 := &x.ListMeta
+		yym161 := z.DecBinary()
+		_ = yym161
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv160) {
+		} else {
+			z.DecFallback(yyv160, false)
+		}
+	}
+	yyj157++
+	if yyhl157 {
+		yyb157 = yyj157 > l
+	} else {
+		yyb157 = r.CheckBreak()
+	}
+	if yyb157 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv162 := &x.Items
+		yym163 := z.DecBinary()
+		_ = yym163
+		if false {
+		} else {
+			h.decSliceRawPodMetrics((*[]RawPodMetrics)(yyv162), d)
+		}
+	}
+	for {
+		yyj157++
+		if yyhl157 {
+			yyb157 = yyj157 > l
+		} else {
+			yyb157 = r.CheckBreak()
+		}
+		if yyb157 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj157-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *RawContainerMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym164 := z.EncBinary()
+		_ = yym164
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep165 := !z.EncBinary()
+			yy2arr165 := z.EncBasicHandle().StructToArray
+			var yyq165 [4]bool
+			_, _, _ = yysep165, yyq165, yy2arr165
+			const yyr165 bool = false
+			yyq165[1] = len(x.Labels) != 0
+			yyq165[3] = len(x.CustomMetrics) != 0
+			if yyr165 || yy2arr165 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn165 int = 2
+				for _, b := range yyq165 {
+					if b {
+						yynn165++
+					}
+				}
+				r.EncodeMapStart(yynn165)
+			}
+			if yyr165 || yy2arr165 {
+				yym167 := z.EncBinary()
+				_ = yym167
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				yym168 := z.EncBinary()
+				_ = yym168
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			}
+			if yyr165 || yy2arr165 {
+				if yyq165[1] {
+					if x.Labels == nil {
+						r.EncodeNil()
+					} else {
+						yym170 := z.EncBinary()
+						_ = yym170
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.Labels, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq165[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("labels"))
+					if x.Labels == nil {
+						r.EncodeNil()
+					} else {
+						yym171 := z.EncBinary()
+						_ = yym171
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.Labels, false, e)
+						}
+					}
+				}
+			}
+			if yyr165 || yy2arr165 {
+				if x.Samples == nil {
+					r.EncodeNil()
+				} else {
+					yym173 := z.EncBinary()
+					_ = yym173
+					if false {
+					} else {
+						h.encSliceContainerSample(([]ContainerSample)(x.Samples), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("samples"))
+				if x.Samples == nil {
+					r.EncodeNil()
+				} else {
+					yym174 := z.EncBinary()
+					_ = yym174
+					if false {
+					} else {
+						h.encSliceContainerSample(([]ContainerSample)(x.Samples), e)
+					}
+				}
+			}
+			if yyr165 || yy2arr165 {
+				if yyq165[3] {
+					if x.CustomMetrics == nil {
+						r.EncodeNil()
+					} else {
+						yym176 := z.EncBinary()
+						_ = yym176
+						if false {
+						} else {
+							h.encSliceCustomMetric(([]CustomMetric)(x.CustomMetrics), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq165[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("customMetrics"))
+					if x.CustomMetrics == nil {
+						r.EncodeNil()
+					} else {
+						yym177 := z.EncBinary()
+						_ = yym177
+						if false {
+						} else {
+							h.encSliceCustomMetric(([]CustomMetric)(x.CustomMetrics), e)
+						}
+					}
+				}
+			}
+			if yysep165 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawContainerMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym178 := z.DecBinary()
+	_ = yym178
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl179 := r.ReadMapStart()
+			if yyl179 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl179, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl179 := r.ReadArrayStart()
+			if yyl179 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl179, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawContainerMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys180Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys180Slc
+	var yyhl180 bool = l >= 0
+	for yyj180 := 0; ; yyj180++ {
+		if yyhl180 {
+			if yyj180 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys180Slc = r.DecodeBytes(yys180Slc, true, true)
+		yys180 := string(yys180Slc)
+		switch yys180 {
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "labels":
+			if r.TryDecodeAsNil() {
+				x.Labels = nil
+			} else {
+				yyv182 := &x.Labels
+				yym183 := z.DecBinary()
+				_ = yym183
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv182, false, d)
+				}
+			}
+		case "samples":
+			if r.TryDecodeAsNil() {
+				x.Samples = nil
+			} else {
+				yyv184 := &x.Samples
+				yym185 := z.DecBinary()
+				_ = yym185
+				if false {
+				} else {
+					h.decSliceContainerSample((*[]ContainerSample)(yyv184), d)
+				}
+			}
+		case "customMetrics":
+			if r.TryDecodeAsNil() {
+				x.CustomMetrics = nil
+			} else {
+				yyv186 := &x.CustomMetrics
+				yym187 := z.DecBinary()
+				_ = yym187
+				if false {
+				} else {
+					h.decSliceCustomMetric((*[]CustomMetric)(yyv186), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys180)
+		} // end switch yys180
+	} // end for yyj180
+	if !yyhl180 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawContainerMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj188 int
+	var yyb188 bool
+	var yyhl188 bool = l >= 0
+	yyj188++
+	if yyhl188 {
+		yyb188 = yyj188 > l
+	} else {
+		yyb188 = r.CheckBreak()
+	}
+	if yyb188 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj188++
+	if yyhl188 {
+		yyb188 = yyj188 > l
+	} else {
+		yyb188 = r.CheckBreak()
+	}
+	if yyb188 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Labels = nil
+	} else {
+		yyv190 := &x.Labels
+		yym191 := z.DecBinary()
+		_ = yym191
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv190, false, d)
+		}
+	}
+	yyj188++
+	if yyhl188 {
+		yyb188 = yyj188 > l
+	} else {
+		yyb188 = r.CheckBreak()
+	}
+	if yyb188 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Samples = nil
+	} else {
+		yyv192 := &x.Samples
+		yym193 := z.DecBinary()
+		_ = yym193
+		if false {
+		} else {
+			h.decSliceContainerSample((*[]ContainerSample)(yyv192), d)
+		}
+	}
+	yyj188++
+	if yyhl188 {
+		yyb188 = yyj188 > l
+	} else {
+		yyb188 = r.CheckBreak()
+	}
+	if yyb188 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.CustomMetrics = nil
+	} else {
+		yyv194 := &x.CustomMetrics
+		yym195 := z.DecBinary()
+		_ = yym195
+		if false {
+		} else {
+			h.decSliceCustomMetric((*[]CustomMetric)(yyv194), d)
+		}
+	}
+	for {
+		yyj188++
+		if yyhl188 {
+			yyb188 = yyj188 > l
+		} else {
+			yyb188 = r.CheckBreak()
+		}
+		if yyb188 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj188-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *NonLocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym196 := z.EncBinary()
+		_ = yym196
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep197 := !z.EncBinary()
+			yy2arr197 := z.EncBasicHandle().StructToArray
+			var yyq197 [3]bool
+			_, _, _ = yysep197, yyq197, yy2arr197
+			const yyr197 bool = false
+			yyq197[2] = x.UID != ""
+			if yyr197 || yy2arr197 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn197 int = 2
+				for _, b := range yyq197 {
+					if b {
+						yynn197++
+					}
+				}
+				r.EncodeMapStart(yynn197)
+			}
+			if yyr197 || yy2arr197 {
+				yym199 := z.EncBinary()
+				_ = yym199
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				yym200 := z.EncBinary()
+				_ = yym200
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			}
+			if yyr197 || yy2arr197 {
+				yym202 := z.EncBinary()
+				_ = yym202
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+				yym203 := z.EncBinary()
+				_ = yym203
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+				}
+			}
+			if yyr197 || yy2arr197 {
+				if yyq197[2] {
+					yym205 := z.EncBinary()
+					_ = yym205
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq197[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("uid"))
+					yym206 := z.EncBinary()
+					_ = yym206
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+					}
+				}
+			}
+			if yysep197 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *NonLocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym207 := z.DecBinary()
+	_ = yym207
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl208 := r.ReadMapStart()
+			if yyl208 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl208, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl208 := r.ReadArrayStart()
+			if yyl208 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl208, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *NonLocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys209Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys209Slc
+	var yyhl209 bool = l >= 0
+	for yyj209 := 0; ; yyj209++ {
+		if yyhl209 {
+			if yyj209 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys209Slc = r.DecodeBytes(yys209Slc, true, true)
+		yys209 := string(yys209Slc)
+		switch yys209 {
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "namespace":
+			if r.TryDecodeAsNil() {
+				x.Namespace = ""
+			} else {
+				x.Namespace = string(r.DecodeString())
+			}
+		case "uid":
+			if r.TryDecodeAsNil() {
+				x.UID = ""
+			} else {
+				x.UID = pkg4_types.UID(r.DecodeString())
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys209)
+		} // end switch yys209
+	} // end for yyj209
+	if !yyhl209 {
+		r.ReadEnd()
+	}
+}
+
+func (x *NonLocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj213 int
+	var yyb213 bool
+	var yyhl213 bool = l >= 0
+	yyj213++
+	if yyhl213 {
+		yyb213 = yyj213 > l
+	} else {
+		yyb213 = r.CheckBreak()
+	}
+	if yyb213 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj213++
+	if yyhl213 {
+		yyb213 = yyj213 > l
+	} else {
+		yyb213 = r.CheckBreak()
+	}
+	if yyb213 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Namespace = ""
+	} else {
+		x.Namespace = string(r.DecodeString())
+	}
+	yyj213++
+	if yyhl213 {
+		yyb213 = yyj213 > l
+	} else {
+		yyb213 = r.CheckBreak()
+	}
+	if yyb213 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.UID = ""
+	} else {
+		x.UID = pkg4_types.UID(r.DecodeString())
+	}
+	for {
+		yyj213++
+		if yyhl213 {
+			yyb213 = yyj213 > l
+		} else {
+			yyb213 = r.CheckBreak()
+		}
+		if yyb213 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj213-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *Sample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym217 := z.EncBinary()
+		_ = yym217
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep218 := !z.EncBinary()
+			yy2arr218 := z.EncBasicHandle().StructToArray
+			var yyq218 [1]bool
+			_, _, _ = yysep218, yyq218, yy2arr218
+			const yyr218 bool = false
+			if yyr218 || yy2arr218 {
+				r.EncodeArrayStart(1)
+			} else {
+				var yynn218 int = 1
+				for _, b := range yyq218 {
+					if b {
+						yynn218++
+					}
+				}
+				r.EncodeMapStart(yynn218)
+			}
+			if yyr218 || yy2arr218 {
+				yy220 := &x.SampleTime
+				yym221 := z.EncBinary()
+				_ = yym221
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy220) {
+				} else if yym221 {
+					z.EncBinaryMarshal(yy220)
+				} else if !yym221 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy220)
+				} else {
+					z.EncFallback(yy220)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy222 := &x.SampleTime
+				yym223 := z.EncBinary()
+				_ = yym223
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy222) {
+				} else if yym223 {
+					z.EncBinaryMarshal(yy222)
+				} else if !yym223 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy222)
+				} else {
+					z.EncFallback(yy222)
+				}
+			}
+			if yysep218 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *Sample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym224 := z.DecBinary()
+	_ = yym224
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl225 := r.ReadMapStart()
+			if yyl225 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl225, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl225 := r.ReadArrayStart()
+			if yyl225 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl225, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Sample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys226Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys226Slc
+	var yyhl226 bool = l >= 0
+	for yyj226 := 0; ; yyj226++ {
+		if yyhl226 {
+			if yyj226 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys226Slc = r.DecodeBytes(yys226Slc, true, true)
+		yys226 := string(yys226Slc)
+		switch yys226 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv227 := &x.SampleTime
+				yym228 := z.DecBinary()
+				_ = yym228
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv227) {
+				} else if yym228 {
+					z.DecBinaryUnmarshal(yyv227)
+				} else if !yym228 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv227)
+				} else {
+					z.DecFallback(yyv227, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys226)
+		} // end switch yys226
+	} // end for yyj226
+	if !yyhl226 {
+		r.ReadEnd()
+	}
+}
+
+func (x *Sample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj229 int
+	var yyb229 bool
+	var yyhl229 bool = l >= 0
+	yyj229++
+	if yyhl229 {
+		yyb229 = yyj229 > l
+	} else {
+		yyb229 = r.CheckBreak()
+	}
+	if yyb229 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv230 := &x.SampleTime
+		yym231 := z.DecBinary()
+		_ = yym231
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv230) {
+		} else if yym231 {
+			z.DecBinaryUnmarshal(yyv230)
+		} else if !yym231 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv230)
+		} else {
+			z.DecFallback(yyv230, false)
+		}
+	}
+	for {
+		yyj229++
+		if yyhl229 {
+			yyb229 = yyj229 > l
+		} else {
+			yyb229 = r.CheckBreak()
+		}
+		if yyb229 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj229-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *AggregateSample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym232 := z.EncBinary()
+		_ = yym232
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep233 := !z.EncBinary()
+			yy2arr233 := z.EncBasicHandle().StructToArray
+			var yyq233 [4]bool
+			_, _, _ = yysep233, yyq233, yy2arr233
+			const yyr233 bool = false
+			yyq233[1] = x.CPU != nil
+			yyq233[2] = x.Memory != nil
+			yyq233[3] = x.Network != nil
+			if yyr233 || yy2arr233 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn233 int = 1
+				for _, b := range yyq233 {
+					if b {
+						yynn233++
+					}
+				}
+				r.EncodeMapStart(yynn233)
+			}
+			if yyr233 || yy2arr233 {
+				yy235 := &x.SampleTime
+				yym236 := z.EncBinary()
+				_ = yym236
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy235) {
+				} else if yym236 {
+					z.EncBinaryMarshal(yy235)
+				} else if !yym236 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy235)
+				} else {
+					z.EncFallback(yy235)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy237 := &x.SampleTime
+				yym238 := z.EncBinary()
+				_ = yym238
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy237) {
+				} else if yym238 {
+					z.EncBinaryMarshal(yy237)
+				} else if !yym238 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy237)
+				} else {
+					z.EncFallback(yy237)
+				}
+			}
+			if yyr233 || yy2arr233 {
+				if yyq233[1] {
+					if x.CPU == nil {
+						r.EncodeNil()
+					} else {
+						x.CPU.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq233[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
+					if x.CPU == nil {
+						r.EncodeNil()
+					} else {
+						x.CPU.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr233 || yy2arr233 {
+				if yyq233[2] {
+					if x.Memory == nil {
+						r.EncodeNil()
+					} else {
+						x.Memory.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq233[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("memory"))
+					if x.Memory == nil {
+						r.EncodeNil()
+					} else {
+						x.Memory.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr233 || yy2arr233 {
+				if yyq233[3] {
+					if x.Network == nil {
+						r.EncodeNil()
+					} else {
+						x.Network.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq233[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("network"))
+					if x.Network == nil {
+						r.EncodeNil()
+					} else {
+						x.Network.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yysep233 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *AggregateSample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym242 := z.DecBinary()
+	_ = yym242
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl243 := r.ReadMapStart()
+			if yyl243 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl243, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl243 := r.ReadArrayStart()
+			if yyl243 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl243, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *AggregateSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys244Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys244Slc
+	var yyhl244 bool = l >= 0
+	for yyj244 := 0; ; yyj244++ {
+		if yyhl244 {
+			if yyj244 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys244Slc = r.DecodeBytes(yys244Slc, true, true)
+		yys244 := string(yys244Slc)
+		switch yys244 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv245 := &x.SampleTime
+				yym246 := z.DecBinary()
+				_ = yym246
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv245) {
+				} else if yym246 {
+					z.DecBinaryUnmarshal(yyv245)
+				} else if !yym246 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv245)
+				} else {
+					z.DecFallback(yyv245, false)
+				}
+			}
+		case "cpu":
+			if r.TryDecodeAsNil() {
+				if x.CPU != nil {
+					x.CPU = nil
+				}
+			} else {
+				if x.CPU == nil {
+					x.CPU = new(CPUMetrics)
+				}
+				x.CPU.CodecDecodeSelf(d)
+			}
+		case "memory":
+			if r.TryDecodeAsNil() {
+				if x.Memory != nil {
+					x.Memory = nil
+				}
+			} else {
+				if x.Memory == nil {
+					x.Memory = new(MemoryMetrics)
+				}
+				x.Memory.CodecDecodeSelf(d)
+			}
+		case "network":
+			if r.TryDecodeAsNil() {
+				if x.Network != nil {
+					x.Network = nil
+				}
+			} else {
+				if x.Network == nil {
+					x.Network = new(NetworkMetrics)
+				}
+				x.Network.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys244)
+		} // end switch yys244
+	} // end for yyj244
+	if !yyhl244 {
+		r.ReadEnd()
+	}
+}
+
+func (x *AggregateSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj250 int
+	var yyb250 bool
+	var yyhl250 bool = l >= 0
+	yyj250++
+	if yyhl250 {
+		yyb250 = yyj250 > l
+	} else {
+		yyb250 = r.CheckBreak()
+	}
+	if yyb250 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv251 := &x.SampleTime
+		yym252 := z.DecBinary()
+		_ = yym252
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv251) {
+		} else if yym252 {
+			z.DecBinaryUnmarshal(yyv251)
+		} else if !yym252 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv251)
+		} else {
+			z.DecFallback(yyv251, false)
+		}
+	}
+	yyj250++
+	if yyhl250 {
+		yyb250 = yyj250 > l
+	} else {
+		yyb250 = r.CheckBreak()
+	}
+	if yyb250 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.CPU != nil {
+			x.CPU = nil
+		}
+	} else {
+		if x.CPU == nil {
+			x.CPU = new(CPUMetrics)
+		}
+		x.CPU.CodecDecodeSelf(d)
+	}
+	yyj250++
+	if yyhl250 {
+		yyb250 = yyj250 > l
+	} else {
+		yyb250 = r.CheckBreak()
+	}
+	if yyb250 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Memory != nil {
+			x.Memory = nil
+		}
+	} else {
+		if x.Memory == nil {
+			x.Memory = new(MemoryMetrics)
+		}
+		x.Memory.CodecDecodeSelf(d)
+	}
+	yyj250++
+	if yyhl250 {
+		yyb250 = yyj250 > l
+	} else {
+		yyb250 = r.CheckBreak()
+	}
+	if yyb250 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Network != nil {
+			x.Network = nil
+		}
+	} else {
+		if x.Network == nil {
+			x.Network = new(NetworkMetrics)
+		}
+		x.Network.CodecDecodeSelf(d)
+	}
+	for {
+		yyj250++
+		if yyhl250 {
+			yyb250 = yyj250 > l
+		} else {
+			yyb250 = r.CheckBreak()
+		}
+		if yyb250 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj250-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *PodSample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym256 := z.EncBinary()
+		_ = yym256
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep257 := !z.EncBinary()
+			yy2arr257 := z.EncBasicHandle().StructToArray
+			var yyq257 [2]bool
+			_, _, _ = yysep257, yyq257, yy2arr257
+			const yyr257 bool = false
+			yyq257[1] = x.Network != nil
+			if yyr257 || yy2arr257 {
+				r.EncodeArrayStart(2)
+			} else {
+				var yynn257 int = 1
+				for _, b := range yyq257 {
+					if b {
+						yynn257++
+					}
+				}
+				r.EncodeMapStart(yynn257)
+			}
+			if yyr257 || yy2arr257 {
+				yy259 := &x.SampleTime
+				yym260 := z.EncBinary()
+				_ = yym260
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy259) {
+				} else if yym260 {
+					z.EncBinaryMarshal(yy259)
+				} else if !yym260 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy259)
+				} else {
+					z.EncFallback(yy259)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy261 := &x.SampleTime
+				yym262 := z.EncBinary()
+				_ = yym262
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy261) {
+				} else if yym262 {
+					z.EncBinaryMarshal(yy261)
+				} else if !yym262 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy261)
+				} else {
+					z.EncFallback(yy261)
+				}
+			}
+			if yyr257 || yy2arr257 {
+				if yyq257[1] {
+					if x.Network == nil {
+						r.EncodeNil()
+					} else {
+						x.Network.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq257[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("network"))
+					if x.Network == nil {
+						r.EncodeNil()
+					} else {
+						x.Network.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yysep257 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *PodSample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym264 := z.DecBinary()
+	_ = yym264
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl265 := r.ReadMapStart()
+			if yyl265 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl265, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl265 := r.ReadArrayStart()
+			if yyl265 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl265, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *PodSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys266Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys266Slc
+	var yyhl266 bool = l >= 0
+	for yyj266 := 0; ; yyj266++ {
+		if yyhl266 {
+			if yyj266 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys266Slc = r.DecodeBytes(yys266Slc, true, true)
+		yys266 := string(yys266Slc)
+		switch yys266 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv267 := &x.SampleTime
+				yym268 := z.DecBinary()
+				_ = yym268
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv267) {
+				} else if yym268 {
+					z.DecBinaryUnmarshal(yyv267)
+				} else if !yym268 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv267)
+				} else {
+					z.DecFallback(yyv267, false)
+				}
+			}
+		case "network":
+			if r.TryDecodeAsNil() {
+				if x.Network != nil {
+					x.Network = nil
+				}
+			} else {
+				if x.Network == nil {
+					x.Network = new(NetworkMetrics)
+				}
+				x.Network.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys266)
+		} // end switch yys266
+	} // end for yyj266
+	if !yyhl266 {
+		r.ReadEnd()
+	}
+}
+
+func (x *PodSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj270 int
+	var yyb270 bool
+	var yyhl270 bool = l >= 0
+	yyj270++
+	if yyhl270 {
+		yyb270 = yyj270 > l
+	} else {
+		yyb270 = r.CheckBreak()
+	}
+	if yyb270 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv271 := &x.SampleTime
+		yym272 := z.DecBinary()
+		_ = yym272
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv271) {
+		} else if yym272 {
+			z.DecBinaryUnmarshal(yyv271)
+		} else if !yym272 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv271)
+		} else {
+			z.DecFallback(yyv271, false)
+		}
+	}
+	yyj270++
+	if yyhl270 {
+		yyb270 = yyj270 > l
+	} else {
+		yyb270 = r.CheckBreak()
+	}
+	if yyb270 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Network != nil {
+			x.Network = nil
+		}
+	} else {
+		if x.Network == nil {
+			x.Network = new(NetworkMetrics)
+		}
+		x.Network.CodecDecodeSelf(d)
+	}
+	for {
+		yyj270++
+		if yyhl270 {
+			yyb270 = yyj270 > l
+		} else {
+			yyb270 = r.CheckBreak()
+		}
+		if yyb270 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj270-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *ContainerSample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym274 := z.EncBinary()
+		_ = yym274
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep275 := !z.EncBinary()
+			yy2arr275 := z.EncBasicHandle().StructToArray
+			var yyq275 [3]bool
+			_, _, _ = yysep275, yyq275, yy2arr275
+			const yyr275 bool = false
+			yyq275[1] = x.CPU != nil
+			yyq275[2] = x.Memory != nil
+			if yyr275 || yy2arr275 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn275 int = 1
+				for _, b := range yyq275 {
+					if b {
+						yynn275++
+					}
+				}
+				r.EncodeMapStart(yynn275)
+			}
+			if yyr275 || yy2arr275 {
+				yy277 := &x.SampleTime
+				yym278 := z.EncBinary()
+				_ = yym278
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy277) {
+				} else if yym278 {
+					z.EncBinaryMarshal(yy277)
+				} else if !yym278 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy277)
+				} else {
+					z.EncFallback(yy277)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy279 := &x.SampleTime
+				yym280 := z.EncBinary()
+				_ = yym280
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy279) {
+				} else if yym280 {
+					z.EncBinaryMarshal(yy279)
+				} else if !yym280 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy279)
+				} else {
+					z.EncFallback(yy279)
+				}
+			}
+			if yyr275 || yy2arr275 {
+				if yyq275[1] {
+					if x.CPU == nil {
+						r.EncodeNil()
+					} else {
+						x.CPU.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq275[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("cpu"))
+					if x.CPU == nil {
+						r.EncodeNil()
+					} else {
+						x.CPU.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr275 || yy2arr275 {
+				if yyq275[2] {
+					if x.Memory == nil {
+						r.EncodeNil()
+					} else {
+						x.Memory.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq275[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("memory"))
+					if x.Memory == nil {
+						r.EncodeNil()
+					} else {
+						x.Memory.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yysep275 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *ContainerSample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym283 := z.DecBinary()
+	_ = yym283
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl284 := r.ReadMapStart()
+			if yyl284 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl284, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl284 := r.ReadArrayStart()
+			if yyl284 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl284, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ContainerSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys285Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys285Slc
+	var yyhl285 bool = l >= 0
+	for yyj285 := 0; ; yyj285++ {
+		if yyhl285 {
+			if yyj285 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys285Slc = r.DecodeBytes(yys285Slc, true, true)
+		yys285 := string(yys285Slc)
+		switch yys285 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv286 := &x.SampleTime
+				yym287 := z.DecBinary()
+				_ = yym287
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv286) {
+				} else if yym287 {
+					z.DecBinaryUnmarshal(yyv286)
+				} else if !yym287 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv286)
+				} else {
+					z.DecFallback(yyv286, false)
+				}
+			}
+		case "cpu":
+			if r.TryDecodeAsNil() {
+				if x.CPU != nil {
+					x.CPU = nil
+				}
+			} else {
+				if x.CPU == nil {
+					x.CPU = new(CPUMetrics)
+				}
+				x.CPU.CodecDecodeSelf(d)
+			}
+		case "memory":
+			if r.TryDecodeAsNil() {
+				if x.Memory != nil {
+					x.Memory = nil
+				}
+			} else {
+				if x.Memory == nil {
+					x.Memory = new(MemoryMetrics)
+				}
+				x.Memory.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys285)
+		} // end switch yys285
+	} // end for yyj285
+	if !yyhl285 {
+		r.ReadEnd()
+	}
+}
+
+func (x *ContainerSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj290 int
+	var yyb290 bool
+	var yyhl290 bool = l >= 0
+	yyj290++
+	if yyhl290 {
+		yyb290 = yyj290 > l
+	} else {
+		yyb290 = r.CheckBreak()
+	}
+	if yyb290 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv291 := &x.SampleTime
+		yym292 := z.DecBinary()
+		_ = yym292
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv291) {
+		} else if yym292 {
+			z.DecBinaryUnmarshal(yyv291)
+		} else if !yym292 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv291)
+		} else {
+			z.DecFallback(yyv291, false)
+		}
+	}
+	yyj290++
+	if yyhl290 {
+		yyb290 = yyj290 > l
+	} else {
+		yyb290 = r.CheckBreak()
+	}
+	if yyb290 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.CPU != nil {
+			x.CPU = nil
+		}
+	} else {
+		if x.CPU == nil {
+			x.CPU = new(CPUMetrics)
+		}
+		x.CPU.CodecDecodeSelf(d)
+	}
+	yyj290++
+	if yyhl290 {
+		yyb290 = yyj290 > l
+	} else {
+		yyb290 = r.CheckBreak()
+	}
+	if yyb290 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Memory != nil {
+			x.Memory = nil
+		}
+	} else {
+		if x.Memory == nil {
+			x.Memory = new(MemoryMetrics)
+		}
+		x.Memory.CodecDecodeSelf(d)
+	}
+	for {
+		yyj290++
+		if yyhl290 {
+			yyb290 = yyj290 > l
+		} else {
+			yyb290 = r.CheckBreak()
+		}
+		if yyb290 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj290-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *NetworkMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym295 := z.EncBinary()
+		_ = yym295
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep296 := !z.EncBinary()
+			yy2arr296 := z.EncBasicHandle().StructToArray
+			var yyq296 [4]bool
+			_, _, _ = yysep296, yyq296, yy2arr296
+			const yyr296 bool = false
+			yyq296[0] = x.RxBytes != nil
+			yyq296[1] = x.RxErrors != nil
+			yyq296[2] = x.TxBytes != nil
+			yyq296[3] = x.TxErrors != nil
+			if yyr296 || yy2arr296 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn296 int = 0
+				for _, b := range yyq296 {
+					if b {
+						yynn296++
+					}
+				}
+				r.EncodeMapStart(yynn296)
+			}
+			if yyr296 || yy2arr296 {
+				if yyq296[0] {
+					if x.RxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym298 := z.EncBinary()
+						_ = yym298
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
+						} else if !yym298 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.RxBytes)
+						} else {
+							z.EncFallback(x.RxBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq296[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("rxBytes"))
+					if x.RxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym299 := z.EncBinary()
+						_ = yym299
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.RxBytes) {
+						} else if !yym299 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.RxBytes)
+						} else {
+							z.EncFallback(x.RxBytes)
+						}
+					}
+				}
+			}
+			if yyr296 || yy2arr296 {
+				if yyq296[1] {
+					if x.RxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy301 := *x.RxErrors
+						yym302 := z.EncBinary()
+						_ = yym302
+						if false {
+						} else {
+							r.EncodeInt(int64(yy301))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq296[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("rxErrors"))
+					if x.RxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy303 := *x.RxErrors
+						yym304 := z.EncBinary()
+						_ = yym304
+						if false {
+						} else {
+							r.EncodeInt(int64(yy303))
+						}
+					}
+				}
+			}
+			if yyr296 || yy2arr296 {
+				if yyq296[2] {
+					if x.TxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym306 := z.EncBinary()
+						_ = yym306
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
+						} else if !yym306 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TxBytes)
+						} else {
+							z.EncFallback(x.TxBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq296[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("txBytes"))
+					if x.TxBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym307 := z.EncBinary()
+						_ = yym307
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TxBytes) {
+						} else if !yym307 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TxBytes)
+						} else {
+							z.EncFallback(x.TxBytes)
+						}
+					}
+				}
+			}
+			if yyr296 || yy2arr296 {
+				if yyq296[3] {
+					if x.TxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy309 := *x.TxErrors
+						yym310 := z.EncBinary()
+						_ = yym310
+						if false {
+						} else {
+							r.EncodeInt(int64(yy309))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq296[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("txErrors"))
+					if x.TxErrors == nil {
+						r.EncodeNil()
+					} else {
+						yy311 := *x.TxErrors
+						yym312 := z.EncBinary()
+						_ = yym312
+						if false {
+						} else {
+							r.EncodeInt(int64(yy311))
+						}
+					}
+				}
+			}
+			if yysep296 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *NetworkMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym313 := z.DecBinary()
+	_ = yym313
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl314 := r.ReadMapStart()
+			if yyl314 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl314, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl314 := r.ReadArrayStart()
+			if yyl314 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl314, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *NetworkMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys315Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys315Slc
+	var yyhl315 bool = l >= 0
+	for yyj315 := 0; ; yyj315++ {
+		if yyhl315 {
+			if yyj315 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys315Slc = r.DecodeBytes(yys315Slc, true, true)
+		yys315 := string(yys315Slc)
+		switch yys315 {
+		case "rxBytes":
+			if r.TryDecodeAsNil() {
+				if x.RxBytes != nil {
+					x.RxBytes = nil
+				}
+			} else {
+				if x.RxBytes == nil {
+					x.RxBytes = new(pkg2_resource.Quantity)
+				}
+				yym317 := z.DecBinary()
+				_ = yym317
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
+				} else if !yym317 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.RxBytes)
+				} else {
+					z.DecFallback(x.RxBytes, false)
+				}
+			}
+		case "rxErrors":
+			if r.TryDecodeAsNil() {
+				if x.RxErrors != nil {
+					x.RxErrors = nil
+				}
+			} else {
+				if x.RxErrors == nil {
+					x.RxErrors = new(int64)
+				}
+				yym319 := z.DecBinary()
+				_ = yym319
+				if false {
+				} else {
+					*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
+				}
+			}
+		case "txBytes":
+			if r.TryDecodeAsNil() {
+				if x.TxBytes != nil {
+					x.TxBytes = nil
+				}
+			} else {
+				if x.TxBytes == nil {
+					x.TxBytes = new(pkg2_resource.Quantity)
+				}
+				yym321 := z.DecBinary()
+				_ = yym321
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
+				} else if !yym321 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.TxBytes)
+				} else {
+					z.DecFallback(x.TxBytes, false)
+				}
+			}
+		case "txErrors":
+			if r.TryDecodeAsNil() {
+				if x.TxErrors != nil {
+					x.TxErrors = nil
+				}
+			} else {
+				if x.TxErrors == nil {
+					x.TxErrors = new(int64)
+				}
+				yym323 := z.DecBinary()
+				_ = yym323
+				if false {
+				} else {
+					*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys315)
+		} // end switch yys315
+	} // end for yyj315
+	if !yyhl315 {
+		r.ReadEnd()
+	}
+}
+
+func (x *NetworkMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj324 int
+	var yyb324 bool
+	var yyhl324 bool = l >= 0
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
+	} else {
+		yyb324 = r.CheckBreak()
+	}
+	if yyb324 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.RxBytes != nil {
+			x.RxBytes = nil
+		}
+	} else {
+		if x.RxBytes == nil {
+			x.RxBytes = new(pkg2_resource.Quantity)
+		}
+		yym326 := z.DecBinary()
+		_ = yym326
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.RxBytes) {
+		} else if !yym326 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.RxBytes)
+		} else {
+			z.DecFallback(x.RxBytes, false)
+		}
+	}
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
+	} else {
+		yyb324 = r.CheckBreak()
+	}
+	if yyb324 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.RxErrors != nil {
+			x.RxErrors = nil
+		}
+	} else {
+		if x.RxErrors == nil {
+			x.RxErrors = new(int64)
+		}
+		yym328 := z.DecBinary()
+		_ = yym328
+		if false {
+		} else {
+			*((*int64)(x.RxErrors)) = int64(r.DecodeInt(64))
+		}
+	}
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
+	} else {
+		yyb324 = r.CheckBreak()
+	}
+	if yyb324 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.TxBytes != nil {
+			x.TxBytes = nil
+		}
+	} else {
+		if x.TxBytes == nil {
+			x.TxBytes = new(pkg2_resource.Quantity)
+		}
+		yym330 := z.DecBinary()
+		_ = yym330
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.TxBytes) {
+		} else if !yym330 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.TxBytes)
+		} else {
+			z.DecFallback(x.TxBytes, false)
+		}
+	}
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
+	} else {
+		yyb324 = r.CheckBreak()
+	}
+	if yyb324 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.TxErrors != nil {
+			x.TxErrors = nil
+		}
+	} else {
+		if x.TxErrors == nil {
+			x.TxErrors = new(int64)
+		}
+		yym332 := z.DecBinary()
+		_ = yym332
+		if false {
+		} else {
+			*((*int64)(x.TxErrors)) = int64(r.DecodeInt(64))
+		}
+	}
+	for {
+		yyj324++
+		if yyhl324 {
+			yyb324 = yyj324 > l
+		} else {
+			yyb324 = r.CheckBreak()
+		}
+		if yyb324 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj324-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *CPUMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym333 := z.EncBinary()
+		_ = yym333
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep334 := !z.EncBinary()
+			yy2arr334 := z.EncBasicHandle().StructToArray
+			var yyq334 [2]bool
+			_, _, _ = yysep334, yyq334, yy2arr334
+			const yyr334 bool = false
+			yyq334[0] = x.TotalCores != nil
+			yyq334[1] = x.LoadAverage != nil
+			if yyr334 || yy2arr334 {
+				r.EncodeArrayStart(2)
+			} else {
+				var yynn334 int = 0
+				for _, b := range yyq334 {
+					if b {
+						yynn334++
+					}
+				}
+				r.EncodeMapStart(yynn334)
+			}
+			if yyr334 || yy2arr334 {
+				if yyq334[0] {
+					if x.TotalCores == nil {
+						r.EncodeNil()
+					} else {
+						yym336 := z.EncBinary()
+						_ = yym336
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
+						} else if !yym336 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TotalCores)
+						} else {
+							z.EncFallback(x.TotalCores)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq334[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("totalCores"))
+					if x.TotalCores == nil {
+						r.EncodeNil()
+					} else {
+						yym337 := z.EncBinary()
+						_ = yym337
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TotalCores) {
+						} else if !yym337 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TotalCores)
+						} else {
+							z.EncFallback(x.TotalCores)
+						}
+					}
+				}
+			}
+			if yyr334 || yy2arr334 {
+				if yyq334[1] {
+					if x.LoadAverage == nil {
+						r.EncodeNil()
+					} else {
+						yym339 := z.EncBinary()
+						_ = yym339
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
+						} else if !yym339 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.LoadAverage)
+						} else {
+							z.EncFallback(x.LoadAverage)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq334[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("loadAverage"))
+					if x.LoadAverage == nil {
+						r.EncodeNil()
+					} else {
+						yym340 := z.EncBinary()
+						_ = yym340
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.LoadAverage) {
+						} else if !yym340 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.LoadAverage)
+						} else {
+							z.EncFallback(x.LoadAverage)
+						}
+					}
+				}
+			}
+			if yysep334 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *CPUMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym341 := z.DecBinary()
+	_ = yym341
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl342 := r.ReadMapStart()
+			if yyl342 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl342, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl342 := r.ReadArrayStart()
+			if yyl342 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl342, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *CPUMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys343Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys343Slc
+	var yyhl343 bool = l >= 0
+	for yyj343 := 0; ; yyj343++ {
+		if yyhl343 {
+			if yyj343 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
+		yys343 := string(yys343Slc)
+		switch yys343 {
+		case "totalCores":
+			if r.TryDecodeAsNil() {
+				if x.TotalCores != nil {
+					x.TotalCores = nil
+				}
+			} else {
+				if x.TotalCores == nil {
+					x.TotalCores = new(pkg2_resource.Quantity)
+				}
+				yym345 := z.DecBinary()
+				_ = yym345
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
+				} else if !yym345 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.TotalCores)
+				} else {
+					z.DecFallback(x.TotalCores, false)
+				}
+			}
+		case "loadAverage":
+			if r.TryDecodeAsNil() {
+				if x.LoadAverage != nil {
+					x.LoadAverage = nil
+				}
+			} else {
+				if x.LoadAverage == nil {
+					x.LoadAverage = new(pkg2_resource.Quantity)
+				}
+				yym347 := z.DecBinary()
+				_ = yym347
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
+				} else if !yym347 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.LoadAverage)
+				} else {
+					z.DecFallback(x.LoadAverage, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys343)
+		} // end switch yys343
+	} // end for yyj343
+	if !yyhl343 {
+		r.ReadEnd()
+	}
+}
+
+func (x *CPUMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj348 int
+	var yyb348 bool
+	var yyhl348 bool = l >= 0
+	yyj348++
+	if yyhl348 {
+		yyb348 = yyj348 > l
+	} else {
+		yyb348 = r.CheckBreak()
+	}
+	if yyb348 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.TotalCores != nil {
+			x.TotalCores = nil
+		}
+	} else {
+		if x.TotalCores == nil {
+			x.TotalCores = new(pkg2_resource.Quantity)
+		}
+		yym350 := z.DecBinary()
+		_ = yym350
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.TotalCores) {
+		} else if !yym350 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.TotalCores)
+		} else {
+			z.DecFallback(x.TotalCores, false)
+		}
+	}
+	yyj348++
+	if yyhl348 {
+		yyb348 = yyj348 > l
+	} else {
+		yyb348 = r.CheckBreak()
+	}
+	if yyb348 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.LoadAverage != nil {
+			x.LoadAverage = nil
+		}
+	} else {
+		if x.LoadAverage == nil {
+			x.LoadAverage = new(pkg2_resource.Quantity)
+		}
+		yym352 := z.DecBinary()
+		_ = yym352
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.LoadAverage) {
+		} else if !yym352 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.LoadAverage)
+		} else {
+			z.DecFallback(x.LoadAverage, false)
+		}
+	}
+	for {
+		yyj348++
+		if yyhl348 {
+			yyb348 = yyj348 > l
+		} else {
+			yyb348 = r.CheckBreak()
+		}
+		if yyb348 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj348-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *MemoryMetrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym353 := z.EncBinary()
+		_ = yym353
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep354 := !z.EncBinary()
+			yy2arr354 := z.EncBasicHandle().StructToArray
+			var yyq354 [4]bool
+			_, _, _ = yysep354, yyq354, yy2arr354
+			const yyr354 bool = false
+			yyq354[0] = x.TotalBytes != nil
+			yyq354[1] = x.UsageBytes != nil
+			yyq354[2] = x.PageFaults != nil
+			yyq354[3] = x.MajorPageFaults != nil
+			if yyr354 || yy2arr354 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn354 int = 0
+				for _, b := range yyq354 {
+					if b {
+						yynn354++
+					}
+				}
+				r.EncodeMapStart(yynn354)
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[0] {
+					if x.TotalBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym356 := z.EncBinary()
+						_ = yym356
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
+						} else if !yym356 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TotalBytes)
+						} else {
+							z.EncFallback(x.TotalBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("totalBytes"))
+					if x.TotalBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym357 := z.EncBinary()
+						_ = yym357
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.TotalBytes) {
+						} else if !yym357 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.TotalBytes)
+						} else {
+							z.EncFallback(x.TotalBytes)
+						}
+					}
+				}
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[1] {
+					if x.UsageBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym359 := z.EncBinary()
+						_ = yym359
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
+						} else if !yym359 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UsageBytes)
+						} else {
+							z.EncFallback(x.UsageBytes)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("usageBytes"))
+					if x.UsageBytes == nil {
+						r.EncodeNil()
+					} else {
+						yym360 := z.EncBinary()
+						_ = yym360
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UsageBytes) {
+						} else if !yym360 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UsageBytes)
+						} else {
+							z.EncFallback(x.UsageBytes)
+						}
+					}
+				}
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[2] {
+					if x.PageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy362 := *x.PageFaults
+						yym363 := z.EncBinary()
+						_ = yym363
+						if false {
+						} else {
+							r.EncodeInt(int64(yy362))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("pageFaults"))
+					if x.PageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy364 := *x.PageFaults
+						yym365 := z.EncBinary()
+						_ = yym365
+						if false {
+						} else {
+							r.EncodeInt(int64(yy364))
+						}
+					}
+				}
+			}
+			if yyr354 || yy2arr354 {
+				if yyq354[3] {
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy367 := *x.MajorPageFaults
+						yym368 := z.EncBinary()
+						_ = yym368
+						if false {
+						} else {
+							r.EncodeInt(int64(yy367))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq354[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("majorPageFaults"))
+					if x.MajorPageFaults == nil {
+						r.EncodeNil()
+					} else {
+						yy369 := *x.MajorPageFaults
+						yym370 := z.EncBinary()
+						_ = yym370
+						if false {
+						} else {
+							r.EncodeInt(int64(yy369))
+						}
+					}
+				}
+			}
+			if yysep354 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *MemoryMetrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym371 := z.DecBinary()
+	_ = yym371
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl372 := r.ReadMapStart()
+			if yyl372 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl372, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl372 := r.ReadArrayStart()
+			if yyl372 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl372, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *MemoryMetrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys373Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys373Slc
+	var yyhl373 bool = l >= 0
+	for yyj373 := 0; ; yyj373++ {
+		if yyhl373 {
+			if yyj373 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys373Slc = r.DecodeBytes(yys373Slc, true, true)
+		yys373 := string(yys373Slc)
+		switch yys373 {
+		case "totalBytes":
+			if r.TryDecodeAsNil() {
+				if x.TotalBytes != nil {
+					x.TotalBytes = nil
+				}
+			} else {
+				if x.TotalBytes == nil {
+					x.TotalBytes = new(pkg2_resource.Quantity)
+				}
+				yym375 := z.DecBinary()
+				_ = yym375
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
+				} else if !yym375 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.TotalBytes)
+				} else {
+					z.DecFallback(x.TotalBytes, false)
+				}
+			}
+		case "usageBytes":
+			if r.TryDecodeAsNil() {
+				if x.UsageBytes != nil {
+					x.UsageBytes = nil
+				}
+			} else {
+				if x.UsageBytes == nil {
+					x.UsageBytes = new(pkg2_resource.Quantity)
+				}
+				yym377 := z.DecBinary()
+				_ = yym377
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
+				} else if !yym377 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.UsageBytes)
+				} else {
+					z.DecFallback(x.UsageBytes, false)
+				}
+			}
+		case "pageFaults":
+			if r.TryDecodeAsNil() {
+				if x.PageFaults != nil {
+					x.PageFaults = nil
+				}
+			} else {
+				if x.PageFaults == nil {
+					x.PageFaults = new(int64)
+				}
+				yym379 := z.DecBinary()
+				_ = yym379
+				if false {
+				} else {
+					*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
+				}
+			}
+		case "majorPageFaults":
+			if r.TryDecodeAsNil() {
+				if x.MajorPageFaults != nil {
+					x.MajorPageFaults = nil
+				}
+			} else {
+				if x.MajorPageFaults == nil {
+					x.MajorPageFaults = new(int64)
+				}
+				yym381 := z.DecBinary()
+				_ = yym381
+				if false {
+				} else {
+					*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys373)
+		} // end switch yys373
+	} // end for yyj373
+	if !yyhl373 {
+		r.ReadEnd()
+	}
+}
+
+func (x *MemoryMetrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj382 int
+	var yyb382 bool
+	var yyhl382 bool = l >= 0
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
+	} else {
+		yyb382 = r.CheckBreak()
+	}
+	if yyb382 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.TotalBytes != nil {
+			x.TotalBytes = nil
+		}
+	} else {
+		if x.TotalBytes == nil {
+			x.TotalBytes = new(pkg2_resource.Quantity)
+		}
+		yym384 := z.DecBinary()
+		_ = yym384
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.TotalBytes) {
+		} else if !yym384 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.TotalBytes)
+		} else {
+			z.DecFallback(x.TotalBytes, false)
+		}
+	}
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
+	} else {
+		yyb382 = r.CheckBreak()
+	}
+	if yyb382 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.UsageBytes != nil {
+			x.UsageBytes = nil
+		}
+	} else {
+		if x.UsageBytes == nil {
+			x.UsageBytes = new(pkg2_resource.Quantity)
+		}
+		yym386 := z.DecBinary()
+		_ = yym386
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.UsageBytes) {
+		} else if !yym386 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.UsageBytes)
+		} else {
+			z.DecFallback(x.UsageBytes, false)
+		}
+	}
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
+	} else {
+		yyb382 = r.CheckBreak()
+	}
+	if yyb382 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.PageFaults != nil {
+			x.PageFaults = nil
+		}
+	} else {
+		if x.PageFaults == nil {
+			x.PageFaults = new(int64)
+		}
+		yym388 := z.DecBinary()
+		_ = yym388
+		if false {
+		} else {
+			*((*int64)(x.PageFaults)) = int64(r.DecodeInt(64))
+		}
+	}
+	yyj382++
+	if yyhl382 {
+		yyb382 = yyj382 > l
+	} else {
+		yyb382 = r.CheckBreak()
+	}
+	if yyb382 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.MajorPageFaults != nil {
+			x.MajorPageFaults = nil
+		}
+	} else {
+		if x.MajorPageFaults == nil {
+			x.MajorPageFaults = new(int64)
+		}
+		yym390 := z.DecBinary()
+		_ = yym390
+		if false {
+		} else {
+			*((*int64)(x.MajorPageFaults)) = int64(r.DecodeInt(64))
+		}
+	}
+	for {
+		yyj382++
+		if yyhl382 {
+			yyb382 = yyj382 > l
+		} else {
+			yyb382 = r.CheckBreak()
+		}
+		if yyb382 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj382-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x CustomMetricType) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	yym391 := z.EncBinary()
+	_ = yym391
+	if false {
+	} else if z.HasExtensions() && z.EncExt(x) {
+	} else {
+		r.EncodeString(codecSelferC_UTF81234, string(x))
+	}
+}
+
+func (x *CustomMetricType) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym392 := z.DecBinary()
+	_ = yym392
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		*((*string)(x)) = r.DecodeString()
+	}
+}
+
+func (x *CustomMetric) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym393 := z.EncBinary()
+		_ = yym393
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep394 := !z.EncBinary()
+			yy2arr394 := z.EncBasicHandle().StructToArray
+			var yyq394 [4]bool
+			_, _, _ = yysep394, yyq394, yy2arr394
+			const yyr394 bool = false
+			yyq394[3] = len(x.Samples) != 0
+			if yyr394 || yy2arr394 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn394 int = 3
+				for _, b := range yyq394 {
+					if b {
+						yynn394++
+					}
+				}
+				r.EncodeMapStart(yynn394)
+			}
+			if yyr394 || yy2arr394 {
+				yym396 := z.EncBinary()
+				_ = yym396
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				yym397 := z.EncBinary()
+				_ = yym397
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			}
+			if yyr394 || yy2arr394 {
+				x.Type.CodecEncodeSelf(e)
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				x.Type.CodecEncodeSelf(e)
+			}
+			if yyr394 || yy2arr394 {
+				yym400 := z.EncBinary()
+				_ = yym400
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("unit"))
+				yym401 := z.EncBinary()
+				_ = yym401
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Unit))
+				}
+			}
+			if yyr394 || yy2arr394 {
+				if yyq394[3] {
+					if x.Samples == nil {
+						r.EncodeNil()
+					} else {
+						yym403 := z.EncBinary()
+						_ = yym403
+						if false {
+						} else {
+							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq394[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("samples"))
+					if x.Samples == nil {
+						r.EncodeNil()
+					} else {
+						yym404 := z.EncBinary()
+						_ = yym404
+						if false {
+						} else {
+							h.encSliceCustomMetricSample(([]CustomMetricSample)(x.Samples), e)
+						}
+					}
+				}
+			}
+			if yysep394 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *CustomMetric) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym405 := z.DecBinary()
+	_ = yym405
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl406 := r.ReadMapStart()
+			if yyl406 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl406, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl406 := r.ReadArrayStart()
+			if yyl406 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl406, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *CustomMetric) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys407Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys407Slc
+	var yyhl407 bool = l >= 0
+	for yyj407 := 0; ; yyj407++ {
+		if yyhl407 {
+			if yyj407 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys407Slc = r.DecodeBytes(yys407Slc, true, true)
+		yys407 := string(yys407Slc)
+		switch yys407 {
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "type":
+			if r.TryDecodeAsNil() {
+				x.Type = ""
+			} else {
+				x.Type = CustomMetricType(r.DecodeString())
+			}
+		case "unit":
+			if r.TryDecodeAsNil() {
+				x.Unit = ""
+			} else {
+				x.Unit = string(r.DecodeString())
+			}
+		case "samples":
+			if r.TryDecodeAsNil() {
+				x.Samples = nil
+			} else {
+				yyv411 := &x.Samples
+				yym412 := z.DecBinary()
+				_ = yym412
+				if false {
+				} else {
+					h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv411), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys407)
+		} // end switch yys407
+	} // end for yyj407
+	if !yyhl407 {
+		r.ReadEnd()
+	}
+}
+
+func (x *CustomMetric) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj413 int
+	var yyb413 bool
+	var yyhl413 bool = l >= 0
+	yyj413++
+	if yyhl413 {
+		yyb413 = yyj413 > l
+	} else {
+		yyb413 = r.CheckBreak()
+	}
+	if yyb413 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj413++
+	if yyhl413 {
+		yyb413 = yyj413 > l
+	} else {
+		yyb413 = r.CheckBreak()
+	}
+	if yyb413 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Type = ""
+	} else {
+		x.Type = CustomMetricType(r.DecodeString())
+	}
+	yyj413++
+	if yyhl413 {
+		yyb413 = yyj413 > l
+	} else {
+		yyb413 = r.CheckBreak()
+	}
+	if yyb413 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Unit = ""
+	} else {
+		x.Unit = string(r.DecodeString())
+	}
+	yyj413++
+	if yyhl413 {
+		yyb413 = yyj413 > l
+	} else {
+		yyb413 = r.CheckBreak()
+	}
+	if yyb413 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Samples = nil
+	} else {
+		yyv417 := &x.Samples
+		yym418 := z.DecBinary()
+		_ = yym418
+		if false {
+		} else {
+			h.decSliceCustomMetricSample((*[]CustomMetricSample)(yyv417), d)
+		}
+	}
+	for {
+		yyj413++
+		if yyhl413 {
+			yyb413 = yyj413 > l
+		} else {
+			yyb413 = r.CheckBreak()
+		}
+		if yyb413 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj413-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *CustomMetricSample) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym419 := z.EncBinary()
+		_ = yym419
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep420 := !z.EncBinary()
+			yy2arr420 := z.EncBasicHandle().StructToArray
+			var yyq420 [3]bool
+			_, _, _ = yysep420, yyq420, yy2arr420
+			const yyr420 bool = false
+			yyq420[1] = x.Label != nil
+			if yyr420 || yy2arr420 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn420 int = 2
+				for _, b := range yyq420 {
+					if b {
+						yynn420++
+					}
+				}
+				r.EncodeMapStart(yynn420)
+			}
+			if yyr420 || yy2arr420 {
+				yy422 := &x.SampleTime
+				yym423 := z.EncBinary()
+				_ = yym423
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy422) {
+				} else if yym423 {
+					z.EncBinaryMarshal(yy422)
+				} else if !yym423 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy422)
+				} else {
+					z.EncFallback(yy422)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("sampleTime"))
+				yy424 := &x.SampleTime
+				yym425 := z.EncBinary()
+				_ = yym425
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy424) {
+				} else if yym425 {
+					z.EncBinaryMarshal(yy424)
+				} else if !yym425 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy424)
+				} else {
+					z.EncFallback(yy424)
+				}
+			}
+			if yyr420 || yy2arr420 {
+				if yyq420[1] {
+					if x.Label == nil {
+						r.EncodeNil()
+					} else {
+						yy427 := *x.Label
+						yym428 := z.EncBinary()
+						_ = yym428
+						if false {
+						} else {
+							r.EncodeString(codecSelferC_UTF81234, string(yy427))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq420[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("label"))
+					if x.Label == nil {
+						r.EncodeNil()
+					} else {
+						yy429 := *x.Label
+						yym430 := z.EncBinary()
+						_ = yym430
+						if false {
+						} else {
+							r.EncodeString(codecSelferC_UTF81234, string(yy429))
+						}
+					}
+				}
+			}
+			if yyr420 || yy2arr420 {
+				yy432 := &x.Value
+				yym433 := z.EncBinary()
+				_ = yym433
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy432) {
+				} else if !yym433 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy432)
+				} else {
+					z.EncFallback(yy432)
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("value"))
+				yy434 := &x.Value
+				yym435 := z.EncBinary()
+				_ = yym435
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy434) {
+				} else if !yym435 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy434)
+				} else {
+					z.EncFallback(yy434)
+				}
+			}
+			if yysep420 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *CustomMetricSample) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym436 := z.DecBinary()
+	_ = yym436
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl437 := r.ReadMapStart()
+			if yyl437 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl437, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl437 := r.ReadArrayStart()
+			if yyl437 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl437, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *CustomMetricSample) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys438Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys438Slc
+	var yyhl438 bool = l >= 0
+	for yyj438 := 0; ; yyj438++ {
+		if yyhl438 {
+			if yyj438 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys438Slc = r.DecodeBytes(yys438Slc, true, true)
+		yys438 := string(yys438Slc)
+		switch yys438 {
+		case "sampleTime":
+			if r.TryDecodeAsNil() {
+				x.SampleTime = pkg1_unversioned.Time{}
+			} else {
+				yyv439 := &x.SampleTime
+				yym440 := z.DecBinary()
+				_ = yym440
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv439) {
+				} else if yym440 {
+					z.DecBinaryUnmarshal(yyv439)
+				} else if !yym440 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv439)
+				} else {
+					z.DecFallback(yyv439, false)
+				}
+			}
+		case "label":
+			if r.TryDecodeAsNil() {
+				if x.Label != nil {
+					x.Label = nil
+				}
+			} else {
+				if x.Label == nil {
+					x.Label = new(string)
+				}
+				yym442 := z.DecBinary()
+				_ = yym442
+				if false {
+				} else {
+					*((*string)(x.Label)) = r.DecodeString()
+				}
+			}
+		case "value":
+			if r.TryDecodeAsNil() {
+				x.Value = pkg2_resource.Quantity{}
+			} else {
+				yyv443 := &x.Value
+				yym444 := z.DecBinary()
+				_ = yym444
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv443) {
+				} else if !yym444 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv443)
+				} else {
+					z.DecFallback(yyv443, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys438)
+		} // end switch yys438
+	} // end for yyj438
+	if !yyhl438 {
+		r.ReadEnd()
+	}
+}
+
+func (x *CustomMetricSample) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj445 int
+	var yyb445 bool
+	var yyhl445 bool = l >= 0
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
+	} else {
+		yyb445 = r.CheckBreak()
+	}
+	if yyb445 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.SampleTime = pkg1_unversioned.Time{}
+	} else {
+		yyv446 := &x.SampleTime
+		yym447 := z.DecBinary()
+		_ = yym447
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv446) {
+		} else if yym447 {
+			z.DecBinaryUnmarshal(yyv446)
+		} else if !yym447 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv446)
+		} else {
+			z.DecFallback(yyv446, false)
+		}
+	}
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
+	} else {
+		yyb445 = r.CheckBreak()
+	}
+	if yyb445 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.Label != nil {
+			x.Label = nil
+		}
+	} else {
+		if x.Label == nil {
+			x.Label = new(string)
+		}
+		yym449 := z.DecBinary()
+		_ = yym449
+		if false {
+		} else {
+			*((*string)(x.Label)) = r.DecodeString()
+		}
+	}
+	yyj445++
+	if yyhl445 {
+		yyb445 = yyj445 > l
+	} else {
+		yyb445 = r.CheckBreak()
+	}
+	if yyb445 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Value = pkg2_resource.Quantity{}
+	} else {
+		yyv450 := &x.Value
+		yym451 := z.DecBinary()
+		_ = yym451
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv450) {
+		} else if !yym451 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv450)
+		} else {
+			z.DecFallback(yyv450, false)
+		}
+	}
+	for {
+		yyj445++
+		if yyhl445 {
+			yyb445 = yyj445 > l
+		} else {
+			yyb445 = r.CheckBreak()
+		}
+		if yyb445 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj445-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *RawMetricsOptions) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym452 := z.EncBinary()
+		_ = yym452
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep453 := !z.EncBinary()
+			yy2arr453 := z.EncBasicHandle().StructToArray
+			var yyq453 [3]bool
+			_, _, _ = yysep453, yyq453, yy2arr453
+			const yyr453 bool = false
+			yyq453[0] = x.SinceTime != nil
+			yyq453[1] = x.UntilTime != nil
+			yyq453[2] = x.MaxSamples != 0
+			if yyr453 || yy2arr453 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn453 int = 0
+				for _, b := range yyq453 {
+					if b {
+						yynn453++
+					}
+				}
+				r.EncodeMapStart(yynn453)
+			}
+			if yyr453 || yy2arr453 {
+				if yyq453[0] {
+					if x.SinceTime == nil {
+						r.EncodeNil()
+					} else {
+						yym455 := z.EncBinary()
+						_ = yym455
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
+						} else if yym455 {
+							z.EncBinaryMarshal(x.SinceTime)
+						} else if !yym455 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.SinceTime)
+						} else {
+							z.EncFallback(x.SinceTime)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq453[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
+					if x.SinceTime == nil {
+						r.EncodeNil()
+					} else {
+						yym456 := z.EncBinary()
+						_ = yym456
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
+						} else if yym456 {
+							z.EncBinaryMarshal(x.SinceTime)
+						} else if !yym456 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.SinceTime)
+						} else {
+							z.EncFallback(x.SinceTime)
+						}
+					}
+				}
+			}
+			if yyr453 || yy2arr453 {
+				if yyq453[1] {
+					if x.UntilTime == nil {
+						r.EncodeNil()
+					} else {
+						yym458 := z.EncBinary()
+						_ = yym458
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
+						} else if yym458 {
+							z.EncBinaryMarshal(x.UntilTime)
+						} else if !yym458 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UntilTime)
+						} else {
+							z.EncFallback(x.UntilTime)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq453[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("untilTime"))
+					if x.UntilTime == nil {
+						r.EncodeNil()
+					} else {
+						yym459 := z.EncBinary()
+						_ = yym459
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.UntilTime) {
+						} else if yym459 {
+							z.EncBinaryMarshal(x.UntilTime)
+						} else if !yym459 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.UntilTime)
+						} else {
+							z.EncFallback(x.UntilTime)
+						}
+					}
+				}
+			}
+			if yyr453 || yy2arr453 {
+				if yyq453[2] {
+					yym461 := z.EncBinary()
+					_ = yym461
+					if false {
+					} else {
+						r.EncodeInt(int64(x.MaxSamples))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq453[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("maxSamples"))
+					yym462 := z.EncBinary()
+					_ = yym462
+					if false {
+					} else {
+						r.EncodeInt(int64(x.MaxSamples))
+					}
+				}
+			}
+			if yysep453 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *RawMetricsOptions) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym463 := z.DecBinary()
+	_ = yym463
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl464 := r.ReadMapStart()
+			if yyl464 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl464, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl464 := r.ReadArrayStart()
+			if yyl464 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl464, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RawMetricsOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys465Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys465Slc
+	var yyhl465 bool = l >= 0
+	for yyj465 := 0; ; yyj465++ {
+		if yyhl465 {
+			if yyj465 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys465Slc = r.DecodeBytes(yys465Slc, true, true)
+		yys465 := string(yys465Slc)
+		switch yys465 {
+		case "sinceTime":
+			if r.TryDecodeAsNil() {
+				if x.SinceTime != nil {
+					x.SinceTime = nil
+				}
+			} else {
+				if x.SinceTime == nil {
+					x.SinceTime = new(pkg1_unversioned.Time)
+				}
+				yym467 := z.DecBinary()
+				_ = yym467
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
+				} else if yym467 {
+					z.DecBinaryUnmarshal(x.SinceTime)
+				} else if !yym467 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.SinceTime)
+				} else {
+					z.DecFallback(x.SinceTime, false)
+				}
+			}
+		case "untilTime":
+			if r.TryDecodeAsNil() {
+				if x.UntilTime != nil {
+					x.UntilTime = nil
+				}
+			} else {
+				if x.UntilTime == nil {
+					x.UntilTime = new(pkg1_unversioned.Time)
+				}
+				yym469 := z.DecBinary()
+				_ = yym469
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
+				} else if yym469 {
+					z.DecBinaryUnmarshal(x.UntilTime)
+				} else if !yym469 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.UntilTime)
+				} else {
+					z.DecFallback(x.UntilTime, false)
+				}
+			}
+		case "maxSamples":
+			if r.TryDecodeAsNil() {
+				x.MaxSamples = 0
+			} else {
+				x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys465)
+		} // end switch yys465
+	} // end for yyj465
+	if !yyhl465 {
+		r.ReadEnd()
+	}
+}
+
+func (x *RawMetricsOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj471 int
+	var yyb471 bool
+	var yyhl471 bool = l >= 0
+	yyj471++
+	if yyhl471 {
+		yyb471 = yyj471 > l
+	} else {
+		yyb471 = r.CheckBreak()
+	}
+	if yyb471 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.SinceTime != nil {
+			x.SinceTime = nil
+		}
+	} else {
+		if x.SinceTime == nil {
+			x.SinceTime = new(pkg1_unversioned.Time)
+		}
+		yym473 := z.DecBinary()
+		_ = yym473
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
+		} else if yym473 {
+			z.DecBinaryUnmarshal(x.SinceTime)
+		} else if !yym473 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.SinceTime)
+		} else {
+			z.DecFallback(x.SinceTime, false)
+		}
+	}
+	yyj471++
+	if yyhl471 {
+		yyb471 = yyj471 > l
+	} else {
+		yyb471 = r.CheckBreak()
+	}
+	if yyb471 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		if x.UntilTime != nil {
+			x.UntilTime = nil
+		}
+	} else {
+		if x.UntilTime == nil {
+			x.UntilTime = new(pkg1_unversioned.Time)
+		}
+		yym475 := z.DecBinary()
+		_ = yym475
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.UntilTime) {
+		} else if yym475 {
+			z.DecBinaryUnmarshal(x.UntilTime)
+		} else if !yym475 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.UntilTime)
+		} else {
+			z.DecFallback(x.UntilTime, false)
+		}
+	}
+	yyj471++
+	if yyhl471 {
+		yyb471 = yyj471 > l
+	} else {
+		yyb471 = r.CheckBreak()
+	}
+	if yyb471 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.MaxSamples = 0
+	} else {
+		x.MaxSamples = int(r.DecodeInt(codecSelferBitsize1234))
+	}
+	for {
+		yyj471++
+		if yyhl471 {
+			yyb471 = yyj471 > l
+		} else {
+			yyb471 = r.CheckBreak()
+		}
+		if yyb471 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj471-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x codecSelfer1234) encSliceAggregateSample(v []AggregateSample, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv477 := range v {
+		yy478 := &yyv477
+		yy478.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceAggregateSample(v *[]AggregateSample, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv479 := *v
+	yyh479, yyl479 := z.DecSliceHelperStart()
+
+	var yyrr479, yyrl479 int
+	var yyc479, yyrt479 bool
+	_, _, _ = yyc479, yyrt479, yyrl479
+	yyrr479 = yyl479
+
+	if yyv479 == nil {
+		if yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 48); yyrt479 {
+			yyrr479 = yyrl479
+		}
+		yyv479 = make([]AggregateSample, yyrl479)
+		yyc479 = true
+	}
+
+	if yyl479 == 0 {
+		if len(yyv479) != 0 {
+			yyv479 = yyv479[:0]
+			yyc479 = true
+		}
+	} else if yyl479 > 0 {
+
+		if yyl479 > cap(yyv479) {
+			yyrl479, yyrt479 = z.DecInferLen(yyl479, z.DecBasicHandle().MaxInitLen, 48)
+			yyv479 = make([]AggregateSample, yyrl479)
+			yyc479 = true
+
+			yyrr479 = len(yyv479)
+		} else if yyl479 != len(yyv479) {
+			yyv479 = yyv479[:yyl479]
+			yyc479 = true
+		}
+		yyj479 := 0
+		for ; yyj479 < yyrr479; yyj479++ {
+			if r.TryDecodeAsNil() {
+				yyv479[yyj479] = AggregateSample{}
+			} else {
+				yyv480 := &yyv479[yyj479]
+				yyv480.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt479 {
+			for ; yyj479 < yyl479; yyj479++ {
+				yyv479 = append(yyv479, AggregateSample{})
+				if r.TryDecodeAsNil() {
+					yyv479[yyj479] = AggregateSample{}
+				} else {
+					yyv481 := &yyv479[yyj479]
+					yyv481.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj479 := 0; !r.CheckBreak(); yyj479++ {
+			if yyj479 >= len(yyv479) {
+				yyv479 = append(yyv479, AggregateSample{}) // var yyz479 AggregateSample
+				yyc479 = true
+			}
+
+			if yyj479 < len(yyv479) {
+				if r.TryDecodeAsNil() {
+					yyv479[yyj479] = AggregateSample{}
+				} else {
+					yyv482 := &yyv479[yyj479]
+					yyv482.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh479.End()
+	}
+	if yyc479 {
+		*v = yyv479
+	}
+
+}
+
+func (x codecSelfer1234) encSliceRawContainerMetrics(v []RawContainerMetrics, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv483 := range v {
+		yy484 := &yyv483
+		yy484.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceRawContainerMetrics(v *[]RawContainerMetrics, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv485 := *v
+	yyh485, yyl485 := z.DecSliceHelperStart()
+
+	var yyrr485, yyrl485 int
+	var yyc485, yyrt485 bool
+	_, _, _ = yyc485, yyrt485, yyrl485
+	yyrr485 = yyl485
+
+	if yyv485 == nil {
+		if yyrl485, yyrt485 = z.DecInferLen(yyl485, z.DecBasicHandle().MaxInitLen, 72); yyrt485 {
+			yyrr485 = yyrl485
+		}
+		yyv485 = make([]RawContainerMetrics, yyrl485)
+		yyc485 = true
+	}
+
+	if yyl485 == 0 {
+		if len(yyv485) != 0 {
+			yyv485 = yyv485[:0]
+			yyc485 = true
+		}
+	} else if yyl485 > 0 {
+
+		if yyl485 > cap(yyv485) {
+			yyrl485, yyrt485 = z.DecInferLen(yyl485, z.DecBasicHandle().MaxInitLen, 72)
+			yyv485 = make([]RawContainerMetrics, yyrl485)
+			yyc485 = true
+
+			yyrr485 = len(yyv485)
+		} else if yyl485 != len(yyv485) {
+			yyv485 = yyv485[:yyl485]
+			yyc485 = true
+		}
+		yyj485 := 0
+		for ; yyj485 < yyrr485; yyj485++ {
+			if r.TryDecodeAsNil() {
+				yyv485[yyj485] = RawContainerMetrics{}
+			} else {
+				yyv486 := &yyv485[yyj485]
+				yyv486.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt485 {
+			for ; yyj485 < yyl485; yyj485++ {
+				yyv485 = append(yyv485, RawContainerMetrics{})
+				if r.TryDecodeAsNil() {
+					yyv485[yyj485] = RawContainerMetrics{}
+				} else {
+					yyv487 := &yyv485[yyj485]
+					yyv487.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj485 := 0; !r.CheckBreak(); yyj485++ {
+			if yyj485 >= len(yyv485) {
+				yyv485 = append(yyv485, RawContainerMetrics{}) // var yyz485 RawContainerMetrics
+				yyc485 = true
+			}
+
+			if yyj485 < len(yyv485) {
+				if r.TryDecodeAsNil() {
+					yyv485[yyj485] = RawContainerMetrics{}
+				} else {
+					yyv488 := &yyv485[yyj485]
+					yyv488.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh485.End()
+	}
+	if yyc485 {
+		*v = yyv485
+	}
+
+}
+
+func (x codecSelfer1234) encSliceRawNodeMetrics(v []RawNodeMetrics, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv489 := range v {
+		yy490 := &yyv489
+		yy490.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceRawNodeMetrics(v *[]RawNodeMetrics, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv491 := *v
+	yyh491, yyl491 := z.DecSliceHelperStart()
+
+	var yyrr491, yyrl491 int
+	var yyc491, yyrt491 bool
+	_, _, _ = yyc491, yyrt491, yyrl491
+	yyrr491 = yyl491
+
+	if yyv491 == nil {
+		if yyrl491, yyrt491 = z.DecInferLen(yyl491, z.DecBasicHandle().MaxInitLen, 128); yyrt491 {
+			yyrr491 = yyrl491
+		}
+		yyv491 = make([]RawNodeMetrics, yyrl491)
+		yyc491 = true
+	}
+
+	if yyl491 == 0 {
+		if len(yyv491) != 0 {
+			yyv491 = yyv491[:0]
+			yyc491 = true
+		}
+	} else if yyl491 > 0 {
+
+		if yyl491 > cap(yyv491) {
+			yyrl491, yyrt491 = z.DecInferLen(yyl491, z.DecBasicHandle().MaxInitLen, 128)
+			yyv491 = make([]RawNodeMetrics, yyrl491)
+			yyc491 = true
+
+			yyrr491 = len(yyv491)
+		} else if yyl491 != len(yyv491) {
+			yyv491 = yyv491[:yyl491]
+			yyc491 = true
+		}
+		yyj491 := 0
+		for ; yyj491 < yyrr491; yyj491++ {
+			if r.TryDecodeAsNil() {
+				yyv491[yyj491] = RawNodeMetrics{}
+			} else {
+				yyv492 := &yyv491[yyj491]
+				yyv492.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt491 {
+			for ; yyj491 < yyl491; yyj491++ {
+				yyv491 = append(yyv491, RawNodeMetrics{})
+				if r.TryDecodeAsNil() {
+					yyv491[yyj491] = RawNodeMetrics{}
+				} else {
+					yyv493 := &yyv491[yyj491]
+					yyv493.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj491 := 0; !r.CheckBreak(); yyj491++ {
+			if yyj491 >= len(yyv491) {
+				yyv491 = append(yyv491, RawNodeMetrics{}) // var yyz491 RawNodeMetrics
+				yyc491 = true
+			}
+
+			if yyj491 < len(yyv491) {
+				if r.TryDecodeAsNil() {
+					yyv491[yyj491] = RawNodeMetrics{}
+				} else {
+					yyv494 := &yyv491[yyj491]
+					yyv494.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh491.End()
+	}
+	if yyc491 {
+		*v = yyv491
+	}
+
+}
+
+func (x codecSelfer1234) encSlicePodSample(v []PodSample, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv495 := range v {
+		yy496 := &yyv495
+		yy496.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSlicePodSample(v *[]PodSample, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv497 := *v
+	yyh497, yyl497 := z.DecSliceHelperStart()
+
+	var yyrr497, yyrl497 int
+	var yyc497, yyrt497 bool
+	_, _, _ = yyc497, yyrt497, yyrl497
+	yyrr497 = yyl497
+
+	if yyv497 == nil {
+		if yyrl497, yyrt497 = z.DecInferLen(yyl497, z.DecBasicHandle().MaxInitLen, 32); yyrt497 {
+			yyrr497 = yyrl497
+		}
+		yyv497 = make([]PodSample, yyrl497)
+		yyc497 = true
+	}
+
+	if yyl497 == 0 {
+		if len(yyv497) != 0 {
+			yyv497 = yyv497[:0]
+			yyc497 = true
+		}
+	} else if yyl497 > 0 {
+
+		if yyl497 > cap(yyv497) {
+			yyrl497, yyrt497 = z.DecInferLen(yyl497, z.DecBasicHandle().MaxInitLen, 32)
+			yyv497 = make([]PodSample, yyrl497)
+			yyc497 = true
+
+			yyrr497 = len(yyv497)
+		} else if yyl497 != len(yyv497) {
+			yyv497 = yyv497[:yyl497]
+			yyc497 = true
+		}
+		yyj497 := 0
+		for ; yyj497 < yyrr497; yyj497++ {
+			if r.TryDecodeAsNil() {
+				yyv497[yyj497] = PodSample{}
+			} else {
+				yyv498 := &yyv497[yyj497]
+				yyv498.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt497 {
+			for ; yyj497 < yyl497; yyj497++ {
+				yyv497 = append(yyv497, PodSample{})
+				if r.TryDecodeAsNil() {
+					yyv497[yyj497] = PodSample{}
+				} else {
+					yyv499 := &yyv497[yyj497]
+					yyv499.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj497 := 0; !r.CheckBreak(); yyj497++ {
+			if yyj497 >= len(yyv497) {
+				yyv497 = append(yyv497, PodSample{}) // var yyz497 PodSample
+				yyc497 = true
+			}
+
+			if yyj497 < len(yyv497) {
+				if r.TryDecodeAsNil() {
+					yyv497[yyj497] = PodSample{}
+				} else {
+					yyv500 := &yyv497[yyj497]
+					yyv500.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh497.End()
+	}
+	if yyc497 {
+		*v = yyv497
+	}
+
+}
+
+func (x codecSelfer1234) encSliceRawPodMetrics(v []RawPodMetrics, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv501 := range v {
+		yy502 := &yyv501
+		yy502.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceRawPodMetrics(v *[]RawPodMetrics, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv503 := *v
+	yyh503, yyl503 := z.DecSliceHelperStart()
+
+	var yyrr503, yyrl503 int
+	var yyc503, yyrt503 bool
+	_, _, _ = yyc503, yyrt503, yyrl503
+	yyrr503 = yyl503
+
+	if yyv503 == nil {
+		if yyrl503, yyrt503 = z.DecInferLen(yyl503, z.DecBasicHandle().MaxInitLen, 160); yyrt503 {
+			yyrr503 = yyrl503
+		}
+		yyv503 = make([]RawPodMetrics, yyrl503)
+		yyc503 = true
+	}
+
+	if yyl503 == 0 {
+		if len(yyv503) != 0 {
+			yyv503 = yyv503[:0]
+			yyc503 = true
+		}
+	} else if yyl503 > 0 {
+
+		if yyl503 > cap(yyv503) {
+			yyrl503, yyrt503 = z.DecInferLen(yyl503, z.DecBasicHandle().MaxInitLen, 160)
+			yyv503 = make([]RawPodMetrics, yyrl503)
+			yyc503 = true
+
+			yyrr503 = len(yyv503)
+		} else if yyl503 != len(yyv503) {
+			yyv503 = yyv503[:yyl503]
+			yyc503 = true
+		}
+		yyj503 := 0
+		for ; yyj503 < yyrr503; yyj503++ {
+			if r.TryDecodeAsNil() {
+				yyv503[yyj503] = RawPodMetrics{}
+			} else {
+				yyv504 := &yyv503[yyj503]
+				yyv504.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt503 {
+			for ; yyj503 < yyl503; yyj503++ {
+				yyv503 = append(yyv503, RawPodMetrics{})
+				if r.TryDecodeAsNil() {
+					yyv503[yyj503] = RawPodMetrics{}
+				} else {
+					yyv505 := &yyv503[yyj503]
+					yyv505.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj503 := 0; !r.CheckBreak(); yyj503++ {
+			if yyj503 >= len(yyv503) {
+				yyv503 = append(yyv503, RawPodMetrics{}) // var yyz503 RawPodMetrics
+				yyc503 = true
+			}
+
+			if yyj503 < len(yyv503) {
+				if r.TryDecodeAsNil() {
+					yyv503[yyj503] = RawPodMetrics{}
+				} else {
+					yyv506 := &yyv503[yyj503]
+					yyv506.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh503.End()
+	}
+	if yyc503 {
+		*v = yyv503
+	}
+
+}
+
+func (x codecSelfer1234) encSliceContainerSample(v []ContainerSample, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv507 := range v {
+		yy508 := &yyv507
+		yy508.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceContainerSample(v *[]ContainerSample, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv509 := *v
+	yyh509, yyl509 := z.DecSliceHelperStart()
+
+	var yyrr509, yyrl509 int
+	var yyc509, yyrt509 bool
+	_, _, _ = yyc509, yyrt509, yyrl509
+	yyrr509 = yyl509
+
+	if yyv509 == nil {
+		if yyrl509, yyrt509 = z.DecInferLen(yyl509, z.DecBasicHandle().MaxInitLen, 40); yyrt509 {
+			yyrr509 = yyrl509
+		}
+		yyv509 = make([]ContainerSample, yyrl509)
+		yyc509 = true
+	}
+
+	if yyl509 == 0 {
+		if len(yyv509) != 0 {
+			yyv509 = yyv509[:0]
+			yyc509 = true
+		}
+	} else if yyl509 > 0 {
+
+		if yyl509 > cap(yyv509) {
+			yyrl509, yyrt509 = z.DecInferLen(yyl509, z.DecBasicHandle().MaxInitLen, 40)
+			yyv509 = make([]ContainerSample, yyrl509)
+			yyc509 = true
+
+			yyrr509 = len(yyv509)
+		} else if yyl509 != len(yyv509) {
+			yyv509 = yyv509[:yyl509]
+			yyc509 = true
+		}
+		yyj509 := 0
+		for ; yyj509 < yyrr509; yyj509++ {
+			if r.TryDecodeAsNil() {
+				yyv509[yyj509] = ContainerSample{}
+			} else {
+				yyv510 := &yyv509[yyj509]
+				yyv510.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt509 {
+			for ; yyj509 < yyl509; yyj509++ {
+				yyv509 = append(yyv509, ContainerSample{})
+				if r.TryDecodeAsNil() {
+					yyv509[yyj509] = ContainerSample{}
+				} else {
+					yyv511 := &yyv509[yyj509]
+					yyv511.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj509 := 0; !r.CheckBreak(); yyj509++ {
+			if yyj509 >= len(yyv509) {
+				yyv509 = append(yyv509, ContainerSample{}) // var yyz509 ContainerSample
+				yyc509 = true
+			}
+
+			if yyj509 < len(yyv509) {
+				if r.TryDecodeAsNil() {
+					yyv509[yyj509] = ContainerSample{}
+				} else {
+					yyv512 := &yyv509[yyj509]
+					yyv512.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh509.End()
+	}
+	if yyc509 {
+		*v = yyv509
+	}
+
+}
+
+func (x codecSelfer1234) encSliceCustomMetric(v []CustomMetric, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv513 := range v {
+		yy514 := &yyv513
+		yy514.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceCustomMetric(v *[]CustomMetric, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv515 := *v
+	yyh515, yyl515 := z.DecSliceHelperStart()
+
+	var yyrr515, yyrl515 int
+	var yyc515, yyrt515 bool
+	_, _, _ = yyc515, yyrt515, yyrl515
+	yyrr515 = yyl515
+
+	if yyv515 == nil {
+		if yyrl515, yyrt515 = z.DecInferLen(yyl515, z.DecBasicHandle().MaxInitLen, 72); yyrt515 {
+			yyrr515 = yyrl515
+		}
+		yyv515 = make([]CustomMetric, yyrl515)
+		yyc515 = true
+	}
+
+	if yyl515 == 0 {
+		if len(yyv515) != 0 {
+			yyv515 = yyv515[:0]
+			yyc515 = true
+		}
+	} else if yyl515 > 0 {
+
+		if yyl515 > cap(yyv515) {
+			yyrl515, yyrt515 = z.DecInferLen(yyl515, z.DecBasicHandle().MaxInitLen, 72)
+			yyv515 = make([]CustomMetric, yyrl515)
+			yyc515 = true
+
+			yyrr515 = len(yyv515)
+		} else if yyl515 != len(yyv515) {
+			yyv515 = yyv515[:yyl515]
+			yyc515 = true
+		}
+		yyj515 := 0
+		for ; yyj515 < yyrr515; yyj515++ {
+			if r.TryDecodeAsNil() {
+				yyv515[yyj515] = CustomMetric{}
+			} else {
+				yyv516 := &yyv515[yyj515]
+				yyv516.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt515 {
+			for ; yyj515 < yyl515; yyj515++ {
+				yyv515 = append(yyv515, CustomMetric{})
+				if r.TryDecodeAsNil() {
+					yyv515[yyj515] = CustomMetric{}
+				} else {
+					yyv517 := &yyv515[yyj515]
+					yyv517.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj515 := 0; !r.CheckBreak(); yyj515++ {
+			if yyj515 >= len(yyv515) {
+				yyv515 = append(yyv515, CustomMetric{}) // var yyz515 CustomMetric
+				yyc515 = true
+			}
+
+			if yyj515 < len(yyv515) {
+				if r.TryDecodeAsNil() {
+					yyv515[yyj515] = CustomMetric{}
+				} else {
+					yyv518 := &yyv515[yyj515]
+					yyv518.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh515.End()
+	}
+	if yyc515 {
+		*v = yyv515
+	}
+
+}
+
+func (x codecSelfer1234) encSliceCustomMetricSample(v []CustomMetricSample, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv519 := range v {
+		yy520 := &yyv519
+		yy520.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceCustomMetricSample(v *[]CustomMetricSample, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv521 := *v
+	yyh521, yyl521 := z.DecSliceHelperStart()
+
+	var yyrr521, yyrl521 int
+	var yyc521, yyrt521 bool
+	_, _, _ = yyc521, yyrt521, yyrl521
+	yyrr521 = yyl521
+
+	if yyv521 == nil {
+		if yyrl521, yyrt521 = z.DecInferLen(yyl521, z.DecBasicHandle().MaxInitLen, 56); yyrt521 {
+			yyrr521 = yyrl521
+		}
+		yyv521 = make([]CustomMetricSample, yyrl521)
+		yyc521 = true
+	}
+
+	if yyl521 == 0 {
+		if len(yyv521) != 0 {
+			yyv521 = yyv521[:0]
+			yyc521 = true
+		}
+	} else if yyl521 > 0 {
+
+		if yyl521 > cap(yyv521) {
+			yyrl521, yyrt521 = z.DecInferLen(yyl521, z.DecBasicHandle().MaxInitLen, 56)
+			yyv521 = make([]CustomMetricSample, yyrl521)
+			yyc521 = true
+
+			yyrr521 = len(yyv521)
+		} else if yyl521 != len(yyv521) {
+			yyv521 = yyv521[:yyl521]
+			yyc521 = true
+		}
+		yyj521 := 0
+		for ; yyj521 < yyrr521; yyj521++ {
+			if r.TryDecodeAsNil() {
+				yyv521[yyj521] = CustomMetricSample{}
+			} else {
+				yyv522 := &yyv521[yyj521]
+				yyv522.CodecDecodeSelf(d)
+			}
+
+		}
+		if yyrt521 {
+			for ; yyj521 < yyl521; yyj521++ {
+				yyv521 = append(yyv521, CustomMetricSample{})
+				if r.TryDecodeAsNil() {
+					yyv521[yyj521] = CustomMetricSample{}
+				} else {
+					yyv523 := &yyv521[yyj521]
+					yyv523.CodecDecodeSelf(d)
+				}
+
+			}
+		}
+
+	} else {
+		for yyj521 := 0; !r.CheckBreak(); yyj521++ {
+			if yyj521 >= len(yyv521) {
+				yyv521 = append(yyv521, CustomMetricSample{}) // var yyz521 CustomMetricSample
+				yyc521 = true
+			}
+
+			if yyj521 < len(yyv521) {
+				if r.TryDecodeAsNil() {
+					yyv521[yyj521] = CustomMetricSample{}
+				} else {
+					yyv524 := &yyv521[yyj521]
+					yyv524.CodecDecodeSelf(d)
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh521.End()
+	}
+	if yyc521 {
+		*v = yyv521
+	}
+
 }

--- a/pkg/apis/metrics/v1alpha1/types.go
+++ b/pkg/apis/metrics/v1alpha1/types.go
@@ -183,13 +183,6 @@ type FilesystemMetrics struct {
 
 // RawMetricsOptions are the query options for raw metrics endpoints.
 type RawMetricsOptions struct {
-	// Only include samples with sampleTime equal to or more recent than this time.
-	// This does not affect cumulative values, which are cumulative from object creation.
-	// Defaults to the beginning of time. Must be older than now and untilTime.
-	SinceTime *unversioned.Time `json:"sinceTime,omitempty"`
-	// Only include samples with sampleTime equal to or less recent than this time.
-	// Defaults to the now. Must be newer than sinceTime.
-	UntilTime *unversioned.Time `json:"untilTime,omitempty"`
 	// Specifies the maximum number of elements in any list of samples.
 	// When the total number of samples exceeds the maximum the most recent samples are returned.
 	// Defaults to unlimited. Minimum value 1.

--- a/pkg/apis/metrics/v1alpha1/types.go
+++ b/pkg/apis/metrics/v1alpha1/types.go
@@ -158,9 +158,6 @@ type CPUMetrics struct {
 	// Total CPU usage (sum of all cores) averaged over the sample window.
 	// The "core" unit can be interpreted as CPU core-seconds per second.
 	TotalCores *resource.Quantity `json:"totalCores,omitempty"`
-	// CPU load that the container is experiencing, represented as a smoothed average of number of
-	// runnable threads.  Load is averaged over the sampling window.
-	LoadAverage *resource.Quantity `json:"loadAverage,omitempty"`
 }
 
 // MemoryMetrics contains data about memory usage.

--- a/pkg/apis/metrics/v1alpha1/types.go
+++ b/pkg/apis/metrics/v1alpha1/types.go
@@ -16,14 +16,208 @@ limitations under the License.
 
 package v1alpha1
 
-import "k8s.io/kubernetes/pkg/api/unversioned"
+import (
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/types"
+)
 
-// Placeholder top-level node resource metrics.
-type RawNode struct {
-	unversioned.TypeMeta `json:",inline"`
+// MetricsMeta describes metadata that top-level metrics resources must have.
+// Metrics data is a synthetic collection of Samples, and thus does not use ObjectMeta.
+// All metrics data is read-only.
+type MetricsMeta struct {
+	// SelfLink is a URL representing this object.
+	// Populated by the system.
+	SelfLink string `json:"selfLink,omitempty"`
 }
 
-// Placeholder top-level pod resource metrics.
-type RawPod struct {
+// RawNode holds node-level unprocessed sample metrics.
+type RawNodeMetrics struct {
 	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata, since this is a synthetic resource.
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+	unversioned.ListMeta `json:"metadata"`
+	// Reference to the measured Node.
+	NodeName string `json:"nodeName"`
+	// Overall node metrics.
+	Total []AggregateSample `json:"total,omitempty" patchStrategy:"merge" patchMergeKey:"sampleTime"`
+	// Metrics of system daemons tracked as raw containers, which may include:
+	//   "/kubelet", "/docker-daemon", "kube-proxy" - Tracks respective component metrics
+	//   "/system" - Tracks metrics of non-kubernetes and non-kernel processes (grouped together)
+	SystemContainers []RawContainerMetrics `json:"systemContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+}
+
+// RawNodeMetricsList holds a list of RawNodeMetrics.
+// Endpoints which return this type respect unversioned.ListOptions
+type RawNodeMetricsList struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata.
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+	unversioned.ListMeta `json:"metadata,omitempty"`
+	// List of raw node metrics.
+	Items []RawNodeMetrics `json:"items"`
+}
+
+// RawPod holds pod-level unprocessed sample metrics.
+type RawPodMetrics struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata, since this is a synthetic resource.
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+	unversioned.ListMeta `json:"metadata"`
+	// Reference to the measured Pod.
+	PodRef NonLocalObjectReference `json:"podRef"`
+	// Metrics of containers in the measured pod.
+	Containers []RawContainerMetrics `json:"containers" patchStrategy:"merge" patchMergeKey:"name"`
+	// Historical metric samples of pod-level resources.
+	Samples []PodSample `json:"samples" patchStrategy:"merge" patchMergeKey:"sampleTime"`
+}
+
+// RawPodMetricsList holds a list of RawPodMetrics.
+// Endpoints which return this type respect unversioned.ListOptions
+type RawPodMetricsList struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata.
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+	unversioned.ListMeta `json:"metadata,omitempty"`
+	// List of raw pod metrics.
+	Items []RawPodMetrics `json:"items"`
+}
+
+// RawContainerMetrics holds container-level unprocessed sample metrics.
+type RawContainerMetrics struct {
+	// Reference to the measured container.
+	Name string `json:"name"`
+	// Metadata labels associated with this container (not Kubernetes labels).
+	// For example, docker labels.
+	Labels map[string]string `json:"labels,omitempty"`
+	// Historical metric samples gathered from the container.
+	Samples []ContainerSample `json:"samples" patchStrategy:"merge" patchMergeKey:"sampleTime"`
+	// Application-specific metrics.
+	CustomMetrics []CustomMetric `json:"customMetrics,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+}
+
+// NonLocalObjectReference contains enough information to locate the referenced object.
+type NonLocalObjectReference struct {
+	Name      string    `json:"name"`
+	Namespace string    `json:"namespace"`
+	UID       types.UID `json:"uid,omitempty"`
+}
+
+// Sample defines metadata common to all sample types.
+// Samples may not be nested within other samples.
+type Sample struct {
+	// The time this data point was collected at.
+	SampleTime unversioned.Time `json:"sampleTime"`
+}
+
+// AggregateSample contains a metric sample point of data aggregated across containers.
+type AggregateSample struct {
+	Sample `json:",inline"`
+	// Metrics pertaining to CPU resources.
+	CPU *CPUMetrics `json:"cpu,omitempty"`
+	// Metrics pertaining to memory (RAM) resources.
+	Memory *MemoryMetrics `json:"memory,omitempty"`
+	// Metrics pertaining to network resources.
+	Network *NetworkMetrics `json:"network,omitempty"`
+}
+
+// PodSample contains a metric sample point of pod-level resources.
+type PodSample struct {
+	Sample `json:",inline"`
+	// Metrics pertaining to network resources.
+	Network *NetworkMetrics `json:"network,omitempty"`
+}
+
+// ContainerSample contains a metric sample point of container-level resources.
+type ContainerSample struct {
+	Sample `json:",inline"`
+	// Metrics pertaining to CPU resources.
+	CPU *CPUMetrics `json:"cpu,omitempty"`
+	// Metrics pertaining to memory (RAM) resources.
+	Memory *MemoryMetrics `json:"memory,omitempty"`
+}
+
+// NetworkMetrics contains data about network resources.
+type NetworkMetrics struct {
+	// Cumulative count of bytes received.
+	RxBytes *resource.Quantity `json:"rxBytes,omitempty"`
+	// Cumulative count of receive errors encountered.
+	RxErrors *int64 `json:"rxErrors,omitempty"`
+	// Cumulative count of bytes transmitted.
+	TxBytes *resource.Quantity `json:"txBytes,omitempty"`
+	// Cumulative count of transmit errors encountered.
+	TxErrors *int64 `json:"txErrors,omitempty"`
+}
+
+// CPUMetrics contains data about CPU usage.
+type CPUMetrics struct {
+	// Total CPU usage (sum of all cores) averaged over the sample window.
+	// The "core" unit can be interpreted as CPU core-seconds per second.
+	TotalCores *resource.Quantity `json:"totalCores,omitempty"`
+	// CPU load that the container is experiencing, represented as a smoothed average of number of
+	// runnable threads.  Load is averaged over the sampling window.
+	LoadAverage *resource.Quantity `json:"loadAverage,omitempty"`
+}
+
+// MemoryMetrics contains data about memory usage.
+type MemoryMetrics struct {
+	// Total memory in use. This includes all memory regardless of when it was accessed.
+	TotalBytes *resource.Quantity `json:"totalBytes,omitempty"`
+	// The amount of working set memory. This includes recently accessed memory,
+	// dirty memory, and kernel memory. UsageBytes is <= TotalBytes.
+	UsageBytes *resource.Quantity `json:"usageBytes,omitempty"`
+	// Cumulative number of minor page faults.
+	PageFaults *int64 `json:"pageFaults,omitempty"`
+	// Cumulative number of major page faults.
+	MajorPageFaults *int64 `json:"majorPageFaults,omitempty"`
+}
+
+// CustomMetricType specifies the type of metric being exported.
+type CustomMetricType string
+
+const (
+	// Instantaneous value. May increase or decrease.
+	CustomMetricGauge CustomMetricType = "Gauge"
+	// A counter-like value that increases monotonically.
+	CustomMetricCumulative CustomMetricType = "Cumulative"
+	// Rate over a time period.
+	CustomMetricDelta CustomMetricType = "Delta"
+)
+
+// CustomMetric provides custom application metric data.
+// See https://github.com/google/cadvisor/blob/master/docs/application_metrics.md
+type CustomMetric struct {
+	// The name of the metric.
+	Name string `json:"name"`
+	// Type of the metric.
+	Type CustomMetricType `json:"type"`
+	// Display Unit for the sample values.
+	Unit string `json:"unit"`
+	// Historical custom metric samples.
+	Samples []CustomMetricSample `json:"samples,omitempty" patchStrategy:"merge" patchMergeKey:"sampleTime"`
+}
+
+// CustomMetric contains a single sample point for a custom metric.
+type CustomMetricSample struct {
+	Sample `json:",inline"`
+	// Label associated with a metric
+	Label *string `json:"label,omitempty"`
+	// The value of the metric at this point.
+	// The unit is defined by the CustomMetric this sample belongs to.
+	Value resource.Quantity `json:"value"`
+}
+
+// RawMetricsOptions are the query options for raw metrics endpoints.
+type RawMetricsOptions struct {
+	// Only include samples with sampleTime equal to or more recent than this time.
+	// This does not affect cumulative values, which are cumulative from object creation.
+	// Defaults to the beginning of time. Must be older than now and untilTime.
+	SinceTime *unversioned.Time `json:"sinceTime,omitempty"`
+	// Only include samples with sampleTime equal to or less recent than this time.
+	// Defaults to the now. Must be newer than sinceTime.
+	UntilTime *unversioned.Time `json:"untilTime,omitempty"`
+	// Specifies the maximum number of elements in any list of samples.
+	// When the total number of samples exceeds the maximum the most recent samples are returned.
+	// Defaults to unlimited. Minimum value 1.
+	MaxSamples int `json:"maxSamples,omitempty"`
 }

--- a/pkg/apis/metrics/v1alpha1/types.go
+++ b/pkg/apis/metrics/v1alpha1/types.go
@@ -92,8 +92,6 @@ type RawContainerMetrics struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// Historical metric samples gathered from the container.
 	Samples []ContainerSample `json:"samples" patchStrategy:"merge" patchMergeKey:"sampleTime"`
-	// Application-specific metrics.
-	CustomMetrics []CustomMetric `json:"customMetrics,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // NonLocalObjectReference contains enough information to locate the referenced object.
@@ -181,41 +179,6 @@ type FilesystemMetrics struct {
 	UsageBytes *resource.Quantity `json:"usageBytes,omitempty"`
 	// Number of bytes that can be consumed by the container on this filesystem.
 	LimitBytes *resource.Quantity `json:"limitBytes,omitempty"`
-}
-
-// CustomMetricType specifies the type of metric being exported.
-type CustomMetricType string
-
-const (
-	// Instantaneous value. May increase or decrease.
-	CustomMetricGauge CustomMetricType = "Gauge"
-	// A counter-like value that increases monotonically.
-	CustomMetricCumulative CustomMetricType = "Cumulative"
-	// Rate over a time period.
-	CustomMetricDelta CustomMetricType = "Delta"
-)
-
-// CustomMetric provides custom application metric data.
-// See https://github.com/google/cadvisor/blob/master/docs/application_metrics.md
-type CustomMetric struct {
-	// The name of the metric.
-	Name string `json:"name"`
-	// Type of the metric.
-	Type CustomMetricType `json:"type"`
-	// Display Unit for the sample values.
-	Unit string `json:"unit"`
-	// Historical custom metric samples.
-	Samples []CustomMetricSample `json:"samples,omitempty" patchStrategy:"merge" patchMergeKey:"sampleTime"`
-}
-
-// CustomMetric contains a single sample point for a custom metric.
-type CustomMetricSample struct {
-	Sample `json:",inline"`
-	// Label associated with a metric
-	Label *string `json:"label,omitempty"`
-	// The value of the metric at this point.
-	// The unit is defined by the CustomMetric this sample belongs to.
-	Value resource.Quantity `json:"value"`
 }
 
 // RawMetricsOptions are the query options for raw metrics endpoints.

--- a/pkg/apis/metrics/v1alpha1/types.go
+++ b/pkg/apis/metrics/v1alpha1/types.go
@@ -119,6 +119,8 @@ type AggregateSample struct {
 	Memory *MemoryMetrics `json:"memory,omitempty"`
 	// Metrics pertaining to network resources.
 	Network *NetworkMetrics `json:"network,omitempty"`
+	// Metrics pertaining to filesystem resources. Reported per-device.
+	Filesystem []FilesystemMetrics `json:"filesystem,omitempty" patchStrategy:"merge" patchMergeKey:"device"`
 }
 
 // PodSample contains a metric sample point of pod-level resources.
@@ -135,6 +137,8 @@ type ContainerSample struct {
 	CPU *CPUMetrics `json:"cpu,omitempty"`
 	// Metrics pertaining to memory (RAM) resources.
 	Memory *MemoryMetrics `json:"memory,omitempty"`
+	// Metrics pertaining to filesystem resources. Reported per-device.
+	Filesystem []FilesystemMetrics `json:"filesystem,omitempty" patchStrategy:"merge" patchMergeKey:"device"`
 }
 
 // NetworkMetrics contains data about network resources.
@@ -170,6 +174,16 @@ type MemoryMetrics struct {
 	PageFaults *int64 `json:"pageFaults,omitempty"`
 	// Cumulative number of major page faults.
 	MajorPageFaults *int64 `json:"majorPageFaults,omitempty"`
+}
+
+// FilesystemMetrics contains data about filesystem usage.
+type FilesystemMetrics struct {
+	// The block device name associated with the filesystem.
+	Device string `json:"device"`
+	// Number of bytes that is consumed by the container on this filesystem.
+	UsageBytes *resource.Quantity `json:"usageBytes,omitempty"`
+	// Number of bytes that can be consumed by the container on this filesystem.
+	LimitBytes *resource.Quantity `json:"limitBytes,omitempty"`
 }
 
 // CustomMetricType specifies the type of metric being exported.

--- a/pkg/apiserver/testing/types.generated.go
+++ b/pkg/apiserver/testing/types.generated.go
@@ -141,16 +141,28 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				yy10 := &x.ObjectMeta
-				yy10.CodecEncodeSelf(e)
+				yym11 := z.EncBinary()
+				_ = yym11
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy10) {
+				} else {
+					z.EncFallback(yy10)
+				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy11 := &x.ObjectMeta
-				yy11.CodecEncodeSelf(e)
+				yy12 := &x.ObjectMeta
+				yym13 := z.EncBinary()
+				_ = yym13
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy12) {
+				} else {
+					z.EncFallback(yy12)
+				}
 			}
 			if yyr2 || yy2arr2 {
 				if yyq2[3] {
-					yym13 := z.EncBinary()
-					_ = yym13
+					yym15 := z.EncBinary()
+					_ = yym15
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
@@ -161,8 +173,8 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("other"))
-					yym14 := z.EncBinary()
-					_ = yym14
+					yym16 := z.EncBinary()
+					_ = yym16
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
@@ -174,8 +186,8 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym16 := z.EncBinary()
-						_ = yym16
+						yym18 := z.EncBinary()
+						_ = yym18
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -190,8 +202,8 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym17 := z.EncBinary()
-						_ = yym17
+						yym19 := z.EncBinary()
+						_ = yym19
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -210,24 +222,24 @@ func (x *Simple) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym18 := z.DecBinary()
-	_ = yym18
+	yym20 := z.DecBinary()
+	_ = yym20
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl19 := r.ReadMapStart()
-			if yyl19 == 0 {
+			yyl21 := r.ReadMapStart()
+			if yyl21 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl19, d)
+				x.codecDecodeSelfFromMap(yyl21, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl19 := r.ReadArrayStart()
-			if yyl19 == 0 {
+			yyl21 := r.ReadArrayStart()
+			if yyl21 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl19, d)
+				x.codecDecodeSelfFromArray(yyl21, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -239,12 +251,12 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys20Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys20Slc
-	var yyhl20 bool = l >= 0
-	for yyj20 := 0; ; yyj20++ {
-		if yyhl20 {
-			if yyj20 >= l {
+	var yys22Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys22Slc
+	var yyhl22 bool = l >= 0
+	for yyj22 := 0; ; yyj22++ {
+		if yyhl22 {
+			if yyj22 >= l {
 				break
 			}
 		} else {
@@ -252,9 +264,9 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys20Slc = r.DecodeBytes(yys20Slc, true, true)
-		yys20 := string(yys20Slc)
-		switch yys20 {
+		yys22Slc = r.DecodeBytes(yys22Slc, true, true)
+		yys22 := string(yys22Slc)
+		switch yys22 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -271,8 +283,14 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv23 := &x.ObjectMeta
-				yyv23.CodecDecodeSelf(d)
+				yyv25 := &x.ObjectMeta
+				yym26 := z.DecBinary()
+				_ = yym26
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv25) {
+				} else {
+					z.DecFallback(yyv25, false)
+				}
 			}
 		case "other":
 			if r.TryDecodeAsNil() {
@@ -284,19 +302,19 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Labels = nil
 			} else {
-				yyv25 := &x.Labels
-				yym26 := z.DecBinary()
-				_ = yym26
+				yyv28 := &x.Labels
+				yym29 := z.DecBinary()
+				_ = yym29
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv25, false, d)
+					z.F.DecMapStringStringX(yyv28, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys20)
-		} // end switch yys20
-	} // end for yyj20
-	if !yyhl20 {
+			z.DecStructFieldNotFound(-1, yys22)
+		} // end switch yys22
+	} // end for yyj22
+	if !yyhl22 {
 		r.ReadEnd()
 	}
 }
@@ -305,16 +323,16 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj27 int
-	var yyb27 bool
-	var yyhl27 bool = l >= 0
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	var yyj30 int
+	var yyb30 bool
+	var yyhl30 bool = l >= 0
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
@@ -323,13 +341,13 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
@@ -338,29 +356,35 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv30 := &x.ObjectMeta
-		yyv30.CodecDecodeSelf(d)
+		yyv33 := &x.ObjectMeta
+		yym34 := z.DecBinary()
+		_ = yym34
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv33) {
+		} else {
+			z.DecFallback(yyv33, false)
+		}
 	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
@@ -369,38 +393,38 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Other = string(r.DecodeString())
 	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
-		yyv32 := &x.Labels
-		yym33 := z.DecBinary()
-		_ = yym33
+		yyv36 := &x.Labels
+		yym37 := z.DecBinary()
+		_ = yym37
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv32, false, d)
+			z.F.DecMapStringStringX(yyv36, false, d)
 		}
 	}
 	for {
-		yyj27++
-		if yyhl27 {
-			yyb27 = yyj27 > l
+		yyj30++
+		if yyhl30 {
+			yyb30 = yyj30 > l
 		} else {
-			yyb27 = r.CheckBreak()
+			yyb30 = r.CheckBreak()
 		}
-		if yyb27 {
+		if yyb30 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj27-1, "")
+		z.DecStructFieldNotFound(yyj30-1, "")
 	}
 	r.ReadEnd()
 }
@@ -412,87 +436,99 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym34 := z.EncBinary()
-		_ = yym34
+		yym38 := z.EncBinary()
+		_ = yym38
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep35 := !z.EncBinary()
-			yy2arr35 := z.EncBasicHandle().StructToArray
-			var yyq35 [5]bool
-			_, _, _ = yysep35, yyq35, yy2arr35
-			const yyr35 bool = false
-			yyq35[0] = x.Kind != ""
-			yyq35[1] = x.APIVersion != ""
-			yyq35[3] = x.Other != ""
-			yyq35[4] = len(x.Labels) != 0
-			if yyr35 || yy2arr35 {
+			yysep39 := !z.EncBinary()
+			yy2arr39 := z.EncBasicHandle().StructToArray
+			var yyq39 [5]bool
+			_, _, _ = yysep39, yyq39, yy2arr39
+			const yyr39 bool = false
+			yyq39[0] = x.Kind != ""
+			yyq39[1] = x.APIVersion != ""
+			yyq39[3] = x.Other != ""
+			yyq39[4] = len(x.Labels) != 0
+			if yyr39 || yy2arr39 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn35 int = 1
-				for _, b := range yyq35 {
+				var yynn39 int = 1
+				for _, b := range yyq39 {
 					if b {
-						yynn35++
+						yynn39++
 					}
 				}
-				r.EncodeMapStart(yynn35)
+				r.EncodeMapStart(yynn39)
 			}
-			if yyr35 || yy2arr35 {
-				if yyq35[0] {
-					yym37 := z.EncBinary()
-					_ = yym37
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq35[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym38 := z.EncBinary()
-					_ = yym38
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr35 || yy2arr35 {
-				if yyq35[1] {
-					yym40 := z.EncBinary()
-					_ = yym40
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq35[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr39 || yy2arr39 {
+				if yyq39[0] {
 					yym41 := z.EncBinary()
 					_ = yym41
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq39[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym42 := z.EncBinary()
+					_ = yym42
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr39 || yy2arr39 {
+				if yyq39[1] {
+					yym44 := z.EncBinary()
+					_ = yym44
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq39[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym45 := z.EncBinary()
+					_ = yym45
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr35 || yy2arr35 {
-				yy43 := &x.ObjectMeta
-				yy43.CodecEncodeSelf(e)
+			if yyr39 || yy2arr39 {
+				yy47 := &x.ObjectMeta
+				yym48 := z.EncBinary()
+				_ = yym48
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy47) {
+				} else {
+					z.EncFallback(yy47)
+				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy44 := &x.ObjectMeta
-				yy44.CodecEncodeSelf(e)
+				yy49 := &x.ObjectMeta
+				yym50 := z.EncBinary()
+				_ = yym50
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy49) {
+				} else {
+					z.EncFallback(yy49)
+				}
 			}
-			if yyr35 || yy2arr35 {
-				if yyq35[3] {
-					yym46 := z.EncBinary()
-					_ = yym46
+			if yyr39 || yy2arr39 {
+				if yyq39[3] {
+					yym52 := z.EncBinary()
+					_ = yym52
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
@@ -501,23 +537,23 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq35[3] {
+				if yyq39[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("other"))
-					yym47 := z.EncBinary()
-					_ = yym47
+					yym53 := z.EncBinary()
+					_ = yym53
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
 					}
 				}
 			}
-			if yyr35 || yy2arr35 {
-				if yyq35[4] {
+			if yyr39 || yy2arr39 {
+				if yyq39[4] {
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym49 := z.EncBinary()
-						_ = yym49
+						yym55 := z.EncBinary()
+						_ = yym55
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -527,13 +563,13 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq35[4] {
+				if yyq39[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("labels"))
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym50 := z.EncBinary()
-						_ = yym50
+						yym56 := z.EncBinary()
+						_ = yym56
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -541,7 +577,7 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep35 {
+			if yysep39 {
 				r.EncodeEnd()
 			}
 		}
@@ -552,24 +588,24 @@ func (x *SimpleRoot) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym51 := z.DecBinary()
-	_ = yym51
+	yym57 := z.DecBinary()
+	_ = yym57
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl52 := r.ReadMapStart()
-			if yyl52 == 0 {
+			yyl58 := r.ReadMapStart()
+			if yyl58 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl52, d)
+				x.codecDecodeSelfFromMap(yyl58, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl52 := r.ReadArrayStart()
-			if yyl52 == 0 {
+			yyl58 := r.ReadArrayStart()
+			if yyl58 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl52, d)
+				x.codecDecodeSelfFromArray(yyl58, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -581,12 +617,12 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys53Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys53Slc
-	var yyhl53 bool = l >= 0
-	for yyj53 := 0; ; yyj53++ {
-		if yyhl53 {
-			if yyj53 >= l {
+	var yys59Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys59Slc
+	var yyhl59 bool = l >= 0
+	for yyj59 := 0; ; yyj59++ {
+		if yyhl59 {
+			if yyj59 >= l {
 				break
 			}
 		} else {
@@ -594,9 +630,9 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys53Slc = r.DecodeBytes(yys53Slc, true, true)
-		yys53 := string(yys53Slc)
-		switch yys53 {
+		yys59Slc = r.DecodeBytes(yys59Slc, true, true)
+		yys59 := string(yys59Slc)
+		switch yys59 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -613,8 +649,14 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv56 := &x.ObjectMeta
-				yyv56.CodecDecodeSelf(d)
+				yyv62 := &x.ObjectMeta
+				yym63 := z.DecBinary()
+				_ = yym63
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv62) {
+				} else {
+					z.DecFallback(yyv62, false)
+				}
 			}
 		case "other":
 			if r.TryDecodeAsNil() {
@@ -626,19 +668,19 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Labels = nil
 			} else {
-				yyv58 := &x.Labels
-				yym59 := z.DecBinary()
-				_ = yym59
+				yyv65 := &x.Labels
+				yym66 := z.DecBinary()
+				_ = yym66
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv58, false, d)
+					z.F.DecMapStringStringX(yyv65, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys53)
-		} // end switch yys53
-	} // end for yyj53
-	if !yyhl53 {
+			z.DecStructFieldNotFound(-1, yys59)
+		} // end switch yys59
+	} // end for yyj59
+	if !yyhl59 {
 		r.ReadEnd()
 	}
 }
@@ -647,16 +689,16 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj60 int
-	var yyb60 bool
-	var yyhl60 bool = l >= 0
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	var yyj67 int
+	var yyb67 bool
+	var yyhl67 bool = l >= 0
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
@@ -665,13 +707,13 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
@@ -680,29 +722,35 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv63 := &x.ObjectMeta
-		yyv63.CodecDecodeSelf(d)
+		yyv70 := &x.ObjectMeta
+		yym71 := z.DecBinary()
+		_ = yym71
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv70) {
+		} else {
+			z.DecFallback(yyv70, false)
+		}
 	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
@@ -711,38 +759,38 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Other = string(r.DecodeString())
 	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
-		yyv65 := &x.Labels
-		yym66 := z.DecBinary()
-		_ = yym66
+		yyv73 := &x.Labels
+		yym74 := z.DecBinary()
+		_ = yym74
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv65, false, d)
+			z.F.DecMapStringStringX(yyv73, false, d)
 		}
 	}
 	for {
-		yyj60++
-		if yyhl60 {
-			yyb60 = yyj60 > l
+		yyj67++
+		if yyhl67 {
+			yyb67 = yyj67 > l
 		} else {
-			yyb60 = r.CheckBreak()
+			yyb67 = r.CheckBreak()
 		}
-		if yyb60 {
+		if yyb67 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj60-1, "")
+		z.DecStructFieldNotFound(yyj67-1, "")
 	}
 	r.ReadEnd()
 }
@@ -754,33 +802,33 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym67 := z.EncBinary()
-		_ = yym67
+		yym75 := z.EncBinary()
+		_ = yym75
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep68 := !z.EncBinary()
-			yy2arr68 := z.EncBasicHandle().StructToArray
-			var yyq68 [5]bool
-			_, _, _ = yysep68, yyq68, yy2arr68
-			const yyr68 bool = false
-			yyq68[0] = x.Kind != ""
-			yyq68[1] = x.APIVersion != ""
-			if yyr68 || yy2arr68 {
+			yysep76 := !z.EncBinary()
+			yy2arr76 := z.EncBasicHandle().StructToArray
+			var yyq76 [5]bool
+			_, _, _ = yysep76, yyq76, yy2arr76
+			const yyr76 bool = false
+			yyq76[0] = x.Kind != ""
+			yyq76[1] = x.APIVersion != ""
+			if yyr76 || yy2arr76 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn68 int = 3
-				for _, b := range yyq68 {
+				var yynn76 int = 3
+				for _, b := range yyq76 {
 					if b {
-						yynn68++
+						yynn76++
 					}
 				}
-				r.EncodeMapStart(yynn68)
+				r.EncodeMapStart(yynn76)
 			}
-			if yyr68 || yy2arr68 {
-				if yyq68[0] {
-					yym70 := z.EncBinary()
-					_ = yym70
+			if yyr76 || yy2arr76 {
+				if yyq76[0] {
+					yym78 := z.EncBinary()
+					_ = yym78
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -789,20 +837,20 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq68[0] {
+				if yyq76[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym71 := z.EncBinary()
-					_ = yym71
+					yym79 := z.EncBinary()
+					_ = yym79
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr68 || yy2arr68 {
-				if yyq68[1] {
-					yym73 := z.EncBinary()
-					_ = yym73
+			if yyr76 || yy2arr76 {
+				if yyq76[1] {
+					yym81 := z.EncBinary()
+					_ = yym81
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -811,65 +859,65 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq68[1] {
+				if yyq76[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym74 := z.EncBinary()
-					_ = yym74
+					yym82 := z.EncBinary()
+					_ = yym82
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr68 || yy2arr68 {
-				yym76 := z.EncBinary()
-				_ = yym76
+			if yyr76 || yy2arr76 {
+				yym84 := z.EncBinary()
+				_ = yym84
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param1))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("param1"))
-				yym77 := z.EncBinary()
-				_ = yym77
+				yym85 := z.EncBinary()
+				_ = yym85
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param1))
 				}
 			}
-			if yyr68 || yy2arr68 {
-				yym79 := z.EncBinary()
-				_ = yym79
+			if yyr76 || yy2arr76 {
+				yym87 := z.EncBinary()
+				_ = yym87
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param2))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("param2"))
-				yym80 := z.EncBinary()
-				_ = yym80
+				yym88 := z.EncBinary()
+				_ = yym88
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param2))
 				}
 			}
-			if yyr68 || yy2arr68 {
-				yym82 := z.EncBinary()
-				_ = yym82
+			if yyr76 || yy2arr76 {
+				yym90 := z.EncBinary()
+				_ = yym90
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("atAPath"))
-				yym83 := z.EncBinary()
-				_ = yym83
+				yym91 := z.EncBinary()
+				_ = yym91
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yysep68 {
+			if yysep76 {
 				r.EncodeEnd()
 			}
 		}
@@ -880,24 +928,24 @@ func (x *SimpleGetOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym84 := z.DecBinary()
-	_ = yym84
+	yym92 := z.DecBinary()
+	_ = yym92
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl85 := r.ReadMapStart()
-			if yyl85 == 0 {
+			yyl93 := r.ReadMapStart()
+			if yyl93 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl85, d)
+				x.codecDecodeSelfFromMap(yyl93, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl85 := r.ReadArrayStart()
-			if yyl85 == 0 {
+			yyl93 := r.ReadArrayStart()
+			if yyl93 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl85, d)
+				x.codecDecodeSelfFromArray(yyl93, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -909,12 +957,12 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys86Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys86Slc
-	var yyhl86 bool = l >= 0
-	for yyj86 := 0; ; yyj86++ {
-		if yyhl86 {
-			if yyj86 >= l {
+	var yys94Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys94Slc
+	var yyhl94 bool = l >= 0
+	for yyj94 := 0; ; yyj94++ {
+		if yyhl94 {
+			if yyj94 >= l {
 				break
 			}
 		} else {
@@ -922,9 +970,9 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys86Slc = r.DecodeBytes(yys86Slc, true, true)
-		yys86 := string(yys86Slc)
-		switch yys86 {
+		yys94Slc = r.DecodeBytes(yys94Slc, true, true)
+		yys94 := string(yys94Slc)
+		switch yys94 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -956,10 +1004,10 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Path = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys86)
-		} // end switch yys86
-	} // end for yyj86
-	if !yyhl86 {
+			z.DecStructFieldNotFound(-1, yys94)
+		} // end switch yys94
+	} // end for yyj94
+	if !yyhl94 {
 		r.ReadEnd()
 	}
 }
@@ -968,16 +1016,16 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj92 int
-	var yyb92 bool
-	var yyhl92 bool = l >= 0
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	var yyj100 int
+	var yyb100 bool
+	var yyhl100 bool = l >= 0
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -986,13 +1034,13 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -1001,13 +1049,13 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -1016,13 +1064,13 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Param1 = string(r.DecodeString())
 	}
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -1031,13 +1079,13 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Param2 = string(r.DecodeString())
 	}
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -1047,16 +1095,16 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.Path = string(r.DecodeString())
 	}
 	for {
-		yyj92++
-		if yyhl92 {
-			yyb92 = yyj92 > l
+		yyj100++
+		if yyhl100 {
+			yyb100 = yyj100 > l
 		} else {
-			yyb92 = r.CheckBreak()
+			yyb100 = r.CheckBreak()
 		}
-		if yyb92 {
+		if yyb100 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj92-1, "")
+		z.DecStructFieldNotFound(yyj100-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1068,34 +1116,34 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym98 := z.EncBinary()
-		_ = yym98
+		yym106 := z.EncBinary()
+		_ = yym106
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep99 := !z.EncBinary()
-			yy2arr99 := z.EncBasicHandle().StructToArray
-			var yyq99 [4]bool
-			_, _, _ = yysep99, yyq99, yy2arr99
-			const yyr99 bool = false
-			yyq99[0] = x.Kind != ""
-			yyq99[1] = x.APIVersion != ""
-			yyq99[3] = len(x.Items) != 0
-			if yyr99 || yy2arr99 {
+			yysep107 := !z.EncBinary()
+			yy2arr107 := z.EncBasicHandle().StructToArray
+			var yyq107 [4]bool
+			_, _, _ = yysep107, yyq107, yy2arr107
+			const yyr107 bool = false
+			yyq107[0] = x.Kind != ""
+			yyq107[1] = x.APIVersion != ""
+			yyq107[3] = len(x.Items) != 0
+			if yyr107 || yy2arr107 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn99 int = 1
-				for _, b := range yyq99 {
+				var yynn107 int = 1
+				for _, b := range yyq107 {
 					if b {
-						yynn99++
+						yynn107++
 					}
 				}
-				r.EncodeMapStart(yynn99)
+				r.EncodeMapStart(yynn107)
 			}
-			if yyr99 || yy2arr99 {
-				if yyq99[0] {
-					yym101 := z.EncBinary()
-					_ = yym101
+			if yyr107 || yy2arr107 {
+				if yyq107[0] {
+					yym109 := z.EncBinary()
+					_ = yym109
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -1104,20 +1152,20 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq99[0] {
+				if yyq107[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym102 := z.EncBinary()
-					_ = yym102
+					yym110 := z.EncBinary()
+					_ = yym110
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr99 || yy2arr99 {
-				if yyq99[1] {
-					yym104 := z.EncBinary()
-					_ = yym104
+			if yyr107 || yy2arr107 {
+				if yyq107[1] {
+					yym112 := z.EncBinary()
+					_ = yym112
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -1126,43 +1174,43 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq99[1] {
+				if yyq107[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym105 := z.EncBinary()
-					_ = yym105
+					yym113 := z.EncBinary()
+					_ = yym113
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr99 || yy2arr99 {
-				yy107 := &x.ListMeta
-				yym108 := z.EncBinary()
-				_ = yym108
+			if yyr107 || yy2arr107 {
+				yy115 := &x.ListMeta
+				yym116 := z.EncBinary()
+				_ = yym116
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy107) {
+				} else if z.HasExtensions() && z.EncExt(yy115) {
 				} else {
-					z.EncFallback(yy107)
+					z.EncFallback(yy115)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy109 := &x.ListMeta
-				yym110 := z.EncBinary()
-				_ = yym110
+				yy117 := &x.ListMeta
+				yym118 := z.EncBinary()
+				_ = yym118
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy109) {
+				} else if z.HasExtensions() && z.EncExt(yy117) {
 				} else {
-					z.EncFallback(yy109)
+					z.EncFallback(yy117)
 				}
 			}
-			if yyr99 || yy2arr99 {
-				if yyq99[3] {
+			if yyr107 || yy2arr107 {
+				if yyq107[3] {
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym112 := z.EncBinary()
-						_ = yym112
+						yym120 := z.EncBinary()
+						_ = yym120
 						if false {
 						} else {
 							h.encSliceSimple(([]Simple)(x.Items), e)
@@ -1172,13 +1220,13 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq99[3] {
+				if yyq107[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym113 := z.EncBinary()
-						_ = yym113
+						yym121 := z.EncBinary()
+						_ = yym121
 						if false {
 						} else {
 							h.encSliceSimple(([]Simple)(x.Items), e)
@@ -1186,7 +1234,7 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep99 {
+			if yysep107 {
 				r.EncodeEnd()
 			}
 		}
@@ -1197,24 +1245,24 @@ func (x *SimpleList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym114 := z.DecBinary()
-	_ = yym114
+	yym122 := z.DecBinary()
+	_ = yym122
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl115 := r.ReadMapStart()
-			if yyl115 == 0 {
+			yyl123 := r.ReadMapStart()
+			if yyl123 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl115, d)
+				x.codecDecodeSelfFromMap(yyl123, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl115 := r.ReadArrayStart()
-			if yyl115 == 0 {
+			yyl123 := r.ReadArrayStart()
+			if yyl123 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl115, d)
+				x.codecDecodeSelfFromArray(yyl123, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1226,12 +1274,12 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys116Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys116Slc
-	var yyhl116 bool = l >= 0
-	for yyj116 := 0; ; yyj116++ {
-		if yyhl116 {
-			if yyj116 >= l {
+	var yys124Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys124Slc
+	var yyhl124 bool = l >= 0
+	for yyj124 := 0; ; yyj124++ {
+		if yyhl124 {
+			if yyj124 >= l {
 				break
 			}
 		} else {
@@ -1239,9 +1287,9 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys116Slc = r.DecodeBytes(yys116Slc, true, true)
-		yys116 := string(yys116Slc)
-		switch yys116 {
+		yys124Slc = r.DecodeBytes(yys124Slc, true, true)
+		yys124 := string(yys124Slc)
+		switch yys124 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -1258,32 +1306,32 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv119 := &x.ListMeta
-				yym120 := z.DecBinary()
-				_ = yym120
+				yyv127 := &x.ListMeta
+				yym128 := z.DecBinary()
+				_ = yym128
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv119) {
+				} else if z.HasExtensions() && z.DecExt(yyv127) {
 				} else {
-					z.DecFallback(yyv119, false)
+					z.DecFallback(yyv127, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv121 := &x.Items
-				yym122 := z.DecBinary()
-				_ = yym122
+				yyv129 := &x.Items
+				yym130 := z.DecBinary()
+				_ = yym130
 				if false {
 				} else {
-					h.decSliceSimple((*[]Simple)(yyv121), d)
+					h.decSliceSimple((*[]Simple)(yyv129), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys116)
-		} // end switch yys116
-	} // end for yyj116
-	if !yyhl116 {
+			z.DecStructFieldNotFound(-1, yys124)
+		} // end switch yys124
+	} // end for yyj124
+	if !yyhl124 {
 		r.ReadEnd()
 	}
 }
@@ -1292,16 +1340,16 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj123 int
-	var yyb123 bool
-	var yyhl123 bool = l >= 0
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
+	var yyj131 int
+	var yyb131 bool
+	var yyhl131 bool = l >= 0
+	yyj131++
+	if yyhl131 {
+		yyb131 = yyj131 > l
 	} else {
-		yyb123 = r.CheckBreak()
+		yyb131 = r.CheckBreak()
 	}
-	if yyb123 {
+	if yyb131 {
 		r.ReadEnd()
 		return
 	}
@@ -1310,13 +1358,13 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
+	yyj131++
+	if yyhl131 {
+		yyb131 = yyj131 > l
 	} else {
-		yyb123 = r.CheckBreak()
+		yyb131 = r.CheckBreak()
 	}
-	if yyb123 {
+	if yyb131 {
 		r.ReadEnd()
 		return
 	}
@@ -1325,60 +1373,60 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
+	yyj131++
+	if yyhl131 {
+		yyb131 = yyj131 > l
 	} else {
-		yyb123 = r.CheckBreak()
+		yyb131 = r.CheckBreak()
 	}
-	if yyb123 {
+	if yyb131 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv126 := &x.ListMeta
-		yym127 := z.DecBinary()
-		_ = yym127
+		yyv134 := &x.ListMeta
+		yym135 := z.DecBinary()
+		_ = yym135
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv126) {
+		} else if z.HasExtensions() && z.DecExt(yyv134) {
 		} else {
-			z.DecFallback(yyv126, false)
+			z.DecFallback(yyv134, false)
 		}
 	}
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
+	yyj131++
+	if yyhl131 {
+		yyb131 = yyj131 > l
 	} else {
-		yyb123 = r.CheckBreak()
+		yyb131 = r.CheckBreak()
 	}
-	if yyb123 {
+	if yyb131 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv128 := &x.Items
-		yym129 := z.DecBinary()
-		_ = yym129
+		yyv136 := &x.Items
+		yym137 := z.DecBinary()
+		_ = yym137
 		if false {
 		} else {
-			h.decSliceSimple((*[]Simple)(yyv128), d)
+			h.decSliceSimple((*[]Simple)(yyv136), d)
 		}
 	}
 	for {
-		yyj123++
-		if yyhl123 {
-			yyb123 = yyj123 > l
+		yyj131++
+		if yyhl131 {
+			yyb131 = yyj131 > l
 		} else {
-			yyb123 = r.CheckBreak()
+			yyb131 = r.CheckBreak()
 		}
-		if yyb123 {
+		if yyb131 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj123-1, "")
+		z.DecStructFieldNotFound(yyj131-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1388,9 +1436,9 @@ func (x codecSelfer1234) encSliceSimple(v []Simple, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv130 := range v {
-		yy131 := &yyv130
-		yy131.CodecEncodeSelf(e)
+	for _, yyv138 := range v {
+		yy139 := &yyv138
+		yy139.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -1400,75 +1448,75 @@ func (x codecSelfer1234) decSliceSimple(v *[]Simple, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv132 := *v
-	yyh132, yyl132 := z.DecSliceHelperStart()
+	yyv140 := *v
+	yyh140, yyl140 := z.DecSliceHelperStart()
 
-	var yyrr132, yyrl132 int
-	var yyc132, yyrt132 bool
-	_, _, _ = yyc132, yyrt132, yyrl132
-	yyrr132 = yyl132
+	var yyrr140, yyrl140 int
+	var yyc140, yyrt140 bool
+	_, _, _ = yyc140, yyrt140, yyrl140
+	yyrr140 = yyl140
 
-	if yyv132 == nil {
-		if yyrl132, yyrt132 = z.DecInferLen(yyl132, z.DecBasicHandle().MaxInitLen, 216); yyrt132 {
-			yyrr132 = yyrl132
+	if yyv140 == nil {
+		if yyrl140, yyrt140 = z.DecInferLen(yyl140, z.DecBasicHandle().MaxInitLen, 216); yyrt140 {
+			yyrr140 = yyrl140
 		}
-		yyv132 = make([]Simple, yyrl132)
-		yyc132 = true
+		yyv140 = make([]Simple, yyrl140)
+		yyc140 = true
 	}
 
-	if yyl132 == 0 {
-		if len(yyv132) != 0 {
-			yyv132 = yyv132[:0]
-			yyc132 = true
+	if yyl140 == 0 {
+		if len(yyv140) != 0 {
+			yyv140 = yyv140[:0]
+			yyc140 = true
 		}
-	} else if yyl132 > 0 {
+	} else if yyl140 > 0 {
 
-		if yyl132 > cap(yyv132) {
-			yyrl132, yyrt132 = z.DecInferLen(yyl132, z.DecBasicHandle().MaxInitLen, 216)
-			yyv132 = make([]Simple, yyrl132)
-			yyc132 = true
+		if yyl140 > cap(yyv140) {
+			yyrl140, yyrt140 = z.DecInferLen(yyl140, z.DecBasicHandle().MaxInitLen, 216)
+			yyv140 = make([]Simple, yyrl140)
+			yyc140 = true
 
-			yyrr132 = len(yyv132)
-		} else if yyl132 != len(yyv132) {
-			yyv132 = yyv132[:yyl132]
-			yyc132 = true
+			yyrr140 = len(yyv140)
+		} else if yyl140 != len(yyv140) {
+			yyv140 = yyv140[:yyl140]
+			yyc140 = true
 		}
-		yyj132 := 0
-		for ; yyj132 < yyrr132; yyj132++ {
+		yyj140 := 0
+		for ; yyj140 < yyrr140; yyj140++ {
 			if r.TryDecodeAsNil() {
-				yyv132[yyj132] = Simple{}
+				yyv140[yyj140] = Simple{}
 			} else {
-				yyv133 := &yyv132[yyj132]
-				yyv133.CodecDecodeSelf(d)
+				yyv141 := &yyv140[yyj140]
+				yyv141.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt132 {
-			for ; yyj132 < yyl132; yyj132++ {
-				yyv132 = append(yyv132, Simple{})
+		if yyrt140 {
+			for ; yyj140 < yyl140; yyj140++ {
+				yyv140 = append(yyv140, Simple{})
 				if r.TryDecodeAsNil() {
-					yyv132[yyj132] = Simple{}
+					yyv140[yyj140] = Simple{}
 				} else {
-					yyv134 := &yyv132[yyj132]
-					yyv134.CodecDecodeSelf(d)
+					yyv142 := &yyv140[yyj140]
+					yyv142.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj132 := 0; !r.CheckBreak(); yyj132++ {
-			if yyj132 >= len(yyv132) {
-				yyv132 = append(yyv132, Simple{}) // var yyz132 Simple
-				yyc132 = true
+		for yyj140 := 0; !r.CheckBreak(); yyj140++ {
+			if yyj140 >= len(yyv140) {
+				yyv140 = append(yyv140, Simple{}) // var yyz140 Simple
+				yyc140 = true
 			}
 
-			if yyj132 < len(yyv132) {
+			if yyj140 < len(yyv140) {
 				if r.TryDecodeAsNil() {
-					yyv132[yyj132] = Simple{}
+					yyv140[yyj140] = Simple{}
 				} else {
-					yyv135 := &yyv132[yyj132]
-					yyv135.CodecDecodeSelf(d)
+					yyv143 := &yyv140[yyj140]
+					yyv143.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -1476,10 +1524,10 @@ func (x codecSelfer1234) decSliceSimple(v *[]Simple, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh132.End()
+		yyh140.End()
 	}
-	if yyc132 {
-		*v = yyv132
+	if yyc140 {
+		*v = yyv140
 	}
 
 }

--- a/pkg/kubectl/testing/types.generated.go
+++ b/pkg/kubectl/testing/types.generated.go
@@ -141,28 +141,40 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				if yyq2[2] {
 					yy10 := &x.ObjectMeta
-					yy10.CodecEncodeSelf(e)
+					yym11 := z.EncBinary()
+					_ = yym11
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy10) {
+					} else {
+						z.EncFallback(yy10)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq2[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy11 := &x.ObjectMeta
-					yy11.CodecEncodeSelf(e)
+					yy12 := &x.ObjectMeta
+					yym13 := z.EncBinary()
+					_ = yym13
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy12) {
+					} else {
+						z.EncFallback(yy12)
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {
-				yym13 := z.EncBinary()
-				_ = yym13
+				yym15 := z.EncBinary()
+				_ = yym15
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Key"))
-				yym14 := z.EncBinary()
-				_ = yym14
+				yym16 := z.EncBinary()
+				_ = yym16
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
@@ -172,8 +184,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Map == nil {
 					r.EncodeNil()
 				} else {
-					yym16 := z.EncBinary()
-					_ = yym16
+					yym18 := z.EncBinary()
+					_ = yym18
 					if false {
 					} else {
 						z.F.EncMapStringIntV(x.Map, false, e)
@@ -184,8 +196,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Map == nil {
 					r.EncodeNil()
 				} else {
-					yym17 := z.EncBinary()
-					_ = yym17
+					yym19 := z.EncBinary()
+					_ = yym19
 					if false {
 					} else {
 						z.F.EncMapStringIntV(x.Map, false, e)
@@ -196,8 +208,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.StringList == nil {
 					r.EncodeNil()
 				} else {
-					yym19 := z.EncBinary()
-					_ = yym19
+					yym21 := z.EncBinary()
+					_ = yym21
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.StringList, false, e)
@@ -208,8 +220,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.StringList == nil {
 					r.EncodeNil()
 				} else {
-					yym20 := z.EncBinary()
-					_ = yym20
+					yym22 := z.EncBinary()
+					_ = yym22
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.StringList, false, e)
@@ -220,8 +232,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IntList == nil {
 					r.EncodeNil()
 				} else {
-					yym22 := z.EncBinary()
-					_ = yym22
+					yym24 := z.EncBinary()
+					_ = yym24
 					if false {
 					} else {
 						z.F.EncSliceIntV(x.IntList, false, e)
@@ -232,8 +244,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IntList == nil {
 					r.EncodeNil()
 				} else {
-					yym23 := z.EncBinary()
-					_ = yym23
+					yym25 := z.EncBinary()
+					_ = yym25
 					if false {
 					} else {
 						z.F.EncSliceIntV(x.IntList, false, e)
@@ -251,24 +263,24 @@ func (x *TestStruct) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym24 := z.DecBinary()
-	_ = yym24
+	yym26 := z.DecBinary()
+	_ = yym26
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl25 := r.ReadMapStart()
-			if yyl25 == 0 {
+			yyl27 := r.ReadMapStart()
+			if yyl27 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl25, d)
+				x.codecDecodeSelfFromMap(yyl27, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl25 := r.ReadArrayStart()
-			if yyl25 == 0 {
+			yyl27 := r.ReadArrayStart()
+			if yyl27 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl25, d)
+				x.codecDecodeSelfFromArray(yyl27, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -280,12 +292,12 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys26Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys26Slc
-	var yyhl26 bool = l >= 0
-	for yyj26 := 0; ; yyj26++ {
-		if yyhl26 {
-			if yyj26 >= l {
+	var yys28Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys28Slc
+	var yyhl28 bool = l >= 0
+	for yyj28 := 0; ; yyj28++ {
+		if yyhl28 {
+			if yyj28 >= l {
 				break
 			}
 		} else {
@@ -293,9 +305,9 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys26Slc = r.DecodeBytes(yys26Slc, true, true)
-		yys26 := string(yys26Slc)
-		switch yys26 {
+		yys28Slc = r.DecodeBytes(yys28Slc, true, true)
+		yys28 := string(yys28Slc)
+		switch yys28 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -312,8 +324,14 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv29 := &x.ObjectMeta
-				yyv29.CodecDecodeSelf(d)
+				yyv31 := &x.ObjectMeta
+				yym32 := z.DecBinary()
+				_ = yym32
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv31) {
+				} else {
+					z.DecFallback(yyv31, false)
+				}
 			}
 		case "Key":
 			if r.TryDecodeAsNil() {
@@ -325,43 +343,43 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Map = nil
 			} else {
-				yyv31 := &x.Map
-				yym32 := z.DecBinary()
-				_ = yym32
+				yyv34 := &x.Map
+				yym35 := z.DecBinary()
+				_ = yym35
 				if false {
 				} else {
-					z.F.DecMapStringIntX(yyv31, false, d)
+					z.F.DecMapStringIntX(yyv34, false, d)
 				}
 			}
 		case "StringList":
 			if r.TryDecodeAsNil() {
 				x.StringList = nil
 			} else {
-				yyv33 := &x.StringList
-				yym34 := z.DecBinary()
-				_ = yym34
+				yyv36 := &x.StringList
+				yym37 := z.DecBinary()
+				_ = yym37
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv33, false, d)
+					z.F.DecSliceStringX(yyv36, false, d)
 				}
 			}
 		case "IntList":
 			if r.TryDecodeAsNil() {
 				x.IntList = nil
 			} else {
-				yyv35 := &x.IntList
-				yym36 := z.DecBinary()
-				_ = yym36
+				yyv38 := &x.IntList
+				yym39 := z.DecBinary()
+				_ = yym39
 				if false {
 				} else {
-					z.F.DecSliceIntX(yyv35, false, d)
+					z.F.DecSliceIntX(yyv38, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys26)
-		} // end switch yys26
-	} // end for yyj26
-	if !yyhl26 {
+			z.DecStructFieldNotFound(-1, yys28)
+		} // end switch yys28
+	} // end for yyj28
+	if !yyhl28 {
 		r.ReadEnd()
 	}
 }
@@ -370,16 +388,16 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj37 int
-	var yyb37 bool
-	var yyhl37 bool = l >= 0
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	var yyj40 int
+	var yyb40 bool
+	var yyhl40 bool = l >= 0
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
@@ -388,13 +406,13 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
@@ -403,29 +421,35 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv40 := &x.ObjectMeta
-		yyv40.CodecDecodeSelf(d)
+		yyv43 := &x.ObjectMeta
+		yym44 := z.DecBinary()
+		_ = yym44
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv43) {
+		} else {
+			z.DecFallback(yyv43, false)
+		}
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
@@ -434,80 +458,80 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Map = nil
 	} else {
-		yyv42 := &x.Map
-		yym43 := z.DecBinary()
-		_ = yym43
+		yyv46 := &x.Map
+		yym47 := z.DecBinary()
+		_ = yym47
 		if false {
 		} else {
-			z.F.DecMapStringIntX(yyv42, false, d)
+			z.F.DecMapStringIntX(yyv46, false, d)
 		}
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.StringList = nil
 	} else {
-		yyv44 := &x.StringList
-		yym45 := z.DecBinary()
-		_ = yym45
+		yyv48 := &x.StringList
+		yym49 := z.DecBinary()
+		_ = yym49
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv44, false, d)
+			z.F.DecSliceStringX(yyv48, false, d)
 		}
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.IntList = nil
 	} else {
-		yyv46 := &x.IntList
-		yym47 := z.DecBinary()
-		_ = yym47
+		yyv50 := &x.IntList
+		yym51 := z.DecBinary()
+		_ = yym51
 		if false {
 		} else {
-			z.F.DecSliceIntX(yyv46, false, d)
+			z.F.DecSliceIntX(yyv50, false, d)
 		}
 	}
 	for {
-		yyj37++
-		if yyhl37 {
-			yyb37 = yyj37 > l
+		yyj40++
+		if yyhl40 {
+			yyb40 = yyj40 > l
 		} else {
-			yyb37 = r.CheckBreak()
+			yyb40 = r.CheckBreak()
 		}
-		if yyb37 {
+		if yyb40 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj37-1, "")
+		z.DecStructFieldNotFound(yyj40-1, "")
 	}
 	r.ReadEnd()
 }

--- a/pkg/storage/testing/types.generated.go
+++ b/pkg/storage/testing/types.generated.go
@@ -139,23 +139,35 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				yy10 := &x.ObjectMeta
-				yy10.CodecEncodeSelf(e)
+				yym11 := z.EncBinary()
+				_ = yym11
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy10) {
+				} else {
+					z.EncFallback(yy10)
+				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy11 := &x.ObjectMeta
-				yy11.CodecEncodeSelf(e)
-			}
-			if yyr2 || yy2arr2 {
+				yy12 := &x.ObjectMeta
 				yym13 := z.EncBinary()
 				_ = yym13
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy12) {
+				} else {
+					z.EncFallback(yy12)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				yym15 := z.EncBinary()
+				_ = yym15
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Value))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yym14 := z.EncBinary()
-				_ = yym14
+				yym16 := z.EncBinary()
+				_ = yym16
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Value))
@@ -172,24 +184,24 @@ func (x *TestResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym15 := z.DecBinary()
-	_ = yym15
+	yym17 := z.DecBinary()
+	_ = yym17
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl16 := r.ReadMapStart()
-			if yyl16 == 0 {
+			yyl18 := r.ReadMapStart()
+			if yyl18 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl16, d)
+				x.codecDecodeSelfFromMap(yyl18, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl16 := r.ReadArrayStart()
-			if yyl16 == 0 {
+			yyl18 := r.ReadArrayStart()
+			if yyl18 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl16, d)
+				x.codecDecodeSelfFromArray(yyl18, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -201,12 +213,12 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys17Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys17Slc
-	var yyhl17 bool = l >= 0
-	for yyj17 := 0; ; yyj17++ {
-		if yyhl17 {
-			if yyj17 >= l {
+	var yys19Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys19Slc
+	var yyhl19 bool = l >= 0
+	for yyj19 := 0; ; yyj19++ {
+		if yyhl19 {
+			if yyj19 >= l {
 				break
 			}
 		} else {
@@ -214,9 +226,9 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys17Slc = r.DecodeBytes(yys17Slc, true, true)
-		yys17 := string(yys17Slc)
-		switch yys17 {
+		yys19Slc = r.DecodeBytes(yys19Slc, true, true)
+		yys19 := string(yys19Slc)
+		switch yys19 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -233,8 +245,14 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv20 := &x.ObjectMeta
-				yyv20.CodecDecodeSelf(d)
+				yyv22 := &x.ObjectMeta
+				yym23 := z.DecBinary()
+				_ = yym23
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv22) {
+				} else {
+					z.DecFallback(yyv22, false)
+				}
 			}
 		case "value":
 			if r.TryDecodeAsNil() {
@@ -243,10 +261,10 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys17)
-		} // end switch yys17
-	} // end for yyj17
-	if !yyhl17 {
+			z.DecStructFieldNotFound(-1, yys19)
+		} // end switch yys19
+	} // end for yyj19
+	if !yyhl19 {
 		r.ReadEnd()
 	}
 }
@@ -255,16 +273,16 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj22 int
-	var yyb22 bool
-	var yyhl22 bool = l >= 0
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
+	var yyj25 int
+	var yyb25 bool
+	var yyhl25 bool = l >= 0
+	yyj25++
+	if yyhl25 {
+		yyb25 = yyj25 > l
 	} else {
-		yyb22 = r.CheckBreak()
+		yyb25 = r.CheckBreak()
 	}
-	if yyb22 {
+	if yyb25 {
 		r.ReadEnd()
 		return
 	}
@@ -273,13 +291,13 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
+	yyj25++
+	if yyhl25 {
+		yyb25 = yyj25 > l
 	} else {
-		yyb22 = r.CheckBreak()
+		yyb25 = r.CheckBreak()
 	}
-	if yyb22 {
+	if yyb25 {
 		r.ReadEnd()
 		return
 	}
@@ -288,29 +306,35 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
+	yyj25++
+	if yyhl25 {
+		yyb25 = yyj25 > l
 	} else {
-		yyb22 = r.CheckBreak()
+		yyb25 = r.CheckBreak()
 	}
-	if yyb22 {
+	if yyb25 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv25 := &x.ObjectMeta
-		yyv25.CodecDecodeSelf(d)
+		yyv28 := &x.ObjectMeta
+		yym29 := z.DecBinary()
+		_ = yym29
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv28) {
+		} else {
+			z.DecFallback(yyv28, false)
+		}
 	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
+	yyj25++
+	if yyhl25 {
+		yyb25 = yyj25 > l
 	} else {
-		yyb22 = r.CheckBreak()
+		yyb25 = r.CheckBreak()
 	}
-	if yyb22 {
+	if yyb25 {
 		r.ReadEnd()
 		return
 	}
@@ -320,16 +344,16 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Value = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj22++
-		if yyhl22 {
-			yyb22 = yyj22 > l
+		yyj25++
+		if yyhl25 {
+			yyb25 = yyj25 > l
 		} else {
-			yyb22 = r.CheckBreak()
+			yyb25 = r.CheckBreak()
 		}
-		if yyb22 {
+		if yyb25 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj22-1, "")
+		z.DecStructFieldNotFound(yyj25-1, "")
 	}
 	r.ReadEnd()
 }


### PR DESCRIPTION
This is an initial specification of the raw metrics kubelet API. The
initial customer of the API will be Heapster, so the fields have been
restricted to those that are necessary to move Heapster off the old
/stats endpoint.

Issue: https://github.com/kubernetes/kubernetes/issues/12483
Proposal (modified to match this PR): https://github.com/timstclair/kubernetes/blob/metrics-beta2/docs/proposals/compute-resource-metrics-api.md

@vishh @bgrant0607 @kubernetes/goog-node @mwielgus @jszczepkowski @piosz @jimmidyson 
