### PR TITLE
Support iqn as well as eui format for iSCSI entity names.

### DIFF
--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -180,6 +180,9 @@ func extractPortalAndIqn(device string) (string, string, error) {
 	portal := device[0:ind1]
 	ind2 := strings.Index(device, "iqn.")
 	if ind2 < 0 {
+		ind2 = strings.Index(device, "eui.")
+	}
+	if ind2 < 0 {
 		return "", "", fmt.Errorf("iscsi detach disk: no iqn in %s", device)
 	}
 	ind := strings.LastIndex(device, "-lun-")

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -68,4 +68,9 @@ func TestExtractPortalAndIqn(t *testing.T) {
 	if err != nil || portal != "127.0.0.1:3260" || iqn != "iqn.2014-12.com.example:test.tgt00" {
 		t.Errorf("extractPortalAndIqn: got %v %s %s", err, portal, iqn)
 	}
+	devicePath = "127.0.0.1:3260-eui.02004567A425678D-lun-0"
+	portal, iqn, err = extractPortalAndIqn(devicePath)
+	if err != nil || portal != "127.0.0.1:3260" || iqn != "eui.02004567A425678D" {
+		t.Errorf("extractPortalAndIqn: got %v %s %s", err, portal, iqn)
+	}
 }


### PR DESCRIPTION
Supported formats are :
iqn.<date code>.<reversed domain>[:<optional suffix>]

eui.<eui-64 identifier>

See [RFC 3721 Section 1](http://www.ietf.org/rfc/rfc3721.txt) for more details
