### PR TITLE
Do not run Latency test as part of scalability suite

### DIFF
--- a/test/e2e/latency.go
+++ b/test/e2e/latency.go
@@ -39,7 +39,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[Performance] Latency [Skipped]", func() {
+var _ = Describe("Latency [Skipped]", func() {
 	var c *client.Client
 	var nodeCount int
 	var additionalPodsPrefix string


### PR DESCRIPTION
This test doesn't provide anything new.
It is causing scalability suite failures (introduced by #17180)
