### PR TITLE
Fix latency.go e2e test

### DIFF
--- a/test/e2e/latency.go
+++ b/test/e2e/latency.go
@@ -53,11 +53,6 @@ var _ = Describe("Latency [Skipped]", func() {
 			c.Pods(ns).Delete(name, nil)
 		}
 
-		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := c.Namespaces().Delete(ns); err != nil {
-			Failf("Couldn't delete ns %s", err)
-		}
-
 		expectNoError(writePerfData(c, fmt.Sprintf(testContext.OutputDir+"/%s", uuid), "after"))
 
 		// Verify latency metrics


### PR DESCRIPTION
Don't explicitly remove namespace - it's removed by the framework and removing it twice is causing failures.
