### PR TITLE
Fixing import format in thirdparty libraries to separate local imports.

### DIFF
--- a/third_party/golang/go/ast/print.go
+++ b/third_party/golang/go/ast/print.go
@@ -8,10 +8,11 @@ package ast
 
 import (
 	"fmt"
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io"
 	"os"
 	"reflect"
+
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 // A FieldFilter may be provided to Fprint to control the output.

--- a/third_party/golang/go/ast/scope.go
+++ b/third_party/golang/go/ast/scope.go
@@ -9,6 +9,7 @@ package ast
 import (
 	"bytes"
 	"fmt"
+
 	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 

--- a/third_party/golang/go/build/build.go
+++ b/third_party/golang/go/build/build.go
@@ -8,10 +8,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"k8s.io/kubernetes/third_party/golang/go/ast"
-	"k8s.io/kubernetes/third_party/golang/go/doc"
-	"k8s.io/kubernetes/third_party/golang/go/parser"
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io"
 	"io/ioutil"
 	"log"
@@ -24,6 +20,11 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"k8s.io/kubernetes/third_party/golang/go/ast"
+	"k8s.io/kubernetes/third_party/golang/go/doc"
+	"k8s.io/kubernetes/third_party/golang/go/parser"
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 // A Context specifies the supporting context for a build.

--- a/third_party/golang/go/doc/doc_test.go
+++ b/third_party/golang/go/doc/doc_test.go
@@ -8,9 +8,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"k8s.io/kubernetes/third_party/golang/go/parser"
-	"k8s.io/kubernetes/third_party/golang/go/printer"
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -18,6 +15,10 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+
+	"k8s.io/kubernetes/third_party/golang/go/parser"
+	"k8s.io/kubernetes/third_party/golang/go/printer"
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 var update = flag.Bool("update", false, "update golden (.out) files")

--- a/third_party/golang/go/parser/error_test.go
+++ b/third_party/golang/go/parser/error_test.go
@@ -23,13 +23,14 @@
 package parser
 
 import (
-	"k8s.io/kubernetes/third_party/golang/go/scanner"
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+
+	"k8s.io/kubernetes/third_party/golang/go/scanner"
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 const testdata = "testdata"

--- a/third_party/golang/go/parser/interface.go
+++ b/third_party/golang/go/parser/interface.go
@@ -9,13 +9,14 @@ package parser
 import (
 	"bytes"
 	"errors"
-	"k8s.io/kubernetes/third_party/golang/go/ast"
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"k8s.io/kubernetes/third_party/golang/go/ast"
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 // If src != nil, readSource converts src to a []byte if possible;

--- a/third_party/golang/go/parser/performance_test.go
+++ b/third_party/golang/go/parser/performance_test.go
@@ -5,9 +5,10 @@
 package parser
 
 import (
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io/ioutil"
 	"testing"
+
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 var src = readFile("parser.go")

--- a/third_party/golang/go/printer/performance_test.go
+++ b/third_party/golang/go/printer/performance_test.go
@@ -9,10 +9,11 @@ package printer
 
 import (
 	"bytes"
-	"k8s.io/kubernetes/third_party/golang/go/ast"
-	"k8s.io/kubernetes/third_party/golang/go/parser"
 	"io"
 	"io/ioutil"
+
+	"k8s.io/kubernetes/third_party/golang/go/ast"
+	"k8s.io/kubernetes/third_party/golang/go/parser"
 	"log"
 	"testing"
 )

--- a/third_party/golang/go/printer/printer.go
+++ b/third_party/golang/go/printer/printer.go
@@ -7,14 +7,15 @@ package printer
 
 import (
 	"fmt"
-	"k8s.io/kubernetes/third_party/golang/go/ast"
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 	"unicode"
+
+	"k8s.io/kubernetes/third_party/golang/go/ast"
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 const (

--- a/third_party/golang/go/scanner/errors.go
+++ b/third_party/golang/go/scanner/errors.go
@@ -6,9 +6,10 @@ package scanner
 
 import (
 	"fmt"
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io"
 	"sort"
+
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 // In an ErrorList, an error is represented by an *Error.

--- a/third_party/golang/go/scanner/scanner_test.go
+++ b/third_party/golang/go/scanner/scanner_test.go
@@ -5,12 +5,13 @@
 package scanner
 
 import (
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 var fset = token.NewFileSet()

--- a/third_party/golang/go/types/scope.go
+++ b/third_party/golang/go/types/scope.go
@@ -9,10 +9,11 @@ package types
 import (
 	"bytes"
 	"fmt"
-	"k8s.io/kubernetes/third_party/golang/go/token"
 	"io"
 	"sort"
 	"strings"
+
+	"k8s.io/kubernetes/third_party/golang/go/token"
 )
 
 // TODO(gri) Provide scopes with a name or other mechanism so that


### PR DESCRIPTION
I've been automating some of my formatting, and noticed that alot of files in third party are following different conventions then the rest of kube.  Here's a patch that fixes these.
