### PR TITLE
Fix skipped tag for cluster upgrade tests in release-1.1

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -144,7 +144,7 @@ func nodeUpgradeGKE(v string) error {
 	return err
 }
 
-var _ = Describe("Skipped", func() {
+var _ = Describe("[Skipped]", func() {
 
 	Describe("Cluster upgrade", func() {
 		svcName, replicas := "baz", 2


### PR DESCRIPTION
Small fix after #17180 to make sure cluster upgrade tests remain being skipped.

This is a commit to release-1.1 rather than a cherry-pick because it's a very small fix and I don't want to pull in all of the other changes.
