### PR TITLE
Re-enabled GCE L7 load balancer e2e

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -651,7 +651,6 @@ case ${JOB_NAME} in
           ${REBOOT_SKIP_TESTS[@]:+${REBOOT_SKIP_TESTS[@]}}\
           ) --ginkgo.focus=$(join_regex_no_empty \
           ${DISRUPTIVE_TESTS[@]:+${DISRUPTIVE_TESTS[@]}} \
-          # This test is not disruptive, however there is no better suite to run it.
           "\[Autoscaling\]\sReplicationController" \
           "GCE\sL7\sLoadBalancer\sController"
           )"}


### PR DESCRIPTION
The test was disabled by mistake in #17718 (see https://github.com/kubernetes/kubernetes/pull/17718#issuecomment-159408453)

cc @ixdy 
