### PR TITLE
don't test kube-proxy in system resource container monitoring e2e

### DIFF
--- a/test/e2e/monitor_resources.go
+++ b/test/e2e/monitor_resources.go
@@ -29,7 +29,7 @@ import (
 
 const datapointAmount = 5
 
-var systemContainers = []string{"/docker-daemon", "/kubelet", "/kube-proxy", "/system"}
+var systemContainers = []string{"/docker-daemon", "/kubelet", "/system"}
 
 //TODO tweak those values.
 var allowedUsage = resourceUsagePerContainer{
@@ -42,11 +42,6 @@ var allowedUsage = resourceUsagePerContainer{
 		CPUUsageInCores:         0.1,
 		MemoryUsageInBytes:      150000000,
 		MemoryWorkingSetInBytes: 150000000,
-	},
-	"/kube-proxy": &containerResourceUsage{
-		CPUUsageInCores:         0.025,
-		MemoryUsageInBytes:      100000000,
-		MemoryWorkingSetInBytes: 100000000,
 	},
 	"/system": &containerResourceUsage{
 		CPUUsageInCores:         0.03,


### PR DESCRIPTION
since it is running in a docker container now

Fixes #17773 cc @gmarek 
