### PR TITLE
Update ObjectTyper for GroupVersion

### DIFF
--- a/pkg/api/ref.go
+++ b/pkg/api/ref.go
@@ -53,10 +53,11 @@ func GetReference(obj runtime.Object) (*ObjectReference, error) {
 	// if we are building an object reference to something not yet persisted, we should fallback to scheme
 	kind := meta.Kind()
 	if kind == "" {
-		_, kind, err = Scheme.ObjectVersionAndKind(obj)
+		gvk, err := Scheme.ObjectKind(obj)
 		if err != nil {
 			return nil, err
 		}
+		kind = gvk.Kind
 	}
 
 	// if the object referenced is actually persisted, we can also get version from meta

--- a/pkg/api/rest/create.go
+++ b/pkg/api/rest/create.go
@@ -111,9 +111,9 @@ func objectMetaAndKind(typer runtime.ObjectTyper, obj runtime.Object) (*api.Obje
 	if err != nil {
 		return nil, "", errors.NewInternalError(err)
 	}
-	_, kind, err := typer.ObjectVersionAndKind(obj)
+	gvk, err := typer.ObjectKind(obj)
 	if err != nil {
 		return nil, "", errors.NewInternalError(err)
 	}
-	return objectMeta, kind, nil
+	return objectMeta, gvk.Kind, nil
 }

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -175,8 +175,10 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			// TODO: uncomment when round trip starts from a versioned object
 			if true { //c.RandBool() {
 				*j = &runtime.Unknown{
-					TypeMeta: runtime.TypeMeta{Kind: "Something", APIVersion: "unknown"},
-					RawJSON:  []byte(`{"apiVersion":"unknown","kind":"Something","someKey":"someValue"}`),
+					// apiVersion has rules now.  Since it includes <group>/<version> and only `v1` can be bare,
+					// then this must choose a valid format to deserialize
+					TypeMeta: runtime.TypeMeta{Kind: "Something", APIVersion: "unknown.group/unknown"},
+					RawJSON:  []byte(`{"apiVersion":"unknown.group/unknown","kind":"Something","someKey":"someValue"}`),
 				}
 			} else {
 				types := []runtime.Object{&api.Pod{}, &api.ReplicationController{}}

--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -78,7 +78,7 @@ func (gvk GroupVersionKind) GroupVersion() GroupVersion {
 	return GroupVersion{Group: gvk.Group, Version: gvk.Version}
 }
 
-func (gvk *GroupVersionKind) String() string {
+func (gvk GroupVersionKind) String() string {
 	return gvk.Group + "/" + gvk.Version + ", Kind=" + gvk.Kind
 }
 

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -745,14 +745,14 @@ func finishRequest(timeout time.Duration, fn resultFunc) (result runtime.Object,
 
 // transformDecodeError adds additional information when a decode fails.
 func transformDecodeError(typer runtime.ObjectTyper, baseErr error, into runtime.Object, body []byte) error {
-	_, kind, err := typer.ObjectVersionAndKind(into)
+	objectGroupVersionKind, err := typer.ObjectKind(into)
 	if err != nil {
 		return err
 	}
-	if version, dataKind, err := typer.DataVersionAndKind(body); err == nil && len(dataKind) > 0 {
-		return errors.NewBadRequest(fmt.Sprintf("%s in version %s cannot be handled as a %s: %v", dataKind, version, kind, baseErr))
+	if dataGroupVersionKind, err := typer.DataKind(body); err == nil && len(dataGroupVersionKind.Kind) > 0 {
+		return errors.NewBadRequest(fmt.Sprintf("%s in version %v cannot be handled as a %s: %v", dataGroupVersionKind.Kind, dataGroupVersionKind.GroupVersion(), objectGroupVersionKind.Kind, baseErr))
 	}
-	return errors.NewBadRequest(fmt.Sprintf("the object provided is unrecognized (must be of type %s): %v", kind, baseErr))
+	return errors.NewBadRequest(fmt.Sprintf("the object provided is unrecognized (must be of type %s): %v", objectGroupVersionKind.Kind, baseErr))
 }
 
 // setSelfLink sets the self link of an object (or the child items in a list) to the base URL of the request

--- a/pkg/auth/authorizer/abac/abac.go
+++ b/pkg/auth/authorizer/abac/abac.go
@@ -77,12 +77,12 @@ func NewFromFile(path string) (policyList, error) {
 			continue
 		}
 
-		version, kind, err := api.Scheme.DataVersionAndKind(b)
+		dataKind, err := api.Scheme.DataKind(b)
 		if err != nil {
 			return nil, policyLoadError{path, i, b, err}
 		}
 
-		if version == "" && kind == "" {
+		if dataKind.IsEmpty() {
 			unversionedLines++
 			// Migrate unversioned policy object
 			oldPolicy := &v0.Policy{}

--- a/pkg/client/unversioned/client_test.go
+++ b/pkg/client/unversioned/client_test.go
@@ -207,7 +207,7 @@ func validateFields(a, b string) bool {
 
 func body(t *testing.T, obj runtime.Object, raw *string) *string {
 	if obj != nil {
-		_, kind, err := api.Scheme.ObjectVersionAndKind(obj)
+		fqKind, err := api.Scheme.ObjectKind(obj)
 		if err != nil {
 			t.Errorf("unexpected encoding error: %v", err)
 		}
@@ -216,18 +216,18 @@ func body(t *testing.T, obj runtime.Object, raw *string) *string {
 		// split the schemes for internal objects.
 		// TODO: caesarxuchao: we should add a map from kind to group in Scheme.
 		var bs []byte
-		if api.Scheme.Recognizes(testapi.Default.GroupAndVersion(), kind) {
+		if api.Scheme.Recognizes(testapi.Default.GroupVersion().WithKind(fqKind.Kind)) {
 			bs, err = testapi.Default.Codec().Encode(obj)
 			if err != nil {
 				t.Errorf("unexpected encoding error: %v", err)
 			}
-		} else if api.Scheme.Recognizes(testapi.Extensions.GroupAndVersion(), kind) {
+		} else if api.Scheme.Recognizes(testapi.Extensions.GroupVersion().WithKind(fqKind.Kind)) {
 			bs, err = testapi.Extensions.Codec().Encode(obj)
 			if err != nil {
 				t.Errorf("unexpected encoding error: %v", err)
 			}
 		} else {
-			t.Errorf("unexpected kind: %v", kind)
+			t.Errorf("unexpected kind: %v", fqKind.Kind)
 		}
 		body := string(bs)
 		return &body

--- a/pkg/client/unversioned/testclient/fixture.go
+++ b/pkg/client/unversioned/testclient/fixture.go
@@ -210,10 +210,11 @@ func (o objects) Kind(gvk unversioned.GroupVersionKind, name string) (runtime.Ob
 }
 
 func (o objects) Add(obj runtime.Object) error {
-	_, kind, err := o.scheme.ObjectVersionAndKind(obj)
+	gvk, err := o.scheme.ObjectKind(obj)
 	if err != nil {
 		return err
 	}
+	kind := gvk.Kind
 
 	switch {
 	case meta.IsListType(obj):

--- a/pkg/conversion/meta.go
+++ b/pkg/conversion/meta.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 // MetaFactory is used to store and retrieve the version and kind
@@ -28,9 +30,9 @@ import (
 type MetaFactory interface {
 	// Update sets the given version and kind onto the object.
 	Update(version, kind string, obj interface{}) error
-	// Interpret should return the version and kind of the wire-format of
+	// Interpret should return the group,version,kind of the wire-format of
 	// the object.
-	Interpret(data []byte) (version, kind string, err error)
+	Interpret(data []byte) (gvk unversioned.GroupVersionKind, err error)
 }
 
 // DefaultMetaFactory is a default factory for versioning objects in JSON. The object
@@ -51,18 +53,23 @@ type SimpleMetaFactory struct {
 	BaseFields []string
 }
 
-// Interpret will return the APIVersion and Kind of the JSON wire-format
+// Interpret will return the group,version,kind of the JSON wire-format
 // encoding of an object, or an error.
-func (SimpleMetaFactory) Interpret(data []byte) (version, kind string, err error) {
+func (SimpleMetaFactory) Interpret(data []byte) (unversioned.GroupVersionKind, error) {
 	findKind := struct {
 		APIVersion string `json:"apiVersion,omitempty"`
 		Kind       string `json:"kind,omitempty"`
 	}{}
-	err = json.Unmarshal(data, &findKind)
+	err := json.Unmarshal(data, &findKind)
 	if err != nil {
-		return "", "", fmt.Errorf("couldn't get version/kind; json parse error: %v", err)
+		return unversioned.GroupVersionKind{}, fmt.Errorf("couldn't get version/kind; json parse error: %v", err)
 	}
-	return findKind.APIVersion, findKind.Kind, nil
+	gv, err := unversioned.ParseGroupVersion(findKind.APIVersion)
+	if err != nil {
+		return unversioned.GroupVersionKind{}, fmt.Errorf("couldn't parse apiVersion: %v", err)
+	}
+
+	return gv.WithKind(findKind.Kind), nil
 }
 
 func (f SimpleMetaFactory) Update(version, kind string, obj interface{}) error {

--- a/pkg/conversion/meta_test.go
+++ b/pkg/conversion/meta_test.go
@@ -26,25 +26,26 @@ import (
 
 func TestSimpleMetaFactoryInterpret(t *testing.T) {
 	factory := SimpleMetaFactory{}
-	version, kind, err := factory.Interpret([]byte(`{"apiVersion":"1","kind":"object"}`))
+	fqKind, err := factory.Interpret([]byte(`{"apiVersion":"g/1","kind":"object"}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if version != "1" || kind != "object" {
-		t.Errorf("unexpected interpret: %s %s", version, kind)
+	expectedFQKind := unversioned.GroupVersionKind{Group: "g", Version: "1", Kind: "object"}
+	if expectedFQKind != fqKind {
+		t.Errorf("unexpected interpret: %s %s", expectedFQKind, fqKind)
 	}
 
 	// no kind or version
-	version, kind, err = factory.Interpret([]byte(`{}`))
+	fqKind, err = factory.Interpret([]byte(`{}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if version != "" || kind != "" {
-		t.Errorf("unexpected interpret: %s %s", version, kind)
+	if !fqKind.IsEmpty() {
+		t.Errorf("unexpected interpret: %s %s", fqKind)
 	}
 
 	// unparsable
-	version, kind, err = factory.Interpret([]byte(`{`))
+	fqKind, err = factory.Interpret([]byte(`{`))
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
@@ -237,10 +238,10 @@ func TestMetaValuesUnregisteredConvert(t *testing.T) {
 	// Register functions to verify that scope.Meta() gets set correctly.
 	err := s.AddConversionFuncs(
 		func(in *InternalSimple, out *ExternalSimple, scope Scope) error {
-			if e, a := "unknown", scope.Meta().SrcVersion; e != a {
+			if e, a := "unknown/unknown", scope.Meta().SrcVersion; e != a {
 				t.Fatalf("Expected '%v', got '%v'", e, a)
 			}
-			if e, a := "unknown", scope.Meta().DestVersion; e != a {
+			if e, a := "unknown/unknown", scope.Meta().DestVersion; e != a {
 				t.Fatalf("Expected '%v', got '%v'", e, a)
 			}
 			scope.Convert(&in.TestString, &out.TestString, 0)

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -253,11 +253,11 @@ func NewAPIFactory() (*cmdutil.Factory, *testFactory, runtime.Codec) {
 				}
 				return c.Pods(t.Namespace).GetLogs(t.Name, opts), nil
 			default:
-				_, kind, err := api.Scheme.ObjectVersionAndKind(object)
+				fqKind, err := api.Scheme.ObjectKind(object)
 				if err != nil {
 					return nil, err
 				}
-				return nil, fmt.Errorf("cannot get the logs from %s", kind)
+				return nil, fmt.Errorf("cannot get the logs from %v", fqKind)
 			}
 		},
 	}

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -216,8 +216,8 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 		}
 		newRc, ok = obj.(*api.ReplicationController)
 		if !ok {
-			if _, kind, err := typer.ObjectVersionAndKind(obj); err == nil {
-				return cmdutil.UsageError(cmd, "%s contains a %s not a ReplicationController", filename, kind)
+			if gvk, err := typer.ObjectKind(obj); err == nil {
+				return cmdutil.UsageError(cmd, "%s contains a %v not a ReplicationController", filename, gvk)
 			}
 			glog.V(4).Infof("Object %#v is not a ReplicationController", obj)
 			return cmdutil.UsageError(cmd, "%s does not specify a valid ReplicationController", filename)
@@ -358,11 +358,11 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 	if outputFormat != "" {
 		return f.PrintObject(cmd, newRc, out)
 	}
-	_, kind, err := api.Scheme.ObjectVersionAndKind(newRc)
+	gvk, err := api.Scheme.ObjectKind(newRc)
 	if err != nil {
 		return err
 	}
-	_, res := meta.KindToResource(kind, false)
+	_, res := meta.KindToResource(gvk.Kind, false)
 	cmdutil.PrintSuccess(mapper, false, out, res, oldName, message)
 	return nil
 }

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -243,7 +243,7 @@ func AsVersionedObjects(infos []*Info, version string) ([]runtime.Object, error)
 		// objects that are not part of api.Scheme must be converted to JSON
 		// TODO: convert to map[string]interface{}, attach to runtime.Unknown?
 		if len(version) > 0 {
-			if _, _, err := api.Scheme.ObjectVersionAndKind(info.Object); runtime.IsNotRegisteredError(err) {
+			if _, err := api.Scheme.ObjectKind(info.Object); runtime.IsNotRegisteredError(err) {
 				// TODO: ideally this would encode to version, but we don't expose multiple codecs here.
 				data, err := info.Mapping.Codec.Encode(info.Object)
 				if err != nil {

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -213,7 +213,7 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 			for i := 0; i < items.Len(); i++ {
 				rawObj := items.Index(i).FieldByName("RawJSON").Interface().([]byte)
 				scheme := api.Scheme
-				version, kind, err := scheme.DataVersionAndKind(rawObj)
+				groupVersionKind, err := scheme.DataKind(rawObj)
 				if err != nil {
 					return err
 				}
@@ -222,8 +222,8 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 					return err
 				}
 				tpmeta := unversioned.TypeMeta{
-					APIVersion: version,
-					Kind:       kind,
+					APIVersion: groupVersionKind.GroupVersion().String(),
+					Kind:       groupVersionKind.Kind,
 				}
 				s := reflect.ValueOf(decodedObj).Elem()
 				s.FieldByName("TypeMeta").Set(reflect.ValueOf(tpmeta))

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -146,7 +146,7 @@ func (t *Tester) TestWatch(valid runtime.Object, labelsPass, labelsFail []labels
 // =============================================================================
 // get codec based on runtime.Object
 func getCodec(obj runtime.Object) (runtime.Codec, error) {
-	_, kind, err := api.Scheme.ObjectVersionAndKind(obj)
+	fqKind, err := api.Scheme.ObjectKind(obj)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected encoding error: %v", err)
 	}
@@ -155,12 +155,12 @@ func getCodec(obj runtime.Object) (runtime.Codec, error) {
 	// split the schemes for internal objects.
 	// TODO: caesarxuchao: we should add a map from kind to group in Scheme.
 	var codec runtime.Codec
-	if api.Scheme.Recognizes(testapi.Default.GroupAndVersion(), kind) {
+	if api.Scheme.Recognizes(testapi.Default.GroupVersion().WithKind(fqKind.Kind)) {
 		codec = testapi.Default.Codec()
-	} else if api.Scheme.Recognizes(testapi.Extensions.GroupAndVersion(), kind) {
+	} else if api.Scheme.Recognizes(testapi.Extensions.GroupVersion().WithKind(fqKind.Kind)) {
 		codec = testapi.Extensions.Codec()
 	} else {
-		return nil, fmt.Errorf("unexpected kind: %v", kind)
+		return nil, fmt.Errorf("unexpected kind: %v", fqKind)
 	}
 	return codec, nil
 }

--- a/pkg/runtime/embedded_test.go
+++ b/pkg/runtime/embedded_test.go
@@ -106,7 +106,7 @@ func TestArrayOfRuntimeObject(t *testing.T) {
 			&EmbeddedTest{ID: "foo"},
 			&EmbeddedTest{ID: "bar"},
 			// TODO: until YAML is removed, this JSON must be in ascending key order to ensure consistent roundtrip serialization
-			&runtime.Unknown{RawJSON: []byte(`{"apiVersion":"unknown","foo":"bar","kind":"OtherTest"}`)},
+			&runtime.Unknown{RawJSON: []byte(`{"apiVersion":"unknown.group/unknown","foo":"bar","kind":"OtherTest"}`)},
 			&ObjectTest{
 				Items: []runtime.Object{
 					&EmbeddedTest{ID: "baz"},
@@ -150,7 +150,7 @@ func TestArrayOfRuntimeObject(t *testing.T) {
 	}
 
 	internal.Items[2].(*runtime.Unknown).Kind = "OtherTest"
-	internal.Items[2].(*runtime.Unknown).APIVersion = "unknown"
+	internal.Items[2].(*runtime.Unknown).APIVersion = "unknown.group/unknown"
 	if e, a := internal.Items, list; !reflect.DeepEqual(e, a) {
 		t.Errorf("mismatched decoded: %s", util.ObjectDiff(e, a))
 	}

--- a/pkg/runtime/helper.go
+++ b/pkg/runtime/helper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/conversion"
 )
 
@@ -56,7 +57,13 @@ func DecodeList(objects []Object, decoders ...ObjectDecoder) []error {
 		switch t := obj.(type) {
 		case *Unknown:
 			for _, decoder := range decoders {
-				if !decoder.Recognizes(t.APIVersion, t.Kind) {
+				gv, err := unversioned.ParseGroupVersion(t.APIVersion)
+				if err != nil {
+					errs = append(errs, err)
+					break
+				}
+
+				if !decoder.Recognizes(gv.WithKind(t.Kind)) {
 					continue
 				}
 				obj, err := decoder.Decode(t.RawJSON)
@@ -77,9 +84,9 @@ type MultiObjectTyper []ObjectTyper
 
 var _ ObjectTyper = MultiObjectTyper{}
 
-func (m MultiObjectTyper) DataVersionAndKind(data []byte) (version, kind string, err error) {
+func (m MultiObjectTyper) DataKind(data []byte) (gvk unversioned.GroupVersionKind, err error) {
 	for _, t := range m {
-		version, kind, err = t.DataVersionAndKind(data)
+		gvk, err = t.DataKind(data)
 		if err == nil {
 			return
 		}
@@ -87,9 +94,9 @@ func (m MultiObjectTyper) DataVersionAndKind(data []byte) (version, kind string,
 	return
 }
 
-func (m MultiObjectTyper) ObjectVersionAndKind(obj Object) (version, kind string, err error) {
+func (m MultiObjectTyper) ObjectKind(obj Object) (gvk unversioned.GroupVersionKind, err error) {
 	for _, t := range m {
-		version, kind, err = t.ObjectVersionAndKind(obj)
+		gvk, err = t.ObjectKind(obj)
 		if err == nil {
 			return
 		}
@@ -97,9 +104,19 @@ func (m MultiObjectTyper) ObjectVersionAndKind(obj Object) (version, kind string
 	return
 }
 
-func (m MultiObjectTyper) Recognizes(version, kind string) bool {
+func (m MultiObjectTyper) ObjectKinds(obj Object) (gvks []unversioned.GroupVersionKind, err error) {
 	for _, t := range m {
-		if t.Recognizes(version, kind) {
+		gvks, err = t.ObjectKinds(obj)
+		if err == nil {
+			return
+		}
+	}
+	return
+}
+
+func (m MultiObjectTyper) Recognizes(gvk unversioned.GroupVersionKind) bool {
+	for _, t := range m {
+		if t.Recognizes(gvk) {
 			return true
 		}
 	}

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -69,13 +69,13 @@ type ObjectCodec interface {
 // TODO: Consider removing this interface?
 type ObjectDecoder interface {
 	Decoder
-	// DataVersionAndKind returns the version and kind of the provided data, or an error
+	// DataVersionAndKind returns the group,version,kind of the provided data, or an error
 	// if another problem is detected. In many cases this method can be as expensive to
 	// invoke as the Decode method.
-	DataVersionAndKind([]byte) (version, kind string, err error)
-	// Recognizes returns true if the scheme is able to handle the provided version and kind
+	DataKind([]byte) (unversioned.GroupVersionKind, error)
+	// Recognizes returns true if the scheme is able to handle the provided group,version,kind
 	// of an object.
-	Recognizes(version, kind string) bool
+	Recognizes(unversioned.GroupVersionKind) bool
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -91,17 +91,20 @@ type ObjectConvertor interface {
 // ObjectTyper contains methods for extracting the APIVersion and Kind
 // of objects.
 type ObjectTyper interface {
-	// DataVersionAndKind returns the version and kind of the provided data, or an error
+	// DataKind returns the group,version,kind of the provided data, or an error
 	// if another problem is detected. In many cases this method can be as expensive to
 	// invoke as the Decode method.
-	DataVersionAndKind([]byte) (version, kind string, err error)
-	// ObjectVersionAndKind returns the version and kind of the provided object, or an
+	DataKind([]byte) (unversioned.GroupVersionKind, error)
+	// ObjectKind returns the default group,version,kind of the provided object, or an
 	// error if the object is not recognized (IsNotRegisteredError will return true).
-	ObjectVersionAndKind(Object) (version, kind string, err error)
+	ObjectKind(Object) (unversioned.GroupVersionKind, error)
+	// ObjectKinds returns the all possible group,version,kind of the provided object, or an
+	// error if the object is not recognized (IsNotRegisteredError will return true).
+	ObjectKinds(Object) ([]unversioned.GroupVersionKind, error)
 	// Recognizes returns true if the scheme is able to handle the provided version and kind,
 	// or more precisely that the provided version is a possible conversion or decoding
 	// target.
-	Recognizes(version, kind string) bool
+	Recognizes(gvk unversioned.GroupVersionKind) bool
 }
 
 // ObjectCreater contains methods for instantiating an object by kind and version.

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -144,7 +144,7 @@ func TestInvalidObjectValueKind(t *testing.T) {
 	embedded := &runtime.EmbeddedObject{}
 	switch obj := embedded.Object.(type) {
 	default:
-		_, _, err := scheme.ObjectVersionAndKind(obj)
+		_, err := scheme.ObjectKind(obj)
 		if err == nil {
 			t.Errorf("Expected error on invalid kind")
 		}

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -33,11 +33,12 @@ var UnstructuredJSONScheme ObjectDecoder = unstructuredJSONScheme{}
 type unstructuredJSONScheme struct{}
 
 var _ Decoder = unstructuredJSONScheme{}
+var _ ObjectDecoder = unstructuredJSONScheme{}
 
 // Recognizes returns true for any version or kind that is specified (internal
 // versions are specifically excluded).
-func (unstructuredJSONScheme) Recognizes(version, kind string) bool {
-	return len(version) > 0 && len(kind) > 0
+func (unstructuredJSONScheme) Recognizes(gvk unversioned.GroupVersionKind) bool {
+	return !gvk.GroupVersion().IsEmpty() && len(gvk.Kind) > 0
 }
 
 func (s unstructuredJSONScheme) Decode(data []byte) (Object, error) {
@@ -90,16 +91,22 @@ func (unstructuredJSONScheme) DecodeParametersInto(paramaters url.Values, obj Ob
 	return nil
 }
 
-func (unstructuredJSONScheme) DataVersionAndKind(data []byte) (version, kind string, err error) {
+func (unstructuredJSONScheme) DataKind(data []byte) (unversioned.GroupVersionKind, error) {
 	obj := TypeMeta{}
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return "", "", err
+		return unversioned.GroupVersionKind{}, err
 	}
 	if len(obj.APIVersion) == 0 {
-		return "", "", conversion.NewMissingVersionErr(string(data))
+		return unversioned.GroupVersionKind{}, conversion.NewMissingVersionErr(string(data))
 	}
 	if len(obj.Kind) == 0 {
-		return "", "", conversion.NewMissingKindErr(string(data))
+		return unversioned.GroupVersionKind{}, conversion.NewMissingKindErr(string(data))
 	}
-	return obj.APIVersion, obj.Kind, nil
+
+	gv, err := unversioned.ParseGroupVersion(obj.APIVersion)
+	if err != nil {
+		return unversioned.GroupVersionKind{}, err
+	}
+
+	return gv.WithKind(obj.Kind), nil
 }


### PR DESCRIPTION
Makes `ObjectTyper` use `GroupVersionKind`.

ref #17216

@liggitt @caesarxuchao 
