### PR TITLE
bump k8s version to v1.1.2 on ubuntu/calico

### DIFF
--- a/docs/getting-started-guides/ubuntu-calico.md
+++ b/docs/getting-started-guides/ubuntu-calico.md
@@ -75,7 +75,7 @@ We'll use the `kubelet` to bootstrap the Kubernetes master processes as containe
 
 ```
 # Get the Kubernetes Release.
-wget https://github.com/kubernetes/kubernetes/releases/download/v1.1.1/kubernetes.tar.gz
+wget https://github.com/kubernetes/kubernetes/releases/download/v1.1.2/kubernetes.tar.gz
 
 # Extract the Kubernetes binaries.
 tar -xf kubernetes.tar.gz


### PR DESCRIPTION
Fix #17794
