### PR TITLE
MESOS: Automated cherry pick of #14646 - SSH tests

### DIFF
--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -47,7 +47,7 @@ mesosslave:
   - MESOS_PORT=5051
   - MESOS_LOG_DIR=/var/log/mesos
   - MESOS_LOGGING_LEVEL=INFO
-  - MESOS_RESOURCES=cpus:4;mem:1280;disk:25600;ports:[21000-21099]
+  - MESOS_RESOURCES=cpus:4;mem:1280;disk:25600;ports:[8000-21099]
   - MESOS_SWITCH_USER=0
   - MESOS_CONTAINERIZERS=docker,mesos
   - DOCKER_DAEMON_ARGS

--- a/test/e2e/core.go
+++ b/test/e2e/core.go
@@ -38,7 +38,7 @@ func CoreDump(dir string) {
 	provider := testContext.Provider
 
 	// requires ssh
-	if !providerIs("gce", "gke") {
+	if !providerIs(providersWithSSH...) {
 		fmt.Printf("Skipping SSH core dump, which is not implemented for %s", provider)
 		return
 	}

--- a/test/e2e/privileged.go
+++ b/test/e2e/privileged.go
@@ -52,6 +52,7 @@ var _ = Describe("PrivilegedPod", func() {
 		f: f,
 	}
 	It("should test privileged pod", func() {
+		SkipUnlessProviderIs(providersWithSSH...)
 
 		By("Getting ssh-able hosts")
 		hosts, err := NodeSSHHosts(config.f.Client)

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -388,14 +388,17 @@ var _ = Describe("Services", func() {
 		ip := pickNodeIP(c)
 		testReachable(ip, nodePort)
 
-		hosts, err := NodeSSHHosts(c)
-		if err != nil {
-			Expect(err).NotTo(HaveOccurred())
-		}
-		cmd := fmt.Sprintf(`test -n "$(ss -ant46 'sport = :%d' | tail -n +2 | grep LISTEN)"`, nodePort)
-		_, _, code, err := SSH(cmd, hosts[0], testContext.Provider)
-		if code != 0 {
-			Failf("expected node port (%d) to be in use", nodePort)
+		// this test uses NodeSSHHosts that does not work if a Node only reports LegacyHostIP
+		if providerIs(providersWithSSH...) {
+			hosts, err := NodeSSHHosts(c)
+			if err != nil {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			cmd := fmt.Sprintf(`test -n "$(ss -ant46 'sport = :%d' | tail -n +2 | grep LISTEN)"`, nodePort)
+			_, _, code, err := SSH(cmd, hosts[0], testContext.Provider)
+			if code != 0 {
+				Failf("expected node port (%d) to be in use", nodePort)
+			}
 		}
 	})
 
@@ -740,14 +743,17 @@ var _ = Describe("Services", func() {
 		err = t.DeleteService(serviceName)
 		Expect(err).NotTo(HaveOccurred())
 
-		hosts, err := NodeSSHHosts(c)
-		if err != nil {
-			Expect(err).NotTo(HaveOccurred())
-		}
-		cmd := fmt.Sprintf(`test -n "$(ss -ant46 'sport = :%d' | tail -n +2 | grep LISTEN)"`, nodePort)
-		_, _, code, err := SSH(cmd, hosts[0], testContext.Provider)
-		if code == 0 {
-			Failf("expected node port (%d) to not be in use", nodePort)
+		// this test uses NodeSSHHosts that does not work if a Node only reports LegacyHostIP
+		if providerIs(providersWithSSH...) {
+			hosts, err := NodeSSHHosts(c)
+			if err != nil {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			cmd := fmt.Sprintf(`test -n "$(ss -ant46 'sport = :%d' | tail -n +2 | grep LISTEN)"`, nodePort)
+			_, _, code, err := SSH(cmd, hosts[0], testContext.Provider)
+			if code == 0 {
+				Failf("expected node port (%d) to not be in use", nodePort)
+			}
 		}
 
 		By(fmt.Sprintf("creating service "+serviceName+" with same NodePort %d", nodePort))

--- a/test/e2e/ssh.go
+++ b/test/e2e/ssh.go
@@ -35,7 +35,7 @@ var _ = Describe("SSH", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// When adding more providers here, also implement their functionality in util.go's getSigner(...).
-		SkipUnlessProviderIs("gce", "gke")
+		SkipUnlessProviderIs(providersWithSSH...)
 	})
 
 	It("should SSH to all nodes and run commands", func() {


### PR DESCRIPTION
Cherry pick of #14646 on release-1.1.

This fixes some e2e tests on release-1.1 which still depend on SSH on the hosts.
