### PR TITLE
Pass ListOptions to List() method in clients

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -305,7 +305,7 @@ func makeTempDirOrDie(prefix string, baseDir string) string {
 func podsOnNodes(c *client.Client, podNamespace string, labelSelector labels.Selector) wait.ConditionFunc {
 	// Wait until all pods are running on the node.
 	return func() (bool, error) {
-		pods, err := c.Pods(podNamespace).List(labelSelector, fields.Everything())
+		pods, err := c.Pods(podNamespace).List(labelSelector, fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			glog.Infof("Unable to get pods to list: %v", err)
 			return false, nil
@@ -431,7 +431,7 @@ containers:
 			namespace := kubetypes.NamespaceDefault
 			if err := wait.Poll(time.Second, longTestTimeout,
 				podRunning(c, namespace, podName)); err != nil {
-				if pods, err := c.Pods(namespace).List(labels.Everything(), fields.Everything()); err == nil {
+				if pods, err := c.Pods(namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{}); err == nil {
 					for _, pod := range pods.Items {
 						glog.Infof("pod found: %s/%s", namespace, pod.Name)
 					}
@@ -539,7 +539,7 @@ func runSelfLinkTestOnNamespace(c *client.Client, namespace string) {
 		glog.Fatalf("Failed listing service with supplied self link '%v': %v", svc.SelfLink, err)
 	}
 
-	svcList, err := services.List(labels.Everything(), fields.Everything())
+	svcList, err := services.List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		glog.Fatalf("Failed listing services: %v", err)
 	}
@@ -760,7 +760,7 @@ func runPatchTest(c *client.Client) {
 
 func runMasterServiceTest(client *client.Client) {
 	time.Sleep(12 * time.Second)
-	svcList, err := client.Services(api.NamespaceDefault).List(labels.Everything(), fields.Everything())
+	svcList, err := client.Services(api.NamespaceDefault).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		glog.Fatalf("Unexpected error listing services: %v", err)
 	}
@@ -887,7 +887,7 @@ func runServiceTest(client *client.Client) {
 		glog.Fatalf("FAILED: service in other namespace should have no endpoints: %v", err)
 	}
 
-	svcList, err := client.Services(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+	svcList, err := client.Services(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		glog.Fatalf("Failed to list services across namespaces: %v", err)
 	}

--- a/contrib/mesos/pkg/scheduler/components/framework/framework.go
+++ b/contrib/mesos/pkg/scheduler/components/framework/framework.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler/podtask"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/kubelet/container"
@@ -647,7 +648,7 @@ func (k *framework) makeTaskRegistryReconciler() taskreconciler.Action {
 // tasks identified by annotations in the Kubernetes pod registry.
 func (k *framework) makePodRegistryReconciler() taskreconciler.Action {
 	return taskreconciler.Action(func(drv bindings.SchedulerDriver, cancel <-chan struct{}) <-chan error {
-		podList, err := k.client.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+		podList, err := k.client.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return proc.ErrorChanf("failed to reconcile pod registry: %v", err)
 		}
@@ -723,7 +724,7 @@ func (k *framework) explicitlyReconcileTasks(driver bindings.SchedulerDriver, ta
 }
 
 func (ks *framework) recoverTasks() error {
-	podList, err := ks.client.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+	podList, err := ks.client.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		log.V(1).Infof("failed to recover pod registry, madness may ensue: %v", err)
 		return err

--- a/contrib/mesos/pkg/service/endpoints_controller.go
+++ b/contrib/mesos/pkg/service/endpoints_controller.go
@@ -60,7 +60,7 @@ func NewEndpointController(client *client.Client) *endpointController {
 	e.serviceStore.Store, e.serviceController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return e.client.Services(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return e.client.Services(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return e.client.Services(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -80,7 +80,7 @@ func NewEndpointController(client *client.Client) *endpointController {
 	e.podStore.Store, e.podController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return e.client.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return e.client.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return e.client.Pods(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -386,7 +386,7 @@ func (e *endpointController) syncService(key string) {
 // some stragglers could have been left behind if the endpoint controller
 // reboots).
 func (e *endpointController) checkLeftoverEndpoints() {
-	list, err := e.client.Endpoints(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+	list, err := e.client.Endpoints(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		glog.Errorf("Unable to list endpoints (%v); orphaned endpoints will not be cleaned up. (They're pretty harmless, but you can restart this component if you want another attempt made.)", err)
 		return

--- a/pkg/client/unversioned/daemon_sets.go
+++ b/pkg/client/unversioned/daemon_sets.go
@@ -31,7 +31,7 @@ type DaemonSetsNamespacer interface {
 }
 
 type DaemonSetInterface interface {
-	List(label labels.Selector, field fields.Selector) (*extensions.DaemonSetList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*extensions.DaemonSetList, error)
 	Get(name string) (*extensions.DaemonSet, error)
 	Create(ctrl *extensions.DaemonSet) (*extensions.DaemonSet, error)
 	Update(ctrl *extensions.DaemonSet) (*extensions.DaemonSet, error)
@@ -53,9 +53,9 @@ func newDaemonSets(c *ExtensionsClient, namespace string) *daemonSets {
 // Ensure statically that daemonSets implements DaemonSetsInterface.
 var _ DaemonSetInterface = &daemonSets{}
 
-func (c *daemonSets) List(label labels.Selector, field fields.Selector) (result *extensions.DaemonSetList, err error) {
+func (c *daemonSets) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *extensions.DaemonSetList, err error) {
 	result = &extensions.DaemonSetList{}
-	err = c.r.Get().Namespace(c.ns).Resource("daemonsets").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("daemonsets").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/daemon_sets_test.go
+++ b/pkg/client/unversioned/daemon_sets_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -56,7 +57,7 @@ func TestListDaemonSets(t *testing.T) {
 			},
 		},
 	}
-	receivedDSs, err := c.Setup(t).Extensions().DaemonSets(ns).List(labels.Everything(), fields.Everything())
+	receivedDSs, err := c.Setup(t).Extensions().DaemonSets(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, receivedDSs, err)
 
 }

--- a/pkg/client/unversioned/deployment.go
+++ b/pkg/client/unversioned/deployment.go
@@ -32,7 +32,7 @@ type DeploymentsNamespacer interface {
 
 // DeploymentInterface has methods to work with Deployment resources.
 type DeploymentInterface interface {
-	List(label labels.Selector, field fields.Selector) (*extensions.DeploymentList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*extensions.DeploymentList, error)
 	Get(name string) (*extensions.Deployment, error)
 	Delete(name string, options *api.DeleteOptions) error
 	Create(*extensions.Deployment) (*extensions.Deployment, error)
@@ -56,9 +56,9 @@ func newDeployments(c *ExtensionsClient, namespace string) *deployments {
 }
 
 // List takes label and field selectors, and returns the list of Deployments that match those selectors.
-func (c *deployments) List(label labels.Selector, field fields.Selector) (result *extensions.DeploymentList, err error) {
+func (c *deployments) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *extensions.DeploymentList, err error) {
 	result = &extensions.DeploymentList{}
-	err = c.client.Get().Namespace(c.ns).Resource("deployments").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.client.Get().Namespace(c.ns).Resource("deployments").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/deployment_test.go
+++ b/pkg/client/unversioned/deployment_test.go
@@ -100,7 +100,7 @@ func TestDeploymentList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: deploymentList},
 	}
-	response, err := c.Setup(t).Deployments(ns).List(labels.Everything(), fields.Everything())
+	response, err := c.Setup(t).Deployments(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, response, err)
 }
 

--- a/pkg/client/unversioned/endpoints.go
+++ b/pkg/client/unversioned/endpoints.go
@@ -34,7 +34,7 @@ type EndpointsNamespacer interface {
 // EndpointsInterface has methods to work with Endpoints resources
 type EndpointsInterface interface {
 	Create(endpoints *api.Endpoints) (*api.Endpoints, error)
-	List(label labels.Selector, field fields.Selector) (*api.EndpointsList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.EndpointsList, error)
 	Get(name string) (*api.Endpoints, error)
 	Delete(name string) error
 	Update(endpoints *api.Endpoints) (*api.Endpoints, error)
@@ -60,11 +60,12 @@ func (c *endpoints) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
 }
 
 // List takes a selector, and returns the list of endpoints that match that selector
-func (c *endpoints) List(label labels.Selector, field fields.Selector) (result *api.EndpointsList, err error) {
+func (c *endpoints) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *api.EndpointsList, err error) {
 	result = &api.EndpointsList{}
 	err = c.r.Get().
 		Namespace(c.ns).
 		Resource("endpoints").
+		VersionedParams(&opts, api.Scheme).
 		LabelsSelectorParam(label).
 		FieldsSelectorParam(field).
 		Do().

--- a/pkg/client/unversioned/endpoints_test.go
+++ b/pkg/client/unversioned/endpoints_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -43,7 +44,7 @@ func TestListEndpoints(t *testing.T) {
 			},
 		},
 	}
-	receivedEndpointsList, err := c.Setup(t).Endpoints(ns).List(labels.Everything(), fields.Everything())
+	receivedEndpointsList, err := c.Setup(t).Endpoints(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, receivedEndpointsList, err)
 }
 

--- a/pkg/client/unversioned/events.go
+++ b/pkg/client/unversioned/events.go
@@ -37,7 +37,7 @@ type EventInterface interface {
 	Create(event *api.Event) (*api.Event, error)
 	Update(event *api.Event) (*api.Event, error)
 	Patch(event *api.Event, data []byte) (*api.Event, error)
-	List(label labels.Selector, field fields.Selector) (*api.EventList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.EventList, error)
 	Get(name string) (*api.Event, error)
 	Watch(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (watch.Interface, error)
 	// Search finds events about the specified object
@@ -117,11 +117,12 @@ func (e *events) Patch(incompleteEvent *api.Event, data []byte) (*api.Event, err
 }
 
 // List returns a list of events matching the selectors.
-func (e *events) List(label labels.Selector, field fields.Selector) (*api.EventList, error) {
+func (e *events) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.EventList, error) {
 	result := &api.EventList{}
 	err := e.client.Get().
 		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
 		Resource("events").
+		VersionedParams(&opts, api.Scheme).
 		LabelsSelectorParam(label).
 		FieldsSelectorParam(field).
 		Do().
@@ -175,7 +176,7 @@ func (e *events) Search(objOrRef runtime.Object) (*api.EventList, error) {
 		refUID = &stringRefUID
 	}
 	fieldSelector := e.GetFieldSelector(&ref.Name, &ref.Namespace, refKind, refUID)
-	return e.List(labels.Everything(), fieldSelector)
+	return e.List(labels.Everything(), fieldSelector, unversioned.ListOptions{})
 }
 
 // Delete deletes an existing event.

--- a/pkg/client/unversioned/events_test.go
+++ b/pkg/client/unversioned/events_test.go
@@ -167,7 +167,7 @@ func TestEventList(t *testing.T) {
 		Response: Response{StatusCode: 200, Body: eventList},
 	}
 	response, err := c.Setup(t).Events(ns).List(labels.Everything(),
-		fields.Everything())
+		fields.Everything(), unversioned.ListOptions{})
 
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)

--- a/pkg/client/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/unversioned/horizontalpodautoscaler.go
@@ -32,7 +32,7 @@ type HorizontalPodAutoscalersNamespacer interface {
 
 // HorizontalPodAutoscalerInterface has methods to work with HorizontalPodAutoscaler resources.
 type HorizontalPodAutoscalerInterface interface {
-	List(label labels.Selector, field fields.Selector) (*extensions.HorizontalPodAutoscalerList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*extensions.HorizontalPodAutoscalerList, error)
 	Get(name string) (*extensions.HorizontalPodAutoscaler, error)
 	Delete(name string, options *api.DeleteOptions) error
 	Create(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (*extensions.HorizontalPodAutoscaler, error)
@@ -56,9 +56,9 @@ func newHorizontalPodAutoscalers(c *ExtensionsClient, namespace string) *horizon
 }
 
 // List takes label and field selectors, and returns the list of horizontalPodAutoscalers that match those selectors.
-func (c *horizontalPodAutoscalers) List(label labels.Selector, field fields.Selector) (result *extensions.HorizontalPodAutoscalerList, err error) {
+func (c *horizontalPodAutoscalers) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *extensions.HorizontalPodAutoscalerList, err error) {
 	result = &extensions.HorizontalPodAutoscalerList{}
-	err = c.client.Get().Namespace(c.ns).Resource("horizontalPodAutoscalers").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.client.Get().Namespace(c.ns).Resource("horizontalPodAutoscalers").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/horizontalpodautoscaler_test.go
+++ b/pkg/client/unversioned/horizontalpodautoscaler_test.go
@@ -100,7 +100,7 @@ func TestHorizontalPodAutoscalerList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: horizontalPodAutoscalerList},
 	}
-	response, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).List(labels.Everything(), fields.Everything())
+	response, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, response, err)
 }
 

--- a/pkg/client/unversioned/ingress.go
+++ b/pkg/client/unversioned/ingress.go
@@ -32,7 +32,7 @@ type IngressNamespacer interface {
 
 // IngressInterface exposes methods to work on Ingress resources.
 type IngressInterface interface {
-	List(label labels.Selector, field fields.Selector) (*extensions.IngressList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*extensions.IngressList, error)
 	Get(name string) (*extensions.Ingress, error)
 	Create(ingress *extensions.Ingress) (*extensions.Ingress, error)
 	Update(ingress *extensions.Ingress) (*extensions.Ingress, error)
@@ -53,9 +53,9 @@ func newIngress(c *ExtensionsClient, namespace string) *ingress {
 }
 
 // List returns a list of ingress that match the label and field selectors.
-func (c *ingress) List(label labels.Selector, field fields.Selector) (result *extensions.IngressList, err error) {
+func (c *ingress) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *extensions.IngressList, err error) {
 	result = &extensions.IngressList{}
-	err = c.r.Get().Namespace(c.ns).Resource("ingresses").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("ingresses").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/ingress_test.go
+++ b/pkg/client/unversioned/ingress_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -56,7 +57,7 @@ func TestListIngress(t *testing.T) {
 			},
 		},
 	}
-	receivedIngressList, err := c.Setup(t).Extensions().Ingress(ns).List(labels.Everything(), fields.Everything())
+	receivedIngressList, err := c.Setup(t).Extensions().Ingress(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, receivedIngressList, err)
 }
 

--- a/pkg/client/unversioned/jobs.go
+++ b/pkg/client/unversioned/jobs.go
@@ -33,7 +33,7 @@ type JobsNamespacer interface {
 
 // JobInterface exposes methods to work on Job resources.
 type JobInterface interface {
-	List(label labels.Selector, field fields.Selector) (*extensions.JobList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*extensions.JobList, error)
 	Get(name string) (*extensions.Job, error)
 	Create(job *extensions.Job) (*extensions.Job, error)
 	Update(job *extensions.Job) (*extensions.Job, error)
@@ -57,9 +57,9 @@ func newJobs(c *ExtensionsClient, namespace string) *jobs {
 var _ JobInterface = &jobs{}
 
 // List returns a list of jobs that match the label and field selectors.
-func (c *jobs) List(label labels.Selector, field fields.Selector) (result *extensions.JobList, err error) {
+func (c *jobs) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *extensions.JobList, err error) {
 	result = &extensions.JobList{}
-	err = c.r.Get().Namespace(c.ns).Resource("jobs").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("jobs").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/jobs_test.go
+++ b/pkg/client/unversioned/jobs_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -56,7 +57,7 @@ func TestListJobs(t *testing.T) {
 			},
 		},
 	}
-	receivedJobList, err := c.Setup(t).Extensions().Jobs(ns).List(labels.Everything(), fields.Everything())
+	receivedJobList, err := c.Setup(t).Extensions().Jobs(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, receivedJobList, err)
 }
 

--- a/pkg/client/unversioned/limit_ranges.go
+++ b/pkg/client/unversioned/limit_ranges.go
@@ -33,7 +33,7 @@ type LimitRangesNamespacer interface {
 
 // LimitRangeInterface has methods to work with LimitRange resources.
 type LimitRangeInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.LimitRangeList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.LimitRangeList, error)
 	Get(name string) (*api.LimitRange, error)
 	Delete(name string) error
 	Create(limitRange *api.LimitRange) (*api.LimitRange, error)
@@ -56,9 +56,9 @@ func newLimitRanges(c *Client, namespace string) *limitRanges {
 }
 
 // List takes a selector, and returns the list of limitRanges that match that selector.
-func (c *limitRanges) List(label labels.Selector, field fields.Selector) (result *api.LimitRangeList, err error) {
+func (c *limitRanges) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *api.LimitRangeList, err error) {
 	result = &api.LimitRangeList{}
-	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/limit_ranges_test.go
+++ b/pkg/client/unversioned/limit_ranges_test.go
@@ -123,7 +123,7 @@ func TestLimitRangeList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: limitRangeList},
 	}
-	response, err := c.Setup(t).LimitRanges(ns).List(labels.Everything(), fields.Everything())
+	response, err := c.Setup(t).LimitRanges(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, response, err)
 }
 

--- a/pkg/client/unversioned/namespaces.go
+++ b/pkg/client/unversioned/namespaces.go
@@ -33,7 +33,7 @@ type NamespacesInterface interface {
 type NamespaceInterface interface {
 	Create(item *api.Namespace) (*api.Namespace, error)
 	Get(name string) (result *api.Namespace, err error)
-	List(label labels.Selector, field fields.Selector) (*api.NamespaceList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.NamespaceList, error)
 	Delete(name string) error
 	Update(item *api.Namespace) (*api.Namespace, error)
 	Watch(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (watch.Interface, error)
@@ -59,10 +59,11 @@ func (c *namespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
 }
 
 // List lists all the namespaces in the cluster.
-func (c *namespaces) List(label labels.Selector, field fields.Selector) (*api.NamespaceList, error) {
+func (c *namespaces) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.NamespaceList, error) {
 	result := &api.NamespaceList{}
 	err := c.r.Get().
 		Resource("namespaces").
+		VersionedParams(&opts, api.Scheme).
 		LabelsSelectorParam(label).
 		FieldsSelectorParam(field).
 		Do().Into(result)

--- a/pkg/client/unversioned/namespaces_test.go
+++ b/pkg/client/unversioned/namespaces_test.go
@@ -93,7 +93,7 @@ func TestNamespaceList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: namespaceList},
 	}
-	response, err := c.Setup(t).Namespaces().List(labels.Everything(), fields.Everything())
+	response, err := c.Setup(t).Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)

--- a/pkg/client/unversioned/nodes.go
+++ b/pkg/client/unversioned/nodes.go
@@ -33,7 +33,7 @@ type NodesInterface interface {
 type NodeInterface interface {
 	Get(name string) (result *api.Node, err error)
 	Create(node *api.Node) (*api.Node, error)
-	List(label labels.Selector, field fields.Selector) (*api.NodeList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.NodeList, error)
 	Delete(name string) error
 	Update(*api.Node) (*api.Node, error)
 	UpdateStatus(*api.Node) (*api.Node, error)
@@ -63,9 +63,9 @@ func (c *nodes) Create(node *api.Node) (*api.Node, error) {
 }
 
 // List takes a selector, and returns the list of nodes that match that selector in the cluster.
-func (c *nodes) List(label labels.Selector, field fields.Selector) (*api.NodeList, error) {
+func (c *nodes) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.NodeList, error) {
 	result := &api.NodeList{}
-	err := c.r.Get().Resource(c.resourceName()).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err := c.r.Get().Resource(c.resourceName()).VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return result, err
 }
 

--- a/pkg/client/unversioned/nodes_test.go
+++ b/pkg/client/unversioned/nodes_test.go
@@ -40,7 +40,7 @@ func TestListNodes(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: &api.NodeList{ListMeta: unversioned.ListMeta{ResourceVersion: "1"}}},
 	}
-	response, err := c.Setup(t).Nodes().List(labels.Everything(), fields.Everything())
+	response, err := c.Setup(t).Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, response, err)
 }
 
@@ -70,7 +70,7 @@ func TestListNodesLabels(t *testing.T) {
 	c.Setup(t)
 	c.QueryValidator[labelSelectorQueryParamName] = validateLabels
 	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
-	receivedNodeList, err := c.Nodes().List(selector, fields.Everything())
+	receivedNodeList, err := c.Nodes().List(selector, fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, receivedNodeList, err)
 }
 

--- a/pkg/client/unversioned/persistentvolume_test.go
+++ b/pkg/client/unversioned/persistentvolume_test.go
@@ -107,7 +107,7 @@ func TestPersistentVolumeList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: persistentVolumeList},
 	}
-	response, err := c.Setup(t).PersistentVolumes().List(labels.Everything(), fields.Everything())
+	response, err := c.Setup(t).PersistentVolumes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, response, err)
 }
 

--- a/pkg/client/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/unversioned/persistentvolumeclaim.go
@@ -33,7 +33,7 @@ type PersistentVolumeClaimsNamespacer interface {
 
 // PersistentVolumeClaimInterface has methods to work with PersistentVolumeClaim resources.
 type PersistentVolumeClaimInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeClaimList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.PersistentVolumeClaimList, error)
 	Get(name string) (*api.PersistentVolumeClaim, error)
 	Create(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
 	Update(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
@@ -53,12 +53,13 @@ func newPersistentVolumeClaims(c *Client, namespace string) *persistentVolumeCla
 	return &persistentVolumeClaims{c, namespace}
 }
 
-func (c *persistentVolumeClaims) List(label labels.Selector, field fields.Selector) (result *api.PersistentVolumeClaimList, err error) {
+func (c *persistentVolumeClaims) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *api.PersistentVolumeClaimList, err error) {
 	result = &api.PersistentVolumeClaimList{}
 
 	err = c.client.Get().
 		Namespace(c.namespace).
 		Resource("persistentVolumeClaims").
+		VersionedParams(&opts, api.Scheme).
 		LabelsSelectorParam(label).
 		FieldsSelectorParam(field).
 		Do().

--- a/pkg/client/unversioned/persistentvolumeclaim_test.go
+++ b/pkg/client/unversioned/persistentvolumeclaim_test.go
@@ -116,7 +116,7 @@ func TestPersistentVolumeClaimList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: persistentVolumeList},
 	}
-	response, err := c.Setup(t).PersistentVolumeClaims(ns).List(labels.Everything(), fields.Everything())
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, response, err)
 }
 

--- a/pkg/client/unversioned/persistentvolumes.go
+++ b/pkg/client/unversioned/persistentvolumes.go
@@ -32,7 +32,7 @@ type PersistentVolumesInterface interface {
 
 // PersistentVolumeInterface has methods to work with PersistentVolume resources.
 type PersistentVolumeInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.PersistentVolumeList, error)
 	Get(name string) (*api.PersistentVolume, error)
 	Create(volume *api.PersistentVolume) (*api.PersistentVolume, error)
 	Update(volume *api.PersistentVolume) (*api.PersistentVolume, error)
@@ -50,10 +50,11 @@ func newPersistentVolumes(c *Client) *persistentVolumes {
 	return &persistentVolumes{c}
 }
 
-func (c *persistentVolumes) List(label labels.Selector, field fields.Selector) (result *api.PersistentVolumeList, err error) {
+func (c *persistentVolumes) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *api.PersistentVolumeList, err error) {
 	result = &api.PersistentVolumeList{}
 	err = c.client.Get().
 		Resource("persistentVolumes").
+		VersionedParams(&opts, api.Scheme).
 		LabelsSelectorParam(label).
 		FieldsSelectorParam(field).
 		Do().

--- a/pkg/client/unversioned/pod_templates.go
+++ b/pkg/client/unversioned/pod_templates.go
@@ -31,7 +31,7 @@ type PodTemplatesNamespacer interface {
 
 // PodTemplateInterface has methods to work with PodTemplate resources.
 type PodTemplateInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.PodTemplateList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.PodTemplateList, error)
 	Get(name string) (*api.PodTemplate, error)
 	Delete(name string, options *api.DeleteOptions) error
 	Create(podTemplate *api.PodTemplate) (*api.PodTemplate, error)
@@ -54,9 +54,9 @@ func newPodTemplates(c *Client, namespace string) *podTemplates {
 }
 
 // List takes label and field selectors, and returns the list of podTemplates that match those selectors.
-func (c *podTemplates) List(label labels.Selector, field fields.Selector) (result *api.PodTemplateList, err error) {
+func (c *podTemplates) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *api.PodTemplateList, err error) {
 	result = &api.PodTemplateList{}
-	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/pod_templates_test.go
+++ b/pkg/client/unversioned/pod_templates_test.go
@@ -98,7 +98,7 @@ func TestPodTemplateList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: podTemplateList},
 	}
-	response, err := c.Setup(t).PodTemplates(ns).List(labels.Everything(), fields.Everything())
+	response, err := c.Setup(t).PodTemplates(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, response, err)
 }
 

--- a/pkg/client/unversioned/pods.go
+++ b/pkg/client/unversioned/pods.go
@@ -31,7 +31,7 @@ type PodsNamespacer interface {
 
 // PodInterface has methods to work with Pod resources.
 type PodInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.PodList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.PodList, error)
 	Get(name string) (*api.Pod, error)
 	Delete(name string, options *api.DeleteOptions) error
 	Create(pod *api.Pod) (*api.Pod, error)
@@ -57,9 +57,9 @@ func newPods(c *Client, namespace string) *pods {
 }
 
 // List takes label and field selectors, and returns the list of pods that match those selectors.
-func (c *pods) List(label labels.Selector, field fields.Selector) (result *api.PodList, err error) {
+func (c *pods) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *api.PodList, err error) {
 	result = &api.PodList{}
-	err = c.r.Get().Namespace(c.ns).Resource("pods").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("pods").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/pods_test.go
+++ b/pkg/client/unversioned/pods_test.go
@@ -34,7 +34,7 @@ func TestListEmptyPods(t *testing.T) {
 		Request:  testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: http.StatusOK, Body: &api.PodList{}},
 	}
-	podList, err := c.Setup(t).Pods(ns).List(labels.Everything(), fields.Everything())
+	podList, err := c.Setup(t).Pods(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, podList, err)
 }
 
@@ -60,7 +60,7 @@ func TestListPods(t *testing.T) {
 			},
 		},
 	}
-	receivedPodList, err := c.Setup(t).Pods(ns).List(labels.Everything(), fields.Everything())
+	receivedPodList, err := c.Setup(t).Pods(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, receivedPodList, err)
 }
 
@@ -94,7 +94,7 @@ func TestListPodsLabels(t *testing.T) {
 	c.Setup(t)
 	c.QueryValidator[labelSelectorQueryParamName] = validateLabels
 	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
-	receivedPodList, err := c.Pods(ns).List(selector, fields.Everything())
+	receivedPodList, err := c.Pods(ns).List(selector, fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, receivedPodList, err)
 }
 

--- a/pkg/client/unversioned/replication_controllers.go
+++ b/pkg/client/unversioned/replication_controllers.go
@@ -31,7 +31,7 @@ type ReplicationControllersNamespacer interface {
 
 // ReplicationControllerInterface has methods to work with ReplicationController resources.
 type ReplicationControllerInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.ReplicationControllerList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.ReplicationControllerList, error)
 	Get(name string) (*api.ReplicationController, error)
 	Create(ctrl *api.ReplicationController) (*api.ReplicationController, error)
 	Update(ctrl *api.ReplicationController) (*api.ReplicationController, error)
@@ -52,9 +52,9 @@ func newReplicationControllers(c *Client, namespace string) *replicationControll
 }
 
 // List takes a selector, and returns the list of replication controllers that match that selector.
-func (c *replicationControllers) List(label labels.Selector, field fields.Selector) (result *api.ReplicationControllerList, err error) {
+func (c *replicationControllers) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *api.ReplicationControllerList, err error) {
 	result = &api.ReplicationControllerList{}
-	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/replication_controllers_test.go
+++ b/pkg/client/unversioned/replication_controllers_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -56,7 +57,7 @@ func TestListControllers(t *testing.T) {
 			},
 		},
 	}
-	receivedControllerList, err := c.Setup(t).ReplicationControllers(ns).List(labels.Everything(), fields.Everything())
+	receivedControllerList, err := c.Setup(t).ReplicationControllers(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, receivedControllerList, err)
 
 }

--- a/pkg/client/unversioned/resource_quotas.go
+++ b/pkg/client/unversioned/resource_quotas.go
@@ -31,7 +31,7 @@ type ResourceQuotasNamespacer interface {
 
 // ResourceQuotaInterface has methods to work with ResourceQuota resources.
 type ResourceQuotaInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.ResourceQuotaList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.ResourceQuotaList, error)
 	Get(name string) (*api.ResourceQuota, error)
 	Delete(name string) error
 	Create(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
@@ -55,9 +55,9 @@ func newResourceQuotas(c *Client, namespace string) *resourceQuotas {
 }
 
 // List takes a selector, and returns the list of resourceQuotas that match that selector.
-func (c *resourceQuotas) List(label labels.Selector, field fields.Selector) (result *api.ResourceQuotaList, err error) {
+func (c *resourceQuotas) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *api.ResourceQuotaList, err error) {
 	result = &api.ResourceQuotaList{}
-	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").VersionedParams(&opts, api.Scheme).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/resource_quotas_test.go
+++ b/pkg/client/unversioned/resource_quotas_test.go
@@ -115,7 +115,7 @@ func TestResourceQuotaList(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200, Body: resourceQuotaList},
 	}
-	response, err := c.Setup(t).ResourceQuotas(ns).List(labels.Everything(), fields.Everything())
+	response, err := c.Setup(t).ResourceQuotas(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, response, err)
 }
 

--- a/pkg/client/unversioned/secrets.go
+++ b/pkg/client/unversioned/secrets.go
@@ -32,7 +32,7 @@ type SecretsInterface interface {
 	Create(secret *api.Secret) (*api.Secret, error)
 	Update(secret *api.Secret) (*api.Secret, error)
 	Delete(name string) error
-	List(label labels.Selector, field fields.Selector) (*api.SecretList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.SecretList, error)
 	Get(name string) (*api.Secret, error)
 	Watch(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (watch.Interface, error)
 }
@@ -64,12 +64,13 @@ func (s *secrets) Create(secret *api.Secret) (*api.Secret, error) {
 }
 
 // List returns a list of secrets matching the selectors.
-func (s *secrets) List(label labels.Selector, field fields.Selector) (*api.SecretList, error) {
+func (s *secrets) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.SecretList, error) {
 	result := &api.SecretList{}
 
 	err := s.client.Get().
 		Namespace(s.namespace).
 		Resource("secrets").
+		VersionedParams(&opts, api.Scheme).
 		LabelsSelectorParam(label).
 		FieldsSelectorParam(field).
 		Do().

--- a/pkg/client/unversioned/service_accounts.go
+++ b/pkg/client/unversioned/service_accounts.go
@@ -32,7 +32,7 @@ type ServiceAccountsInterface interface {
 	Create(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error)
 	Update(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error)
 	Delete(name string) error
-	List(label labels.Selector, field fields.Selector) (*api.ServiceAccountList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.ServiceAccountList, error)
 	Get(name string) (*api.ServiceAccount, error)
 	Watch(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (watch.Interface, error)
 }
@@ -64,12 +64,13 @@ func (s *serviceAccounts) Create(serviceAccount *api.ServiceAccount) (*api.Servi
 }
 
 // List returns a list of serviceAccounts matching the selectors.
-func (s *serviceAccounts) List(label labels.Selector, field fields.Selector) (*api.ServiceAccountList, error) {
+func (s *serviceAccounts) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.ServiceAccountList, error) {
 	result := &api.ServiceAccountList{}
 
 	err := s.client.Get().
 		Namespace(s.namespace).
 		Resource("serviceAccounts").
+		VersionedParams(&opts, api.Scheme).
 		LabelsSelectorParam(label).
 		FieldsSelectorParam(field).
 		Do().

--- a/pkg/client/unversioned/services.go
+++ b/pkg/client/unversioned/services.go
@@ -32,7 +32,7 @@ type ServicesNamespacer interface {
 
 // ServiceInterface has methods to work with Service resources.
 type ServiceInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.ServiceList, error)
+	List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.ServiceList, error)
 	Get(name string) (*api.Service, error)
 	Create(srv *api.Service) (*api.Service, error)
 	Update(srv *api.Service) (*api.Service, error)
@@ -53,11 +53,12 @@ func newServices(c *Client, namespace string) *services {
 }
 
 // List takes a selector, and returns the list of services that match that selector
-func (c *services) List(label labels.Selector, field fields.Selector) (result *api.ServiceList, err error) {
+func (c *services) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (result *api.ServiceList, err error) {
 	result = &api.ServiceList{}
 	err = c.r.Get().
 		Namespace(c.ns).
 		Resource("services").
+		VersionedParams(&opts, api.Scheme).
 		LabelsSelectorParam(label).
 		FieldsSelectorParam(field).
 		Do().

--- a/pkg/client/unversioned/services_test.go
+++ b/pkg/client/unversioned/services_test.go
@@ -55,7 +55,7 @@ func TestListServices(t *testing.T) {
 			},
 		},
 	}
-	receivedServiceList, err := c.Setup(t).Services(ns).List(labels.Everything(), fields.Everything())
+	receivedServiceList, err := c.Setup(t).Services(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	t.Logf("received services: %v %#v", err, receivedServiceList)
 	c.Validate(t, receivedServiceList, err)
 }
@@ -92,7 +92,7 @@ func TestListServicesLabels(t *testing.T) {
 	c.Setup(t)
 	c.QueryValidator[labelSelectorQueryParamName] = validateLabels
 	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
-	receivedServiceList, err := c.Services(ns).List(selector, fields.Everything())
+	receivedServiceList, err := c.Services(ns).List(selector, fields.Everything(), unversioned.ListOptions{})
 	c.Validate(t, receivedServiceList, err)
 }
 

--- a/pkg/client/unversioned/testclient/fake_daemon_sets.go
+++ b/pkg/client/unversioned/testclient/fake_daemon_sets.go
@@ -43,7 +43,7 @@ func (c *FakeDaemonSets) Get(name string) (*extensions.DaemonSet, error) {
 	return obj.(*extensions.DaemonSet), err
 }
 
-func (c *FakeDaemonSets) List(label labels.Selector, field fields.Selector) (*extensions.DaemonSetList, error) {
+func (c *FakeDaemonSets) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*extensions.DaemonSetList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("daemonsets", c.Namespace, label, field), &extensions.DaemonSetList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_deployments.go
+++ b/pkg/client/unversioned/testclient/fake_deployments.go
@@ -41,7 +41,7 @@ func (c *FakeDeployments) Get(name string) (*extensions.Deployment, error) {
 	return obj.(*extensions.Deployment), err
 }
 
-func (c *FakeDeployments) List(label labels.Selector, field fields.Selector) (*extensions.DeploymentList, error) {
+func (c *FakeDeployments) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*extensions.DeploymentList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("deployments", c.Namespace, label, field), &extensions.DeploymentList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_endpoints.go
+++ b/pkg/client/unversioned/testclient/fake_endpoints.go
@@ -40,7 +40,7 @@ func (c *FakeEndpoints) Get(name string) (*api.Endpoints, error) {
 	return obj.(*api.Endpoints), err
 }
 
-func (c *FakeEndpoints) List(label labels.Selector, field fields.Selector) (*api.EndpointsList, error) {
+func (c *FakeEndpoints) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.EndpointsList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("endpoints", c.Namespace, label, field), &api.EndpointsList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_events.go
+++ b/pkg/client/unversioned/testclient/fake_events.go
@@ -47,7 +47,7 @@ func (c *FakeEvents) Get(name string) (*api.Event, error) {
 }
 
 // List returns a list of events matching the selectors.
-func (c *FakeEvents) List(label labels.Selector, field fields.Selector) (*api.EventList, error) {
+func (c *FakeEvents) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.EventList, error) {
 	action := NewRootListAction("events", label, field)
 	if c.Namespace != "" {
 		action = NewListAction("events", c.Namespace, label, field)

--- a/pkg/client/unversioned/testclient/fake_horizontal_pod_autoscalers.go
+++ b/pkg/client/unversioned/testclient/fake_horizontal_pod_autoscalers.go
@@ -41,7 +41,7 @@ func (c *FakeHorizontalPodAutoscalers) Get(name string) (*extensions.HorizontalP
 	return obj.(*extensions.HorizontalPodAutoscaler), err
 }
 
-func (c *FakeHorizontalPodAutoscalers) List(label labels.Selector, field fields.Selector) (*extensions.HorizontalPodAutoscalerList, error) {
+func (c *FakeHorizontalPodAutoscalers) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*extensions.HorizontalPodAutoscalerList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("horizontalpodautoscalers", c.Namespace, label, field), &extensions.HorizontalPodAutoscalerList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_ingress.go
+++ b/pkg/client/unversioned/testclient/fake_ingress.go
@@ -41,7 +41,7 @@ func (c *FakeIngress) Get(name string) (*extensions.Ingress, error) {
 	return obj.(*extensions.Ingress), err
 }
 
-func (c *FakeIngress) List(label labels.Selector, fields fields.Selector) (*extensions.IngressList, error) {
+func (c *FakeIngress) List(label labels.Selector, fields fields.Selector, opts unversioned.ListOptions) (*extensions.IngressList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("ingresses", c.Namespace, label, nil), &extensions.IngressList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_jobs.go
+++ b/pkg/client/unversioned/testclient/fake_jobs.go
@@ -41,7 +41,7 @@ func (c *FakeJobs) Get(name string) (*extensions.Job, error) {
 	return obj.(*extensions.Job), err
 }
 
-func (c *FakeJobs) List(label labels.Selector, fields fields.Selector) (*extensions.JobList, error) {
+func (c *FakeJobs) List(label labels.Selector, fields fields.Selector, opts unversioned.ListOptions) (*extensions.JobList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("jobs", c.Namespace, label, nil), &extensions.JobList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_limit_ranges.go
+++ b/pkg/client/unversioned/testclient/fake_limit_ranges.go
@@ -40,7 +40,7 @@ func (c *FakeLimitRanges) Get(name string) (*api.LimitRange, error) {
 	return obj.(*api.LimitRange), err
 }
 
-func (c *FakeLimitRanges) List(label labels.Selector, field fields.Selector) (*api.LimitRangeList, error) {
+func (c *FakeLimitRanges) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.LimitRangeList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("limitranges", c.Namespace, label, field), &api.LimitRangeList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_namespaces.go
+++ b/pkg/client/unversioned/testclient/fake_namespaces.go
@@ -39,7 +39,7 @@ func (c *FakeNamespaces) Get(name string) (*api.Namespace, error) {
 	return obj.(*api.Namespace), err
 }
 
-func (c *FakeNamespaces) List(label labels.Selector, field fields.Selector) (*api.NamespaceList, error) {
+func (c *FakeNamespaces) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.NamespaceList, error) {
 	obj, err := c.Fake.Invokes(NewRootListAction("namespaces", label, field), &api.NamespaceList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_nodes.go
+++ b/pkg/client/unversioned/testclient/fake_nodes.go
@@ -39,7 +39,7 @@ func (c *FakeNodes) Get(name string) (*api.Node, error) {
 	return obj.(*api.Node), err
 }
 
-func (c *FakeNodes) List(label labels.Selector, field fields.Selector) (*api.NodeList, error) {
+func (c *FakeNodes) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.NodeList, error) {
 	obj, err := c.Fake.Invokes(NewRootListAction("nodes", label, field), &api.NodeList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_persistent_volume_claims.go
+++ b/pkg/client/unversioned/testclient/fake_persistent_volume_claims.go
@@ -38,7 +38,7 @@ func (c *FakePersistentVolumeClaims) Get(name string) (*api.PersistentVolumeClai
 	return obj.(*api.PersistentVolumeClaim), err
 }
 
-func (c *FakePersistentVolumeClaims) List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeClaimList, error) {
+func (c *FakePersistentVolumeClaims) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.PersistentVolumeClaimList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("persistentvolumeclaims", c.Namespace, label, field), &api.PersistentVolumeClaimList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_persistent_volumes.go
+++ b/pkg/client/unversioned/testclient/fake_persistent_volumes.go
@@ -37,7 +37,7 @@ func (c *FakePersistentVolumes) Get(name string) (*api.PersistentVolume, error) 
 	return obj.(*api.PersistentVolume), err
 }
 
-func (c *FakePersistentVolumes) List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeList, error) {
+func (c *FakePersistentVolumes) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.PersistentVolumeList, error) {
 	obj, err := c.Fake.Invokes(NewRootListAction("persistentvolumes", label, field), &api.PersistentVolumeList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_pod_templates.go
+++ b/pkg/client/unversioned/testclient/fake_pod_templates.go
@@ -40,7 +40,7 @@ func (c *FakePodTemplates) Get(name string) (*api.PodTemplate, error) {
 	return obj.(*api.PodTemplate), err
 }
 
-func (c *FakePodTemplates) List(label labels.Selector, field fields.Selector) (*api.PodTemplateList, error) {
+func (c *FakePodTemplates) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.PodTemplateList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("podtemplates", c.Namespace, label, field), &api.PodTemplateList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_pods.go
+++ b/pkg/client/unversioned/testclient/fake_pods.go
@@ -41,7 +41,7 @@ func (c *FakePods) Get(name string) (*api.Pod, error) {
 	return obj.(*api.Pod), err
 }
 
-func (c *FakePods) List(label labels.Selector, field fields.Selector) (*api.PodList, error) {
+func (c *FakePods) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.PodList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("pods", c.Namespace, label, field), &api.PodList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_replication_controllers.go
+++ b/pkg/client/unversioned/testclient/fake_replication_controllers.go
@@ -40,7 +40,7 @@ func (c *FakeReplicationControllers) Get(name string) (*api.ReplicationControlle
 	return obj.(*api.ReplicationController), err
 }
 
-func (c *FakeReplicationControllers) List(label labels.Selector, field fields.Selector) (*api.ReplicationControllerList, error) {
+func (c *FakeReplicationControllers) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.ReplicationControllerList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("replicationcontrollers", c.Namespace, label, field), &api.ReplicationControllerList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_resource_quotas.go
+++ b/pkg/client/unversioned/testclient/fake_resource_quotas.go
@@ -40,7 +40,7 @@ func (c *FakeResourceQuotas) Get(name string) (*api.ResourceQuota, error) {
 	return obj.(*api.ResourceQuota), err
 }
 
-func (c *FakeResourceQuotas) List(label labels.Selector, field fields.Selector) (*api.ResourceQuotaList, error) {
+func (c *FakeResourceQuotas) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.ResourceQuotaList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("resourcequotas", c.Namespace, label, field), &api.ResourceQuotaList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_secrets.go
+++ b/pkg/client/unversioned/testclient/fake_secrets.go
@@ -40,7 +40,7 @@ func (c *FakeSecrets) Get(name string) (*api.Secret, error) {
 	return obj.(*api.Secret), err
 }
 
-func (c *FakeSecrets) List(label labels.Selector, field fields.Selector) (*api.SecretList, error) {
+func (c *FakeSecrets) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.SecretList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("secrets", c.Namespace, label, field), &api.SecretList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_service_accounts.go
+++ b/pkg/client/unversioned/testclient/fake_service_accounts.go
@@ -40,7 +40,7 @@ func (c *FakeServiceAccounts) Get(name string) (*api.ServiceAccount, error) {
 	return obj.(*api.ServiceAccount), err
 }
 
-func (c *FakeServiceAccounts) List(label labels.Selector, field fields.Selector) (*api.ServiceAccountList, error) {
+func (c *FakeServiceAccounts) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.ServiceAccountList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("serviceaccounts", c.Namespace, label, field), &api.ServiceAccountList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/fake_services.go
+++ b/pkg/client/unversioned/testclient/fake_services.go
@@ -41,7 +41,7 @@ func (c *FakeServices) Get(name string) (*api.Service, error) {
 	return obj.(*api.Service), err
 }
 
-func (c *FakeServices) List(label labels.Selector, field fields.Selector) (*api.ServiceList, error) {
+func (c *FakeServices) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.ServiceList, error) {
 	obj, err := c.Fake.Invokes(NewListAction("services", c.Namespace, label, field), &api.ServiceList{})
 	if obj == nil {
 		return nil, err

--- a/pkg/client/unversioned/testclient/testclient_test.go
+++ b/pkg/client/unversioned/testclient/testclient_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -34,7 +35,7 @@ func TestNewClient(t *testing.T) {
 	}
 	client := &Fake{}
 	client.AddReactor("*", "*", ObjectReaction(o, testapi.Default.RESTMapper()))
-	list, err := client.Services("test").List(labels.Everything(), fields.Everything())
+	list, err := client.Services("test").List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +44,7 @@ func TestNewClient(t *testing.T) {
 	}
 
 	// When list is invoked a second time, the same results are returned.
-	list, err = client.Services("test").List(labels.Everything(), fields.Everything())
+	list, err = client.Services("test").List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,12 +66,12 @@ func TestErrors(t *testing.T) {
 	})
 	client := &Fake{}
 	client.AddReactor("*", "*", ObjectReaction(o, testapi.Default.RESTMapper()))
-	_, err := client.Services("test").List(labels.Everything(), fields.Everything())
+	_, err := client.Services("test").List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if !errors.IsNotFound(err) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	t.Logf("error: %#v", err.(*errors.StatusError).Status())
-	_, err = client.Services("test").List(labels.Everything(), fields.Everything())
+	_, err = client.Services("test").List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if !errors.IsForbidden(err) {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/controller/daemon/controller.go
+++ b/pkg/controller/daemon/controller.go
@@ -98,7 +98,7 @@ func NewDaemonSetsController(kubeClient client.Interface, resyncPeriod controlle
 	dsc.dsStore.Store, dsc.dsController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return dsc.kubeClient.Extensions().DaemonSets(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return dsc.kubeClient.Extensions().DaemonSets(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return dsc.kubeClient.Extensions().DaemonSets(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -130,7 +130,7 @@ func NewDaemonSetsController(kubeClient client.Interface, resyncPeriod controlle
 	dsc.podStore.Store, dsc.podController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return dsc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return dsc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return dsc.kubeClient.Pods(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -148,7 +148,7 @@ func NewDaemonSetsController(kubeClient client.Interface, resyncPeriod controlle
 	dsc.nodeStore.Store, dsc.nodeController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return dsc.kubeClient.Nodes().List(labels.Everything(), fields.Everything())
+				return dsc.kubeClient.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return dsc.kubeClient.Nodes().Watch(labels.Everything(), fields.Everything(), options)

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -60,7 +61,7 @@ func (d *DeploymentController) Run(syncPeriod time.Duration) {
 }
 
 func (d *DeploymentController) reconcileDeployments() []error {
-	list, err := d.expClient.Deployments(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+	list, err := d.expClient.Deployments(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return []error{fmt.Errorf("error listing deployments: %v", err)}
 	}

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -64,7 +64,7 @@ func NewEndpointController(client *client.Client, resyncPeriod controller.Resync
 	e.serviceStore.Store, e.serviceController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return e.client.Services(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return e.client.Services(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return e.client.Services(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -85,7 +85,7 @@ func NewEndpointController(client *client.Client, resyncPeriod controller.Resync
 	e.podStore.Store, e.podController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return e.client.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return e.client.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return e.client.Pods(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -386,7 +386,7 @@ func (e *EndpointController) syncService(key string) {
 // some stragglers could have been left behind if the endpoint controller
 // reboots).
 func (e *EndpointController) checkLeftoverEndpoints() {
-	list, err := e.client.Endpoints(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+	list, err := e.client.Endpoints(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		glog.Errorf("Unable to list endpoints (%v); orphaned endpoints will not be cleaned up. (They're pretty harmless, but you can restart this component if you want another attempt made.)", err)
 		return

--- a/pkg/controller/gc/gc_controller.go
+++ b/pkg/controller/gc/gc_controller.go
@@ -67,7 +67,7 @@ func New(kubeClient client.Interface, resyncPeriod controller.ResyncPeriodFunc, 
 	gcc.podStore.Store, gcc.podStoreSyncer = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return gcc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), terminatedSelector)
+				return gcc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), terminatedSelector, unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return gcc.kubeClient.Pods(api.NamespaceAll).Watch(labels.Everything(), terminatedSelector, options)

--- a/pkg/controller/job/controller.go
+++ b/pkg/controller/job/controller.go
@@ -86,7 +86,7 @@ func NewJobController(kubeClient client.Interface, resyncPeriod controller.Resyn
 	jm.jobStore.Store, jm.jobController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return jm.kubeClient.Extensions().Jobs(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return jm.kubeClient.Extensions().Jobs(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return jm.kubeClient.Extensions().Jobs(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -109,7 +109,7 @@ func NewJobController(kubeClient client.Interface, resyncPeriod controller.Resyn
 	jm.podStore.Store, jm.podController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return jm.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return jm.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return jm.kubeClient.Pods(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -48,7 +48,7 @@ func NewNamespaceController(kubeClient client.Interface, versions *unversioned.A
 	_, controller = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return kubeClient.Namespaces().List(labels.Everything(), fields.Everything())
+				return kubeClient.Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return kubeClient.Namespaces().Watch(labels.Everything(), fields.Everything(), options)
@@ -339,7 +339,7 @@ func syncNamespace(kubeClient client.Interface, versions *unversioned.APIVersion
 }
 
 func deleteLimitRanges(kubeClient client.Interface, ns string) error {
-	items, err := kubeClient.LimitRanges(ns).List(labels.Everything(), fields.Everything())
+	items, err := kubeClient.LimitRanges(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -353,7 +353,7 @@ func deleteLimitRanges(kubeClient client.Interface, ns string) error {
 }
 
 func deleteResourceQuotas(kubeClient client.Interface, ns string) error {
-	resourceQuotas, err := kubeClient.ResourceQuotas(ns).List(labels.Everything(), fields.Everything())
+	resourceQuotas, err := kubeClient.ResourceQuotas(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func deleteResourceQuotas(kubeClient client.Interface, ns string) error {
 }
 
 func deleteServiceAccounts(kubeClient client.Interface, ns string) error {
-	items, err := kubeClient.ServiceAccounts(ns).List(labels.Everything(), fields.Everything())
+	items, err := kubeClient.ServiceAccounts(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -381,7 +381,7 @@ func deleteServiceAccounts(kubeClient client.Interface, ns string) error {
 }
 
 func deleteServices(kubeClient client.Interface, ns string) error {
-	items, err := kubeClient.Services(ns).List(labels.Everything(), fields.Everything())
+	items, err := kubeClient.Services(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func deleteServices(kubeClient client.Interface, ns string) error {
 }
 
 func deleteReplicationControllers(kubeClient client.Interface, ns string) error {
-	items, err := kubeClient.ReplicationControllers(ns).List(labels.Everything(), fields.Everything())
+	items, err := kubeClient.ReplicationControllers(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -409,7 +409,7 @@ func deleteReplicationControllers(kubeClient client.Interface, ns string) error 
 }
 
 func deletePods(kubeClient client.Interface, ns string, before unversioned.Time) (int64, error) {
-	items, err := kubeClient.Pods(ns).List(labels.Everything(), fields.Everything())
+	items, err := kubeClient.Pods(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return 0, err
 	}
@@ -438,7 +438,7 @@ func deletePods(kubeClient client.Interface, ns string, before unversioned.Time)
 }
 
 func deleteEvents(kubeClient client.Interface, ns string) error {
-	items, err := kubeClient.Events(ns).List(labels.Everything(), fields.Everything())
+	items, err := kubeClient.Events(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func deleteEvents(kubeClient client.Interface, ns string) error {
 }
 
 func deleteSecrets(kubeClient client.Interface, ns string) error {
-	items, err := kubeClient.Secrets(ns).List(labels.Everything(), fields.Everything())
+	items, err := kubeClient.Secrets(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -466,7 +466,7 @@ func deleteSecrets(kubeClient client.Interface, ns string) error {
 }
 
 func deletePersistentVolumeClaims(kubeClient client.Interface, ns string) error {
-	items, err := kubeClient.PersistentVolumeClaims(ns).List(labels.Everything(), fields.Everything())
+	items, err := kubeClient.PersistentVolumeClaims(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -480,7 +480,7 @@ func deletePersistentVolumeClaims(kubeClient client.Interface, ns string) error 
 }
 
 func deleteHorizontalPodAutoscalers(expClient client.ExtensionsInterface, ns string) error {
-	items, err := expClient.HorizontalPodAutoscalers(ns).List(labels.Everything(), fields.Everything())
+	items, err := expClient.HorizontalPodAutoscalers(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -494,7 +494,7 @@ func deleteHorizontalPodAutoscalers(expClient client.ExtensionsInterface, ns str
 }
 
 func deleteDaemonSets(expClient client.ExtensionsInterface, ns string) error {
-	items, err := expClient.DaemonSets(ns).List(labels.Everything(), fields.Everything())
+	items, err := expClient.DaemonSets(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -508,7 +508,7 @@ func deleteDaemonSets(expClient client.ExtensionsInterface, ns string) error {
 }
 
 func deleteJobs(expClient client.ExtensionsInterface, ns string) error {
-	items, err := expClient.Jobs(ns).List(labels.Everything(), fields.Everything())
+	items, err := expClient.Jobs(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -522,7 +522,7 @@ func deleteJobs(expClient client.ExtensionsInterface, ns string) error {
 }
 
 func deleteDeployments(expClient client.ExtensionsInterface, ns string) error {
-	items, err := expClient.Deployments(ns).List(labels.Everything(), fields.Everything())
+	items, err := expClient.Deployments(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -536,7 +536,7 @@ func deleteDeployments(expClient client.ExtensionsInterface, ns string) error {
 }
 
 func deleteIngress(expClient client.ExtensionsInterface, ns string) error {
-	items, err := expClient.Ingress(ns).List(labels.Everything(), fields.Everything())
+	items, err := expClient.Ingress(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -164,7 +164,7 @@ func NewNodeController(
 	nc.podStore.Store, nc.podController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return nc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return nc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return nc.kubeClient.Pods(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -180,7 +180,7 @@ func NewNodeController(
 	nc.nodeStore.Store, nc.nodeController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return nc.kubeClient.Nodes().List(labels.Everything(), fields.Everything())
+				return nc.kubeClient.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return nc.kubeClient.Nodes().Watch(labels.Everything(), fields.Everything(), options)
@@ -347,7 +347,7 @@ func forcefullyDeletePod(c client.Interface, pod *api.Pod) {
 // post "NodeReady==ConditionUnknown". It also evicts all pods if node is not ready or
 // not reachable for a long period of time.
 func (nc *NodeController) monitorNodeStatus() error {
-	nodes, err := nc.kubeClient.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := nc.kubeClient.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -684,7 +684,7 @@ func (nc *NodeController) tryUpdateNodeStatus(node *api.Node) (time.Duration, ap
 // returns true if the provided node still has pods scheduled to it, or an error if
 // the server could not be contacted.
 func (nc *NodeController) hasPods(nodeName string) (bool, error) {
-	pods, err := nc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.OneTermEqualSelector(client.PodHost, nodeName))
+	pods, err := nc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.OneTermEqualSelector(client.PodHost, nodeName), unversioned.ListOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -717,7 +717,7 @@ func (nc *NodeController) cancelPodEviction(nodeName string) bool {
 // if any pods were deleted.
 func (nc *NodeController) deletePods(nodeName string) (bool, error) {
 	remaining := false
-	pods, err := nc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.OneTermEqualSelector(client.PodHost, nodeName))
+	pods, err := nc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.OneTermEqualSelector(client.PodHost, nodeName), unversioned.ListOptions{})
 	if err != nil {
 		return remaining, err
 	}
@@ -756,7 +756,8 @@ func (nc *NodeController) terminatePods(nodeName string, since time.Time) (bool,
 	complete := true
 
 	pods, err := nc.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(),
-		fields.OneTermEqualSelector(client.PodHost, nodeName))
+		fields.OneTermEqualSelector(client.PodHost, nodeName),
+		unversioned.ListOptions{})
 	if err != nil {
 		return false, nextAttempt, err
 	}

--- a/pkg/controller/node/nodecontroller_test.go
+++ b/pkg/controller/node/nodecontroller_test.go
@@ -91,7 +91,7 @@ func (m *FakeNodeHandler) Get(name string) (*api.Node, error) {
 	return nil, nil
 }
 
-func (m *FakeNodeHandler) List(label labels.Selector, field fields.Selector) (*api.NodeList, error) {
+func (m *FakeNodeHandler) List(label labels.Selector, field fields.Selector, opts unversioned.ListOptions) (*api.NodeList, error) {
 	defer func() { m.RequestCount++ }()
 	var nodes []*api.Node
 	for i := 0; i < len(m.UpdatedNodes); i++ {

--- a/pkg/controller/persistentvolume/persistentvolume_claim_binder_controller.go
+++ b/pkg/controller/persistentvolume/persistentvolume_claim_binder_controller.go
@@ -58,7 +58,7 @@ func NewPersistentVolumeClaimBinder(kubeClient client.Interface, syncPeriod time
 	_, volumeController := framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return kubeClient.PersistentVolumes().List(labels.Everything(), fields.Everything())
+				return kubeClient.PersistentVolumes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return kubeClient.PersistentVolumes().Watch(labels.Everything(), fields.Everything(), options)
@@ -76,7 +76,7 @@ func NewPersistentVolumeClaimBinder(kubeClient client.Interface, syncPeriod time
 	_, claimController := framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return kubeClient.PersistentVolumeClaims(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return kubeClient.PersistentVolumeClaims(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return kubeClient.PersistentVolumeClaims(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)

--- a/pkg/controller/persistentvolume/persistentvolume_recycler_controller.go
+++ b/pkg/controller/persistentvolume/persistentvolume_recycler_controller.go
@@ -65,7 +65,7 @@ func NewPersistentVolumeRecycler(kubeClient client.Interface, syncPeriod time.Du
 	_, volumeController := framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return kubeClient.PersistentVolumes().List(labels.Everything(), fields.Everything())
+				return kubeClient.PersistentVolumes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return kubeClient.PersistentVolumes().Watch(labels.Everything(), fields.Everything(), options)

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -176,7 +176,7 @@ func (a *HorizontalController) reconcileAutoscaler(hpa extensions.HorizontalPodA
 
 func (a *HorizontalController) reconcileAutoscalers() error {
 	ns := api.NamespaceAll
-	list, err := a.client.Extensions().HorizontalPodAutoscalers(ns).List(labels.Everything(), fields.Everything())
+	list, err := a.client.Extensions().HorizontalPodAutoscalers(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error listing nodes: %v", err)
 	}

--- a/pkg/controller/podautoscaler/metrics/metrics_client.go
+++ b/pkg/controller/podautoscaler/metrics/metrics_client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -120,7 +121,7 @@ func (h *HeapsterMetricsClient) GetCPUUtilization(namespace string, selector map
 
 func (h *HeapsterMetricsClient) GetResourceConsumptionAndRequest(resourceName api.ResourceName, namespace string, selector map[string]string) (consumption *ResourceConsumption, request *resource.Quantity, err error) {
 	podList, err := h.client.Pods(namespace).
-		List(labels.SelectorFromSet(labels.Set(selector)), fields.Everything())
+		List(labels.SelectorFromSet(labels.Set(selector)), fields.Everything(), unversioned.ListOptions{})
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get pod list: %v", err)

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -109,7 +109,7 @@ func NewReplicationManager(kubeClient client.Interface, resyncPeriod controller.
 	rm.rcStore.Store, rm.rcController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return rm.kubeClient.ReplicationControllers(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return rm.kubeClient.ReplicationControllers(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return rm.kubeClient.ReplicationControllers(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -150,7 +150,7 @@ func NewReplicationManager(kubeClient client.Interface, resyncPeriod controller.
 	rm.podStore.Store, rm.podController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return rm.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return rm.kubeClient.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return rm.kubeClient.Pods(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -58,7 +59,7 @@ func (rm *ResourceQuotaController) Run(period time.Duration) {
 
 func (rm *ResourceQuotaController) synchronize() {
 	var resourceQuotas []api.ResourceQuota
-	list, err := rm.kubeClient.ResourceQuotas(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+	list, err := rm.kubeClient.ResourceQuotas(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		glog.Errorf("Synchronization error: %v (%#v)", err, err)
 	}
@@ -142,7 +143,7 @@ func (rm *ResourceQuotaController) syncResourceQuota(quota api.ResourceQuota) (e
 
 	pods := &api.PodList{}
 	if set[api.ResourcePods] || set[api.ResourceMemory] || set[api.ResourceCPU] {
-		pods, err = rm.kubeClient.Pods(usage.Namespace).List(labels.Everything(), fields.Everything())
+		pods, err = rm.kubeClient.Pods(usage.Namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -165,31 +166,31 @@ func (rm *ResourceQuotaController) syncResourceQuota(quota api.ResourceQuota) (e
 		case api.ResourcePods:
 			value = resource.NewQuantity(int64(len(filteredPods)), resource.DecimalSI)
 		case api.ResourceServices:
-			items, err := rm.kubeClient.Services(usage.Namespace).List(labels.Everything(), fields.Everything())
+			items, err := rm.kubeClient.Services(usage.Namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				return err
 			}
 			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
 		case api.ResourceReplicationControllers:
-			items, err := rm.kubeClient.ReplicationControllers(usage.Namespace).List(labels.Everything(), fields.Everything())
+			items, err := rm.kubeClient.ReplicationControllers(usage.Namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				return err
 			}
 			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
 		case api.ResourceQuotas:
-			items, err := rm.kubeClient.ResourceQuotas(usage.Namespace).List(labels.Everything(), fields.Everything())
+			items, err := rm.kubeClient.ResourceQuotas(usage.Namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				return err
 			}
 			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
 		case api.ResourceSecrets:
-			items, err := rm.kubeClient.Secrets(usage.Namespace).List(labels.Everything(), fields.Everything())
+			items, err := rm.kubeClient.Secrets(usage.Namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				return err
 			}
 			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
 		case api.ResourcePersistentVolumeClaims:
-			items, err := rm.kubeClient.PersistentVolumeClaims(usage.Namespace).List(labels.Everything(), fields.Everything())
+			items, err := rm.kubeClient.PersistentVolumeClaims(usage.Namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/route/routecontroller.go
+++ b/pkg/controller/route/routecontroller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/fields"
@@ -61,7 +62,7 @@ func (rc *RouteController) reconcileNodeRoutes() error {
 	}
 	// TODO (cjcullen): use pkg/controller/framework.NewInformer to watch this
 	// and reduce the number of lists needed.
-	nodeList, err := rc.kubeClient.Nodes().List(labels.Everything(), fields.Everything())
+	nodeList, err := rc.kubeClient.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error listing nodes: %v", err)
 	}

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -79,7 +79,7 @@ func NewServiceAccountsController(cl client.Interface, options ServiceAccountsCo
 	e.serviceAccounts, e.serviceAccountController = framework.NewIndexerInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return e.client.ServiceAccounts(api.NamespaceAll).List(labels.Everything(), accountSelector)
+				return e.client.ServiceAccounts(api.NamespaceAll).List(labels.Everything(), accountSelector, unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return e.client.ServiceAccounts(api.NamespaceAll).Watch(labels.Everything(), accountSelector, options)
@@ -96,7 +96,7 @@ func NewServiceAccountsController(cl client.Interface, options ServiceAccountsCo
 	e.namespaces, e.namespaceController = framework.NewIndexerInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return e.client.Namespaces().List(labels.Everything(), fields.Everything())
+				return e.client.Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return e.client.Namespaces().Watch(labels.Everything(), fields.Everything(), options)

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -64,7 +64,7 @@ func NewTokensController(cl client.Interface, options TokensControllerOptions) *
 	e.serviceAccounts, e.serviceAccountController = framework.NewIndexerInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return e.client.ServiceAccounts(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return e.client.ServiceAccounts(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return e.client.ServiceAccounts(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -84,7 +84,7 @@ func NewTokensController(cl client.Interface, options TokensControllerOptions) *
 	e.secrets, e.secretController = framework.NewIndexerInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return e.client.Secrets(api.NamespaceAll).List(labels.Everything(), tokenSelector)
+				return e.client.Secrets(api.NamespaceAll).List(labels.Everything(), tokenSelector, unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return e.client.Secrets(api.NamespaceAll).Watch(labels.Everything(), tokenSelector, options)

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -342,7 +342,7 @@ func GetFirstPod(client *client.Client, namespace string, selector map[string]st
 	var pods *api.PodList
 	for pods == nil || len(pods.Items) == 0 {
 		var err error
-		if pods, err = client.Pods(namespace).List(labels.SelectorFromSet(selector), fields.Everything()); err != nil {
+		if pods, err = client.Pods(namespace).List(labels.SelectorFromSet(selector), fields.Everything(), unversioned.ListOptions{}); err != nil {
 			return nil, err
 		}
 		if len(pods.Items) == 0 {

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -141,11 +141,11 @@ func (d *NamespaceDescriber) Describe(namespace, name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resourceQuotaList, err := d.ResourceQuotas(name).List(labels.Everything(), fields.Everything())
+	resourceQuotaList, err := d.ResourceQuotas(name).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return "", err
 	}
-	limitRangeList, err := d.LimitRanges(name).List(labels.Everything(), fields.Everything())
+	limitRangeList, err := d.LimitRanges(name).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -424,7 +424,8 @@ func (d *PodDescriber) Describe(namespace, name string) (string, error) {
 		eventsInterface := d.Events(namespace)
 		events, err2 := eventsInterface.List(
 			labels.Everything(),
-			eventsInterface.GetFieldSelector(&name, &namespace, nil, nil))
+			eventsInterface.GetFieldSelector(&name, &namespace, nil, nil),
+			unversioned.ListOptions{})
 		if err2 == nil && len(events.Items) > 0 {
 			return tabbedString(func(out io.Writer) error {
 				fmt.Fprintf(out, "Pod '%v': error '%v', but found events.\n", name, err)
@@ -1190,7 +1191,7 @@ func (d *ServiceAccountDescriber) Describe(namespace, name string) (string, erro
 	tokens := []api.Secret{}
 
 	tokenSelector := fields.SelectorFromSet(map[string]string{client.SecretType: string(api.SecretTypeServiceAccountToken)})
-	secrets, err := d.Secrets(namespace).List(labels.Everything(), tokenSelector)
+	secrets, err := d.Secrets(namespace).List(labels.Everything(), tokenSelector, unversioned.ListOptions{})
 	if err == nil {
 		for _, s := range secrets.Items {
 			name, _ := s.Annotations[api.ServiceAccountNameKey]
@@ -1267,7 +1268,7 @@ func (d *NodeDescriber) Describe(namespace, name string) (string, error) {
 	}
 
 	var pods []*api.Pod
-	allPods, err := d.Pods(namespace).List(labels.Everything(), fields.Everything())
+	allPods, err := d.Pods(namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -1545,7 +1546,7 @@ func (dd *DeploymentDescriber) Describe(namespace, name string) (string, error) 
 func getDaemonSetsForLabels(c client.DaemonSetInterface, labelsToMatch labels.Labels) ([]extensions.DaemonSet, error) {
 	// Get all daemon sets
 	// TODO: this needs a namespace scope as argument
-	dss, err := c.List(labels.Everything(), fields.Everything())
+	dss, err := c.List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting daemon set: %v", err)
 	}
@@ -1572,7 +1573,7 @@ func getDaemonSetsForLabels(c client.DaemonSetInterface, labelsToMatch labels.La
 func getReplicationControllersForLabels(c client.ReplicationControllerInterface, labelsToMatch labels.Labels) ([]api.ReplicationController, error) {
 	// Get all replication controllers.
 	// TODO this needs a namespace scope as argument
-	rcs, err := c.List(labels.Everything(), fields.Everything())
+	rcs, err := c.List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting replication controllers: %v", err)
 	}
@@ -1603,7 +1604,7 @@ func printReplicationControllersByLabels(matchingRCs []*api.ReplicationControlle
 }
 
 func getPodStatusForController(c client.PodInterface, selector labels.Selector) (running, waiting, succeeded, failed int, err error) {
-	rcPods, err := c.List(selector, fields.Everything())
+	rcPods, err := c.List(selector, fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return
 	}

--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -363,7 +364,7 @@ func (r *RollingUpdater) pollForReadyPods(interval, timeout time.Duration, oldRc
 		anyReady := false
 		for _, controller := range controllers {
 			selector := labels.Set(controller.Spec.Selector).AsSelector()
-			pods, err := r.c.Pods(controller.Namespace).List(selector, fields.Everything())
+			pods, err := r.c.Pods(controller.Namespace).List(selector, fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -627,7 +628,7 @@ func AddDeploymentKeyToReplicationController(oldRc *api.ReplicationController, c
 
 	// Update all pods managed by the rc to have the new hash label, so they are correctly adopted
 	// TODO: extract the code from the label command and re-use it here.
-	podList, err := client.Pods(namespace).List(labels.SelectorFromSet(oldRc.Spec.Selector), fields.Everything())
+	podList, err := client.Pods(namespace).List(labels.SelectorFromSet(oldRc.Spec.Selector), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -677,7 +678,7 @@ func AddDeploymentKeyToReplicationController(oldRc *api.ReplicationController, c
 	// Clean up any orphaned pods that don't have the new label, this can happen if the rc manager
 	// doesn't see the update to its pod template and creates a new pod with the old labels after
 	// we've finished re-adopting existing pods to the rc.
-	podList, err = client.Pods(namespace).List(labels.SelectorFromSet(selectorCopy), fields.Everything())
+	podList, err = client.Pods(namespace).List(labels.SelectorFromSet(selectorCopy), fields.Everything(), unversioned.ListOptions{})
 	for ix := range podList.Items {
 		pod := &podList.Items[ix]
 		if value, found := pod.Labels[deploymentKey]; !found || value != deploymentValue {
@@ -718,7 +719,7 @@ func updateWithRetries(rcClient client.ReplicationControllerInterface, rc *api.R
 }
 
 func FindSourceController(r client.ReplicationControllersNamespacer, namespace, name string) (*api.ReplicationController, error) {
-	list, err := r.ReplicationControllers(namespace).List(labels.Everything(), fields.Everything())
+	list, err := r.ReplicationControllers(namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -109,7 +109,7 @@ type objInterface interface {
 
 // getOverlappingControllers finds rcs that this controller overlaps, as well as rcs overlapping this controller.
 func getOverlappingControllers(c client.ReplicationControllerInterface, rc *api.ReplicationController) ([]api.ReplicationController, error) {
-	rcs, err := c.List(labels.Everything(), fields.Everything())
+	rcs, err := c.List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting replication controllers: %v", err)
 	}
@@ -252,7 +252,7 @@ func (reaper *JobReaper) Stop(namespace, name string, timeout time.Duration, gra
 	}
 	// at this point only dead pods are left, that should be removed
 	selector, _ := extensions.PodSelectorAsSelector(job.Spec.Selector)
-	podList, err := pods.List(selector, fields.Everything())
+	podList, err := pods.List(selector, fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -237,7 +237,7 @@ func NewMainKubelet(
 		// than an interface. There is no way to construct a list+watcher using resource name.
 		listWatch := &cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return kubeClient.Services(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return kubeClient.Services(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return kubeClient.Services(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -254,7 +254,7 @@ func NewMainKubelet(
 		fieldSelector := fields.Set{client.ObjectNameField: nodeName}.AsSelector()
 		listWatch := &cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return kubeClient.Nodes().List(labels.Everything(), fieldSelector)
+				return kubeClient.Nodes().List(labels.Everything(), fieldSelector, unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return kubeClient.Nodes().Watch(labels.Everything(), fieldSelector, options)

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -110,7 +110,7 @@ func (c *realRecyclerClient) WatchPod(name, namespace, resourceVersion string, s
 
 	podLW := &cache.ListWatch{
 		ListFunc: func() (runtime.Object, error) {
-			return c.client.Pods(namespace).List(labels.Everything(), fieldSelector)
+			return c.client.Pods(namespace).List(labels.Everything(), fieldSelector, unversioned.ListOptions{})
 		},
 		WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 			return c.client.Pods(namespace).Watch(labels.Everything(), fieldSelector, options)

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -101,7 +101,7 @@ func (l *limitRanger) Admit(a admission.Attributes) (err error) {
 func NewLimitRanger(client client.Interface, limitFunc LimitFunc) admission.Interface {
 	lw := &cache.ListWatch{
 		ListFunc: func() (runtime.Object, error) {
-			return client.LimitRanges(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+			return client.LimitRanges(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		},
 		WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 			return client.LimitRanges(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -86,7 +86,7 @@ func NewProvision(c client.Interface) admission.Interface {
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return c.Namespaces().List(labels.Everything(), fields.Everything())
+				return c.Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), options)

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -93,7 +93,7 @@ func NewExists(c client.Interface) admission.Interface {
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return c.Namespaces().List(labels.Everything(), fields.Everything())
+				return c.Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), options)

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -110,7 +110,7 @@ func NewLifecycle(c client.Interface) admission.Interface {
 	reflector := cache.NewReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return c.Namespaces().List(labels.Everything(), fields.Everything())
+				return c.Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), options)

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -52,7 +52,7 @@ type quota struct {
 func NewResourceQuota(client client.Interface) admission.Interface {
 	lw := &cache.ListWatch{
 		ListFunc: func() (runtime.Object, error) {
-			return client.ResourceQuotas(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+			return client.ResourceQuotas(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		},
 		WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 			return client.ResourceQuotas(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -84,7 +84,7 @@ func NewServiceAccount(cl client.Interface) *serviceAccount {
 	serviceAccountsIndexer, serviceAccountsReflector := cache.NewNamespaceKeyedIndexerAndReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return cl.ServiceAccounts(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+				return cl.ServiceAccounts(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return cl.ServiceAccounts(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), options)
@@ -98,7 +98,7 @@ func NewServiceAccount(cl client.Interface) *serviceAccount {
 	secretsIndexer, secretsReflector := cache.NewNamespaceKeyedIndexerAndReflector(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return cl.Secrets(api.NamespaceAll).List(labels.Everything(), tokenSelector)
+				return cl.Secrets(api.NamespaceAll).List(labels.Everything(), tokenSelector, unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return cl.Secrets(api.NamespaceAll).Watch(labels.Everything(), tokenSelector, options)

--- a/test/e2e/cadvisor.go
+++ b/test/e2e/cadvisor.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -49,7 +50,7 @@ var _ = Describe("Cadvisor", func() {
 
 func CheckCadvisorHealthOnAllNodes(c *client.Client, timeout time.Duration) {
 	By("getting list of nodes")
-	nodeList, err := c.Nodes().List(labels.Everything(), fields.Everything())
+	nodeList, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	expectNoError(err)
 	var errors []error
 	retries := maxRetries

--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 
@@ -43,7 +44,7 @@ var _ = Describe("[Autoscaling] [Skipped]", func() {
 	BeforeEach(func() {
 		SkipUnlessProviderIs("gce")
 
-		nodes, err := f.Client.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := f.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err)
 		nodeCount = len(nodes.Items)
 		Expect(nodeCount).NotTo(BeZero())

--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -412,7 +413,7 @@ func runCmd(command string, args ...string) (string, string, error) {
 func validate(f *Framework, svcNameWant, rcNameWant string, ingress api.LoadBalancerIngress, podsWant int) error {
 	Logf("Beginning cluster validation")
 	// Verify RC.
-	rcs, err := f.Client.ReplicationControllers(f.Namespace.Name).List(labels.Everything(), fields.Everything())
+	rcs, err := f.Client.ReplicationControllers(f.Namespace.Name).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error listing RCs: %v", err)
 	}

--- a/test/e2e/daemon_restart.go
+++ b/test/e2e/daemon_restart.go
@@ -171,7 +171,7 @@ func replacePods(pods []*api.Pod, store cache.Store) {
 // getContainerRestarts returns the count of container restarts across all pods matching the given labelSelector,
 // and a list of nodenames across which these containers restarted.
 func getContainerRestarts(c *client.Client, ns string, labelSelector labels.Selector) (int, []string) {
-	pods, err := c.Pods(ns).List(labelSelector, fields.Everything())
+	pods, err := c.Pods(ns).List(labelSelector, fields.Everything(), unversioned.ListOptions{})
 	expectNoError(err)
 	failedContainers := 0
 	containerRestartNodes := sets.NewString()
@@ -221,7 +221,7 @@ var _ = Describe("DaemonRestart", func() {
 		newPods, controller = controllerframework.NewInformer(
 			&cache.ListWatch{
 				ListFunc: func() (runtime.Object, error) {
-					return framework.Client.Pods(ns).List(labelSelector, fields.Everything())
+					return framework.Client.Pods(ns).List(labelSelector, fields.Everything(), unversioned.ListOptions{})
 				},
 				WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 					return framework.Client.Pods(ns).Watch(labelSelector, fields.Everything(), options)

--- a/test/e2e/daemon_set.go
+++ b/test/e2e/daemon_set.go
@@ -114,7 +114,7 @@ var _ = Describe("Daemon set", func() {
 		By("Stop a daemon pod, check that the daemon pod is revived.")
 		podClient := c.Pods(ns)
 
-		podList, err := podClient.List(labels.Set(label).AsSelector(), fields.Everything())
+		podList, err := podClient.List(labels.Set(label).AsSelector(), fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(podList.Items)).To(BeNumerically(">", 0))
 		pod := podList.Items[0]
@@ -160,7 +160,7 @@ var _ = Describe("Daemon set", func() {
 
 		By("Change label of node, check that daemon pod is launched.")
 		nodeClient := c.Nodes()
-		nodeList, err := nodeClient.List(labels.Everything(), fields.Everything())
+		nodeList, err := nodeClient.List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		Expect(len(nodeList.Items)).To(BeNumerically(">", 0))
 		newNode, err := setDaemonSetNodeLabels(c, nodeList.Items[0].Name, nodeSelector)
 		Expect(err).NotTo(HaveOccurred(), "error setting labels on node")
@@ -196,7 +196,7 @@ func separateDaemonSetNodeLabels(labels map[string]string) (map[string]string, m
 
 func clearDaemonSetNodeLabels(c *client.Client) error {
 	nodeClient := c.Nodes()
-	nodeList, err := nodeClient.List(labels.Everything(), fields.Everything())
+	nodeList, err := nodeClient.List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func setDaemonSetNodeLabels(c *client.Client, nodeName string, labels map[string
 
 func checkDaemonPodOnNodes(f *Framework, selector map[string]string, nodeNames []string) func() (bool, error) {
 	return func() (bool, error) {
-		podList, err := f.Client.Pods(f.Namespace.Name).List(labels.Set(selector).AsSelector(), fields.Everything())
+		podList, err := f.Client.Pods(f.Namespace.Name).List(labels.Set(selector).AsSelector(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return false, nil
 		}
@@ -279,7 +279,7 @@ func checkDaemonPodOnNodes(f *Framework, selector map[string]string, nodeNames [
 
 func checkRunningOnAllNodes(f *Framework, selector map[string]string) func() (bool, error) {
 	return func() (bool, error) {
-		nodeList, err := f.Client.Nodes().List(labels.Everything(), fields.Everything())
+		nodeList, err := f.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return false, nil
 		}

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -123,7 +123,7 @@ var _ = Describe("Density [Skipped]", func() {
 		ns = framework.Namespace.Name
 		var err error
 
-		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err)
 		nodeCount = len(nodes.Items)
 		Expect(nodeCount).NotTo(BeZero())
@@ -200,7 +200,7 @@ var _ = Describe("Density [Skipped]", func() {
 			_, controller := controllerframework.NewInformer(
 				&cache.ListWatch{
 					ListFunc: func() (runtime.Object, error) {
-						return c.Events(ns).List(labels.Everything(), fields.Everything())
+						return c.Events(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 					},
 					WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 						return c.Events(ns).Watch(labels.Everything(), fields.Everything(), options)
@@ -283,7 +283,7 @@ var _ = Describe("Density [Skipped]", func() {
 				_, controller := controllerframework.NewInformer(
 					&cache.ListWatch{
 						ListFunc: func() (runtime.Object, error) {
-							return c.Pods(ns).List(labels.SelectorFromSet(labels.Set{"name": additionalPodsPrefix}), fields.Everything())
+							return c.Pods(ns).List(labels.SelectorFromSet(labels.Set{"name": additionalPodsPrefix}), fields.Everything(), unversioned.ListOptions{})
 						},
 						WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 							return c.Pods(ns).Watch(labels.SelectorFromSet(labels.Set{"name": additionalPodsPrefix}), fields.Everything(), options)
@@ -335,7 +335,8 @@ var _ = Describe("Density [Skipped]", func() {
 						"involvedObject.kind":      "Pod",
 						"involvedObject.namespace": ns,
 						"source":                   "scheduler",
-					}.AsSelector())
+					}.AsSelector(),
+					unversioned.ListOptions{})
 				expectNoError(err)
 				for k := range createTimes {
 					for _, event := range schedEvents.Items {

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -191,7 +191,7 @@ var _ = Describe("DNS", func() {
 
 		systemClient := f.Client.Pods(api.NamespaceSystem)
 		By("Waiting for DNS Service to be Running")
-		dnsPods, err := systemClient.List(dnsServiceLableSelector, fields.Everything())
+		dnsPods, err := systemClient.List(dnsServiceLableSelector, fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Failf("Failed to list all dns service pods")
 		}
@@ -229,7 +229,7 @@ var _ = Describe("DNS", func() {
 		systemClient := f.Client.Pods(api.NamespaceSystem)
 
 		By("Waiting for DNS Service to be Running")
-		dnsPods, err := systemClient.List(dnsServiceLableSelector, fields.Everything())
+		dnsPods, err := systemClient.List(dnsServiceLableSelector, fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Failf("Failed to list all dns service pods")
 		}

--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 
@@ -85,7 +86,7 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 	// Wait for the Elasticsearch pods to enter the running state.
 	By("Checking to make sure the Elasticsearch pods are running")
 	label := labels.SelectorFromSet(labels.Set(map[string]string{esKey: esValue}))
-	pods, err := f.Client.Pods(api.NamespaceSystem).List(label, fields.Everything())
+	pods, err := f.Client.Pods(api.NamespaceSystem).List(label, fields.Everything(), unversioned.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	for _, pod := range pods.Items {
 		err = waitForPodRunningInNamespace(f.Client, pod.Name, api.NamespaceSystem)
@@ -171,7 +172,7 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 	}
 
 	// Obtain a list of nodes so we can place one synthetic logger on each node.
-	nodes, err := f.Client.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := f.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		Failf("Failed to list nodes: %v", err)
 	}
@@ -257,7 +258,7 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 	for start := time.Now(); time.Since(start) < ingestionTimeout; time.Sleep(10 * time.Second) {
 
 		// Debugging code to report the status of the elasticsearch logging endpoints.
-		esPods, err := f.Client.Pods(api.NamespaceSystem).List(labels.Set{esKey: esValue}.AsSelector(), fields.Everything())
+		esPods, err := f.Client.Pods(api.NamespaceSystem).List(labels.Set{esKey: esValue}.AsSelector(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Logf("Attempt to list Elasticsearch nodes encountered a problem -- may retry: %v", err)
 			continue

--- a/test/e2e/etcd_failure.go
+++ b/test/e2e/etcd_failure.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -108,7 +109,7 @@ func checkExistingRCRecovers(f *Framework) {
 
 	By("deleting pods from existing replication controller")
 	expectNoError(wait.Poll(time.Millisecond*500, time.Second*60, func() (bool, error) {
-		pods, err := podClient.List(rcSelector, fields.Everything())
+		pods, err := podClient.List(rcSelector, fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Logf("apiserver returned error, as expected before recovery: %v", err)
 			return false, nil
@@ -126,7 +127,7 @@ func checkExistingRCRecovers(f *Framework) {
 
 	By("waiting for replication controller to recover")
 	expectNoError(wait.Poll(time.Millisecond*500, time.Second*60, func() (bool, error) {
-		pods, err := podClient.List(rcSelector, fields.Everything())
+		pods, err := podClient.List(rcSelector, fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		for _, pod := range pods.Items {
 			if pod.DeletionTimestamp == nil && api.IsPodReady(&pod) {

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
@@ -72,7 +73,7 @@ var _ = Describe("Events", func() {
 		expectNoError(framework.WaitForPodRunning(pod.Name))
 
 		By("verifying the pod is in kubernetes")
-		pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything())
+		pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything(), unversioned.ListOptions{})
 		Expect(len(pods.Items)).To(Equal(1))
 
 		By("retrieving the pod")
@@ -93,6 +94,7 @@ var _ = Describe("Events", func() {
 					"involvedObject.namespace": framework.Namespace.Name,
 					"source":                   "scheduler",
 				}.AsSelector(),
+				unversioned.ListOptions{},
 			)
 			if err != nil {
 				return false, err
@@ -114,6 +116,7 @@ var _ = Describe("Events", func() {
 					"involvedObject.namespace": framework.Namespace.Name,
 					"source":                   "kubelet",
 				}.AsSelector(),
+				unversioned.ListOptions{},
 			)
 			if err != nil {
 				return false, err

--- a/test/e2e/example_cluster_dns.go
+++ b/test/e2e/example_cluster_dns.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -104,7 +105,7 @@ var _ = Describe("[Example] ClusterDns", func() {
 		// the application itself may have not been initialized. Just query the application.
 		for _, ns := range namespaces {
 			label := labels.SelectorFromSet(labels.Set(map[string]string{"name": backendRcName}))
-			pods, err := c.Pods(ns.Name).List(label, fields.Everything())
+			pods, err := c.Pods(ns.Name).List(label, fields.Everything(), unversioned.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			err = podsResponding(c, ns.Name, backendPodName, false, pods)
 			Expect(err).NotTo(HaveOccurred(), "waiting for all pods to respond")
@@ -123,7 +124,7 @@ var _ = Describe("[Example] ClusterDns", func() {
 		// dns error or timeout.
 		// This code is probably unnecessary, but let's stay on the safe side.
 		label := labels.SelectorFromSet(labels.Set(map[string]string{"name": backendPodName}))
-		pods, err := c.Pods(namespaces[0].Name).List(label, fields.Everything())
+		pods, err := c.Pods(namespaces[0].Name).List(label, fields.Everything(), unversioned.ListOptions{})
 
 		if err != nil || pods == nil || len(pods.Items) == 0 {
 			Failf("no running pods found")

--- a/test/e2e/example_k8petstore.go
+++ b/test/e2e/example_k8petstore.go
@@ -20,7 +20,8 @@ import (
 	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"log"
@@ -46,7 +47,7 @@ const (
 
 // readTransactions reads # of transactions from the k8petstore web server endpoint.
 // for more details see the source of the k8petstore web server.
-func readTransactions(c *unversioned.Client, ns string) (error, int) {
+func readTransactions(c *client.Client, ns string) (error, int) {
 	body, err := c.Get().
 		Namespace(ns).
 		Prefix("proxy").
@@ -64,7 +65,7 @@ func readTransactions(c *unversioned.Client, ns string) (error, int) {
 
 // runK8petstore runs the k8petstore application, bound to external nodeport, and
 // polls until minExpected transactions are acquired, in a maximum of maxSeconds.
-func runK8petstore(restServers int, loadGenerators int, c *unversioned.Client, ns string, minExpected int, maxTime time.Duration) {
+func runK8petstore(restServers int, loadGenerators int, c *client.Client, ns string, minExpected int, maxTime time.Duration) {
 
 	var err error = nil
 	k8bpsScriptLocation := filepath.Join(testContext.RepoRoot, "examples/k8petstore/k8petstore-nodeport.sh")
@@ -157,7 +158,7 @@ var _ = Describe("[Example] Pet Store [Skipped]", func() {
 	f := NewFramework("petstore")
 
 	It(fmt.Sprintf("should scale to persist a nominal number ( %v ) of transactions in %v seconds", k8bpsSmokeTestTransactions, k8bpsSmokeTestTimeout), func() {
-		minions, err := f.Client.Nodes().List(labels.Everything(), fields.Everything())
+		minions, err := f.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		minionCount = len(minions.Items)
 

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -462,7 +463,7 @@ func prepareResourceWithReplacedString(inputFile, old, new string) string {
 func forEachPod(c *client.Client, ns, selectorKey, selectorValue string, fn func(api.Pod)) {
 	pods := []*api.Pod{}
 	for t := time.Now(); time.Since(t) < podListTimeout; time.Sleep(poll) {
-		podList, err := c.Pods(ns).List(labels.SelectorFromSet(labels.Set(map[string]string{selectorKey: selectorValue})), fields.Everything())
+		podList, err := c.Pods(ns).List(labels.SelectorFromSet(labels.Set(map[string]string{selectorKey: selectorValue})), fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		for _, pod := range podList.Items {
 			if pod.Status.Phase == api.PodPending || pod.Status.Phase == api.PodRunning {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -105,7 +105,7 @@ func (f *Framework) afterEach() {
 	// Print events if the test failed.
 	if CurrentGinkgoTestDescription().Failed {
 		By(fmt.Sprintf("Collecting events from namespace %q.", f.Namespace.Name))
-		events, err := f.Client.Events(f.Namespace.Name).List(labels.Everything(), fields.Everything())
+		events, err := f.Client.Events(f.Namespace.Name).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, e := range events.Items {
@@ -179,7 +179,7 @@ func (f *Framework) WaitForAnEndpoint(serviceName string) error {
 	for {
 		// TODO: Endpoints client should take a field selector so we
 		// don't have to list everything.
-		list, err := f.Client.Endpoints(f.Namespace.Name).List(labels.Everything(), fields.Everything())
+		list, err := f.Client.Endpoints(f.Namespace.Name).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return err
 		}

--- a/test/e2e/garbage_collector.go
+++ b/test/e2e/garbage_collector.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
@@ -56,7 +57,7 @@ var _ = Describe("Garbage collector", func() {
 		// 20 seconds.
 		time.Sleep(30 * time.Second)
 
-		pods, err := f.Client.Pods(f.Namespace.Name).List(labels.Everything(), fields.Everything())
+		pods, err := f.Client.Pods(f.Namespace.Name).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(pods.Items)).To(BeNumerically("==", 100))
 	})

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -28,6 +28,7 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
@@ -211,7 +212,7 @@ func gcloudDelete(resource, name string) {
 // kubectlLogLBController logs kubectl debug output for the L7 controller pod.
 func kubectlLogLBController(c *client.Client, ns string) {
 	selector := labels.SelectorFromSet(labels.Set(controllerLabels))
-	podList, err := c.Pods(api.NamespaceAll).List(selector, fields.Everything())
+	podList, err := c.Pods(api.NamespaceAll).List(selector, fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		Logf("Cannot log L7 controller output, error listing pods %v", err)
 		return
@@ -424,7 +425,7 @@ var _ = Describe("GCE L7 LoadBalancer Controller", func() {
 		}
 		// Delete all Ingress, then wait for the controller to cleanup.
 		ings, err := client.Extensions().Ingress(ns).List(
-			labels.Everything(), fields.Everything())
+			labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Logf("WARNING: Failed to list ingress: %+v", err)
 		} else {
@@ -483,7 +484,7 @@ var _ = Describe("GCE L7 LoadBalancer Controller", func() {
 		}
 
 		ings, err := client.Extensions().Ingress(ns).List(
-			labels.Everything(), fields.Everything())
+			labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, ing := range ings.Items {

--- a/test/e2e/job.go
+++ b/test/e2e/job.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
@@ -259,7 +260,7 @@ func deleteJob(c *client.Client, ns, name string) error {
 func waitForAllPodsRunning(c *client.Client, ns, jobName string, parallelism int) error {
 	label := labels.SelectorFromSet(labels.Set(map[string]string{jobSelectorKey: jobName}))
 	return wait.Poll(poll, jobTimeout, func() (bool, error) {
-		pods, err := c.Pods(ns).List(label, fields.Everything())
+		pods, err := c.Pods(ns).List(label, fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/kibana_logging.go
+++ b/test/e2e/kibana_logging.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 
@@ -69,7 +70,7 @@ func ClusterLevelLoggingWithKibana(f *Framework) {
 	// Wait for the Kibana pod(s) to enter the running state.
 	By("Checking to make sure the Kibana pods are running")
 	label := labels.SelectorFromSet(labels.Set(map[string]string{kibanaKey: kibanaValue}))
-	pods, err := f.Client.Pods(api.NamespaceSystem).List(label, fields.Everything())
+	pods, err := f.Client.Pods(api.NamespaceSystem).List(label, fields.Everything(), unversioned.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	for _, pod := range pods.Items {
 		err = waitForPodRunningInNamespace(f.Client, pod.Name, api.NamespaceSystem)

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -530,7 +530,7 @@ var _ = Describe("Kubectl client", func() {
 			checkOutput(output, requiredStrings)
 
 			// Node
-			nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+			nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			node := nodes.Items[0]
 			output = runKubectlOrDie("describe", "node", node.Name)
@@ -1088,7 +1088,7 @@ func forEachReplicationController(c *client.Client, ns, selectorKey, selectorVal
 	var rcs *api.ReplicationControllerList
 	var err error
 	for t := time.Now(); time.Since(t) < podListTimeout; time.Sleep(poll) {
-		rcs, err = c.ReplicationControllers(ns).List(labels.SelectorFromSet(labels.Set(map[string]string{selectorKey: selectorValue})), fields.Everything())
+		rcs, err = c.ReplicationControllers(ns).List(labels.SelectorFromSet(labels.Set(map[string]string{selectorKey: selectorValue})), fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		if len(rcs.Items) > 0 {
 			break

--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -95,7 +96,7 @@ var _ = Describe("kubelet", func() {
 	var resourceMonitor *resourceMonitor
 
 	BeforeEach(func() {
-		nodes, err := framework.Client.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := framework.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err)
 		numNodes = len(nodes.Items)
 		nodeNames = sets.NewString()

--- a/test/e2e/kubelet_perf.go
+++ b/test/e2e/kubelet_perf.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -104,7 +105,7 @@ var _ = Describe("Kubelet", func() {
 	var resourceMonitor *resourceMonitor
 
 	BeforeEach(func() {
-		nodes, err := framework.Client.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := framework.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err)
 		nodeNames = sets.NewString()
 		for _, node := range nodes.Items {

--- a/test/e2e/kubelet_stats.go
+++ b/test/e2e/kubelet_stats.go
@@ -33,6 +33,7 @@ import (
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/prometheus/common/model"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/kubelet"
@@ -270,11 +271,11 @@ func getOneTimeResourceUsageOnNode(
 }
 
 func getKubeSystemContainersResourceUsage(c *client.Client) (resourceUsagePerContainer, error) {
-	pods, err := c.Pods("kube-system").List(labels.Everything(), fields.Everything())
+	pods, err := c.Pods("kube-system").List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return resourceUsagePerContainer{}, err
 	}
-	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return resourceUsagePerContainer{}, err
 	}
@@ -651,7 +652,7 @@ func newResourceMonitor(c *client.Client, containerNames []string, pollingInterv
 }
 
 func (r *resourceMonitor) Start() {
-	nodes, err := r.client.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := r.client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		Failf("resourceMonitor: unable to get list of nodes: %v", err)
 	}

--- a/test/e2e/kubeproxy.go
+++ b/test/e2e/kubeproxy.go
@@ -430,7 +430,7 @@ func (config *KubeProxyTestConfig) setup() {
 	}
 
 	By("Getting two nodes")
-	nodeList, err := config.f.Client.Nodes().List(labels.Everything(), fields.Everything())
+	nodeList, err := config.f.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get node list: %v", err))
 	config.externalAddrs = NodeAddresses(nodeList, api.NodeExternalIP)
 	if len(config.externalAddrs) < 2 {
@@ -458,7 +458,7 @@ func (config *KubeProxyTestConfig) setup() {
 
 func (config *KubeProxyTestConfig) cleanup() {
 	nsClient := config.getNamespacesClient()
-	nsList, err := nsClient.List(nil, nil)
+	nsList, err := nsClient.List(nil, nil, unversioned.ListOptions{})
 	if err == nil {
 		for _, ns := range nsList.Items {
 			if strings.Contains(ns.Name, config.f.BaseName) && ns.Name != config.f.Namespace.Name {
@@ -469,7 +469,7 @@ func (config *KubeProxyTestConfig) cleanup() {
 }
 
 func (config *KubeProxyTestConfig) createNetProxyPods(podName string, selector map[string]string) []*api.Pod {
-	nodes, err := config.f.Client.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := config.f.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	// create pods, one for each node

--- a/test/e2e/latency.go
+++ b/test/e2e/latency.go
@@ -69,7 +69,7 @@ var _ = Describe("Latency [Skipped]", func() {
 		ns = framework.Namespace.Name
 		var err error
 
-		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err)
 		nodeCount = len(nodes.Items)
 		Expect(nodeCount).NotTo(BeZero())
@@ -144,7 +144,7 @@ func runLatencyTest(nodeCount int, c *client.Client, ns string) {
 	_, informer := framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return c.Pods(ns).List(labels.SelectorFromSet(labels.Set{"name": additionalPodsPrefix}), fields.Everything())
+				return c.Pods(ns).List(labels.SelectorFromSet(labels.Set{"name": additionalPodsPrefix}), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return c.Pods(ns).Watch(labels.SelectorFromSet(labels.Set{"name": additionalPodsPrefix}), fields.Everything(), options)
@@ -195,7 +195,8 @@ func runLatencyTest(nodeCount int, c *client.Client, ns string) {
 			"involvedObject.kind":      "Pod",
 			"involvedObject.namespace": ns,
 			"source":                   "scheduler",
-		}.AsSelector())
+		}.AsSelector(),
+		unversioned.ListOptions{})
 	expectNoError(err)
 	for k := range createTimestamps {
 		for _, event := range schedEvents.Items {

--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -70,7 +71,7 @@ var _ = Describe("[Performance] Load capacity [Skipped]", func() {
 	BeforeEach(func() {
 		c = framework.Client
 		ns = framework.Namespace.Name
-		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err)
 		nodeCount = len(nodes.Items)
 		Expect(nodeCount).NotTo(BeZero())
@@ -209,7 +210,7 @@ func scaleRC(wg *sync.WaitGroup, config *RCConfig) {
 	expectNoError(ScaleRC(config.Client, config.Namespace, config.Name, newSize, true),
 		fmt.Sprintf("scaling rc %s for the first time", config.Name))
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"name": config.Name}))
-	_, err := config.Client.Pods(config.Namespace).List(selector, fields.Everything())
+	_, err := config.Client.Pods(config.Namespace).List(selector, fields.Everything(), unversioned.ListOptions{})
 	expectNoError(err, fmt.Sprintf("listing pods from rc %v", config.Name))
 }
 

--- a/test/e2e/mesos.go
+++ b/test/e2e/mesos.go
@@ -45,7 +45,7 @@ var _ = Describe("Mesos", func() {
 		nodeClient := framework.Client.Nodes()
 
 		rackA := labels.SelectorFromSet(map[string]string{"k8s.mesosphere.io/attribute-rack": "1"})
-		nodes, err := nodeClient.List(rackA, fields.Everything())
+		nodes, err := nodeClient.List(rackA, fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Failf("Failed to query for node: %v", err)
 		}
@@ -64,7 +64,7 @@ var _ = Describe("Mesos", func() {
 		client := framework.Client
 		expectNoError(allNodesReady(client, util.ForeverTestTimeout), "all nodes ready")
 
-		nodelist, err := client.Nodes().List(labels.Everything(), fields.Everything())
+		nodelist, err := client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err, "nodes fetched from apiserver")
 
 		const ns = "static-pods"
@@ -109,7 +109,7 @@ var _ = Describe("Mesos", func() {
 		role1 := labels.SelectorFromSet(map[string]string{
 			"k8s.mesosphere.io/attribute-role": "role1",
 		})
-		nodes, err := nodeClient.List(role1, fields.Everything())
+		nodes, err := nodeClient.List(role1, fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err)
 
 		Expect(nodes.Items[0].Name).To(Equal(pod.Spec.NodeName))

--- a/test/e2e/metrics_util.go
+++ b/test/e2e/metrics_util.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -180,7 +181,7 @@ func listPodsLatencyThreshold(numNodes int) time.Duration {
 // Prints top five summary metrics for request types with latency and returns
 // number of such request types above threshold.
 func HighLatencyRequests(c *client.Client) (int, error) {
-	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return 0, err
 	}

--- a/test/e2e/monitor_resources.go
+++ b/test/e2e/monitor_resources.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"time"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -88,7 +89,7 @@ var _ = Describe("Resource usage of system containers", func() {
 
 	It("should not exceed expected amount.", func() {
 		By("Getting ResourceConsumption on all nodes")
-		nodeList, err := c.Nodes().List(labels.Everything(), fields.Everything())
+		nodeList, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err)
 
 		resourceUsagePerNode := make(map[string][]resourceUsagePerContainer)

--- a/test/e2e/monitoring.go
+++ b/test/e2e/monitoring.go
@@ -23,6 +23,7 @@ import (
 
 	influxdb "github.com/influxdb/influxdb/client"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -77,7 +78,7 @@ func verifyExpectedRcsExistAndGetExpectedPods(c *client.Client) ([]string, error
 	// situation when a heapster-monitoring-v1 and heapster-monitoring-v2 replication controller
 	// is running (which would be an error except during a rolling update).
 	for _, rcLabel := range rcLabels {
-		rcList, err := c.ReplicationControllers(api.NamespaceSystem).List(labels.Set{"k8s-app": rcLabel}.AsSelector(), fields.Everything())
+		rcList, err := c.ReplicationControllers(api.NamespaceSystem).List(labels.Set{"k8s-app": rcLabel}.AsSelector(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +87,7 @@ func verifyExpectedRcsExistAndGetExpectedPods(c *client.Client) ([]string, error
 				rcLabel, len(rcList.Items))
 		}
 		for _, rc := range rcList.Items {
-			podList, err := c.Pods(api.NamespaceSystem).List(labels.Set(rc.Spec.Selector).AsSelector(), fields.Everything())
+			podList, err := c.Pods(api.NamespaceSystem).List(labels.Set(rc.Spec.Selector).AsSelector(), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -102,7 +103,7 @@ func verifyExpectedRcsExistAndGetExpectedPods(c *client.Client) ([]string, error
 }
 
 func expectedServicesExist(c *client.Client) error {
-	serviceList, err := c.Services(api.NamespaceSystem).List(labels.Everything(), fields.Everything())
+	serviceList, err := c.Services(api.NamespaceSystem).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -120,7 +121,7 @@ func expectedServicesExist(c *client.Client) error {
 }
 
 func getAllNodesInCluster(c *client.Client) ([]string, error) {
-	nodeList, err := c.Nodes().List(labels.Everything(), fields.Everything())
+	nodeList, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/namespace.go
+++ b/test/e2e/namespace.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -60,7 +61,7 @@ func extinguish(c *client.Client, totalNS int, maxAllowedAfterDel int, maxSecond
 	expectNoError(wait.Poll(2*time.Second, time.Duration(maxSeconds)*time.Second,
 		func() (bool, error) {
 			var cnt = 0
-			nsList, err := c.Namespaces().List(labels.Everything(), fields.Everything())
+			nsList, err := c.Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				return false, err
 			}

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -138,7 +138,7 @@ var _ = Describe("Networking", func() {
 
 		By("Creating a webserver (pending) pod on each node")
 
-		nodes, err := f.Client.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := f.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Failf("Failed to list nodes: %v", err)
 		}

--- a/test/e2e/nodeoutofdisk.go
+++ b/test/e2e/nodeoutofdisk.go
@@ -24,6 +24,7 @@ import (
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -140,7 +141,8 @@ var _ = Describe("NodeOutOfDisk", func() {
 					"involvedObject.namespace": ns,
 					"source":                   "scheduler",
 					"reason":                   "FailedScheduling",
-				}.AsSelector())
+				}.AsSelector(),
+				unversioned.ListOptions{})
 			expectNoError(err)
 
 			if len(schedEvents.Items) > 0 {
@@ -201,7 +203,7 @@ func createOutOfDiskPod(c *client.Client, ns, name string, milliCPU int64) {
 func availCpu(c *client.Client, node *api.Node) (int64, error) {
 	podClient := c.Pods(api.NamespaceAll)
 
-	pods, err := podClient.List(labels.Everything(), fields.Set{"spec.nodeName": node.Name}.AsSelector())
+	pods, err := podClient.List(labels.Everything(), fields.Set{"spec.nodeName": node.Name}.AsSelector(), unversioned.ListOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to retrieve all the pods on node %s: %v", node.Name, err)
 	}

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -55,7 +55,7 @@ var _ = Describe("Pod Disks", func() {
 
 		podClient = framework.Client.Pods(framework.Namespace.Name)
 
-		nodes, err := framework.Client.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := framework.Client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		expectNoError(err, "Failed to list nodes for e2e cluster.")
 
 		Expect(len(nodes.Items)).To(BeNumerically(">=", 2), "Requires at least 2 nodes")

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -300,7 +300,7 @@ var _ = Describe("Pods", func() {
 		}
 
 		By("setting up watch")
-		pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything())
+		pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Failf("Failed to query for pods: %v", err)
 		}
@@ -323,7 +323,7 @@ var _ = Describe("Pods", func() {
 		}
 
 		By("verifying the pod is in kubernetes")
-		pods, err = podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything())
+		pods, err = podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Failf("Failed to query for pods: %v", err)
 		}
@@ -367,7 +367,7 @@ var _ = Describe("Pods", func() {
 		Expect(lastPod.DeletionTimestamp).ToNot(BeNil())
 		Expect(lastPod.Spec.TerminationGracePeriodSeconds).ToNot(BeZero())
 
-		pods, err = podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything())
+		pods, err = podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Fail(fmt.Sprintf("Failed to list pods to verify deletion: %v", err))
 		}
@@ -421,7 +421,7 @@ var _ = Describe("Pods", func() {
 		expectNoError(framework.WaitForPodRunning(pod.Name))
 
 		By("verifying the pod is in kubernetes")
-		pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything())
+		pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything(), unversioned.ListOptions{})
 		Expect(len(pods.Items)).To(Equal(1))
 
 		// Standard get, update retry loop
@@ -451,7 +451,7 @@ var _ = Describe("Pods", func() {
 		expectNoError(framework.WaitForPodRunning(pod.Name))
 
 		By("verifying the updated pod is in kubernetes")
-		pods, err = podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything())
+		pods, err = podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything(), unversioned.ListOptions{})
 		Expect(len(pods.Items)).To(Equal(1))
 		Logf("Pod update OK")
 	})
@@ -1037,7 +1037,7 @@ var _ = Describe("Pods", func() {
 			expectNoError(framework.WaitForPodRunning(pod.Name))
 
 			By("verifying the pod is in kubernetes")
-			pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})))
+			pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				Failf("Failed to query for pods: %v", err)
 			}
@@ -1110,7 +1110,7 @@ var _ = Describe("Pods", func() {
 			expectNoError(framework.WaitForPodRunning(pod.Name))
 
 			By("verifying the pod is in kubernetes")
-			pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})))
+			pods, err := podClient.List(labels.SelectorFromSet(labels.Set(map[string]string{"time": value})), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				Failf("Failed to query for pods: %v", err)
 			}

--- a/test/e2e/proxy.go
+++ b/test/e2e/proxy.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -252,7 +253,7 @@ func truncate(b []byte, maxLen int) []byte {
 }
 
 func pickNode(c *client.Client) (string, error) {
-	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/reboot.go
+++ b/test/e2e/reboot.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -61,7 +62,7 @@ var _ = Describe("Reboot", func() {
 			// events for the kube-system namespace on failures
 			namespaceName := api.NamespaceSystem
 			By(fmt.Sprintf("Collecting events from namespace %q.", namespaceName))
-			events, err := f.Client.Events(namespaceName).List(labels.Everything(), fields.Everything())
+			events, err := f.Client.Events(namespaceName).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, e := range events.Items {

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -234,7 +234,7 @@ func podsCreated(c *client.Client, ns, name string, replicas int) (*api.PodList,
 	// List the pods, making sure we observe all the replicas.
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
-		pods, err := c.Pods(ns).List(label, fields.Everything())
+		pods, err := c.Pods(ns).List(label, fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -397,7 +397,7 @@ var _ = Describe("Nodes", func() {
 	BeforeEach(func() {
 		c = framework.Client
 		ns = framework.Namespace.Name
-		systemPods, err := c.Pods(api.NamespaceSystem).List(labels.Everything(), fields.Everything())
+		systemPods, err := c.Pods(api.NamespaceSystem).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		systemPodsNo = len(systemPods.Items)
 	})
@@ -511,7 +511,7 @@ var _ = Describe("Nodes", func() {
 
 				By("choose a node with at least one pod - we will block some network traffic on this node")
 				label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
-				pods, err := c.Pods(ns).List(label, fields.Everything()) // list pods after all have been scheduled
+				pods, err := c.Pods(ns).List(label, fields.Everything(), unversioned.ListOptions{}) // list pods after all have been scheduled
 				Expect(err).NotTo(HaveOccurred())
 				nodeName := pods.Items[0].Spec.NodeName
 

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -1043,7 +1044,7 @@ func validateEndpointsOrFail(c *client.Client, namespace, serviceName string, ex
 		i++
 	}
 
-	if pods, err := c.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything()); err == nil {
+	if pods, err := c.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{}); err == nil {
 		for _, pod := range pods.Items {
 			Logf("Pod %s\t%s\t%s\t%s", pod.Namespace, pod.Name, pod.Spec.NodeName, pod.DeletionTimestamp)
 		}
@@ -1095,7 +1096,7 @@ func collectAddresses(nodes *api.NodeList, addressType api.NodeAddressType) []st
 }
 
 func getNodePublicIps(c *client.Client) ([]string, error) {
-	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -42,7 +43,7 @@ var _ = Describe("ServiceAccounts", func() {
 		expectNoError(wait.Poll(time.Millisecond*500, time.Second*10, func() (bool, error) {
 			By("getting the auto-created API token")
 			tokenSelector := fields.SelectorFromSet(map[string]string{client.SecretType: string(api.SecretTypeServiceAccountToken)})
-			secrets, err := f.Client.Secrets(f.Namespace.Name).List(labels.Everything(), tokenSelector)
+			secrets, err := f.Client.Secrets(f.Namespace.Name).List(labels.Everything(), tokenSelector, unversioned.ListOptions{})
 			if err != nil {
 				return false, err
 			}

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -280,7 +280,7 @@ func startEndpointWatcher(f *Framework, q *endpointQueries) {
 	_, controller := framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func() (runtime.Object, error) {
-				return f.Client.Endpoints(f.Namespace.Name).List(labels.Everything(), fields.Everything())
+				return f.Client.Endpoints(f.Namespace.Name).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			},
 			WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 				return f.Client.Endpoints(f.Namespace.Name).Watch(labels.Everything(), fields.Everything(), options)

--- a/test/e2e/serviceloadbalancers.go
+++ b/test/e2e/serviceloadbalancers.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -112,7 +113,7 @@ func (h *haproxyControllerTester) start(namespace string) (err error) {
 	labelSelector := labels.SelectorFromSet(
 		labels.Set(map[string]string{"name": h.rcName}))
 	pods, err := h.client.Pods(h.rcNamespace).List(
-		labelSelector, fields.Everything())
+		labelSelector, fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -162,7 +162,7 @@ type podStore struct {
 func newPodStore(c *client.Client, namespace string, label labels.Selector, field fields.Selector) *podStore {
 	lw := &cache.ListWatch{
 		ListFunc: func() (runtime.Object, error) {
-			return c.Pods(namespace).List(label, field)
+			return c.Pods(namespace).List(label, field, unversioned.ListOptions{})
 		},
 		WatchFunc: func(options unversioned.ListOptions) (watch.Interface, error) {
 			return c.Pods(namespace).Watch(label, field, options)
@@ -364,7 +364,7 @@ func waitForPodsRunningReady(ns string, minPods int, timeout time.Duration) erro
 		// We get the new list of pods and replication controllers in every
 		// iteration because more pods come online during startup and we want to
 		// ensure they are also checked.
-		rcList, err := c.ReplicationControllers(ns).List(labels.Everything(), fields.Everything())
+		rcList, err := c.ReplicationControllers(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Logf("Error getting replication controllers in namespace '%s': %v", ns, err)
 			return false, nil
@@ -374,7 +374,7 @@ func waitForPodsRunningReady(ns string, minPods int, timeout time.Duration) erro
 			replicas += rc.Spec.Replicas
 		}
 
-		podList, err := c.Pods(ns).List(labels.Everything(), fields.Everything())
+		podList, err := c.Pods(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Logf("Error getting pods in namespace '%s': %v", ns, err)
 			return false, nil
@@ -418,7 +418,7 @@ func waitForPodsRunningReady(ns string, minPods int, timeout time.Duration) erro
 // Returns the list of deleted namespaces or an error.
 func deleteNamespaces(c *client.Client, deleteFilter, skipFilter []string) ([]string, error) {
 	By("Deleting namespaces")
-	nsList, err := c.Namespaces().List(labels.Everything(), fields.Everything())
+	nsList, err := c.Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	var deleted []string
 	var wg sync.WaitGroup
@@ -465,7 +465,7 @@ func waitForNamespacesDeleted(c *client.Client, namespaces []string, timeout tim
 	//Now POLL until all namespaces have been eradicated.
 	return wait.Poll(2*time.Second, timeout,
 		func() (bool, error) {
-			nsList, err := c.Namespaces().List(labels.Everything(), fields.Everything())
+			nsList, err := c.Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -597,7 +597,7 @@ func checkTestingNSDeletedExcept(c *client.Client, skip string) error {
 
 	Logf("Waiting for terminating namespaces to be deleted...")
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(15 * time.Second) {
-		namespaces, err := c.Namespaces().List(labels.Everything(), fields.Everything())
+		namespaces, err := c.Namespaces().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Logf("Listing namespaces failed: %v", err)
 			continue
@@ -639,7 +639,7 @@ func deleteNS(c *client.Client, namespace string, timeout time.Duration) error {
 	// check for pods that were not deleted
 	remaining := []string{}
 	missingTimestamp := false
-	if pods, perr := c.Pods(namespace).List(labels.Everything(), fields.Everything()); perr == nil {
+	if pods, perr := c.Pods(namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{}); perr == nil {
 		for _, pod := range pods.Items {
 			Logf("Pod %s %s on node %s remains, has deletion timestamp %s", namespace, pod.Name, pod.Spec.NodeName, pod.DeletionTimestamp)
 			remaining = append(remaining, pod.Name)
@@ -727,7 +727,7 @@ func waitForRCPodOnNode(c *client.Client, ns, rcName, node string) (*api.Pod, er
 	var p *api.Pod = nil
 	err := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
 		Logf("Waiting for pod %s to appear on node %s", rcName, node)
-		pods, err := c.Pods(ns).List(label, fields.Everything())
+		pods, err := c.Pods(ns).List(label, fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -746,7 +746,7 @@ func waitForRCPodOnNode(c *client.Client, ns, rcName, node string) (*api.Pod, er
 func waitForPodToDisappear(c *client.Client, ns, podName string, label labels.Selector, interval, timeout time.Duration) error {
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		Logf("Waiting for pod %s to disappear", podName)
-		pods, err := c.Pods(ns).List(label, fields.Everything())
+		pods, err := c.Pods(ns).List(label, fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -808,7 +808,7 @@ func waitForService(c *client.Client, namespace, name string, exist bool, interv
 func waitForServiceEndpointsNum(c *client.Client, namespace, serviceName string, expectNum int, interval, timeout time.Duration) error {
 	return wait.Poll(interval, timeout, func() (bool, error) {
 		Logf("Waiting for amount of service:%s endpoints to %d", serviceName, expectNum)
-		list, err := c.Endpoints(namespace).List(labels.Everything(), fields.Everything())
+		list, err := c.Endpoints(namespace).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -876,7 +876,7 @@ type podResponseChecker struct {
 // checkAllResponses issues GETs to all pods in the context and verify they reply with pod name.
 func (r podResponseChecker) checkAllResponses() (done bool, err error) {
 	successes := 0
-	currentPods, err := r.c.Pods(r.ns).List(r.label, fields.Everything())
+	currentPods, err := r.c.Pods(r.ns).List(r.label, fields.Everything(), unversioned.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	for i, pod := range r.pods.Items {
 		// Check that the replica list remains unchanged, otherwise we have problems.
@@ -1612,7 +1612,7 @@ func (config *RCConfig) start() error {
 
 	if oldRunning != config.Replicas {
 		// List only pods from a given replication controller.
-		if pods, err := config.Client.Pods(api.NamespaceAll).List(label, fields.Everything()); err == nil {
+		if pods, err := config.Client.Pods(api.NamespaceAll).List(label, fields.Everything(), unversioned.ListOptions{}); err == nil {
 
 			for _, pod := range pods.Items {
 				Logf("Pod %s\t%s\t%s\t%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase, pod.DeletionTimestamp)
@@ -1641,7 +1641,7 @@ func dumpPodDebugInfo(c *client.Client, pods []*api.Pod) {
 }
 
 func dumpAllPodInfo(c *client.Client) {
-	pods, err := c.Pods("").List(labels.Everything(), fields.Everything())
+	pods, err := c.Pods("").List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		Logf("unable to fetch pod debug info: %v", err)
 	}
@@ -1649,7 +1649,7 @@ func dumpAllPodInfo(c *client.Client) {
 }
 
 func dumpAllNodeInfo(c *client.Client) {
-	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		Logf("unable to fetch node list: %v", err)
 		return
@@ -1704,7 +1704,8 @@ func getNodeEvents(c *client.Client, nodeName string) []api.Event {
 			"involvedObject.name":      nodeName,
 			"involvedObject.namespace": api.NamespaceAll,
 			"source":                   "kubelet",
-		}.AsSelector())
+		}.AsSelector(),
+		unversioned.ListOptions{})
 	if err != nil {
 		Logf("Unexpected error retrieving node events %v", err)
 		return []api.Event{}
@@ -1769,7 +1770,7 @@ waitLoop:
 // Wait up to 10 minutes for getting pods with certain label
 func waitForPodsWithLabel(c *client.Client, ns string, label labels.Selector) (pods *api.PodList, err error) {
 	for t := time.Now(); time.Since(t) < podListTimeout; time.Sleep(poll) {
-		pods, err = c.Pods(ns).List(label, fields.Everything())
+		pods, err = c.Pods(ns).List(label, fields.Everything(), unversioned.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		if len(pods.Items) > 0 {
 			break
@@ -1820,7 +1821,7 @@ func DeleteRC(c *client.Client, ns, name string) error {
 // have completed termination).
 func waitForRCPodsGone(c *client.Client, rc *api.ReplicationController) error {
 	return wait.PollImmediate(poll, 2*time.Minute, func() (bool, error) {
-		if pods, err := c.Pods(rc.Namespace).List(labels.SelectorFromSet(rc.Spec.Selector), fields.Everything()); err == nil && len(pods.Items) == 0 {
+		if pods, err := c.Pods(rc.Namespace).List(labels.SelectorFromSet(rc.Spec.Selector), fields.Everything(), unversioned.ListOptions{}); err == nil && len(pods.Items) == 0 {
 			return true, nil
 		}
 		return false, nil
@@ -1900,7 +1901,7 @@ func listNodes(c *client.Client, label labels.Selector, field fields.Selector) (
 	var nodes *api.NodeList
 	var errLast error
 	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
-		nodes, errLast = c.Nodes().List(label, field)
+		nodes, errLast = c.Nodes().List(label, field, unversioned.ListOptions{})
 		return errLast == nil, nil
 	}) != nil {
 		return nil, fmt.Errorf("listNodes() failed with last error: %v", errLast)
@@ -1989,7 +1990,7 @@ func NodeAddresses(nodelist *api.NodeList, addrType api.NodeAddressType) []strin
 // if it can't find an external IP for every node, though it still returns all
 // hosts that it found in that case.
 func NodeSSHHosts(c *client.Client) ([]string, error) {
-	nodelist, err := c.Nodes().List(labels.Everything(), fields.Everything())
+	nodelist, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting nodes: %v", err)
 	}
@@ -2237,7 +2238,7 @@ func allNodesReady(c *client.Client, timeout time.Duration) error {
 	var notReady []api.Node
 	err := wait.PollImmediate(poll, timeout, func() (bool, error) {
 		notReady = nil
-		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -2356,7 +2357,7 @@ func waitForApiserverUp(c *client.Client) error {
 // waitForClusterSize waits until the cluster has desired size and there is no not-ready nodes in it.
 func waitForClusterSize(c *client.Client, size int, timeout time.Duration) error {
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(20 * time.Second) {
-		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err := c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err != nil {
 			Logf("Failed to list nodes: %v", err)
 			continue
@@ -2550,7 +2551,7 @@ func getNodePortURL(client *client.Client, ns, name string, svcPort int) (string
 	if err != nil {
 		return "", err
 	}
-	nodes, err := client.Nodes().List(labels.Everything(), fields.Everything())
+	nodes, err := client.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -55,7 +55,7 @@ func TestClient(t *testing.T) {
 		t.Errorf("expected %#v, got %#v", e, a)
 	}
 
-	pods, err := client.Pods(ns).List(labels.Everything(), fields.Everything())
+	pods, err := client.Pods(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestClient(t *testing.T) {
 	}
 
 	// pod is shown, but not scheduled
-	pods, err = client.Pods(ns).List(labels.Everything(), fields.Everything())
+	pods, err = client.Pods(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -241,7 +242,7 @@ func StartPods(numPods int, host string, restClient *client.Client) error {
 		glog.Infof("StartPods took %v with numPods %d", time.Since(start), numPods)
 	}()
 	hostField := fields.OneTermEqualSelector(client.PodHost, host)
-	pods, err := restClient.Pods(TestNS).List(labels.Everything(), hostField)
+	pods, err := restClient.Pods(TestNS).List(labels.Everything(), hostField, unversioned.ListOptions{})
 	if err != nil || len(pods.Items) == numPods {
 		return err
 	}

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -110,7 +111,7 @@ func TestApiserverMetrics(t *testing.T) {
 	// Make a request to the apiserver to ensure there's at least one data point
 	// for the metrics we're expecting -- otherwise, they won't be exported.
 	client := client.NewOrDie(&client.Config{Host: s.URL, GroupVersion: testapi.Default.GroupVersion()})
-	if _, err := client.Pods(api.NamespaceDefault).List(labels.Everything(), fields.Everything()); err != nil {
+	if _, err := client.Pods(api.NamespaceDefault).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{}); err != nil {
 		t.Fatalf("unexpected error getting pods: %v", err)
 	}
 

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/authenticator/bearertoken"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
@@ -172,7 +173,7 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 	tokensToCleanup := sets.NewString(token1Name, token2Name, token3Name)
 	err = wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
 		// Get all secrets in the namespace
-		secrets, err := c.Secrets(ns).List(labels.Everything(), fields.Everything())
+		secrets, err := c.Secrets(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		// Retrieval errors should fail
 		if err != nil {
 			return false, err
@@ -536,8 +537,14 @@ func doServiceAccountAPIRequests(t *testing.T, c *client.Client, ns string, auth
 	}
 
 	readOps := []testOperation{
-		func() error { _, err := c.Secrets(ns).List(labels.Everything(), fields.Everything()); return err },
-		func() error { _, err := c.Pods(ns).List(labels.Everything(), fields.Everything()); return err },
+		func() error {
+			_, err := c.Secrets(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
+			return err
+		},
+		func() error {
+			_, err := c.Pods(ns).List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
+			return err
+		},
 	}
 	writeOps := []testOperation{
 		func() error { _, err := c.Secrets(ns).Create(testSecret); return err },

--- a/test/soak/cauldron/cauldron.go
+++ b/test/soak/cauldron/cauldron.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -68,7 +69,7 @@ func main() {
 
 	var nodes *api.NodeList
 	for start := time.Now(); time.Since(start) < nodeListTimeout; time.Sleep(2 * time.Second) {
-		nodes, err = c.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err = c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err == nil {
 			break
 		}

--- a/test/soak/serve_hostnames/serve_hostnames.go
+++ b/test/soak/serve_hostnames/serve_hostnames.go
@@ -89,7 +89,7 @@ func main() {
 
 	var nodes *api.NodeList
 	for start := time.Now(); time.Since(start) < nodeListTimeout; time.Sleep(2 * time.Second) {
-		nodes, err = c.Nodes().List(labels.Everything(), fields.Everything())
+		nodes, err = c.Nodes().List(labels.Everything(), fields.Everything(), unversioned.ListOptions{})
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
This is pretty much mechanical change.

In the followup PR, I'm going to stop passing field/label Selectors explicitly (similarly to what we do in apiserver:
https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/generic/etcd/etcd.go#L164
)

Ref #15945

@caesarxuchao @lavalamp 
