### PR TITLE
MESOS: add CONFORMANCE_BRANCH override

### DIFF
--- a/contrib/mesos/ci/test-conformance.sh
+++ b/contrib/mesos/ci/test-conformance.sh
@@ -31,4 +31,19 @@ TEST_ARGS="$@"
 
 KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
-"${KUBE_ROOT}/contrib/mesos/ci/run-with-cluster.sh" KUBECONFIG=~/.kube/config hack/conformance-test.sh ${TEST_ARGS}
+if [ -n "${CONFORMANCE_BRANCH}" ]; then
+	# checkout CONFORMANCE_BRANCH, but leave the contrib/mesos/ci directory
+	# untouched.
+	TEST_CMD="
+git fetch https://github.com/kubernetes/kubernetes ${CONFORMANCE_BRANCH} &&
+git checkout FETCH_HEAD -- . ':(exclude)contrib/mesos/ci/**' &&
+git reset FETCH_HEAD &&
+git clean -d -f -- . ':(exclude)contrib/mesos/ci/**' &&
+git status &&
+make all &&
+"
+else
+	TEST_CMD=""
+fi
+TEST_CMD+="KUBECONFIG=~/.kube/config hack/conformance-test.sh"
+"${KUBE_ROOT}/contrib/mesos/ci/run-with-cluster.sh" ${TEST_CMD} ${TEST_ARGS}


### PR DESCRIPTION
As a k8sm developer I have to create official conformance test logs using conformance tests from a certain branch against another branch.

Add the CONFORMANCE_BRANCH environment variable to the conformance CI script. If set, 
- the given branch will be checked out
- after kube-up.sh has finished
- before the conformance tests are run.
- without touching contrib/mesos/ci
- including a recompile to get an up-to-date e2e binary for that branch.

If CONFORMANCE_BRANCH is not set, nothing changes.
