### PR TITLE
conformance: support annotated tags

### DIFF
--- a/hack/conformance-test.sh
+++ b/hack/conformance-test.sh
@@ -70,7 +70,7 @@ echo -n "Conformance test SHA:"
 HEAD_SHA=$(git rev-parse HEAD)
 echo $HEAD_SHA
 echo "Conformance test version tag(s):"
-git show-ref | grep $HEAD_SHA | grep refs/tags
+git tag --points-at $HEAD_SHA
 echo
 echo "Conformance test checking conformance with Kubernetes version 1.0"
 


### PR DESCRIPTION
The former code listed all tags with show-ref which lists the actual tag commit
hash for annotated tags, not the dereferences hash. Although through `-d`
git-show-ref can also dereference annotated tags, this complicated the command
even more due do addition unpadding of the found tags.

Anyway, this code does the same in one command, available since git 1.7.
