### PR TITLE
MESOS/CI: call docker-run interactively and with terminal

### DIFF
--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -72,9 +72,9 @@ exec docker run \
   -e "MESOS_DOCKER_OVERLAY_DIR=${MESOS_DOCKER_WORK_DIR}/overlay" \
   -e "KUBERNETES_CONTRIB=mesos" \
   -e "KUBERNETES_PROVIDER=mesos/docker" \
-  -e "TERM=ansi" \
   -e "USER=root" \
   -e "E2E_REPORT_DIR=${MESOS_DOCKER_WORK_DIR}/reports" \
+  -t $(tty &>/dev/null && echo "-i") \
   mesosphere/kubernetes-mesos-test \
   -ceux "\
     make clean all && \

--- a/contrib/mesos/ci/run.sh
+++ b/contrib/mesos/ci/run.sh
@@ -50,7 +50,7 @@ exec docker run \
   -v "/var/run/docker.sock:/var/run/docker.sock" \
   -v "${DOCKER_BIN_PATH}:/usr/bin/docker" \
   -e "KUBERNETES_CONTRIB=mesos" \
-  -e "TERM=ansi" \
   -e "USER=root" \
+  -t $(tty &>/dev/null && echo "-i") \
   mesosphere/kubernetes-mesos-test \
   -ceux "${RUN_CMD}"


### PR DESCRIPTION
- passing `-i` to enable signal handling in a tty.
- passing `-t` to enable passing of the TERM env var.

Alternative to https://github.com/kubernetes/kubernetes/pull/17748
