### PR TITLE
MESOS/CI-FLAKE: workaround 'namespace already exists' during kube-up

### DIFF
--- a/cluster/mesos/docker/deploy-addons.sh
+++ b/cluster/mesos/docker/deploy-addons.sh
@@ -53,8 +53,8 @@ function deploy_ui {
 }
 
 # create the kube-system and static-pods namespaces
-"${kubectl}" create -f "${KUBE_ROOT}/cluster/mesos/docker/kube-system-ns.yaml"
-"${kubectl}" create -f "${KUBE_ROOT}/cluster/mesos/docker/static-pods-ns.yaml"
+"${kubectl}" apply -f "${KUBE_ROOT}/cluster/mesos/docker/kube-system-ns.yaml"
+"${kubectl}" apply -f "${KUBE_ROOT}/cluster/mesos/docker/static-pods-ns.yaml"
 
 if [ "${ENABLE_CLUSTER_DNS}" == true ]; then
   cluster::mesos::docker::run_in_temp_dir 'k8sm-dns' 'deploy_dns'


### PR DESCRIPTION
Once in a while we get

```
[16:31:36][Step 7/7] Error from server: error when creating "/go/src/github.com/GoogleCloudPlatform/kubernetes/cluster/mesos/docker/kube-system-ns.yaml": namespaces "kube-system" already exists
```

Using apply we workaround this.
