### PR TITLE
Minion->Node rename: kube-util hosting provider helper functions for #1111

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -196,7 +196,7 @@ function find-running-minions () {
   done
 }
 
-function detect-minions () {
+function detect-nodes () {
   find-running-minions
 
   # This is inefficient, but we want NODE_NAMES / NODE_IDS to be ordered the same as KUBE_NODE_IP_ADDRESSES
@@ -1105,7 +1105,7 @@ function check-cluster() {
 
   sleep 5
 
-  detect-minions > $LOG
+  detect-nodes > $LOG
 
   # Don't bail on errors, we want to be able to print some info.
   set +e

--- a/cluster/centos/util.sh
+++ b/cluster/centos/util.sh
@@ -222,8 +222,8 @@ function provision-master() {
   local master_ip=${MASTER#*@}
   ensure-setup-dir ${MASTER}
 
-  # scp -r ${SSH_OPTS} master config-default.sh copy-files.sh util.sh "${MASTER}:${KUBE_TEMP}" 
-  kube-scp ${MASTER} "${ROOT}/../saltbase/salt/generate-cert/make-ca-cert.sh ${ROOT}/binaries/master ${ROOT}/master ${ROOT}/config-default.sh ${ROOT}/util.sh" "${KUBE_TEMP}" 
+  # scp -r ${SSH_OPTS} master config-default.sh copy-files.sh util.sh "${MASTER}:${KUBE_TEMP}"
+  kube-scp ${MASTER} "${ROOT}/../saltbase/salt/generate-cert/make-ca-cert.sh ${ROOT}/binaries/master ${ROOT}/master ${ROOT}/config-default.sh ${ROOT}/util.sh" "${KUBE_TEMP}"
   kube-ssh "${MASTER}" " \
     sudo cp -r ${KUBE_TEMP}/master/bin /opt/kubernetes; \
     sudo chmod -R +x /opt/kubernetes/bin; \

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -184,7 +184,7 @@ function prepare-node-upgrade() {
   echo "== Preparing node upgrade (to ${KUBE_VERSION}). ==" >&2
   SANITIZED_VERSION=$(echo ${KUBE_VERSION} | sed 's/[\.\+]/-/g')
 
-  detect-minion-names
+  detect-node-names
 
   # TODO(zmerlynn): Refactor setting scope flags.
   local scope_flags=

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -215,7 +215,7 @@ function upload-server-tars() {
 #   NODE_INSTANCE_PREFIX
 # Vars set:
 #   NODE_NAMES
-function detect-minion-names {
+function detect-node-names {
   detect-project
   NODE_NAMES=($(gcloud compute instance-groups managed list-instances \
     "${NODE_INSTANCE_PREFIX}-group" --zone "${ZONE}" --project "${PROJECT}" \
@@ -230,9 +230,9 @@ function detect-minion-names {
 # Vars set:
 #   NODE_NAMES
 #   KUBE_NODE_IP_ADDRESSES (array)
-function detect-minions () {
+function detect-nodes () {
   detect-project
-  detect-minion-names
+  detect-node-names
   KUBE_NODE_IP_ADDRESSES=()
   for (( i=0; i<${#NODE_NAMES[@]}; i++)); do
     local minion_ip=$(gcloud compute instances describe --project "${PROJECT}" --zone "${ZONE}" \
@@ -686,7 +686,7 @@ function kube-up {
       "${NODE_INSTANCE_PREFIX}-group" \
 			--zone "${ZONE}" \
 			--project "${PROJECT}" || true;
-  detect-minion-names
+  detect-node-names
   detect-master
 
   # Create autoscaler for nodes if requested
@@ -1027,7 +1027,7 @@ function prepare-push() {
   ensure-temp-dir
   detect-project
   detect-master
-  detect-minion-names
+  detect-node-names
   get-kubeconfig-basicauth
   get-kubeconfig-bearertoken
 

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -168,7 +168,7 @@ function test-setup() {
   echo "... in gke:test-setup()" >&2
   # Detect the project into $PROJECT if it isn't set
   detect-project >&2
-  detect-minions >&2
+  detect-nodes >&2
 
   # At this point, CLUSTER_NAME should have been used, so its value is final.
   NODE_TAG=$($GCLOUD compute instances describe ${NODE_NAMES[0]} --project="${PROJECT}" --zone="${ZONE}" | grep -o "gke-${CLUSTER_NAME}-.\{8\}-node" | head -1)
@@ -210,9 +210,9 @@ function detect-master() {
 #   none
 # Vars set:
 #   NODE_NAMES
-function detect-minions() {
-  echo "... in gke:detect-minions()" >&2
-  detect-minion-names
+function detect-nodes() {
+  echo "... in gke:detect-nodes()" >&2
+  detect-node-names
 }
 
 # Detect minions created in the minion group
@@ -221,8 +221,8 @@ function detect-minions() {
 #   none
 # Vars set:
 #   NODE_NAMES
-function detect-minion-names {
-  echo "... in gke:detect-minion-names()" >&2
+function detect-node-names {
+  echo "... in gke:detect-node-names()" >&2
   detect-project
   detect-node-instance-group
   NODE_NAMES=($(gcloud compute instance-groups managed list-instances \

--- a/cluster/juju/util.sh
+++ b/cluster/juju/util.sh
@@ -59,7 +59,7 @@ function detect-master() {
     export KUBE_SERVER=http://${KUBE_MASTER_IP}:8080
 }
 
-function detect-minions() {
+function detect-nodes() {
     # Run the Juju command that gets the minion private IP addresses.
     local ipoutput
     ipoutput=$(juju run --service kubernetes "unit-get private-address" --format=json)
@@ -97,7 +97,7 @@ function kube-up() {
     # Sleep due to juju bug http://pad.lv/1432759
     sleep-status
     detect-master
-    detect-minions
+    detect-nodes
 
     local prefix=$RANDOM
     export KUBE_CERT="/tmp/${prefix}-kubecfg.crt"

--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -24,13 +24,13 @@ function detect-master {
 	echo "KUBE_MASTER: $KUBE_MASTER" 1>&2
 }
 
-# Get minion names if they are not static.
-function detect-minion-names {
+# Get node names if they are not static.
+function detect-node-names {
 	echo "NODE_NAMES: [${NODE_NAMES[*]}]" 1>&2
 }
 
-# Get minion IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
-function detect-minions {
+# Get node IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
+function detect-nodes {
 	echo "KUBE_NODE_IP_ADDRESSES: [${KUBE_NODE_IP_ADDRESSES[*]}]" 1>&2
 }
 

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -207,7 +207,7 @@ function detect-master {
 # Get minion IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
 # These Mesos slaves MAY host Kublets,
 # but might not have a Kublet running unless a kubernetes task has been scheduled on them.
-function detect-minions {
+function detect-nodes {
   local docker_ids=$(docker ps --filter="name=docker_mesosslave" --quiet)
   if [ -z "${docker_ids}" ]; then
     echo "ERROR: Mesos slave(s) not running" 1>&2
@@ -291,7 +291,7 @@ function kube-up {
   cluster::mesos::docker::run_in_docker_test await-health-check "-t=${MESOS_DOCKER_API_TIMEOUT}" http://apiserver:8888/healthz
 
   detect-master
-  detect-minions
+  detect-nodes
   create-kubeconfig
 
   echo "Deploying Addons" 1>&2

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -26,8 +26,8 @@ function detect-master () {
 }
 
 # Get minion IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
-function detect-minions {
-  echo "Minions already detected" 1>&2
+function detect-nodes {
+  echo "Nodes already detected" 1>&2
   KUBE_NODE_IP_ADDRESSES=("${NODE_IPS[@]}")
 }
 
@@ -277,7 +277,7 @@ function verify-cluster {
     echo "  https://${MASTER_IP}:9090"
     echo
     echo "For more information on Cockpit, visit http://cockpit-project.org"
-    echo 
+    echo
     echo "The user name and password to use is located in ${KUBECONFIG}"
     echo
   )

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -48,7 +48,7 @@ function detect-master {
 #   NODE_NAMES
 # Vars set:
 #   KUBE_NODE_IP_ADDRESS (array)
-function detect-minions {
+function detect-nodes {
   KUBE_NODE_IP_ADDRESSES=()
   for (( i=0; i<${#NODE_NAMES[@]}; i++)); do
     local minion_ip=$(govc vm.ip ${NODE_NAMES[$i]})
@@ -294,7 +294,7 @@ function kube-up {
   fi
 
   # Print minion IPs, so user can log in for debugging.
-  detect-minions
+  detect-nodes
   echo
 
   echo "Waiting for master and minion initialization."


### PR DESCRIPTION
Straightforward rename of the cluster/kube-util hosting provider helper functions:
- detect-nodes()
- detect-node-names

Doesn't include `detect-minion-image()` because that is in cluster/aws only. Not technically a kube-util helper function... but I can add it!

_This is another step towards completing #1111 and was cherry-picked out of #17024 to simplify that PR._

@derekwaynecarr
