### PR TITLE
Allow go2idl to generate non-Go file types

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/generator-for-group.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-group.go
@@ -57,12 +57,12 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		"group":                      g.group,
 		"Group":                      namer.IC(g.group),
 		"types":                      g.types,
-		"Config":                     c.Universe.Get(types.Name{pkgUnversioned, "Config"}),
-		"DefaultKubernetesUserAgent": c.Universe.Get(types.Name{pkgUnversioned, "DefaultKubernetesUserAgent"}),
-		"RESTClient":                 c.Universe.Get(types.Name{pkgUnversioned, "RESTClient"}),
-		"RESTClientFor":              c.Universe.Get(types.Name{pkgUnversioned, "RESTClientFor"}),
-		"latestGroup":                c.Universe.Get(types.Name{pkgLatest, "Group"}),
-		"GroupOrDie":                 c.Universe.Get(types.Name{pkgLatest, "GroupOrDie"}),
+		"Config":                     c.Universe.Get(types.Name{Package: pkgUnversioned, Name: "Config"}),
+		"DefaultKubernetesUserAgent": c.Universe.Get(types.Name{Package: pkgUnversioned, Name: "DefaultKubernetesUserAgent"}),
+		"RESTClient":                 c.Universe.Get(types.Name{Package: pkgUnversioned, Name: "RESTClient"}),
+		"RESTClientFor":              c.Universe.Get(types.Name{Package: pkgUnversioned, Name: "RESTClientFor"}),
+		"latestGroup":                c.Universe.Get(types.Name{Package: pkgLatest, Name: "Group"}),
+		"GroupOrDie":                 c.Universe.Get(types.Name{Package: pkgLatest, Name: "GroupOrDie"}),
 	}
 	sw.Do(groupInterfaceTemplate, m)
 	sw.Do(groupClientTemplate, m)

--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -54,11 +54,11 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		"type":             t,
 		"package":          pkg,
 		"Package":          namer.IC(pkg),
-		"fieldSelector":    c.Universe.Get(types.Name{"k8s.io/kubernetes/pkg/fields", "Selector"}),
-		"labelSelector":    c.Universe.Get(types.Name{"k8s.io/kubernetes/pkg/labels", "Selector"}),
-		"watchInterface":   c.Universe.Get(types.Name{"k8s.io/kubernetes/pkg/watch", "Interface"}),
-		"apiDeleteOptions": c.Universe.Get(types.Name{"k8s.io/kubernetes/pkg/api", "DeleteOptions"}),
-		"apiListOptions":   c.Universe.Get(types.Name{"k8s.io/kubernetes/pkg/api", "ListOptions"}),
+		"fieldSelector":    c.Universe.Get(types.Name{Package: "k8s.io/kubernetes/pkg/fields", Name: "Selector"}),
+		"labelSelector":    c.Universe.Get(types.Name{Package: "k8s.io/kubernetes/pkg/labels", Name: "Selector"}),
+		"watchInterface":   c.Universe.Get(types.Name{Package: "k8s.io/kubernetes/pkg/watch", Name: "Interface"}),
+		"apiDeleteOptions": c.Universe.Get(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "DeleteOptions"}),
+		"apiListOptions":   c.Universe.Get(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "ListOptions"}),
 	}
 	sw.Do(namespacerTemplate, m)
 	sw.Do(interfaceTemplate, m)

--- a/cmd/libs/go2idl/generator/default_generator.go
+++ b/cmd/libs/go2idl/generator/default_generator.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/kubernetes/cmd/libs/go2idl/types"
 )
 
+const (
+	GolangFileType = "golang"
+)
+
 // DefaultGen implements a do-nothing Generator.
 //
 // It can be used to implement static content files.
@@ -45,6 +49,7 @@ func (d DefaultGen) PackageVars(*Context) []string                       { retur
 func (d DefaultGen) PackageConsts(*Context) []string                     { return []string{} }
 func (d DefaultGen) GenerateType(*Context, *types.Type, io.Writer) error { return nil }
 func (d DefaultGen) Filename() string                                    { return d.OptionalName + ".go" }
+func (d DefaultGen) FileType() string                                    { return GolangFileType }
 
 func (d DefaultGen) Init(c *Context, w io.Writer) error {
 	_, err := w.Write(d.OptionalBody)

--- a/cmd/libs/go2idl/generator/snippet_writer.go
+++ b/cmd/libs/go2idl/generator/snippet_writer.go
@@ -116,6 +116,10 @@ func (s *SnippetWriter) Do(format string, args interface{}) *SnippetWriter {
 	return s
 }
 
+func (s *SnippetWriter) Out() io.Writer {
+	return s.w
+}
+
 // Error returns any encountered error.
 func (s *SnippetWriter) Error() error {
 	return s.err

--- a/cmd/libs/go2idl/namer/namer_test.go
+++ b/cmd/libs/go2idl/namer/namer_test.go
@@ -27,26 +27,26 @@ func TestNameStrategy(t *testing.T) {
 	u := types.Universe{}
 
 	// Add some types.
-	base := u.Get(types.Name{"foo/bar", "Baz"})
+	base := u.Get(types.Name{Package: "foo/bar", Name: "Baz"})
 	base.Kind = types.Struct
 
-	tmp := u.Get(types.Name{"", "[]bar.Baz"})
+	tmp := u.Get(types.Name{Package: "", Name: "[]bar.Baz"})
 	tmp.Kind = types.Slice
 	tmp.Elem = base
 
-	tmp = u.Get(types.Name{"", "map[string]bar.Baz"})
+	tmp = u.Get(types.Name{Package: "", Name: "map[string]bar.Baz"})
 	tmp.Kind = types.Map
 	tmp.Key = types.String
 	tmp.Elem = base
 
-	tmp = u.Get(types.Name{"foo/other", "Baz"})
+	tmp = u.Get(types.Name{Package: "foo/other", Name: "Baz"})
 	tmp.Kind = types.Struct
 	tmp.Members = []types.Member{{
 		Embedded: true,
 		Type:     base,
 	}}
 
-	u.Get(types.Name{"", "string"})
+	u.Get(types.Name{Package: "", Name: "string"})
 
 	o := Orderer{NewPublicNamer(0)}
 	order := o.Order(u)

--- a/cmd/libs/go2idl/parser/parse.go
+++ b/cmd/libs/go2idl/parser/parse.go
@@ -83,6 +83,11 @@ func New() *Builder {
 	}
 }
 
+// AddBuildTags adds the specified build tags to the parse context.
+func (b *Builder) AddBuildTags(tags ...string) {
+	b.context.BuildTags = append(b.context.BuildTags, tags...)
+}
+
 // Get package information from the go/build package. Automatically excludes
 // e.g. test files and files for other platforms-- there is quite a bit of
 // logic of that nature in the build package.

--- a/cmd/libs/go2idl/parser/parse_test.go
+++ b/cmd/libs/go2idl/parser/parse_test.go
@@ -175,7 +175,7 @@ type Blah struct {
 
 	_, u, o := construct(t, structTest, namer.NewPublicNamer(0))
 	t.Logf("%#v", o)
-	blahT := u.Get(types.Name{"base/foo/proto", "Blah"})
+	blahT := u.Get(types.Name{Package: "base/foo/proto", Name: "Blah"})
 	if blahT == nil {
 		t.Fatal("type not found")
 	}
@@ -344,11 +344,11 @@ type Interface interface{Method(a, b string) (c, d string)}
 		}
 
 		// Also do some one-off checks
-		gtest := u.Get(types.Name{"g", "Test"})
+		gtest := u.Get(types.Name{Package: "g", Name: "Test"})
 		if e, a := 1, len(gtest.Methods); e != a {
 			t.Errorf("expected %v but found %v methods: %#v", e, a, gtest)
 		}
-		iface := u.Get(types.Name{"g", "Interface"})
+		iface := u.Get(types.Name{Package: "g", Name: "Interface"})
 		if e, a := 1, len(iface.Methods); e != a {
 			t.Errorf("expected %v but found %v methods: %#v", e, a, iface)
 		}

--- a/cmd/libs/go2idl/types/flatten_test.go
+++ b/cmd/libs/go2idl/types/flatten_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestFlatten(t *testing.T) {
 	mapType := &Type{
-		Name: Name{"", "map[string]string"},
+		Name: Name{Package: "", Name: "map[string]string"},
 		Kind: Map,
 		Key:  String,
 		Elem: String,
@@ -33,7 +33,7 @@ func TestFlatten(t *testing.T) {
 			Name:     "Baz",
 			Embedded: true,
 			Type: &Type{
-				Name: Name{"pkg", "Baz"},
+				Name: Name{Package: "pkg", Name: "Baz"},
 				Kind: Struct,
 				Members: []Member{
 					{Name: "Foo", Type: String},
@@ -41,7 +41,7 @@ func TestFlatten(t *testing.T) {
 						Name:     "Qux",
 						Embedded: true,
 						Type: &Type{
-							Name:    Name{"pkg", "Qux"},
+							Name:    Name{Package: "pkg", Name: "Qux"},
 							Kind:    Struct,
 							Members: []Member{{Name: "Zot", Type: String}},
 						},

--- a/cmd/libs/go2idl/types/types.go
+++ b/cmd/libs/go2idl/types/types.go
@@ -18,10 +18,13 @@ package types
 
 // A type name may have a package qualifier.
 type Name struct {
-	// Empty if embedded or builtin. This is the package path.
+	// Empty if embedded or builtin. This is the package path unless Path is specified.
 	Package string
 	// The type name.
 	Name string
+	// An optional location of the type definition for languages that can have disjoint
+	// packages and paths.
+	Path string
 }
 
 // String returns the name formatted as a string.
@@ -104,7 +107,7 @@ func (p *Package) Get(typeName string) *Type {
 			return t
 		}
 	}
-	t := &Type{Name: Name{p.Path, typeName}}
+	t := &Type{Name: Name{Package: p.Path, Name: typeName}}
 	p.Types[typeName] = t
 	return t
 }
@@ -280,6 +283,22 @@ var (
 		Name: Name{Name: "uint"},
 		Kind: Builtin,
 	}
+	Uintptr = &Type{
+		Name: Name{Name: "uintptr"},
+		Kind: Builtin,
+	}
+	Float64 = &Type{
+		Name: Name{Name: "float64"},
+		Kind: Builtin,
+	}
+	Float32 = &Type{
+		Name: Name{Name: "float32"},
+		Kind: Builtin,
+	}
+	Float = &Type{
+		Name: Name{Name: "float"},
+		Kind: Builtin,
+	}
 	Bool = &Type{
 		Name: Name{Name: "bool"},
 		Kind: Builtin,
@@ -291,19 +310,23 @@ var (
 
 	builtins = &Package{
 		Types: map[string]*Type{
-			"bool":   Bool,
-			"string": String,
-			"int":    Int,
-			"int64":  Int64,
-			"int32":  Int32,
-			"int16":  Int16,
-			"int8":   Byte,
-			"uint":   Uint,
-			"uint64": Uint64,
-			"uint32": Uint32,
-			"uint16": Uint16,
-			"uint8":  Byte,
-			"byte":   Byte,
+			"bool":    Bool,
+			"string":  String,
+			"int":     Int,
+			"int64":   Int64,
+			"int32":   Int32,
+			"int16":   Int16,
+			"int8":    Byte,
+			"uint":    Uint,
+			"uint64":  Uint64,
+			"uint32":  Uint32,
+			"uint16":  Uint16,
+			"uint8":   Byte,
+			"uintptr": Uintptr,
+			"byte":    Byte,
+			"float":   Float,
+			"float64": Float64,
+			"float32": Float32,
 		},
 		Imports: map[string]*Package{},
 		Path:    "",

--- a/cmd/libs/go2idl/types/types_test.go
+++ b/cmd/libs/go2idl/types/types_test.go
@@ -25,7 +25,7 @@ func TestGetBuiltin(t *testing.T) {
 	if builtinPkg := u.Package(""); builtinPkg.Has("string") {
 		t.Errorf("Expected builtin package to not have builtins until they're asked for explicitly. %#v", builtinPkg)
 	}
-	s := u.Get(Name{"", "string"})
+	s := u.Get(Name{Package: "", Name: "string"})
 	if s != String {
 		t.Errorf("Expected canonical string type.")
 	}
@@ -39,7 +39,7 @@ func TestGetBuiltin(t *testing.T) {
 
 func TestGetMarker(t *testing.T) {
 	u := Universe{}
-	n := Name{"path/to/package", "Foo"}
+	n := Name{Package: "path/to/package", Name: "Foo"}
 	f := u.Get(n)
 	if f == nil || f.Name != n {
 		t.Errorf("Expected marker type.")


### PR DESCRIPTION
Remove some indentation from file generation for specific languages,
allow SnippetWriter's io.Writer to be accessed, and add Path to
types.Name for languages where Package and Path can be disjoint.

Extracted from #16649, prereq for protobuf generation support.
