### PR TITLE
make EventType a strong type, instead of string

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1781,12 +1781,14 @@ type EventSource struct {
 	Host string `json:"host,omitempty"`
 }
 
+type EventType string
+
 // Valid values for event types (new types could be added in future)
 const (
 	// Information only and will not cause any problems
-	EventTypeNormal string = "Normal"
+	EventTypeNormal EventType = "Normal"
 	// These events are to warn that something might go wrong
-	EventTypeWarning string = "Warning"
+	EventTypeWarning EventType = "Warning"
 )
 
 // Event is a report of an event somewhere in the cluster.
@@ -1821,7 +1823,7 @@ type Event struct {
 	Count int `json:"count,omitempty"`
 
 	// Type of this event (Normal, Warning), new types could be added in the future.
-	Type string `json:"type,omitempty"`
+	Type EventType `json:"type,omitempty"`
 }
 
 // EventList is a list of events.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2220,12 +2220,14 @@ type EventSource struct {
 	Host string `json:"host,omitempty"`
 }
 
+type EventType string
+
 // Valid values for event types (new types could be added in future)
 const (
 	// Information only and will not cause any problems
-	EventTypeNormal string = "Normal"
+	EventTypeNormal EventType = "Normal"
 	// These events are to warn that something might go wrong
-	EventTypeWarning string = "Warning"
+	EventTypeWarning EventType = "Warning"
 )
 
 // Event is a report of an event somewhere in the cluster.
@@ -2261,7 +2263,7 @@ type Event struct {
 	Count int `json:"count,omitempty"`
 
 	// Type of this event (Normal, Warning), new types could be added in the future
-	Type string `json:"type,omitempty"`
+	Type EventType `json:"type,omitempty"`
 }
 
 // EventList is a list of events.


### PR DESCRIPTION
make EventType a strong type, instead of string.

For easier reviewing, have not run `./hack/update-generated-conversions.sh`, `./hack/update-generated-deep-copies.sh` and  `./hack/update-codecgen.sh` to update related auto generated files.

I would run those generation scripts and update this PR if it looks good for reviewers.
