### PR TITLE
MESOS/CI: clone conformance branch into subdir

### DIFF
--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -81,6 +81,6 @@ exec docker run \
     trap 'timeout 5m ./cluster/kube-down.sh' EXIT && \
     ./cluster/kube-down.sh && \
     ./cluster/kube-up.sh && \
-    trap 'test \$? != 0 && export MESOS_DOCKER_DUMP_LOGS=true; timeout 5m ./cluster/kube-down.sh' EXIT && \
+    trap \"test \\\$? != 0 && export MESOS_DOCKER_DUMP_LOGS=true; cd \${PWD} && timeout 5m ./cluster/kube-down.sh\" EXIT && \
     ${RUN_CMD}
   "

--- a/contrib/mesos/ci/test-conformance.sh
+++ b/contrib/mesos/ci/test-conformance.sh
@@ -31,19 +31,13 @@ TEST_ARGS="$@"
 
 KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
+TEST_CMD="KUBECONFIG=~/.kube/config hack/conformance-test.sh"
 if [ -n "${CONFORMANCE_BRANCH}" ]; then
-	# checkout CONFORMANCE_BRANCH, but leave the contrib/mesos/ci directory
-	# untouched.
+	# create a CONFORMANCE_BRANCH clone in a subdirectory
 	TEST_CMD="
-git fetch https://github.com/kubernetes/kubernetes ${CONFORMANCE_BRANCH} &&
-git checkout FETCH_HEAD -- . ':(exclude)contrib/mesos/ci/**' &&
-git reset FETCH_HEAD &&
-git clean -d -f -- . ':(exclude)contrib/mesos/ci/**' &&
-git status &&
-make all &&
-"
-else
-	TEST_CMD=""
+git fetch https://github.com/kubernetes/kubernetes --tags -q ${CONFORMANCE_BRANCH} &&
+git clone -s -b ${CONFORMANCE_BRANCH} . conformance &&
+cd conformance && make all && ${TEST_CMD}"
 fi
-TEST_CMD+="KUBECONFIG=~/.kube/config hack/conformance-test.sh"
+
 "${KUBE_ROOT}/contrib/mesos/ci/run-with-cluster.sh" ${TEST_CMD} ${TEST_ARGS}


### PR DESCRIPTION
In order to properly shutdown the docker-compose cluster, after the conformance
test it is necessary to have the original version again. Running the conformance
tests from a clone in subdir with the right branch given by CONFORMANCE_BRANCH
is much easier.
