### PR TITLE
MESOS/CI: call kube-down.sh first to stop dangling containers

### DIFF
--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -79,6 +79,7 @@ exec docker run \
   -ceux "\
     make clean all && \
     trap 'timeout 5m ./cluster/kube-down.sh' EXIT && \
+    ./cluster/kube-down.sh && \
     ./cluster/kube-up.sh && \
     trap 'test \$? != 0 && export MESOS_DOCKER_DUMP_LOGS=true; timeout 5m ./cluster/kube-down.sh' EXIT && \
     ${RUN_CMD}


### PR DESCRIPTION
When test runs terminate early without calling kube-down.sh, we get dangling docker containers. These lead to those odd "10.10.10.10 already taken" and "kube-system namespace already exists" flakes on cluster startup. This PR fixes this by calling kube-down.sh before starting up a new cluster. Because one usually does this on a local machine anyway, those flakes never showed up locally.
