### PR TITLE
Make errors aggregating safer

### DIFF
--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -29,10 +29,16 @@ type Aggregate interface {
 // is itself an implementation of the error interface.  If the slice is empty,
 // this returns nil.
 func NewAggregate(errlist []error) Aggregate {
-	if len(errlist) == 0 {
+	errs := []error{}
+	for _, err := range errlist {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) == 0 {
 		return nil
 	}
-	return aggregate(errlist)
+	return aggregate(errs)
 }
 
 // This helper implements the error and Errors interfaces.  Keeping it private


### PR DESCRIPTION
If a nil error sneaked into the error list that was about to be aggregated,
a panic would be guaranteed. Not anymore.

@thockin 
