### PR TITLE
[ubuntu] use vxlan as default backend

### DIFF
--- a/cluster/ubuntu/reconfDocker.sh
+++ b/cluster/ubuntu/reconfDocker.sh
@@ -38,7 +38,7 @@ function config_etcd {
         exit 2
       fi
 
-      /opt/bin/etcdctl mk /coreos.com/network/config "{\"Network\":\"${FLANNEL_NET}\"}"
+      /opt/bin/etcdctl mk /coreos.com/network/config "{\"Network\":\"${FLANNEL_NET}\", \"Backend\": {\"Type\": \"vxlan\"}}"
       attempt=$((attempt+1))
       sleep 3
     fi


### PR DESCRIPTION
We have very good reason to update flannel to vxlan back-end.

| Qperf test | Flannel  UDP | Flannel VxLAN |
| --- | --- | --- |
| TCP bandwidth | 28.7 MB/s | 47.8 MB/s |
| TCP latency | 200 µs | 127 µs |
