### PR TITLE
avoid unschedulable pods in networking.go

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -145,7 +145,7 @@ var _ = Describe("Networking", func() {
 		// previous tests may have cause failures of some nodes. Let's skip
 		// 'Not Ready' nodes, just in case (there is no need to fail the test).
 		filterNodes(nodes, func(node api.Node) bool {
-			return isNodeConditionSetAsExpected(&node, api.NodeReady, true)
+			return !node.Spec.Unschedulable && isNodeConditionSetAsExpected(&node, api.NodeReady, true)
 		})
 
 		if len(nodes.Items) == 0 {


### PR DESCRIPTION
modify `networking.go` to  steer clear of Unschedulable nodes.... I've done some teseting on 3 node with 1 node unscheduled.  E2E's now running in CI so they should catch this as well.
