### PR TITLE
[Documentation] There shouldn't be a replication controller

### DIFF
--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -287,7 +287,6 @@ NAME              CLUSTER_IP       EXTERNAL_IP       PORT(S)       SELECTOR     
 
 $ ./cluster/kubectl.sh get replicationcontrollers
 CONTROLLER   CONTAINER(S)   IMAGE(S)   SELECTOR       REPLICAS   AGE
-my-nginx     my-nginx       nginx      run=my-nginx   3          1m
 ```
 
 We did not start any services, hence there are none listed. But we see three replicas displayed properly.


### PR DESCRIPTION
As described in the sentence below it.
"We did not start any services, hence there are none listed."
