### PR TITLE
Fix upstart name

### DIFF
--- a/docs/admin/daemons.md
+++ b/docs/admin/daemons.md
@@ -170,7 +170,7 @@ Support for updating DaemonSets and controlled updating of nodes is planned.
 ### Init Scripts
 
 It is certainly possible to run daemon processes by directly starting them on a node (e.g using
-`init`, `upstartd`, or `systemd`).  This is perfectly fine.  However, there are several advantages to
+`init`, `upstart`, or `systemd`).  This is perfectly fine.  However, there are several advantages to
 running such processes via a DaemonSet:
 
 - Ability to monitor and manage logs for daemons in the same way as applications.


### PR DESCRIPTION
There is no such thing as upstartd, the binary and project have always been called upstart.
