### PR TITLE
Ubernetes Lite: Volumes can dictate zone scheduling

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -126,7 +126,7 @@ if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
 fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,PersistentVolumeLabel
 
 # Optional: Enable/disable public IP assignment for minions.
 # Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -122,7 +122,7 @@ if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
 fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,PersistentVolumeLabel
 
 # Optional: Enable/disable public IP assignment for minions.
 # Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!

--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -33,6 +33,7 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"

--- a/docs/admin/kube-apiserver.md
+++ b/docs/admin/kube-apiserver.md
@@ -51,7 +51,7 @@ kube-apiserver
 ### Options
 
 ```
-      --admission-control="AlwaysAdmit": Ordered list of plug-ins to do admission control of resources into cluster. Comma-delimited list of: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, DenyEscalatingExec, DenyExecOnPrivileged, InitialResources, LimitRanger, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, ResourceQuota, SecurityContextDeny, ServiceAccount
+      --admission-control="AlwaysAdmit": Ordered list of plug-ins to do admission control of resources into cluster. Comma-delimited list of: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, DenyEscalatingExec, DenyExecOnPrivileged, InitialResources, LimitRanger, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, PersistentVolumeLabel, ResourceQuota, SecurityContextDeny, ServiceAccount
       --admission-control-config-file="": File with admission control configuration.
       --advertise-address=<nil>: The IP address on which to advertise the apiserver to members of the cluster. This address must be reachable by the rest of the cluster. If blank, the --bind-address will be used. If --bind-address is unspecified, the host's default interface will be used.
       --allow-privileged[=false]: If true, allow privileged containers.

--- a/docs/devel/scheduler_algorithm.md
+++ b/docs/devel/scheduler_algorithm.md
@@ -41,6 +41,7 @@ For each unscheduled Pod, the Kubernetes scheduler tries to find a node across t
 The purpose of filtering the nodes is to filter out the nodes that do not meet certain requirements of the Pod. For example, if the free resource on a node (measured by the capacity minus the sum of the resource requests of all the Pods that already run on the node) is less than the Pod's required resource, the node should not be considered in the ranking phase so it is filtered out. Currently, there are several "predicates" implementing different filtering policies, including:
 
 - `NoDiskConflict`: Evaluate if a pod can fit due to the volumes it requests, and those that are already mounted.
+- `NoVolumeZoneConflict`: Evaluate if the volumes a pod requests are available on the node, given the Zone restrictions.
 - `PodFitsResources`: Check if the free resource (CPU and Memory) meets the requirement of the Pod. The free resource is measured by the capacity minus the sum of requests of all Pods on the node. To learn more about the resource QoS in Kubernetes, please check [QoS proposal](../proposals/resource-qos.md).
 - `PodFitsHostPorts`: Check if any HostPort required by the Pod is already occupied on the node.
 - `PodFitsHost`: Filter out all nodes except the one specified in the PodSpec's NodeName field.

--- a/examples/scheduler-policy-config.json
+++ b/examples/scheduler-policy-config.json
@@ -5,6 +5,7 @@
 	{"name" : "PodFitsPorts"},
 	{"name" : "PodFitsResources"},
 	{"name" : "NoDiskConflict"},
+	{"name" : "NoVolumeZoneConflict"},
 	{"name" : "MatchNodeSelector"},
 	{"name" : "HostName"}
 	],

--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -417,3 +417,42 @@ func (s *StoreToJobLister) GetPodJobs(pod *api.Pod) (jobs []extensions.Job, err 
 	}
 	return
 }
+
+// Typed wrapper around a store of PersistentVolumes
+type StoreToPVFetcher struct {
+	Store
+}
+
+// GetPersistentVolumeInfo returns cached data for the PersistentVolume 'id'.
+func (s *StoreToPVFetcher) GetPersistentVolumeInfo(id string) (*api.PersistentVolume, error) {
+	o, exists, err := s.Get(&api.PersistentVolume{ObjectMeta: api.ObjectMeta{Name: id}})
+
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving PersistentVolume '%v' from cache: %v", id, err)
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("PersistentVolume '%v' is not in cache", id)
+	}
+
+	return o.(*api.PersistentVolume), nil
+}
+
+// Typed wrapper around a store of PersistentVolumeClaims
+type StoreToPVCFetcher struct {
+	Store
+}
+
+// GetPersistentVolumeClaimInfo returns cached data for the PersistentVolumeClaim 'id'.
+func (s *StoreToPVCFetcher) GetPersistentVolumeClaimInfo(namespace string, id string) (*api.PersistentVolumeClaim, error) {
+	o, exists, err := s.Get(&api.PersistentVolumeClaim{ObjectMeta: api.ObjectMeta{Namespace: namespace, Name: id}})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving PersistentVolumeClaim '%s/%s' from cache: %v", namespace, id, err)
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("PersistentVolumeClaim '%s/%s' is not in cache", namespace, id)
+	}
+
+	return o.(*api.PersistentVolumeClaim), nil
+}

--- a/plugin/pkg/admission/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package label
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+)
+
+func init() {
+	admission.RegisterPlugin("PersistentVolumeLabel", func(client client.Interface, config io.Reader) (admission.Interface, error) {
+		persistentVolumeLabelAdmission := NewPersistentVolumeLabel()
+		return persistentVolumeLabelAdmission, nil
+	})
+}
+
+var _ = admission.Interface(&persistentVolumeLabel{})
+
+type persistentVolumeLabel struct {
+	*admission.Handler
+
+	mutex      sync.Mutex
+	ebsVolumes aws.Volumes
+}
+
+// NewPersistentVolumeLabel returns an admission.Interface implementation which adds labels to PersistentVolume CREATE requests,
+// based on the labels provided by the underlying cloud provider.
+//
+// As a side effect, the cloud provider may block invalid or non-existent volumes.
+func NewPersistentVolumeLabel() *persistentVolumeLabel {
+	return &persistentVolumeLabel{
+		Handler: admission.NewHandler(admission.Create),
+	}
+}
+
+func (l *persistentVolumeLabel) Admit(a admission.Attributes) (err error) {
+	if a.GetResource() != api.Resource("persistentvolumes") {
+		return nil
+	}
+	obj := a.GetObject()
+	if obj == nil {
+		return nil
+	}
+	volume, ok := obj.(*api.PersistentVolume)
+	if !ok {
+		return nil
+	}
+
+	var volumeLabels map[string]string
+	if volume.Spec.AWSElasticBlockStore != nil {
+		labels, err := l.findAWSEBSLabels(volume)
+		if err != nil {
+			return admission.NewForbidden(a, fmt.Errorf("error querying AWS EBS volume %s: %v", volume.Spec.AWSElasticBlockStore.VolumeID, err))
+		}
+		volumeLabels = labels
+	}
+
+	if len(volumeLabels) != 0 {
+		if volume.Labels == nil {
+			volume.Labels = make(map[string]string)
+		}
+		for k, v := range volumeLabels {
+			// We (silently) replace labels if they are provided.
+			// This should be OK because they are in the kubernetes.io namespace
+			// i.e. we own them
+			volume.Labels[k] = v
+		}
+	}
+
+	return nil
+}
+
+func (l *persistentVolumeLabel) findAWSEBSLabels(volume *api.PersistentVolume) (map[string]string, error) {
+	ebsVolumes, err := l.getEBSVolumes()
+	if err != nil {
+		return nil, err
+	}
+	if ebsVolumes == nil {
+		return nil, fmt.Errorf("unable to build AWS cloud provider for EBS")
+	}
+
+	// TODO: GetVolumeLabels is actually a method on the Volumes interface
+	// If that gets standardized we can refactor to reduce code duplication
+	labels, err := ebsVolumes.GetVolumeLabels(volume.Spec.AWSElasticBlockStore.VolumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	return labels, err
+}
+
+// getEBSVolumes returns the AWS Volumes interface for ebs
+func (l *persistentVolumeLabel) getEBSVolumes() (aws.Volumes, error) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if l.ebsVolumes == nil {
+		cloudProvider, err := cloudprovider.GetCloudProvider("aws", nil)
+		if err != nil || cloudProvider == nil {
+			return nil, err
+		}
+		awsCloudProvider, ok := cloudProvider.(*aws.AWSCloud)
+		if !ok {
+			// GetCloudProvider has gone very wrong
+			return nil, fmt.Errorf("error retrieving AWS cloud provider")
+		}
+		l.ebsVolumes = awsCloudProvider
+	}
+	return l.ebsVolumes, nil
+}

--- a/plugin/pkg/admission/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package label
+
+import (
+	"testing"
+
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+)
+
+type mockVolumes struct {
+	volumeLabels      map[string]string
+	volumeLabelsError error
+}
+
+var _ aws.Volumes = &mockVolumes{}
+
+func (v *mockVolumes) AttachDisk(instanceName string, volumeName string, readOnly bool) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (v *mockVolumes) DetachDisk(instanceName string, volumeName string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (v *mockVolumes) CreateVolume(volumeOptions *aws.VolumeOptions) (volumeName string, err error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (v *mockVolumes) DeleteVolume(volumeName string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (v *mockVolumes) GetVolumeLabels(volumeName string) (map[string]string, error) {
+	return v.volumeLabels, v.volumeLabelsError
+}
+
+func mockVolumeFailure(err error) *mockVolumes {
+	return &mockVolumes{volumeLabelsError: err}
+}
+
+func mockVolumeLabels(labels map[string]string) *mockVolumes {
+	return &mockVolumes{volumeLabels: labels}
+}
+
+// TestAdmission
+func TestAdmission(t *testing.T) {
+	pvHandler := NewPersistentVolumeLabel()
+	handler := admission.NewChainHandler(pvHandler)
+	ignoredPV := api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{Name: "noncloud", Namespace: "myns"},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{
+					Path: "/",
+				},
+			},
+		},
+	}
+	awsPV := api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{Name: "noncloud", Namespace: "myns"},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{
+					VolumeID: "123",
+				},
+			},
+		},
+	}
+
+	// Non-cloud PVs are ignored
+	err := handler.Admit(admission.NewAttributesRecord(&ignoredPV, api.Kind("PersistentVolume"), ignoredPV.Namespace, ignoredPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler (on ignored pv): %v", err)
+	}
+
+	// We only add labels on creation
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Delete, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler (when deleting aws pv):  %v", err)
+	}
+
+	// Errors from the cloudprovider block creation of the volume
+	pvHandler.ebsVolumes = mockVolumeFailure(fmt.Errorf("invalid volume"))
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	if err == nil {
+		t.Errorf("Expected error when aws pv info fails")
+	}
+
+	// Don't add labels if the cloudprovider doesn't return any
+	labels := make(map[string]string)
+	pvHandler.ebsVolumes = mockVolumeLabels(labels)
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Expected no error when creating aws pv")
+	}
+	if len(awsPV.ObjectMeta.Labels) != 0 {
+		t.Errorf("Unexpected number of labels")
+	}
+
+	// Don't panic if the cloudprovider returns nil, nil
+	pvHandler.ebsVolumes = mockVolumeFailure(nil)
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Expected no error when cloud provider returns empty labels")
+	}
+
+	// Labels from the cloudprovider should be applied to the volume
+	labels = make(map[string]string)
+	labels["a"] = "1"
+	labels["b"] = "2"
+	pvHandler.ebsVolumes = mockVolumeLabels(labels)
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Expected no error when creating aws pv")
+	}
+	if awsPV.Labels["a"] != "1" || awsPV.Labels["b"] != "2" {
+		t.Errorf("Expected label a to be added when creating aws pv")
+	}
+
+	// User-provided labels should be honored, but cloudprovider labels replace them when they overlap
+	awsPV.ObjectMeta.Labels = make(map[string]string)
+	awsPV.ObjectMeta.Labels["a"] = "not1"
+	awsPV.ObjectMeta.Labels["c"] = "3"
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Expected no error when creating aws pv")
+	}
+	if awsPV.Labels["a"] != "1" || awsPV.Labels["b"] != "2" {
+		t.Errorf("Expected cloudprovider labels to replace user labels when creating aws pv")
+	}
+	if awsPV.Labels["c"] != "3" {
+		t.Errorf("Expected (non-conflicting) user provided labels to be honored when creating aws pv")
+	}
+
+}

--- a/plugin/pkg/admission/persistentvolume/label/doc.go
+++ b/plugin/pkg/admission/persistentvolume/label/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// labels created persistent volumes with zone information
+// as provided by the cloud provider
+package label

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -26,10 +26,19 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 type NodeInfo interface {
 	GetNodeInfo(nodeID string) (*api.Node, error)
+}
+
+type PersistentVolumeInfo interface {
+	GetPersistentVolumeInfo(pvID string) (*api.PersistentVolume, error)
+}
+
+type PersistentVolumeClaimInfo interface {
+	GetPersistentVolumeClaimInfo(namespace string, pvcID string) (*api.PersistentVolumeClaim, error)
 }
 
 type StaticNodeInfo struct {
@@ -133,6 +142,108 @@ func NoDiskConflict(pod *api.Pod, existingPods []*api.Pod, node string) (bool, e
 			}
 		}
 	}
+	return true, nil
+}
+
+type VolumeZoneChecker struct {
+	nodeInfo NodeInfo
+	pvInfo   PersistentVolumeInfo
+	pvcInfo  PersistentVolumeClaimInfo
+}
+
+// VolumeZonePredicate evaluates if a pod can fit due to the volumes it requests, given
+// that some volumes may have zone scheduling constraints.  The requirement is that any
+// volume zone-labels must match the equivalent zone-labels on the node.  It is OK for
+// the node to have more zone-label constraints (for example, a hypothetical replicated
+// volume might allow region-wide access)
+//
+// Currently this is only supported with PersistentVolumeClaims, and looks to the labels
+// only on the bound PersistentVolume.
+//
+// Working with volumes declared inline in the pod specification (i.e. not
+// using a PersistentVolume) is likely to be harder, as it would require
+// determining the zone of a volume during scheduling, and that is likely to
+// require calling out to the cloud provider.  It seems that we are moving away
+// from inline volume declarations anyway.
+func NewVolumeZonePredicate(nodeInfo NodeInfo, pvInfo PersistentVolumeInfo, pvcInfo PersistentVolumeClaimInfo) algorithm.FitPredicate {
+	c := &VolumeZoneChecker{
+		nodeInfo: nodeInfo,
+		pvInfo:   pvInfo,
+		pvcInfo:  pvcInfo,
+	}
+	return c.predicate
+}
+
+func (c *VolumeZoneChecker) predicate(pod *api.Pod, existingPods []*api.Pod, nodeID string) (bool, error) {
+	node, err := c.nodeInfo.GetNodeInfo(nodeID)
+	if err != nil {
+		return false, err
+	}
+	if node == nil {
+		return false, fmt.Errorf("node not found: %q", nodeID)
+	}
+
+	nodeConstraints := make(map[string]string)
+	for k, v := range node.ObjectMeta.Labels {
+		if k != unversioned.LabelZoneFailureDomain && k != unversioned.LabelZoneRegion {
+			continue
+		}
+		nodeConstraints[k] = v
+	}
+
+	if len(nodeConstraints) == 0 {
+		// The node has no zone constraints, so we're OK to schedule.
+		// In practice, when using zones, all nodes must be labeled with zone labels.
+		// We want to fast-path this case though.
+		return true, nil
+	}
+
+	namespace := pod.Namespace
+
+	manifest := &(pod.Spec)
+	for i := range manifest.Volumes {
+		volume := &manifest.Volumes[i]
+		if volume.PersistentVolumeClaim != nil {
+			pvcName := volume.PersistentVolumeClaim.ClaimName
+			if pvcName == "" {
+				return false, fmt.Errorf("PersistentVolumeClaim had no name: %q", pvcName)
+			}
+			pvc, err := c.pvcInfo.GetPersistentVolumeClaimInfo(namespace, pvcName)
+			if err != nil {
+				return false, err
+			}
+
+			if pvc == nil {
+				return false, fmt.Errorf("PersistentVolumeClaim was not found: %q", pvcName)
+			}
+
+			pvName := pvc.Spec.VolumeName
+			if pvName == "" {
+				return false, fmt.Errorf("PersistentVolumeClaim is not bound: %q", pvcName)
+			}
+
+			pv, err := c.pvInfo.GetPersistentVolumeInfo(pvName)
+			if err != nil {
+				return false, err
+			}
+
+			if pv == nil {
+				return false, fmt.Errorf("PersistentVolume not found: %q", pvName)
+			}
+
+			for k, v := range pv.ObjectMeta.Labels {
+				if k != unversioned.LabelZoneFailureDomain && k != unversioned.LabelZoneRegion {
+					continue
+				}
+				nodeV, _ := nodeConstraints[k]
+				if v != nodeV {
+					glog.V(2).Infof("Won't schedule pod %q onto node %q due to volume %q (mismatch on %q)", pod.Name, nodeID, pvName, k)
+					return false, nil
+				}
+			}
+		}
+	}
+
 	return true, nil
 }
 

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -64,6 +64,13 @@ func defaultPredicates() sets.String {
 		),
 		// Fit is determined by non-conflicting disk volumes.
 		factory.RegisterFitPredicate("NoDiskConflict", predicates.NoDiskConflict),
+		// Fit is determined by volume zone requirements.
+		factory.RegisterFitPredicateFactory(
+			"NoVolumeZoneConflict",
+			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
+				return predicates.NewVolumeZonePredicate(args.NodeInfo, args.PVInfo, args.PVCInfo)
+			},
+		),
 		// Fit is determined by node selector query.
 		factory.RegisterFitPredicateFactory(
 			"MatchNodeSelector",

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -38,6 +38,8 @@ type PluginFactoryArgs struct {
 	algorithm.ControllerLister
 	NodeLister algorithm.NodeLister
 	NodeInfo   predicates.NodeInfo
+	PVInfo     predicates.PersistentVolumeInfo
+	PVCInfo    predicates.PersistentVolumeClaimInfo
 }
 
 // A FitPredicateFactory produces a FitPredicate from the given args.


### PR DESCRIPTION
For AWS EBS, a volume can only be attached to a node in the same AZ.
The scheduler must therefore detect if a volume is being attached to a
pod, and ensure that the pod is scheduled on a node in the same AZ as
the volume.

So that the scheduler need not query the cloud provider every time, and
to support decoupled operation (e.g. bare metal) we tag the volume with
our placement labels.  This is done automatically by means of an
admission controller on AWS when a PersistentVolume is created backed by
an EBS volume.

Support for tagging GCE PVs will follow.

Pods that specify a volume directly (i.e. without using a
PersistentVolumeClaim) will not currently be scheduled correctly (i.e.
they will be scheduled without zone-awareness).
