### PR TITLE
docs(getting-started): add AZ_LOCATION information to README

### DIFF
--- a/docs/getting-started-guides/coreos/azure/README.md
+++ b/docs/getting-started-guides/coreos/azure/README.md
@@ -69,10 +69,10 @@ First, you need to install some of the dependencies with
 npm install
 ```
 
-If you want to choose your location do:
-a list of locations can be found here [AZ Locations](https://azure.microsoft.com/en-us/regions/)
+If you want to choose your location run:
 
 ``` sh
+# https://azure.microsoft.com/en-us/regions/
 export AZ_LOCATION=<desired_location_value>
 ```
 

--- a/docs/getting-started-guides/coreos/azure/README.md
+++ b/docs/getting-started-guides/coreos/azure/README.md
@@ -69,6 +69,13 @@ First, you need to install some of the dependencies with
 npm install
 ```
 
+If you want to choose your location do:
+a list of locations can be found here [AZ Locations](https://azure.microsoft.com/en-us/regions/)
+
+``` sh
+export AZ_LOCATION=<desired_location_value>
+```
+
 Now, all you need to do is:
 
 ```sh


### PR DESCRIPTION
The current azure installed failed for me with the default location. There was no information on how to set the location in the README, so I figured this would help others.
