### PR TITLE
MESOS/CI: name FETCH_HEAD as CONFORMANCE_BRANCH

### DIFF
--- a/contrib/mesos/ci/test-conformance.sh
+++ b/contrib/mesos/ci/test-conformance.sh
@@ -36,6 +36,7 @@ if [ -n "${CONFORMANCE_BRANCH}" ]; then
 	# create a CONFORMANCE_BRANCH clone in a subdirectory
 	TEST_CMD="
 git fetch https://github.com/kubernetes/kubernetes --tags -q ${CONFORMANCE_BRANCH} &&
+git branch -f ${CONFORMANCE_BRANCH} FETCH_HEAD &&
 git clone -s -b ${CONFORMANCE_BRANCH} . conformance &&
 cd conformance && make all && ${TEST_CMD}"
 fi


### PR DESCRIPTION
After fetch from an explicit URL no local branch is created. Hence, we have to do that manually, possibly overwriting the previous, already existing branch.
