### PR TITLE
Pod labeling should return correct messages

### DIFF
--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -227,6 +228,7 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 		}
 
 		var outputObj runtime.Object
+		dataChangeMsg := "not labeled"
 		if cmdutil.GetFlagBool(cmd, "dry-run") {
 			err = labelFunc(info.Object, overwrite, resourceVersion, lbls, remove)
 			if err != nil {
@@ -239,12 +241,22 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			if err != nil {
 				return err
 			}
+			meta, err := api.ObjectMetaFor(obj)
+			for _, label := range remove {
+				if _, ok := meta.Labels[label]; !ok {
+					fmt.Fprintf(out, "label %q not found.\n", label)
+				}
+			}
+
 			if err := labelFunc(obj, overwrite, resourceVersion, lbls, remove); err != nil {
 				return err
 			}
 			newData, err := json.Marshal(obj)
 			if err != nil {
 				return err
+			}
+			if !reflect.DeepEqual(oldData, newData) {
+				dataChangeMsg = "labeled"
 			}
 			patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, obj)
 			if err != nil {
@@ -267,7 +279,7 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 		if outputFormat != "" {
 			return f.PrintObject(cmd, outputObj, out)
 		}
-		cmdutil.PrintSuccess(mapper, false, out, info.Mapping.Resource, info.Name, "labeled")
+		cmdutil.PrintSuccess(mapper, false, out, info.Mapping.Resource, info.Name, dataChangeMsg)
 		return nil
 	})
 }


### PR DESCRIPTION
When deleting undefined labeles from the pod, kubectl should return appropriate message instead of `pod xxx labeled`, which misleading.
Proposed change would print msg:

```
$ cluster/kubectl.sh pod/redis-slave-0ooo8 test1-
label test1 not found.
pod redis-slave-0ooo8 not labeled
```
