### PR TITLE
Gave pods their own cache store

### DIFF
--- a/cluster/addons/dns/kube2sky/kube2sky.go
+++ b/cluster/addons/dns/kube2sky/kube2sky.go
@@ -86,8 +86,10 @@ type kube2sky struct {
 	etcdMutationTimeout time.Duration
 	// A cache that contains all the endpoints in the system.
 	endpointsStore kcache.Store
-	// A cache that contains all the servicess in the system.
+	// A cache that contains all the services in the system.
 	servicesStore kcache.Store
+	// A cache that contains all the pods in the system.
+	podsStore kcache.Store
 	// Lock for controlling access to headless services.
 	mlock sync.Mutex
 }
@@ -583,7 +585,7 @@ func main() {
 
 	ks.endpointsStore = watchEndpoints(kubeClient, &ks)
 	ks.servicesStore = watchForServices(kubeClient, &ks)
-	ks.servicesStore = watchPods(kubeClient, &ks)
+	ks.podsStore = watchPods(kubeClient, &ks)
 
 	select {}
 }


### PR DESCRIPTION
I was having some DNS issues in my cluster and while troubleshooting noticed that pods didn't have their own cache, but was using the services one. Not sure if that could cause any other issues with services + dns. 
