### PR TITLE
AWS EBS Examplea: Use new volume id syntax

### DIFF
--- a/docs/user-guide/volumes.md
+++ b/docs/user-guide/volumes.md
@@ -272,11 +272,9 @@ spec:
   - name: test-volume
     # This AWS EBS volume must already exist.
     awsElasticBlockStore:
-      volumeID: aws://<availability-zone>/<volume-id>
+      volumeID: <volume-id>
       fsType: ext4
 ```
-
-(Note: the syntax of volumeID is currently awkward; #10181 fixes it)
 
 ### nfs
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/17957
