### PR TITLE
rkt: rewrote GetPods to use rkt's api service

### DIFF
--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package rkt
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	appcschema "github.com/appc/spec/schema"
+	appctypes "github.com/appc/spec/schema/types"
 	rktapi "github.com/coreos/rkt/api/v1alpha"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/types"
 )
 
 func TestCheckVersion(t *testing.T) {
@@ -196,4 +200,262 @@ func TestListImages(t *testing.T) {
 
 		fr.CleanCalls()
 	}
+}
+
+func TestGetPods(t *testing.T) {
+	fr := newFakeRktInterface()
+	fs := newFakeSystemd()
+	r := &Runtime{apisvc: fr, systemd: fs}
+
+	tests := []struct {
+		k8sUID        types.UID
+		k8sName       string
+		k8sNamespace  string
+		k8sCreation   int64
+		k8sRestart    int
+		k8sContHashes []uint64
+		rktPodState   rktapi.PodState
+		pods          []*rktapi.Pod
+	}{
+		{},
+		{
+			k8sUID:        types.UID("0"),
+			k8sName:       "guestbook",
+			k8sNamespace:  "default",
+			k8sCreation:   10000000000,
+			k8sRestart:    1,
+			k8sContHashes: []uint64{2353434678},
+			rktPodState:   rktapi.PodState_POD_STATE_RUNNING,
+			pods: []*rktapi.Pod{
+				{
+					State: rktapi.PodState_POD_STATE_RUNNING,
+					Apps: []*rktapi.App{
+						{
+							Name: "test",
+							Image: &rktapi.Image{
+								Name: "test",
+								Manifest: mustMarshalImageManifest(
+									&appcschema.ImageManifest{
+										ACKind:    appcschema.ImageManifestKind,
+										ACVersion: appcschema.AppContainerVersion,
+										Name:      *appctypes.MustACIdentifier("test"),
+										Annotations: appctypes.Annotations{
+											appctypes.Annotation{
+												Name:  *appctypes.MustACIdentifier(k8sRktContainerHashAnno),
+												Value: "2353434678",
+											},
+										},
+									},
+								),
+							},
+						},
+					},
+					Manifest: mustMarshalPodManifest(
+						&appcschema.PodManifest{
+							ACKind:    appcschema.PodManifestKind,
+							ACVersion: appcschema.AppContainerVersion,
+							Annotations: appctypes.Annotations{
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktKubeletAnno),
+									Value: k8sRktKubeletAnnoValue,
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktUIDAnno),
+									Value: "0",
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktNameAnno),
+									Value: "guestbook",
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktNamespaceAnno),
+									Value: "default",
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktCreationTimeAnno),
+									Value: "10000000000",
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktRestartCountAnno),
+									Value: "1",
+								},
+							},
+						},
+					),
+				},
+			},
+		},
+		{
+			k8sUID:        types.UID("1"),
+			k8sName:       "test-pod",
+			k8sNamespace:  "default",
+			k8sCreation:   10000000001,
+			k8sRestart:    3,
+			k8sContHashes: []uint64{2353434682, 8732645},
+			rktPodState:   rktapi.PodState_POD_STATE_EXITED,
+			pods: []*rktapi.Pod{
+				{
+					State: rktapi.PodState_POD_STATE_EXITED,
+					Apps: []*rktapi.App{
+						{
+							Name: "test",
+							Image: &rktapi.Image{
+								Name: "test",
+								Manifest: mustMarshalImageManifest(
+									&appcschema.ImageManifest{
+										ACKind:    appcschema.ImageManifestKind,
+										ACVersion: appcschema.AppContainerVersion,
+										Name:      *appctypes.MustACIdentifier("test"),
+										Annotations: appctypes.Annotations{
+											appctypes.Annotation{
+												Name:  *appctypes.MustACIdentifier(k8sRktContainerHashAnno),
+												Value: "2353434682",
+											},
+										},
+									},
+								),
+							},
+						},
+						{
+							Name: "test2",
+							Image: &rktapi.Image{
+								Name: "test2",
+								Manifest: mustMarshalImageManifest(
+									&appcschema.ImageManifest{
+										ACKind:    appcschema.ImageManifestKind,
+										ACVersion: appcschema.AppContainerVersion,
+										Name:      *appctypes.MustACIdentifier("test2"),
+										Annotations: appctypes.Annotations{
+											appctypes.Annotation{
+												Name:  *appctypes.MustACIdentifier(k8sRktContainerHashAnno),
+												Value: "8732645",
+											},
+										},
+									},
+								),
+							},
+						},
+					},
+					Manifest: mustMarshalPodManifest(
+						&appcschema.PodManifest{
+							ACKind:    appcschema.PodManifestKind,
+							ACVersion: appcschema.AppContainerVersion,
+							Annotations: appctypes.Annotations{
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktKubeletAnno),
+									Value: k8sRktKubeletAnnoValue,
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktUIDAnno),
+									Value: "1",
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktNameAnno),
+									Value: "test-pod",
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktNamespaceAnno),
+									Value: "default",
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktCreationTimeAnno),
+									Value: "10000000001",
+								},
+								appctypes.Annotation{
+									Name:  *appctypes.MustACIdentifier(k8sRktRestartCountAnno),
+									Value: "3",
+								},
+							},
+						},
+					),
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		fr.pods = tt.pods
+
+		pods, err := r.GetPods(true)
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		assert.Equal(t, len(pods), len(tt.pods), fmt.Sprintf("test case %d: mismatched number of pods", i))
+
+		for j, pod := range pods {
+			assert.Equal(t, pod.ID, tt.k8sUID, fmt.Sprintf("test case %d: mismatched UIDs", i))
+			assert.Equal(t, pod.Name, tt.k8sName, fmt.Sprintf("test case %d: mismatched Names", i))
+			assert.Equal(t, pod.Namespace, tt.k8sNamespace, fmt.Sprintf("test case %d: mismatched Namespaces", i))
+			assert.Equal(t, len(pod.Containers), len(tt.pods[j].Apps), fmt.Sprintf("test case %d: mismatched number of containers", i))
+			for k, cont := range pod.Containers {
+				assert.Equal(t, cont.Created, tt.k8sCreation, fmt.Sprintf("test case %d: mismatched creation times", i))
+				assert.Equal(t, cont.Hash, tt.k8sContHashes[k], fmt.Sprintf("test case %d: mismatched container hashes", i))
+			}
+		}
+
+		var inspectPodCalls []string
+		for range pods {
+			inspectPodCalls = append(inspectPodCalls, "InspectPod")
+		}
+		assert.Equal(t, append([]string{"ListPods"}, inspectPodCalls...), fr.called, fmt.Sprintf("test case %d: unexpected called list", i))
+
+		fr.CleanCalls()
+	}
+}
+
+func TestGetPodsFilter(t *testing.T) {
+	fr := newFakeRktInterface()
+	fs := newFakeSystemd()
+	r := &Runtime{apisvc: fr, systemd: fs}
+
+	for _, test := range []struct {
+		All            bool
+		ExpectedFilter *rktapi.PodFilter
+	}{
+		{
+			true,
+			&rktapi.PodFilter{
+				Annotations: []*rktapi.KeyValue{
+					{
+						Key:   k8sRktKubeletAnno,
+						Value: k8sRktKubeletAnnoValue,
+					},
+				},
+			},
+		},
+		{
+			false,
+			&rktapi.PodFilter{
+				States: []rktapi.PodState{rktapi.PodState_POD_STATE_RUNNING},
+				Annotations: []*rktapi.KeyValue{
+					{
+						Key:   k8sRktKubeletAnno,
+						Value: k8sRktKubeletAnnoValue,
+					},
+				},
+			},
+		},
+	} {
+		_, err := r.GetPods(test.All)
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		assert.Equal(t, test.ExpectedFilter, fr.podFilter, "filters didn't match when all=%b", test.All)
+	}
+}
+
+func mustMarshalPodManifest(man *appcschema.PodManifest) []byte {
+	manblob, err := json.Marshal(man)
+	if err != nil {
+		panic(err)
+	}
+	return manblob
+}
+
+func mustMarshalImageManifest(man *appcschema.ImageManifest) []byte {
+	manblob, err := json.Marshal(man)
+	if err != nil {
+		panic(err)
+	}
+	return manblob
 }


### PR DESCRIPTION
This commit modifies the kubelet to use rkt's new API service when the kubelet wants to list all current pods.

This involved adding annotations to the rkt pod's manifest that contain
information about the kubernetes pod, which is later read by the
kubelet.
