### PR TITLE
Fix missing field selector conversions in v1

### DIFF
--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -91,6 +91,7 @@ func addConversionFuncs() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
+				"metadata.namespace",
 				"status.replicas":
 				return label, value, nil
 			default:
@@ -113,7 +114,9 @@ func addConversionFuncs() {
 				"involvedObject.fieldPath",
 				"reason",
 				"source",
-				"type":
+				"type",
+				"metadata.namespace",
+				"metadata.name":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
@@ -126,7 +129,8 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "status.phase":
+			case "status.phase",
+				"metadata.name":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
@@ -139,7 +143,9 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Secret",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "type":
+			case "type",
+				"metadata.namespace",
+				"metadata.name":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
@@ -152,7 +158,8 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1", "ServiceAccount",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name":
+			case "metadata.name",
+				"metadata.namespace":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
@@ -165,7 +172,22 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Endpoints",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name":
+			case "metadata.namespace",
+				"metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Service",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.namespace",
+				"metadata.name":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/17974

The conversion functions were blocking the usage of `ObjectMeta` related fields.

See where we add default field selectors here:
https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/generic/matcher.go#L30
