### PR TITLE
Add debugging output to mungedocs when --verbose=true.

### DIFF
--- a/cmd/mungedocs/mungedocs.go
+++ b/cmd/mungedocs/mungedocs.go
@@ -29,6 +29,7 @@ import (
 )
 
 var (
+	verbose = flag.Bool("verbose", false, "On verification failure, emit pre-munge and post-munge versions.")
 	verify  = flag.Bool("verify", false, "Exit with status 1 if files would have needed changes but do not change.")
 	rootDir = flag.String("root-dir", "", "Root directory containing documents to be processed.")
 	// "repo-root" seems like a dumb name, this is the relative path (from rootDir) to get to the repoRoot
@@ -108,6 +109,10 @@ func (f fileProcessor) visit(path string) error {
 				filePrinted = true
 			}
 			fmt.Printf("%s:\n", munge.name)
+			if *verbose {
+				fmt.Printf("INPUT: <<<%v>>>\n", mungeLines)
+				fmt.Printf("MUNGED: <<<%v>>>\n", after)
+			}
 			if err != nil {
 				fmt.Println(err)
 				errFound = true

--- a/hack/after-build/verify-generated-docs.sh
+++ b/hack/after-build/verify-generated-docs.sh
@@ -35,7 +35,8 @@ EXAMPLEROOT="${KUBE_ROOT}/examples/"
 
 # mungedocs --verify can (and should) be run on the real docs, otherwise their
 # links will be distorted. --verify means that it will not make changes.
-"${mungedocs}" "--verify=true" "--root-dir=${DOCROOT}" && ret=0 || ret=$?
+# --verbose gives us output we can use for a diff.
+"${mungedocs}" "--verify=true" "--verbose=true" "--root-dir=${DOCROOT}" && ret=0 || ret=$?
 if [[ $ret -eq 1 ]]; then
   echo "${DOCROOT} is out of date. Please run hack/update-generated-docs.sh"
   exit 1
@@ -45,7 +46,7 @@ if [[ $ret -gt 1 ]]; then
   exit 1
 fi
 
-"${mungedocs}" "--verify=true" "--root-dir=${EXAMPLEROOT}" && ret=0 || ret=$?
+"${mungedocs}" "--verify=true" "--verbose=true" "--root-dir=${EXAMPLEROOT}" && ret=0 || ret=$?
 if [[ $ret -eq 1 ]]; then
   echo "${EXAMPLEROOT} is out of date. Please run hack/update-generated-docs.sh"
   exit 1


### PR DESCRIPTION
Hope to understand why verify-generated-docs is failing on jenkins but
not here.
