### PR TITLE
Remove APIStatus from the client

### DIFF
--- a/pkg/client/unversioned/client.go
+++ b/pkg/client/unversioned/client.go
@@ -120,12 +120,6 @@ type VersionInterface interface {
 	ServerAPIVersions() (*unversioned.APIVersions, error)
 }
 
-// APIStatus is exposed by errors that can be converted to an api.Status object
-// for finer grained details.
-type APIStatus interface {
-	Status() unversioned.Status
-}
-
 // Client is the implementation of a Kubernetes client.
 type Client struct {
 	*RESTClient

--- a/pkg/client/unversioned/request.go
+++ b/pkg/client/unversioned/request.go
@@ -686,7 +686,7 @@ func (r *Request) Stream() (io.ReadCloser, error) {
 		if runtimeObject, err := r.codec.Decode(bodyBytes); err == nil {
 			statusError := errors.FromObject(runtimeObject)
 
-			if _, ok := statusError.(APIStatus); ok {
+			if _, ok := statusError.(errors.APIStatus); ok {
 				return nil, statusError
 			}
 		}

--- a/pkg/client/unversioned/request_test.go
+++ b/pkg/client/unversioned/request_test.go
@@ -333,7 +333,7 @@ func TestTransformResponse(t *testing.T) {
 		if hasErr != test.Error {
 			t.Errorf("%d: unexpected error: %t %v", i, test.Error, err)
 		} else if hasErr && test.Response.StatusCode > 399 {
-			status, ok := err.(APIStatus)
+			status, ok := err.(apierrors.APIStatus)
 			if !ok {
 				t.Errorf("%d: response should have been transformable into APIStatus: %v", i, err)
 				continue

--- a/pkg/client/unversioned/restclient_test.go
+++ b/pkg/client/unversioned/restclient_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/util"
@@ -92,7 +93,7 @@ func TestDoRequestFailed(t *testing.T) {
 	if err == nil || body != nil {
 		t.Errorf("unexpected non-error: %#v", body)
 	}
-	ss, ok := err.(APIStatus)
+	ss, ok := err.(errors.APIStatus)
 	if !ok {
 		t.Errorf("unexpected error type %v", err)
 	}

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/editor"
@@ -370,7 +369,7 @@ func (r *editResults) addError(err error, info *resource.Info) string {
 		reason := editReason{
 			head: fmt.Sprintf("%s %s was not valid", info.Mapping.Kind, info.Name),
 		}
-		if err, ok := err.(client.APIStatus); ok {
+		if err, ok := err.(errors.APIStatus); ok {
 			if details := err.Status().Details; details != nil {
 				for _, cause := range details.Causes {
 					reason.other = append(reason.other, cause.Message)

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -57,7 +56,7 @@ type debugError interface {
 // souce is the filename or URL to the template file(*.json or *.yaml), or stdin to use to handle the resource.
 func AddSourceToErr(verb string, source string, err error) error {
 	if source != "" {
-		if statusError, ok := err.(*errors.StatusError); ok {
+		if statusError, ok := err.(errors.APIStatus); ok {
 			status := statusError.Status()
 			status.Message = fmt.Sprintf("error when %s %q: %v", verb, source, status.Message)
 			return &errors.StatusError{ErrStatus: status}
@@ -145,7 +144,7 @@ func StandardErrorMessage(err error) (string, bool) {
 	if debugErr, ok := err.(debugError); ok {
 		glog.V(4).Infof(debugErr.DebugError())
 	}
-	_, isStatus := err.(client.APIStatus)
+	_, isStatus := err.(errors.APIStatus)
 	switch {
 	case isStatus:
 		return fmt.Sprintf("Error from server: %s", err.Error()), true


### PR DESCRIPTION
Everything that used it also depended on pkg/api/errors. It was a
needless abstraction since it was always an *errors.StatusError.

cc @kubernetes/sig-api-machinery @kubernetes/goog-csi 
