### PR TITLE
Add cluster/test-conformance.sh script

### DIFF
--- a/cluster/test-conformance.sh
+++ b/cluster/test-conformance.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Conformance Tests a running Kubernetes cluster.
+# Validates that the cluster was deployed, is accessible, and at least
+# satisfies end-to-end tests marked as being a part of the conformance suite.
+# Emphasis on broad coverage and being non-destructive over thoroughness.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+TEST_ARGS="$@"
+
+exec "${KUBE_ROOT}/hack/conformance-test.sh" ${TEST_ARGS}

--- a/hack/conformance-test.sh
+++ b/hack/conformance-test.sh
@@ -61,6 +61,7 @@
 # a new column for conformance at that new version, and notify
 # community.
 
+TEST_ARGS="$@"
 
 : ${KUBECONFIG:?"Must set KUBECONFIG before running conformance test."}
 echo "Conformance test using current-context of ${KUBECONFIG}"
@@ -83,5 +84,4 @@ echo "Conformance test checking conformance with Kubernetes version 1.0"
 
 declare -x KUBERNETES_CONFORMANCE_TEST="y"
 declare -x NUM_NODES=4
-hack/ginkgo-e2e.sh -ginkgo.focus='\[Conformance\]' -ginkgo.skip='\[Skipped\]'
-exit $?
+exec hack/ginkgo-e2e.sh -ginkgo.focus='\[Conformance\]' -ginkgo.skip='\[Skipped\]' ${TEST_ARGS}


### PR DESCRIPTION
- Add support for passing args to conformance tests

This unofficially deprecates `hack/conformance-test.sh` in favor of `cluster/test-conformance.sh`, which is consistent with the other cluster test harnesses (smoke, e2e, network).

At some point in the future, We'll probably want to move the script content into the new script (once CI stops using it).

Example usage:

```
KUBECONFIG=~/.kube/config ./cluster/test-conformance.sh -ginkgo.dryRun -ginkgo.randomizeAllSpecs=false
```
