### PR TITLE
Print out kubectl version in hack/test-cmd.sh

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -187,6 +187,9 @@ kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/api/v1/nodes/127.0.0.1" "
 # Expose kubectl directly for readability
 PATH="${KUBE_OUTPUT_HOSTBIN}":$PATH
 
+kube::log::status "Checking kubectl version"
+kubectl version
+
 runTests() {
   version="$1"
   echo "Testing api version: $1"


### PR DESCRIPTION
The `kubernetes-test-go` Jenkins job mysteriously failed between 10:54am and 1:55pm today in `hack/test-cmd.sh`. There were no changes for either transition.

```
FAIL!
Get rc {{range.items}}{{.metadata.name}}:{{end}}
  Expected: frontend:
  Got:      frontend:nginx-deployment-b0bh8:
(B
./hack/test-cmd.sh
(B
!!! Error in ./hack/test-cmd.sh:50
  'return 1' exited with status 1
Call stack:
  1: ./hack/test-cmd.sh:50 runTests(...)
  2: ./hack/test-cmd.sh:1264 main(...)
Exiting with status 1
```

I have no idea what went wrong, but I want to log kubectl version (this PR) just to verify that we're definitely running the correct version of binaries.
