### PR TITLE
ubuntu: skip binaries downloading if specified version exists

### DIFF
--- a/cluster/ubuntu/download-release.sh
+++ b/cluster/ubuntu/download-release.sh
@@ -26,50 +26,49 @@ function cleanup {
 }
 trap cleanup SIGHUP SIGINT SIGTERM
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
-pushd ${KUBE_ROOT}/cluster/ubuntu
-
+pushd $(dirname $0)
 mkdir -p binaries/master
 mkdir -p binaries/minion
 
 # flannel
 FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.3"}
 echo "Prepare flannel ${FLANNEL_VERSION} release ..."
-if [ ! -f flannel.tar.gz ] ; then
+grep -q "^${FLANNEL_VERSION}\$" binaries/.flannel 2>/dev/null || {
   curl -L  https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz -o flannel.tar.gz
   tar xzf flannel.tar.gz
-fi
-cp flannel-${FLANNEL_VERSION}/flanneld binaries/master
-cp flannel-${FLANNEL_VERSION}/flanneld binaries/minion
+  cp flannel-${FLANNEL_VERSION}/flanneld binaries/master
+  cp flannel-${FLANNEL_VERSION}/flanneld binaries/minion
+  echo ${FLANNEL_VERSION} > binaries/.flannel
+}
 
 # ectd
 ETCD_VERSION=${ETCD_VERSION:-"2.2.1"}
 ETCD="etcd-v${ETCD_VERSION}-linux-amd64"
 echo "Prepare etcd ${ETCD_VERSION} release ..."
-if [ ! -f etcd.tar.gz ] ; then
+grep -q "^${ETCD_VERSION}\$" binaries/.etcd 2>/dev/null || {
   curl -L https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/${ETCD}.tar.gz -o etcd.tar.gz
   tar xzf etcd.tar.gz
-fi
-cp $ETCD/etcd $ETCD/etcdctl binaries/master
+  cp ${ETCD}/etcd ${ETCD}/etcdctl binaries/master
+  echo ${ETCD_VERSION} > binaries/.etcd
+}
 
 # k8s
 KUBE_VERSION=${KUBE_VERSION:-"1.1.2"}
 echo "Prepare kubernetes ${KUBE_VERSION} release ..."
-if [ ! -f kubernetes.tar.gz ] ; then
+grep -q "^${KUBE_VERSION}\$" binaries/.kubernetes 2>/dev/null || {
   curl -L https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v${KUBE_VERSION}/kubernetes.tar.gz -o kubernetes.tar.gz
   tar xzf kubernetes.tar.gz
-fi
-pushd kubernetes/server
-tar xzf kubernetes-server-linux-amd64.tar.gz
-popd
-cp kubernetes/server/kubernetes/server/bin/kube-apiserver \
-   kubernetes/server/kubernetes/server/bin/kube-controller-manager \
-   kubernetes/server/kubernetes/server/bin/kube-scheduler binaries/master
-
-cp kubernetes/server/kubernetes/server/bin/kubelet \
-   kubernetes/server/kubernetes/server/bin/kube-proxy binaries/minion
-
-cp kubernetes/server/kubernetes/server/bin/kubectl binaries/
+  pushd kubernetes/server
+  tar xzf kubernetes-server-linux-amd64.tar.gz
+  popd
+  cp kubernetes/server/kubernetes/server/bin/kube-apiserver \
+     kubernetes/server/kubernetes/server/bin/kube-controller-manager \
+     kubernetes/server/kubernetes/server/bin/kube-scheduler binaries/master
+  cp kubernetes/server/kubernetes/server/bin/kubelet \
+     kubernetes/server/kubernetes/server/bin/kube-proxy binaries/minion
+  cp kubernetes/server/kubernetes/server/bin/kubectl binaries/
+  echo ${KUBE_VERSION} > binaries/.kubernetes
+}
 
 rm -rf flannel* kubernetes* etcd*
 

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -306,9 +306,6 @@ function kube-up() {
   source "${KUBE_ROOT}/cluster/ubuntu/${KUBE_CONFIG_FILE:-config-default.sh}"
 
   # downloading tarball release
-  if [[ -d "${KUBE_ROOT}/cluster/ubuntu/binaries" ]]; then
-    rm -rf "${KUBE_ROOT}/cluster/ubuntu/binaries"
-  fi
   "${KUBE_ROOT}/cluster/ubuntu/download-release.sh"
 
   setClusterInfo


### PR DESCRIPTION
Sometimes we need to run `kube-up.sh` again and again when something wrong. We should skip downloading binaries if the specified version already exists.
