### PR TITLE
examples: guestbook-go: remove id field from rc

### DIFF
--- a/examples/guestbook-go/redis-slave-controller.json
+++ b/examples/guestbook-go/redis-slave-controller.json
@@ -1,7 +1,6 @@
 {
    "kind":"ReplicationController",
    "apiVersion":"v1",
-   "id":"redis-slave",
    "metadata":{
       "name":"redis-slave",
       "labels":{


### PR DESCRIPTION
Remove the id field to fix this error:

```
$ kubectl create -f redis-slave-controller.json
error validating "redis-slave-controller.json": error validating data: found invalid field id for v1.ReplicationController; if you choose to ignore these errors, turn validation off with --validate=false
```

Fixes #17846
