### PR TITLE
Make dns service works in container

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -48,6 +48,7 @@ spec:
         args:
         # command = "/kube2sky"
         - -domain={{ pillar['dns_domain'] }}
+        - -kube_master_url={{ pillar['kubeapi_server'] }} # IP Kubernets Api Server
       - name: skydns
         image: gcr.io/google_containers/skydns:2015-10-13-8c72f8c
         resources:


### PR DESCRIPTION
To fix the issue reported at:  http://stackoverflow.com/questions/33255676/configure-kube-dns-when-running-kubernetes-via-docker and
http://stackoverflow.com/questions/33969180/skydns-does-not-work-with-kubernetes-1-1-2/34012665#34012665
