### PR TITLE
update more kubectl APIs for groupversion

### DIFF
--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -42,6 +42,12 @@ var (
 	IsRegistered = allGroups.IsRegistered
 )
 
+// ExternalVersions is a list of all external versions for this API group in order of
+// most preferred to least preferred
+var ExternalVersions = []unversioned.GroupVersion{
+	{Group: "", Version: "v1"},
+}
+
 // GroupMetaMap is a map between group names and their metadata.
 type GroupMetaMap map[string]*GroupMeta
 

--- a/pkg/client/unversioned/client_test.go
+++ b/pkg/client/unversioned/client_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -496,7 +497,7 @@ func TestGetSwaggerSchema(t *testing.T) {
 	}
 
 	client := NewOrDie(&Config{Host: server.URL})
-	got, err := client.SwaggerSchema("v1")
+	got, err := client.SwaggerSchema(v1.SchemeGroupVersion)
 	if err != nil {
 		t.Fatalf("unexpected encoding error: %v", err)
 	}
@@ -506,7 +507,7 @@ func TestGetSwaggerSchema(t *testing.T) {
 }
 
 func TestGetSwaggerSchemaFail(t *testing.T) {
-	expErr := "API version: v4 is not supported by the server. Use one of: [v1 v2 v3]"
+	expErr := "API version: api.group/v4 is not supported by the server. Use one of: [v1 v2 v3]"
 
 	server, err := swaggerSchemaFakeServer()
 	if err != nil {
@@ -514,7 +515,7 @@ func TestGetSwaggerSchemaFail(t *testing.T) {
 	}
 
 	client := NewOrDie(&Config{Host: server.URL})
-	got, err := client.SwaggerSchema("v4")
+	got, err := client.SwaggerSchema(unversioned.GroupVersion{Group: "api.group", Version: "v4"})
 	if got != nil {
 		t.Fatalf("unexpected response: %v", got)
 	}

--- a/pkg/client/unversioned/clientcmd/api/latest/latest.go
+++ b/pkg/client/unversioned/clientcmd/api/latest/latest.go
@@ -17,12 +17,15 @@ limitations under the License.
 package latest
 
 import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
 // Version is the string that represents the current external default version.
 const Version = "v1"
+
+var ExternalVersion = unversioned.GroupVersion{Group: "", Version: "v1"}
 
 // OldestVersion is the string that represents the oldest server version supported,
 // for client code that wants to hardcode the lowest common denominator.

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/version"
@@ -306,10 +307,14 @@ func (c *Fake) ComponentStatuses() client.ComponentStatusInterface {
 }
 
 // SwaggerSchema returns an empty swagger.ApiDeclaration for testing
-func (c *Fake) SwaggerSchema(version string) (*swagger.ApiDeclaration, error) {
+func (c *Fake) SwaggerSchema(version unversioned.GroupVersion) (*swagger.ApiDeclaration, error) {
 	action := ActionImpl{}
 	action.Verb = "get"
-	action.Resource = "/swaggerapi/api/" + version
+	if version == v1.SchemeGroupVersion {
+		action.Resource = "/swaggerapi/api/" + version.Version
+	} else {
+		action.Resource = "/swaggerapi/apis/" + version.Group + "/" + version.Version
+	}
 
 	c.Invokes(action, nil)
 	return &swagger.ApiDeclaration{}, nil

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -95,7 +95,7 @@ func RunAutoscale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 	}
 	info := infos[0]
 	mapping := info.ResourceMapping()
-	if err := f.CanBeAutoscaled(mapping.GroupVersionKind.Kind); err != nil {
+	if err := f.CanBeAutoscaled(mapping.GroupVersionKind.GroupKind()); err != nil {
 		return err
 	}
 

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
@@ -70,16 +69,12 @@ func NewCmdConfigView(out io.Writer, ConfigAccess ConfigAccess) *cobra.Command {
 			}
 
 			printer, _, err := cmdutil.PrinterForCommand(cmd)
-			if err != nil {
-				glog.FatalDepth(1, err)
-			}
-			version := cmdutil.OutputVersion(cmd, latest.Version)
+			cmdutil.CheckErr(err)
+			version, err := cmdutil.OutputVersion(cmd, &latest.ExternalVersion)
+			cmdutil.CheckErr(err)
 			printer = kubectl.NewVersionedPrinter(printer, clientcmdapi.Scheme, version)
 
-			if err := options.Run(out, printer); err != nil {
-				glog.FatalDepth(1, err)
-			}
-
+			cmdutil.CheckErr(options.Run(out, printer))
 		},
 	}
 

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -90,17 +90,16 @@ type ConvertOptions struct {
 	out     io.Writer
 	printer kubectl.ResourcePrinter
 
-	outputVersion string
+	outputVersion unversioned.GroupVersion
 }
 
 // Complete collects information required to run Convert command from command line.
 func (o *ConvertOptions) Complete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) (err error) {
-	o.outputVersion = cmdutil.OutputVersion(cmd, latest.GroupOrDie("").GroupVersion.Version)
-	outputGV, err := unversioned.ParseGroupVersion(o.outputVersion)
+	o.outputVersion, err = cmdutil.OutputVersion(cmd, &latest.ExternalVersions[0])
 	if err != nil {
-		return fmt.Errorf("unable to parse group/version from %q: %v", o.outputVersion, err)
+		return err
 	}
-	if !registered.IsRegisteredAPIGroupVersion(outputGV) {
+	if !registered.IsRegisteredAPIGroupVersion(o.outputVersion) {
 		cmdutil.UsageError(cmd, "'%s' is not a registered version.", o.outputVersion)
 	}
 
@@ -152,7 +151,7 @@ func (o *ConvertOptions) RunConvert() error {
 		return err
 	}
 
-	objects, err := resource.AsVersionedObject(infos, false, o.outputVersion)
+	objects, err := resource.AsVersionedObject(infos, false, o.outputVersion.String())
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
@@ -70,7 +71,8 @@ func RunExplain(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []st
 	}
 
 	recursive := cmdutil.GetFlagBool(cmd, "recursive")
-	apiV := cmdutil.GetFlagString(cmd, "api-version")
+	apiVersionString := cmdutil.GetFlagString(cmd, "api-version")
+	apiVersion := unversioned.GroupVersion{}
 
 	mapper, _ := f.Object()
 	// TODO: After we figured out the new syntax to separate group and resource, allow
@@ -87,14 +89,21 @@ func RunExplain(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []st
 		return err
 	}
 
-	if len(apiV) == 0 {
+	if len(apiVersionString) == 0 {
 		groupMeta, err := latest.Group(gvk.Group)
 		if err != nil {
 			return err
 		}
-		apiV = groupMeta.GroupVersion.String()
+		apiVersion = groupMeta.GroupVersion
+
+	} else {
+		apiVersion, err = unversioned.ParseGroupVersion(apiVersionString)
+		if err != nil {
+			return nil
+		}
 	}
-	swagSchema, err := kubectl.GetSwaggerSchema(apiV, client)
+
+	swagSchema, err := kubectl.GetSwaggerSchema(apiVersion, client)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -120,7 +120,7 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	}
 	info := infos[0]
 	mapping := info.ResourceMapping()
-	if err := f.CanBeExposed(mapping.GroupVersionKind.Kind); err != nil {
+	if err := f.CanBeExposed(mapping.GroupVersionKind.GroupKind()); err != nil {
 		return err
 	}
 	// Get the input object

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -209,8 +209,11 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 
 		// the outermost object will be converted to the output-version, but inner
 		// objects can use their mappings
-		version := cmdutil.OutputVersionFromGroupVersion(cmd, clientConfig.GroupVersion)
-		obj, err := resource.AsVersionedObject(infos, !singular, version)
+		version, err := cmdutil.OutputVersion(cmd, clientConfig.GroupVersion)
+		if err != nil {
+			return err
+		}
+		obj, err := resource.AsVersionedObject(infos, !singular, version.String())
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -164,7 +164,7 @@ func TestGetUnknownSchemaObjectListGeneric(t *testing.T) {
 			rcVersion:       testapi.Default.Version(),
 		},
 		"handles second specific version": {
-			outputVersion:   "unlikelyversion",
+			outputVersion:   "unlikely.group/unlikelyversion",
 			listVersion:     testapi.Default.Version(),
 			testtypeVersion: unlikelyGV.String(),
 			rcVersion:       testapi.Default.Version(), // see expected behavior 3b

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -170,15 +170,15 @@ func TestLabelsForObject(t *testing.T) {
 func TestCanBeExposed(t *testing.T) {
 	factory := NewFactory(nil)
 	tests := []struct {
-		kind      string
+		kind      unversioned.GroupKind
 		expectErr bool
 	}{
 		{
-			kind:      "ReplicationController",
+			kind:      api.Kind("ReplicationController"),
 			expectErr: false,
 		},
 		{
-			kind:      "Node",
+			kind:      api.Kind("Node"),
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -76,22 +76,18 @@ func ValidateOutputArgs(cmd *cobra.Command) error {
 }
 
 // OutputVersion returns the preferred output version for generic content (JSON, YAML, or templates)
-// TODO, when this has no callers, replace it with OutputVersionFromGroupVersion.  Also this shoudl return a GroupVersion
-func OutputVersion(cmd *cobra.Command, defaultVersion string) string {
-	outputVersion := GetFlagString(cmd, "output-version")
-	if len(outputVersion) == 0 {
-		outputVersion = defaultVersion
-	}
-	return outputVersion
-}
+// defaultVersion is never mutated.  Nil simply allows clean passing in common usage from client.Config
+func OutputVersion(cmd *cobra.Command, defaultVersion *unversioned.GroupVersion) (unversioned.GroupVersion, error) {
+	outputVersionString := GetFlagString(cmd, "output-version")
+	if len(outputVersionString) == 0 {
+		if defaultVersion == nil {
+			return unversioned.GroupVersion{}, nil
+		}
 
-// OutputVersionFromGroupVersion returns the preferred output version for generic content (JSON, YAML, or templates)
-func OutputVersionFromGroupVersion(cmd *cobra.Command, defaultGV *unversioned.GroupVersion) string {
-	outputVersion := GetFlagString(cmd, "output-version")
-	if len(outputVersion) == 0 && defaultGV != nil {
-		outputVersion = defaultGV.String()
+		return *defaultVersion, nil
 	}
-	return outputVersion
+
+	return unversioned.ParseGroupVersion(outputVersionString)
 }
 
 // PrinterForCommand returns the default printer for this command.

--- a/pkg/kubectl/explain.go
+++ b/pkg/kubectl/explain.go
@@ -24,6 +24,7 @@ import (
 	"github.com/emicklei/go-restful/swagger"
 
 	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	apiutil "k8s.io/kubernetes/pkg/api/util"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 )
@@ -32,8 +33,8 @@ var allModels = make(map[string]*swagger.NamedModel)
 var recursive = false // this is global for convenience, can become int for multiple levels
 
 // GetSwaggerSchema returns the swagger spec from master
-func GetSwaggerSchema(apiVer string, kubeClient client.Interface) (*swagger.ApiDeclaration, error) {
-	swaggerSchema, err := kubeClient.SwaggerSchema(apiVer)
+func GetSwaggerSchema(version unversioned.GroupVersion, kubeClient client.Interface) (*swagger.ApiDeclaration, error) {
+	swaggerSchema, err := kubeClient.SwaggerSchema(version)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read swagger schema from server: %v", err)
 	}

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -64,7 +64,7 @@ func TestVersionedPrinter(t *testing.T) {
 			return nil
 		}),
 		api.Scheme,
-		testapi.Default.Version(),
+		*testapi.Default.GroupVersion(),
 	)
 	if err := p.PrintObj(original, nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -422,7 +422,7 @@ func TestTemplateStrings(t *testing.T) {
 		t.Fatalf("tmpl fail: %v", err)
 	}
 
-	printer := NewVersionedPrinter(p, api.Scheme, testapi.Default.Version())
+	printer := NewVersionedPrinter(p, api.Scheme, *testapi.Default.GroupVersion())
 
 	for name, item := range table {
 		buffer := &bytes.Buffer{}


### PR DESCRIPTION
This continues work towards explicitly typing all `GroupVersions` in kubectl

ref https://github.com/kubernetes/kubernetes/issues/17216

@caesarxuchao @liggitt 
@kubernetes/rh-cluster-infra @ncdc can you find a reviewer to help spread the load?
