### PR TITLE
kubelet runonce: create data dirs

### DIFF
--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -18,6 +18,7 @@ package kubelet
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/golang/glog"
@@ -41,6 +42,18 @@ type RunPodResult struct {
 
 // RunOnce polls from one configuration update and run the associated pods.
 func (kl *Kubelet) RunOnce(updates <-chan kubetypes.PodUpdate) ([]RunPodResult, error) {
+	// Setup filesystem directories.
+	if err := kl.setupDataDirs(); err != nil {
+		return nil, err
+	}
+
+	// If the container logs directory does not exist, create it.
+	if _, err := os.Stat(containerLogsDir); err != nil {
+		if err := kl.os.Mkdir(containerLogsDir, 0755); err != nil {
+			glog.Errorf("Failed to create directory %q: %v", containerLogsDir, err)
+		}
+	}
+
 	select {
 	case u := <-updates:
 		glog.Infof("processing manifest with %d pods", len(u.Pods))


### PR DESCRIPTION
data and log directories are not created for kubelet in runonce mode, which leads to errors when kubelet tries to create pod directories under `/var/lib/kubelet` and symlink container logs to `/var/log/containers`.

The test is already creating these dirs and failing if it can't, so not sure how you want to handle the change wrt the test.
