### PR TITLE
Configure upgrade jobs from 1.0 on release-1.0

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -64,7 +64,6 @@ function join_regex_no_empty() {
 #   $GCE_DEFAULT_SKIP_TESTS
 #   $GCE_FLAKY_TESTS
 #   $GCE_SLOW_TESTS
-#   $GKE_FLAKY_TESTS
 #
 # Args:
 #   $1 old_version:  the version to deploy a cluster at, and old e2e tests to run
@@ -98,7 +97,6 @@ function configure_upgrade_step() {
         ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
         ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
         ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-        ${GKE_FLAKY_TESTS[@]:+${GKE_FLAKY_TESTS[@]}} \
         )"
 
   if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -410,6 +410,39 @@ case ${JOB_NAME} in
     : ${KUBE_GCS_STAGING_PATH_SUFFIX:="release-1.0"}
     : ${PROJECT:="k8s-jkns-e2e-gce-release"}
     ;;
+
+  # kubernetes-upgrade-gke-1.0-release
+  #
+  # Configurations for step2, step4, and step6 live in the current release
+  # branch.
+
+  kubernetes-upgrade-1.0-release-gke-step1-deploy)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-1.0-release-gke-step3-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-1.0-release-gke-step5-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  # kubernetes-upgrade-gke-1.0-master
+  #
+  # Configurations for step2, step4, and step6 live in master.
+
+  kubernetes-upgrade-1.0-master-gke-step1-deploy)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-master' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-1.0-master-gke-step3-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-master' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-1.0-master-gke-step5-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-master' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
 esac
 
 # AWS variables

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -47,6 +47,163 @@ function join_regex_no_empty() {
     fi
 }
 
+# Properly configure globals for an upgrade step in a GKE or GCE upgrade suite
+#
+# These suites:
+#   step1: launch a cluster at $old_version,
+#   step2: upgrades the master to $new_version,
+#   step3: runs $old_version e2es,
+#   step4: upgrades the rest of the cluster,
+#   step5: runs $old_version e2es again, then
+#   step6: runs $new_version e2es and tears down the cluster.
+#
+# Assumes globals:
+#   $JOB_NAME
+#   $KUBERNETES_PROVIDER
+#   $GKE_DEFAULT_SKIP_TESTS
+#   $GCE_DEFAULT_SKIP_TESTS
+#   $GCE_FLAKY_TESTS
+#   $GCE_SLOW_TESTS
+#   $GKE_FLAKY_TESTS
+#
+# Args:
+#   $1 old_version:  the version to deploy a cluster at, and old e2e tests to run
+#                    against the upgraded cluster (should be something like
+#                    'release/latest', to work with JENKINS_PUBLISHED_VERSION logic)
+#   $2 new_version:  the version to upgrade the cluster to, and new e2e tests to run
+#                    against the upgraded cluster (should be something like
+#                    'ci/latest', to work with JENKINS_PUBLISHED_VERSION logic)
+#   $3 cluster_name: determines E2E_CLUSTER_NAME and E2E_NETWORK
+#   $4 project:      determines PROJECT
+
+function configure_upgrade_step() {
+  local -r old_version="$1"
+  local -r new_version="$2"
+  local -r cluster_name="$3"
+  local -r project="$4"
+
+  [[ "${JOB_NAME}" =~ .*-(step[1-6])-.* ]] || {
+    echo "JOB_NAME ${JOB_NAME} is not a valid upgrade job name, could not parse"
+    exit 1
+  }
+  local -r step="${BASH_REMATCH[1]}"
+
+  local -r gce_test_args="--ginkgo.skip=$(join_regex_allow_empty \
+        ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+        ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+        ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
+        )"
+  local -r gke_test_args="--ginkgo.skip=$(join_regex_allow_empty \
+        ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
+        ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+        ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+        ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
+        ${GKE_FLAKY_TESTS[@]:+${GKE_FLAKY_TESTS[@]}} \
+        )"
+
+  if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
+    DOGFOOD_GCLOUD="true"
+    GKE_API_ENDPOINT="https://test-container.sandbox.googleapis.com/"
+  fi
+
+  E2E_CLUSTER_NAME="$cluster_name"
+  E2E_NETWORK="$cluster_name"
+  PROJECT="$project"
+
+  case $step in
+    step1)
+      # Deploy at old version
+      JENKINS_PUBLISHED_VERSION="${old_version}"
+
+      E2E_UP="true"
+      E2E_TEST="false"
+      E2E_DOWN="false"
+
+      if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
+        E2E_SET_CLUSTER_API_VERSION=y
+      fi
+      ;;
+
+    step2)
+      # Use upgrade logic of version we're upgrading to.
+      JENKINS_PUBLISHED_VERSION="${new_version}"
+      JENKINS_FORCE_GET_TARS=y
+
+      E2E_OPT="--check_version_skew=false"
+      E2E_UP="false"
+      E2E_TEST="true"
+      E2E_DOWN="false"
+      GINKGO_TEST_ARGS="--ginkgo.focus=Cluster\sUpgrade.*upgrade-master --upgrade-target=${new_version}"
+      ;;
+
+    step3)
+      # Run old e2es
+      JENKINS_PUBLISHED_VERSION="${old_version}"
+      JENKINS_FORCE_GET_TARS=y
+
+      E2E_OPT="--check_version_skew=false"
+      E2E_UP="false"
+      E2E_TEST="true"
+      E2E_DOWN="false"
+
+      if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
+        GINKGO_TEST_ARGS="${gke_test_args}"
+      else
+        GINKGO_TEST_ARGS="${gce_test_args}"
+      fi
+      ;;
+
+    step4)
+      # Use upgrade logic of version we're upgrading to.
+      JENKINS_PUBLISHED_VERSION="${new_version}"
+      JENKINS_FORCE_GET_TARS=y
+
+      E2E_OPT="--check_version_skew=false"
+      E2E_UP="false"
+      E2E_TEST="true"
+      E2E_DOWN="false"
+      GINKGO_TEST_ARGS="--ginkgo.focus=Cluster\sUpgrade.*upgrade-cluster --upgrade-target=${new_version}"
+      ;;
+
+    step5)
+      # Run old e2es
+      JENKINS_PUBLISHED_VERSION="${old_version}"
+      JENKINS_FORCE_GET_TARS=y
+
+      E2E_OPT="--check_version_skew=false"
+      E2E_UP="false"
+      E2E_TEST="true"
+      E2E_DOWN="false"
+
+      if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
+        GINKGO_TEST_ARGS="${gke_test_args}"
+      else
+        GINKGO_TEST_ARGS="${gce_test_args}"
+      fi
+      ;;
+
+    step6)
+      # Run new e2es
+      JENKINS_PUBLISHED_VERSION="${new_version}"
+      JENKINS_FORCE_GET_TARS=y
+
+      # TODO(15011): these really shouldn't be (very) version skewed, but
+      # because we have to get ci/latest again, it could get slightly out of
+      # whack.
+      E2E_OPT="--check_version_skew=false"
+      E2E_UP="false"
+      E2E_TEST="true"
+      E2E_DOWN="true"
+
+      if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
+        GINKGO_TEST_ARGS="${gke_test_args}"
+      else
+        GINKGO_TEST_ARGS="${gce_test_args}"
+      fi
+      ;;
+  esac
+}
+
 echo "--------------------------------------------------------------------------------"
 echo "Initial Environment:"
 printenv | sort
@@ -253,7 +410,6 @@ case ${JOB_NAME} in
     : ${KUBE_GCS_STAGING_PATH_SUFFIX:="release-1.0"}
     : ${PROJECT:="k8s-jkns-e2e-gce-release"}
     ;;
-
 esac
 
 # AWS variables

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -414,32 +414,32 @@ case ${JOB_NAME} in
   # Configurations for step2, step4, and step6 live in the current release
   # branch.
 
-  kubernetes-upgrade-1.0-release-gke-step1-deploy)
-    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-release-step1-deploy)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-release-gke-step3-e2e-old)
-    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-release-step3-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-release-gke-step5-e2e-old)
-    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-release-step5-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
   # kubernetes-upgrade-gke-1.0-master
   #
   # Configurations for step2, step4, and step6 live in master.
 
-  kubernetes-upgrade-1.0-master-gke-step1-deploy)
-    configure_upgrade_step 'ci/latest-1.0' 'configured-in-master' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-master-step1-deploy)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-master' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-master-gke-step3-e2e-old)
-    configure_upgrade_step 'ci/latest-1.0' 'configured-in-master' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-master-step3-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-master' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-master-gke-step5-e2e-old)
-    configure_upgrade_step 'ci/latest-1.0' 'configured-in-master' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-master-step5-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-master' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 esac
 

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -409,21 +409,21 @@ case ${JOB_NAME} in
     : ${PROJECT:="k8s-jkns-e2e-gce-release"}
     ;;
 
-  # kubernetes-upgrade-gke-1.0-release
+  # kubernetes-upgrade-gke-1.0-current-release
   #
   # Configurations for step2, step4, and step6 live in the current release
   # branch.
 
-  kubernetes-upgrade-gke-1.0-release-step1-deploy)
-    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-current-release-step1-deploy)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'upgrade-gke-1-0-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-1.0-release-step3-e2e-old)
-    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-current-release-step3-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'upgrade-gke-1-0-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-1.0-release-step5-e2e-old)
-    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-current-release-step5-e2e-old)
+    configure_upgrade_step 'ci/latest-1.0' 'configured-in-current-release-branch' 'upgrade-gke-1-0-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
   # kubernetes-upgrade-gke-1.0-master

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -411,6 +411,9 @@ case ${JOB_NAME} in
 
   # kubernetes-upgrade-gke-1.0-current-release
   #
+  # Test upgrades from the latest release-1.0 build to the latest current
+  # release build.
+  #
   # Configurations for step2, step4, and step6 live in the current release
   # branch.
 
@@ -427,6 +430,8 @@ case ${JOB_NAME} in
     ;;
 
   # kubernetes-upgrade-gke-1.0-master
+  #
+  # Test upgrades from the latest release-1.0 build to the latest master build.
   #
   # Configurations for step2, step4, and step6 live in master.
 


### PR DESCRIPTION
This includes an (edited) cherry-pick of #17746 plus configs for upgrade jobs that drive _from_ `release-1.0`.
