### PR TITLE
Configure upgrade jobs from 1.0 to 1.1 and stable to current-release on release-1.1

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -794,6 +794,32 @@ case ${JOB_NAME} in
   kubernetes-upgrade-gke-1.0-release-step6-e2e-new)
     configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
+
+  # kubernetes-upgrade-gke-stable-release
+
+  kubernetes-upgrade-gke-stable-release-step1-deploy)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-stable-release-step2-upgrade-master)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-stable-release-step3-e2e-old)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-stable-release-step4-upgrade-cluster)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-stable-release-step5-e2e-old)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-stable-release-step6-e2e-new)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
 esac
 
 # AWS variables

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -765,6 +765,8 @@ case ${JOB_NAME} in
 
   # kubernetes-upgrade-gke-1.1-master
   #
+  # Test upgrades from the latest release-1.1 build to the latest master build.
+  #
   # Configurations for step2, step4, and step6 live in master.
 
   kubernetes-upgrade-gke-1.1-master-step1-deploy)
@@ -781,6 +783,9 @@ case ${JOB_NAME} in
 
   # kubernetes-upgrade-gke-1.0-current-release
   #
+  # Test upgrades from the latest release-1.0 build to the latest current
+  # release build.
+  #
   # Configurations for step1, step3, and step5 live in the release-1.0 branch.
 
   kubernetes-upgrade-gke-1.0-current-release-step2-upgrade-master)
@@ -796,6 +801,8 @@ case ${JOB_NAME} in
     ;;
 
   # kubernetes-upgrade-gke-stable-current-release
+  #
+  # Test upgrades from the stable build to the latest current release build.
 
   kubernetes-upgrade-gke-stable-current-release-step1-deploy)
     configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-current-release' 'kubernetes-jenkins-gke-upgrade'

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -763,6 +763,22 @@ case ${JOB_NAME} in
     : ${AWS_SHARED_CREDENTIALS_FILE=/var/lib/jenkins/.aws/credentials}
     ;;
 
+  # kubernetes-upgrade-gke-1.1-master
+  #
+  # Configurations for step2, step4, and step6 live in master.
+
+  kubernetes-upgrade-gke-1.1-master-step1-deploy)
+    configure_upgrade_step 'ci/latest-1.1' 'configured-in-master' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-1.1-master-step3-e2e-old)
+    configure_upgrade_step 'ci/latest-1.1' 'configured-in-master' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-1.1-master-step5-e2e-old)
+    configure_upgrade_step 'ci/latest-1.1' 'configured-in-master' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
   # kubernetes-upgrade-gke-1.0-release
   #
   # Configurations for step1, step3, and step5 live in the release-1.0 branch.

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -779,46 +779,46 @@ case ${JOB_NAME} in
     configure_upgrade_step 'ci/latest-1.1' 'configured-in-master' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  # kubernetes-upgrade-gke-1.0-release
+  # kubernetes-upgrade-gke-1.0-current-release
   #
   # Configurations for step1, step3, and step5 live in the release-1.0 branch.
 
-  kubernetes-upgrade-gke-1.0-release-step2-upgrade-master)
-    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-current-release-step2-upgrade-master)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-1.0-release-step4-upgrade-cluster)
-    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-current-release-step4-upgrade-cluster)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-1.0-release-step6-e2e-new)
-    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-current-release-step6-e2e-new)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  # kubernetes-upgrade-gke-stable-release
+  # kubernetes-upgrade-gke-stable-current-release
 
-  kubernetes-upgrade-gke-stable-release-step1-deploy)
-    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-stable-current-release-step1-deploy)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-stable-release-step2-upgrade-master)
-    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-stable-current-release-step2-upgrade-master)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-stable-release-step3-e2e-old)
-    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-stable-current-release-step3-e2e-old)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-stable-release-step4-upgrade-cluster)
-    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-stable-current-release-step4-upgrade-cluster)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-stable-release-step5-e2e-old)
-    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-stable-current-release-step5-e2e-old)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-stable-release-step6-e2e-new)
-    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-stable-current-release-step6-e2e-new)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gke-stable-current-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 esac
 

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -767,16 +767,16 @@ case ${JOB_NAME} in
   #
   # Configurations for step1, step3, and step5 live in the release-1.0 branch.
 
-  kubernetes-upgrade-1.0-release-gke-step2-upgrade-master)
-    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-release-step2-upgrade-master)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-release-gke-step4-upgrade-cluster)
-    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-release-step4-upgrade-cluster)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-release-gke-step6-e2e-new)
-    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-release-step6-e2e-new)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-release' 'kubernetes-jenkins-gke-upgrade'
     ;;
 esac
 

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -84,7 +84,6 @@ function get_latest_trusty_image() {
 #   $GCE_DEFAULT_SKIP_TESTS
 #   $GCE_FLAKY_TESTS
 #   $GCE_SLOW_TESTS
-#   $GKE_FLAKY_TESTS
 #
 # Args:
 #   $1 old_version:  the version to deploy a cluster at, and old e2e tests to run
@@ -118,7 +117,6 @@ function configure_upgrade_step() {
         ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
         ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
         ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-        ${GKE_FLAKY_TESTS[@]:+${GKE_FLAKY_TESTS[@]}} \
         )"
 
   if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -762,6 +762,22 @@ case ${JOB_NAME} in
     # Needed to be able to create PD from the e2e test
     : ${AWS_SHARED_CREDENTIALS_FILE=/var/lib/jenkins/.aws/credentials}
     ;;
+
+  # kubernetes-upgrade-gke-1.0-release
+  #
+  # Configurations for step1, step3, and step5 live in the release-1.0 branch.
+
+  kubernetes-upgrade-1.0-release-gke-step2-upgrade-master)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-1.0-release-gke-step4-upgrade-cluster)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-1.0-release-gke-step6-e2e-new)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'gke-upgrade-1-0-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
 esac
 
 # AWS variables


### PR DESCRIPTION
This includes an (edited) cherry-pick of #17746 plus configs for upgrade jobs that drive _from_ `release-1.0` _to_ `release-1.1`/current release.
