### PR TITLE
Configure gke-upgrade jobs from 1.0 and 1.1 to master on master

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -1167,16 +1167,16 @@ case ${JOB_NAME} in
   #
   # Configurations for step1, step3, and step5 live in the release-1.0 branch.
 
-  kubernetes-upgrade-1.0-master-gke-step2-upgrade-master)
-    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-master-step2-upgrade-master)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-master-gke-step4-upgrade-cluster)
-    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-master-step4-upgrade-cluster)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-master-gke-step6-e2e-new)
-    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+  kubernetes-upgrade-gke-1.0-master-step6-e2e-new)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
   # kubernetes-upgrade-gce

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -1179,6 +1179,22 @@ case ${JOB_NAME} in
     configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
+  # kubernetes-upgrade-gke-1.1-master
+  #
+  # Configurations for step1, step3, and step5 live in the release-1.1 branch.
+
+  kubernetes-upgrade-gke-1.1-master-step2-upgrade-master)
+    configure_upgrade_step 'configured-in-release-1.1' 'ci/latest' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-1.1-master-step4-upgrade-cluster)
+    configure_upgrade_step 'configured-in-release-1.1' 'ci/latest' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-1.1-master-step6-e2e-new)
+    configure_upgrade_step 'configured-in-release-1.1' 'ci/latest' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
   # kubernetes-upgrade-gce
   #
   # This suite:

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -1163,125 +1163,20 @@ case ${JOB_NAME} in
           )"}
     ;;
 
-  # kubernetes-upgrade-gke-1.0-current-release
+  # kubernetes-upgrade-gke-1.0-master
   #
-  # This suite:
-  #
-  # 1. launches a cluster at ci/latest-1.0,
-  # 2. upgrades the master to CURRENT_RELEASE_PUBLISHED_VERSION
-  # 3. runs ci/latest-1.0 e2es,
-  # 4. upgrades the rest of the cluster,
-  # 5. runs ci/latest-1.0 e2es again, then
-  # 6. runs CURRENT_RELEASE_PUBLISHED_VERSION e2es and tears down the cluster.
+  # Configurations for step1, step3, and step5 live in the release-1.0 branch.
 
-  kubernetes-upgrade-1.0-current-release-gke-step1-deploy)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-1-0"}
-    : ${E2E_NETWORK:="gke-upgrade-1-0"}
-    : ${JENKINS_PUBLISHED_VERSION:="ci/latest-1.0"}
-    : ${E2E_SET_CLUSTER_API_VERSION:=y}
-    : ${PROJECT:="kubernetes-jenkins-gke-upgrade"}
-    : ${E2E_UP:="true"}
-    : ${E2E_TEST:="false"}
-    : ${E2E_DOWN:="false"}
+  kubernetes-upgrade-1.0-master-gke-step2-upgrade-master)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-current-release-gke-step2-upgrade-master)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-1-0"}
-    : ${E2E_NETWORK:="gke-upgrade-1-0"}
-    : ${E2E_OPT:="--check_version_skew=false"}
-    # Use upgrade logic of version we're upgrading to.
-    : ${JENKINS_PUBLISHED_VERSION:="${CURRENT_RELEASE_PUBLISHED_VERSION}"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    : ${PROJECT:="kubernetes-jenkins-gke-upgrade"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Cluster\sUpgrade.*upgrade-master --upgrade-target=${CURRENT_RELEASE_PUBLISHED_VERSION}"}
+  kubernetes-upgrade-1.0-master-gke-step4-upgrade-cluster)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-1.0-current-release-gke-step3-e2e-old)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-1-0"}
-    : ${E2E_NETWORK:="gke-upgrade-1-0"}
-    : ${E2E_OPT:="--check_version_skew=false"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    # Run old e2es
-    : ${JENKINS_PUBLISHED_VERSION:="ci/latest-1.0"}
-    : ${PROJECT:="kubernetes-jenkins-gke-upgrade"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GKE_FLAKY_TESTS[@]:+${GKE_FLAKY_TESTS[@]}} \
-          )"}
-    ;;
-
-  kubernetes-upgrade-1.0-current-release-gke-step4-upgrade-cluster)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-1-0"}
-    : ${E2E_NETWORK:="gke-upgrade-1-0"}
-    : ${E2E_OPT:="--check_version_skew=false"}
-    # Use upgrade logic of version we're upgrading to.
-    : ${JENKINS_PUBLISHED_VERSION:="${CURRENT_RELEASE_PUBLISHED_VERSION}"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    : ${PROJECT:="kubernetes-jenkins-gke-upgrade"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Cluster\sUpgrade.*upgrade-cluster --upgrade-target=${CURRENT_RELEASE_PUBLISHED_VERSION}"}
-    ;;
-
-  kubernetes-upgrade-1.0-current-release-gke-step5-e2e-old)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-1-0"}
-    : ${E2E_NETWORK:="gke-upgrade-1-0"}
-    : ${E2E_OPT:="--check_version_skew=false"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    # Run old e2es
-    : ${JENKINS_PUBLISHED_VERSION:="ci/latest-1.0"}
-    : ${PROJECT:="kubernetes-jenkins-gke-upgrade"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GKE_FLAKY_TESTS[@]:+${GKE_FLAKY_TESTS[@]}} \
-          )"}
-    ;;
-
-  kubernetes-upgrade-1.0-current-release-gke-step6-e2e-new)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-1-0"}
-    : ${E2E_NETWORK:="gke-upgrade-1-0"}
-    # TODO(15011): these really shouldn't be (very) version skewed, but because
-    # we have to get CURRENT_RELEASE_PUBLISHED_VERSION again, it could get slightly out of whack.
-    : ${E2E_OPT:="--check_version_skew=false"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    : ${JENKINS_PUBLISHED_VERSION:="${CURRENT_RELEASE_PUBLISHED_VERSION}"}
-    : ${PROJECT:="kubernetes-jenkins-gke-upgrade"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GKE_FLAKY_TESTS[@]:+${GKE_FLAKY_TESTS[@]}} \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          )"}
+  kubernetes-upgrade-1.0-master-gke-step6-e2e-new)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'gke-upgrade-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
   # kubernetes-upgrade-gce
@@ -1404,7 +1299,7 @@ case ${JOB_NAME} in
   # 5. runs ci/latest-1.0 e2es again, then
   # 6. runs CURRENT_RELEASE_PUBLISHED_VERSION e2es and tears down the cluster.
 
-    kubernetes-upgrade-1.0-current-release-gce-step1-deploy)
+  kubernetes-upgrade-1.0-current-release-gce-step1-deploy)
     : ${E2E_CLUSTER_NAME:="gce-upgrade-1-0"}
     : ${E2E_NETWORK:="gce-upgrade-1-0"}
     : ${JENKINS_PUBLISHED_VERSION:="ci/latest-1.0"}

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -1165,6 +1165,8 @@ case ${JOB_NAME} in
 
   # kubernetes-upgrade-gke-1.0-master
   #
+  # Test upgrades from the latest release-1.0 build to the latest master build.
+  #
   # Configurations for step1, step3, and step5 live in the release-1.0 branch.
 
   kubernetes-upgrade-gke-1.0-master-step2-upgrade-master)
@@ -1180,6 +1182,8 @@ case ${JOB_NAME} in
     ;;
 
   # kubernetes-upgrade-gke-1.1-master
+  #
+  # Test upgrades from the latest release-1.1 build to the latest master build.
   #
   # Configurations for step1, step3, and step5 live in the release-1.1 branch.
 


### PR DESCRIPTION
This includes configs for upgrade jobs that drive _from_ `release-1.0` _to_ `master`, and removes old jobs for upgrading from 1.0 on GCE.
