### PR TITLE
[Client-gen] Tracking variables, functions and types separately in go2idl

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/generator-for-group.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-group.go
@@ -57,12 +57,12 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		"group":                      g.group,
 		"Group":                      namer.IC(g.group),
 		"types":                      g.types,
-		"Config":                     c.Universe.Get(types.Name{Package: pkgUnversioned, Name: "Config"}),
-		"DefaultKubernetesUserAgent": c.Universe.Get(types.Name{Package: pkgUnversioned, Name: "DefaultKubernetesUserAgent"}),
-		"RESTClient":                 c.Universe.Get(types.Name{Package: pkgUnversioned, Name: "RESTClient"}),
-		"RESTClientFor":              c.Universe.Get(types.Name{Package: pkgUnversioned, Name: "RESTClientFor"}),
-		"latestGroup":                c.Universe.Get(types.Name{Package: pkgLatest, Name: "Group"}),
-		"GroupOrDie":                 c.Universe.Get(types.Name{Package: pkgLatest, Name: "GroupOrDie"}),
+		"Config":                     c.Universe.Type(types.Name{Package: pkgUnversioned, Name: "Config"}),
+		"DefaultKubernetesUserAgent": c.Universe.Function(types.Name{Package: pkgUnversioned, Name: "DefaultKubernetesUserAgent"}),
+		"RESTClient":                 c.Universe.Type(types.Name{Package: pkgUnversioned, Name: "RESTClient"}),
+		"RESTClientFor":              c.Universe.Function(types.Name{Package: pkgUnversioned, Name: "RESTClientFor"}),
+		"latestGroup":                c.Universe.Variable(types.Name{Package: pkgLatest, Name: "Group"}),
+		"GroupOrDie":                 c.Universe.Variable(types.Name{Package: pkgLatest, Name: "GroupOrDie"}),
 	}
 	sw.Do(groupInterfaceTemplate, m)
 	sw.Do(groupClientTemplate, m)

--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -54,9 +54,9 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		"type":             t,
 		"package":          pkg,
 		"Package":          namer.IC(pkg),
-		"watchInterface":   c.Universe.Get(types.Name{Package: "k8s.io/kubernetes/pkg/watch", Name: "Interface"}),
-		"apiDeleteOptions": c.Universe.Get(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "DeleteOptions"}),
-		"unvListOptions":   c.Universe.Get(types.Name{Package: "k8s.io/kubernetes/pkg/api/unversioned", Name: "ListOptions"}),
+		"watchInterface":   c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/watch", Name: "Interface"}),
+		"apiDeleteOptions": c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "DeleteOptions"}),
+		"unvListOptions":   c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api/unversioned", Name: "ListOptions"}),
 	}
 	sw.Do(namespacerTemplate, m)
 	sw.Do(interfaceTemplate, m)

--- a/cmd/libs/go2idl/namer/namer_test.go
+++ b/cmd/libs/go2idl/namer/namer_test.go
@@ -27,26 +27,26 @@ func TestNameStrategy(t *testing.T) {
 	u := types.Universe{}
 
 	// Add some types.
-	base := u.Get(types.Name{Package: "foo/bar", Name: "Baz"})
+	base := u.Type(types.Name{Package: "foo/bar", Name: "Baz"})
 	base.Kind = types.Struct
 
-	tmp := u.Get(types.Name{Package: "", Name: "[]bar.Baz"})
+	tmp := u.Type(types.Name{Package: "", Name: "[]bar.Baz"})
 	tmp.Kind = types.Slice
 	tmp.Elem = base
 
-	tmp = u.Get(types.Name{Package: "", Name: "map[string]bar.Baz"})
+	tmp = u.Type(types.Name{Package: "", Name: "map[string]bar.Baz"})
 	tmp.Kind = types.Map
 	tmp.Key = types.String
 	tmp.Elem = base
 
-	tmp = u.Get(types.Name{Package: "foo/other", Name: "Baz"})
+	tmp = u.Type(types.Name{Package: "foo/other", Name: "Baz"})
 	tmp.Kind = types.Struct
 	tmp.Members = []types.Member{{
 		Embedded: true,
 		Type:     base,
 	}}
 
-	u.Get(types.Name{Package: "", Name: "string"})
+	u.Type(types.Name{Package: "", Name: "string"})
 
 	o := Orderer{NewPublicNamer(0)}
 	order := o.Order(u)

--- a/cmd/libs/go2idl/namer/order.go
+++ b/cmd/libs/go2idl/namer/order.go
@@ -37,6 +37,12 @@ func (o *Orderer) Order(u types.Universe) []*types.Type {
 		for _, t := range p.Types {
 			list.types = append(list.types, t)
 		}
+		for _, f := range p.Functions {
+			list.types = append(list.types, f)
+		}
+		for _, v := range p.Variables {
+			list.types = append(list.types, v)
+		}
 	}
 	sort.Sort(list)
 	return list.types

--- a/cmd/libs/go2idl/types/types.go
+++ b/cmd/libs/go2idl/types/types.go
@@ -61,11 +61,17 @@ const (
 
 	// The remaining types are included for completeness, but are not well
 	// supported.
-	Array       Kind = "Array" // Array is just like slice, but has a fixed length.
-	Chan        Kind = "Chan"
-	Func        Kind = "Func"
-	Unknown     Kind = ""
-	Unsupported Kind = "Unsupported"
+	Array Kind = "Array" // Array is just like slice, but has a fixed length.
+	Chan  Kind = "Chan"
+	Func  Kind = "Func"
+
+	// DeclarationOf is different from other Kinds; it indicates that instead of
+	// representing an actual Type, the type is a declaration of an instance of
+	// a type. E.g., a top-level function, variable, or constant. See the
+	// comment for Type.Name for more detail.
+	DeclarationOf Kind = "DeclarationOf"
+	Unknown       Kind = ""
+	Unsupported   Kind = "Unsupported"
 )
 
 // Package holds package-level information.
@@ -84,6 +90,14 @@ type Package struct {
 	// package name).
 	Types map[string]*Type
 
+	// Functions within this package, indexed by their name (*not* including
+	// package name).
+	Functions map[string]*Type
+
+	// Global variables within this package, indexed by their name (*not* including
+	// package name).
+	Variables map[string]*Type
+
 	// Packages imported by this package, indexed by (canonicalized)
 	// package path.
 	Imports map[string]*Package
@@ -96,7 +110,7 @@ func (p *Package) Has(name string) bool {
 }
 
 // Get (or add) the given type
-func (p *Package) Get(typeName string) *Type {
+func (p *Package) Type(typeName string) *Type {
 	if t, ok := p.Types[typeName]; ok {
 		return t
 	}
@@ -109,6 +123,32 @@ func (p *Package) Get(typeName string) *Type {
 	}
 	t := &Type{Name: Name{Package: p.Path, Name: typeName}}
 	p.Types[typeName] = t
+	return t
+}
+
+// Get (or add) the given function. If a function is added, it's the caller's
+// responsibility to finish construction of the function by setting Underlying
+// to the correct type.
+func (p *Package) Function(funcName string) *Type {
+	if t, ok := p.Functions[funcName]; ok {
+		return t
+	}
+	t := &Type{Name: Name{Package: p.Path, Name: funcName}}
+	t.Kind = DeclarationOf
+	p.Functions[funcName] = t
+	return t
+}
+
+// Get (or add) the given varaible. If a variable is added, it's the caller's
+// responsibility to finish construction of the variable by setting Underlying
+// to the correct type.
+func (p *Package) Variable(varName string) *Type {
+	if t, ok := p.Variables[varName]; ok {
+		return t
+	}
+	t := &Type{Name: Name{Package: p.Path, Name: varName}}
+	t.Kind = DeclarationOf
+	p.Variables[varName] = t
 	return t
 }
 
@@ -127,8 +167,24 @@ type Universe map[string]*Package
 // types will always be found, even if they haven't been explicitly added to
 // the map. If a non-existing type is requested, u will create (a marker for)
 // it.
-func (u Universe) Get(n Name) *Type {
-	return u.Package(n.Package).Get(n.Name)
+func (u Universe) Type(n Name) *Type {
+	return u.Package(n.Package).Type(n.Name)
+}
+
+// Function returns the canonical function for the given fully-qualified name.
+// If a non-existing function is requested, u will create (a marker for) it.
+// If a marker is created, it's the caller's responsibility to finish
+// construction of the function by setting Underlying to the correct type.
+func (u Universe) Function(n Name) *Type {
+	return u.Package(n.Package).Function(n.Name)
+}
+
+// Variable returns the canonical variable for the given fully-qualified name.
+// If a non-existing variable is requested, u will create (a marker for) it.
+// If a marker is created, it's the caller's responsibility to finish
+// construction of the variable by setting Underlying to the correct type.
+func (u Universe) Variable(n Name) *Type {
+	return u.Package(n.Package).Variable(n.Name)
 }
 
 // AddImports registers import lines for packageName. May be called multiple times.
@@ -146,9 +202,11 @@ func (u Universe) Package(packagePath string) *Package {
 		return p
 	}
 	p := &Package{
-		Path:    packagePath,
-		Types:   map[string]*Type{},
-		Imports: map[string]*Package{},
+		Path:      packagePath,
+		Types:     map[string]*Type{},
+		Functions: map[string]*Type{},
+		Variables: map[string]*Type{},
+		Imports:   map[string]*Package{},
 	}
 	u[packagePath] = p
 	return p
@@ -159,6 +217,11 @@ type Type struct {
 	// There are two general categories of types, those explicitly named
 	// and those anonymous. Named ones will have a non-empty package in the
 	// name field.
+	//
+	// An exception: If Kind == DeclarationOf, then this name is the name of a
+	// top-level function, variable, or const, and the type can be found in Underlying.
+	// We do this to allow the naming system to work against these objects, even
+	// though they aren't strictly speaking types.
 	Name Name
 
 	// The general kind of this type.
@@ -178,6 +241,7 @@ type Type struct {
 	Key *Type
 
 	// If Kind == Alias, this is the underlying type.
+	// If Kind == DeclarationOf, this is the type of the declaration.
 	Underlying *Type
 
 	// If Kind == Interface, this is the list of all required functions.

--- a/cmd/libs/go2idl/types/types_test.go
+++ b/cmd/libs/go2idl/types/types_test.go
@@ -25,7 +25,7 @@ func TestGetBuiltin(t *testing.T) {
 	if builtinPkg := u.Package(""); builtinPkg.Has("string") {
 		t.Errorf("Expected builtin package to not have builtins until they're asked for explicitly. %#v", builtinPkg)
 	}
-	s := u.Get(Name{Package: "", Name: "string"})
+	s := u.Type(Name{Package: "", Name: "string"})
 	if s != String {
 		t.Errorf("Expected canonical string type.")
 	}
@@ -40,7 +40,7 @@ func TestGetBuiltin(t *testing.T) {
 func TestGetMarker(t *testing.T) {
 	u := Universe{}
 	n := Name{Package: "path/to/package", Name: "Foo"}
-	f := u.Get(n)
+	f := u.Type(n)
 	if f == nil || f.Name != n {
 		t.Errorf("Expected marker type.")
 	}


### PR DESCRIPTION
This PR tracks variables, functions and types separately in go2idl. It reuses the types.Type struct to hold all three of them.

@lavalamp @wojtek-t

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/18039)

<!-- Reviewable:end -->
