### PR TITLE
Fix local cluster script

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -282,6 +282,7 @@ function start_kubelet {
         --address="127.0.0.1" \
         --api-servers="${API_HOST}:${API_PORT}" \
         --cpu-cfs-quota=${CPU_CFS_QUOTA} \
+        --cluster-dns="127.0.0.1" \
         --port="$KUBELET_PORT" >"${KUBELET_LOG}" 2>&1 &
       KUBELET_PID=$!
     else


### PR DESCRIPTION
After #15645 is merged, pod with ClusterDNSFirst Policy (default) cannot be created when clusterDNS is not known. This causes pods in local cluster failed to run by default. 

```
NAME             READY     STATUS              RESTARTS   AGE
frontend-2vvak   0/1       ContainerCreating   0          6m
```

```
Events:
  FirstSeen LastSeen    Count   From            SubobjectPath   Type        Reason          Message
  ─────────   ────────    ───── ────            ───────────── ────────    ──────          ───────
  6m        6m      1   {scheduler }                Normal      Scheduled       Successfully assigned frontend-2vvak to 127.0.0.1
  6m        1s      35  {kubelet 127.0.0.1}         Warning     MissingClusterDNS   kubelet does not have ClusterDNS IP configured and cannot create Pod using "ClusterFirst" policy
  6m        1s      35  {kubelet 127.0.0.1}         Warning     FailedSync      Error syncing pod, skipping: kubelet does not have ClusterDNS IP configured and cannot create Pod using "ClusterFirst" policy. pod:"frontend-2vvak_default"
```

Set cluster DNS of kubelet in the script to fix it. 

cc @ArtfulCoder @kubernetes/goog-cluster @kubernetes/goog-node 
