### PR TITLE
Revert "SkyDNS is the only NS for Pods with DNSPolicy=ClusterFirst"

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -248,7 +248,7 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 		3*time.Second,  /* NodeStatusUpdateFrequency */
 		10*time.Second, /* SyncFrequency */
 		40,             /* MaxPods */
-		cm, net.ParseIP("127.0.0.1"))
+		cm)
 
 	kubeletapp.RunKubelet(kcfg)
 	// Kubelet (machine)
@@ -281,8 +281,7 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 		10*time.Second, /* SyncFrequency */
 
 		40, /* MaxPods */
-		cm,
-		net.ParseIP("127.0.0.1"))
+		cm)
 
 	kubeletapp.RunKubelet(kcfg)
 	return apiServer.URL, configFilePath

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -704,7 +704,7 @@ func SimpleKubelet(client *client.Client,
 	osInterface kubecontainer.OSInterface,
 	fileCheckFrequency, httpCheckFrequency, minimumGCAge, nodeStatusUpdateFrequency, syncFrequency time.Duration,
 	maxPods int,
-	containerManager cm.ContainerManager, clusterDNS net.IP) *KubeletConfig {
+	containerManager cm.ContainerManager) *KubeletConfig {
 	imageGCPolicy := kubelet.ImageGCPolicy{
 		HighThresholdPercent: 90,
 		LowThresholdPercent:  80,
@@ -719,7 +719,6 @@ func SimpleKubelet(client *client.Client,
 		CAdvisorInterface:         cadvisorInterface,
 		CgroupRoot:                "",
 		Cloud:                     cloud,
-		ClusterDNS:                clusterDNS,
 		ConfigFile:                configFilePath,
 		ContainerManager:          containerManager,
 		ContainerRuntime:          "docker",

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1466,7 +1466,7 @@ func (kl *Kubelet) podFieldSelectorRuntimeValue(fs *api.ObjectFieldSelector, pod
 // domains of the cluster.
 func (kl *Kubelet) getClusterDNS(pod *api.Pod) ([]string, []string, error) {
 	var hostDNS, hostSearch []string
-	// Get host DNS settings
+	// Get host DNS settings and append them to cluster DNS settings.
 	if kl.resolverConfig != "" {
 		f, err := os.Open(kl.resolverConfig)
 		if err != nil {
@@ -1496,17 +1496,9 @@ func (kl *Kubelet) getClusterDNS(pod *api.Pod) ([]string, []string, error) {
 	var dns, dnsSearch []string
 
 	if kl.clusterDNS != nil {
-		// for a pod with DNSClusterFirst policy, the cluster DNS server is the only nameserver configured for
-		// the pod. The cluster DNS server itself will forward queries to other nameservers that is configured to use,
-		// in case the cluster DNS server cannot resolve the DNS query itself
-		dns = []string{kl.clusterDNS.String()}
+		dns = append([]string{kl.clusterDNS.String()}, hostDNS...)
 	} else {
-		// clusterDNS is not known.
-		// pod with ClusterDNSFirst Policy cannot be created
-		kl.recorder.Eventf(pod, api.EventTypeWarning, "MissingClusterDNS", "kubelet does not have ClusterDNS IP configured and cannot create Pod using %q policy", pod.Spec.DNSPolicy)
-		log := fmt.Sprintf("kubelet does not have ClusterDNS IP configured and cannot create Pod using %q policy. pod:%q", pod.Spec.DNSPolicy, kubecontainer.GetPodFullName(pod))
-		kl.recorder.Eventf(kl.nodeRef, api.EventTypeWarning, "MissingClusterDNS", log)
-		return nil, nil, fmt.Errorf(log)
+		dns = hostDNS
 	}
 	if kl.clusterDomain != "" {
 		nsSvcDomain := fmt.Sprintf("%s.svc.%s", pod.Namespace, kl.clusterDomain)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1020,8 +1020,8 @@ func TestDNSConfigurationParams(t *testing.T) {
 		}
 	}
 	t.Logf("nameservers %+v", options[1].DNS)
-	if len(options[0].DNS) != 1 {
-		t.Errorf("expected cluster nameserver only, got %+v", options[0].DNS)
+	if len(options[0].DNS) != len(options[1].DNS)+1 {
+		t.Errorf("expected prepend of cluster nameserver, got %+v", options[0].DNS)
 	} else if options[0].DNS[0] != clusterNS {
 		t.Errorf("expected nameserver %s, got %v", clusterNS, options[0].DNS[0])
 	}

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -72,7 +72,6 @@ func NewHollowKubelet(
 			10*time.Second,         /* SyncFrequency */
 			40,                     /* MaxPods */
 			containerManager,
-			nil,
 		),
 	}
 }


### PR DESCRIPTION
Reverts kubernetes/kubernetes#15645

I think this is the culprit for issue #18056. I'll manually merge on LGTM.
