### PR TITLE
e2e: Remove specific Gluster repo.

### DIFF
--- a/cluster/saltbase/salt/e2e/init.sls
+++ b/cluster/saltbase/salt/e2e/init.sls
@@ -1,18 +1,6 @@
 e2e:
-
-{% if grains['os_family'] == 'Debian' and  grains['oscodename'] == 'wheezy' %}
-  # Add GlusterFS 3.5.2 Debian repo - Wheezy has Gluster 3.2 and that's too old for us.
-  pkgrepo.managed:
-    - name: deb http://download.gluster.org/pub/gluster/glusterfs/3.5/3.5.2/Debian/wheezy/apt wheezy main
-    - dist: wheezy
-    - file: /etc/apt/sources.list.d/gluster.list
-    - key_url: http://download.gluster.org/pub/gluster/glusterfs/3.5/3.5.2/Debian/wheezy/pubkey.gpg
-{% endif %}
-
   # Install various packages required by e2e tests to all hosts.
-  # 'pkg.latest' is used to install updated glusterfs-client from the repo above,
-  # GCE image already has glusterfs-client 3.2.5, which is too old.
-  pkg.latest:
+  pkg.installed:
     - refresh: true
     - pkgs:
       - targetcli


### PR DESCRIPTION
Debian Wheezy image in GCE has already the correct one.
