### PR TITLE
Cascading delete deployment

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -966,15 +966,14 @@ __EOF__
   # Clean-up
   kubectl delete job/pi "${kube_flags[@]}"
 
-  # TODO(madhusudancs): Fix this when Scale group issues are resolved (see issue #18528).
-  # ### Scale a deployment
-  # kubectl create -f examples/extensions/deployment.yaml "${kube_flags[@]}"
-  # # Command
-  # kubectl scale --current-replicas=3 --replicas=1 deployment/nginx-deployment
-  # # Post-condition: 1 replica for nginx-deployment
-  # kube::test::get_object_assert 'deployment nginx-deployment' "{{$deployment_replicas}}" '1'
-  # # Clean-up
-  # kubectl delete deployment/nginx-deployment "${kube_flags[@]}"
+  ### Scale a deployment
+  kubectl create -f docs/user-guide/deployment.yaml "${kube_flags[@]}"
+  # Command
+  kubectl scale --current-replicas=3 --replicas=1 deployment/nginx-deployment
+  # Post-condition: 1 replica for nginx-deployment
+  kube::test::get_object_assert 'deployment nginx-deployment' "{{$deployment_replicas}}" '1'
+  # Clean-up
+  kubectl delete deployment/nginx-deployment "${kube_flags[@]}"
 
   ### Expose a deployment as a service
   kubectl create -f docs/user-guide/deployment.yaml "${kube_flags[@]}"

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -637,13 +637,13 @@ runTests() {
   # Post-Condition: service "nginx" has configuration annotation
   [[ "$(kubectl get svc nginx -o yaml "${kube_flags[@]}" | grep kubectl.kubernetes.io/last-applied-configuration)" ]]
   # Clean up
-  kubectl delete rc,svc nginx 
+  kubectl delete rc,svc nginx
   ## 6. kubectl autoscale --save-config should generate configuration annotation
   # Pre-Condition: no RC exists, then create the rc "frontend", which shouldn't have configuration annotation
   kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" ''
   kubectl create -f examples/guestbook/frontend-controller.yaml "${kube_flags[@]}"
   ! [[ "$(kubectl get rc frontend -o yaml "${kube_flags[@]}" | grep kubectl.kubernetes.io/last-applied-configuration)" ]]
-  # Command: autoscale rc "frontend" 
+  # Command: autoscale rc "frontend"
   kubectl autoscale -f examples/guestbook/frontend-controller.yaml --save-config "${kube_flags[@]}" --max=2
   # Post-Condition: hpa "frontend" has configuration annotation
   [[ "$(kubectl get hpa frontend -o yaml "${kube_flags[@]}" | grep kubectl.kubernetes.io/last-applied-configuration)" ]]
@@ -653,21 +653,21 @@ runTests() {
   ## kubectl apply should create the resource that doesn't exist yet
   # Pre-Condition: no POD exists
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
-  # Command: apply a pod "test-pod" (doesn't exist) should create this pod 
+  # Command: apply a pod "test-pod" (doesn't exist) should create this pod
   kubectl apply -f hack/testdata/pod.yaml "${kube_flags[@]}"
   # Post-Condition: pod "test-pod" is created
   kube::test::get_object_assert 'pods test-pod' "{{${labels_field}.name}}" 'test-pod-label'
   # Post-Condition: pod "test-pod" has configuration annotation
   [[ "$(kubectl get pods test-pod -o yaml "${kube_flags[@]}" | grep kubectl.kubernetes.io/last-applied-configuration)" ]]
-  # Clean up 
+  # Clean up
   kubectl delete pods test-pod "${kube_flags[@]}"
 
-  ## kubectl run should create deployments or jobs 
+  ## kubectl run should create deployments or jobs
   # Pre-Condition: no Job exists
   kube::test::get_object_assert jobs "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl run pi --generator=job/v1beta1 --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(20)' "${kube_flags[@]}"
-  # Post-Condition: Job "pi" is created 
+  # Post-Condition: Job "pi" is created
   kube::test::get_object_assert jobs "{{range.items}}{{$id_field}}:{{end}}" 'pi:'
   # Clean up
   kubectl delete jobs pi "${kube_flags[@]}"
@@ -675,11 +675,10 @@ runTests() {
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl run nginx --image=nginx --generator=deployment/v1beta1 "${kube_flags[@]}"
-  # Post-Condition: Deployment "nginx" is created 
+  # Post-Condition: Deployment "nginx" is created
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" 'nginx:'
-  # Clean up 
+  # Clean up
   kubectl delete deployment nginx "${kube_flags[@]}"
-  kubectl delete rc -l pod-template-hash "${kube_flags[@]}"
 
   ##############
   # Namespaces #
@@ -721,7 +720,7 @@ runTests() {
   # Command
   kubectl delete "${kube_flags[@]}" pod --namespace=other valid-pod --grace-period=0
   # Post-condition: valid-pod POD doesn't exist
-  kube::test::get_object_assert 'pods --namespace=other' "{{range.items}}{{$id_field}}:{{end}}" ''  
+  kube::test::get_object_assert 'pods --namespace=other' "{{range.items}}{{$id_field}}:{{end}}" ''
   # Clean up
   kubectl delete namespace other
 
@@ -966,6 +965,7 @@ __EOF__
   kube::test::get_object_assert 'job pi' "{{$job_parallelism_field}}" '2'
   # Clean-up
   kubectl delete job/pi "${kube_flags[@]}"
+
   # TODO(madhusudancs): Fix this when Scale group issues are resolved (see issue #18528).
   # ### Scale a deployment
   # kubectl create -f examples/extensions/deployment.yaml "${kube_flags[@]}"
@@ -975,8 +975,6 @@ __EOF__
   # kube::test::get_object_assert 'deployment nginx-deployment' "{{$deployment_replicas}}" '1'
   # # Clean-up
   # kubectl delete deployment/nginx-deployment "${kube_flags[@]}"
-  # # TODO: Remove once deployment reaping is implemented
-  # kubectl delete rs --all "${kube_flags[@]}"
 
   ### Expose a deployment as a service
   kubectl create -f docs/user-guide/deployment.yaml "${kube_flags[@]}"
@@ -988,8 +986,6 @@ __EOF__
   kube::test::get_object_assert 'service nginx-deployment' "{{$port_field}}" '80'
   # Clean-up
   kubectl delete deployment/nginx-deployment service/nginx-deployment "${kube_flags[@]}"
-  # TODO: Remove once deployment reaping is implemented
-  kubectl delete rs --all "${kube_flags[@]}"
 
   ### Expose replication controller as service
   kubectl create -f examples/guestbook/frontend-controller.yaml "${kube_flags[@]}"
@@ -1094,7 +1090,7 @@ __EOF__
   # Clean up
   kubectl delete rc frontend "${kube_flags[@]}"
 
-  ### Auto scale deployment 
+  ### Auto scale deployment
   # Pre-condition: no deployment exists
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
@@ -1106,9 +1102,8 @@ __EOF__
   # Clean up
   kubectl delete hpa nginx-deployment "${kube_flags[@]}"
   kubectl delete deployment nginx-deployment "${kube_flags[@]}"
-  kubectl delete rs -l pod-template-hash "${kube_flags[@]}"
 
-  ### Rollback a deployment 
+  ### Rollback a deployment
   # Pre-condition: no deployment exists
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
@@ -1330,7 +1325,7 @@ __EOF__
     # cleaning
     rm "${temp_editor}"
     # Command
-    # We need to set --overwrite, because otherwise, if the first attempt to run "kubectl label" 
+    # We need to set --overwrite, because otherwise, if the first attempt to run "kubectl label"
     # fails on some, but not all, of the resources, retries will fail because it tries to modify
     # existing labels.
     kubectl-with-retry label -f $file labeled=true --overwrite "${kube_flags[@]}"
@@ -1349,7 +1344,7 @@ __EOF__
     fi
     # Command
     # Command
-    # We need to set --overwrite, because otherwise, if the first attempt to run "kubectl annotate" 
+    # We need to set --overwrite, because otherwise, if the first attempt to run "kubectl annotate"
     # fails on some, but not all, of the resources, retries will fail because it tries to modify
     # existing annotations.
     kubectl-with-retry annotate -f $file annotated=true --overwrite "${kube_flags[@]}"

--- a/pkg/kubectl/scale.go
+++ b/pkg/kubectl/scale.go
@@ -48,9 +48,8 @@ func ScalerFor(kind unversioned.GroupKind, c client.Interface) (Scaler, error) {
 		return &ReplicaSetScaler{c.Extensions()}, nil
 	case extensions.Kind("Job"):
 		return &JobScaler{c.Extensions()}, nil
-		// TODO(madhusudancs): Fix this when Scale group issues are resolved (see issue #18528).
-		// case extensions.Kind("Deployment"):
-		// 	return &DeploymentScaler{c.Extensions()}, nil
+	case extensions.Kind("Deployment"):
+		return &DeploymentScaler{c.Extensions()}, nil
 	}
 	return nil, fmt.Errorf("no scaler has been implemented for %q", kind)
 }
@@ -328,57 +327,55 @@ func (precondition *ScalePrecondition) ValidateDeployment(deployment *extensions
 	return nil
 }
 
-// TODO(madhusudancs): Fix this when Scale group issues are resolved (see issue #18528).
-// type DeploymentScaler struct {
-// 	c client.ExtensionsInterface
-// }
+type DeploymentScaler struct {
+	c client.ExtensionsInterface
+}
 
-// // ScaleSimple is responsible for updating a deployment's desired replicas count.
-// func (scaler *DeploymentScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) error {
-// 	deployment, err := scaler.c.Deployments(namespace).Get(name)
-// 	if err != nil {
-// 		return ScaleError{ScaleGetFailure, "Unknown", err}
-// 	}
-// 	if preconditions != nil {
-// 		if err := preconditions.ValidateDeployment(deployment); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	scale, err := extensions.ScaleFromDeployment(deployment)
-// 	if err != nil {
-// 		return ScaleError{ScaleUpdateFailure, deployment.ResourceVersion, err}
-// 	}
-// 	scale.Spec.Replicas = int(newSize)
-// 	if _, err := scaler.c.Scales(namespace).Update("Deployment", scale); err != nil {
-// 		if errors.IsInvalid(err) {
-// 			return ScaleError{ScaleUpdateInvalidFailure, deployment.ResourceVersion, err}
-// 		}
-// 		return ScaleError{ScaleUpdateFailure, deployment.ResourceVersion, err}
-// 	}
-// 	return nil
-// }
+// ScaleSimple is responsible for updating a deployment's desired replicas count.
+func (scaler *DeploymentScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) error {
+	deployment, err := scaler.c.Deployments(namespace).Get(name)
+	if err != nil {
+		return ScaleError{ScaleGetFailure, "Unknown", err}
+	}
+	if preconditions != nil {
+		if err := preconditions.ValidateDeployment(deployment); err != nil {
+			return err
+		}
+	}
 
-// // Scale updates a deployment to a new size, with optional precondition check (if preconditions is not nil),
-// // optional retries (if retry is not nil), and then optionally waits for the status to reach desired count.
-// func (scaler *DeploymentScaler) Scale(namespace, name string, newSize uint, preconditions *ScalePrecondition, retry, waitForReplicas *RetryParams) error {
-// 	if preconditions == nil {
-// 		preconditions = &ScalePrecondition{-1, ""}
-// 	}
-// 	if retry == nil {
-// 		// Make it try only once, immediately
-// 		retry = &RetryParams{Interval: time.Millisecond, Timeout: time.Millisecond}
-// 	}
-// 	cond := ScaleCondition(scaler, preconditions, namespace, name, newSize)
-// 	if err := wait.Poll(retry.Interval, retry.Timeout, cond); err != nil {
-// 		return err
-// 	}
-// 	if waitForReplicas != nil {
-// 		deployment, err := scaler.c.Deployments(namespace).Get(name)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return wait.Poll(waitForReplicas.Interval, waitForReplicas.Timeout,
-// 			client.DeploymentHasDesiredReplicas(scaler.c, deployment))
-// 	}
-// 	return nil
-// }
+	// TODO(madhusudancs): Fix this when Scale group issues are resolved (see issue #18528).
+	// For now I'm falling back to regular Deployment update operation.
+	deployment.Spec.Replicas = int(newSize)
+	if _, err := scaler.c.Deployments(namespace).Update(deployment); err != nil {
+		if errors.IsInvalid(err) {
+			return ScaleError{ScaleUpdateInvalidFailure, deployment.ResourceVersion, err}
+		}
+		return ScaleError{ScaleUpdateFailure, deployment.ResourceVersion, err}
+	}
+	return nil
+}
+
+// Scale updates a deployment to a new size, with optional precondition check (if preconditions is not nil),
+// optional retries (if retry is not nil), and then optionally waits for the status to reach desired count.
+func (scaler *DeploymentScaler) Scale(namespace, name string, newSize uint, preconditions *ScalePrecondition, retry, waitForReplicas *RetryParams) error {
+	if preconditions == nil {
+		preconditions = &ScalePrecondition{-1, ""}
+	}
+	if retry == nil {
+		// Make it try only once, immediately
+		retry = &RetryParams{Interval: time.Millisecond, Timeout: time.Millisecond}
+	}
+	cond := ScaleCondition(scaler, preconditions, namespace, name, newSize)
+	if err := wait.Poll(retry.Interval, retry.Timeout, cond); err != nil {
+		return err
+	}
+	if waitForReplicas != nil {
+		deployment, err := scaler.c.Deployments(namespace).Get(name)
+		if err != nil {
+			return err
+		}
+		return wait.Poll(waitForReplicas.Interval, waitForReplicas.Timeout,
+			client.DeploymentHasDesiredReplicas(scaler.c, deployment))
+	}
+	return nil
+}

--- a/pkg/kubectl/scale_test.go
+++ b/pkg/kubectl/scale_test.go
@@ -488,145 +488,118 @@ func TestValidateJob(t *testing.T) {
 	}
 }
 
-// TODO(madhusudancs): Fix this when Scale group issues are resolved (see issue #18528).
+type ErrorDeployments struct {
+	testclient.FakeDeployments
+	invalid bool
+}
 
-// type ErrorScales struct {
-// 	testclient.FakeScales
-// 	invalid bool
-// }
+func (c *ErrorDeployments) Update(deployment *extensions.Deployment) (*extensions.Deployment, error) {
+	if c.invalid {
+		return nil, kerrors.NewInvalid(extensions.Kind(deployment.Kind), deployment.Name, nil)
+	}
+	return nil, errors.New("deployment update failure")
+}
 
-// func (c *ErrorScales) Update(kind string, scale *extensions.Scale) (*extensions.Scale, error) {
-// 	if c.invalid {
-// 		return nil, kerrors.NewInvalid(extensions.Kind(scale.Kind), scale.Name, nil)
-// 	}
-// 	return nil, errors.New("scale update failure")
-// }
+func (c *ErrorDeployments) Get(name string) (*extensions.Deployment, error) {
+	return &extensions.Deployment{
+		Spec: extensions.DeploymentSpec{
+			Replicas: 0,
+		},
+	}, nil
+}
 
-// func (c *ErrorScales) Get(kind, name string) (*extensions.Scale, error) {
-// 	return &extensions.Scale{
-// 		Spec: extensions.ScaleSpec{
-// 			Replicas: 0,
-// 		},
-// 	}, nil
-// }
+type ErrorDeploymentClient struct {
+	testclient.FakeExperimental
+	invalid bool
+}
 
-// type ErrorDeployments struct {
-// 	testclient.FakeDeployments
-// 	invalid bool
-// }
+func (c *ErrorDeploymentClient) Deployments(namespace string) client.DeploymentInterface {
+	return &ErrorDeployments{testclient.FakeDeployments{Fake: &c.FakeExperimental, Namespace: namespace}, c.invalid}
+}
 
-// func (c *ErrorDeployments) Update(deployment *extensions.Deployment) (*extensions.Deployment, error) {
-// 	if c.invalid {
-// 		return nil, kerrors.NewInvalid(extensions.Kind(deployment.Kind), deployment.Name, nil)
-// 	}
-// 	return nil, errors.New("deployment update failure")
-// }
+func TestDeploymentScaleRetry(t *testing.T) {
+	fake := &ErrorDeploymentClient{FakeExperimental: testclient.FakeExperimental{Fake: &testclient.Fake{}}, invalid: false}
+	scaler := &DeploymentScaler{fake}
+	preconditions := &ScalePrecondition{-1, ""}
+	count := uint(3)
+	name := "foo"
+	namespace := "default"
 
-// func (c *ErrorDeployments) Get(name string) (*extensions.Deployment, error) {
-// 	return &extensions.Deployment{
-// 		Spec: extensions.DeploymentSpec{
-// 			Replicas: 0,
-// 		},
-// 	}, nil
-// }
+	scaleFunc := ScaleCondition(scaler, preconditions, namespace, name, count)
+	pass, err := scaleFunc()
+	if pass != false {
+		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
+	}
+	if err != nil {
+		t.Errorf("Did not expect an error on update failure, got %v", err)
+	}
+	preconditions = &ScalePrecondition{3, ""}
+	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count)
+	pass, err = scaleFunc()
+	if err == nil {
+		t.Errorf("Expected error on precondition failure")
+	}
+}
 
-// type ErrorDeploymentClient struct {
-// 	testclient.FakeExperimental
-// 	invalid bool
-// }
+func TestDeploymentScale(t *testing.T) {
+	fake := &testclient.FakeExperimental{Fake: &testclient.Fake{}}
+	scaler := DeploymentScaler{fake}
+	preconditions := ScalePrecondition{-1, ""}
+	count := uint(3)
+	name := "foo"
+	scaler.Scale("default", name, count, &preconditions, nil, nil)
 
-// func (c *ErrorDeploymentClient) Deployments(namespace string) client.DeploymentInterface {
-// 	return &ErrorDeployments{testclient.FakeDeployments{Fake: &c.FakeExperimental, Namespace: namespace}, c.invalid}
-// }
+	actions := fake.Actions()
+	if len(actions) != 2 {
+		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", actions)
+	}
+	if action, ok := actions[0].(testclient.GetAction); !ok || action.GetResource() != "deployments" || action.GetName() != name {
+		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
+	}
+	if action, ok := actions[1].(testclient.UpdateAction); !ok || action.GetResource() != "deployments" || action.GetObject().(*extensions.Deployment).Spec.Replicas != int(count) {
+		t.Errorf("unexpected action %v, expected update-deployment with replicas = %d", actions[1], count)
+	}
+}
 
-// func (c *ErrorDeploymentClient) Scales(namespace string) client.ScaleInterface {
-// 	return &ErrorScales{testclient.FakeScales{Fake: &c.FakeExperimental, Namespace: namespace}, c.invalid}
-// }
+func TestDeploymentScaleInvalid(t *testing.T) {
+	fake := &ErrorDeploymentClient{FakeExperimental: testclient.FakeExperimental{Fake: &testclient.Fake{}}, invalid: true}
+	scaler := DeploymentScaler{fake}
+	preconditions := ScalePrecondition{-1, ""}
+	count := uint(3)
+	name := "foo"
+	namespace := "default"
 
-// func TestDeploymentScaleRetry(t *testing.T) {
-// 	fake := &ErrorDeploymentClient{FakeExperimental: testclient.FakeExperimental{Fake: &testclient.Fake{}}, invalid: false}
-// 	scaler := &DeploymentScaler{fake}
-// 	preconditions := &ScalePrecondition{-1, ""}
-// 	count := uint(3)
-// 	name := "foo"
-// 	namespace := "default"
+	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count)
+	pass, err := scaleFunc()
+	if pass {
+		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
+	}
+	e, ok := err.(ScaleError)
+	if err == nil || !ok || e.FailureType != ScaleUpdateInvalidFailure {
+		t.Errorf("Expected error on invalid update failure, got %v", err)
+	}
+}
 
-// 	scaleFunc := ScaleCondition(scaler, preconditions, namespace, name, count)
-// 	pass, err := scaleFunc()
-// 	if pass != false {
-// 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
-// 	}
-// 	if err != nil {
-// 		t.Errorf("Did not expect an error on update failure, got %v", err)
-// 	}
-// 	preconditions = &ScalePrecondition{3, ""}
-// 	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count)
-// 	pass, err = scaleFunc()
-// 	if err == nil {
-// 		t.Errorf("Expected error on precondition failure")
-// 	}
-// }
+func TestDeploymentScaleFailsPreconditions(t *testing.T) {
+	fake := testclient.NewSimpleFake(&extensions.Deployment{
+		Spec: extensions.DeploymentSpec{
+			Replicas: 10,
+		},
+	})
+	scaler := DeploymentScaler{&testclient.FakeExperimental{fake}}
+	preconditions := ScalePrecondition{2, ""}
+	count := uint(3)
+	name := "foo"
+	scaler.Scale("default", name, count, &preconditions, nil, nil)
 
-// func TestDeploymentScale(t *testing.T) {
-// 	fake := &testclient.FakeExperimental{Fake: &testclient.Fake{}}
-// 	scaler := DeploymentScaler{fake}
-// 	preconditions := ScalePrecondition{-1, ""}
-// 	count := uint(3)
-// 	name := "foo"
-// 	scaler.Scale("default", name, count, &preconditions, nil, nil)
-
-// 	actions := fake.Actions()
-// 	if len(actions) != 2 {
-// 		t.Errorf("unexpected actions: %v, expected 2 actions (get, update)", actions)
-// 	}
-// 	if action, ok := actions[0].(testclient.GetAction); !ok || action.GetResource() != "deployments" || action.GetName() != name {
-// 		t.Errorf("unexpected action: %v, expected get-replicationController %s", actions[0], name)
-// 	}
-// 	// TODO: The testclient needs to support subresources
-// 	if action, ok := actions[1].(testclient.UpdateAction); !ok || action.GetResource() != "Deployment" || action.GetObject().(*extensions.Scale).Spec.Replicas != int(count) {
-// 		t.Errorf("unexpected action %v, expected update-deployment-scale with replicas = %d", actions[1], count)
-// 	}
-// }
-
-// func TestDeploymentScaleInvalid(t *testing.T) {
-// 	fake := &ErrorDeploymentClient{FakeExperimental: testclient.FakeExperimental{Fake: &testclient.Fake{}}, invalid: true}
-// 	scaler := DeploymentScaler{fake}
-// 	preconditions := ScalePrecondition{-1, ""}
-// 	count := uint(3)
-// 	name := "foo"
-// 	namespace := "default"
-
-// 	scaleFunc := ScaleCondition(&scaler, &preconditions, namespace, name, count)
-// 	pass, err := scaleFunc()
-// 	if pass {
-// 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
-// 	}
-// 	e, ok := err.(ScaleError)
-// 	if err == nil || !ok || e.FailureType != ScaleUpdateInvalidFailure {
-// 		t.Errorf("Expected error on invalid update failure, got %v", err)
-// 	}
-// }
-
-// func TestDeploymentScaleFailsPreconditions(t *testing.T) {
-// 	fake := testclient.NewSimpleFake(&extensions.Deployment{
-// 		Spec: extensions.DeploymentSpec{
-// 			Replicas: 10,
-// 		},
-// 	})
-// 	scaler := DeploymentScaler{&testclient.FakeExperimental{fake}}
-// 	preconditions := ScalePrecondition{2, ""}
-// 	count := uint(3)
-// 	name := "foo"
-// 	scaler.Scale("default", name, count, &preconditions, nil, nil)
-
-// 	actions := fake.Actions()
-// 	if len(actions) != 1 {
-// 		t.Errorf("unexpected actions: %v, expected 1 actions (get)", actions)
-// 	}
-// 	if action, ok := actions[0].(testclient.GetAction); !ok || action.GetResource() != "deployments" || action.GetName() != name {
-// 		t.Errorf("unexpected action: %v, expected get-deployment %s", actions[0], name)
-// 	}
-// }
+	actions := fake.Actions()
+	if len(actions) != 1 {
+		t.Errorf("unexpected actions: %v, expected 1 actions (get)", actions)
+	}
+	if action, ok := actions[0].(testclient.GetAction); !ok || action.GetResource() != "deployments" || action.GetName() != name {
+		t.Errorf("unexpected action: %v, expected get-deployment %s", actions[0], name)
+	}
+}
 
 func TestValidateDeployment(t *testing.T) {
 	zero, ten, twenty := 0, 10, 20

--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -535,19 +535,6 @@ func TestDeploymentStop(t *testing.T) {
 						Replicas: 0,
 					},
 				},
-				&extensions.Scale{ // UPDATE
-					ObjectMeta: api.ObjectMeta{
-						Name:      name,
-						Namespace: ns,
-					},
-					Spec: extensions.ScaleSpec{
-						Replicas: 0,
-					},
-					Status: extensions.ScaleStatus{
-						Replicas: 0,
-						Selector: map[string]string{"k1": "v1"},
-					},
-				},
 			},
 			StopError: nil,
 			ExpectedActions: []string{"get:deployments", "update:deployments",
@@ -558,19 +545,6 @@ func TestDeploymentStop(t *testing.T) {
 			Name: "Deployment with single replicaset",
 			Objs: []runtime.Object{
 				&deployment, // GET
-				&extensions.Scale{ // UPDATE
-					ObjectMeta: api.ObjectMeta{
-						Name:      name,
-						Namespace: ns,
-					},
-					Spec: extensions.ScaleSpec{
-						Replicas: 0,
-					},
-					Status: extensions.ScaleStatus{
-						Replicas: 0,
-						Selector: map[string]string{"k1": "v1"},
-					},
-				},
 				&extensions.ReplicaSetList{ // LIST
 					Items: []extensions.ReplicaSet{
 						{

--- a/test/e2e/job.go
+++ b/test/e2e/job.go
@@ -160,7 +160,7 @@ var _ = Describe("Job", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should stop a job", func() {
+	It("should delete a job", func() {
 		By("Creating a job")
 		job := newTestJob("notTerminate", "foo", api.RestartPolicyNever, parallelism, completions)
 		job, err := createJob(f.Client, f.Namespace.Name, job)
@@ -170,7 +170,7 @@ var _ = Describe("Job", func() {
 		err = waitForAllPodsRunning(f.Client, f.Namespace.Name, job.Name, parallelism)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("scale job down")
+		By("delete a job")
 		reaper, err := kubectl.ReaperFor(extensions.Kind("Job"), f.Client)
 		Expect(err).NotTo(HaveOccurred())
 		timeout := 1 * time.Minute


### PR DESCRIPTION
This implements reaper for deployments. I've had to modify `ObjectReaction` to get subresource from request, when specified and exists (1st commit) for update scale to work properly. Though this solution might not be perfect, need to test it more extensively. 
But most importantly current implementation of `GetOldRCs` does not return any RC if the pods where removed already, which unfortunately means that old RC don't get removed. 

@kargakis @nikhiljindal ideas?

Fixes #18078
