### PR TITLE
WIP/MESOS/SCHEDULER: reduce podtask state

### DIFF
--- a/contrib/mesos/pkg/scheduler/components/deleter/deleter.go
+++ b/contrib/mesos/pkg/scheduler/components/deleter/deleter.go
@@ -95,16 +95,9 @@ func (k *deleter) DeleteOne(pod *queuer.Pod) error {
 	// cleanup is easier (unregister) since there's no state to sync
 	case podtask.StatePending:
 		if !task.Has(podtask.Launched) {
-			// we've been invoked in between Schedule() and Bind()
-			if task.HasAcceptedOffer() {
-				task.Offer.Release()
-				task.Reset()
-				task.Set(podtask.Deleted)
-				//TODO(jdef) probably want better handling here
-				if err := k.sched.Tasks().Update(task); err != nil {
-					return err
-				}
-			}
+			// if this pod is between scheduling and binding the scheduler
+			// will notice because it takes the k.sched lock and gets the task
+			// again from the registry.
 			k.sched.Tasks().Unregister(task)
 			return nil
 		}

--- a/contrib/mesos/pkg/scheduler/components/scheduler.go
+++ b/contrib/mesos/pkg/scheduler/components/scheduler.go
@@ -120,7 +120,7 @@ func New(
 		podtask.InstallDebugHandlers(core.Tasks(), mux)
 	})
 
-	core.controller = controller.New(client, algorithm, recorder, q.Yield, errorHandler.Error, binder, startLatch)
+	core.controller = controller.New(core, client, algorithm, recorder, q.Yield, errorHandler.Error, binder, startLatch)
 	return core
 }
 
@@ -144,6 +144,6 @@ func (c *sched) KillTask(id string) error {
 	return c.framework.KillTask(id)
 }
 
-func (c *sched) LaunchTask(t *podtask.T) error {
-	return c.framework.LaunchTask(t)
+func (c *sched) LaunchTask(t *podtask.T, spec *podtask.Spec) error {
+	return c.framework.LaunchTask(t, spec)
 }

--- a/contrib/mesos/pkg/scheduler/meta/annotations.go
+++ b/contrib/mesos/pkg/scheduler/meta/annotations.go
@@ -24,7 +24,6 @@ const (
 
 	TaskIdKey                = "k8s.mesosphere.io/taskId"
 	SlaveIdKey               = "k8s.mesosphere.io/slaveId"
-	OfferIdKey               = "k8s.mesosphere.io/offerId"
 	ExecutorIdKey            = "k8s.mesosphere.io/executorId"
 	ExecutorResourcesKey     = "k8s.mesosphere.io/executorResources"
 	PortMappingKey           = "k8s.mesosphere.io/portMapping"

--- a/contrib/mesos/pkg/scheduler/podtask/debug.go
+++ b/contrib/mesos/pkg/scheduler/podtask/debug.go
@@ -36,11 +36,7 @@ func InstallDebugHandlers(reg Registry, mux *http.ServeMux) {
 			if err := func() (err error) {
 				podName := task.Pod.Name
 				podNamespace := task.Pod.Namespace
-				offerId := ""
-				if task.Offer != nil {
-					offerId = task.Offer.Id()
-				}
-				_, err = io.WriteString(w, fmt.Sprintf("%v\t%v/%v\t%v\t%v\n", task.ID, podNamespace, podName, task.State, offerId))
+				_, err = io.WriteString(w, fmt.Sprintf("%v\t%v/%v\t%v\n", task.ID, podNamespace, podName, task.State))
 				return
 			}(); err != nil {
 				log.Warningf("aborting debug handler: %v", err)

--- a/contrib/mesos/pkg/scheduler/podtask/procurement.go
+++ b/contrib/mesos/pkg/scheduler/podtask/procurement.go
@@ -84,7 +84,9 @@ func (ps *ProcureState) Result() (*Spec, *mesos.Offer) {
 // and a deep copy of the given offer.
 func NewProcureState(offer *mesos.Offer) *ProcureState {
 	return &ProcureState{
-		spec:  &Spec{},
+		spec: &Spec{
+			OfferID: offer.GetId(),
+		},
 		offer: proto.Clone(offer).(*mesos.Offer),
 	}
 }

--- a/contrib/mesos/pkg/scheduler/podtask/registry.go
+++ b/contrib/mesos/pkg/scheduler/podtask/registry.go
@@ -130,8 +130,6 @@ func (k *inMemoryRegistry) Update(task *T) error {
 	case StateUnknown:
 		return fmt.Errorf("no such task: %v", task.ID)
 	case StatePending:
-		internal.Offer = task.Offer
-		internal.Spec = task.Spec
 		internal.Flags = map[FlagType]struct{}{}
 		fallthrough
 	case StateRunning:

--- a/contrib/mesos/pkg/scheduler/podtask/registry_test.go
+++ b/contrib/mesos/pkg/scheduler/podtask/registry_test.go
@@ -162,8 +162,6 @@ func TestInMemoryRegistry_Update(t *testing.T) {
 	offerId := mesosutil.NewOfferID("foo")
 	mesosOffer := &mesos.Offer{Id: offerId}
 	storage.Add([]*mesos.Offer{mesosOffer})
-	offer, ok := storage.Get(offerId.GetValue())
-	assert.True(ok)
 
 	// create registry
 	registry := NewInMemoryRegistry()
@@ -176,20 +174,6 @@ func TestInMemoryRegistry_Update(t *testing.T) {
 	assert.NoError(err)
 	a_clone, _ := registry.Get(a.ID)
 	assert.Equal(StatePending, a_clone.State)
-
-	// offer is updated while pending
-	a.Offer = offer
-	err = registry.Update(a)
-	assert.NoError(err)
-	a_clone, _ = registry.Get(a.ID)
-	assert.Equal(offer.Id(), a_clone.Offer.Id())
-
-	// spec is updated while pending
-	a.Spec = &Spec{SlaveID: "slave-1"}
-	err = registry.Update(a)
-	assert.NoError(err)
-	a_clone, _ = registry.Get(a.ID)
-	assert.Equal("slave-1", a_clone.Spec.SlaveID)
 
 	// flags are updated while pending
 	a.Flags[Launched] = struct{}{}
@@ -211,13 +195,6 @@ func TestInMemoryRegistry_Update(t *testing.T) {
 	assert.True(found_launched)
 	_, found_bound := a_clone.Flags[Bound]
 	assert.True(found_bound)
-
-	// spec is ignored while running
-	a.Spec = &Spec{SlaveID: "slave-2"}
-	err = registry.Update(a)
-	assert.NoError(err)
-	a_clone, _ = registry.Get(a.ID)
-	assert.Equal("slave-1", a_clone.Spec.SlaveID)
 
 	// error when finished
 	registry.UpdateStatus(fakeStatusUpdate(a.ID, mesos.TaskState_TASK_FINISHED))

--- a/contrib/mesos/pkg/scheduler/scheduler.go
+++ b/contrib/mesos/pkg/scheduler/scheduler.go
@@ -32,6 +32,6 @@ type Scheduler interface {
 	Offers() offers.Registry
 	Reconcile(t *podtask.T)
 	KillTask(id string) error
-	LaunchTask(t *podtask.T) error
+	LaunchTask(t *podtask.T, spec *podtask.Spec) error
 	Run(done <-chan struct{})
 }

--- a/contrib/mesos/pkg/scheduler/scheduler_mock.go
+++ b/contrib/mesos/pkg/scheduler/scheduler_mock.go
@@ -63,8 +63,8 @@ func (m *MockScheduler) KillTask(taskId string) error {
 	return args.Error(0)
 }
 
-func (m *MockScheduler) LaunchTask(task *podtask.T) error {
-	args := m.Called(task)
+func (m *MockScheduler) LaunchTask(task *podtask.T, spec *podtask.Spec) error {
+	args := m.Called(task, spec)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
- removed `podtask.T.Spec` and make podtask.Spec a transient information
  during scheduling
- removed `podtask.T.Offer`, only store the OfferID in the spec
- between scheduling and launching _nothing is persisted_, everything is transient (with the little exception that the used offer is `Acquired`
- when the task is successfully launched, the `Launched` flag is set and the podtask is updated with that in the registry

Less state is better state.
