### PR TITLE
SkyDNS is the only NS for Pods with DNSPolicy=ClusterFirst

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -248,7 +248,7 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 		3*time.Second,  /* NodeStatusUpdateFrequency */
 		10*time.Second, /* SyncFrequency */
 		40,             /* MaxPods */
-		cm)
+		cm, net.ParseIP("127.0.0.1"))
 
 	kubeletapp.RunKubelet(kcfg)
 	// Kubelet (machine)
@@ -281,7 +281,8 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 		10*time.Second, /* SyncFrequency */
 
 		40, /* MaxPods */
-		cm)
+		cm,
+		net.ParseIP("127.0.0.1"))
 
 	kubeletapp.RunKubelet(kcfg)
 	return apiServer.URL, configFilePath

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -704,7 +704,7 @@ func SimpleKubelet(client *client.Client,
 	osInterface kubecontainer.OSInterface,
 	fileCheckFrequency, httpCheckFrequency, minimumGCAge, nodeStatusUpdateFrequency, syncFrequency time.Duration,
 	maxPods int,
-	containerManager cm.ContainerManager) *KubeletConfig {
+	containerManager cm.ContainerManager, clusterDNS net.IP) *KubeletConfig {
 	imageGCPolicy := kubelet.ImageGCPolicy{
 		HighThresholdPercent: 90,
 		LowThresholdPercent:  80,
@@ -719,6 +719,7 @@ func SimpleKubelet(client *client.Client,
 		CAdvisorInterface:         cadvisorInterface,
 		CgroupRoot:                "",
 		Cloud:                     cloud,
+		ClusterDNS:                clusterDNS,
 		ConfigFile:                configFilePath,
 		ContainerManager:          containerManager,
 		ContainerRuntime:          "docker",

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1020,8 +1020,8 @@ func TestDNSConfigurationParams(t *testing.T) {
 		}
 	}
 	t.Logf("nameservers %+v", options[1].DNS)
-	if len(options[0].DNS) != len(options[1].DNS)+1 {
-		t.Errorf("expected prepend of cluster nameserver, got %+v", options[0].DNS)
+	if len(options[0].DNS) != 1 {
+		t.Errorf("expected cluster nameserver only, got %+v", options[0].DNS)
 	} else if options[0].DNS[0] != clusterNS {
 		t.Errorf("expected nameserver %s, got %v", clusterNS, options[0].DNS[0])
 	}

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -72,6 +72,7 @@ func NewHollowKubelet(
 			10*time.Second,         /* SyncFrequency */
 			40,                     /* MaxPods */
 			containerManager,
+			nil,
 		),
 	}
 }


### PR DESCRIPTION
#15645 was rolled back.

Addresses issue : #15592
Created this PR to take it forward again, with one additional change:
 For pods with ClusterFirst DNSPolicy and kubelet without DNSCluster,  the pod will be created with DNSDefault policy.
