### PR TITLE
remove Versions from GroupMeta

### DIFF
--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -20,7 +20,6 @@ package install
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -57,13 +56,10 @@ func init() {
 		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
 	}
 
-	var versions []string
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
 	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		versions = append(versions, registeredGroupVersions[i].Version)
 		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
 	}
-	groupMeta.Versions = versions
 	groupMeta.GroupVersions = registeredGroupVersions
 
 	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
@@ -111,7 +107,7 @@ func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 	default:
 		{
 			g, _ := latest.Group("")
-			return nil, fmt.Errorf("unsupported storage version: %s (valid: %s)", version, strings.Join(g.Versions, ", "))
+			return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 		}
 	}
 }

--- a/pkg/api/install/install_test.go
+++ b/pkg/api/install/install_test.go
@@ -66,8 +66,8 @@ func TestInterfacesFor(t *testing.T) {
 	if _, err := latest.GroupOrDie("").InterfacesFor(""); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, version := range append([]string{latest.GroupOrDie("").GroupVersion.Version}, latest.GroupOrDie("").Versions...) {
-		if vi, err := latest.GroupOrDie("").InterfacesFor(version); err != nil || vi == nil {
+	for i, version := range latest.GroupOrDie("").GroupVersions {
+		if vi, err := latest.GroupOrDie("").InterfacesFor(version.Version); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
@@ -86,10 +86,8 @@ func TestRESTMapper(t *testing.T) {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("").Versions {
-		currGroupVersion := unversioned.GroupVersion{Version: version}
-
-		mapping, err := latest.GroupOrDie("").RESTMapper.RESTMapping(rcGVK.GroupKind(), currGroupVersion.String())
+	for _, version := range latest.GroupOrDie("").GroupVersions {
+		mapping, err := latest.GroupOrDie("").RESTMapper.RESTMapping(rcGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -97,11 +95,11 @@ func TestRESTMapper(t *testing.T) {
 		if mapping.Resource != "replicationControllers" && mapping.Resource != "replicationcontrollers" {
 			t.Errorf("incorrect resource name: %#v", mapping)
 		}
-		if mapping.GroupVersionKind.GroupVersion() != currGroupVersion {
+		if mapping.GroupVersionKind.GroupVersion() != version {
 			t.Errorf("incorrect version: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("").InterfacesFor(currGroupVersion.String())
+		interfaces, _ := latest.GroupOrDie("").InterfacesFor(version.String())
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -109,13 +109,6 @@ type GroupMeta struct {
 	// GroupVersion represents the current external default version of the group.
 	GroupVersion unversioned.GroupVersion
 
-	// Versions is the list of versions that are recognized in code. The order
-	// provided is assumed to be from the oldest to the newest, e.g.,
-	// Versions[0] == oldest and Versions[N-1] == newest.
-	// Clients may choose to prefer the latter items in the list over the former
-	// items when presented with a set of versions to choose.
-	Versions []string
-
 	// GroupVersions is Group + Versions. This is to avoid string concatenation
 	// in many places.
 	GroupVersions []unversioned.GroupVersion

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -20,7 +20,6 @@ package install
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -53,13 +52,10 @@ func init() {
 		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
 	}
 
-	var versions []string
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
 	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		versions = append(versions, registeredGroupVersions[i].Version)
 		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
 	}
-	groupMeta.Versions = versions
 	groupMeta.GroupVersions = registeredGroupVersions
 
 	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
@@ -87,6 +83,6 @@ func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 		}, nil
 	default:
 		g, _ := latest.Group("componentconfig")
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %s)", version, strings.Join(g.Versions, ", "))
+		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/apis/componentconfig/install/install_test.go
+++ b/pkg/apis/componentconfig/install/install_test.go
@@ -65,8 +65,8 @@ func TestRESTMapper(t *testing.T) {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("componentconfig").Versions {
-		mapping, err := latest.GroupOrDie("componentconfig").RESTMapper.RESTMapping(proxyGVK.GroupKind(), version)
+	for _, version := range latest.GroupOrDie("componentconfig").GroupVersions {
+		mapping, err := latest.GroupOrDie("componentconfig").RESTMapper.RESTMapping(proxyGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			continue

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -20,7 +20,6 @@ package install
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -53,13 +52,10 @@ func init() {
 		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
 	}
 
-	var versions []string
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
 	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		versions = append(versions, registeredGroupVersions[i].Version)
 		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
 	}
-	groupMeta.Versions = versions
 	groupMeta.GroupVersions = registeredGroupVersions
 
 	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
@@ -87,6 +83,6 @@ func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 		}, nil
 	default:
 		g, _ := latest.Group("extensions")
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %s)", version, strings.Join(g.Versions, ", "))
+		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/apis/extensions/install/install_test.go
+++ b/pkg/apis/extensions/install/install_test.go
@@ -87,8 +87,8 @@ func TestRESTMapper(t *testing.T) {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("extensions").Versions {
-		mapping, err := latest.GroupOrDie("extensions").RESTMapper.RESTMapping(hpaGVK.GroupKind(), version)
+	for _, version := range latest.GroupOrDie("extensions").GroupVersions {
+		mapping, err := latest.GroupOrDie("extensions").RESTMapper.RESTMapping(hpaGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/pkg/apis/metrics/install/install.go
+++ b/pkg/apis/metrics/install/install.go
@@ -20,7 +20,6 @@ package install
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -53,13 +52,10 @@ func init() {
 		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
 	}
 
-	var versions []string
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
 	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		versions = append(versions, registeredGroupVersions[i].Version)
 		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
 	}
-	groupMeta.Versions = versions
 	groupMeta.GroupVersions = registeredGroupVersions
 
 	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
@@ -87,6 +83,6 @@ func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 		}, nil
 	default:
 		g, _ := latest.Group("metrics")
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %s)", version, strings.Join(g.Versions, ", "))
+		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/client/unversioned/extensions.go
+++ b/pkg/client/unversioned/extensions.go
@@ -19,7 +19,6 @@ package unversioned
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -146,8 +145,8 @@ func setExtensionsDefaults(config *Config) error {
 
 	versionInterfaces, err := g.InterfacesFor(config.GroupVersion.String())
 	if err != nil {
-		return fmt.Errorf("Extensions API group/version '%v' is not recognized (valid values: %s)",
-			config.GroupVersion, strings.Join(latest.GroupOrDie("extensions").Versions, ", "))
+		return fmt.Errorf("Extensions API group/version '%v' is not recognized (valid values: %v)",
+			config.GroupVersion, g.GroupVersions)
 	}
 	config.Codec = versionInterfaces.Codec
 	if config.QPS == 0 {

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -385,7 +385,7 @@ func SetKubernetesDefaults(config *Config) error {
 	}
 	versionInterfaces, err := latest.GroupOrDie("").InterfacesFor(config.GroupVersion.String())
 	if err != nil {
-		return fmt.Errorf("API version '%v' is not recognized (valid values: %s)", *config.GroupVersion, strings.Join(latest.GroupOrDie("").Versions, ", "))
+		return fmt.Errorf("API version '%v' is not recognized (valid values: %v)", *config.GroupVersion, latest.GroupOrDie("").GroupVersions)
 	}
 	if config.Codec == nil {
 		config.Codec = versionInterfaces.Codec


### PR DESCRIPTION
`GroupMeta.Version` is an unneeded field.  This removes it.

Going through a more extensive refactor for direct group metadata dependencies, I found this.

@caesarxuchao ptal
