### PR TITLE
WIP: Check if pod still exists before sending status update

### DIFF
--- a/pkg/kubelet/status/manager.go
+++ b/pkg/kubelet/status/manager.go
@@ -320,6 +320,12 @@ func (m *manager) syncBatch() {
 
 // syncPod syncs the given status with the API server. The caller must not hold the lock.
 func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
+	if _, ok := m.podManager.GetPodByUID(uid); !ok {
+		glog.V(2).Infof("Pod %q has been deleted; skipping status update", uid)
+		m.deletePodStatus(uid)
+		return
+	}
+
 	// TODO: make me easier to express from client code
 	pod, err := m.kubeClient.Pods(status.podNamespace).Get(status.podName)
 	if errors.IsNotFound(err) {


### PR DESCRIPTION
There is a window of time where the old static pod may attempt to send status
update to the mirror pod created by the _new_ static pod. This would cause
incorrect versioning in the status manager. This change checks the pod manager
to ensure that the pod still exist before sending out update.
