### PR TITLE
Prepare kube-system pods manifest for trusty nodes.

### DIFF
--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -218,19 +218,19 @@ script
 	set -o errexit
 	set -o nounset
 
-	# Configuration files are located at /etc/saltbase.
+	# Kube-system pod manifest files are located at /etc/kube-manifests.
 	. /etc/kube-env
 	# Fluentd
 	if [ "${ENABLE_NODE_LOGGING:-}" = "true" ]; then
 		if [ "${LOGGING_DESTINATION:-}" = "gcp" ]; then
-			cp /etc/saltbase/kubernetes/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml /etc/kubernetes/manifests/
+			cp /etc/kube-manifests/fluentd-gcp.yaml /etc/kubernetes/manifests/
 		elif [ "${LOGGING_DESTINATION:-}" = "elasticsearch" ]; then
-			cp /etc/saltbase/kubernetes/saltbase/salt/fluentd-es/fluentd-es.yaml /etc/kubernetes/manifests/
+			cp /etc/kube-manifests/fluentd-es.yaml /etc/kubernetes/manifests/
 		fi
 	fi
 	# Kube-registry-proxy
 	if [ "${ENABLE_CLUSTER_REGISTRY:-}" = "true" ]; then
-		cp /etc/saltbase/kubernetes/saltbase/salt/kube-registry-proxy/kube-registry-proxy.yaml /etc/kubernetes/manifests/
+		cp /etc/kube-manifests/kube-registry-proxy.yaml /etc/kubernetes/manifests/
 	fi
 end script
 

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -156,8 +156,40 @@ function copy-if-not-staged() {
   fi
 }
 
+# Prepare a tarball of kube-system manifests for trusty based cluster.
+#
+# Vars set:
+#   KUBE_MANIFESTS_TAR_URL
+#   KUBE_MANIFESTS_TAR_HASH
+function prepare-manifests-tar() {
+  KUBE_MANIFESTS_TAR_URL=
+  KUBE_MANIFESTS_TAR_HASH=
+  if [[ "${OS_DISTRIBUTION}" != "trusty" ]]; then
+    return
+  fi
+  local tmp_dir="${KUBE_TEMP}/kube-manifests"
+  mkdir -p ${tmp_dir}
+  # The manifests used by nodes can be directly used on non-salt system.
+  # We simply copy them from cluster/saltbase/salt.
+  local salt_dir="${KUBE_ROOT}/cluster/saltbase/salt"
+  cp -f "${salt_dir}/fluentd-es/fluentd-es.yaml" "${tmp_dir}"
+  cp -f "${salt_dir}/fluentd-gcp/fluentd-gcp.yaml" "${tmp_dir}"
+  cp -f "${salt_dir}/kube-registry-proxy/kube-registry-proxy.yaml" "${tmp_dir}"
+
+  local kube_manifests_tar="${KUBE_TEMP}/kube-manifests.tar.gz"
+  tar czf "${kube_manifests_tar}" -C "${KUBE_TEMP}" kube-manifests
+  KUBE_MANIFESTS_TAR_HASH=$(sha1sum-file "${kube_manifests_tar}")
+  local kube_manifests_gs_url="${staging_path}/${kube_manifests_tar##*/}"
+  copy-if-not-staged "${staging_path}" "${kube_manifests_gs_url}" "${kube_manifests_tar}" "${KUBE_MANIFESTS_TAR_HASH}"
+  # Convert from gs:// URL to an https:// URL
+  KUBE_MANIFESTS_TAR_URL="${kube_manifests_gs_url/gs:\/\//https://storage.googleapis.com/}"
+}
+
+
 # Take the local tar files and upload them to Google Storage.  They will then be
 # downloaded by the master as part of the start up script for the master.
+# If running on Ubuntu trusty, we also pack the dir cluster/gce/trusty/kube-manifest
+# and upload it to Google Storage.
 #
 # Assumed vars:
 #   PROJECT
@@ -207,6 +239,12 @@ function upload-server-tars() {
   # Convert from gs:// URL to an https:// URL
   SERVER_BINARY_TAR_URL="${server_binary_gs_url/gs:\/\//https://storage.googleapis.com/}"
   SALT_TAR_URL="${salt_gs_url/gs:\/\//https://storage.googleapis.com/}"
+
+  # Create a tar for kube-system manifests files and stage it.
+  # TODO(andyzheng0831): After finishing k8s master on trusty (issue #16702),
+  # we will not need to stage the salt tar for trusty anymore.
+  # TODO(andyzheng0831): Add release support for this tar, in case GKE will it.
+  prepare-manifests-tar
 }
 
 # Detect minions created in the minion group
@@ -1311,6 +1349,12 @@ EOF
   if [ -n "${TERMINATED_POD_GC_THRESHOLD:-}" ]; then
     cat >>$file <<EOF
 TERMINATED_POD_GC_THRESHOLD: $(yaml-quote ${TERMINATED_POD_GC_THRESHOLD})
+EOF
+  fi
+  if [[ "${OS_DISTRIBUTION}" == "trusty" ]]; then
+    cat >>$file <<EOF
+KUBE_MANIFESTS_TAR_URL: $(yaml-quote ${KUBE_MANIFESTS_TAR_URL})
+KUBE_MANIFESTS_TAR_HASH: $(yaml-quote ${KUBE_MANIFESTS_TAR_HASH})
 EOF
   fi
   if [ -n "${TEST_CLUSTER:-}" ]; then


### PR DESCRIPTION
The current trusty node support does not rely on salt, but it still downloads the salt tarball to extract needed kube-system pods manifest files for simplicity. However, this method will not work for master on trusty, because there are several manifest files with salt configuration. This change get rids of using salt tarball in trusty nodes. Instead, we put the manifest files under the directory cluster/gce/trusty/kube-manifest. For ongoing work of master on trusty, we will follow the same logic to get kube-system pods manifest.
