### PR TITLE
Jenkins: Blacklist hpa tests for Trusty and Trusty beta

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -243,12 +243,20 @@ TRUSTY_DEFAULT_SKIP_TESTS=(
 
 TRUSTY_SKIP_TESTS=(
     "${TRUSTY_DEFAULT_SKIP_TESTS[@]}"
+    # These tests rely on cadvisor, which doesn't quite work with Trusty and
+    # Trusty dev images yet. An internal issue has been filed to track the fix.
+    # TODO(wonderfly): Remove this once the internal issue is fixed.
     "Monitoring\sshould\sverify\smonitoring\spods\sand\sall\scluster\snodes\sare\savailable\son\sinfluxdb\susing\sheapster"
+    "Horizontal\spod\sautoscaling"
 )
 
 TRUSTY_DEV_SKIP_TESTS=(
     "${TRUSTY_DEFAULT_SKIP_TESTS[@]}"
+    # These tests rely on cadvisor, which doesn't quite work with Trusty and
+    # Trusty dev images yet. An internal issue has been filed to track the fix.
+    # TODO(wonderfly): Remove this once the internal issue is fixed.
     "Monitoring\sshould\sverify\smonitoring\spods\sand\sall\scluster\snodes\sare\savailable\son\sinfluxdb\susing\sheapster"
+    "Horizontal\spod\sautoscaling"
 )
 
 TRUSTY_BETA_SKIP_TESTS=(


### PR DESCRIPTION
Because of a known internal issue, cadvisor related tests don't work with Trusty
and Trusty beta yet. Disable them until the issue is fixed.

@ixdy 
cc/ @andyzheng0831 @vishh for context

Tested on internal Jenkins
