### PR TITLE
Do not delete pod status entry when apiserver returns NotFound error

### DIFF
--- a/pkg/kubelet/status/manager.go
+++ b/pkg/kubelet/status/manager.go
@@ -323,8 +323,9 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 	// TODO: make me easier to express from client code
 	pod, err := m.kubeClient.Pods(status.podNamespace).Get(status.podName)
 	if errors.IsNotFound(err) {
-		glog.V(3).Infof("Pod %q (%s) was deleted on the server", status.podName, uid)
-		m.deletePodStatus(uid)
+		glog.V(3).Infof("Pod %q (%s) does not exist on the server", status.podName, uid)
+		// If the Pod is deleted the status will be cleared in
+		// RemoveOrphanedStatuses, so we just ignore the update here.
 		return
 	}
 	if err == nil {

--- a/pkg/kubelet/status/manager_test.go
+++ b/pkg/kubelet/status/manager_test.go
@@ -264,8 +264,6 @@ func TestSyncBatchIgnoresNotFound(t *testing.T) {
 	verifyActions(t, syncer.kubeClient, []testclient.Action{
 		testclient.GetActionImpl{ActionImpl: testclient.ActionImpl{Verb: "get", Resource: "pods"}},
 	})
-	_, found := syncer.GetPodStatus(testPod.UID)
-	assert.False(t, found, "Pod status should have been deleted")
 }
 
 func TestSyncBatch(t *testing.T) {


### PR DESCRIPTION
The logic doesn't apply to static pods as their corresponding mirror pod may
not have been created yet, or may be in the process of recreation. Deleting the
pod status immediately resets the version of the status for the static pod,
while the apiStatusVersion remains unchanged. This could lead to incorrect
versioning and hence stale pod status in the apiserver.
