### PR TITLE
Increase verification limits for kubeproxy in scalability tests

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -89,7 +89,7 @@ func density30AddonResourceVerifier() map[string]resourceConstraint {
 		memoryConstraint: 100 * (1024 * 1024),
 	}
 	constraints["kube-proxy"] = resourceConstraint{
-		cpuConstraint:    0.01,
+		cpuConstraint:    0.02,
 		memoryConstraint: 20 * (1024 * 1024),
 	}
 	constraints["l7-lb-controller"] = resourceConstraint{


### PR DESCRIPTION
Should fix recent scalability failures.

@gmarek 
