### PR TITLE
refactor&bugfix image gc

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	"k8s.io/kubernetes/pkg/kubelet/im"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -392,7 +393,7 @@ func (s *KubeletServer) UnsecuredKubeletConfig() (*KubeletConfig, error) {
 		dockerExecHandler = &dockertools.NativeExecHandler{}
 	}
 
-	imageGCPolicy := kubelet.ImageGCPolicy{
+	imageGCPolicy := im.ImageGCPolicy{
 		HighThresholdPercent: s.ImageGCHighThresholdPercent,
 		LowThresholdPercent:  s.ImageGCLowThresholdPercent,
 	}
@@ -702,7 +703,7 @@ func SimpleKubelet(client *client.Client,
 	fileCheckFrequency, httpCheckFrequency, minimumGCAge, nodeStatusUpdateFrequency, syncFrequency time.Duration,
 	maxPods int,
 	containerManager cm.ContainerManager, clusterDNS net.IP) *KubeletConfig {
-	imageGCPolicy := kubelet.ImageGCPolicy{
+	imageGCPolicy := im.ImageGCPolicy{
 		HighThresholdPercent: 90,
 		LowThresholdPercent:  80,
 	}
@@ -912,7 +913,7 @@ type KubeletConfig struct {
 	HostPIDSources                 []string
 	HostIPCSources                 []string
 	HTTPCheckFrequency             time.Duration
-	ImageGCPolicy                  kubelet.ImageGCPolicy
+	ImageGCPolicy                  im.ImageGCPolicy
 	KubeClient                     *client.Client
 	ManifestURL                    string
 	ManifestURLHeader              http.Header

--- a/pkg/kubelet/im/interface.go
+++ b/pkg/kubelet/im/interface.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package im
+
+type ImageGC interface {
+	// Applies the garbage collection policy. Errors include being unable to free
+	// enough space as per the garbage collection policy.
+	GarbageCollect() error
+}

--- a/pkg/kubelet/rkt/image_gc.go
+++ b/pkg/kubelet/rkt/image_gc.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import "github.com/golang/glog"
+import "k8s.io/kubernetes/pkg/kubelet/im"
+
+// ImageGC manages and garbage collects the container images for rkt.
+type realImageGC struct {
+	runtime *Runtime
+}
+
+func NewImageGC(r *Runtime) im.ImageGC {
+	return &realImageGC{runtime: r}
+}
+
+// GarbageCollect collects the images.
+func (im *realImageGC) GarbageCollect() error {
+	if _, err := im.runtime.runCommand("image", "gc"); err != nil {
+		glog.Errorf("rkt: Failed to gc image: %v", err)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This PR refactor the image gc logic and fix a bug:
- rename `image_manager.go` as `image_gc.go`, and move it to it's own package
- remove the `Start()` method from `ImageGC` interface. It seems useless, since it has not management functionality.(If I am wrong, feel free to correct me)
- fix a bug in image gc https://github.com/kubernetes/kubernetes/issues/18140 by adding a field `minAge`, which indicates the minimum age at which a image can be garbage collected. If a image is not old enough, don't garbage collect it .
