### PR TITLE
make group dependencies explicit

### DIFF
--- a/cmd/kube-version-change/version.go
+++ b/cmd/kube-version-change/version.go
@@ -39,7 +39,7 @@ var (
 	inputSource   = flag.StringP("input", "i", "-", "Input source; '-' means stdin")
 	outputDest    = flag.StringP("output", "o", "-", "Output destination; '-' means stdout")
 	rewrite       = flag.StringP("rewrite", "r", "", "If nonempty, use this as both input and output.")
-	outputVersion = flag.StringP("out-version", "v", latest.GroupOrDie("").GroupVersion.Version, "Version to convert input to")
+	outputVersion = flag.StringP("out-version", "v", latest.PreferredExternalVersion.Version, "Version to convert input to")
 )
 
 // isYAML determines whether data is JSON or YAML formatted by seeing

--- a/examples/https-nginx/make_secret.go
+++ b/examples/https-nginx/make_secret.go
@@ -66,5 +66,5 @@ func main() {
 			"nginx.key": nginxKey,
 		},
 	}
-	fmt.Printf(runtime.EncodeOrDie(latest.GroupOrDie("").Codec, secret))
+	fmt.Printf(runtime.EncodeOrDie(latest.Codec, secret))
 }

--- a/examples/sharing-clusters/make_secret.go
+++ b/examples/sharing-clusters/make_secret.go
@@ -59,5 +59,5 @@ func main() {
 			"config": cfg,
 		},
 	}
-	fmt.Printf(runtime.EncodeOrDie(latest.GroupOrDie("").Codec, secret))
+	fmt.Printf(runtime.EncodeOrDie(latest.Codec, secret))
 }

--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -20,7 +20,6 @@ package install
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -57,13 +56,10 @@ func init() {
 		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
 	}
 
-	var versions []string
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
 	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		versions = append(versions, registeredGroupVersions[i].Version)
 		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
 	}
-	groupMeta.Versions = versions
 	groupMeta.GroupVersions = registeredGroupVersions
 
 	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
@@ -111,7 +107,7 @@ func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 	default:
 		{
 			g, _ := latest.Group("")
-			return nil, fmt.Errorf("unsupported storage version: %s (valid: %s)", version, strings.Join(g.Versions, ", "))
+			return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 		}
 	}
 }

--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -19,27 +19,13 @@ limitations under the License.
 package install
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/api/latest"
-	"k8s.io/kubernetes/pkg/util/sets"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/meta"
-	"k8s.io/kubernetes/pkg/api/registered"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 )
-
-// userResources is a group of resources mostly used by a kubectl user
-var userResources = []string{"rc", "svc", "pods", "pvc"}
-
-const importPrefix = "k8s.io/kubernetes/pkg/api"
-
-var accessor = meta.NewAccessor()
 
 func init() {
 	groupMeta, err := latest.RegisterGroup("")
@@ -48,66 +34,14 @@ func init() {
 		return
 	}
 
-	// Use the first API version in the list of registered versions as the latest.
-	registeredGroupVersions := registered.GroupVersionsForGroup("")
-	groupVersion := registeredGroupVersions[0]
 	*groupMeta = latest.GroupMeta{
-		GroupVersion: groupVersion,
-		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
+		GroupVersion:  latest.ExternalVersions[0],
+		GroupVersions: latest.ExternalVersions,
+		Codec:         latest.Codec,
+		RESTMapper:    latest.RESTMapper,
+		SelfLinker:    runtime.SelfLinker(latest.Accessor),
+		InterfacesFor: latest.InterfacesFor,
 	}
 
-	worstToBestGroupVersions := []unversioned.GroupVersion{}
-	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
-	}
-	groupMeta.GroupVersions = registeredGroupVersions
-
-	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
-
-	// the list of kinds that are scoped at the root of the api hierarchy
-	// if a kind is not enumerated here, it is assumed to have a namespace scope
-	rootScoped := sets.NewString(
-		"Node",
-		"Namespace",
-		"PersistentVolume",
-		"ComponentStatus",
-	)
-
-	// these kinds should be excluded from the list of resources
-	ignoredKinds := sets.NewString(
-		"ListOptions",
-		"DeleteOptions",
-		"Status",
-		"PodLogOptions",
-		"PodExecOptions",
-		"PodAttachOptions",
-		"PodProxyOptions",
-		"ThirdPartyResource",
-		"ThirdPartyResourceData",
-		"ThirdPartyResourceList")
-
-	mapper := api.NewDefaultRESTMapper(worstToBestGroupVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
-	// setup aliases for groups of resources
-	mapper.AddResourceAlias("all", userResources...)
-	groupMeta.RESTMapper = mapper
 	api.RegisterRESTMapper(groupMeta.RESTMapper)
-	groupMeta.InterfacesFor = interfacesFor
-}
-
-// InterfacesFor returns the default Codec and ResourceVersioner for a given version
-// string, or an error if the version is not known.
-func interfacesFor(version string) (*meta.VersionInterfaces, error) {
-	switch version {
-	case "v1":
-		return &meta.VersionInterfaces{
-			Codec:            v1.Codec,
-			ObjectConvertor:  api.Scheme,
-			MetadataAccessor: accessor,
-		}, nil
-	default:
-		{
-			g, _ := latest.Group("")
-			return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
-		}
-	}
 }

--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -28,19 +28,23 @@ import (
 )
 
 func init() {
-	groupMeta, err := latest.RegisterGroup("")
-	if err != nil {
-		glog.V(4).Infof("%v", err)
+	// this means that the entire group is disabled
+	if len(latest.ExternalVersions) == 0 {
 		return
 	}
 
-	*groupMeta = latest.GroupMeta{
+	groupMeta := latest.GroupMeta{
 		GroupVersion:  latest.ExternalVersions[0],
 		GroupVersions: latest.ExternalVersions,
 		Codec:         latest.Codec,
 		RESTMapper:    latest.RESTMapper,
 		SelfLinker:    runtime.SelfLinker(latest.Accessor),
 		InterfacesFor: latest.InterfacesFor,
+	}
+
+	if err := latest.RegisterGroup(groupMeta); err != nil {
+		glog.V(4).Infof("%v", err)
+		return
 	}
 
 	api.RegisterRESTMapper(groupMeta.RESTMapper)

--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -34,7 +34,7 @@ func init() {
 	}
 
 	groupMeta := latest.GroupMeta{
-		GroupVersion:  latest.ExternalVersions[0],
+		GroupVersion:  latest.PreferredExternalVersion,
 		GroupVersions: latest.ExternalVersions,
 		Codec:         latest.Codec,
 		RESTMapper:    latest.RESTMapper,

--- a/pkg/api/install/install_test.go
+++ b/pkg/api/install/install_test.go
@@ -66,8 +66,8 @@ func TestInterfacesFor(t *testing.T) {
 	if _, err := latest.GroupOrDie("").InterfacesFor(""); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, version := range append([]string{latest.GroupOrDie("").GroupVersion.Version}, latest.GroupOrDie("").Versions...) {
-		if vi, err := latest.GroupOrDie("").InterfacesFor(version); err != nil || vi == nil {
+	for i, version := range latest.GroupOrDie("").GroupVersions {
+		if vi, err := latest.GroupOrDie("").InterfacesFor(version.Version); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
@@ -86,10 +86,8 @@ func TestRESTMapper(t *testing.T) {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("").Versions {
-		currGroupVersion := unversioned.GroupVersion{Version: version}
-
-		mapping, err := latest.GroupOrDie("").RESTMapper.RESTMapping(rcGVK.GroupKind(), currGroupVersion.String())
+	for _, version := range latest.GroupOrDie("").GroupVersions {
+		mapping, err := latest.GroupOrDie("").RESTMapper.RESTMapping(rcGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -97,11 +95,11 @@ func TestRESTMapper(t *testing.T) {
 		if mapping.Resource != "replicationControllers" && mapping.Resource != "replicationcontrollers" {
 			t.Errorf("incorrect resource name: %#v", mapping)
 		}
-		if mapping.GroupVersionKind.GroupVersion() != currGroupVersion {
+		if mapping.GroupVersionKind.GroupVersion() != version {
 			t.Errorf("incorrect version: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("").InterfacesFor(currGroupVersion.String())
+		interfaces, _ := latest.GroupOrDie("").InterfacesFor(version.String())
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/api/install/install_test.go
+++ b/pkg/api/install/install_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestResourceVersioner(t *testing.T) {
 	pod := internal.Pod{ObjectMeta: internal.ObjectMeta{ResourceVersion: "10"}}
-	version, err := accessor.ResourceVersion(&pod)
+	version, err := latest.Accessor.ResourceVersion(&pod)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestResourceVersioner(t *testing.T) {
 	}
 
 	podList := internal.PodList{ListMeta: unversioned.ListMeta{ResourceVersion: "10"}}
-	version, err = accessor.ResourceVersion(&podList)
+	version, err = latest.Accessor.ResourceVersion(&podList)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/api/install/install_test.go
+++ b/pkg/api/install/install_test.go
@@ -45,11 +45,12 @@ func TestResourceVersioner(t *testing.T) {
 	}
 }
 
+// TODO its weird to round-trip an internal type
 func TestCodec(t *testing.T) {
 	pod := internal.Pod{}
 	// We do want to use package latest rather than testapi here, because we
 	// want to test if the package install and package latest work as expected.
-	data, err := latest.GroupOrDie("").Codec.Encode(&pod)
+	data, err := latest.Codec.Encode(&pod)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,17 +58,17 @@ func TestCodec(t *testing.T) {
 	if err := json.Unmarshal(data, &other); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if other.APIVersion != latest.GroupOrDie("").GroupVersion.Version || other.Kind != "Pod" {
+	if other.APIVersion != latest.PreferredExternalVersion.Version || other.Kind != "Pod" {
 		t.Errorf("unexpected unmarshalled object %#v", other)
 	}
 }
 
 func TestInterfacesFor(t *testing.T) {
-	if _, err := latest.GroupOrDie("").InterfacesFor(""); err == nil {
+	if _, err := latest.InterfacesFor(""); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, version := range latest.GroupOrDie("").GroupVersions {
-		if vi, err := latest.GroupOrDie("").InterfacesFor(version.Version); err != nil || vi == nil {
+	for i, version := range latest.ExternalVersions {
+		if vi, err := latest.InterfacesFor(version.String()); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
@@ -78,16 +79,16 @@ func TestRESTMapper(t *testing.T) {
 	rcGVK := gv.WithKind("ReplicationController")
 	podTemplateGVK := gv.WithKind("PodTemplate")
 
-	if gvk, err := latest.GroupOrDie("").RESTMapper.KindFor("replicationcontrollers"); err != nil || gvk != rcGVK {
+	if gvk, err := latest.RESTMapper.KindFor("replicationcontrollers"); err != nil || gvk != rcGVK {
 		t.Errorf("unexpected version mapping: %v %v", gvk, err)
 	}
 
-	if m, err := latest.GroupOrDie("").RESTMapper.RESTMapping(podTemplateGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != podTemplateGVK || m.Resource != "podtemplates" {
+	if m, err := latest.RESTMapper.RESTMapping(podTemplateGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != podTemplateGVK || m.Resource != "podtemplates" {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("").GroupVersions {
-		mapping, err := latest.GroupOrDie("").RESTMapper.RESTMapping(rcGVK.GroupKind(), version.Version)
+	for _, version := range latest.ExternalVersions {
+		mapping, err := latest.RESTMapper.RESTMapping(rcGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -99,7 +100,7 @@ func TestRESTMapper(t *testing.T) {
 			t.Errorf("incorrect version: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("").InterfacesFor(version.String())
+		interfaces, _ := latest.InterfacesFor(version.String())
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/api/latest/group_register.go
+++ b/pkg/api/latest/group_register.go
@@ -32,8 +32,6 @@ var (
 	Group = allGroups.Group
 	// RegisterGroup is a shortcut to allGroups.RegisterGroup.
 	RegisterGroup = allGroups.RegisterGroup
-	// GroupOrDie is a shortcut to allGroups.GroupOrDie.
-	GroupOrDie = allGroups.GroupOrDie
 	// AllPreferredGroupVersions returns the preferred versions of all
 	// registered groups in the form of "group1/version1,group2/version2,..."
 	AllPreferredGroupVersions = allGroups.AllPreferredGroupVersions
@@ -72,22 +70,6 @@ func (g GroupMetaMap) Group(group string) (GroupMeta, error) {
 func (g GroupMetaMap) IsRegistered(group string) bool {
 	_, found := g[group]
 	return found
-}
-
-// TODO: This is an expedient function, because we don't check if a Group is
-// supported throughout the code base. We will abandon this function and
-// checking the error returned by the Group() function.
-func (g GroupMetaMap) GroupOrDie(group string) GroupMeta {
-	groupMeta, found := g[group]
-	if !found {
-		const msg = "Please check the KUBE_API_VERSIONS environment variable."
-		if group == "" {
-			panic("The legacy v1 API is not registered. " + msg)
-		} else {
-			panic(fmt.Sprintf("No version is registered for group %s. ", group) + msg)
-		}
-	}
-	return *groupMeta
 }
 
 // AllPreferredGroupVersions returns the preferred versions of all registered

--- a/pkg/api/latest/group_register.go
+++ b/pkg/api/latest/group_register.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latest
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/registered"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+var (
+	allGroups = GroupMetaMap{}
+	// Group is a shortcut to allGroups.Group.
+	Group = allGroups.Group
+	// RegisterGroup is a shortcut to allGroups.RegisterGroup.
+	RegisterGroup = allGroups.RegisterGroup
+	// GroupOrDie is a shortcut to allGroups.GroupOrDie.
+	GroupOrDie = allGroups.GroupOrDie
+	// AllPreferredGroupVersions returns the preferred versions of all
+	// registered groups in the form of "group1/version1,group2/version2,..."
+	AllPreferredGroupVersions = allGroups.AllPreferredGroupVersions
+	// IsRegistered is a shortcut to allGroups.IsRegistered.
+	IsRegistered = allGroups.IsRegistered
+)
+
+// GroupMetaMap is a map between group names and their metadata.
+type GroupMetaMap map[string]*GroupMeta
+
+// RegisterGroup registers a group to GroupMetaMap.
+func (g GroupMetaMap) RegisterGroup(group string) (*GroupMeta, error) {
+	_, found := g[group]
+	if found {
+		return nil, fmt.Errorf("group %v is already registered", g)
+	}
+	if len(registered.GroupVersionsForGroup(group)) == 0 {
+		return nil, fmt.Errorf("No version is registered for group %v", group)
+	}
+	g[group] = &GroupMeta{}
+	return g[group], nil
+}
+
+// Group returns the metadata of a group if the gruop is registered, otherwise
+// an erorr is returned.
+func (g GroupMetaMap) Group(group string) (*GroupMeta, error) {
+	groupMeta, found := g[group]
+	if !found {
+		return nil, fmt.Errorf("no version is registered for group %v", group)
+	}
+	return groupMeta, nil
+}
+
+// IsRegistered takes a string and determines if it's one of the registered groups
+func (g GroupMetaMap) IsRegistered(group string) bool {
+	_, found := g[group]
+	return found
+}
+
+// TODO: This is an expedient function, because we don't check if a Group is
+// supported throughout the code base. We will abandon this function and
+// checking the error returned by the Group() function.
+func (g GroupMetaMap) GroupOrDie(group string) *GroupMeta {
+	groupMeta, found := g[group]
+	if !found {
+		const msg = "Please check the KUBE_API_VERSIONS environment variable."
+		if group == "" {
+			panic("The legacy v1 API is not registered. " + msg)
+		} else {
+			panic(fmt.Sprintf("No version is registered for group %s. ", group) + msg)
+		}
+	}
+	return groupMeta
+}
+
+// AllPreferredGroupVersions returns the preferred versions of all registered
+// groups in the form of "group1/version1,group2/version2,..."
+func (g GroupMetaMap) AllPreferredGroupVersions() string {
+	if len(g) == 0 {
+		return ""
+	}
+	var defaults []string
+	for _, groupMeta := range g {
+		defaults = append(defaults, groupMeta.GroupVersion.String())
+	}
+	sort.Strings(defaults)
+	return strings.Join(defaults, ",")
+}
+
+// GroupMeta stores the metadata of a group, such as the latest supported version.
+type GroupMeta struct {
+	// GroupVersion represents the current external default version of the group.
+	GroupVersion unversioned.GroupVersion
+
+	// Versions is the list of versions that are recognized in code. The order
+	// provided is assumed to be from the oldest to the newest, e.g.,
+	// Versions[0] == oldest and Versions[N-1] == newest.
+	// Clients may choose to prefer the latter items in the list over the former
+	// items when presented with a set of versions to choose.
+	Versions []string
+
+	// GroupVersions is Group + Versions. This is to avoid string concatenation
+	// in many places.
+	GroupVersions []unversioned.GroupVersion
+
+	// Codec is the default codec for serializing output that should use
+	// the latest supported version.  Use this Codec when writing to
+	// disk, a data store that is not dynamically versioned, or in tests.
+	// This codec can decode any object that Kubernetes is aware of.
+	Codec runtime.Codec
+
+	// SelfLinker can set or get the SelfLink field of all API types.
+	// TODO: when versioning changes, make this part of each API definition.
+	// TODO(lavalamp): Combine SelfLinker & ResourceVersioner interfaces, force all uses
+	// to go through the InterfacesFor method below.
+	SelfLinker runtime.SelfLinker
+
+	// RESTMapper provides the default mapping between REST paths and the objects declared in api.Scheme and all known
+	// Kubernetes versions.
+	RESTMapper meta.RESTMapper
+
+	// InterfacesFor returns the default Codec and ResourceVersioner for a given version
+	// string, or an error if the version is not known.
+	InterfacesFor func(version string) (*meta.VersionInterfaces, error)
+}

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -115,13 +115,6 @@ type GroupMeta struct {
 	// GroupVersion represents the current external default version of the group.
 	GroupVersion unversioned.GroupVersion
 
-	// Versions is the list of versions that are recognized in code. The order
-	// provided is assumed to be from the oldest to the newest, e.g.,
-	// Versions[0] == oldest and Versions[N-1] == newest.
-	// Clients may choose to prefer the latter items in the list over the former
-	// items when presented with a set of versions to choose.
-	Versions []string
-
 	// GroupVersions is Group + Versions. This is to avoid string concatenation
 	// in many places.
 	GroupVersions []unversioned.GroupVersion

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -20,7 +20,6 @@ package install
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -53,13 +52,10 @@ func init() {
 		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
 	}
 
-	var versions []string
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
 	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		versions = append(versions, registeredGroupVersions[i].Version)
 		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
 	}
-	groupMeta.Versions = versions
 	groupMeta.GroupVersions = registeredGroupVersions
 
 	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
@@ -87,6 +83,6 @@ func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 		}, nil
 	default:
 		g, _ := latest.Group("componentconfig")
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %s)", version, strings.Join(g.Versions, ", "))
+		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -34,7 +34,7 @@ func init() {
 	}
 
 	groupMeta := latest.GroupMeta{
-		GroupVersion:  cclatest.ExternalVersions[0],
+		GroupVersion:  cclatest.PreferredExternalVersion,
 		GroupVersions: cclatest.ExternalVersions,
 		Codec:         cclatest.Codec,
 		RESTMapper:    cclatest.RESTMapper,

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -23,25 +23,28 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
-	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	cclatest "k8s.io/kubernetes/pkg/apis/componentconfig/latest"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
 func init() {
-	groupMeta, err := latest.RegisterGroup(componentconfig.SchemeGroupVersion.Group)
-	if err != nil {
-		glog.V(4).Infof("%v", err)
+	// this means that the entire group is disabled
+	if len(cclatest.ExternalVersions) == 0 {
 		return
 	}
 
-	*groupMeta = latest.GroupMeta{
+	groupMeta := latest.GroupMeta{
 		GroupVersion:  cclatest.ExternalVersions[0],
 		GroupVersions: cclatest.ExternalVersions,
 		Codec:         cclatest.Codec,
 		RESTMapper:    cclatest.RESTMapper,
 		SelfLinker:    runtime.SelfLinker(cclatest.Accessor),
 		InterfacesFor: cclatest.InterfacesFor,
+	}
+
+	if err := latest.RegisterGroup(groupMeta); err != nil {
+		glog.V(4).Infof("%v", err)
+		return
 	}
 
 	api.RegisterRESTMapper(groupMeta.RESTMapper)

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -19,70 +19,30 @@ limitations under the License.
 package install
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
-	"k8s.io/kubernetes/pkg/api/meta"
-	"k8s.io/kubernetes/pkg/api/registered"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	_ "k8s.io/kubernetes/pkg/apis/componentconfig"
-	"k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
+	"k8s.io/kubernetes/pkg/apis/componentconfig"
+	cclatest "k8s.io/kubernetes/pkg/apis/componentconfig/latest"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-const importPrefix = "k8s.io/kubernetes/pkg/apis/componentconfig"
-
-var accessor = meta.NewAccessor()
-
 func init() {
-	groupMeta, err := latest.RegisterGroup("componentconfig")
+	groupMeta, err := latest.RegisterGroup(componentconfig.SchemeGroupVersion.Group)
 	if err != nil {
 		glog.V(4).Infof("%v", err)
 		return
 	}
 
-	registeredGroupVersions := registered.GroupVersionsForGroup("componentconfig")
-	groupVersion := registeredGroupVersions[0]
 	*groupMeta = latest.GroupMeta{
-		GroupVersion: groupVersion,
-		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
+		GroupVersion:  cclatest.ExternalVersions[0],
+		GroupVersions: cclatest.ExternalVersions,
+		Codec:         cclatest.Codec,
+		RESTMapper:    cclatest.RESTMapper,
+		SelfLinker:    runtime.SelfLinker(cclatest.Accessor),
+		InterfacesFor: cclatest.InterfacesFor,
 	}
 
-	worstToBestGroupVersions := []unversioned.GroupVersion{}
-	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
-	}
-	groupMeta.GroupVersions = registeredGroupVersions
-
-	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
-
-	// the list of kinds that are scoped at the root of the api hierarchy
-	// if a kind is not enumerated here, it is assumed to have a namespace scope
-	rootScoped := sets.NewString()
-
-	ignoredKinds := sets.NewString()
-
-	groupMeta.RESTMapper = api.NewDefaultRESTMapper(worstToBestGroupVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
 	api.RegisterRESTMapper(groupMeta.RESTMapper)
-	groupMeta.InterfacesFor = interfacesFor
-}
-
-// interfacesFor returns the default Codec and ResourceVersioner for a given version
-// string, or an error if the version is not known.
-func interfacesFor(version string) (*meta.VersionInterfaces, error) {
-	switch version {
-	case "componentconfig/v1alpha1":
-		return &meta.VersionInterfaces{
-			Codec:            v1alpha1.Codec,
-			ObjectConvertor:  api.Scheme,
-			MetadataAccessor: accessor,
-		}, nil
-	default:
-		g, _ := latest.Group("componentconfig")
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
-	}
 }

--- a/pkg/apis/componentconfig/install/install_test.go
+++ b/pkg/apis/componentconfig/install/install_test.go
@@ -65,8 +65,8 @@ func TestRESTMapper(t *testing.T) {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("componentconfig").Versions {
-		mapping, err := latest.GroupOrDie("componentconfig").RESTMapper.RESTMapping(proxyGVK.GroupKind(), version)
+	for _, version := range latest.GroupOrDie("componentconfig").GroupVersions {
+		mapping, err := latest.GroupOrDie("componentconfig").RESTMapper.RESTMapping(proxyGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			continue

--- a/pkg/apis/componentconfig/install/install_test.go
+++ b/pkg/apis/componentconfig/install/install_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
+	cclatest "k8s.io/kubernetes/pkg/apis/componentconfig/latest"
 )
 
 func TestCodec(t *testing.T) {
@@ -37,17 +38,17 @@ func TestCodec(t *testing.T) {
 	if err := json.Unmarshal(data, &other); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if other.APIVersion != latest.GroupOrDie("componentconfig").GroupVersion.String() || other.Kind != "KubeProxyConfiguration" {
+	if other.APIVersion != cclatest.ExternalVersions[0].String() || other.Kind != "KubeProxyConfiguration" {
 		t.Errorf("unexpected unmarshalled object %#v", other)
 	}
 }
 
 func TestInterfacesFor(t *testing.T) {
-	if _, err := latest.GroupOrDie("componentconfig").InterfacesFor(""); err == nil {
+	if _, err := cclatest.InterfacesFor(""); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, groupVersion := range append([]unversioned.GroupVersion{latest.GroupOrDie("componentconfig").GroupVersion}, latest.GroupOrDie("componentconfig").GroupVersions...) {
-		if vi, err := latest.GroupOrDie("componentconfig").InterfacesFor(groupVersion.String()); err != nil || vi == nil {
+	for i, groupVersion := range append([]unversioned.GroupVersion{cclatest.ExternalVersions[0]}, cclatest.ExternalVersions...) {
+		if vi, err := cclatest.InterfacesFor(groupVersion.String()); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}

--- a/pkg/apis/componentconfig/install/install_test.go
+++ b/pkg/apis/componentconfig/install/install_test.go
@@ -20,17 +20,17 @@ import (
 	"encoding/json"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	cclatest "k8s.io/kubernetes/pkg/apis/componentconfig/latest"
 )
 
+// TODO its weird to round-trip an internal type
 func TestCodec(t *testing.T) {
 	daemonSet := componentconfig.KubeProxyConfiguration{}
 	// We do want to use package latest rather than testapi here, because we
 	// want to test if the package install and package latest work as expected.
-	data, err := latest.GroupOrDie("componentconfig").Codec.Encode(&daemonSet)
+	data, err := cclatest.Codec.Encode(&daemonSet)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestCodec(t *testing.T) {
 	if err := json.Unmarshal(data, &other); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if other.APIVersion != cclatest.ExternalVersions[0].String() || other.Kind != "KubeProxyConfiguration" {
+	if other.APIVersion != cclatest.PreferredExternalVersion.String() || other.Kind != "KubeProxyConfiguration" {
 		t.Errorf("unexpected unmarshalled object %#v", other)
 	}
 }
@@ -47,7 +47,7 @@ func TestInterfacesFor(t *testing.T) {
 	if _, err := cclatest.InterfacesFor(""); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, groupVersion := range append([]unversioned.GroupVersion{cclatest.ExternalVersions[0]}, cclatest.ExternalVersions...) {
+	for i, groupVersion := range append([]unversioned.GroupVersion{cclatest.PreferredExternalVersion}, cclatest.ExternalVersions...) {
 		if vi, err := cclatest.InterfacesFor(groupVersion.String()); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
@@ -58,16 +58,16 @@ func TestRESTMapper(t *testing.T) {
 	gv := unversioned.GroupVersion{Group: "componentconfig", Version: "v1alpha1"}
 	proxyGVK := gv.WithKind("KubeProxyConfiguration")
 
-	if gvk, err := latest.GroupOrDie("componentconfig").RESTMapper.KindFor("kubeproxyconfiguration"); err != nil || gvk != proxyGVK {
+	if gvk, err := cclatest.RESTMapper.KindFor("kubeproxyconfiguration"); err != nil || gvk != proxyGVK {
 		t.Errorf("unexpected version mapping: %v %v", gvk, err)
 	}
 
-	if m, err := latest.GroupOrDie("componentconfig").RESTMapper.RESTMapping(proxyGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != proxyGVK || m.Resource != "kubeproxyconfigurations" {
+	if m, err := cclatest.RESTMapper.RESTMapping(proxyGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != proxyGVK || m.Resource != "kubeproxyconfigurations" {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("componentconfig").GroupVersions {
-		mapping, err := latest.GroupOrDie("componentconfig").RESTMapper.RESTMapping(proxyGVK.GroupKind(), version.Version)
+	for _, version := range cclatest.ExternalVersions {
+		mapping, err := cclatest.RESTMapper.RESTMapping(proxyGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			continue
@@ -80,7 +80,7 @@ func TestRESTMapper(t *testing.T) {
 			t.Errorf("incorrect groupVersion: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("componentconfig").InterfacesFor(gv.String())
+		interfaces, _ := cclatest.InterfacesFor(gv.String())
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/apis/componentconfig/latest/latest.go
+++ b/pkg/apis/componentconfig/latest/latest.go
@@ -23,16 +23,17 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/componentconfig"
+	"k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // ExternalVersions lists all known external versions for this group from most preferred to least preferred
-var ExternalVersions = []unversioned.GroupVersion{v1.SchemeGroupVersion}
+var ExternalVersions = []unversioned.GroupVersion{v1alpha1.SchemeGroupVersion}
 
 // Codec is the Codec for the most preferred ExternalVersion
-var Codec = v1.Codec
+var Codec = v1alpha1.Codec
 
 // RESTMapper is a RESTMapper for all versions of the API group
 var RESTMapper meta.RESTMapper
@@ -42,7 +43,7 @@ var Accessor = meta.NewAccessor()
 func init() {
 	finalExternalVersions := []unversioned.GroupVersion{}
 
-	for _, allowedVersion := range registered.GroupVersionsForGroup(api.SchemeGroupVersion.Group) {
+	for _, allowedVersion := range registered.GroupVersionsForGroup(componentconfig.SchemeGroupVersion.Group) {
 		for _, externalVersion := range ExternalVersions {
 			if externalVersion == allowedVersion {
 				finalExternalVersions = append(finalExternalVersions, externalVersion)
@@ -56,12 +57,9 @@ func init() {
 		Codec = runtime.CodecFor(api.Scheme, ExternalVersions[0].String())
 		RESTMapper = newRESTMapper()
 	}
-
 }
 
-var userResources = []string{"rc", "svc", "pods", "pvc"}
-
-const importPrefix = "k8s.io/kubernetes/pkg/api"
+const importPrefix = "k8s.io/kubernetes/pkg/apis/componentconfig"
 
 func newRESTMapper() meta.RESTMapper {
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
@@ -71,44 +69,25 @@ func newRESTMapper() meta.RESTMapper {
 
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
-	rootScoped := sets.NewString(
-		"Node",
-		"Namespace",
-		"PersistentVolume",
-		"ComponentStatus",
-	)
+	rootScoped := sets.NewString()
 
-	// these kinds should be excluded from the list of resources
-	ignoredKinds := sets.NewString(
-		"ListOptions",
-		"DeleteOptions",
-		"Status",
-		"PodLogOptions",
-		"PodExecOptions",
-		"PodAttachOptions",
-		"PodProxyOptions",
-		"ThirdPartyResource",
-		"ThirdPartyResourceData",
-		"ThirdPartyResourceList")
+	ignoredKinds := sets.NewString()
 
-	mapper := api.NewDefaultRESTMapper(worstToBestGroupVersions, InterfacesFor, importPrefix, ignoredKinds, rootScoped)
-	// setup aliases for groups of resources
-	mapper.AddResourceAlias("all", userResources...)
-	return mapper
+	return api.NewDefaultRESTMapper(worstToBestGroupVersions, InterfacesFor, importPrefix, ignoredKinds, rootScoped)
 }
 
-// InterfacesFor returns the default Codec and ResourceVersioner for a given version
+// interfacesFor returns the default Codec and ResourceVersioner for a given version
 // string, or an error if the version is not known.
 func InterfacesFor(version string) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.SchemeGroupVersion.String():
+	case v1alpha1.SchemeGroupVersion.String():
 		return &meta.VersionInterfaces{
-			Codec:            v1.Codec,
+			Codec:            v1alpha1.Codec,
 			ObjectConvertor:  api.Scheme,
 			MetadataAccessor: Accessor,
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, ExternalVersions)
+		return nil, fmt.Errorf("unsupported storage version: %s (valid: %s)", version, ExternalVersions)
 	}
 }

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -20,7 +20,6 @@ package install
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -53,13 +52,10 @@ func init() {
 		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
 	}
 
-	var versions []string
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
 	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		versions = append(versions, registeredGroupVersions[i].Version)
 		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
 	}
-	groupMeta.Versions = versions
 	groupMeta.GroupVersions = registeredGroupVersions
 
 	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
@@ -87,6 +83,6 @@ func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 		}, nil
 	default:
 		g, _ := latest.Group("extensions")
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %s)", version, strings.Join(g.Versions, ", "))
+		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -19,70 +19,30 @@ limitations under the License.
 package install
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
-	"k8s.io/kubernetes/pkg/api/meta"
-	"k8s.io/kubernetes/pkg/api/registered"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	_ "k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	extlatest "k8s.io/kubernetes/pkg/apis/extensions/latest"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-const importPrefix = "k8s.io/kubernetes/pkg/apis/extensions"
-
-var accessor = meta.NewAccessor()
-
 func init() {
-	groupMeta, err := latest.RegisterGroup("extensions")
+	groupMeta, err := latest.RegisterGroup(extensions.SchemeGroupVersion.Group)
 	if err != nil {
 		glog.V(4).Infof("%v", err)
 		return
 	}
 
-	registeredGroupVersions := registered.GroupVersionsForGroup("extensions")
-	groupVersion := registeredGroupVersions[0]
 	*groupMeta = latest.GroupMeta{
-		GroupVersion: groupVersion,
-		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
+		GroupVersion:  extlatest.ExternalVersions[0],
+		GroupVersions: extlatest.ExternalVersions,
+		Codec:         extlatest.Codec,
+		RESTMapper:    extlatest.RESTMapper,
+		SelfLinker:    runtime.SelfLinker(extlatest.Accessor),
+		InterfacesFor: extlatest.InterfacesFor,
 	}
 
-	worstToBestGroupVersions := []unversioned.GroupVersion{}
-	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
-	}
-	groupMeta.GroupVersions = registeredGroupVersions
-
-	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
-
-	// the list of kinds that are scoped at the root of the api hierarchy
-	// if a kind is not enumerated here, it is assumed to have a namespace scope
-	rootScoped := sets.NewString()
-
-	ignoredKinds := sets.NewString()
-
-	groupMeta.RESTMapper = api.NewDefaultRESTMapper(worstToBestGroupVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
 	api.RegisterRESTMapper(groupMeta.RESTMapper)
-	groupMeta.InterfacesFor = interfacesFor
-}
-
-// InterfacesFor returns the default Codec and ResourceVersioner for a given version
-// string, or an error if the version is not known.
-func interfacesFor(version string) (*meta.VersionInterfaces, error) {
-	switch version {
-	case "extensions/v1beta1":
-		return &meta.VersionInterfaces{
-			Codec:            v1beta1.Codec,
-			ObjectConvertor:  api.Scheme,
-			MetadataAccessor: accessor,
-		}, nil
-	default:
-		g, _ := latest.Group("extensions")
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
-	}
 }

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -23,25 +23,28 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 	extlatest "k8s.io/kubernetes/pkg/apis/extensions/latest"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
 func init() {
-	groupMeta, err := latest.RegisterGroup(extensions.SchemeGroupVersion.Group)
-	if err != nil {
-		glog.V(4).Infof("%v", err)
+	// this means that the entire group is disabled
+	if len(extlatest.ExternalVersions) == 0 {
 		return
 	}
 
-	*groupMeta = latest.GroupMeta{
+	groupMeta := latest.GroupMeta{
 		GroupVersion:  extlatest.ExternalVersions[0],
 		GroupVersions: extlatest.ExternalVersions,
 		Codec:         extlatest.Codec,
 		RESTMapper:    extlatest.RESTMapper,
 		SelfLinker:    runtime.SelfLinker(extlatest.Accessor),
 		InterfacesFor: extlatest.InterfacesFor,
+	}
+
+	if err := latest.RegisterGroup(groupMeta); err != nil {
+		glog.V(4).Infof("%v", err)
+		return
 	}
 
 	api.RegisterRESTMapper(groupMeta.RESTMapper)

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -34,7 +34,7 @@ func init() {
 	}
 
 	groupMeta := latest.GroupMeta{
-		GroupVersion:  extlatest.ExternalVersions[0],
+		GroupVersion:  extlatest.PreferredExternalVersion,
 		GroupVersions: extlatest.ExternalVersions,
 		Codec:         extlatest.Codec,
 		RESTMapper:    extlatest.RESTMapper,

--- a/pkg/apis/extensions/install/install_test.go
+++ b/pkg/apis/extensions/install/install_test.go
@@ -87,8 +87,8 @@ func TestRESTMapper(t *testing.T) {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("extensions").Versions {
-		mapping, err := latest.GroupOrDie("extensions").RESTMapper.RESTMapping(hpaGVK.GroupKind(), version)
+	for _, version := range latest.GroupOrDie("extensions").GroupVersions {
+		mapping, err := latest.GroupOrDie("extensions").RESTMapper.RESTMapping(hpaGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/pkg/apis/extensions/install/install_test.go
+++ b/pkg/apis/extensions/install/install_test.go
@@ -24,11 +24,12 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	extlatest "k8s.io/kubernetes/pkg/apis/extensions/latest"
 )
 
 func TestResourceVersioner(t *testing.T) {
 	daemonSet := extensions.DaemonSet{ObjectMeta: api.ObjectMeta{ResourceVersion: "10"}}
-	version, err := accessor.ResourceVersion(&daemonSet)
+	version, err := extlatest.Accessor.ResourceVersion(&daemonSet)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -37,7 +38,7 @@ func TestResourceVersioner(t *testing.T) {
 	}
 
 	daemonSetList := extensions.DaemonSetList{ListMeta: unversioned.ListMeta{ResourceVersion: "10"}}
-	version, err = accessor.ResourceVersion(&daemonSetList)
+	version, err = extlatest.Accessor.ResourceVersion(&daemonSetList)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -58,17 +59,17 @@ func TestCodec(t *testing.T) {
 	if err := json.Unmarshal(data, &other); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if other.APIVersion != latest.GroupOrDie("extensions").GroupVersion.String() || other.Kind != "DaemonSet" {
+	if other.APIVersion != extlatest.ExternalVersions[0].String() || other.Kind != "DaemonSet" {
 		t.Errorf("unexpected unmarshalled object %#v", other)
 	}
 }
 
 func TestInterfacesFor(t *testing.T) {
-	if _, err := latest.GroupOrDie("extensions").InterfacesFor(""); err == nil {
+	if _, err := extlatest.InterfacesFor(""); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, groupVersion := range append([]unversioned.GroupVersion{latest.GroupOrDie("extensions").GroupVersion}, latest.GroupOrDie("extensions").GroupVersions...) {
-		if vi, err := latest.GroupOrDie("extensions").InterfacesFor(groupVersion.String()); err != nil || vi == nil {
+	for i, groupVersion := range append([]unversioned.GroupVersion{extlatest.ExternalVersions[0]}, extlatest.ExternalVersions...) {
+		if vi, err := extlatest.InterfacesFor(groupVersion.String()); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
@@ -100,7 +101,7 @@ func TestRESTMapper(t *testing.T) {
 			t.Errorf("incorrect groupVersion: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("extensions").InterfacesFor(gv.String())
+		interfaces, _ := extlatest.InterfacesFor(gv.String())
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/apis/extensions/install/install_test.go
+++ b/pkg/apis/extensions/install/install_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	extlatest "k8s.io/kubernetes/pkg/apis/extensions/latest"
@@ -47,19 +46,21 @@ func TestResourceVersioner(t *testing.T) {
 	}
 }
 
+// TODO its weird to round-trip an internal type
 func TestCodec(t *testing.T) {
 	daemonSet := extensions.DaemonSet{}
 	// We do want to use package latest rather than testapi here, because we
 	// want to test if the package install and package latest work as expected.
-	data, err := latest.GroupOrDie("extensions").Codec.Encode(&daemonSet)
+	data, err := extlatest.Codec.Encode(&daemonSet)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
 	other := extensions.DaemonSet{}
 	if err := json.Unmarshal(data, &other); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if other.APIVersion != extlatest.ExternalVersions[0].String() || other.Kind != "DaemonSet" {
+	if other.APIVersion != extlatest.PreferredExternalVersion.String() || other.Kind != "DaemonSet" {
 		t.Errorf("unexpected unmarshalled object %#v", other)
 	}
 }
@@ -68,7 +69,7 @@ func TestInterfacesFor(t *testing.T) {
 	if _, err := extlatest.InterfacesFor(""); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, groupVersion := range append([]unversioned.GroupVersion{extlatest.ExternalVersions[0]}, extlatest.ExternalVersions...) {
+	for i, groupVersion := range append([]unversioned.GroupVersion{extlatest.PreferredExternalVersion}, extlatest.ExternalVersions...) {
 		if vi, err := extlatest.InterfacesFor(groupVersion.String()); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
@@ -80,16 +81,16 @@ func TestRESTMapper(t *testing.T) {
 	hpaGVK := gv.WithKind("HorizontalPodAutoscaler")
 	daemonSetGVK := gv.WithKind("DaemonSet")
 
-	if gvk, err := latest.GroupOrDie("extensions").RESTMapper.KindFor("horizontalpodautoscalers"); err != nil || gvk != hpaGVK {
+	if gvk, err := extlatest.RESTMapper.KindFor("horizontalpodautoscalers"); err != nil || gvk != hpaGVK {
 		t.Errorf("unexpected version mapping: %v %v", gvk, err)
 	}
 
-	if m, err := latest.GroupOrDie("extensions").RESTMapper.RESTMapping(daemonSetGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != daemonSetGVK || m.Resource != "daemonsets" {
+	if m, err := extlatest.RESTMapper.RESTMapping(daemonSetGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != daemonSetGVK || m.Resource != "daemonsets" {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("extensions").GroupVersions {
-		mapping, err := latest.GroupOrDie("extensions").RESTMapper.RESTMapping(hpaGVK.GroupKind(), version.Version)
+	for _, version := range extlatest.ExternalVersions {
+		mapping, err := extlatest.RESTMapper.RESTMapping(hpaGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/pkg/apis/extensions/latest/latest.go
+++ b/pkg/apis/extensions/latest/latest.go
@@ -23,16 +23,17 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // ExternalVersions lists all known external versions for this group from most preferred to least preferred
-var ExternalVersions = []unversioned.GroupVersion{v1.SchemeGroupVersion}
+var ExternalVersions = []unversioned.GroupVersion{v1beta1.SchemeGroupVersion}
 
 // Codec is the Codec for the most preferred ExternalVersion
-var Codec = v1.Codec
+var Codec = v1beta1.Codec
 
 // RESTMapper is a RESTMapper for all versions of the API group
 var RESTMapper meta.RESTMapper
@@ -42,7 +43,7 @@ var Accessor = meta.NewAccessor()
 func init() {
 	finalExternalVersions := []unversioned.GroupVersion{}
 
-	for _, allowedVersion := range registered.GroupVersionsForGroup(api.SchemeGroupVersion.Group) {
+	for _, allowedVersion := range registered.GroupVersionsForGroup(extensions.SchemeGroupVersion.Group) {
 		for _, externalVersion := range ExternalVersions {
 			if externalVersion == allowedVersion {
 				finalExternalVersions = append(finalExternalVersions, externalVersion)
@@ -56,12 +57,9 @@ func init() {
 		Codec = runtime.CodecFor(api.Scheme, ExternalVersions[0].String())
 		RESTMapper = newRESTMapper()
 	}
-
 }
 
-var userResources = []string{"rc", "svc", "pods", "pvc"}
-
-const importPrefix = "k8s.io/kubernetes/pkg/api"
+const importPrefix = "k8s.io/kubernetes/pkg/apis/extensions"
 
 func newRESTMapper() meta.RESTMapper {
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
@@ -71,39 +69,20 @@ func newRESTMapper() meta.RESTMapper {
 
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
-	rootScoped := sets.NewString(
-		"Node",
-		"Namespace",
-		"PersistentVolume",
-		"ComponentStatus",
-	)
+	rootScoped := sets.NewString()
 
-	// these kinds should be excluded from the list of resources
-	ignoredKinds := sets.NewString(
-		"ListOptions",
-		"DeleteOptions",
-		"Status",
-		"PodLogOptions",
-		"PodExecOptions",
-		"PodAttachOptions",
-		"PodProxyOptions",
-		"ThirdPartyResource",
-		"ThirdPartyResourceData",
-		"ThirdPartyResourceList")
+	ignoredKinds := sets.NewString()
 
-	mapper := api.NewDefaultRESTMapper(worstToBestGroupVersions, InterfacesFor, importPrefix, ignoredKinds, rootScoped)
-	// setup aliases for groups of resources
-	mapper.AddResourceAlias("all", userResources...)
-	return mapper
+	return api.NewDefaultRESTMapper(worstToBestGroupVersions, InterfacesFor, importPrefix, ignoredKinds, rootScoped)
 }
 
 // InterfacesFor returns the default Codec and ResourceVersioner for a given version
 // string, or an error if the version is not known.
 func InterfacesFor(version string) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.SchemeGroupVersion.String():
+	case v1beta1.SchemeGroupVersion.String():
 		return &meta.VersionInterfaces{
-			Codec:            v1.Codec,
+			Codec:            v1beta1.Codec,
 			ObjectConvertor:  api.Scheme,
 			MetadataAccessor: Accessor,
 		}, nil

--- a/pkg/apis/extensions/latest/latest.go
+++ b/pkg/apis/extensions/latest/latest.go
@@ -29,34 +29,42 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-// ExternalVersions lists all known external versions for this group from most preferred to least preferred
-var ExternalVersions = []unversioned.GroupVersion{v1beta1.SchemeGroupVersion}
+// ExternalVersions lists all allowed external versions for this group from most preferred to least preferred
+var ExternalVersions = []unversioned.GroupVersion{}
+
+// PreferredExternalVersion is the most preferred external version (ExternalVersions[0])
+var PreferredExternalVersion = unversioned.GroupVersion{}
 
 // Codec is the Codec for the most preferred ExternalVersion
-var Codec = v1beta1.Codec
+var Codec runtime.Codec
 
 // RESTMapper is a RESTMapper for all versions of the API group
 var RESTMapper meta.RESTMapper
 
 var Accessor = meta.NewAccessor()
 
+// availableVersions lists all known external versions for this group from most preferred to least preferred
+var availableVersions = []unversioned.GroupVersion{v1beta1.SchemeGroupVersion}
+
 func init() {
 	finalExternalVersions := []unversioned.GroupVersion{}
 
 	for _, allowedVersion := range registered.GroupVersionsForGroup(extensions.SchemeGroupVersion.Group) {
-		for _, externalVersion := range ExternalVersions {
+		for _, externalVersion := range availableVersions {
 			if externalVersion == allowedVersion {
 				finalExternalVersions = append(finalExternalVersions, externalVersion)
 			}
 		}
 	}
 
-	ExternalVersions = finalExternalVersions
-	Codec = nil
-	if len(ExternalVersions) > 0 {
-		Codec = runtime.CodecFor(api.Scheme, ExternalVersions[0].String())
-		RESTMapper = newRESTMapper()
+	if len(finalExternalVersions) == 0 {
+		return
 	}
+
+	ExternalVersions = finalExternalVersions
+	PreferredExternalVersion = ExternalVersions[0]
+	Codec = runtime.CodecFor(api.Scheme, PreferredExternalVersion.String())
+	RESTMapper = newRESTMapper()
 }
 
 const importPrefix = "k8s.io/kubernetes/pkg/apis/extensions"
@@ -78,8 +86,8 @@ func newRESTMapper() meta.RESTMapper {
 
 // InterfacesFor returns the default Codec and ResourceVersioner for a given version
 // string, or an error if the version is not known.
-func InterfacesFor(version string) (*meta.VersionInterfaces, error) {
-	switch version {
+func InterfacesFor(groupVersionString string) (*meta.VersionInterfaces, error) {
+	switch groupVersionString {
 	case v1beta1.SchemeGroupVersion.String():
 		return &meta.VersionInterfaces{
 			Codec:            v1beta1.Codec,
@@ -88,6 +96,10 @@ func InterfacesFor(version string) (*meta.VersionInterfaces, error) {
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, ExternalVersions)
+		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", groupVersionString, ExternalVersions)
 	}
+}
+
+func IsEnabled() bool {
+	return len(ExternalVersions) > 0
 }

--- a/pkg/apis/metrics/install/install.go
+++ b/pkg/apis/metrics/install/install.go
@@ -20,7 +20,6 @@ package install
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -53,13 +52,10 @@ func init() {
 		Codec:        runtime.CodecFor(api.Scheme, groupVersion.String()),
 	}
 
-	var versions []string
 	worstToBestGroupVersions := []unversioned.GroupVersion{}
 	for i := len(registeredGroupVersions) - 1; i >= 0; i-- {
-		versions = append(versions, registeredGroupVersions[i].Version)
 		worstToBestGroupVersions = append(worstToBestGroupVersions, registeredGroupVersions[i])
 	}
-	groupMeta.Versions = versions
 	groupMeta.GroupVersions = registeredGroupVersions
 
 	groupMeta.SelfLinker = runtime.SelfLinker(accessor)
@@ -87,6 +83,6 @@ func interfacesFor(version string) (*meta.VersionInterfaces, error) {
 		}, nil
 	default:
 		g, _ := latest.Group("metrics")
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %s)", version, strings.Join(g.Versions, ", "))
+		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/apis/metrics/install/install.go
+++ b/pkg/apis/metrics/install/install.go
@@ -23,25 +23,28 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
-	"k8s.io/kubernetes/pkg/apis/metrics"
 	metlatest "k8s.io/kubernetes/pkg/apis/metrics/latest"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
 func init() {
-	groupMeta, err := latest.RegisterGroup(metrics.SchemeGroupVersion.Group)
-	if err != nil {
-		glog.V(4).Infof("%v", err)
+	// this means that the entire group is disabled
+	if len(metlatest.ExternalVersions) == 0 {
 		return
 	}
 
-	*groupMeta = latest.GroupMeta{
+	groupMeta := latest.GroupMeta{
 		GroupVersion:  metlatest.ExternalVersions[0],
 		GroupVersions: metlatest.ExternalVersions,
 		Codec:         metlatest.Codec,
 		RESTMapper:    metlatest.RESTMapper,
 		SelfLinker:    runtime.SelfLinker(metlatest.Accessor),
 		InterfacesFor: metlatest.InterfacesFor,
+	}
+
+	if err := latest.RegisterGroup(groupMeta); err != nil {
+		glog.V(4).Infof("%v", err)
+		return
 	}
 
 	api.RegisterRESTMapper(groupMeta.RESTMapper)

--- a/pkg/apis/metrics/install/install.go
+++ b/pkg/apis/metrics/install/install.go
@@ -34,7 +34,7 @@ func init() {
 	}
 
 	groupMeta := latest.GroupMeta{
-		GroupVersion:  metlatest.ExternalVersions[0],
+		GroupVersion:  metlatest.PreferredExternalVersion,
 		GroupVersions: metlatest.ExternalVersions,
 		Codec:         metlatest.Codec,
 		RESTMapper:    metlatest.RESTMapper,

--- a/pkg/apis/metrics/latest/latest.go
+++ b/pkg/apis/metrics/latest/latest.go
@@ -29,34 +29,42 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-// ExternalVersions lists all known external versions for this group from most preferred to least preferred
-var ExternalVersions = []unversioned.GroupVersion{v1alpha1.SchemeGroupVersion}
+// ExternalVersions lists all allowed external versions for this group from most preferred to least preferred
+var ExternalVersions = []unversioned.GroupVersion{}
+
+// PreferredExternalVersion is the most preferred external version (ExternalVersions[0])
+var PreferredExternalVersion = unversioned.GroupVersion{}
 
 // Codec is the Codec for the most preferred ExternalVersion
-var Codec = v1alpha1.Codec
+var Codec runtime.Codec
 
 // RESTMapper is a RESTMapper for all versions of the API group
 var RESTMapper meta.RESTMapper
 
 var Accessor = meta.NewAccessor()
 
+// availableVersions lists all known external versions for this group from most preferred to least preferred
+var availableVersions = []unversioned.GroupVersion{v1alpha1.SchemeGroupVersion}
+
 func init() {
 	finalExternalVersions := []unversioned.GroupVersion{}
 
 	for _, allowedVersion := range registered.GroupVersionsForGroup(metrics.SchemeGroupVersion.Group) {
-		for _, externalVersion := range ExternalVersions {
+		for _, externalVersion := range availableVersions {
 			if externalVersion == allowedVersion {
 				finalExternalVersions = append(finalExternalVersions, externalVersion)
 			}
 		}
 	}
 
-	ExternalVersions = finalExternalVersions
-	Codec = nil
-	if len(ExternalVersions) > 0 {
-		Codec = runtime.CodecFor(api.Scheme, ExternalVersions[0].String())
-		RESTMapper = newRESTMapper()
+	if len(finalExternalVersions) == 0 {
+		return
 	}
+
+	ExternalVersions = finalExternalVersions
+	PreferredExternalVersion = ExternalVersions[0]
+	Codec = runtime.CodecFor(api.Scheme, PreferredExternalVersion.String())
+	RESTMapper = newRESTMapper()
 }
 
 const importPrefix = "k8s.io/kubernetes/pkg/apis/metrics"
@@ -78,8 +86,8 @@ func newRESTMapper() meta.RESTMapper {
 
 // InterfacesFor returns the default Codec and ResourceVersioner for a given version
 // string, or an error if the version is not known.
-func InterfacesFor(version string) (*meta.VersionInterfaces, error) {
-	switch version {
+func InterfacesFor(groupVersionString string) (*meta.VersionInterfaces, error) {
+	switch groupVersionString {
 	case v1alpha1.SchemeGroupVersion.String():
 		return &meta.VersionInterfaces{
 			Codec:            v1alpha1.Codec,
@@ -87,6 +95,10 @@ func InterfacesFor(version string) (*meta.VersionInterfaces, error) {
 			MetadataAccessor: Accessor,
 		}, nil
 	default:
-		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, ExternalVersions)
+		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", groupVersionString, ExternalVersions)
 	}
+}
+
+func IsEnabled() bool {
+	return len(ExternalVersions) > 0
 }

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -210,7 +210,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 	glog.Errorln(buffer.String())
 
 	// TODO: make status unversioned or plumb enough of the request to deduce the requested API version
-	errorJSON(apierrors.NewGenericServerResponse(http.StatusInternalServerError, "", "", "", "", 0, false), latest.GroupOrDie("").Codec, httpWriter)
+	errorJSON(apierrors.NewGenericServerResponse(http.StatusInternalServerError, "", "", "", "", 0, false), latest.Codec, httpWriter)
 }
 
 func InstallServiceErrorHandler(container *restful.Container, requestResolver *RequestInfoResolver, apiVersions []string) {
@@ -221,7 +221,7 @@ func InstallServiceErrorHandler(container *restful.Container, requestResolver *R
 
 func serviceErrorHandler(requestResolver *RequestInfoResolver, apiVersions []string, serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
 	requestInfo, err := requestResolver.GetRequestInfo(request.Request)
-	codec := latest.GroupOrDie("").Codec
+	codec := latest.Codec
 	if err == nil && requestInfo.APIVersion != "" {
 		// check if the api version is valid.
 		for _, version := range apiVersions {

--- a/pkg/apiserver/resthandler_test.go
+++ b/pkg/apiserver/resthandler_test.go
@@ -152,7 +152,7 @@ func (tc *patchTestCase) Run(t *testing.T) {
 	namespace := tc.startingPod.Namespace
 	name := tc.startingPod.Name
 
-	codec := latest.GroupOrDie("").Codec
+	codec := latest.Codec
 
 	testPatcher := &testPatcher{}
 	testPatcher.startingPod = tc.startingPod

--- a/pkg/client/unversioned/extensions.go
+++ b/pkg/client/unversioned/extensions.go
@@ -19,7 +19,6 @@ package unversioned
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -146,8 +145,8 @@ func setExtensionsDefaults(config *Config) error {
 
 	versionInterfaces, err := g.InterfacesFor(config.GroupVersion.String())
 	if err != nil {
-		return fmt.Errorf("Extensions API group/version '%v' is not recognized (valid values: %s)",
-			config.GroupVersion, strings.Join(latest.GroupOrDie("extensions").Versions, ", "))
+		return fmt.Errorf("Extensions API group/version '%v' is not recognized (valid values: %v)",
+			config.GroupVersion, g.GroupVersions)
 	}
 	config.Codec = versionInterfaces.Codec
 	if config.QPS == 0 {

--- a/pkg/client/unversioned/extensions.go
+++ b/pkg/client/unversioned/extensions.go
@@ -20,8 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	extlatest "k8s.io/kubernetes/pkg/apis/extensions/latest"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -129,24 +130,24 @@ func NewExtensionsOrDie(c *Config) *ExtensionsClient {
 
 func setExtensionsDefaults(config *Config) error {
 	// if experimental group is not registered, return an error
-	g, err := latest.Group("extensions")
-	if err != nil {
-		return err
+	if !extlatest.IsEnabled() {
+		return fmt.Errorf("group %v is not enabled", extensions.SchemeGroupVersion)
 	}
+
 	config.Prefix = "apis/"
 	if config.UserAgent == "" {
 		config.UserAgent = DefaultKubernetesUserAgent()
 	}
 	// TODO: Unconditionally set the config.Version, until we fix the config.
 	//if config.Version == "" {
-	copyGroupVersion := g.GroupVersion
+	copyGroupVersion := extlatest.PreferredExternalVersion
 	config.GroupVersion = &copyGroupVersion
 	//}
 
-	versionInterfaces, err := g.InterfacesFor(config.GroupVersion.String())
+	versionInterfaces, err := extlatest.InterfacesFor(config.GroupVersion.String())
 	if err != nil {
 		return fmt.Errorf("Extensions API group/version '%v' is not recognized (valid values: %v)",
-			config.GroupVersion, g.GroupVersions)
+			config.GroupVersion, extlatest.ExternalVersions)
 	}
 	config.Codec = versionInterfaces.Codec
 	if config.QPS == 0 {

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -366,7 +366,7 @@ func SetKubernetesDefaults(config *Config) error {
 	}
 	versionInterfaces, err := latest.GroupOrDie("").InterfacesFor(config.GroupVersion.String())
 	if err != nil {
-		return fmt.Errorf("API version '%v' is not recognized (valid values: %s)", *config.GroupVersion, strings.Join(latest.GroupOrDie("").Versions, ", "))
+		return fmt.Errorf("API version '%v' is not recognized (valid values: %v)", *config.GroupVersion, latest.GroupOrDie("").GroupVersions)
 	}
 	if config.Codec == nil {
 		config.Codec = versionInterfaces.Codec

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	extlatest "k8s.io/kubernetes/pkg/apis/extensions/latest"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -132,7 +133,7 @@ func New(c *Config) (*Client, error) {
 		return nil, err
 	}
 
-	if _, err := latest.Group("extensions"); err != nil {
+	if !extlatest.IsEnabled() {
 		return &Client{RESTClient: client, ExtensionsClient: nil, DiscoveryClient: discoveryClient}, nil
 	}
 	experimentalConfig := *c
@@ -364,9 +365,9 @@ func SetKubernetesDefaults(config *Config) error {
 	if config.GroupVersion == nil {
 		config.GroupVersion = defaultVersionFor(config)
 	}
-	versionInterfaces, err := latest.GroupOrDie("").InterfacesFor(config.GroupVersion.String())
+	versionInterfaces, err := latest.InterfacesFor(config.GroupVersion.String())
 	if err != nil {
-		return fmt.Errorf("API version '%v' is not recognized (valid values: %v)", *config.GroupVersion, latest.GroupOrDie("").GroupVersions)
+		return fmt.Errorf("API version '%v' is not recognized (valid values: %v)", *config.GroupVersion, latest.ExternalVersions)
 	}
 	if config.Codec == nil {
 		config.Codec = versionInterfaces.Codec
@@ -525,7 +526,7 @@ func defaultVersionFor(config *Config) *unversioned.GroupVersion {
 		// Clients default to the preferred code API version
 		// TODO: implement version negotiation (highest version supported by server)
 		// TODO this drops out when groupmeta is refactored
-		copyGroupVersion := latest.GroupOrDie("").GroupVersion
+		copyGroupVersion := latest.PreferredExternalVersion
 		return &copyGroupVersion
 	}
 

--- a/pkg/client/unversioned/jobs.go
+++ b/pkg/client/unversioned/jobs.go
@@ -88,7 +88,7 @@ func (c *jobs) Delete(name string, options *api.DeleteOptions) (err error) {
 		return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Do().Error()
 	}
 
-	body, err := api.Scheme.EncodeToVersion(options, latest.GroupOrDie("").GroupVersion.String())
+	body, err := api.Scheme.EncodeToVersion(options, latest.PreferredExternalVersion.String())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -259,7 +259,7 @@ func getPodsAnnotationSet(template *api.PodTemplateSpec, object runtime.Object) 
 	if err != nil {
 		return desiredAnnotations, fmt.Errorf("unable to get controller reference: %v", err)
 	}
-	createdByRefJson, err := latest.GroupOrDie("").Codec.Encode(&api.SerializedReference{
+	createdByRefJson, err := latest.Codec.Encode(&api.SerializedReference{
 		Reference: *createdByRef,
 	})
 	if err != nil {

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -95,7 +95,7 @@ type ConvertOptions struct {
 
 // Complete collects information required to run Convert command from command line.
 func (o *ConvertOptions) Complete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) (err error) {
-	o.outputVersion, err = cmdutil.OutputVersion(cmd, &latest.ExternalVersions[0])
+	o.outputVersion, err = cmdutil.OutputVersion(cmd, &latest.PreferredExternalVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -363,7 +363,7 @@ func Merge(dst runtime.Object, fragment, kind string) (runtime.Object, error) {
 	if !ok {
 		return nil, fmt.Errorf("apiVersion must be a string")
 	}
-	i, err := latest.GroupOrDie("").InterfacesFor(versionString)
+	i, err := latest.InterfacesFor(versionString)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -221,7 +221,7 @@ func AsVersionedObject(infos []*Info, forceList bool, version string) (runtime.O
 		object = objects[0]
 	} else {
 		object = &api.List{Items: objects}
-		converted, err := tryConvert(api.Scheme, object, version, latest.GroupOrDie("").GroupVersion.Version)
+		converted, err := tryConvert(api.Scheme, object, version, latest.PreferredExternalVersion.Version)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -78,7 +78,7 @@ func getSelfLink(name, namespace string) string {
 	if len(namespace) == 0 {
 		namespace = api.NamespaceDefault
 	}
-	selfLink = fmt.Sprintf("/api/"+latest.GroupOrDie("").GroupVersion.Version+"/pods/namespaces/%s/%s", name, namespace)
+	selfLink = fmt.Sprintf("/api/"+latest.PreferredExternalVersion.Version+"/pods/namespaces/%s/%s", name, namespace)
 	return selfLink
 }
 

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -658,7 +658,7 @@ func (dm *DockerManager) runContainer(
 	}
 	if container.Lifecycle != nil && container.Lifecycle.PreStop != nil {
 		// TODO: This is kind of hacky, we should really just encode the bits we need.
-		data, err := latest.GroupOrDie("").Codec.Encode(pod)
+		data, err := latest.Codec.Encode(pod)
 		if err != nil {
 			glog.Errorf("Failed to encode pod: %s for prestop hook", pod.Name)
 		} else {
@@ -1409,7 +1409,7 @@ func containerAndPodFromLabels(inspect *docker.Container) (pod *api.Pod, contain
 	// the pod data may not be set
 	if body, found := labels[kubernetesPodLabel]; found {
 		pod = &api.Pod{}
-		if err = latest.GroupOrDie("").Codec.DecodeInto([]byte(body), pod); err == nil {
+		if err = latest.Codec.DecodeInto([]byte(body), pod); err == nil {
 			name := labels[kubernetesContainerLabel]
 			for ix := range pod.Spec.Containers {
 				if pod.Spec.Containers[ix].Name == name {

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -470,7 +470,7 @@ func encodePods(pods []*api.Pod) (data []byte, err error) {
 	for _, pod := range pods {
 		podList.Items = append(podList.Items, *pod)
 	}
-	return latest.GroupOrDie("").Codec.Encode(podList)
+	return latest.Codec.Encode(podList)
 }
 
 // getPods returns a list of pods bound to the Kubelet and their spec.

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -30,12 +30,12 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	extlatest "k8s.io/kubernetes/pkg/apis/extensions/latest"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/registry/endpoint"
@@ -329,14 +329,12 @@ func TestExpapi(t *testing.T) {
 	master, etcdserver, config, assert := setUp(t)
 	defer etcdserver.Terminate(t)
 
-	extensionsGroupMeta := latest.GroupOrDie("extensions")
-
 	expAPIGroup := master.experimental(&config)
 	assert.Equal(expAPIGroup.Root, master.apiGroupPrefix)
-	assert.Equal(expAPIGroup.Mapper, extensionsGroupMeta.RESTMapper)
-	assert.Equal(expAPIGroup.Codec, extensionsGroupMeta.Codec)
-	assert.Equal(expAPIGroup.Linker, extensionsGroupMeta.SelfLinker)
-	assert.Equal(expAPIGroup.GroupVersion, extensionsGroupMeta.GroupVersion)
+	assert.Equal(expAPIGroup.Mapper, extlatest.RESTMapper)
+	assert.Equal(expAPIGroup.Codec, extlatest.Codec)
+	assert.Equal(expAPIGroup.Linker, runtime.SelfLinker(extlatest.Accessor))
+	assert.Equal(expAPIGroup.GroupVersion, extlatest.PreferredExternalVersion)
 }
 
 // TestGetNodeAddresses verifies that proper results are returned

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -24,11 +24,11 @@ import (
 	"net/url"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	extlatest "k8s.io/kubernetes/pkg/apis/extensions/latest"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -69,7 +69,7 @@ func (t *thirdPartyResourceDataMapper) RESTMapping(gk unversioned.GroupKind, ver
 	// TODO figure out why we're doing this rewriting
 	extensionGK := unversioned.GroupKind{Group: "extensions", Kind: "ThirdPartyResourceData"}
 
-	mapping, err := t.mapper.RESTMapping(extensionGK, latest.GroupOrDie("extensions").GroupVersion.Version)
+	mapping, err := t.mapper.RESTMapping(extensionGK, extlatest.PreferredExternalVersion.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/io/io.go
+++ b/pkg/util/io/io.go
@@ -39,7 +39,7 @@ func LoadPodFromFile(filePath string) (*api.Pod, error) {
 	}
 	pod := &api.Pod{}
 
-	if err := latest.GroupOrDie("").Codec.DecodeInto(podDef, pod); err != nil {
+	if err := latest.Codec.DecodeInto(podDef, pod); err != nil {
 		return nil, fmt.Errorf("failed decoding file: %v", err)
 	}
 	return pod, nil
@@ -50,7 +50,7 @@ func SavePodToFile(pod *api.Pod, filePath string, perm os.FileMode) error {
 	if filePath == "" {
 		return fmt.Errorf("file path not specified")
 	}
-	data, err := latest.GroupOrDie("").Codec.Encode(pod)
+	data, err := latest.Codec.Encode(pod)
 	if err != nil {
 		return fmt.Errorf("failed encoding pod: %v", err)
 	}

--- a/pkg/util/io/io_test.go
+++ b/pkg/util/io/io_test.go
@@ -32,8 +32,8 @@ func TestSavePodToFile(t *testing.T) {
 	pod := volume.NewPersistentVolumeRecyclerPodTemplate()
 
 	// sets all default values on a pod for equality comparison after decoding from file
-	encoded, err := latest.GroupOrDie("").Codec.Encode(pod)
-	latest.GroupOrDie("").Codec.DecodeInto(encoded, pod)
+	encoded, err := latest.Codec.Encode(pod)
+	latest.Codec.DecodeInto(encoded, pod)
 
 	path := fmt.Sprintf("/tmp/kube-io-test-%s", uuid.New())
 	defer os.Remove(path)

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -42,7 +42,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      "dns-test-" + string(util.NewUUID()),

--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -313,7 +313,7 @@ func testPodWithVolume(image, path string, source *api.EmptyDirVolumeSource) *ap
 	return &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name: podName,

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -111,7 +111,7 @@ func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod 
 	return &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name: podName,

--- a/test/e2e/kubelet_etc_hosts.go
+++ b/test/e2e/kubelet_etc_hosts.go
@@ -143,7 +143,7 @@ func (config *KubeletManagedHostConfig) createPodSpec(podName string) *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      podName,
@@ -204,7 +204,7 @@ func (config *KubeletManagedHostConfig) createPodSpecWithHostNetwork(podName str
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      podName,

--- a/test/e2e/kubeproxy.go
+++ b/test/e2e/kubeproxy.go
@@ -255,7 +255,7 @@ func (config *KubeProxyTestConfig) createNetShellPodSpec(podName string, node st
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      podName,
@@ -295,7 +295,7 @@ func (config *KubeProxyTestConfig) createTestPodSpec() *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      testPodName,

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -414,7 +414,7 @@ func testPDPod(diskNames []string, targetHost string, readOnly bool, numContaine
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name: "pd-test-" + string(util.NewUUID()),

--- a/test/e2e/privileged.go
+++ b/test/e2e/privileged.go
@@ -102,7 +102,7 @@ func (config *PrivilegedPodTestConfig) createPrivilegedPodSpec() *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      privilegedPodName,

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -188,7 +188,7 @@ func rcByNameContainer(name string, replicas int, image string, labels map[strin
 	return &api.ReplicationController{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "ReplicationController",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name: name,

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2098,7 +2098,7 @@ func NewHostExecPodSpec(ns, name string) *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.PreferredExternalVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      name,


### PR DESCRIPTION
Refactors group registration to be immutable and then expresses direct group dependencies as package dependencies.

ref https://github.com/kubernetes/kubernetes/issues/17216

@liggitt your turn again if you're up for it
@caesarxuchao @kubernetes/rh-cluster-infra 
