### PR TITLE
kubectl: Make scaling smarter

### DIFF
--- a/pkg/client/unversioned/conditions.go
+++ b/pkg/client/unversioned/conditions.go
@@ -54,7 +54,7 @@ func JobHasDesiredParallelism(c ExtensionsInterface, job *extensions.Job) wait.C
 		}
 
 		// desired parallelism can be either the exact number, in which case return immediately
-		if job.Status.Active == *job.Spec.Parallelism {
+		if job.Spec.Parallelism != nil && job.Status.Active == *job.Spec.Parallelism {
 			return true, nil
 		}
 		// otherwise count successful

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -146,6 +146,10 @@ func RunScale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	errs := []error{}
 	for _, info := range infos {
 		if err := scaler.Scale(info.Namespace, info.Name, uint(count), precondition, retry, waitForReplicas); err != nil {
+			if scaleErr, ok := err.(kubectl.ScaleError); ok && scaleErr.FailureType == kubectl.AlreadyScaled {
+				cmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, "already scaled")
+				continue
+			}
 			errs = append(errs, err)
 			continue
 		}


### PR DESCRIPTION
Skip updating resources that already meet the desired replica count.
This change has an impact in both `kubectl scale` and `kubectl delete` in
that reapable resources that already have the desired replicas (number
provided via --replicas for `scale`, or zero for `delete`) won't be updated
again and a "already scaled" message will be printed (in case of `scale`).

@kubernetes/kubectl 
