### PR TITLE
Revert "Change to alpha/beta for bandwidth annotations"

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3295,7 +3295,7 @@ func validateBandwidthIsReasonable(rsrc *resource.Quantity) error {
 }
 
 func extractBandwidthResources(pod *api.Pod) (ingress, egress *resource.Quantity, err error) {
-	str, found := pod.Annotations["net.alpha.kubernetes.io/ingress-bandwidth"]
+	str, found := pod.Annotations["kubernetes.io/ingress-bandwidth"]
 	if found {
 		if ingress, err = resource.ParseQuantity(str); err != nil {
 			return nil, nil, err
@@ -3304,7 +3304,7 @@ func extractBandwidthResources(pod *api.Pod) (ingress, egress *resource.Quantity
 			return nil, nil, err
 		}
 	}
-	str, found = pod.Annotations["net.alpha.kubernetes.io/egress-bandwidth"]
+	str, found = pod.Annotations["kubernetes.io/egress-bandwidth"]
 	if found {
 		if egress, err = resource.ParseQuantity(str); err != nil {
 			return nil, nil, err

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -4014,7 +4014,7 @@ func TestCleanupBandwidthLimits(t *testing.T) {
 					ObjectMeta: api.ObjectMeta{
 						Name: "foo",
 						Annotations: map[string]string{
-							"net.alpha.kubernetes.io/ingress-bandwidth": "10M",
+							"kubernetes.io/ingress-bandwidth": "10M",
 						},
 					},
 				},
@@ -4039,7 +4039,7 @@ func TestCleanupBandwidthLimits(t *testing.T) {
 					ObjectMeta: api.ObjectMeta{
 						Name: "foo",
 						Annotations: map[string]string{
-							"net.alpha.kubernetes.io/ingress-bandwidth": "10M",
+							"kubernetes.io/ingress-bandwidth": "10M",
 						},
 					},
 				},
@@ -4065,7 +4065,7 @@ func TestCleanupBandwidthLimits(t *testing.T) {
 					ObjectMeta: api.ObjectMeta{
 						Name: "foo",
 						Annotations: map[string]string{
-							"net.alpha.kubernetes.io/ingress-bandwidth": "10M",
+							"kubernetes.io/ingress-bandwidth": "10M",
 						},
 					},
 				},
@@ -4090,7 +4090,7 @@ func TestCleanupBandwidthLimits(t *testing.T) {
 					ObjectMeta: api.ObjectMeta{
 						Name: "foo",
 						Annotations: map[string]string{
-							"net.alpha.kubernetes.io/ingress-bandwidth": "10M",
+							"kubernetes.io/ingress-bandwidth": "10M",
 						},
 					},
 				},
@@ -4178,7 +4178,7 @@ func TestExtractBandwidthResources(t *testing.T) {
 			pod: &api.Pod{
 				ObjectMeta: api.ObjectMeta{
 					Annotations: map[string]string{
-						"net.alpha.kubernetes.io/ingress-bandwidth": "10M",
+						"kubernetes.io/ingress-bandwidth": "10M",
 					},
 				},
 			},
@@ -4188,7 +4188,7 @@ func TestExtractBandwidthResources(t *testing.T) {
 			pod: &api.Pod{
 				ObjectMeta: api.ObjectMeta{
 					Annotations: map[string]string{
-						"net.alpha.kubernetes.io/egress-bandwidth": "10M",
+						"kubernetes.io/egress-bandwidth": "10M",
 					},
 				},
 			},
@@ -4198,8 +4198,8 @@ func TestExtractBandwidthResources(t *testing.T) {
 			pod: &api.Pod{
 				ObjectMeta: api.ObjectMeta{
 					Annotations: map[string]string{
-						"net.alpha.kubernetes.io/ingress-bandwidth": "4M",
-						"net.alpha.kubernetes.io/egress-bandwidth":  "20M",
+						"kubernetes.io/ingress-bandwidth": "4M",
+						"kubernetes.io/egress-bandwidth":  "20M",
 					},
 				},
 			},
@@ -4210,7 +4210,7 @@ func TestExtractBandwidthResources(t *testing.T) {
 			pod: &api.Pod{
 				ObjectMeta: api.ObjectMeta{
 					Annotations: map[string]string{
-						"net.alpha.kubernetes.io/ingress-bandwidth": "foo",
+						"kubernetes.io/ingress-bandwidth": "foo",
 					},
 				},
 			},


### PR DESCRIPTION
This reverts commit 2f4c3035be6a4188c12e8c45f5c6fe7f1a94fa38.

Since this did not get cherry-picked into 1.1, the original annotation name has to stand.

@zmerlynn 
