### PR TITLE
Centos baremetal: fix kube-up failure and update default k8s install version to v1.1.1

### DIFF
--- a/cluster/centos/config-build.sh
+++ b/cluster/centos/config-build.sh
@@ -26,7 +26,7 @@ FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.3"}
 ETCD_VERSION=${ETCD_VERSION:-"2.2.1"}
 
 # Define k8s version to use.
-K8S_VERSION=${K8S_VERSION:-"1.0.4"}
+K8S_VERSION=${K8S_VERSION:-"1.1.1"}
 
 FLANNEL_DOWNLOAD_URL=\
 "https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz"

--- a/cluster/centos/util.sh
+++ b/cluster/centos/util.sh
@@ -293,7 +293,7 @@ function kube-scp() {
 #   KUBE_USER
 #   KUBE_PASSWORD
 function get-password {
-  get-kubeconfig-basicauth
+  load-or-gen-kube-basicauth
   if [[ -z "${KUBE_USER}" || -z "${KUBE_PASSWORD}" ]]; then
     KUBE_USER=admin
     KUBE_PASSWORD=$(python -c 'import string,random; \


### PR DESCRIPTION
1. fix centos baremetal kube-up failure
2. update default download k8s version to v1.1.1 in Centos baremetal scripts
