### PR TITLE
Fixes crash when proxy is run with --cleanup-iptables=true.

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -181,6 +181,7 @@ func NewProxyServerDefault(config *ProxyServerConfig) (*ProxyServer, error) {
 		dbus := utildbus.New()
 		IptInterface := utiliptables.New(execer, dbus, protocol)
 		return &ProxyServer{
+			Config:       config,
 			IptInterface: IptInterface,
 		}, nil
 	}


### PR DESCRIPTION
Closes #18196
