### PR TITLE
Properly close http connection on TestList

### DIFF
--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -984,6 +984,7 @@ func TestList(t *testing.T) {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("%d: unexpected status: %d from url %s, Expected: %d, %#v", i, resp.StatusCode, testCase.url, http.StatusOK, resp)
 			body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
If not, using `go test -count=n` would make them pile up and ultimately
get to the limit of open files:

```
apiserver_test.go:984: 17: unexpected error: Get http://127.0.0.1:44131/apis/test.group/version/simple: dial tcp 127.0.0.1:44131: socket: too many open files
```

Steps to reproduce (no longer fails):

```
godep go test -short -run '^$' -o test .
./test -test.run '^TestList$' -test.count 100
```

Note that this might not fail if your `ulimit -n` is not low enough.

I've spotted multiple issues like this one while trying to run all the tests a large number of times without restarting the test processes. This makes files and connections that weren't closed properly to stick around.

More PRs to come.

CC @mikedanese 
