### PR TITLE
Properly close servers and files in unversioned

### DIFF
--- a/pkg/client/unversioned/client_test.go
+++ b/pkg/client/unversioned/client_test.go
@@ -46,6 +46,7 @@ func TestGetServerVersion(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
+	defer server.Close()
 	client := NewOrDie(&Config{Host: server.URL})
 
 	got, err := client.ServerVersion()
@@ -80,6 +81,7 @@ func TestGetServerGroupsWithV1Server(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
+	defer server.Close()
 	client := NewOrDie(&Config{Host: server.URL})
 	// ServerGroups should not return an error even if server returns error at /api and /apis
 	apiGroupList, err := client.Discovery().ServerGroups()
@@ -115,6 +117,7 @@ func TestGetServerResourcesWithV1Server(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
+	defer server.Close()
 	client := NewOrDie(&Config{Host: server.URL})
 	// ServerResources should not return an error even if server returns error at /api/v1.
 	resourceMap, err := client.Discovery().ServerResources()
@@ -206,6 +209,7 @@ func TestGetServerResources(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
+	defer server.Close()
 	client := NewOrDie(&Config{Host: server.URL})
 	for _, test := range tests {
 		got, err := client.Discovery().ServerResourcesForGroupVersion(test.request)
@@ -266,6 +270,7 @@ func TestGetSwaggerSchema(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected encoding error: %v", err)
 	}
+	defer server.Close()
 
 	client := NewOrDie(&Config{Host: server.URL})
 	got, err := client.SwaggerSchema(v1.SchemeGroupVersion)
@@ -284,6 +289,7 @@ func TestGetSwaggerSchemaFail(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected encoding error: %v", err)
 	}
+	defer server.Close()
 
 	client := NewOrDie(&Config{Host: server.URL})
 	got, err := client.SwaggerSchema(unversioned.GroupVersion{Group: "api.group", Version: "v4"})

--- a/pkg/client/unversioned/daemon_sets_test.go
+++ b/pkg/client/unversioned/daemon_sets_test.go
@@ -60,6 +60,7 @@ func TestListDaemonSets(t *testing.T) {
 		},
 	}
 	receivedDSs, err := c.Setup(t).Extensions().DaemonSets(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, receivedDSs, err)
 
 }
@@ -85,6 +86,7 @@ func TestGetDaemonSet(t *testing.T) {
 		},
 	}
 	receivedDaemonSet, err := c.Setup(t).Extensions().DaemonSets(ns).Get("foo")
+	defer c.Close()
 	c.Validate(t, receivedDaemonSet, err)
 }
 
@@ -92,6 +94,7 @@ func TestGetDaemonSetWithNoName(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{Error: true}
 	receivedPod, err := c.Setup(t).Extensions().DaemonSets(ns).Get("")
+	defer c.Close()
 	if (err != nil) && (err.Error() != simple.NameRequiredError) {
 		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
 	}
@@ -123,6 +126,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 		},
 	}
 	receivedDaemonSet, err := c.Setup(t).Extensions().DaemonSets(ns).Update(requestDaemonSet)
+	defer c.Close()
 	c.Validate(t, receivedDaemonSet, err)
 }
 
@@ -151,6 +155,7 @@ func TestUpdateDaemonSetUpdateStatus(t *testing.T) {
 		},
 	}
 	receivedDaemonSet, err := c.Setup(t).Extensions().DaemonSets(ns).UpdateStatus(requestDaemonSet)
+	defer c.Close()
 	c.Validate(t, receivedDaemonSet, err)
 }
 
@@ -161,6 +166,7 @@ func TestDeleteDaemon(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Extensions().DaemonSets(ns).Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -188,5 +194,6 @@ func TestCreateDaemonSet(t *testing.T) {
 		},
 	}
 	receivedDaemonSet, err := c.Setup(t).Extensions().DaemonSets(ns).Create(requestDaemonSet)
+	defer c.Close()
 	c.Validate(t, receivedDaemonSet, err)
 }

--- a/pkg/client/unversioned/deployment_test.go
+++ b/pkg/client/unversioned/deployment_test.go
@@ -56,6 +56,7 @@ func TestDeploymentCreate(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).Deployments(ns).Create(&deployment)
+	defer c.Close()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -81,6 +82,7 @@ func TestDeploymentGet(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).Deployments(ns).Get("abc")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -106,6 +108,7 @@ func TestDeploymentList(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: deploymentList},
 	}
 	response, err := c.Setup(t).Deployments(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -127,6 +130,7 @@ func TestDeploymentUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: deployment},
 	}
 	response, err := c.Setup(t).Deployments(ns).Update(deployment)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -148,6 +152,7 @@ func TestDeploymentUpdateStatus(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: deployment},
 	}
 	response, err := c.Setup(t).Deployments(ns).UpdateStatus(deployment)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -162,6 +167,7 @@ func TestDeploymentDelete(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Deployments(ns).Delete("foo", nil)
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -175,6 +181,7 @@ func TestDeploymentWatch(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	_, err := c.Setup(t).Deployments(api.NamespaceAll).Watch(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -203,6 +210,7 @@ func TestListDeploymentsLabels(t *testing.T) {
 		},
 	}
 	c.Setup(t)
+	defer c.Close()
 	c.QueryValidator[labelSelectorQueryParamName] = simple.ValidateLabels
 	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
 	options := api.ListOptions{LabelSelector: selector}

--- a/pkg/client/unversioned/endpoints_test.go
+++ b/pkg/client/unversioned/endpoints_test.go
@@ -47,6 +47,7 @@ func TestListEndpoints(t *testing.T) {
 		},
 	}
 	receivedEndpointsList, err := c.Setup(t).Endpoints(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, receivedEndpointsList, err)
 }
 
@@ -57,6 +58,7 @@ func TestGetEndpoints(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: &api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "endpoint-1"}}},
 	}
 	response, err := c.Setup(t).Endpoints(ns).Get("endpoint-1")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -64,6 +66,7 @@ func TestGetEndpointWithNoName(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{Error: true}
 	receivedPod, err := c.Setup(t).Endpoints(ns).Get("")
+	defer c.Close()
 	if (err != nil) && (err.Error() != simple.NameRequiredError) {
 		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
 	}

--- a/pkg/client/unversioned/events_test.go
+++ b/pkg/client/unversioned/events_test.go
@@ -56,6 +56,7 @@ func TestEventSearch(t *testing.T) {
 			},
 		},
 	)
+	defer c.Close()
 	c.Validate(t, eventList, err)
 }
 
@@ -89,6 +90,7 @@ func TestEventCreate(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).Events(api.NamespaceDefault).Create(event)
+	defer c.Close()
 
 	if err != nil {
 		t.Fatalf("%v should be nil.", err)
@@ -129,6 +131,7 @@ func TestEventGet(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).Events("other").Get("1")
+	defer c.Close()
 
 	if err != nil {
 		t.Fatalf("%v should be nil.", err)
@@ -170,6 +173,7 @@ func TestEventList(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: eventList},
 	}
 	response, err := c.Setup(t).Events(ns).List(api.ListOptions{})
+	defer c.Close()
 
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)
@@ -196,5 +200,6 @@ func TestEventDelete(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Events(ns).Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/unversioned/helper_test.go
+++ b/pkg/client/unversioned/helper_test.go
@@ -185,6 +185,7 @@ func TestHelperGetServerAPIVersions(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
+	defer server.Close()
 	got, err := ServerAPIVersions(&Config{Host: server.URL, GroupVersion: &unversioned.GroupVersion{Group: "invalid version", Version: "one"}, Codec: testapi.Default.Codec()})
 	if err != nil {
 		t.Fatalf("unexpected encoding error: %v", err)

--- a/pkg/client/unversioned/horizontalpodautoscaler_test.go
+++ b/pkg/client/unversioned/horizontalpodautoscaler_test.go
@@ -53,6 +53,7 @@ func TestHorizontalPodAutoscalerCreate(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).Create(&horizontalPodAutoscaler)
+	defer c.Close()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -78,6 +79,7 @@ func TestHorizontalPodAutoscalerGet(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).Get("abc")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -103,6 +105,7 @@ func TestHorizontalPodAutoscalerList(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: horizontalPodAutoscalerList},
 	}
 	response, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -120,6 +123,7 @@ func TestHorizontalPodAutoscalerUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: horizontalPodAutoscaler},
 	}
 	response, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).Update(horizontalPodAutoscaler)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -137,6 +141,7 @@ func TestHorizontalPodAutoscalerUpdateStatus(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: horizontalPodAutoscaler},
 	}
 	response, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).UpdateStatus(horizontalPodAutoscaler)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -147,6 +152,7 @@ func TestHorizontalPodAutoscalerDelete(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Extensions().HorizontalPodAutoscalers(ns).Delete("foo", nil)
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -159,5 +165,6 @@ func TestHorizontalPodAutoscalerWatch(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	_, err := c.Setup(t).Extensions().HorizontalPodAutoscalers(api.NamespaceAll).Watch(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/unversioned/ingress_test.go
+++ b/pkg/client/unversioned/ingress_test.go
@@ -60,6 +60,7 @@ func TestListIngress(t *testing.T) {
 		},
 	}
 	receivedIngressList, err := c.Setup(t).Extensions().Ingress(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, receivedIngressList, err)
 }
 
@@ -88,6 +89,7 @@ func TestGetIngress(t *testing.T) {
 		},
 	}
 	receivedIngress, err := c.Setup(t).Extensions().Ingress(ns).Get("foo")
+	defer c.Close()
 	c.Validate(t, receivedIngress, err)
 }
 
@@ -95,6 +97,7 @@ func TestGetIngressWithNoName(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{Error: true}
 	receivedIngress, err := c.Setup(t).Extensions().Ingress(ns).Get("")
+	defer c.Close()
 	if (err != nil) && (err.Error() != simple.NameRequiredError) {
 		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
 	}
@@ -134,6 +137,7 @@ func TestUpdateIngress(t *testing.T) {
 		},
 	}
 	receivedIngress, err := c.Setup(t).Extensions().Ingress(ns).Update(requestIngress)
+	defer c.Close()
 	c.Validate(t, receivedIngress, err)
 }
 
@@ -180,6 +184,7 @@ func TestUpdateIngressStatus(t *testing.T) {
 		},
 	}
 	receivedIngress, err := c.Setup(t).Extensions().Ingress(ns).UpdateStatus(requestIngress)
+	defer c.Close()
 	c.Validate(t, receivedIngress, err)
 }
 
@@ -194,6 +199,7 @@ func TestDeleteIngress(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Extensions().Ingress(ns).Delete("foo", nil)
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -229,5 +235,6 @@ func TestCreateIngress(t *testing.T) {
 		},
 	}
 	receivedIngress, err := c.Setup(t).Extensions().Ingress(ns).Create(requestIngress)
+	defer c.Close()
 	c.Validate(t, receivedIngress, err)
 }

--- a/pkg/client/unversioned/jobs_test.go
+++ b/pkg/client/unversioned/jobs_test.go
@@ -60,6 +60,7 @@ func TestListJobs(t *testing.T) {
 		},
 	}
 	receivedJobList, err := c.Setup(t).Extensions().Jobs(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, receivedJobList, err)
 }
 
@@ -88,6 +89,7 @@ func TestGetJob(t *testing.T) {
 		},
 	}
 	receivedJob, err := c.Setup(t).Extensions().Jobs(ns).Get("foo")
+	defer c.Close()
 	c.Validate(t, receivedJob, err)
 }
 
@@ -95,6 +97,7 @@ func TestGetJobWithNoName(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{Error: true}
 	receivedJob, err := c.Setup(t).Extensions().Jobs(ns).Get("")
+	defer c.Close()
 	if (err != nil) && (err.Error() != simple.NameRequiredError) {
 		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
 	}
@@ -134,6 +137,7 @@ func TestUpdateJob(t *testing.T) {
 		},
 	}
 	receivedJob, err := c.Setup(t).Extensions().Jobs(ns).Update(requestJob)
+	defer c.Close()
 	c.Validate(t, receivedJob, err)
 }
 
@@ -172,6 +176,7 @@ func TestUpdateJobStatus(t *testing.T) {
 		},
 	}
 	receivedJob, err := c.Setup(t).Extensions().Jobs(ns).UpdateStatus(requestJob)
+	defer c.Close()
 	c.Validate(t, receivedJob, err)
 }
 
@@ -186,6 +191,7 @@ func TestDeleteJob(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Extensions().Jobs(ns).Delete("foo", nil)
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -221,5 +227,6 @@ func TestCreateJob(t *testing.T) {
 		},
 	}
 	receivedJob, err := c.Setup(t).Extensions().Jobs(ns).Create(requestJob)
+	defer c.Close()
 	c.Validate(t, receivedJob, err)
 }

--- a/pkg/client/unversioned/limit_ranges_test.go
+++ b/pkg/client/unversioned/limit_ranges_test.go
@@ -67,6 +67,7 @@ func TestLimitRangeCreate(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).LimitRanges(ns).Create(limitRange)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -103,6 +104,7 @@ func TestLimitRangeGet(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).LimitRanges(ns).Get("abc")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -126,6 +128,7 @@ func TestLimitRangeList(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: limitRangeList},
 	}
 	response, err := c.Setup(t).LimitRanges(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -157,6 +160,7 @@ func TestLimitRangeUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: limitRange},
 	}
 	response, err := c.Setup(t).LimitRanges(ns).Update(limitRange)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -187,6 +191,7 @@ func TestInvalidLimitRangeUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: limitRange},
 	}
 	_, err := c.Setup(t).LimitRanges(ns).Update(limitRange)
+	defer c.Close()
 	if err == nil {
 		t.Errorf("Expected an error due to missing ResourceVersion")
 	}
@@ -199,6 +204,7 @@ func TestLimitRangeDelete(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).LimitRanges(ns).Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -211,5 +217,6 @@ func TestLimitRangeWatch(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	_, err := c.Setup(t).LimitRanges(api.NamespaceAll).Watch(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/unversioned/namespaces_test.go
+++ b/pkg/client/unversioned/namespaces_test.go
@@ -45,6 +45,7 @@ func TestNamespaceCreate(t *testing.T) {
 
 	// from the source ns, provision a new global namespace "foo"
 	response, err := c.Setup(t).Namespaces().Create(namespace)
+	defer c.Close()
 
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)
@@ -69,6 +70,7 @@ func TestNamespaceGet(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).Namespaces().Get("foo")
+	defer c.Close()
 
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)
@@ -96,6 +98,7 @@ func TestNamespaceList(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: namespaceList},
 	}
 	response, err := c.Setup(t).Namespaces().List(api.ListOptions{})
+	defer c.Close()
 
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)
@@ -132,6 +135,7 @@ func TestNamespaceUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: requestNamespace},
 	}
 	receivedNamespace, err := c.Setup(t).Namespaces().Update(requestNamespace)
+	defer c.Close()
 	c.Validate(t, receivedNamespace, err)
 }
 
@@ -157,6 +161,7 @@ func TestNamespaceFinalize(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: requestNamespace},
 	}
 	receivedNamespace, err := c.Setup(t).Namespaces().Finalize(requestNamespace)
+	defer c.Close()
 	c.Validate(t, receivedNamespace, err)
 }
 
@@ -166,6 +171,7 @@ func TestNamespaceDelete(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Namespaces().Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -178,5 +184,6 @@ func TestNamespaceWatch(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	_, err := c.Setup(t).Namespaces().Watch(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/unversioned/nodes_test.go
+++ b/pkg/client/unversioned/nodes_test.go
@@ -45,6 +45,7 @@ func TestListNodes(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: &api.NodeList{ListMeta: unversioned.ListMeta{ResourceVersion: "1"}}},
 	}
 	response, err := c.Setup(t).Nodes().List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -72,6 +73,7 @@ func TestListNodesLabels(t *testing.T) {
 		},
 	}
 	c.Setup(t)
+	defer c.Close()
 	c.QueryValidator[labelSelectorQueryParamName] = simple.ValidateLabels
 	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
 	options := api.ListOptions{LabelSelector: selector}
@@ -88,12 +90,14 @@ func TestGetNode(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: &api.Node{ObjectMeta: api.ObjectMeta{Name: "node-1"}}},
 	}
 	response, err := c.Setup(t).Nodes().Get("1")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
 func TestGetNodeWithNoName(t *testing.T) {
 	c := &simple.Client{Error: true}
 	receivedNode, err := c.Setup(t).Nodes().Get("")
+	defer c.Close()
 	if (err != nil) && (err.Error() != simple.NameRequiredError) {
 		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
 	}
@@ -127,6 +131,7 @@ func TestCreateNode(t *testing.T) {
 		},
 	}
 	receivedNode, err := c.Setup(t).Nodes().Create(requestNode)
+	defer c.Close()
 	c.Validate(t, receivedNode, err)
 }
 
@@ -139,6 +144,7 @@ func TestDeleteNode(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Nodes().Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -166,5 +172,6 @@ func TestUpdateNode(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: requestNode},
 	}
 	response, err := c.Setup(t).Nodes().Update(requestNode)
+	defer c.Close()
 	c.Validate(t, response, err)
 }

--- a/pkg/client/unversioned/persistentvolume_test.go
+++ b/pkg/client/unversioned/persistentvolume_test.go
@@ -60,6 +60,7 @@ func TestPersistentVolumeCreate(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).PersistentVolumes().Create(pv)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -89,6 +90,7 @@ func TestPersistentVolumeGet(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).PersistentVolumes().Get("abc")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -110,6 +112,7 @@ func TestPersistentVolumeList(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: persistentVolumeList},
 	}
 	response, err := c.Setup(t).PersistentVolumes().List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -133,6 +136,7 @@ func TestPersistentVolumeUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: persistentVolume},
 	}
 	response, err := c.Setup(t).PersistentVolumes().Update(persistentVolume)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -163,6 +167,7 @@ func TestPersistentVolumeStatusUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: persistentVolume},
 	}
 	response, err := c.Setup(t).PersistentVolumes().UpdateStatus(persistentVolume)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -172,6 +177,7 @@ func TestPersistentVolumeDelete(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).PersistentVolumes().Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -184,5 +190,6 @@ func TestPersistentVolumeWatch(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	_, err := c.Setup(t).PersistentVolumes().Watch(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/unversioned/persistentvolumeclaim_test.go
+++ b/pkg/client/unversioned/persistentvolumeclaim_test.go
@@ -64,6 +64,7 @@ func TestPersistentVolumeClaimCreate(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).Create(pv)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -97,6 +98,7 @@ func TestPersistentVolumeClaimGet(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).Get("abc")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -119,6 +121,7 @@ func TestPersistentVolumeClaimList(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: persistentVolumeList},
 	}
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -146,6 +149,7 @@ func TestPersistentVolumeClaimUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
 	}
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).Update(persistentVolumeClaim)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -179,6 +183,7 @@ func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
 	}
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).UpdateStatus(persistentVolumeClaim)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -189,6 +194,7 @@ func TestPersistentVolumeClaimDelete(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).PersistentVolumeClaims(ns).Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -201,5 +207,6 @@ func TestPersistentVolumeClaimWatch(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	_, err := c.Setup(t).PersistentVolumeClaims(api.NamespaceAll).Watch(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/unversioned/pod_templates_test.go
+++ b/pkg/client/unversioned/pod_templates_test.go
@@ -53,6 +53,7 @@ func TestPodTemplateCreate(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).PodTemplates(ns).Create(&podTemplate)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -76,6 +77,7 @@ func TestPodTemplateGet(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).PodTemplates(ns).Get("abc")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -101,6 +103,7 @@ func TestPodTemplateList(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: podTemplateList},
 	}
 	response, err := c.Setup(t).PodTemplates(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -119,6 +122,7 @@ func TestPodTemplateUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: podTemplate},
 	}
 	response, err := c.Setup(t).PodTemplates(ns).Update(podTemplate)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -129,6 +133,7 @@ func TestPodTemplateDelete(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).PodTemplates(ns).Delete("foo", nil)
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -141,5 +146,6 @@ func TestPodTemplateWatch(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	_, err := c.Setup(t).PodTemplates(api.NamespaceAll).Watch(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/unversioned/pods_test.go
+++ b/pkg/client/unversioned/pods_test.go
@@ -37,6 +37,7 @@ func TestListEmptyPods(t *testing.T) {
 		Response: simple.Response{StatusCode: http.StatusOK, Body: &api.PodList{}},
 	}
 	podList, err := c.Setup(t).Pods(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, podList, err)
 }
 
@@ -63,6 +64,7 @@ func TestListPods(t *testing.T) {
 		},
 	}
 	receivedPodList, err := c.Setup(t).Pods(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, receivedPodList, err)
 }
 
@@ -94,6 +96,7 @@ func TestListPodsLabels(t *testing.T) {
 		},
 	}
 	c.Setup(t)
+	defer c.Close()
 	c.QueryValidator[labelSelectorQueryParamName] = simple.ValidateLabels
 	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
 	options := api.ListOptions{LabelSelector: selector}
@@ -121,6 +124,7 @@ func TestGetPod(t *testing.T) {
 		},
 	}
 	receivedPod, err := c.Setup(t).Pods(ns).Get("foo")
+	defer c.Close()
 	c.Validate(t, receivedPod, err)
 }
 
@@ -128,6 +132,7 @@ func TestGetPodWithNoName(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{Error: true}
 	receivedPod, err := c.Setup(t).Pods(ns).Get("")
+	defer c.Close()
 	if (err != nil) && (err.Error() != simple.NameRequiredError) {
 		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
 	}
@@ -142,6 +147,7 @@ func TestDeletePod(t *testing.T) {
 		Response: simple.Response{StatusCode: http.StatusOK},
 	}
 	err := c.Setup(t).Pods(ns).Delete("foo", nil)
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -166,6 +172,7 @@ func TestCreatePod(t *testing.T) {
 		},
 	}
 	receivedPod, err := c.Setup(t).Pods(ns).Create(requestPod)
+	defer c.Close()
 	c.Validate(t, receivedPod, err)
 }
 
@@ -189,6 +196,7 @@ func TestUpdatePod(t *testing.T) {
 		Response: simple.Response{StatusCode: http.StatusOK, Body: requestPod},
 	}
 	receivedPod, err := c.Setup(t).Pods(ns).Update(requestPod)
+	defer c.Close()
 	c.Validate(t, receivedPod, err)
 }
 
@@ -211,6 +219,7 @@ func TestPodGetLogs(t *testing.T) {
 	}
 
 	body, err := c.Setup(t).Pods(ns).GetLogs("podName", opts).Stream()
+	defer c.Close()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/client/unversioned/replication_controllers_test.go
+++ b/pkg/client/unversioned/replication_controllers_test.go
@@ -60,6 +60,7 @@ func TestListControllers(t *testing.T) {
 		},
 	}
 	receivedControllerList, err := c.Setup(t).ReplicationControllers(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, receivedControllerList, err)
 
 }
@@ -86,6 +87,7 @@ func TestGetController(t *testing.T) {
 		},
 	}
 	receivedController, err := c.Setup(t).ReplicationControllers(ns).Get("foo")
+	defer c.Close()
 	c.Validate(t, receivedController, err)
 }
 
@@ -93,6 +95,7 @@ func TestGetControllerWithNoName(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{Error: true}
 	receivedPod, err := c.Setup(t).ReplicationControllers(ns).Get("")
+	defer c.Close()
 	if (err != nil) && (err.Error() != simple.NameRequiredError) {
 		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
 	}
@@ -125,6 +128,7 @@ func TestUpdateController(t *testing.T) {
 		},
 	}
 	receivedController, err := c.Setup(t).ReplicationControllers(ns).Update(requestController)
+	defer c.Close()
 	c.Validate(t, receivedController, err)
 }
 
@@ -156,6 +160,7 @@ func TestUpdateStatusController(t *testing.T) {
 		},
 	}
 	receivedController, err := c.Setup(t).ReplicationControllers(ns).UpdateStatus(requestController)
+	defer c.Close()
 	c.Validate(t, receivedController, err)
 }
 func TestDeleteController(t *testing.T) {
@@ -165,6 +170,7 @@ func TestDeleteController(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).ReplicationControllers(ns).Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -193,5 +199,6 @@ func TestCreateController(t *testing.T) {
 		},
 	}
 	receivedController, err := c.Setup(t).ReplicationControllers(ns).Create(requestController)
+	defer c.Close()
 	c.Validate(t, receivedController, err)
 }

--- a/pkg/client/unversioned/request_test.go
+++ b/pkg/client/unversioned/request_test.go
@@ -241,6 +241,7 @@ func TestRequestBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create temp file")
 	}
+	defer f.Close()
 	os.Remove(f.Name())
 	r = (&Request{}).Body(f.Name())
 	if r.err == nil || r.body != nil {
@@ -943,6 +944,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+	defer file.Close()
 
 	_, err = file.Write(reqBodyExpected)
 	if err != nil {

--- a/pkg/client/unversioned/resource_quotas_test.go
+++ b/pkg/client/unversioned/resource_quotas_test.go
@@ -63,6 +63,7 @@ func TestResourceQuotaCreate(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).ResourceQuotas(ns).Create(resourceQuota)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -95,6 +96,7 @@ func TestResourceQuotaGet(t *testing.T) {
 	}
 
 	response, err := c.Setup(t).ResourceQuotas(ns).Get("abc")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -118,6 +120,7 @@ func TestResourceQuotaList(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: resourceQuotaList},
 	}
 	response, err := c.Setup(t).ResourceQuotas(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -145,6 +148,7 @@ func TestResourceQuotaUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: resourceQuota},
 	}
 	response, err := c.Setup(t).ResourceQuotas(ns).Update(resourceQuota)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -175,6 +179,7 @@ func TestResourceQuotaStatusUpdate(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: resourceQuota},
 	}
 	response, err := c.Setup(t).ResourceQuotas(ns).UpdateStatus(resourceQuota)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -185,6 +190,7 @@ func TestResourceQuotaDelete(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).ResourceQuotas(ns).Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -197,5 +203,6 @@ func TestResourceQuotaWatch(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	_, err := c.Setup(t).ResourceQuotas(api.NamespaceAll).Watch(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/unversioned/services_test.go
+++ b/pkg/client/unversioned/services_test.go
@@ -60,6 +60,7 @@ func TestListServices(t *testing.T) {
 		},
 	}
 	receivedServiceList, err := c.Setup(t).Services(ns).List(api.ListOptions{})
+	defer c.Close()
 	t.Logf("received services: %v %#v", err, receivedServiceList)
 	c.Validate(t, receivedServiceList, err)
 }
@@ -94,6 +95,7 @@ func TestListServicesLabels(t *testing.T) {
 		},
 	}
 	c.Setup(t)
+	defer c.Close()
 	c.QueryValidator[labelSelectorQueryParamName] = simple.ValidateLabels
 	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
 	options := api.ListOptions{LabelSelector: selector}
@@ -111,6 +113,7 @@ func TestGetService(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
 	}
 	response, err := c.Setup(t).Services(ns).Get("1")
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -118,6 +121,7 @@ func TestGetServiceWithNoName(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{Error: true}
 	receivedPod, err := c.Setup(t).Services(ns).Get("")
+	defer c.Close()
 	if (err != nil) && (err.Error() != simple.NameRequiredError) {
 		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
 	}
@@ -136,6 +140,7 @@ func TestCreateService(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
 	}
 	response, err := c.Setup(t).Services(ns).Create(&api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}})
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -147,6 +152,7 @@ func TestUpdateService(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, Body: svc},
 	}
 	response, err := c.Setup(t).Services(ns).Update(svc)
+	defer c.Close()
 	c.Validate(t, response, err)
 }
 
@@ -157,6 +163,7 @@ func TestDeleteService(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Services(ns).Delete("1")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -172,6 +179,7 @@ func TestServiceProxyGet(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, RawBody: &body},
 	}
 	response, err := c.Setup(t).Services(ns).ProxyGet("", "service-1", "", "foo", map[string]string{"param-name": "param-value"}).DoRaw()
+	defer c.Close()
 	c.ValidateRaw(t, response, err)
 
 	// With scheme and port specified
@@ -184,5 +192,6 @@ func TestServiceProxyGet(t *testing.T) {
 		Response: simple.Response{StatusCode: 200, RawBody: &body},
 	}
 	response, err = c.Setup(t).Services(ns).ProxyGet("https", "service-1", "my-port", "foo", map[string]string{"param-name": "param-value"}).DoRaw()
+	defer c.Close()
 	c.ValidateRaw(t, response, err)
 }

--- a/pkg/client/unversioned/testclient/simple/simple_testclient.go
+++ b/pkg/client/unversioned/testclient/simple/simple_testclient.go
@@ -91,6 +91,12 @@ func (c *Client) Setup(t *testing.T) *Client {
 	return c
 }
 
+func (c *Client) Close() {
+	if c.server != nil {
+		c.server.Close()
+	}
+}
+
 func (c *Client) ServerURL() string {
 	return c.server.URL
 }
@@ -112,8 +118,6 @@ func (c *Client) ValidateRaw(t *testing.T, received []byte, err error) {
 }
 
 func (c *Client) ValidateCommon(t *testing.T, err error) {
-	defer c.server.Close()
-
 	if c.Error {
 		if err == nil {
 			t.Errorf("error expected for %#v, got none", c.Request)

--- a/pkg/client/unversioned/thirdpartyresources_test.go
+++ b/pkg/client/unversioned/thirdpartyresources_test.go
@@ -55,6 +55,7 @@ func TestListThirdPartyResources(t *testing.T) {
 		},
 	}
 	receivedDSs, err := c.Setup(t).Extensions().ThirdPartyResources(ns).List(api.ListOptions{})
+	defer c.Close()
 	c.Validate(t, receivedDSs, err)
 
 }
@@ -78,6 +79,7 @@ func TestGetThirdPartyResource(t *testing.T) {
 		},
 	}
 	receivedThirdPartyResource, err := c.Setup(t).Extensions().ThirdPartyResources(ns).Get("foo")
+	defer c.Close()
 	c.Validate(t, receivedThirdPartyResource, err)
 }
 
@@ -85,6 +87,7 @@ func TestGetThirdPartyResourceWithNoName(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{Error: true}
 	receivedPod, err := c.Setup(t).Extensions().ThirdPartyResources(ns).Get("")
+	defer c.Close()
 	if (err != nil) && (err.Error() != simple.NameRequiredError) {
 		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
 	}
@@ -114,6 +117,7 @@ func TestUpdateThirdPartyResource(t *testing.T) {
 		},
 	}
 	receivedThirdPartyResource, err := c.Setup(t).Extensions().ThirdPartyResources(ns).Update(requestThirdPartyResource)
+	defer c.Close()
 	c.Validate(t, receivedThirdPartyResource, err)
 }
 
@@ -139,6 +143,7 @@ func TestUpdateThirdPartyResourceUpdateStatus(t *testing.T) {
 		},
 	}
 	receivedThirdPartyResource, err := c.Setup(t).Extensions().ThirdPartyResources(ns).UpdateStatus(requestThirdPartyResource)
+	defer c.Close()
 	c.Validate(t, receivedThirdPartyResource, err)
 }
 
@@ -149,6 +154,7 @@ func TestDeleteThirdPartyResource(t *testing.T) {
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Extensions().ThirdPartyResources(ns).Delete("foo")
+	defer c.Close()
 	c.Validate(t, nil, err)
 }
 
@@ -174,5 +180,6 @@ func TestCreateThirdPartyResource(t *testing.T) {
 		},
 	}
 	receivedThirdPartyResource, err := c.Setup(t).Extensions().ThirdPartyResources(ns).Create(requestThirdPartyResource)
+	defer c.Close()
 	c.Validate(t, receivedThirdPartyResource, err)
 }


### PR DESCRIPTION
Follow-up to #18249.

Unlike that one, though, keeping all test http servers closed will be a challenge. Very few were being closed here, so there probably are some open PRs out there which add more tests that don't close their test servers properly.

The issue is that the test server is created under the hood in the `c.Setup(t)` call, so it may not be obvious that one must do `defer c.server.Close()` right after it.

The good news is that this is easy to test. You just have to enter the `pkg/client/unversioned` package and run:

``` sh
ulimit -n 20
godep go test -count=100
```

If any of the tests left something open, it will surely pile up and reach the open file limit. I wonder if we could include this as part of CI, at least for very error-prone packages that make heavy use of test servers like `pkg/client/unversioned`.
