### PR TITLE
Fixed the Dockerfile for building redis image

### DIFF
--- a/examples/redis/image/Dockerfile
+++ b/examples/redis/image/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get install -yy -q python
 COPY redis-master.conf /redis-master/redis.conf
 COPY redis-slave.conf /redis-slave/redis.conf
 COPY run.sh /run.sh
-COPY sentinel.py /sentinel.py
 
 CMD [ "/run.sh" ]
 ENTRYPOINT [ "sh", "-c" ]


### PR DESCRIPTION
The Dockerfile copies a non-existent file, which fails the image
building process. As a result, the built image is incomplete. This
seems to be the reason why the redis example doesn't work (because
the docker image kubernetes/redis:v1 is incorrectly built).
