### PR TITLE
Remove periodSeconds, unavailable in 1.1

### DIFF
--- a/cluster/addons/cluster-loadbalancing/glbc/glbc-controller.yaml
+++ b/cluster/addons/cluster-loadbalancing/glbc/glbc-controller.yaml
@@ -52,8 +52,6 @@ spec:
             port: 8081
             scheme: HTTP
           initialDelaySeconds: 30
-          # healthz reaches out to GCE
-          periodSeconds: 30
           timeoutSeconds: 5
         name: l7-lb-controller
         resources:


### PR DESCRIPTION
Didn't realize "periodSeconds" is from: https://github.com/kubernetes/kubernetes/commit/1e88a682da871a4a7f811dc5efcfe3890be8bbf8, which is not in 1.1. So currently the gke-e2e cluster doesn't even start the loadbalancer controller.
