### PR TITLE
100% noninclusive upper bound for CPUUtilization target to avoid user…

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -72,6 +72,8 @@ func (a *HorizontalController) computeReplicasForCPUUtilization(hpa extensions.H
 		// Since we always take maximum number of replicas from all policies it is safe
 		// to just return 0.
 		return 0, nil, time.Time{}, nil
+	} else if hpa.Spec.CPUUtilization.TargetPercentage >= 100 {
+		glog.Errorf("CPUUtilization is too high, %v, high demand scenarios will not breach utilization threshold, and thus, they won't scale", hpa.Spec.CPUUtilization.TargetPercentage)
 	}
 	currentReplicas := scale.Status.Replicas
 	currentUtilization, timestamp, err := a.metricsClient.GetCPUUtilization(hpa.Namespace, scale.Status.Selector)


### PR DESCRIPTION
…-error that might lead to a scale starvation scenario.   (subsumes #18291) .  @Szczepkowski (or anyone else who worked on the HPA pod spec) to review as he wrote this part of the spec in the docs/design/horizontal-pod-autoscaler.md file . 

The scenario this attempts to flag out by error logging.
1. pod cpu utilization goal > pod resources (i.e. target defined as 50%, but podspec only requests 25%)
2. pod starts to scale up. but only scales to 25% usage.
3. pod gets flooded w/ requests, needs more CPU, but stays below 50%.
4. HPA doesn't add new pods : because the CPU target is never breached.
