### PR TITLE
kubectl: Optimize job reaper

### DIFF
--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -306,9 +306,8 @@ func TestJobStop(t *testing.T) {
 					},
 				},
 			},
-			StopError: nil,
-			ExpectedActions: []string{"get:jobs", "get:jobs", "update:jobs",
-				"get:jobs", "get:jobs", "list:pods", "delete:jobs"},
+			StopError:       nil,
+			ExpectedActions: []string{"get:jobs", "delete:jobs", "list:pods"},
 		},
 		{
 			Name: "JobWithDeadPods",
@@ -353,9 +352,8 @@ func TestJobStop(t *testing.T) {
 					},
 				},
 			},
-			StopError: nil,
-			ExpectedActions: []string{"get:jobs", "get:jobs", "update:jobs",
-				"get:jobs", "get:jobs", "list:pods", "delete:pods", "delete:jobs"},
+			StopError:       nil,
+			ExpectedActions: []string{"get:jobs", "delete:jobs", "list:pods", "delete:pods"},
 		},
 	}
 


### PR DESCRIPTION
Remove scaling of the job since it is redundant. Makes the whole job
deletion process via the cli faster. Deleting a job with 20 pods that
involves scaling (note: of its parallelism) takes from ~4-5s up to ~16s
whereas deletion with the same number of pods that doesn't involve
scaling takes from ~3s up to ~7s on the same machine. This is because
scaling additionally involves a GET, a PUT, and at least two more GETs
in the case of a deletion.

sample: http://pastebin.com/1CW9NS9J

@soltysh @kubernetes/kubectl 

Found out while working on https://github.com/kubernetes/kubernetes/pull/18169
