### PR TITLE
kubernetes-build job configs

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-build.yaml
+++ b/hack/jenkins/job-configs/kubernetes-build.yaml
@@ -1,0 +1,65 @@
+- job-template:
+    name: 'kubernetes-{build}'
+    description: 'Grab the latest from GitHub, build. Test owner: Build Cop.'
+    logrotate:
+        numToKeep: 200
+    builders:
+        - shell: './hack/jenkins/build.sh'
+    properties:
+        # Mail Watcher Plugin alerts the specified address whenever a job config is updated or deleted.
+        - raw:
+            xml: |
+                <org.jenkinsci.plugins.mailwatcher.WatcherJobProperty plugin="mail-watcher-plugin@1.13">
+                    <watcherAddresses>cloud-kubernetes-team@google.com</watcherAddresses>
+                </org.jenkinsci.plugins.mailwatcher.WatcherJobProperty>
+    publishers:
+        - claim-build
+        - email-ext:
+            recipients: $DEFAULT_RECIPIENTS, cloud-kubernetes-team@google.com
+            presend-script: $DEFAULT_PRESEND_SCRIPT
+            fail: true
+            fixed: true
+            send-to:
+                - culprits
+                - recipients
+        - google-cloud-storage:
+            credentials-id: kubernetes-jenkins
+            uploads:
+                - build-log:
+                    log-name: build-log.txt
+                    storage-location: gs://kubernetes-jenkins/logs/$JOB_NAME/$BUILD_NUMBER
+                    share-publicly: true
+                    upload-for-failed-jobs: true
+        - logparser:
+            parse-rules: /jenkins-master-data/log_parser_rules.txt
+            unstable-on-warning: false
+            fail-on-error: false
+    scm:
+        - git:
+            url: https://github.com/kubernetes/kubernetes
+            branches:
+                - '{branch}'
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/kubernetes
+            wipe-workspace: false
+            skip-tag: true
+    triggers:
+        - pollscm:
+            cron: 'H/2 * * * *'
+    wrappers:
+        - timeout:
+            timeout: 30
+            abort: true
+        - timestamps
+
+- project:
+    name: kubernetes-builds
+    build:
+        - 'build':
+            branch: 'master'
+        - 'build-1.0':
+            branch: 'release-1.0'
+        - 'build-1.1':
+            branch: 'release-1.1'
+    jobs:
+        - 'kubernetes-{build}'

--- a/hack/jenkins/job-configs/kubernetes-update-jenkins-jobs.yaml
+++ b/hack/jenkins/job-configs/kubernetes-update-jenkins-jobs.yaml
@@ -1,9 +1,9 @@
 - job:
     name: kubernetes-update-jenkins-jobs
-    description: "Update Jenkins jobs"
+    description: 'Update Jenkins jobs'
 
     triggers:
-        - timed: "H/15 * * * *"
+        - timed: 'H/15 * * * *'
 
     builders:
-        - shell: "curl -fsS https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/update-jobs.sh | /bin/bash -"
+        - shell: 'curl -fsS https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/update-jobs.sh | /bin/bash -'

--- a/hack/jenkins/update-jobs.sh
+++ b/hack/jenkins/update-jobs.sh
@@ -42,4 +42,4 @@ fi
 
 docker exec job-builder git checkout master
 docker exec job-builder git pull
-docker exec job-builder jenkins-jobs test ${config_dir}
+docker exec job-builder jenkins-jobs update ${config_dir}


### PR DESCRIPTION
This is all three kubernetes-build jobs currently running in Jenkins, specified in a YAML file for Jenkins Job Builder to manage. The only real restriction on style is that fields that will have variable substitution from JJB should be quoted, such as `name: 'kubernetes-{build}'`.

~~Please do not merge until #17996 is merged.~~ I've backed up the current `config.xml` for these three and I can revert this if something breaks. I've also tested the new 1.0 build config in Jenkins and it passed. The diff between these and the old configs is nearly invisible from the configure job page on Jenkins, and minor in terms of the generated XML. The only config change is that I have all three poll every two minutes, instead of every hour for the release builds and every two minutes for the master build. That's simple to change back if necessary, but it should be cheap.

@ixdy should the branch be of the form `master`, `*/master`, or `refs/heads/master`? Right now I've got it set to the first, but the second is what's in Jenkins, and the third is what Jenkins recommends.

@kubernetes/goog-testing #18122 
