### PR TITLE
WIP: Add kubectl diff <pod> -c container command

### DIFF
--- a/pkg/client/unversioned/pods.go
+++ b/pkg/client/unversioned/pods.go
@@ -38,6 +38,8 @@ type PodInterface interface {
 	Bind(binding *api.Binding) error
 	UpdateStatus(pod *api.Pod) (*api.Pod, error)
 	GetLogs(name string, opts *api.PodLogOptions) *Request
+	// TODO: need a podDiffOptions
+	GetDiff(name string, opts *api.PodLogOptions) *Request
 }
 
 // pods implements PodsNamespacer interface
@@ -120,4 +122,9 @@ func (c *pods) UpdateStatus(pod *api.Pod) (result *api.Pod, err error) {
 // Get constructs a request for getting the logs for a pod
 func (c *pods) GetLogs(name string, opts *api.PodLogOptions) *Request {
 	return c.r.Get().Namespace(c.ns).Name(name).Resource("pods").SubResource("log").VersionedParams(opts, api.Scheme)
+}
+
+// Get constructs a request for getting the diff for a pod
+func (c *pods) GetDiff(name string, opts *api.PodLogOptions) *Request {
+	return c.r.Get().Namespace(c.ns).Name(name).Resource("pods").SubResource("diff").VersionedParams(opts, api.Scheme)
 }

--- a/pkg/client/unversioned/testclient/fake_pods.go
+++ b/pkg/client/unversioned/testclient/fake_pods.go
@@ -116,3 +116,15 @@ func (c *FakePods) GetLogs(name string, opts *api.PodLogOptions) *client.Request
 	_, _ = c.Fake.Invokes(action, &api.Pod{})
 	return &client.Request{}
 }
+
+func (c *FakePods) GetDiff(name string, opts *api.PodLogOptions) *client.Request {
+	action := GenericActionImpl{}
+	action.Verb = "get"
+	action.Namespace = c.Namespace
+	action.Resource = "pod"
+	action.Subresource = "diff"
+	action.Value = opts
+
+	_, _ = c.Fake.Invokes(action, &api.Pod{})
+	return &client.Request{}
+}

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -159,6 +159,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 
 	cmds.AddCommand(NewCmdNamespace(out))
 	cmds.AddCommand(NewCmdLogs(f, out))
+	cmds.AddCommand(NewCmdDiff(f, out))
 	cmds.AddCommand(NewCmdRollingUpdate(f, out))
 	cmds.AddCommand(NewCmdScale(f, out))
 

--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"io"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+const (
+	diff_example = `# Inspect filesystem changes for the only container in pod nginx
+$ kubectl diff nginx
+
+# Inspect filesystem changes for the ruby container in the pod web-1
+$ kubectl diff -c ruby web-1`
+)
+
+type DiffOptions struct {
+	Namespace   string
+	ResourceArg string
+	Options     runtime.Object
+
+	Mapper       meta.RESTMapper
+	Typer        runtime.ObjectTyper
+	ClientMapper resource.ClientMapper
+
+	DiffForObject func(object, options runtime.Object) (*client.Request, error)
+
+	Out io.Writer
+}
+
+// NewCmdDiff creates a new pod logs command
+func NewCmdDiff(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+	o := &DiffOptions{}
+	cmd := &cobra.Command{
+		Use:     "diff POD [-c CONTAINER]",
+		Short:   "Inspect the filesystem changes for a container in a pod.",
+		Long:    "Inspect the filesystem changes for a container in a pod.  If the pod has only one container, the container name is optional.",
+		Example: diff_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, out, cmd, args))
+			if err := o.Validate(); err != nil {
+				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))
+			}
+			_, err := o.RunDiff()
+			cmdutil.CheckErr(err)
+		},
+		Aliases: []string{"diff"},
+	}
+	cmd.Flags().StringP("container", "c", "", "Print the logs of this container")
+	return cmd
+}
+
+func (o *DiffOptions) Complete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	//containerName := cmdutil.GetFlagString(cmd, "container")
+	switch len(args) {
+	case 0:
+		return cmdutil.UsageError(cmd, "POD is required for diff")
+	case 1:
+		o.ResourceArg = args[0]
+	case 2:
+		if cmd.Flag("container").Changed {
+			return cmdutil.UsageError(cmd, "only one of -c, [CONTAINER] arg is allowed")
+		}
+		o.ResourceArg = args[0]
+		//containerName = args[1]
+	default:
+		return cmdutil.UsageError(cmd, "diff POD [-c CONTAINER]")
+	}
+	var err error
+	o.Namespace, _, err = f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	// TODO need a pod diff options object
+	diffOptions := &api.PodLogOptions{}
+	o.Options = diffOptions
+	o.Mapper, o.Typer = f.Object()
+	o.ClientMapper = f.ClientMapperForCommand()
+	o.DiffForObject = f.DiffForObject
+	o.Out = out
+	return nil
+}
+
+func (o DiffOptions) Validate() error {
+	if len(o.ResourceArg) == 0 {
+		return errors.New("a pod must be specified")
+	}
+	// TODO: need a diff options
+	/*
+		logsOptions, ok := o.Options.(*api.PodLogOptions)
+		if !ok {
+			return errors.New("unexpected diff options object")
+		}
+		if errs := validation.ValidatePodLogOptions(logsOptions); len(errs) > 0 {
+			return errs.ToAggregate()
+		}
+	*/
+	return nil
+}
+
+// RunDiff retrieves a pod diff
+func (o DiffOptions) RunDiff() (int64, error) {
+	infos, err := resource.NewBuilder(o.Mapper, o.Typer, o.ClientMapper).
+		NamespaceParam(o.Namespace).DefaultNamespace().
+		ResourceNames("pods", o.ResourceArg).
+		SingleResourceType().
+		Do().Infos()
+	if err != nil {
+		return 0, err
+	}
+	if len(infos) != 1 {
+		return 0, errors.New("expected a resource")
+	}
+	info := infos[0]
+
+	req, err := o.DiffForObject(info.Object, o.Options)
+	if err != nil {
+		return 0, err
+	}
+
+	readCloser, err := req.Stream()
+	if err != nil {
+		return 0, err
+	}
+	defer readCloser.Close()
+
+	return io.Copy(o.Out, readCloser)
+}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -86,6 +86,8 @@ type Factory struct {
 	LabelsForObject func(object runtime.Object) (map[string]string, error)
 	// LogsForObject returns a request for the logs associated with the provided object
 	LogsForObject func(object, options runtime.Object) (*client.Request, error)
+	// DiffForObject returns a request for the diff associated with the provided object
+	DiffForObject func(object, options runtime.Object) (*client.Request, error)
 	// Returns a schema that can validate objects stored on disk.
 	Validator func(validate bool, cacheDir string) (validation.Schema, error)
 	// Returns the default namespace to use in cases where no
@@ -239,6 +241,27 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 					return nil, errors.New("provided options object is not a PodLogOptions")
 				}
 				return c.Pods(t.Namespace).GetLogs(t.Name, opts), nil
+			default:
+				_, kind, err := api.Scheme.ObjectVersionAndKind(object)
+				if err != nil {
+					return nil, err
+				}
+				return nil, fmt.Errorf("cannot get the logs from %s", kind)
+			}
+		},
+		DiffForObject: func(object, options runtime.Object) (*client.Request, error) {
+			c, err := clients.ClientForVersion("")
+			if err != nil {
+				return nil, err
+			}
+
+			switch t := object.(type) {
+			case *api.Pod:
+				opts, ok := options.(*api.PodLogOptions)
+				if !ok {
+					return nil, errors.New("provided options object is not a PodLogOptions")
+				}
+				return c.Pods(t.Namespace).GetDiff(t.Name, opts), nil
 			default:
 				_, kind, err := api.Scheme.ObjectVersionAndKind(object)
 				if err != nil {

--- a/pkg/kubelet/container/fake_runtime.go
+++ b/pkg/kubelet/container/fake_runtime.go
@@ -285,6 +285,14 @@ func (f *FakeRuntime) RunInContainer(containerID ContainerID, cmd []string) ([]b
 	return []byte{}, f.Err
 }
 
+func (f *FakeRuntime) DiffContainer(id ContainerID) ([]byte, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	f.CalledFunctions = append(f.CalledFunctions, "DiffContainer")
+	return []byte{}, f.Err
+}
+
 func (f *FakeRuntime) GetContainerLogs(pod *api.Pod, containerID ContainerID, logOptions *api.PodLogOptions, stdout, stderr io.Writer) (err error) {
 	f.Lock()
 	defer f.Unlock()

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -125,10 +125,15 @@ type Runtime interface {
 	ContainerCommandRunner
 	// ContainerAttach encapsulates the attaching to containers for testability
 	ContainerAttacher
+	ContainerDiffer
 }
 
 type ContainerAttacher interface {
 	AttachContainer(id ContainerID, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) (err error)
+}
+
+type ContainerDiffer interface {
+	DiffContainer(id ContainerID) ([]byte, error)
 }
 
 // CommandRunner encapsulates the command runner interfaces for testability.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -58,6 +58,7 @@ const (
 type DockerInterface interface {
 	ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error)
 	InspectContainer(id string) (*docker.Container, error)
+	ContainerChanges(id string) ([]docker.Change, error)
 	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error
 	StopContainer(id string, timeout uint) error

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -213,6 +213,17 @@ func (f *FakeDockerClient) InspectContainer(id string) (*docker.Container, error
 	return nil, err
 }
 
+// InspectContainer is a test-spy implementation of DockerInterface.InspectContainer.
+// It adds an entry "inspect" to the internal method call record.
+func (f *FakeDockerClient) ContainerChanges(id string) ([]docker.Change, error) {
+	f.Lock()
+	defer f.Unlock()
+	f.called = append(f.called, "diff_container")
+	err := f.popError("diff_container")
+	// TODO: is something better needed here
+	return nil, err
+}
+
 // InspectImage is a test-spy implementation of DockerInterface.InspectImage.
 // It adds an entry "inspect" to the internal method call record.
 func (f *FakeDockerClient) InspectImage(name string) (*docker.Image, error) {

--- a/pkg/kubelet/dockertools/instrumented_docker.go
+++ b/pkg/kubelet/dockertools/instrumented_docker.go
@@ -55,6 +55,15 @@ func (in instrumentedDockerInterface) ListContainers(options docker.ListContaine
 	return out, err
 }
 
+func (in instrumentedDockerInterface) ContainerChanges(id string) ([]docker.Change, error) {
+	const operation = "diff_container"
+	defer recordOperation(operation, time.Now())
+
+	out, err := in.client.ContainerChanges(id)
+	recordError(operation, err)
+	return out, err
+}
+
 func (in instrumentedDockerInterface) InspectContainer(id string) (*docker.Container, error) {
 	const operation = "inspect_container"
 	defer recordOperation(operation, time.Now())

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -1023,6 +1023,19 @@ func (dm *DockerManager) runInContainerUsingNsinit(containerID kubecontainer.Con
 	return c.CombinedOutput()
 }
 
+func (dm *DockerManager) DiffContainer(containerID kubecontainer.ContainerID) ([]byte, error) {
+	changes, err := dm.client.ContainerChanges(containerID.ID)
+	if err != nil {
+		return nil, err
+	}
+	// TODO make this better
+	result := ""
+	for _, change := range changes {
+		result = result + change.String() + "\n"
+	}
+	return []byte(result), nil
+}
+
 // RunInContainer uses nsinit to run the command inside the container identified by containerID
 func (dm *DockerManager) RunInContainer(containerID kubecontainer.ContainerID, cmd []string) ([]byte, error) {
 	// If native exec support does not exist in the local docker daemon use nsinit.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3186,6 +3186,20 @@ func (kl *Kubelet) findContainer(podFullName string, podUID types.UID, container
 	return pod.FindContainerByName(containerName), nil
 }
 
+// TODO
+func (kl *Kubelet) DiffContainer(podFullName string, podUID types.UID, containerName string) ([]byte, error) {
+	podUID = kl.podManager.TranslatePodUID(podUID)
+	container, err := kl.findContainer(podFullName, podUID, containerName)
+	if err != nil {
+		return nil, err
+	}
+	if container == nil {
+		return nil, fmt.Errorf("container not found (%q)", containerName)
+	}
+
+	return kl.containerRuntime.DiffContainer(container.ID)
+}
+
 // Run a command in a container, returns the combined stdout, stderr as an array of bytes
 func (kl *Kubelet) RunInContainer(podFullName string, podUID types.UID, containerName string, cmd []string) ([]byte, error) {
 	podUID = kl.podManager.TranslatePodUID(podUID)

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1105,6 +1105,11 @@ func (r *Runtime) RunInContainer(containerID kubecontainer.ContainerID, cmd []st
 	return result, err
 }
 
+// TODO: do this
+func (r *Runtime) DiffContainer(id kubecontainer.ContainerID) ([]byte, error) {
+	return nil, fmt.Errorf("NOT SUPPORTED")
+}
+
 // rktExitError implemets /pkg/util/exec.ExitError interface.
 type rktExitError struct{ *exec.ExitError }
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -577,6 +577,7 @@ func (m *Master) init(c *Config) {
 		"pods/attach":      podStorage.Attach,
 		"pods/status":      podStorage.Status,
 		"pods/log":         podStorage.Log,
+		"pods/diff":        podStorage.Diff,
 		"pods/exec":        podStorage.Exec,
 		"pods/portforward": podStorage.PortForward,
 		"pods/proxy":       podStorage.Proxy,

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -48,6 +48,7 @@ type PodStorage struct {
 	Exec        *podrest.ExecREST
 	Attach      *podrest.AttachREST
 	PortForward *podrest.PortForwardREST
+	Diff        *podrest.DiffREST
 }
 
 // REST implements a RESTStorage for pods against etcd
@@ -106,6 +107,7 @@ func NewStorage(
 		Exec:        &podrest.ExecREST{Store: store, KubeletConn: k},
 		Attach:      &podrest.AttachREST{Store: store, KubeletConn: k},
 		PortForward: &podrest.PortForwardREST{Store: store, KubeletConn: k},
+		Diff:        &podrest.DiffREST{Store: store, KubeletConn: k},
 	}
 }
 


### PR DESCRIPTION
Add a `kubectl diff` command to let you inspect the filesystem changes made to a container in a pod.  This basically lets you see the equivalent of `docker diff` which is useful to see what has mutated from the COW filesystem from the base image.  

Good for debugging problems around the downward API, secrets, etc.

**Terminal 1**

``` shell
cluster/kubectl.sh run -i --tty busybox --image=busybox --restart=Never
Waiting for pod default/busybox-yxmx9 to be running, status is Pending, pod ready: false
Waiting for pod default/busybox-yxmx9 to be running, status is Pending, pod ready: false

Hit enter for command prompt

/ # touch derek.is.awesome
/ # 
```

**Terminal 2**

``` shell
$ cluster/kubectl.sh diff busybox-yxmx9
A /derek.is.awesome
A /run
A /run/secrets
C /var
A /var/run
A /var/run/secrets
A /var/run/secrets/kubernetes.io
A /var/run/secrets/kubernetes.io/serviceaccount
C /root
A /root/.ash_history
```

@smarterclayton @bgrant0607 @kubernetes/rh-cluster-infra @kubernetes/kubectl 
