### PR TITLE
Fix bug when getting old RCs of a deployment

### DIFF
--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -61,7 +61,11 @@ func GetOldRCs(deployment extensions.Deployment, c client.Interface) ([]*api.Rep
 		}
 	}
 	requiredRCs := []*api.ReplicationController{}
-	for _, value := range oldRCs {
+	// Note that go reuses the same memory location for every iteration,
+	// which means the 'value' returned from range will have the same address.
+	// Therefore, we should use the returned 'index' instead.
+	for i := range oldRCs {
+		value := oldRCs[i]
 		requiredRCs = append(requiredRCs, &value)
 	}
 	return requiredRCs, nil


### PR DESCRIPTION
Deployment has be acting unexpectedly for certain cases. Hunted down the failed cases and found that there's a bug when getting old RCs. Fix the bug that `GetOldRCs` returns a list of the same old RC incorrectly (because `range` reuses the same memory location). 

cc @lavalamp @nikhiljindal @kubernetes/sig-config 
