### PR TITLE
WIP: Run master in an ASG

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -77,9 +77,9 @@ POLL_SLEEP_INTERVAL=3
 SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET
 CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.244.0.0/16}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
-# If set to Elastic IP, master instance will be associated with this IP.
-# If set to auto, a new Elastic IP will be acquired
-# Otherwise amazon-given public ip will be used (it'll change with reboot).
+# If set to an Elastic IP address, master instance will be associated with this IP.
+# Otherwise a new Elastic IP will be acquired
+# (We used to accept 'auto' to mean 'allocate elastic ip', but now that is the default)
 MASTER_RESERVED_IP="${MASTER_RESERVED_IP:-}"
 
 # Runtime config

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -75,9 +75,9 @@ POLL_SLEEP_INTERVAL=3
 SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET
 CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.245.0.0/16}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
-# If set to Elastic IP, master instance will be associated with this IP.
-# If set to auto, a new Elastic IP will be acquired
-# Otherwise amazon-given public ip will be used (it'll change with reboot).
+# If set to an Elastic IP address, master instance will be associated with this IP.
+# Otherwise a new Elastic IP will be acquired
+# (We used to accept 'auto' to mean 'allocate elastic ip', but now that is the default)
 MASTER_RESERVED_IP="${MASTER_RESERVED_IP:-}"
 RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 

--- a/cluster/aws/templates/install-release.sh
+++ b/cluster/aws/templates/install-release.sh
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Download release
+# Untar downloaded files & install release
 
-echo "Downloading binary release tar ($SERVER_BINARY_TAR_URL)"
-download-or-bust "$SERVER_BINARY_TAR_URL"
+echo "Unpacking Salt tree"
+rm -rf kubernetes
+tar xzf "${SALT_TAR_URL##*/}"
 
-echo "Downloading binary release tar ($SALT_TAR_URL)"
-download-or-bust "$SALT_TAR_URL"
+echo "Running release install script"
+sudo kubernetes/saltbase/install.sh "${SERVER_BINARY_TAR_URL##*/}"

--- a/cluster/aws/templates/master-bootstrap.sh
+++ b/cluster/aws/templates/master-bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 The Kubernetes Authors All rights reserved.
+# Copyright 2015 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Download release
+echo "Extracting & running kube-bootstrap"
+rm -f kube-bootstrap
+tar xzf "${SERVER_BINARY_TAR_URL##*/}" --strip-components=3 kubernetes/server/bin/kube-bootstrap
 
-echo "Downloading binary release tar ($SERVER_BINARY_TAR_URL)"
-download-or-bust "$SERVER_BINARY_TAR_URL"
+mkdir -p /etc/kubernetes/
+echo "${BOOTSTRAP_JSON}" >/etc/kubernetes/bootstrap.json
 
-echo "Downloading binary release tar ($SALT_TAR_URL)"
-download-or-bust "$SALT_TAR_URL"
+./kube-bootstrap --config /etc/kubernetes/bootstrap.json

--- a/cluster/aws/templates/salt-master.sh
+++ b/cluster/aws/templates/salt-master.sh
@@ -44,6 +44,7 @@ env_to_salt docker_root
 env_to_salt kubelet_root
 env_to_salt master_extra_sans
 env_to_salt runtime_config
+env_to_salt advertise_address
 
 # Auto accept all keys from minions that try to join
 mkdir -p /etc/salt/master.d

--- a/cluster/aws/templates/setup-master-pd.sh
+++ b/cluster/aws/templates/setup-master-pd.sh
@@ -14,27 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Format and mount the disk, create directories on it for all of the master's
+# Create directories on the master disk for all the master's
 # persistent data, and link them to where they're used.
-
-echo "Waiting for master pd to be attached"
-attempt=0
-while true; do
-  echo Attempt "$(($attempt+1))" to check for /dev/xvdb
-  if [[ -e /dev/xvdb ]]; then
-    echo "Found /dev/xvdb"
-    break
-  fi
-  attempt=$(($attempt+1))
-  sleep 1
-done
-
-# Mount Master Persistent Disk
-echo "Mounting master-pd"
-mkdir -p /mnt/master-pd
-mkfs -t ext4 /dev/xvdb
-echo "/dev/xvdb  /mnt/master-pd  ext4  noatime  0 0" >> /etc/fstab
-mount /mnt/master-pd
 
 # Contains all the data stored in etcd
 mkdir -m 700 -p /mnt/master-pd/var/etcd

--- a/cmd/kube-bootstrap/app/plugins.go
+++ b/cmd/kube-bootstrap/app/plugins.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+// This file exists to force the desired plugin implementations to be linked.
+import (
+	//Cloud providers
+	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+)

--- a/cmd/kube-bootstrap/app/server.go
+++ b/cmd/kube-bootstrap/app/server.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app does all of the work necessary to configure and run a
+// Kubernetes app process.
+package app
+
+import (
+	"k8s.io/kubernetes/pkg/bootstrap"
+
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+)
+
+// BootstrapServerConfig contains configures and runs a Kubernetes proxy server
+type BootstrapServerConfig struct {
+	ConfigFile string
+}
+
+type BootstrapServer struct {
+	Config       *BootstrapServerConfig
+	Bootstrapper *bootstrap.Bootstrapper
+}
+
+// AddFlags adds flags for a specific BootstrapServer to the specified FlagSet
+func (s *BootstrapServerConfig) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&s.ConfigFile, "config", s.ConfigFile, "The path to the configuration file.")
+}
+
+func NewBootstrapServerConfig() *BootstrapServerConfig {
+	return &BootstrapServerConfig{
+		ConfigFile: "/etc/kubernetes/config",
+	}
+}
+
+func NewBootstrapServer(config *BootstrapServerConfig, bootstrapper *bootstrap.Bootstrapper) (*BootstrapServer, error) {
+	return &BootstrapServer{
+		Config:       config,
+		Bootstrapper: bootstrapper,
+	}, nil
+}
+
+// NewBootstrapServerDefault creates a new BootstrapServer BootstrapServer with default parameters.
+func NewBootstrapServerDefault(config *BootstrapServerConfig) (*BootstrapServer, error) {
+	bootstrapper := bootstrap.NewBootstrapper(config.ConfigFile)
+	return NewBootstrapServer(config, bootstrapper)
+}
+
+// Run runs the specified BootstrapServer, which bootstraps the machine.
+// If it encounters an error, it will sleep and retry.
+// Thus on exit the bootstrap has succeeded.
+func (s *BootstrapServer) Run(_ []string) error {
+	for {
+		err := s.Bootstrapper.RunOnce()
+		if err == nil {
+			return nil
+		}
+		glog.Warningf("error during bootstrapping (will sleep and retry): %v", err)
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/cmd/kube-bootstrap/bootstrap.go
+++ b/cmd/kube-bootstrap/bootstrap.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"k8s.io/kubernetes/cmd/kube-bootstrap/app"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/version/verflag"
+
+	"github.com/spf13/pflag"
+)
+
+func main() {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	config := app.NewBootstrapServerConfig()
+	config.AddFlags(pflag.CommandLine)
+
+	util.InitFlags()
+	util.InitLogs()
+	defer util.FlushLogs()
+
+	verflag.PrintAndExitIfRequested()
+
+	s, err := app.NewBootstrapServerDefault(config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	if err = s.Run(pflag.CommandLine.Args()); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -30,6 +30,7 @@ kube::golang::server_targets() {
   local targets=(
     cmd/kube-proxy
     cmd/kube-apiserver
+    cmd/kube-bootstrap
     cmd/kube-controller-manager
     cmd/kubelet
     cmd/kubemark

--- a/pkg/bootstrap/bootstrapper.go
+++ b/pkg/bootstrap/bootstrapper.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/mount"
+)
+
+// Bootstrapper is the main bootstrapping manager class
+type Bootstrapper struct {
+	ConfigFile      string
+	config          Configuration
+	cloudProvider   cloudprovider.Interface
+	masterBootstrap cloudprovider.MasterBootstrap
+}
+
+// NewBootstrapper creates a Bootstrapper instance.
+func NewBootstrapper(configFile string) *Bootstrapper {
+	b := &Bootstrapper{ConfigFile: configFile}
+	return b
+}
+
+// RunOnce is the main entry point for Bootstrapper; it performs all configuration
+func (b *Bootstrapper) RunOnce() error {
+	err := b.readConfig()
+	if err != nil {
+		return fmt.Errorf("unable to read configuration: %v", err)
+	}
+
+	err = b.buildCloudProvider()
+	if err != nil {
+		return fmt.Errorf("unable to build cloud provider: %v", err)
+	}
+
+	// The master volume acts as a mutex, so we always mount it first
+	err = b.mountMasterVolume()
+	if err != nil {
+		return fmt.Errorf("unable to mount master volume: %v", err)
+	}
+
+	err = b.configureMasterPublicIP()
+	if err != nil {
+		return fmt.Errorf("unable to associate master IP: %v", err)
+	}
+
+	err = b.configureMasterPrivateIP()
+	if err != nil {
+		return fmt.Errorf("unable to associate master IP: %v", err)
+	}
+
+	err = b.configureMasterRoute()
+	if err != nil {
+		return fmt.Errorf("unable to configure master route: %v", err)
+	}
+
+	// All is well
+	glog.Info("Bootstrapping completed successfully")
+	return nil
+}
+
+func (b *Bootstrapper) readConfig() error {
+	configBytes, err := ioutil.ReadFile(b.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("error reading config file (%s): %v", b.ConfigFile, err)
+	}
+
+	err = json.Unmarshal(configBytes, &b.config)
+	if err != nil {
+		return fmt.Errorf("error parsing config file (%s): %v", b.ConfigFile, err)
+	}
+
+	return nil
+}
+
+func (b *Bootstrapper) buildCloudProvider() error {
+	cloudProvider, err := cloudprovider.GetCloudProvider(b.config.CloudProvider, strings.NewReader(b.config.CloudProviderConfig))
+	if err != nil {
+		return fmt.Errorf("error initializing cloud provider: %v", err)
+	}
+	if cloudProvider == nil {
+		return fmt.Errorf("cloud provider not found (%s)", b.config.CloudProvider)
+	}
+
+	masterBootstrap, ok := cloudProvider.MasterBootstrap()
+	if !ok {
+		return fmt.Errorf("cloud provider does not support master bootstrap (%s)", b.config.CloudProvider)
+	}
+	b.cloudProvider = cloudProvider
+	b.masterBootstrap = masterBootstrap
+
+	return nil
+}
+
+func (b *Bootstrapper) configureMasterPublicIP() error {
+	ipString := b.config.MasterPublicIP
+
+	ip := net.ParseIP(ipString)
+	if ip == nil {
+		return fmt.Errorf("error parsing public IP (%q)", ipString)
+	}
+
+	err := b.masterBootstrap.AttachPublicIP(ip)
+	if err != nil {
+		// TODO: This is retryable
+		return fmt.Errorf("error attaching public IP (%q): %v", ipString, err)
+	}
+
+	return nil
+}
+
+func (b *Bootstrapper) configureMasterPrivateIP() error {
+	ipString := b.config.MasterPrivateIP
+
+	ip, ipNet, err := net.ParseCIDR(ipString)
+	if err != nil {
+		return fmt.Errorf("error parsing private IP CIDR (%q): %v", ipString, err)
+	}
+
+	err = b.masterBootstrap.AttachPrivateIP(ip, ipNet)
+	if err != nil {
+		// TODO: This is retryable
+		return fmt.Errorf("error attaching private IP (%q): %v", ipString, err)
+	}
+
+	return nil
+}
+
+func (b *Bootstrapper) mountMasterVolume() error {
+	// We could discover the volume using metadata (at least on AWS),
+	// but it is probably easier just to rely on it being present in config
+	volumeID := b.config.MasterVolume
+
+	device, err := b.masterBootstrap.AttachMasterVolume(volumeID)
+	if err != nil {
+		// TODO: This is retryable
+		return fmt.Errorf("error attaching volume (%s): %v", volumeID, err)
+	}
+
+	mounter := mount.New()
+	diskMounter := &mount.SafeFormatAndMount{mounter, exec.New()}
+
+	target := "/mnt/master-pd"
+	err = os.MkdirAll(target, 0755)
+	if err != nil {
+		return fmt.Errorf("error creating directory %q: %v", target, err)
+	}
+
+	fsType := "ext4"
+	options := []string{"noatime"}
+	err = diskMounter.Mount(device, target, fsType, options)
+	if err != nil {
+		// TODO: This is retryable (?)
+		return fmt.Errorf("error mounting volume (%s): %v", volumeID, err)
+	}
+
+	return nil
+}
+
+func (b *Bootstrapper) configureMasterRoute() error {
+	// Once we have it insert our entry into the routing table
+	routes, ok := b.cloudProvider.Routes()
+	if !ok {
+		// TODO: Should this just be a warning?
+		return fmt.Errorf("cloudprovider %s does not support routes", b.config.CloudProvider)
+	}
+
+	// TODO: Is there a better way to get "my name"?
+	instances, ok := b.cloudProvider.Instances()
+	if !ok {
+		return fmt.Errorf("cloudprovider %s does not support instance info", b.config.CloudProvider)
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("error getting hostname: %v", err)
+	}
+
+	myNodeName, err := instances.CurrentNodeName(hostname)
+	if err != nil {
+		return fmt.Errorf("unable to determine current node name: %v", err)
+	}
+
+	route := &cloudprovider.Route{
+		TargetInstance:  myNodeName,
+		DestinationCIDR: b.config.MasterCIDR,
+	}
+
+	nameHint := "" // TODO: master?
+	err = routes.CreateRoute(b.config.ClusterID, nameHint, route)
+	if err != nil {
+		return fmt.Errorf("error creating route: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"encoding/json"
+
+	"github.com/golang/glog"
+)
+
+type Configuration struct {
+	CloudProvider       string
+	CloudProviderConfig string
+
+	MasterPublicIP  string
+	MasterPrivateIP string
+	MasterCIDR      string
+
+	ClusterID string
+
+	MasterVolume string
+}
+
+func (c *Configuration) AsJson() string {
+	j, err := json.Marshal(c)
+	if err != nil {
+		glog.Fatalf("error marshalling configuration to JSON: %v", err)
+	}
+	return string(j)
+}

--- a/pkg/bootstrap/doc.go
+++ b/pkg/bootstrap/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package bootstrap manages initial configuration of a new node
+package bootstrap

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -41,6 +41,8 @@ type Interface interface {
 	ProviderName() string
 	// ScrubDNS provides an opportunity for cloud-provider-specific code to process DNS settings for pods.
 	ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string)
+	// MasterBootstrap returns a MasterBootstrap interface. Also returns true if the interface is supported, false otherwise.
+	MasterBootstrap() (MasterBootstrap, bool)
 }
 
 // Clusters is an abstract, pluggable interface for clusters of containers.
@@ -155,4 +157,18 @@ type Zone struct {
 type Zones interface {
 	// GetZone returns the Zone containing the current failure zone and locality region that the program is running in
 	GetZone() (Zone, error)
+}
+
+// MasterBoostrap is an abstract, pluggable interface for performing master boostrap tasks
+type MasterBootstrap interface {
+	// AttachMasterVolume attaches the specified volume at the 'master' mountpoint
+	// A master volume stores state for the master, and can also perform simple mutex/leader election
+	// The volume id will typically be an ID for the default volume type for that cloud,
+	// but is an opaque token typically provided to the bootstrapper in a config file.
+	AttachMasterVolume(volumeID string) (string, error)
+
+	// Attaches the specified public IP to the local machine, which is acting as the master
+	AttachPublicIP(ip net.IP) error
+	// Attaches the specified private IP to the local machine, which is acting as the master
+	AttachPrivateIP(ip net.IP, ipNet *net.IPNet) error
 }

--- a/pkg/cloudprovider/providers/aws/aws_routes.go
+++ b/pkg/cloudprovider/providers/aws/aws_routes.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
@@ -106,6 +107,32 @@ func (s *AWSCloud) CreateRoute(clusterName string, nameHint string, route *cloud
 	table, err := s.findRouteTable(clusterName)
 	if err != nil {
 		return err
+	}
+
+	var deleteRoute *ec2.Route
+	for _, r := range table.Routes {
+		destinationCIDR := aws.StringValue(r.DestinationCidrBlock)
+
+		if destinationCIDR != route.DestinationCIDR {
+			continue
+		}
+
+		if aws.StringValue(r.State) == ec2.RouteStateBlackhole {
+			deleteRoute = r
+		}
+	}
+
+	if deleteRoute != nil {
+		glog.Infof("deleting blackholed route: %s", aws.StringValue(deleteRoute.DestinationCidrBlock))
+
+		request := &ec2.DeleteRouteInput{}
+		request.DestinationCidrBlock = deleteRoute.DestinationCidrBlock
+		request.RouteTableId = table.RouteTableId
+
+		_, err = s.ec2.DeleteRoute(request)
+		if err != nil {
+			return fmt.Errorf("error deleting AWS route (%s): %v", deleteRoute.DestinationCidrBlock, err)
+		}
 	}
 
 	request := &ec2.CreateRouteInput{}

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -116,6 +116,10 @@ func (f *FakeCloud) Zones() (cloudprovider.Zones, bool) {
 	return f, true
 }
 
+func (f *FakeCloud) MasterBootstrap() (cloudprovider.MasterBootstrap, bool) {
+	return f, false
+}
+
 func (f *FakeCloud) Routes() (cloudprovider.Routes, bool) {
 	return f, true
 }

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -268,6 +268,13 @@ func (gce *GCECloud) Zones() (cloudprovider.Zones, bool) {
 	return gce, true
 }
 
+// MasterBootstrap returns an implementation of MasterBootstrap for Google Compute Engine.
+// However the driver does not currently support master volumes,
+// so this implementation always returns (nil, false).
+func (gce *GCECloud) MasterBootstrap() (cloudprovider.MasterBootstrap, bool) {
+	return nil, false
+}
+
 // Routes returns an implementation of Routes for Google Compute Engine.
 func (gce *GCECloud) Routes() (cloudprovider.Routes, bool) {
 	return gce, true

--- a/pkg/cloudprovider/providers/mesos/mesos.go
+++ b/pkg/cloudprovider/providers/mesos/mesos.go
@@ -116,6 +116,13 @@ func (c *MesosCloud) Zones() (cloudprovider.Zones, bool) {
 	return nil, false
 }
 
+// MasterBootstrap returns an implementation of MasterBootstrap for Mesos.
+// However the driver does not currently support master volumes,
+// so this implementation always returns (nil, false).
+func (c *MesosCloud) MasterBootstrap() (cloudprovider.MasterBootstrap, bool) {
+	return nil, false
+}
+
 // Clusters returns a copy of the Mesos cloud Clusters implementation.
 // Mesos does not provide support for multiple clusters.
 func (c *MesosCloud) Clusters() (cloudprovider.Clusters, bool) {

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -911,6 +911,14 @@ func (os *OpenStack) Zones() (cloudprovider.Zones, bool) {
 
 	return os, true
 }
+
+// MasterBootstrap returns an implementation of MasterBootstrap for Openstack.
+// However the driver does not currently support master volumes,
+// so this implementation always returns (nil, false).
+func (os *OpenStack) MasterBootstrap() (cloudprovider.MasterBootstrap, bool) {
+	return nil, false
+}
+
 func (os *OpenStack) GetZone() (cloudprovider.Zone, error) {
 	glog.V(1).Infof("Current zone is %v", os.region)
 

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -143,6 +143,13 @@ func (v *OVirtCloud) Zones() (cloudprovider.Zones, bool) {
 	return nil, false
 }
 
+// MasterBootstrap returns an implementation of MasterBootstrap for oVirt cloud.
+// However the driver does not currently support master volumes,
+// so this implementation always returns (nil, false).
+func (v *OVirtCloud) MasterBootstrap() (cloudprovider.MasterBootstrap, bool) {
+	return nil, false
+}
+
 // Routes returns an implementation of Routes for oVirt cloud
 func (v *OVirtCloud) Routes() (cloudprovider.Routes, bool) {
 	return nil, false

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -377,6 +377,13 @@ func (os *Rackspace) Zones() (cloudprovider.Zones, bool) {
 	return os, true
 }
 
+// MasterBootstrap returns an implementation of MasterBootstrap for Rackspace cloud.
+// However the driver does not currently support master volumes,
+// so this implementation always returns (nil, false).
+func (r *Rackspace) MasterBootstrap() (cloudprovider.MasterBootstrap, bool) {
+	return nil, false
+}
+
 func (os *Rackspace) Routes() (cloudprovider.Routes, bool) {
 	return nil, false
 }

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -101,7 +101,8 @@ func (util *AWSDiskUtil) DetachDisk(c *awsElasticBlockStoreCleaner) error {
 		glog.V(2).Info("Error getting volume provider for volumeID ", c.volumeID, ": ", err)
 		return err
 	}
-	if err := volumes.DetachDisk("", c.volumeID); err != nil {
+	_, err = volumes.DetachDisk("", c.volumeID)
+	if err != nil {
 		glog.V(2).Info("Error detaching disk ", c.volumeID, ": ", err)
 		return err
 	}

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -384,7 +384,8 @@ func detachPD(hostName, pdName string) error {
 		if !ok {
 			return fmt.Errorf("Provider does not support volumes")
 		}
-		return volumes.DetachDisk(hostName, pdName)
+		_, err := volumes.DetachDisk(hostName, pdName)
+		return err
 	}
 }
 


### PR DESCRIPTION
Proof-of-concept of running the master in an autoscaling group, working towards auto-healing or HA master.

In an autoscaling group we can't specify a persistent disk (or an elastic IP).  So we pass a small amount of configuration that specifies the master persistent disk and the elastic IP to grab.  Instances launched by the master ASG will try to mount the persistent disk; an instance that acquired the volume mount will then self-assign the elastic IP and also configure the routing table appropriately.

We run the ASG with min-size=max-size=1.  If the master instances goes away the ASG should relaunch a replacement which will then take over the role of master.

We could also run min-size=max-size=2 for a quicker time-to-recovery; the master volume acts as a mutex so the 'second' instance will just spin trying to mount the volume.

In future, we could specify e.g. 3 volumes & 3 IP addresses, and have a master cluster self-configure, again treating the volumes as a simple mutex (as well as a way to break symmetry and give each node an identity).

The code comprises a fairly large amount of kube-up boilerplate to run the master in an ASG.  There is some complexity because we can't tag elastic IPs, so we have to tag the elastic IP on the ASG.

We also introduce a kube-bootstrap component in Go.  Its role right now is to try to mount the volume, and then to set up the elastic IP and the route table.  It reuses the cloudprovider API to do so.  We could probably write this in bash also, but then we couldn't reuse the cloudprovider code.

The configuration is provided as a JSON object, in the hopes that this can eventually converge with the work being done to have configuration objects managed by k8s itself.

cc @quinton-hoole
