### PR TITLE
use constants for group names

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/capabilities"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -445,7 +446,7 @@ func (s *APIServer) Run(_ []string) error {
 		glog.Fatalf("Invalid server address: %v", err)
 	}
 
-	legacyV1Group, err := latest.Group("")
+	legacyV1Group, err := latest.Group(api.GroupName)
 	if err != nil {
 		return err
 	}
@@ -463,7 +464,7 @@ func (s *APIServer) Run(_ []string) error {
 	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	if !apiGroupVersionOverrides["extensions/v1beta1"].Disable {
-		expGroup, err := latest.Group("extensions")
+		expGroup, err := latest.Group(extensions.GroupName)
 		if err != nil {
 			glog.Fatalf("Extensions API is enabled in runtime config, but not enabled in the environment variable KUBE_API_VERSIONS. Error: %v", err)
 		}
@@ -474,7 +475,7 @@ func (s *APIServer) Run(_ []string) error {
 		if err != nil {
 			glog.Fatalf("Invalid extensions storage version or misconfigured etcd: %v", err)
 		}
-		storageDestinations.AddAPIGroup("extensions", expEtcdStorage)
+		storageDestinations.AddAPIGroup(extensions.GroupName, expEtcdStorage)
 	}
 
 	updateEtcdOverrides(s.EtcdServersOverrides, storageVersions, s.EtcdPathPrefix, &storageDestinations, newEtcd)

--- a/cmd/kube-apiserver/app/server_test.go
+++ b/cmd/kube-apiserver/app/server_test.go
@@ -22,7 +22,9 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/storage"
 )
@@ -78,16 +80,16 @@ func TestGenerateStorageVersionMap(t *testing.T) {
 			legacyVersion:   "v1",
 			storageVersions: "v1,extensions/v1beta1",
 			expectedMap: map[string]string{
-				"":           "v1",
-				"extensions": "extensions/v1beta1",
+				api.GroupName:        "v1",
+				extensions.GroupName: "extensions/v1beta1",
 			},
 		},
 		{
 			legacyVersion:   "",
 			storageVersions: "extensions/v1beta1,v1",
 			expectedMap: map[string]string{
-				"":           "v1",
-				"extensions": "extensions/v1beta1",
+				api.GroupName:        "v1",
+				extensions.GroupName: "extensions/v1beta1",
 			},
 		},
 		{
@@ -113,17 +115,17 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 		servers  []string
 	}{
 		{
-			apigroup: "",
+			apigroup: api.GroupName,
 			resource: "resource",
 			servers:  []string{"http://127.0.0.1:10000"},
 		},
 		{
-			apigroup: "",
+			apigroup: api.GroupName,
 			resource: "resource",
 			servers:  []string{"http://127.0.0.1:10000", "http://127.0.0.1:20000"},
 		},
 		{
-			apigroup: "extensions",
+			apigroup: extensions.GroupName,
 			resource: "resource",
 			servers:  []string{"http://127.0.0.1:10000"},
 		},

--- a/cmd/kube-version-change/version.go
+++ b/cmd/kube-version-change/version.go
@@ -39,7 +39,7 @@ var (
 	inputSource   = flag.StringP("input", "i", "-", "Input source; '-' means stdin")
 	outputDest    = flag.StringP("output", "o", "-", "Output destination; '-' means stdout")
 	rewrite       = flag.StringP("rewrite", "r", "", "If nonempty, use this as both input and output.")
-	outputVersion = flag.StringP("out-version", "v", latest.GroupOrDie("").GroupVersion.Version, "Version to convert input to")
+	outputVersion = flag.StringP("out-version", "v", latest.GroupOrDie(api.GroupName).GroupVersion.Version, "Version to convert input to")
 )
 
 // isYAML determines whether data is JSON or YAML formatted by seeing

--- a/examples/https-nginx/make_secret.go
+++ b/examples/https-nginx/make_secret.go
@@ -66,5 +66,5 @@ func main() {
 			"nginx.key": nginxKey,
 		},
 	}
-	fmt.Printf(runtime.EncodeOrDie(latest.GroupOrDie("").Codec, secret))
+	fmt.Printf(runtime.EncodeOrDie(latest.GroupOrDie(api.GroupName).Codec, secret))
 }

--- a/examples/sharing-clusters/make_secret.go
+++ b/examples/sharing-clusters/make_secret.go
@@ -59,5 +59,5 @@ func main() {
 			"config": cfg,
 		},
 	}
-	fmt.Printf(runtime.EncodeOrDie(latest.GroupOrDie("").Codec, secret))
+	fmt.Printf(runtime.EncodeOrDie(latest.GroupOrDie(api.GroupName).Codec, secret))
 }

--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/util/sets"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -42,14 +42,14 @@ const importPrefix = "k8s.io/kubernetes/pkg/api"
 var accessor = meta.NewAccessor()
 
 func init() {
-	groupMeta, err := latest.RegisterGroup("")
+	groupMeta, err := latest.RegisterGroup(api.GroupName)
 	if err != nil {
 		glog.V(4).Infof("%v", err)
 		return
 	}
 
 	// Use the first API version in the list of registered versions as the latest.
-	registeredGroupVersions := registered.GroupVersionsForGroup("")
+	registeredGroupVersions := registered.GroupVersionsForGroup(api.GroupName)
 	groupVersion := registeredGroupVersions[0]
 	*groupMeta = latest.GroupMeta{
 		GroupVersion: groupVersion,
@@ -106,7 +106,7 @@ func interfacesFor(version unversioned.GroupVersion) (*meta.VersionInterfaces, e
 		}, nil
 	default:
 		{
-			g, _ := latest.Group("")
+			g, _ := latest.Group(api.GroupName)
 			return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 		}
 	}

--- a/pkg/api/install/install_test.go
+++ b/pkg/api/install/install_test.go
@@ -49,7 +49,7 @@ func TestCodec(t *testing.T) {
 	pod := internal.Pod{}
 	// We do want to use package latest rather than testapi here, because we
 	// want to test if the package install and package latest work as expected.
-	data, err := latest.GroupOrDie("").Codec.Encode(&pod)
+	data, err := latest.GroupOrDie(internal.GroupName).Codec.Encode(&pod)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,17 +57,17 @@ func TestCodec(t *testing.T) {
 	if err := json.Unmarshal(data, &other); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if other.APIVersion != latest.GroupOrDie("").GroupVersion.Version || other.Kind != "Pod" {
+	if other.APIVersion != latest.GroupOrDie(internal.GroupName).GroupVersion.Version || other.Kind != "Pod" {
 		t.Errorf("unexpected unmarshalled object %#v", other)
 	}
 }
 
 func TestInterfacesFor(t *testing.T) {
-	if _, err := latest.GroupOrDie("").InterfacesFor(internal.SchemeGroupVersion); err == nil {
+	if _, err := latest.GroupOrDie(internal.GroupName).InterfacesFor(internal.SchemeGroupVersion); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, version := range latest.GroupOrDie("").GroupVersions {
-		if vi, err := latest.GroupOrDie("").InterfacesFor(version); err != nil || vi == nil {
+	for i, version := range latest.GroupOrDie(internal.GroupName).GroupVersions {
+		if vi, err := latest.GroupOrDie(internal.GroupName).InterfacesFor(version); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
@@ -78,16 +78,16 @@ func TestRESTMapper(t *testing.T) {
 	rcGVK := gv.WithKind("ReplicationController")
 	podTemplateGVK := gv.WithKind("PodTemplate")
 
-	if gvk, err := latest.GroupOrDie("").RESTMapper.KindFor("replicationcontrollers"); err != nil || gvk != rcGVK {
+	if gvk, err := latest.GroupOrDie(internal.GroupName).RESTMapper.KindFor("replicationcontrollers"); err != nil || gvk != rcGVK {
 		t.Errorf("unexpected version mapping: %v %v", gvk, err)
 	}
 
-	if m, err := latest.GroupOrDie("").RESTMapper.RESTMapping(podTemplateGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != podTemplateGVK || m.Resource != "podtemplates" {
+	if m, err := latest.GroupOrDie(internal.GroupName).RESTMapper.RESTMapping(podTemplateGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != podTemplateGVK || m.Resource != "podtemplates" {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("").GroupVersions {
-		mapping, err := latest.GroupOrDie("").RESTMapper.RESTMapping(rcGVK.GroupKind(), version.Version)
+	for _, version := range latest.GroupOrDie(internal.GroupName).GroupVersions {
+		mapping, err := latest.GroupOrDie(internal.GroupName).RESTMapper.RESTMapping(rcGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -99,7 +99,7 @@ func TestRESTMapper(t *testing.T) {
 			t.Errorf("incorrect version: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("").InterfacesFor(version)
+		interfaces, _ := latest.GroupOrDie(internal.GroupName).InterfacesFor(version)
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -24,8 +24,11 @@ import (
 // Scheme is the default instance of runtime.Scheme to which types in the Kubernetes API are already registered.
 var Scheme = runtime.NewScheme()
 
+// GroupName is the group name use in this package
+const GroupName = ""
+
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = unversioned.GroupVersion{Group: "", Version: ""}
+var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: ""}
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
 func Kind(kind string) unversioned.GroupKind {

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -59,21 +59,21 @@ func init() {
 		}
 	}
 
-	if _, ok := Groups[api.SchemeGroupVersion.Group]; !ok {
-		Groups[api.SchemeGroupVersion.Group] = TestGroup{
-			externalGroupVersion: unversioned.GroupVersion{Group: api.SchemeGroupVersion.Group, Version: latest.GroupOrDie(api.SchemeGroupVersion.Group).GroupVersion.Version},
+	if _, ok := Groups[api.GroupName]; !ok {
+		Groups[api.GroupName] = TestGroup{
+			externalGroupVersion: unversioned.GroupVersion{Group: api.GroupName, Version: latest.GroupOrDie(api.GroupName).GroupVersion.Version},
 			internalGroupVersion: api.SchemeGroupVersion,
 		}
 	}
-	if _, ok := Groups[extensions.SchemeGroupVersion.Group]; !ok {
-		Groups[extensions.SchemeGroupVersion.Group] = TestGroup{
-			externalGroupVersion: unversioned.GroupVersion{Group: extensions.SchemeGroupVersion.Group, Version: latest.GroupOrDie(extensions.SchemeGroupVersion.Group).GroupVersion.Version},
+	if _, ok := Groups[extensions.GroupName]; !ok {
+		Groups[extensions.GroupName] = TestGroup{
+			externalGroupVersion: unversioned.GroupVersion{Group: extensions.GroupName, Version: latest.GroupOrDie(extensions.GroupName).GroupVersion.Version},
 			internalGroupVersion: extensions.SchemeGroupVersion,
 		}
 	}
 
-	Default = Groups[api.SchemeGroupVersion.Group]
-	Extensions = Groups[extensions.SchemeGroupVersion.Group]
+	Default = Groups[api.GroupName]
+	Extensions = Groups[extensions.GroupName]
 }
 
 func (g TestGroup) GroupVersion() *unversioned.GroupVersion {
@@ -122,7 +122,7 @@ func (g TestGroup) MetadataAccessor() meta.MetadataAccessor {
 // 'resource' should be the resource path, e.g. "pods" for the Pod type. 'name' should be
 // empty for lists.
 func (g TestGroup) SelfLink(resource, name string) string {
-	if g.externalGroupVersion.Group == api.SchemeGroupVersion.Group {
+	if g.externalGroupVersion.Group == api.GroupName {
 		if name == "" {
 			return fmt.Sprintf("/api/%s/%s", g.externalGroupVersion.Version, resource)
 		}
@@ -142,7 +142,7 @@ func (g TestGroup) SelfLink(resource, name string) string {
 // /api/v1/watch/namespaces/foo/pods/pod0 for v1.
 func (g TestGroup) ResourcePathWithPrefix(prefix, resource, namespace, name string) string {
 	var path string
-	if g.externalGroupVersion.Group == api.SchemeGroupVersion.Group {
+	if g.externalGroupVersion.Group == api.GroupName {
 		path = "/api/" + g.externalGroupVersion.Version
 	} else {
 		// TODO: switch back once we have proper multiple group support

--- a/pkg/api/v1/register.go
+++ b/pkg/api/v1/register.go
@@ -23,8 +23,11 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
+// GroupName is the group name use in this package
+const GroupName = ""
+
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = unversioned.GroupVersion{Group: "", Version: "v1"}
+var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1"}
 
 // Codec encodes internal objects to the v1 scheme
 var Codec = runtime.CodecFor(api.Scheme, SchemeGroupVersion.String())

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	_ "k8s.io/kubernetes/pkg/apis/componentconfig"
+	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	"k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -39,13 +39,13 @@ const importPrefix = "k8s.io/kubernetes/pkg/apis/componentconfig"
 var accessor = meta.NewAccessor()
 
 func init() {
-	groupMeta, err := latest.RegisterGroup("componentconfig")
+	groupMeta, err := latest.RegisterGroup(componentconfig.GroupName)
 	if err != nil {
 		glog.V(4).Infof("%v", err)
 		return
 	}
 
-	registeredGroupVersions := registered.GroupVersionsForGroup("componentconfig")
+	registeredGroupVersions := registered.GroupVersionsForGroup(componentconfig.GroupName)
 	groupVersion := registeredGroupVersions[0]
 	*groupMeta = latest.GroupMeta{
 		GroupVersion: groupVersion,
@@ -82,7 +82,7 @@ func interfacesFor(version unversioned.GroupVersion) (*meta.VersionInterfaces, e
 			MetadataAccessor: accessor,
 		}, nil
 	default:
-		g, _ := latest.Group("componentconfig")
+		g, _ := latest.Group(componentconfig.GroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/apis/componentconfig/install/install_test.go
+++ b/pkg/apis/componentconfig/install/install_test.go
@@ -29,7 +29,7 @@ func TestCodec(t *testing.T) {
 	daemonSet := componentconfig.KubeProxyConfiguration{}
 	// We do want to use package latest rather than testapi here, because we
 	// want to test if the package install and package latest work as expected.
-	data, err := latest.GroupOrDie("componentconfig").Codec.Encode(&daemonSet)
+	data, err := latest.GroupOrDie(componentconfig.GroupName).Codec.Encode(&daemonSet)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -37,36 +37,36 @@ func TestCodec(t *testing.T) {
 	if err := json.Unmarshal(data, &other); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if other.APIVersion != latest.GroupOrDie("componentconfig").GroupVersion.String() || other.Kind != "KubeProxyConfiguration" {
+	if other.APIVersion != latest.GroupOrDie(componentconfig.GroupName).GroupVersion.String() || other.Kind != "KubeProxyConfiguration" {
 		t.Errorf("unexpected unmarshalled object %#v", other)
 	}
 }
 
 func TestInterfacesFor(t *testing.T) {
-	if _, err := latest.GroupOrDie("componentconfig").InterfacesFor(componentconfig.SchemeGroupVersion); err == nil {
+	if _, err := latest.GroupOrDie(componentconfig.GroupName).InterfacesFor(componentconfig.SchemeGroupVersion); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, version := range latest.GroupOrDie("componentconfig").GroupVersions {
-		if vi, err := latest.GroupOrDie("componentconfig").InterfacesFor(version); err != nil || vi == nil {
+	for i, version := range latest.GroupOrDie(componentconfig.GroupName).GroupVersions {
+		if vi, err := latest.GroupOrDie(componentconfig.GroupName).InterfacesFor(version); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
 }
 
 func TestRESTMapper(t *testing.T) {
-	gv := unversioned.GroupVersion{Group: "componentconfig", Version: "v1alpha1"}
+	gv := unversioned.GroupVersion{Group: componentconfig.GroupName, Version: "v1alpha1"}
 	proxyGVK := gv.WithKind("KubeProxyConfiguration")
 
-	if gvk, err := latest.GroupOrDie("componentconfig").RESTMapper.KindFor("kubeproxyconfiguration"); err != nil || gvk != proxyGVK {
+	if gvk, err := latest.GroupOrDie(componentconfig.GroupName).RESTMapper.KindFor("kubeproxyconfiguration"); err != nil || gvk != proxyGVK {
 		t.Errorf("unexpected version mapping: %v %v", gvk, err)
 	}
 
-	if m, err := latest.GroupOrDie("componentconfig").RESTMapper.RESTMapping(proxyGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != proxyGVK || m.Resource != "kubeproxyconfigurations" {
+	if m, err := latest.GroupOrDie(componentconfig.GroupName).RESTMapper.RESTMapping(proxyGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != proxyGVK || m.Resource != "kubeproxyconfigurations" {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("componentconfig").GroupVersions {
-		mapping, err := latest.GroupOrDie("componentconfig").RESTMapper.RESTMapping(proxyGVK.GroupKind(), version.Version)
+	for _, version := range latest.GroupOrDie(componentconfig.GroupName).GroupVersions {
+		mapping, err := latest.GroupOrDie(componentconfig.GroupName).RESTMapper.RESTMapping(proxyGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			continue
@@ -79,7 +79,7 @@ func TestRESTMapper(t *testing.T) {
 			t.Errorf("incorrect groupVersion: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("componentconfig").InterfacesFor(version)
+		interfaces, _ := latest.GroupOrDie(componentconfig.GroupName).InterfacesFor(version)
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/apis/componentconfig/register.go
+++ b/pkg/apis/componentconfig/register.go
@@ -25,8 +25,11 @@ func init() {
 	addKnownTypes()
 }
 
+// GroupName is the group name use in this package
+const GroupName = "componentconfig"
+
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = unversioned.GroupVersion{Group: "componentconfig", Version: ""}
+var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: ""}
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
 func Kind(kind string) unversioned.GroupKind {

--- a/pkg/apis/componentconfig/v1alpha1/register.go
+++ b/pkg/apis/componentconfig/v1alpha1/register.go
@@ -22,8 +22,11 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
+// GroupName is the group name use in this package
+const GroupName = "componentconfig"
+
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = unversioned.GroupVersion{Group: "componentconfig", Version: "v1alpha1"}
+var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 
 var Codec = runtime.CodecFor(api.Scheme, SchemeGroupVersion.String())
 

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	_ "k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -39,13 +39,13 @@ const importPrefix = "k8s.io/kubernetes/pkg/apis/extensions"
 var accessor = meta.NewAccessor()
 
 func init() {
-	groupMeta, err := latest.RegisterGroup("extensions")
+	groupMeta, err := latest.RegisterGroup(extensions.GroupName)
 	if err != nil {
 		glog.V(4).Infof("%v", err)
 		return
 	}
 
-	registeredGroupVersions := registered.GroupVersionsForGroup("extensions")
+	registeredGroupVersions := registered.GroupVersionsForGroup(extensions.GroupName)
 	groupVersion := registeredGroupVersions[0]
 	*groupMeta = latest.GroupMeta{
 		GroupVersion: groupVersion,
@@ -82,7 +82,7 @@ func interfacesFor(version unversioned.GroupVersion) (*meta.VersionInterfaces, e
 			MetadataAccessor: accessor,
 		}, nil
 	default:
-		g, _ := latest.Group("extensions")
+		g, _ := latest.Group(extensions.GroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/apis/extensions/install/install_test.go
+++ b/pkg/apis/extensions/install/install_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
 func TestResourceVersioner(t *testing.T) {
@@ -50,7 +51,7 @@ func TestCodec(t *testing.T) {
 	daemonSet := extensions.DaemonSet{}
 	// We do want to use package latest rather than testapi here, because we
 	// want to test if the package install and package latest work as expected.
-	data, err := latest.GroupOrDie("extensions").Codec.Encode(&daemonSet)
+	data, err := latest.GroupOrDie(extensions.GroupName).Codec.Encode(&daemonSet)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -58,37 +59,37 @@ func TestCodec(t *testing.T) {
 	if err := json.Unmarshal(data, &other); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if other.APIVersion != latest.GroupOrDie("extensions").GroupVersion.String() || other.Kind != "DaemonSet" {
+	if other.APIVersion != latest.GroupOrDie(extensions.GroupName).GroupVersion.String() || other.Kind != "DaemonSet" {
 		t.Errorf("unexpected unmarshalled object %#v", other)
 	}
 }
 
 func TestInterfacesFor(t *testing.T) {
-	if _, err := latest.GroupOrDie("extensions").InterfacesFor(extensions.SchemeGroupVersion); err == nil {
+	if _, err := latest.GroupOrDie(extensions.GroupName).InterfacesFor(extensions.SchemeGroupVersion); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, version := range latest.GroupOrDie("extensions").GroupVersions {
-		if vi, err := latest.GroupOrDie("extensions").InterfacesFor(version); err != nil || vi == nil {
+	for i, version := range latest.GroupOrDie(extensions.GroupName).GroupVersions {
+		if vi, err := latest.GroupOrDie(extensions.GroupName).InterfacesFor(version); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
 }
 
 func TestRESTMapper(t *testing.T) {
-	gv := unversioned.GroupVersion{Group: "extensions", Version: "v1beta1"}
+	gv := v1beta1.SchemeGroupVersion
 	hpaGVK := gv.WithKind("HorizontalPodAutoscaler")
 	daemonSetGVK := gv.WithKind("DaemonSet")
 
-	if gvk, err := latest.GroupOrDie("extensions").RESTMapper.KindFor("horizontalpodautoscalers"); err != nil || gvk != hpaGVK {
+	if gvk, err := latest.GroupOrDie(extensions.GroupName).RESTMapper.KindFor("horizontalpodautoscalers"); err != nil || gvk != hpaGVK {
 		t.Errorf("unexpected version mapping: %v %v", gvk, err)
 	}
 
-	if m, err := latest.GroupOrDie("extensions").RESTMapper.RESTMapping(daemonSetGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != daemonSetGVK || m.Resource != "daemonsets" {
+	if m, err := latest.GroupOrDie(extensions.GroupName).RESTMapper.RESTMapping(daemonSetGVK.GroupKind(), ""); err != nil || m.GroupVersionKind != daemonSetGVK || m.Resource != "daemonsets" {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}
 
-	for _, version := range latest.GroupOrDie("extensions").GroupVersions {
-		mapping, err := latest.GroupOrDie("extensions").RESTMapper.RESTMapping(hpaGVK.GroupKind(), version.Version)
+	for _, version := range latest.GroupOrDie(extensions.GroupName).GroupVersions {
+		mapping, err := latest.GroupOrDie(extensions.GroupName).RESTMapper.RESTMapping(hpaGVK.GroupKind(), version.Version)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -100,7 +101,7 @@ func TestRESTMapper(t *testing.T) {
 			t.Errorf("incorrect groupVersion: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("extensions").InterfacesFor(version)
+		interfaces, _ := latest.GroupOrDie(extensions.GroupName).InterfacesFor(version)
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/apis/extensions/register.go
+++ b/pkg/apis/extensions/register.go
@@ -21,8 +21,11 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
+// GroupName is the group name use in this package
+const GroupName = "extensions"
+
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = unversioned.GroupVersion{Group: "extensions", Version: ""}
+var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: ""}
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
 func Kind(kind string) unversioned.GroupKind {

--- a/pkg/apis/extensions/v1beta1/defaults.go
+++ b/pkg/apis/extensions/v1beta1/defaults.go
@@ -25,7 +25,7 @@ func addDefaultingFuncs() {
 	api.Scheme.AddDefaultingFuncs(
 		func(obj *APIVersion) {
 			if len(obj.APIGroup) == 0 {
-				obj.APIGroup = "extensions"
+				obj.APIGroup = GroupName
 			}
 		},
 		func(obj *DaemonSet) {

--- a/pkg/apis/extensions/v1beta1/register.go
+++ b/pkg/apis/extensions/v1beta1/register.go
@@ -22,8 +22,11 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
+// GroupName is the group name use in this package
+const GroupName = "extensions"
+
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = unversioned.GroupVersion{Group: "extensions", Version: "v1beta1"}
+var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1beta1"}
 
 var Codec = runtime.CodecFor(api.Scheme, SchemeGroupVersion.String())
 

--- a/pkg/apis/metrics/install/install.go
+++ b/pkg/apis/metrics/install/install.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	_ "k8s.io/kubernetes/pkg/apis/metrics"
+	"k8s.io/kubernetes/pkg/apis/metrics"
 	"k8s.io/kubernetes/pkg/apis/metrics/v1alpha1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -39,13 +39,13 @@ const importPrefix = "k8s.io/kubernetes/pkg/apis/metrics"
 var accessor = meta.NewAccessor()
 
 func init() {
-	groupMeta, err := latest.RegisterGroup("metrics")
+	groupMeta, err := latest.RegisterGroup(metrics.GroupName)
 	if err != nil {
 		glog.V(4).Infof("%v", err)
 		return
 	}
 
-	registeredGroupVersions := registered.GroupVersionsForGroup("metrics")
+	registeredGroupVersions := registered.GroupVersionsForGroup(metrics.GroupName)
 	groupVersion := registeredGroupVersions[0]
 	*groupMeta = latest.GroupMeta{
 		GroupVersion: groupVersion,
@@ -82,7 +82,7 @@ func interfacesFor(version unversioned.GroupVersion) (*meta.VersionInterfaces, e
 			MetadataAccessor: accessor,
 		}, nil
 	default:
-		g, _ := latest.Group("metrics")
+		g, _ := latest.Group(metrics.GroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/apis/metrics/register.go
+++ b/pkg/apis/metrics/register.go
@@ -26,8 +26,11 @@ func init() {
 	addKnownTypes()
 }
 
+// GroupName is the group name use in this package
+const GroupName = "metrics"
+
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = unversioned.GroupVersion{Group: "metrics", Version: ""}
+var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: ""}
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
 func Kind(kind string) unversioned.GroupKind {

--- a/pkg/apis/metrics/v1alpha1/register.go
+++ b/pkg/apis/metrics/v1alpha1/register.go
@@ -22,8 +22,11 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
+// GroupName is the group name use in this package
+const GroupName = "metrics"
+
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = unversioned.GroupVersion{Group: "metrics", Version: "v1alpha1"}
+var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 
 var Codec = runtime.CodecFor(api.Scheme, SchemeGroupVersion.String())
 

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
 	watchjson "k8s.io/kubernetes/pkg/watch/json"
@@ -136,7 +137,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		}
 
 		// TODO This keeps it doing what it was doing before, but it doesn't feel right.
-		if fqKind.Group == "extensions" && fqKind.Kind == "ThirdPartyResourceData" {
+		if fqKind.Group == extensions.GroupName && fqKind.Kind == "ThirdPartyResourceData" {
 			fqKindToRegister = fqKind
 			fqKindToRegister.Group = a.group.GroupVersion.Group
 			fqKindToRegister.Version = a.group.GroupVersion.Version

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -211,7 +211,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 	glog.Errorln(buffer.String())
 
 	// TODO: make status unversioned or plumb enough of the request to deduce the requested API version
-	errorJSON(apierrors.NewGenericServerResponse(http.StatusInternalServerError, "", "", "", "", 0, false), latest.GroupOrDie("").Codec, httpWriter)
+	errorJSON(apierrors.NewGenericServerResponse(http.StatusInternalServerError, "", "", "", "", 0, false), latest.GroupOrDie(api.GroupName).Codec, httpWriter)
 }
 
 func InstallServiceErrorHandler(container *restful.Container, requestResolver *RequestInfoResolver, apiVersions []string) {
@@ -222,7 +222,7 @@ func InstallServiceErrorHandler(container *restful.Container, requestResolver *R
 
 func serviceErrorHandler(requestResolver *RequestInfoResolver, apiVersions []string, serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
 	requestInfo, err := requestResolver.GetRequestInfo(request.Request)
-	codec := latest.GroupOrDie("").Codec
+	codec := latest.GroupOrDie(api.GroupName).Codec
 	if err == nil && requestInfo.APIVersion != "" {
 		// check if the api version is valid.
 		for _, version := range apiVersions {

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
@@ -281,7 +282,7 @@ func TestGetAttribs(t *testing.T) {
 				Verb:            "list",
 				Path:            "/apis/extensions/v1beta1/namespaces/myns/jobs",
 				ResourceRequest: true,
-				APIGroup:        "extensions",
+				APIGroup:        extensions.GroupName,
 				Namespace:       "myns",
 				Resource:        "jobs",
 			},

--- a/pkg/apiserver/resthandler_test.go
+++ b/pkg/apiserver/resthandler_test.go
@@ -152,7 +152,7 @@ func (tc *patchTestCase) Run(t *testing.T) {
 	namespace := tc.startingPod.Namespace
 	name := tc.startingPod.Name
 
-	codec := latest.GroupOrDie("").Codec
+	codec := latest.GroupOrDie(api.GroupName).Codec
 
 	testPatcher := &testPatcher{}
 	testPatcher.startingPod = tc.startingPod

--- a/pkg/client/unversioned/extensions.go
+++ b/pkg/client/unversioned/extensions.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -134,7 +135,7 @@ func NewExtensionsOrDie(c *Config) *ExtensionsClient {
 
 func setExtensionsDefaults(config *Config) error {
 	// if experimental group is not registered, return an error
-	g, err := latest.Group("extensions")
+	g, err := latest.Group(extensions.GroupName)
 	if err != nil {
 		return err
 	}
@@ -151,7 +152,7 @@ func setExtensionsDefaults(config *Config) error {
 	versionInterfaces, err := g.InterfacesFor(*config.GroupVersion)
 	if err != nil {
 		return fmt.Errorf("Extensions API group/version '%v' is not recognized (valid values: %v)",
-			config.GroupVersion, g.GroupVersions)
+			config.GroupVersion, latest.GroupOrDie(extensions.GroupName).GroupVersions)
 	}
 	config.Codec = versionInterfaces.Codec
 	if config.QPS == 0 {

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -132,7 +133,7 @@ func New(c *Config) (*Client, error) {
 		return nil, err
 	}
 
-	if _, err := latest.Group("extensions"); err != nil {
+	if _, err := latest.Group(extensions.GroupName); err != nil {
 		return &Client{RESTClient: client, ExtensionsClient: nil, DiscoveryClient: discoveryClient}, nil
 	}
 	experimentalConfig := *c
@@ -364,9 +365,9 @@ func SetKubernetesDefaults(config *Config) error {
 	if config.GroupVersion == nil {
 		config.GroupVersion = defaultVersionFor(config)
 	}
-	versionInterfaces, err := latest.GroupOrDie("").InterfacesFor(*config.GroupVersion)
+	versionInterfaces, err := latest.GroupOrDie(api.GroupName).InterfacesFor(*config.GroupVersion)
 	if err != nil {
-		return fmt.Errorf("API version '%v' is not recognized (valid values: %v)", *config.GroupVersion, latest.GroupOrDie("").GroupVersions)
+		return fmt.Errorf("API version '%v' is not recognized (valid values: %v)", *config.GroupVersion, latest.GroupOrDie(api.GroupName).GroupVersions)
 	}
 	if config.Codec == nil {
 		config.Codec = versionInterfaces.Codec
@@ -525,7 +526,7 @@ func defaultVersionFor(config *Config) *unversioned.GroupVersion {
 		// Clients default to the preferred code API version
 		// TODO: implement version negotiation (highest version supported by server)
 		// TODO this drops out when groupmeta is refactored
-		copyGroupVersion := latest.GroupOrDie("").GroupVersion
+		copyGroupVersion := latest.GroupOrDie(api.GroupName).GroupVersion
 		return &copyGroupVersion
 	}
 

--- a/pkg/client/unversioned/jobs.go
+++ b/pkg/client/unversioned/jobs.go
@@ -87,7 +87,7 @@ func (c *jobs) Delete(name string, options *api.DeleteOptions) (err error) {
 		return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Do().Error()
 	}
 
-	body, err := api.Scheme.EncodeToVersion(options, latest.GroupOrDie("").GroupVersion.String())
+	body, err := api.Scheme.EncodeToVersion(options, latest.GroupOrDie(api.GroupName).GroupVersion.String())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -259,7 +259,7 @@ func getPodsAnnotationSet(template *api.PodTemplateSpec, object runtime.Object) 
 	if err != nil {
 		return desiredAnnotations, fmt.Errorf("unable to get controller reference: %v", err)
 	}
-	createdByRefJson, err := latest.GroupOrDie("").Codec.Encode(&api.SerializedReference{
+	createdByRefJson, err := latest.GroupOrDie(api.GroupName).Codec.Encode(&api.SerializedReference{
 		Reference: *createdByRef,
 	})
 	if err != nil {

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -164,9 +164,9 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				return nil, err
 			}
 			switch gvk.Group {
-			case api.SchemeGroupVersion.Group:
+			case api.GroupName:
 				return client.RESTClient, nil
-			case extensions.SchemeGroupVersion.Group:
+			case extensions.GroupName:
 				return client.ExtensionsClient.RESTClient, nil
 			}
 			return nil, fmt.Errorf("unable to get RESTClient for resource '%s'", mapping.Resource)
@@ -500,7 +500,7 @@ func (c *clientSwaggerSchema) ValidateBytes(data []byte) error {
 	if ok := registered.IsRegisteredAPIGroupVersion(gvk.GroupVersion()); !ok {
 		return fmt.Errorf("API version %q isn't supported, only supports API versions %q", gvk.GroupVersion().String(), registered.RegisteredGroupVersions)
 	}
-	if gvk.Group == "extensions" {
+	if gvk.Group == extensions.GroupName {
 		if c.c.ExtensionsClient == nil {
 			return errors.New("unable to validate: no experimental client")
 		}

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -381,7 +382,7 @@ func Merge(dst runtime.Object, fragment, kind string) (runtime.Object, error) {
 		return nil, err
 	}
 
-	i, err := latest.GroupOrDie("").InterfacesFor(groupVersion)
+	i, err := latest.GroupOrDie(api.GroupName).InterfacesFor(groupVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -221,7 +221,7 @@ func AsVersionedObject(infos []*Info, forceList bool, version string) (runtime.O
 		object = objects[0]
 	} else {
 		object = &api.List{Items: objects}
-		converted, err := tryConvert(api.Scheme, object, version, latest.GroupOrDie("").GroupVersion.Version)
+		converted, err := tryConvert(api.Scheme, object, version, latest.GroupOrDie(api.GroupName).GroupVersion.Version)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -78,7 +78,7 @@ func getSelfLink(name, namespace string) string {
 	if len(namespace) == 0 {
 		namespace = api.NamespaceDefault
 	}
-	selfLink = fmt.Sprintf("/api/"+latest.GroupOrDie("").GroupVersion.Version+"/pods/namespaces/%s/%s", name, namespace)
+	selfLink = fmt.Sprintf("/api/"+latest.GroupOrDie(api.GroupName).GroupVersion.Version+"/pods/namespaces/%s/%s", name, namespace)
 	return selfLink
 }
 

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -659,7 +659,7 @@ func (dm *DockerManager) runContainer(
 	}
 	if container.Lifecycle != nil && container.Lifecycle.PreStop != nil {
 		// TODO: This is kind of hacky, we should really just encode the bits we need.
-		data, err := latest.GroupOrDie("").Codec.Encode(pod)
+		data, err := latest.GroupOrDie(api.GroupName).Codec.Encode(pod)
 		if err != nil {
 			glog.Errorf("Failed to encode pod: %s for prestop hook", pod.Name)
 		} else {
@@ -1410,7 +1410,7 @@ func containerAndPodFromLabels(inspect *docker.Container) (pod *api.Pod, contain
 	// the pod data may not be set
 	if body, found := labels[kubernetesPodLabel]; found {
 		pod = &api.Pod{}
-		if err = latest.GroupOrDie("").Codec.DecodeInto([]byte(body), pod); err == nil {
+		if err = latest.GroupOrDie(api.GroupName).Codec.DecodeInto([]byte(body), pod); err == nil {
 			name := labels[kubernetesContainerLabel]
 			for ix := range pod.Spec.Containers {
 				if pod.Spec.Containers[ix].Name == name {

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -470,7 +470,7 @@ func encodePods(pods []*api.Pod) (data []byte, err error) {
 	for _, pod := range pods {
 		podList.Items = append(podList.Items, *pod)
 	}
-	return latest.GroupOrDie("").Codec.Encode(podList)
+	return latest.GroupOrDie(api.GroupName).Codec.Encode(podList)
 }
 
 // getPods returns a list of pods bound to the Kubelet and their spec.

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -64,12 +64,12 @@ func setUp(t *testing.T) (Master, *etcdtesting.EtcdTestServer, Config, *assert.A
 	storageVersions := make(map[string]string)
 	storageDestinations := NewStorageDestinations()
 	storageDestinations.AddAPIGroup(
-		"", etcdstorage.NewEtcdStorage(server.Client, testapi.Default.Codec(), etcdtest.PathPrefix()))
+		api.GroupName, etcdstorage.NewEtcdStorage(server.Client, testapi.Default.Codec(), etcdtest.PathPrefix()))
 	storageDestinations.AddAPIGroup(
-		"extensions", etcdstorage.NewEtcdStorage(server.Client, testapi.Extensions.Codec(), etcdtest.PathPrefix()))
+		extensions.GroupName, etcdstorage.NewEtcdStorage(server.Client, testapi.Extensions.Codec(), etcdtest.PathPrefix()))
 	config.StorageDestinations = storageDestinations
-	storageVersions[""] = testapi.Default.GroupVersion().String()
-	storageVersions["extensions"] = testapi.Extensions.GroupVersion().String()
+	storageVersions[api.GroupName] = testapi.Default.GroupVersion().String()
+	storageVersions[extensions.GroupName] = testapi.Extensions.GroupVersion().String()
 	config.StorageVersions = storageVersions
 	config.PublicAddress = net.ParseIP("192.168.10.4")
 	master.nodeRegistry = registrytest.NewNodeRegistry([]string{"node1", "node2"}, api.NodeResources{})
@@ -328,7 +328,7 @@ func TestExpapi(t *testing.T) {
 	master, etcdserver, config, assert := setUp(t)
 	defer etcdserver.Terminate(t)
 
-	extensionsGroupMeta := latest.GroupOrDie("extensions")
+	extensionsGroupMeta := latest.GroupOrDie(extensions.GroupName)
 
 	expAPIGroup := master.experimental(&config)
 	assert.Equal(expAPIGroup.Root, master.apiGroupPrefix)
@@ -409,7 +409,7 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expectGroupName := "extensions"
+	expectGroupName := extensions.GroupName
 	expectVersions := []unversioned.GroupVersionForDiscovery{
 		{
 			GroupVersion: testapi.Extensions.GroupVersion().String(),
@@ -417,8 +417,8 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 		},
 	}
 	expectPreferredVersion := unversioned.GroupVersionForDiscovery{
-		GroupVersion: config.StorageVersions["extensions"],
-		Version:      apiutil.GetVersion(config.StorageVersions["extensions"]),
+		GroupVersion: config.StorageVersions[extensions.GroupName],
+		Version:      apiutil.GetVersion(config.StorageVersions[extensions.GroupName]),
 	}
 	assert.Equal(expectGroupName, groupList.Groups[0].Name)
 	assert.Equal(expectVersions, groupList.Groups[0].Versions)

--- a/pkg/registry/daemonset/etcd/etcd_test.go
+++ b/pkg/registry/daemonset/etcd/etcd_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
+	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
 	daemonSetStorage, statusStorage := NewREST(etcdStorage, generic.UndecoratedStorage)
 	return daemonSetStorage, statusStorage, server
 }

--- a/pkg/registry/deployment/etcd/etcd_test.go
+++ b/pkg/registry/deployment/etcd/etcd_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*DeploymentStorage, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
+	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
 	deploymentStorage := NewStorage(etcdStorage, generic.UndecoratedStorage)
 	return &deploymentStorage, server
 }

--- a/pkg/registry/horizontalpodautoscaler/etcd/etcd_test.go
+++ b/pkg/registry/horizontalpodautoscaler/etcd/etcd_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
+	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
 	horizontalPodAutoscalerStorage, statusStorage := NewREST(etcdStorage, generic.UndecoratedStorage)
 	return horizontalPodAutoscalerStorage, statusStorage, server
 }

--- a/pkg/registry/ingress/etcd/etcd_test.go
+++ b/pkg/registry/ingress/etcd/etcd_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
+	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
 	ingressStorage, statusStorage := NewREST(etcdStorage, generic.UndecoratedStorage)
 	return ingressStorage, statusStorage, server
 }

--- a/pkg/registry/job/etcd/etcd_test.go
+++ b/pkg/registry/job/etcd/etcd_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
+	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
 	jobStorage, statusStorage := NewREST(etcdStorage, generic.UndecoratedStorage)
 	return jobStorage, statusStorage, server
 }

--- a/pkg/registry/thirdpartyresource/etcd/etcd_test.go
+++ b/pkg/registry/thirdpartyresource/etcd/etcd_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
+	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
 	return NewREST(etcdStorage, generic.UndecoratedStorage), server
 }
 

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -68,9 +68,9 @@ func (t *thirdPartyResourceDataMapper) RESTMapping(gk unversioned.GroupKind, ver
 	}
 
 	// TODO figure out why we're doing this rewriting
-	extensionGK := unversioned.GroupKind{Group: "extensions", Kind: "ThirdPartyResourceData"}
+	extensionGK := unversioned.GroupKind{Group: extensions.GroupName, Kind: "ThirdPartyResourceData"}
 
-	mapping, err := t.mapper.RESTMapping(extensionGK, latest.GroupOrDie("extensions").GroupVersion.Version)
+	mapping, err := t.mapper.RESTMapping(extensionGK, latest.GroupOrDie(extensions.GroupName).GroupVersion.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/thirdpartyresourcedata/etcd/etcd_test.go
+++ b/pkg/registry/thirdpartyresourcedata/etcd/etcd_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
+	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
 	return NewREST(etcdStorage, generic.UndecoratedStorage, "foo", "bar"), server
 }
 

--- a/pkg/util/io/io.go
+++ b/pkg/util/io/io.go
@@ -39,7 +39,7 @@ func LoadPodFromFile(filePath string) (*api.Pod, error) {
 	}
 	pod := &api.Pod{}
 
-	if err := latest.GroupOrDie("").Codec.DecodeInto(podDef, pod); err != nil {
+	if err := latest.GroupOrDie(api.GroupName).Codec.DecodeInto(podDef, pod); err != nil {
 		return nil, fmt.Errorf("failed decoding file: %v", err)
 	}
 	return pod, nil
@@ -50,7 +50,7 @@ func SavePodToFile(pod *api.Pod, filePath string, perm os.FileMode) error {
 	if filePath == "" {
 		return fmt.Errorf("file path not specified")
 	}
-	data, err := latest.GroupOrDie("").Codec.Encode(pod)
+	data, err := latest.GroupOrDie(api.GroupName).Codec.Encode(pod)
 	if err != nil {
 		return fmt.Errorf("failed encoding pod: %v", err)
 	}

--- a/pkg/util/io/io_test.go
+++ b/pkg/util/io/io_test.go
@@ -32,8 +32,8 @@ func TestSavePodToFile(t *testing.T) {
 	pod := volume.NewPersistentVolumeRecyclerPodTemplate()
 
 	// sets all default values on a pod for equality comparison after decoding from file
-	encoded, err := latest.GroupOrDie("").Codec.Encode(pod)
-	latest.GroupOrDie("").Codec.DecodeInto(encoded, pod)
+	encoded, err := latest.GroupOrDie(api.GroupName).Codec.Encode(pod)
+	latest.GroupOrDie(api.GroupName).Codec.DecodeInto(encoded, pod)
 
 	path := fmt.Sprintf("/tmp/kube-io-test-%s", uuid.New())
 	defer os.Remove(path)

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -42,7 +42,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      "dns-test-" + string(util.NewUUID()),

--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -313,7 +313,7 @@ func testPodWithVolume(image, path string, source *api.EmptyDirVolumeSource) *ap
 	return &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name: podName,

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -111,7 +111,7 @@ func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod 
 	return &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name: podName,

--- a/test/e2e/kubelet_etc_hosts.go
+++ b/test/e2e/kubelet_etc_hosts.go
@@ -143,7 +143,7 @@ func (config *KubeletManagedHostConfig) createPodSpec(podName string) *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      podName,
@@ -204,7 +204,7 @@ func (config *KubeletManagedHostConfig) createPodSpecWithHostNetwork(podName str
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      podName,

--- a/test/e2e/kubeproxy.go
+++ b/test/e2e/kubeproxy.go
@@ -255,7 +255,7 @@ func (config *KubeProxyTestConfig) createNetShellPodSpec(podName string, node st
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      podName,
@@ -295,7 +295,7 @@ func (config *KubeProxyTestConfig) createTestPodSpec() *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      testPodName,

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -414,7 +414,7 @@ func testPDPod(diskNames []string, targetHost string, readOnly bool, numContaine
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name: "pd-test-" + string(util.NewUUID()),

--- a/test/e2e/privileged.go
+++ b/test/e2e/privileged.go
@@ -102,7 +102,7 @@ func (config *PrivilegedPodTestConfig) createPrivilegedPodSpec() *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      privilegedPodName,

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -188,7 +188,7 @@ func rcByNameContainer(name string, replicas int, image string, labels map[strin
 	return &api.ReplicationController{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "ReplicationController",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name: name,

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2099,7 +2099,7 @@ func NewHostExecPodSpec(ns, name string) *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: latest.GroupOrDie("").GroupVersion.Version,
+			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.Version,
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      name,

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -38,6 +38,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/authenticator/bearertoken"
@@ -755,8 +756,8 @@ func TestAuthorizationAttributeDetermination(t *testing.T) {
 		URL                string
 		expectedAttributes authorizer.Attributes
 	}{
-		"prefix/version/resource":       {"GET", "/api/v1/pods", authorizer.AttributesRecord{APIGroup: "", Resource: "pods"}},
-		"prefix/group/version/resource": {"GET", "/apis/extensions/v1/pods", authorizer.AttributesRecord{APIGroup: "extensions", Resource: "pods"}},
+		"prefix/version/resource":       {"GET", "/api/v1/pods", authorizer.AttributesRecord{APIGroup: api.GroupName, Resource: "pods"}},
+		"prefix/group/version/resource": {"GET", "/apis/extensions/v1/pods", authorizer.AttributesRecord{APIGroup: extensions.GroupName, Resource: "pods"}},
 	}
 
 	currentAuthorizationAttributesIndex := 0

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -29,6 +29,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -138,12 +139,12 @@ func NewMasterConfig() *master.Config {
 	etcdClient := NewEtcdClient()
 	storageVersions := make(map[string]string)
 	etcdStorage := etcdstorage.NewEtcdStorage(etcdClient, testapi.Default.Codec(), etcdtest.PathPrefix())
-	storageVersions[""] = testapi.Default.GroupVersion().String()
+	storageVersions[api.GroupName] = testapi.Default.GroupVersion().String()
 	expEtcdStorage := NewExtensionsEtcdStorage(etcdClient)
-	storageVersions["extensions"] = testapi.Extensions.GroupVersion().String()
+	storageVersions[extensions.GroupName] = testapi.Extensions.GroupVersion().String()
 	storageDestinations := master.NewStorageDestinations()
-	storageDestinations.AddAPIGroup("", etcdStorage)
-	storageDestinations.AddAPIGroup("extensions", expEtcdStorage)
+	storageDestinations.AddAPIGroup(api.GroupName, etcdStorage)
+	storageDestinations.AddAPIGroup(extensions.GroupName, expEtcdStorage)
 
 	return &master.Config{
 		StorageDestinations: storageDestinations,


### PR DESCRIPTION
Let's start small.  Group names are constants, this makes constants for each API group and uses them consistently throughout the code when referring to that particular group name.

@lavalamp @caesarxuchao 
