### PR TITLE
update test to pass properly and reflect actual behavior

### DIFF
--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -210,15 +210,19 @@ func TestRESTMapperResourceSingularizer(t *testing.T) {
 		{Kind: "Status", MixedCase: false, Plural: "statuses", Singular: "status"},
 
 		{Kind: "lowercase", MixedCase: false, Plural: "lowercases", Singular: "lowercase"},
-		// Don't add extra s if the original object is already plural
-		{Kind: "lowercases", MixedCase: false, Plural: "lowercases", Singular: "lowercases"},
+		// TODO this test is broken.  This updates to reflect actual behavior.  Kinds are expected to be singular
+		// old (incorrect), coment: Don't add extra s if the original object is already plural
+		{Kind: "lowercases", MixedCase: false, Plural: "lowercaseses", Singular: "lowercases"},
 	}
 	for i, testCase := range testCases {
 		mapper := NewDefaultRESTMapper([]unversioned.GroupVersion{testGroupVersion}, fakeInterfaces)
 		// create singular/plural mapping
 		mapper.Add(testGroupVersion.WithKind(testCase.Kind), RESTScopeNamespace, testCase.MixedCase)
 
-		singular, _ := mapper.ResourceSingularizer(testCase.Plural)
+		singular, err := mapper.ResourceSingularizer(testCase.Plural)
+		if err != nil {
+			t.Errorf("%d: unexpected error: %v", i, err)
+		}
 		if singular != testCase.Singular {
 			t.Errorf("%d: mismatched singular: %s, should be %s", i, singular, testCase.Singular)
 		}


### PR DESCRIPTION
The existing code was always erroring and simply returning the default, "I failed" output, which happened to pass the test.  This tightens the handling to fail on errors and updates the test case to reflect what's actually happening.

Kinds are expected to singular, not plural.

@janetkuo I think you wrote the original test: https://github.com/kubernetes/kubernetes/pull/10652/files#diff-c9c115e8b8a40ad87d50a100d746b178R147.
