### PR TITLE
Expose master components

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -111,7 +111,7 @@ type CMServer struct {
 func NewCMServer() *CMServer {
 	s := CMServer{
 		Port:                              ports.ControllerManagerPort,
-		Address:                           net.ParseIP("127.0.0.1"),
+		Address:                           net.ParseIP("0.0.0.0"),
 		ConcurrentEndpointSyncs:           5,
 		ConcurrentRCSyncs:                 5,
 		ConcurrentDSCSyncs:                2,

--- a/docs/admin/kube-controller-manager.md
+++ b/docs/admin/kube-controller-manager.md
@@ -55,7 +55,7 @@ kube-controller-manager
 ### Options
 
 ```
-      --address=127.0.0.1: The IP address to serve on (set to 0.0.0.0 for all interfaces)
+      --address=0.0.0.0: The IP address to serve on (set to 0.0.0.0 for all interfaces)
       --allocate-node-cidrs[=false]: Should CIDRs for Pods be allocated and set on the cloud provider.
       --cloud-config="": The path to the cloud provider configuration file.  Empty string for no configuration file.
       --cloud-provider="": The provider for cloud services.  Empty string for no provider.


### PR DESCRIPTION
To enable reading scheduler/controller manager metrics through master proxy.

cc @lavalamp 

@roberthbailey - how does it look from the GKE perspective?
