### PR TITLE
update InterfacesFor to use GroupVersion

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -280,10 +280,15 @@ func (s *APIServer) verifyClusterIPFlags() {
 
 type newEtcdFunc func([]string, meta.VersionInterfacesFunc, string, string) (storage.Interface, error)
 
-func newEtcd(etcdServerList []string, interfacesFunc meta.VersionInterfacesFunc, storageVersion, pathPrefix string) (etcdStorage storage.Interface, err error) {
-	if storageVersion == "" {
+func newEtcd(etcdServerList []string, interfacesFunc meta.VersionInterfacesFunc, storageGroupVersionString, pathPrefix string) (etcdStorage storage.Interface, err error) {
+	if storageGroupVersionString == "" {
 		return etcdStorage, fmt.Errorf("storageVersion is required to create a etcd storage")
 	}
+	storageVersion, err := unversioned.ParseGroupVersion(storageGroupVersionString)
+	if err != nil {
+		return nil, err
+	}
+
 	var storageConfig etcdstorage.EtcdConfig
 	storageConfig.ServerList = etcdServerList
 	storageConfig.Prefix = pathPrefix

--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -96,9 +96,9 @@ func init() {
 
 // InterfacesFor returns the default Codec and ResourceVersioner for a given version
 // string, or an error if the version is not known.
-func interfacesFor(version string) (*meta.VersionInterfaces, error) {
+func interfacesFor(version unversioned.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case "v1":
+	case v1.SchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			Codec:            v1.Codec,
 			ObjectConvertor:  api.Scheme,

--- a/pkg/api/install/install_test.go
+++ b/pkg/api/install/install_test.go
@@ -63,11 +63,11 @@ func TestCodec(t *testing.T) {
 }
 
 func TestInterfacesFor(t *testing.T) {
-	if _, err := latest.GroupOrDie("").InterfacesFor(""); err == nil {
+	if _, err := latest.GroupOrDie("").InterfacesFor(internal.SchemeGroupVersion); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
 	for i, version := range latest.GroupOrDie("").GroupVersions {
-		if vi, err := latest.GroupOrDie("").InterfacesFor(version.Version); err != nil || vi == nil {
+		if vi, err := latest.GroupOrDie("").InterfacesFor(version); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
@@ -99,7 +99,7 @@ func TestRESTMapper(t *testing.T) {
 			t.Errorf("incorrect version: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("").InterfacesFor(version.String())
+		interfaces, _ := latest.GroupOrDie("").InterfacesFor(version)
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -136,6 +136,6 @@ type GroupMeta struct {
 	RESTMapper meta.RESTMapper
 
 	// InterfacesFor returns the default Codec and ResourceVersioner for a given version
-	// string, or an error if the version is not known.
-	InterfacesFor func(version string) (*meta.VersionInterfaces, error)
+	// or an error if the version is not known.
+	InterfacesFor func(version unversioned.GroupVersion) (*meta.VersionInterfaces, error)
 }

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -84,7 +84,7 @@ var _ RESTMapper = &DefaultRESTMapper{}
 
 // VersionInterfacesFunc returns the appropriate codec, typer, and metadata accessor for a
 // given api version, or an error if no such api version exists.
-type VersionInterfacesFunc func(apiVersion string) (*VersionInterfaces, error)
+type VersionInterfacesFunc func(version unversioned.GroupVersion) (*VersionInterfaces, error)
 
 // NewDefaultRESTMapper initializes a mapping between Kind and APIVersion
 // to a resource name and back based on the objects in a runtime.Scheme
@@ -232,7 +232,7 @@ func (m *DefaultRESTMapper) RESTMapping(gk unversioned.GroupKind, versions ...st
 		return nil, fmt.Errorf("the provided version %q and kind %q cannot be mapped to a supported scope", gvk.GroupVersion().String(), gvk.Kind)
 	}
 
-	interfaces, err := m.interfacesFunc(gvk.GroupVersion().String())
+	interfaces, err := m.interfacesFunc(gvk.GroupVersion())
 	if err != nil {
 		return nil, fmt.Errorf("the provided version %q has no relevant versions", gvk.GroupVersion().String())
 	}

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -76,13 +76,13 @@ var validCodec = fakeCodec{}
 var validAccessor = resourceAccessor{}
 var validConvertor = fakeConvertor{}
 
-func fakeInterfaces(version string) (*VersionInterfaces, error) {
+func fakeInterfaces(version unversioned.GroupVersion) (*VersionInterfaces, error) {
 	return &VersionInterfaces{Codec: validCodec, ObjectConvertor: validConvertor, MetadataAccessor: validAccessor}, nil
 }
 
 var unmatchedErr = errors.New("no version")
 
-func unmatchedVersionInterfaces(version string) (*VersionInterfaces, error) {
+func unmatchedVersionInterfaces(version unversioned.GroupVersion) (*VersionInterfaces, error) {
 	return nil, unmatchedErr
 }
 

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -91,7 +91,7 @@ func (g TestGroup) InternalGroupVersion() unversioned.GroupVersion {
 // KUBE_TEST_API env var.
 func (g TestGroup) Codec() runtime.Codec {
 	// TODO: caesarxuchao: Restructure the body once we have a central `latest`.
-	interfaces, err := latest.GroupOrDie(g.externalGroupVersion.Group).InterfacesFor(g.externalGroupVersion.String())
+	interfaces, err := latest.GroupOrDie(g.externalGroupVersion.Group).InterfacesFor(g.externalGroupVersion)
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +101,7 @@ func (g TestGroup) Codec() runtime.Codec {
 // Converter returns the api.Scheme for the API version to test against, as set by the
 // KUBE_TEST_API env var.
 func (g TestGroup) Converter() runtime.ObjectConvertor {
-	interfaces, err := latest.GroupOrDie(g.externalGroupVersion.Group).InterfacesFor(g.externalGroupVersion.String())
+	interfaces, err := latest.GroupOrDie(g.externalGroupVersion.Group).InterfacesFor(g.externalGroupVersion)
 	if err != nil {
 		panic(err)
 	}
@@ -111,7 +111,7 @@ func (g TestGroup) Converter() runtime.ObjectConvertor {
 // MetadataAccessor returns the MetadataAccessor for the API version to test against,
 // as set by the KUBE_TEST_API env var.
 func (g TestGroup) MetadataAccessor() meta.MetadataAccessor {
-	interfaces, err := latest.GroupOrDie(g.externalGroupVersion.Group).InterfacesFor(g.externalGroupVersion.String())
+	interfaces, err := latest.GroupOrDie(g.externalGroupVersion.Group).InterfacesFor(g.externalGroupVersion)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -73,9 +73,9 @@ func init() {
 
 // interfacesFor returns the default Codec and ResourceVersioner for a given version
 // string, or an error if the version is not known.
-func interfacesFor(version string) (*meta.VersionInterfaces, error) {
+func interfacesFor(version unversioned.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case "componentconfig/v1alpha1":
+	case v1alpha1.SchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			Codec:            v1alpha1.Codec,
 			ObjectConvertor:  api.Scheme,

--- a/pkg/apis/componentconfig/install/install_test.go
+++ b/pkg/apis/componentconfig/install/install_test.go
@@ -43,11 +43,11 @@ func TestCodec(t *testing.T) {
 }
 
 func TestInterfacesFor(t *testing.T) {
-	if _, err := latest.GroupOrDie("componentconfig").InterfacesFor(""); err == nil {
+	if _, err := latest.GroupOrDie("componentconfig").InterfacesFor(componentconfig.SchemeGroupVersion); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, groupVersion := range append([]unversioned.GroupVersion{latest.GroupOrDie("componentconfig").GroupVersion}, latest.GroupOrDie("componentconfig").GroupVersions...) {
-		if vi, err := latest.GroupOrDie("componentconfig").InterfacesFor(groupVersion.String()); err != nil || vi == nil {
+	for i, version := range latest.GroupOrDie("componentconfig").GroupVersions {
+		if vi, err := latest.GroupOrDie("componentconfig").InterfacesFor(version); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
@@ -75,11 +75,11 @@ func TestRESTMapper(t *testing.T) {
 		if mapping.Resource != "kubeproxyconfigurations" {
 			t.Errorf("incorrect resource name: %#v", mapping)
 		}
-		if mapping.GroupVersionKind.GroupVersion() != gv {
+		if mapping.GroupVersionKind.GroupVersion() != version {
 			t.Errorf("incorrect groupVersion: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("componentconfig").InterfacesFor(gv.String())
+		interfaces, _ := latest.GroupOrDie("componentconfig").InterfacesFor(version)
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -73,9 +73,9 @@ func init() {
 
 // InterfacesFor returns the default Codec and ResourceVersioner for a given version
 // string, or an error if the version is not known.
-func interfacesFor(version string) (*meta.VersionInterfaces, error) {
+func interfacesFor(version unversioned.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case "extensions/v1beta1":
+	case v1beta1.SchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			Codec:            v1beta1.Codec,
 			ObjectConvertor:  api.Scheme,

--- a/pkg/apis/extensions/install/install_test.go
+++ b/pkg/apis/extensions/install/install_test.go
@@ -64,11 +64,11 @@ func TestCodec(t *testing.T) {
 }
 
 func TestInterfacesFor(t *testing.T) {
-	if _, err := latest.GroupOrDie("extensions").InterfacesFor(""); err == nil {
+	if _, err := latest.GroupOrDie("extensions").InterfacesFor(extensions.SchemeGroupVersion); err == nil {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
-	for i, groupVersion := range append([]unversioned.GroupVersion{latest.GroupOrDie("extensions").GroupVersion}, latest.GroupOrDie("extensions").GroupVersions...) {
-		if vi, err := latest.GroupOrDie("extensions").InterfacesFor(groupVersion.String()); err != nil || vi == nil {
+	for i, version := range latest.GroupOrDie("extensions").GroupVersions {
+		if vi, err := latest.GroupOrDie("extensions").InterfacesFor(version); err != nil || vi == nil {
 			t.Fatalf("%d: unexpected result: %v", i, err)
 		}
 	}
@@ -96,11 +96,11 @@ func TestRESTMapper(t *testing.T) {
 		if mapping.Resource != "horizontalpodautoscalers" {
 			t.Errorf("incorrect resource name: %#v", mapping)
 		}
-		if mapping.GroupVersionKind.GroupVersion() != gv {
+		if mapping.GroupVersionKind.GroupVersion() != version {
 			t.Errorf("incorrect groupVersion: %v", mapping)
 		}
 
-		interfaces, _ := latest.GroupOrDie("extensions").InterfacesFor(gv.String())
+		interfaces, _ := latest.GroupOrDie("extensions").InterfacesFor(version)
 		if mapping.Codec != interfaces.Codec {
 			t.Errorf("unexpected codec: %#v, expected: %#v", mapping, interfaces)
 		}

--- a/pkg/apis/metrics/install/install.go
+++ b/pkg/apis/metrics/install/install.go
@@ -73,9 +73,9 @@ func init() {
 
 // InterfacesFor returns the default Codec and ResourceVersioner for a given version
 // string, or an error if the version is not known.
-func interfacesFor(version string) (*meta.VersionInterfaces, error) {
+func interfacesFor(version unversioned.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case "metrics/v1alpha1":
+	case v1alpha1.SchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			Codec:            v1alpha1.Codec,
 			ObjectConvertor:  api.Scheme,

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -78,12 +78,8 @@ var mapper, namespaceMapper meta.RESTMapper // The mappers with namespace and wi
 var admissionControl admission.Interface
 var requestContextMapper api.RequestContextMapper
 
-func interfacesFor(version string) (*meta.VersionInterfaces, error) {
-	gv, err := unversioned.ParseGroupVersion(version)
-	if err != nil {
-		return nil, err
-	}
-	switch gv {
+func interfacesFor(version unversioned.GroupVersion) (*meta.VersionInterfaces, error) {
+	switch version {
 	case testGroupVersion:
 		return &meta.VersionInterfaces{
 			Codec:            codec,

--- a/pkg/client/unversioned/extensions.go
+++ b/pkg/client/unversioned/extensions.go
@@ -143,7 +143,7 @@ func setExtensionsDefaults(config *Config) error {
 	config.GroupVersion = &copyGroupVersion
 	//}
 
-	versionInterfaces, err := g.InterfacesFor(config.GroupVersion.String())
+	versionInterfaces, err := g.InterfacesFor(*config.GroupVersion)
 	if err != nil {
 		return fmt.Errorf("Extensions API group/version '%v' is not recognized (valid values: %v)",
 			config.GroupVersion, g.GroupVersions)

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -364,7 +364,7 @@ func SetKubernetesDefaults(config *Config) error {
 	if config.GroupVersion == nil {
 		config.GroupVersion = defaultVersionFor(config)
 	}
-	versionInterfaces, err := latest.GroupOrDie("").InterfacesFor(config.GroupVersion.String())
+	versionInterfaces, err := latest.GroupOrDie("").InterfacesFor(*config.GroupVersion)
 	if err != nil {
 		return fmt.Errorf("API version '%v' is not recognized (valid values: %v)", *config.GroupVersion, latest.GroupOrDie("").GroupVersions)
 	}

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -91,12 +91,12 @@ func newExternalScheme() (*runtime.Scheme, meta.RESTMapper, runtime.Codec) {
 	scheme.AddKnownTypeWithName(validVersionGV.WithKind("Type"), &ExternalType2{})
 
 	codec := runtime.CodecFor(scheme, unlikelyGV.String())
-	mapper := meta.NewDefaultRESTMapper([]unversioned.GroupVersion{unlikelyGV, validVersionGV}, func(version string) (*meta.VersionInterfaces, error) {
+	mapper := meta.NewDefaultRESTMapper([]unversioned.GroupVersion{unlikelyGV, validVersionGV}, func(version unversioned.GroupVersion) (*meta.VersionInterfaces, error) {
 		return &meta.VersionInterfaces{
-			Codec:            runtime.CodecFor(scheme, version),
+			Codec:            runtime.CodecFor(scheme, version.String()),
 			ObjectConvertor:  scheme,
 			MetadataAccessor: meta.NewAccessor(),
-		}, versionErrIfFalse(version == validVersionGV.String() || version == unlikelyGV.String())
+		}, versionErrIfFalse(version == validVersionGV || version == unlikelyGV)
 	})
 	for _, gv := range []unversioned.GroupVersion{unlikelyGV, validVersionGV} {
 		for kind := range scheme.KnownTypes(gv) {

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -376,7 +376,12 @@ func Merge(dst runtime.Object, fragment, kind string) (runtime.Object, error) {
 	if !ok {
 		return nil, fmt.Errorf("apiVersion must be a string")
 	}
-	i, err := latest.GroupOrDie("").InterfacesFor(versionString)
+	groupVersion, err := unversioned.ParseGroupVersion(versionString)
+	if err != nil {
+		return nil, err
+	}
+
+	i, err := latest.GroupOrDie("").InterfacesFor(groupVersion)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
update InterfacesFor to use GroupVersion.  Should be non-contentious. 

@caesarxuchao @liggitt 
