### PR TITLE
Quote string to preserve newlines in output in list-resources script

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -42,7 +42,7 @@ function gcloud-compute-list() {
   while true; do
     echo "Attempt ${attempt} to list ${resource} in GCE"
     if result=$(gcloud compute ${resource} list --project=${PROJECT} ${@:2} | grep "${GREP_REGEX}"); then
-      echo ${result}
+      echo "${result}"
       return
     fi
     echo -e "${color_yellow}Attempt ${attempt} failed to list ${resource}. Retrying.${color_norm}" >&2


### PR DESCRIPTION
Some missing quotes were causing output from `gcloud` to get squashed on one line, e.g.

```
[ disks ]
Attempt 1 to list disks in GCE
NAME ZONE SIZE_GB TYPE STATUS e2e-gce-master-1-991eb2fd-9b1f-11e5-a592-42010af0226b us-central1-f 10 pd-standard READY e2e-gce-master-1-master us-central1-f 10 pd-standard READY e2e-gce-master-1-master-pd us-central1-f 20 pd-ssd READY e2e-gce-master-1-minion-7s3f us-central1-f 100 pd-standard READY e2e-gce-master-1-minion-c44b us-central1-f 100 pd-standard READY e2e-gce-master-1-minion-ekva us-central1-f 100 pd-standard READY e2e-gce-master-1-minion-i2b4 us-central1-f 100 pd-standard READY e2e-gce-master-1-minion-q9ai us-central1-f 100 pd-standard READY e2e-gce-master-1-minion-xlqw us-central1-f 100 pd-standard READY
```

This was likely to make diffing more useless.

By simply quoting the string passed to `echo`, the newlines are preserved.
