### PR TITLE
Use Service SessionAffinity as ClientIP to help with GCE LB creation

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1406,6 +1406,7 @@ func (t *WebserverTest) BuildServiceSpec() *api.Service {
 				Port:       80,
 				TargetPort: intstr.FromInt(80),
 			}},
+			SessionAffinity: api.ServiceAffinityClientIP,
 		},
 	}
 	return service


### PR DESCRIPTION
Helps with #13818
