### PR TITLE
Deleting unused master.ClusterName param

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -35,11 +35,6 @@
 
 {% set address = "--address=127.0.0.1" -%}
 
-{% set cluster_name = "" -%}
-{% if pillar['instance_prefix'] is defined -%}
-  {% set cluster_name = "--cluster-name=" + pillar['instance_prefix'] -%}
-{% endif -%}
-
 {% set bind_address = "" -%}
 {% if grains.publicAddressOverride is defined -%}
   {% set bind_address = "--bind-address=" + grains.publicAddressOverride -%}
@@ -92,7 +87,7 @@
 {% endif -%}
 
 {% set params = address + " " + etcd_servers + " " + etcd_servers_overrides + " " + cloud_provider + " " + cloud_config + " " + runtime_config + " " + admission_control + " " + service_cluster_ip_range + " " + client_ca_file + " " + basic_auth_file + " " + min_request_timeout -%}
-{% set params = params + " " + cluster_name + " " + cert_file + " " + key_file + " --secure-port=" + secure_port + " " + token_auth_file + " " + bind_address + " " + pillar['log_level'] + " " + advertise_address  + " " + proxy_ssh_options -%}
+{% set params = params + " " + cert_file + " " + key_file + " --secure-port=" + secure_port + " " + token_auth_file + " " + bind_address + " " + pillar['log_level'] + " " + advertise_address  + " " + proxy_ssh_options -%}
 
 # test_args has to be kept at the end, so they'll overwrite any prior configuration
 {% if pillar['apiserver_test_args'] is defined -%}

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -106,7 +106,6 @@ type APIServer struct {
 	MasterServiceNamespace     string
 	RuntimeConfig              util.ConfigurationMap
 	KubeletConfig              kubeletclient.KubeletClientConfig
-	ClusterName                string
 	EnableProfiling            bool
 	EnableWatchCache           bool
 	MaxRequestsInFlight        int
@@ -133,7 +132,6 @@ func NewAPIServer() *APIServer {
 		EtcdPathPrefix:         master.DefaultEtcdPathPrefix,
 		EnableLogsSupport:      true,
 		MasterServiceNamespace: api.NamespaceDefault,
-		ClusterName:            "kubernetes",
 		CertDirectory:          "/var/run/kubernetes",
 		StorageVersions:        latest.AllPreferredGroupVersions(),
 
@@ -242,7 +240,6 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.MarkDeprecated("service-node-ports", "see --service-node-port-range instead.")
 	fs.StringVar(&s.MasterServiceNamespace, "master-service-namespace", s.MasterServiceNamespace, "The namespace from which the kubernetes master services should be injected into pods")
 	fs.Var(&s.RuntimeConfig, "runtime-config", "A set of key=value pairs that describe runtime configuration that may be passed to apiserver. apis/<groupVersion> key can be used to turn on/off specific api versions. apis/<groupVersion>/<resource> can be used to turn on/off specific resources. api/all and api/legacy are special keys to control all and legacy api versions respectively.")
-	fs.StringVar(&s.ClusterName, "cluster-name", s.ClusterName, "The instance prefix for the cluster")
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
 	// TODO: enable cache in integration tests.
 	fs.BoolVar(&s.EnableWatchCache, "watch-cache", true, "Enable watch caching in the apiserver")
@@ -559,7 +556,6 @@ func (s *APIServer) Run(_ []string) error {
 		AdmissionControl:          admissionController,
 		APIGroupVersionOverrides:  apiGroupVersionOverrides,
 		MasterServiceNamespace:    s.MasterServiceNamespace,
-		ClusterName:               s.ClusterName,
 		ExternalHost:              s.ExternalHost,
 		MinRequestTimeout:         s.MinRequestTimeout,
 		ProxyDialer:               proxyDialerFn,

--- a/docs/admin/kube-apiserver.md
+++ b/docs/admin/kube-apiserver.md
@@ -62,7 +62,6 @@ kube-apiserver
       --client-ca-file="": If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
       --cloud-config="": The path to the cloud provider configuration file.  Empty string for no configuration file.
       --cloud-provider="": The provider for cloud services.  Empty string for no provider.
-      --cluster-name="kubernetes": The instance prefix for the cluster
       --cors-allowed-origins=[]: List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  If this list is empty CORS will not be enabled.
       --etcd-prefix="/registry": The prefix for all resource paths in etcd.
       --etcd-servers=[]: List of etcd servers to watch (http://ip:port), comma separated. Mutually exclusive with -etcd-config

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -232,9 +232,6 @@ type Config struct {
 	// expire.
 	CacheTimeout time.Duration
 
-	// The name of the cluster.
-	ClusterName string
-
 	// The range of IPs to be assigned to services with type=ClusterIP or greater
 	ServiceClusterIPRange *net.IPNet
 


### PR DESCRIPTION
Forked from https://github.com/kubernetes/kubernetes/pull/18113

Its not used anywhere, seems safe to delete.

@smarterclayton Can you please confirm that openshift does not use it?

cc @lavalamp 
