### PR TITLE
Add 7-stage upgrade jobs

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -695,165 +695,25 @@ case ${JOB_NAME} in
           )"}
     ;;
 
-  # kubernetes-upgrade-gke
-
-  kubernetes-upgrade-gke-step1-deploy)
-    configure_upgrade_step 'release/latest' 'ci/latest' 'gke-upgrade' 'kubernetes-jenkins-gke-upgrade'
-    ;;
-
-  kubernetes-upgrade-gke-step2-upgrade-master)
-    configure_upgrade_step 'release/latest' 'ci/latest' 'gke-upgrade' 'kubernetes-jenkins-gke-upgrade'
-    ;;
-
-  kubernetes-upgrade-gke-step3-e2e-old)
-    configure_upgrade_step 'release/latest' 'ci/latest' 'gke-upgrade' 'kubernetes-jenkins-gke-upgrade'
-    ;;
-
-  kubernetes-upgrade-gke-step4-upgrade-cluster)
-    configure_upgrade_step 'release/latest' 'ci/latest' 'gke-upgrade' 'kubernetes-jenkins-gke-upgrade'
-    ;;
-
-  kubernetes-upgrade-gke-step5-e2e-old)
-    configure_upgrade_step 'release/latest' 'ci/latest' 'gke-upgrade' 'kubernetes-jenkins-gke-upgrade'
-    ;;
-
-  kubernetes-upgrade-gke-step6-e2e-new)
-    configure_upgrade_step 'release/latest' 'ci/latest' 'gke-upgrade' 'kubernetes-jenkins-gke-upgrade'
-    ;;
-
-  # kubernetes-upgrade-gke-stable-latest
-  #
-  # This suite:
-  #
-  # 1. launches a cluster at release/stable,
-  # 2. upgrades the master to release/latest,
-  # 3. runs release/stable e2es,
-  # 4. upgrades the rest of the cluster,
-  # 5. runs release/stable e2es again, then
-  # 6. runs release/latest e2es and tears down the cluster.
-
-  kubernetes-upgrade-stable-latest-gke-step1-deploy)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-stable-latest"}
-    : ${E2E_NETWORK:="gke-upgrade-stable-latest"}
-    : ${JENKINS_PUBLISHED_VERSION:="release/stable"}
-    : ${E2E_SET_CLUSTER_API_VERSION:=y}
-    : ${PROJECT:="k8s-jkns-upgrade-fixed-1"}
-    : ${E2E_UP:="true"}
-    : ${E2E_TEST:="false"}
-    : ${E2E_DOWN:="false"}
-    ;;
-
-  kubernetes-upgrade-stable-latest-gke-step2-upgrade-master)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-stable-latest"}
-    : ${E2E_NETWORK:="gke-upgrade-stable-latest"}
-    : ${E2E_OPT:="--check_version_skew=false"}
-    # Use upgrade logic of version we're upgrading to.
-    : ${JENKINS_PUBLISHED_VERSION:="release/latest"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    : ${PROJECT:="k8s-jkns-upgrade-fixed-1"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Cluster\sUpgrade.*upgrade-master --upgrade-target=release/latest"}
-    ;;
-
-  kubernetes-upgrade-stable-latest-gke-step3-e2e-old)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-stable-latest"}
-    : ${E2E_NETWORK:="gke-upgrade-stable-latest"}
-    : ${E2E_OPT:="--check_version_skew=false"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    # Run old e2es
-    : ${JENKINS_PUBLISHED_VERSION:="release/stable"}
-    : ${PROJECT:="k8s-jkns-upgrade-fixed-1"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GKE_FLAKY_TESTS[@]:+${GKE_FLAKY_TESTS[@]}} \
-          )"}
-    ;;
-
-  kubernetes-upgrade-stable-latest-gke-step4-upgrade-cluster)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-stable-latest"}
-    : ${E2E_NETWORK:="gke-upgrade-stable-latest"}
-    : ${E2E_OPT:="--check_version_skew=false"}
-    # Use upgrade logic of version we're upgrading to.
-    : ${JENKINS_PUBLISHED_VERSION:="release/latest"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    : ${PROJECT:="k8s-jkns-upgrade-fixed-1"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Cluster\sUpgrade.*upgrade-cluster --upgrade-target=release/latest"}
-    ;;
-
-  kubernetes-upgrade-stable-latest-gke-step5-e2e-old)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-stable-latest"}
-    : ${E2E_NETWORK:="gke-upgrade-stable-latest"}
-    : ${E2E_OPT:="--check_version_skew=false"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    # Run old e2es
-    : ${JENKINS_PUBLISHED_VERSION:="release/stable"}
-    : ${PROJECT:="k8s-jkns-upgrade-fixed-1"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GKE_FLAKY_TESTS[@]:+${GKE_FLAKY_TESTS[@]}} \
-          )"}
-    ;;
-
-  kubernetes-upgrade-stable-latest-gke-step6-e2e-new)
-    : ${DOGFOOD_GCLOUD:="true"}
-    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
-    : ${E2E_CLUSTER_NAME:="gke-upgrade-stable-latest"}
-    : ${E2E_NETWORK:="gke-upgrade-stable-latest"}
-    : ${JENKINS_FORCE_GET_TARS:=y}
-    : ${JENKINS_PUBLISHED_VERSION:="release/latest"}
-    : ${PROJECT:="k8s-jkns-upgrade-fixed-1"}
-    : ${E2E_UP:="false"}
-    : ${E2E_TEST:="true"}
-    : ${E2E_DOWN:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GKE_FLAKY_TESTS[@]:+${GKE_FLAKY_TESTS[@]}} \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          )"}
-    ;;
-
   # kubernetes-upgrade-gke-1.0-master
   #
   # Test upgrades from the latest release-1.0 build to the latest master build.
   #
-  # Configurations for step1, step3, and step5 live in the release-1.0 branch.
+  # Configurations for step1, step4, and step6 live in the release-1.0 branch.
 
-  kubernetes-upgrade-gke-1.0-master-step2-upgrade-master)
+  kubernetes-upgrade-gke-1.0-master-step2-kubectl-e2e-new)
     configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-1.0-master-step4-upgrade-cluster)
+  kubernetes-upgrade-gke-1.0-master-step3-upgrade-master)
     configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-1.0-master-step6-e2e-new)
+  kubernetes-upgrade-gke-1.0-master-step5-upgrade-cluster)
+    configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-1.0-master-step7-e2e-new)
     configure_upgrade_step 'configured-in-release-1.0' 'ci/latest' 'upgrade-gke-1-0-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
@@ -861,17 +721,21 @@ case ${JOB_NAME} in
   #
   # Test upgrades from the latest release-1.1 build to the latest master build.
   #
-  # Configurations for step1, step3, and step5 live in the release-1.1 branch.
+  # Configurations for step1, step4, and step6 live in the release-1.1 branch.
 
-  kubernetes-upgrade-gke-1.1-master-step2-upgrade-master)
+  kubernetes-upgrade-gke-1.1-master-step2-kubectl-e2e-new)
     configure_upgrade_step 'configured-in-release-1.1' 'ci/latest' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-1.1-master-step4-upgrade-cluster)
+  kubernetes-upgrade-gke-1.1-master-step3-upgrade-master)
     configure_upgrade_step 'configured-in-release-1.1' 'ci/latest' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
-  kubernetes-upgrade-gke-1.1-master-step6-e2e-new)
+  kubernetes-upgrade-gke-1.1-master-step5-upgrade-cluster)
+    configure_upgrade_step 'configured-in-release-1.1' 'ci/latest' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  kubernetes-upgrade-gke-1.1-master-step7-e2e-new)
     configure_upgrade_step 'configured-in-release-1.1' 'ci/latest' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -51,11 +51,12 @@ function join_regex_no_empty() {
 #
 # These suites:
 #   step1: launch a cluster at $old_version,
-#   step2: upgrades the master to $new_version,
-#   step3: runs $old_version e2es,
-#   step4: upgrades the rest of the cluster,
-#   step5: runs $old_version e2es again, then
-#   step6: runs $new_version e2es and tears down the cluster.
+#   step2: runs $new_version Kubectl e2es,
+#   step3: upgrades the master to $new_version,
+#   step4: runs $old_version e2es,
+#   step5: upgrades the rest of the cluster,
+#   step6: runs $old_version e2es again, then
+#   step7: runs $new_version e2es and tears down the cluster.
 #
 # Assumes globals:
 #   $JOB_NAME
@@ -125,6 +126,18 @@ function configure_upgrade_step() {
       ;;
 
     step2)
+      # Run new e2e kubectl tests
+      JENKINS_PUBLISHED_VERSION="${new_version}"
+      JENKINS_FORCE_GET_TARS=y
+
+      E2E_OPT="--check_version_skew=false"
+      E2E_UP="false"
+      E2E_TEST="true"
+      E2E_DOWN="false"
+      GINKGO_TEST_ARGS="--ginkgo.focus=Kubectl"
+      ;;
+
+    step3)
       # Use upgrade logic of version we're upgrading to.
       JENKINS_PUBLISHED_VERSION="${new_version}"
       JENKINS_FORCE_GET_TARS=y
@@ -136,7 +149,7 @@ function configure_upgrade_step() {
       GINKGO_TEST_ARGS="--ginkgo.focus=Cluster\sUpgrade.*upgrade-master --upgrade-target=${new_version}"
       ;;
 
-    step3)
+    step4)
       # Run old e2es
       JENKINS_PUBLISHED_VERSION="${old_version}"
       JENKINS_FORCE_GET_TARS=y
@@ -153,7 +166,7 @@ function configure_upgrade_step() {
       fi
       ;;
 
-    step4)
+    step5)
       # Use upgrade logic of version we're upgrading to.
       JENKINS_PUBLISHED_VERSION="${new_version}"
       JENKINS_FORCE_GET_TARS=y
@@ -165,7 +178,7 @@ function configure_upgrade_step() {
       GINKGO_TEST_ARGS="--ginkgo.focus=Cluster\sUpgrade.*upgrade-cluster --upgrade-target=${new_version}"
       ;;
 
-    step5)
+    step6)
       # Run old e2es
       JENKINS_PUBLISHED_VERSION="${old_version}"
       JENKINS_FORCE_GET_TARS=y
@@ -182,7 +195,7 @@ function configure_upgrade_step() {
       fi
       ;;
 
-    step6)
+    step7)
       # Run new e2es
       JENKINS_PUBLISHED_VERSION="${new_version}"
       JENKINS_FORCE_GET_TARS=y


### PR DESCRIPTION
Add version-skewed Kubectl tests to the upgrade jobs to get visibility that new `kubectl` will work with old cluster.
