### PR TITLE
pkg/kubelet: force NodeReady condition to be last on existing nodes

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2570,6 +2570,7 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 	// NOTE(aaronlevy): NodeReady condition needs to be the last in the list of node conditions.
 	// This is due to an issue with version skewed kubelet and master components.
 	// ref: https://github.com/kubernetes/kubernetes/issues/16961
+	// TODO: Remove the code after we drop support for v1.0 kubelets
 	lastIndex := len(node.Status.Conditions) - 1
 	for i := range node.Status.Conditions {
 		if node.Status.Conditions[i].Type == api.NodeReady && i < lastIndex {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2789,18 +2789,18 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 			Status: api.NodeStatus{
 				Conditions: []api.NodeCondition{
 					{
-						Type:               api.NodeOutOfDisk,
-						Status:             api.ConditionTrue,
-						Reason:             "KubeletOutOfDisk",
-						Message:            "out of disk space",
-						LastHeartbeatTime:  unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						LastTransitionTime: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-					},
-					{
 						Type:               api.NodeReady,
 						Status:             api.ConditionTrue,
 						Reason:             "KubeletReady",
 						Message:            fmt.Sprintf("kubelet is posting ready status"),
+						LastHeartbeatTime:  unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						LastTransitionTime: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					},
+					{
+						Type:               api.NodeOutOfDisk,
+						Status:             api.ConditionTrue,
+						Reason:             "KubeletOutOfDisk",
+						Message:            "out of disk space",
 						LastHeartbeatTime:  unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 						LastTransitionTime: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 					},


### PR DESCRIPTION
Oversight on my part from: https://github.com/kubernetes/kubernetes/pull/17975

Existing nodes will only update the NodeReady condition in place, which means existing nodes will still be affected by the version skew issue (NodeOutOfDisk condition will be last).

This change swaps the NodeReady condition as the last in the slice. In hindsight adding this stub at the end of the function was probably a cleaner approach.

I've also updated TestUpdateExistingNodeStatus to test that the expected state of an existing node will be updated.
