### PR TITLE
Tidy up Pod docs a bit

### DIFF
--- a/docs/user-guide/pods.md
+++ b/docs/user-guide/pods.md
@@ -39,8 +39,8 @@ Documentation for other releases can be found at
 - [Pods](#pods)
   - [What is a _pod_?](#what-is-a-pod)
   - [Motivation for pods](#motivation-for-pods)
-    - [Resource sharing and communication](#resource-sharing-and-communication)
     - [Management](#management)
+    - [Resource sharing and communication](#resource-sharing-and-communication)
   - [Uses of pods](#uses-of-pods)
   - [Alternatives considered](#alternatives-considered)
   - [Durability of pods (or lack thereof)](#durability-of-pods-or-lack-thereof)
@@ -50,42 +50,91 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: GENERATED_TOC -->
 
-In Kubernetes, rather than individual application containers, _pods_ are the smallest deployable units that can be created, scheduled, and managed.
+_pods_ are the smallest deployable units of computing that can be created and
+managed in Kubernetes.
 
 ## What is a _pod_?
 
-A _pod_ (as in a pod of whales or pea pod) corresponds to a colocated group of applications running with a shared context. Within that context, the applications may also have individual cgroup isolations applied. A pod models an application-specific "logical host" in a containerized environment. It may contain one or more applications which are relatively tightly coupled &mdash; in a pre-container world, they would have executed on the same physical or virtual host.
+A _pod_ (as in a pod of whales or pea pod) is a group of one or more containers
+(such as Docker containers), the shared storage for those containers, and
+options about how to run the containers.  Pods are always co-located and
+co-scheduled, and run in a shared context.  A pod models an
+application-specific "logical host" - it contains one or more application
+containers which are relatively tightly coupled &mdash; in a pre-container
+world, they would have executed on the same physical or virtual machine.
 
-The context of the pod can be defined as the conjunction of several Linux namespaces:
+While Kubernetes supports more container runtimes than just Docker, Docker is
+the most commonly known runtime, and it helps to describe pods in Docker terms.
 
-* PID namespace (applications within the pod can see each other's processes)
-* network namespace (applications within the pod have access to the same IP and port space)
-* IPC namespace (applications within the pod can use SystemV IPC or POSIX message queues to communicate)
-* UTS namespace (applications within the pod share a hostname)
+The shared context of a pod is a set of Linux namespaces, cgroups, and
+potentially other facets of isolation - the same things that isolate a Docker
+container.  Within a pod's context, the individual applications may have
+further sub-isolations applied.
 
-Applications within a pod also have access to shared volumes, which are defined at the pod level and made available in each application's filesystem. Additionally, a pod may define top-level cgroup isolations which form an outer bound to any individual isolation applied to constituent applications.
+Containers within a pod share an IP address and port space, and
+can find each other via `localhost`. They can also communicate with each
+other using standard inter-process communications like SystemV semaphores or
+POSIX shared memory.  Containers in different pods have distinct IP addresses
+and can not communicate by IPC.
 
-In terms of [Docker](https://www.docker.com/) constructs, a pod consists of a colocated group of Docker containers with shared [volumes](volumes.md). PID namespace sharing is not yet implemented with Docker.
+Applications within a pod also have access to shared volumes, which are defined
+as part of a pod and are made available to be mounted into each application's
+filesystem.
 
-Like individual application containers, pods are considered to be relatively ephemeral rather than durable entities. As discussed in [life of a pod](pod-states.md), pods are scheduled to nodes and remain there until termination (according to restart policy) or deletion. When a node dies, the pods scheduled to that node are deleted. Specific pods are never rescheduled to new nodes; instead, they must be replaced (see [replication controller](replication-controller.md) for more details). (In the future, a higher-level API may support pod migration.)
+In terms of [Docker](https://www.docker.com/) constructs, a pod is modelled as
+a group of Docker containers with shared namespaces and shared
+[volumes](volumes.md). PID namespace sharing is not yet implemented in Docker.
+
+Like individual application containers, pods are considered to be relatively
+ephemeral (rather than durable) entities. As discussed in [life of a
+pod](pod-states.md), pods are created, assigned a unique ID (UID), and
+scheduled to nodes where they remain until termination (according to restart
+policy) or deletion. If a node dies, the pods scheduled to that node are
+deleted, after a timeout period. A given pod (as defined by a UID) is not
+"rescheduled" to a new node; instead, it can be replaced by an identical pod,
+with even the same name if desired, but with a new UID (see [replication
+controller](replication-controller.md) for more details). (In the future, a
+higher-level API may support pod migration.)
+
+When something is said to have the same lifetime as a pod, such as a volume,
+that means that it exists as long as that pod (with that UID) exists. If that
+pod is deleted for any reason, even if an identical replacement is created, the
+related thing (e.g. volume) is also destroyed and created anew.
 
 ## Motivation for pods
 
-### Resource sharing and communication
-
-Pods facilitate data sharing and communication among their constituents.
-
-The applications in the pod all use the same network namespace/IP and port space, and can find and communicate with each other using localhost. Each pod has an IP address in a flat shared networking namespace that has full communication with other physical computers and containers across the network. The hostname is set to the pod's Name for the application containers within the pod. [More details on networking](../admin/networking.md).
-
-In addition to defining the application containers that run in the pod, the pod specifies a set of shared storage volumes. Volumes enable data to survive container restarts and to be shared among the applications within the pod.
-
 ### Management
 
-Pods also simplify application deployment and management by providing a higher-level abstraction than the raw, low-level container interface. Pods serve as units of deployment and horizontal scaling/replication. Co-location (co-scheduling), fate sharing, coordinated replication, resource sharing, and dependency management are handled automatically.
+Pods are a model of the pattern of multiple cooperating processes which form a
+cohesive unit of service.  They simplify application deployment and management
+by providing a higher-level abstraction than the set of their constituent
+applications. Pods serve as unit of deployment, horizontal scaling, and
+replication. Colocation (co-scheduling), shared fate (e.g. termination),
+coordinated replication, resource sharing, and dependency management are
+handled automatically for containers in a pod.
+
+### Resource sharing and communication
+
+Pods enable data sharing and communication among their constituents.
+
+The applications in a pod all use the same network namespace (same IP and port
+space), and can thus "find" each other and communicate using `localhost`.
+Because of this, applications in a pod must coordinate their usage of ports.
+Each pod has an IP address in a flat shared networking space that has full
+communication with other physical computers and pods across the network.
+
+The hostname is set to the pod's Name for the application containers within the
+pod. [More details on networking](../admin/networking.md).
+
+In addition to defining the application containers that run in the pod, the pod
+specifies a set of shared storage volumes. Volumes enable data to survive
+container restarts and to be shared among the applications within the pod.
 
 ## Uses of pods
 
-Pods can be used to host vertically integrated application stacks, but their primary motivation is to support co-located, co-managed helper programs, such as:
+Pods can be used to host vertically integrated application stacks (e.g. LAMP),
+but their primary motivation is to support co-located, co-managed helper
+programs, such as:
 
 * content management systems, file and data loaders, local cache managers, etc.
 * log and checkpoint backup, compression, rotation, snapshotting, etc.
@@ -93,22 +142,34 @@ Pods can be used to host vertically integrated application stacks, but their pri
 * proxies, bridges, and adapters
 * controllers, managers, configurators, and updaters
 
-Individual pods are not intended to run multiple instances of the same application, in general.
+Individual pods are not intended to run multiple instances of the same
+application, in general.
 
-For a longer explanation, see [The Distributed System ToolKit: Patterns for Composite Containers](http://blog.kubernetes.io/2015/06/the-distributed-system-toolkit-patterns.html).
+For a longer explanation, see [The Distributed System ToolKit: Patterns for
+Composite
+Containers](http://blog.kubernetes.io/2015/06/the-distributed-system-toolkit-patterns.html).
 
 ## Alternatives considered
 
 _Why not just run multiple programs in a single (Docker) container?_
 
-1. Transparency. Making the containers within the pod visible to the infrastructure enables the infrastructure to provide services to those containers, such as process management and resource monitoring. This facilitates a number of conveniences for users.
-2. Decoupling software dependencies. The individual containers may be rebuilt and redeployed independently. Kubernetes may even support live updates of individual containers someday.
-3. Ease of use. Users don't need to run their own process managers, worry about signal and exit-code propagation, etc.
-4. Efficiency. Because the infrastructure takes on more responsibility, containers can be lighter weight.
+1. Transparency. Making the containers within the pod visible to the
+   infrastructure enables the infrastructure to provide services to those
+   containers, such as process management and resource monitoring. This
+   facilitates a number of conveniences for users.
+2. Decoupling software dependencies. The individual containers may be
+   versioned, rebuilt and redeployed independently. Kubernetes may even support
+   live updates of individual containers someday.
+3. Ease of use. Users don't need to run their own process managers, worry about
+   signal and exit-code propagation, etc.
+4. Efficiency. Because the infrastructure takes on more responsibility,
+   containers can be lighter weight.
 
 _Why not support affinity-based co-scheduling of containers?_
 
-That approach would provide co-location, but would not provide most of the benefits of pods, such as resource sharing, IPC, guaranteed fate sharing, and simplified management.
+That approach would provide co-location, but would not provide most of the
+benefits of pods, such as resource sharing, IPC, guaranteed fate sharing, and
+simplified management.
 
 ## Durability of pods (or lack thereof)
 


### PR DESCRIPTION
In response to a user question I wanted to point them to a doc, but this doc 
was a little hard to digest.  I did not do the whole doc, just the first sections which seemed most introductory.  I could do the rest.
