### PR TITLE
Improve label selector validations' error messages

### DIFF
--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -671,8 +671,8 @@ func (p *Parser) parseExactValue() (sets.String, error) {
 //           <value-set> ::= "(" <values> ")"
 //              <values> ::= VALUE | VALUE "," <values>
 // <exact-match-restriction> ::= ["="|"=="|"!="] VALUE
-// KEY is a sequence of one or more characters following [ DNS_SUBDOMAIN "/" ] DNS_LABEL
-// VALUE is a sequence of zero or more characters "([A-Za-z0-9_-\.])". Max length is 64 character.
+// KEY is a sequence of one or more characters following [ DNS_SUBDOMAIN "/" ] DNS_LABEL. Max length is 63 characters.
+// VALUE is a sequence of zero or more characters "([A-Za-z0-9_-\.])". Max length is 63 characters.
 // Delimiter is white space: (' ', '\t')
 // Example of valid syntax:
 //  "x in (foo,,baz),y,z notin ()"
@@ -697,7 +697,8 @@ func Parse(selector string) (Selector, error) {
 	return nil, error
 }
 
-const qualifiedNameErrorMsg string = "must match regex [" + validation.DNS1123SubdomainFmt + " / ] " + validation.DNS1123LabelFmt
+var qualifiedNameErrorMsg string = fmt.Sprintf(`must be a qualified name (at most %d characters, matching regex %s), with an optional DNS subdomain prefix (at most %d characters, matching regex %s) and slash (/): e.g. "MyName" or "example.com/MyName"`, validation.QualifiedNameMaxLength, validation.QualifiedNameFmt, validation.DNS1123SubdomainMaxLength, validation.DNS1123SubdomainFmt)
+var labelValueErrorMsg string = fmt.Sprintf(`must have at most %d characters, matching regex %s: e.g. "MyValue" or ""`, validation.LabelValueMaxLength, validation.LabelValueFmt)
 
 func validateLabelKey(k string) error {
 	if !validation.IsQualifiedName(k) {
@@ -708,8 +709,7 @@ func validateLabelKey(k string) error {
 
 func validateLabelValue(v string) error {
 	if !validation.IsValidLabelValue(v) {
-		//FIXME: this is not the right regex!
-		return fmt.Errorf("invalid label value: %s", qualifiedNameErrorMsg)
+		return fmt.Errorf("invalid label value: %s", labelValueErrorMsg)
 	}
 	return nil
 }


### PR DESCRIPTION
When a label selector fails validation, the error message shown currently only mentions a regex validation and doesn't mention the 63-character limit validation. When I encountered this error message, it took me a little time to look through the source to find that there was a character limit validation.

The error message for a label value's validation also incorrectly shows the validation regex for a key (and not the validation regex for a value); there was a `FIXME` comment mentioning this.

The [error messages used in the API's validations](https://github.com/kubernetes/kubernetes/blob/master/pkg/api/validation/validation.go#L53-L54) are much more complete and accurate, so using those here should fix these issues, making these error messages more helpful.
