### PR TITLE
Add a script to run local docker based cluster

### DIFF
--- a/cluster/get-kube-local.sh
+++ b/cluster/get-kube-local.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will download latest version of kubectl command line tool and will
+# bring up a local Kubernetes cluster with a single node.
+#
+# Usage:
+#   wget -q -O - https://get.k8s.io/local | bash
+# or
+#   curl -sS https://get.k8s.io/local | bash
+#
+# On Mac OS X you'll have to additionally pass env variable:
+#   wget -q -O - https://get.k8s.io/local | KUBE_HOST=<docker_machine_ip> bash -c
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_HOST=${KUBE_HOST:-localhost}
+
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+ORANGE="\033[0;33m"
+
+function echo_green {
+  echo -e "${GREEN}$1"; tput sgr0
+}
+
+function echo_red {
+  echo -e "${RED}$1"; tput sgr0
+}
+
+function echo_orange {
+  echo -e "${ORANGE}$1"; tput sgr0
+}
+
+function run {
+  output=`$1 2>&1 || true`
+  if [ $? -eq 0 ]; then
+    echo_green "SUCCESS"
+  else
+    echo_red "FAILED"
+    echo $output >&2
+    exit 1
+  fi
+}
+
+function create_cluster {
+  echo "Creating a local cluster:"
+  echo -e -n "\tStarting kubelet..."
+  run "docker run \
+  --volume=/:/rootfs:ro \
+  --volume=/sys:/sys:ro \
+  --volume=/dev:/dev \
+  --volume=/var/lib/docker/:/var/lib/docker:rw \
+  --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+  --volume=/var/run:/var/run:rw \
+  --net=host \
+  --pid=host \
+  --privileged=true \
+  -d \
+  gcr.io/google_containers/hyperkube-${arch}:${release} \
+    /hyperkube kubelet \
+      --containerized \
+      --hostname-override="127.0.0.1" \
+      --address="0.0.0.0" \
+      --api-servers=http://localhost:8080 \
+      --config=/etc/kubernetes/manifests \
+      --allow-privileged=true \
+      --v=2"
+
+  echo -e -n "\tWaiting for master components to start..."
+  while true; do
+    local running_count=`kubectl -s=http://${KUBE_HOST}:8080 get pods --no-headers 2>/dev/null | grep "Running" | wc -l`
+    # We expect to have 3 running pods - etcd, master and kube-proxy.
+    if [ "$running_count" -ge 3 ]; then
+      break
+    fi
+    echo -n "."
+    sleep 1
+  done
+  echo_green "SUCCESS"
+  echo_green "Cluster created!"
+  echo ""
+  kubectl -s http://${KUBE_HOST}:8080 clusterinfo
+}
+
+function get_latest_version_number {
+  local -r latest_url="https://storage.googleapis.com/kubernetes-release/release/stable.txt"
+  if [[ $(which wget) ]]; then
+    wget -qO- ${latest_url}
+  elif [[ $(which curl) ]]; then
+    curl -Ss ${latest_url}
+  else
+    echo_red "Couldn't find curl or wget.  Bailing out."
+    exit 4
+  fi
+}
+
+release=$(get_latest_version_number)
+
+uname=$(uname)
+if [[ "${uname}" == "Darwin" ]]; then
+  platform="darwin"
+elif [[ "${uname}" == "Linux" ]]; then
+  platform="linux"
+else
+  echo_red "Unknown, unsupported platform: (${uname})."
+  echo_red "Supported platforms: Linux, Darwin."
+  echo_red "Bailing out."
+  exit 2
+fi
+
+machine=$(uname -m)
+if [[ "${machine}" == "x86_64" ]]; then
+  arch="amd64"
+elif [[ "${machine}" == "i686" ]]; then
+  arch="386"
+elif [[ "${machine}" == "arm*" ]]; then
+  arch="arm"
+elif [[ "${machine}" == "s390x*" ]]; then
+  arch="s390x"
+else
+  echo_red "Unknown, unsupported architecture (${machine})."
+  echo_red "Supported architectures x86_64, i686, arm, s390x."
+  echo_red "Bailing out."
+  exit 3
+fi
+
+kubectl_url=https://storage.googleapis.com/kubernetes-release/release/${release}/bin/${platform}/${arch}/kubectl
+
+if [[ `ls . | grep ^kubectl$ | wc -l` -lt 1 ]]; then
+  echo -n "Downloading kubectl binary..."
+  if [[ $(which wget) ]]; then
+    run "wget ${kubectl_url}"
+  elif [[ $(which curl) ]]; then
+    run "curl -L ${kubectl_url}"
+  else
+    echo_red "Couldn't find curl or wget.  Bailing out."
+    exit 1
+  fi
+  chmod a+x kubectl
+  echo ""
+else
+  echo "Detected existing kubectl binary. Skipping download."
+fi
+
+create_cluster
+
+echo ""
+echo ""
+echo "To list the nodes in your cluster run"
+echo_orange "\tkubectl -s=http://${KUBE_HOST}:8080 get nodes"
+echo ""
+echo "To run your first pod run"
+echo_orange "\tkubectl -s http://${KUBE_HOST}:8080 run nginx --image=nginx --port=80"


### PR DESCRIPTION
This introduces a script to run a local docker based cluster, which is similar to what we already have for a regular cluster. Once we fix remaining issues with docker based setup I'd like to serve it from `get.k8s.io/local` so that user can play with kubernetes using just one command.

Output from the successful run of this script:

``` sh
$ ./cluster/get-kube-local.sh 
Downloading kubectl binary...SUCCESS

Creating a local cluster:
    Starting kubelet...SUCCESS
    Waiting for master components to start...................SUCCESS
Cluster created!

Kubernetes master is running at http://localhost:8080


To list the nodes in your cluster run
    kubectl -s=http://localhost:8080 get nodes

To run your first pod run
    kubectl -s http://localhost:8080 run nginx --image=nginx --port=80
```

@brendandburns - I assigned this to you as wrote the other script for regular clusters, but feel free to reassign.

@roberthbailey @mikedanese 

Ref #12722

This depends on #18351
