### PR TITLE
Node e2e changes for jenkins hosts

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// To run tests in this suite
+// `$ ginkgo -- --node-name node-e2e-test-1  --api-server-address <serveraddress> --logtostderr`
 package e2e_node
 
 import (


### PR DESCRIPTION
Changes to make node e2e tests run on jenkins.
- Improve documentation and method naming
- Fix command this is run remotely
- Never reschedule the busybox logging test pod since it is supposed to terminate
- Update log test condition retrylogic to correctly retry instead of failing the test
- localhost -> 127.0.0.1 to work on coreos
- give name to etcd to work on coreos
- allow using full hostname for nodename for coreos
- fix issue where an error in TearDown was causing framework to hang
