### PR TITLE
Add kubernetes-e2e-gce job to git

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -224,6 +224,7 @@ E2E_OPT=${E2E_OPT:-""}
 # Set environment variables shared for all of the GCE Jenkins projects.
 if [[ ${JOB_NAME} =~ ^kubernetes-.*-gce ]]; then
   KUBERNETES_PROVIDER="gce"
+  : ${GCE_SERVICE_ACCOUNT:=$(gcloud auth list 2> /dev/null | grep active | cut -f3 -d' ')}
   : ${E2E_MIN_STARTUP_PODS:="1"}
   : ${E2E_ZONE:="us-central1-f"}
   : ${NUM_NODES_PARALLEL:="6"}  # Number of nodes required to run all of the tests in parallel
@@ -389,6 +390,7 @@ case ${JOB_NAME} in
   # Runs all non-flaky, non-slow tests on GCE, sequentially.
   kubernetes-e2e-gce)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e"}
+    : ${E2E_PUBLISH_GREEN_VERSION:="true"}
     : ${E2E_NETWORK:="e2e-gce"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \

--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -1,0 +1,47 @@
+# Mail Watcher Plugin alerts the specified address whenever a job config is updated or deleted.
+- property:
+    name: mail-watcher
+    properties:
+        - raw:
+            xml: |
+                <org.jenkinsci.plugins.mailwatcher.WatcherJobProperty plugin="mail-watcher-plugin@1.13">
+                    <watcherAddresses>cloud-kubernetes-team@google.com</watcherAddresses>
+                </org.jenkinsci.plugins.mailwatcher.WatcherJobProperty>
+
+- publisher:
+    name: gcs-uploader
+    publishers:
+        - google-cloud-storage:
+            credentials-id: kubernetes-jenkins
+            uploads:
+                - build-log:
+                    log-name: build-log.txt
+                    storage-location: gs://kubernetes-jenkins/logs/$JOB_NAME/$BUILD_NUMBER
+                    share-publicly: true
+                    upload-for-failed-jobs: true
+
+# Default log parser rules.
+- publisher:
+    name: log-parser
+    publishers:
+        - logparser:
+            parse-rules: /jenkins-master-data/log_parser_rules.txt
+            unstable-on-warning: false
+            fail-on-error: false
+
+# There is a junit JJB tag, but it doesn't handle the flaky-test-handler plugin.
+- publisher:
+    name: junit-publisher
+    publishers:
+        - raw:
+            xml: |
+                <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.9">
+                    <testResults>_artifacts/junit*.xml</testResults>
+                    <keepLongStdio>true</keepLongStdio>
+                    <testDataPublishers>
+                        <de.esailors.jenkins.teststability.StabilityTestDataPublisher plugin="test-stability@1.0"/>
+                        <com.google.jenkins.flakyTestHandler.plugin.JUnitFlakyTestDataPublisher plugin="flaky-test-handler@1.0.1"/>
+                        <hudson.plugins.claim.ClaimTestDataPublisher plugin="claim@2.7"/>
+                    </testDataPublishers>
+                    <healthScaleFactor>100.0</healthScaleFactor>
+                </hudson.tasks.junit.JUnitResultArchiver>

--- a/hack/jenkins/job-configs/kubernetes-build.yaml
+++ b/hack/jenkins/job-configs/kubernetes-build.yaml
@@ -6,12 +6,7 @@
     builders:
         - shell: './hack/jenkins/build.sh'
     properties:
-        # Mail Watcher Plugin alerts the specified address whenever a job config is updated or deleted.
-        - raw:
-            xml: |
-                <org.jenkinsci.plugins.mailwatcher.WatcherJobProperty plugin="mail-watcher-plugin@1.13">
-                    <watcherAddresses>cloud-kubernetes-team@google.com</watcherAddresses>
-                </org.jenkinsci.plugins.mailwatcher.WatcherJobProperty>
+        - mail-watcher
     publishers:
         - claim-build
         - email-ext:
@@ -22,18 +17,8 @@
             send-to:
                 - culprits
                 - recipients
-        - google-cloud-storage:
-            credentials-id: kubernetes-jenkins
-            uploads:
-                - build-log:
-                    log-name: build-log.txt
-                    storage-location: gs://kubernetes-jenkins/logs/$JOB_NAME/$BUILD_NUMBER
-                    share-publicly: true
-                    upload-for-failed-jobs: true
-        - logparser:
-            parse-rules: /jenkins-master-data/log_parser_rules.txt
-            unstable-on-warning: false
-            fail-on-error: false
+        - gcs-uploader
+        - log-parser
     scm:
         - git:
             url: https://github.com/kubernetes/kubernetes

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -1,0 +1,38 @@
+- job-template:
+    name: 'kubernetes-e2e-{suffix}'
+    description: 'Run E2E tests on GCE using the latest successful build. Test owner: Build Cop.'
+    logrotate:
+        daysToKeep: 7
+    builders:
+        - shell: |
+            curl -fsS -o upload-to-gcs.sh --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" && source upload-to-gcs.sh; rm -f upload-to-gcs.sh
+            curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e.sh" | bash -
+    properties:
+        - mail-watcher
+    publishers:
+        - claim-build
+        - email-ext
+        - gcs-uploader
+        - log-parser
+        - junit-publisher
+    triggers:
+        - reverse:
+            jobs: kubernetes-build
+            result: success
+        - timed: 'H/30 * * * *'
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - timeout:
+            timeout: 150
+            abort: true
+            fail: true
+        - timestamps
+        - workspace-cleanup
+
+- project:
+    name: kubernetes-e2e
+    suffix:
+        - 'gce'
+    jobs:
+        - 'kubernetes-e2e-{suffix}'

--- a/hack/jenkins/job-configs/kubernetes-update-jenkins-jobs.yaml
+++ b/hack/jenkins/job-configs/kubernetes-update-jenkins-jobs.yaml
@@ -1,6 +1,6 @@
 - job:
     name: kubernetes-update-jenkins-jobs
-    description: 'Update Jenkins jobs'
+    description: 'Update Jenkins jobs. Test owner: spxtr.'
 
     triggers:
         - timed: 'H/15 * * * *'


### PR DESCRIPTION
I think it might be a good idea to add this job on its own, make sure it's working right, then add the rest of the GCE E2E tests in a second PR. For the most part they have the same settings, except for easy-to-substitute things like timeout duration or branch. I have backed up the current config.

Changes to the config:
- We no longer block if kubernetes-build is unstable or failing. I can add this back in, if necessary.
- We no longer publish to slack. The Jenkins slack plugin puts authentication info in every job config, which is unacceptable here. See [this issue](https://github.com/jenkinsci/slack-plugin/issues/159). It looks like work in in progress to fix this.
#18122
