### PR TITLE
Update the command line of kubelet in Trusty nodes.

### DIFF
--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -137,6 +137,7 @@ script
 		--configure-cbr0=true \
 		--cgroup-root=/ \
 		--system-container=/system \
+		--nosystemd=true \
 		${ARGS}
 end script
 


### PR DESCRIPTION
This change is to pick up the fix in PR #18178. It avoids confusing cadvisor when systemd is present in an instance but does not act as the init system.
