### PR TITLE
Fix queryparams convert

### DIFF
--- a/pkg/conversion/queryparams/convert.go
+++ b/pkg/conversion/queryparams/convert.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -144,6 +145,12 @@ func convertStruct(result url.Values, st reflect.Type, sv reflect.Value) {
 				addListOfParams(result, tag, omitempty, field)
 			}
 		case isStructKind(kind) && !(zeroValue(field) && omitempty):
+			if selector, ok := field.Interface().(unversioned.LabelSelector); ok {
+				addParam(result, tag, omitempty, reflect.ValueOf(selector.Selector.String()))
+			}
+			if selector, ok := field.Interface().(unversioned.FieldSelector); ok {
+				addParam(result, tag, omitempty, reflect.ValueOf(selector.Selector.String()))
+			}
 			convertStruct(result, ft, field)
 		}
 	}


### PR DESCRIPTION
When the ListOptions is added to a request associated with a resource in the "extensions" group, the `versioned` [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/client/unversioned/request.go#L420) will be an unversioned.ListOptions, then in the following [convert](https://github.com/kubernetes/kubernetes/blob/master/pkg/client/unversioned/request.go#L425), the content in the LabelSelector/FieldSelector is ignored (https://github.com/kubernetes/kubernetes/blob/master/pkg/conversion/queryparams/convert.go#L126) because it does not have a json tag(https://github.com/kubernetes/kubernetes/blob/master/pkg/api/unversioned/selector.go#L29).

This problem does not exist for a resource in the "" group, because the the `versioned` [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/client/unversioned/request.go#L420) will be `v1.ListOptions` and its [LabelSelector/FieldSelector](https://github.com/kubernetes/kubernetes/blob/master/pkg/api/v1/types.go#L2060) is `string`.

This PR fix the conversion and add a test.

This is blocking #18231.

@wojtek-t 
