### PR TITLE
ResourceQuota and LimitRanger ignore pod updates to fix kubectl patch

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1198,6 +1198,10 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) validation.ErrorList {
 	// Tricky, we need to copy the container list so that we don't overwrite the update
 	var newContainers []api.Container
 	for ix, container := range pod.Spec.Containers {
+		// NOTE: it is very important that if we ever support updating a containers resource requirements
+		// that we coordinate that change by ensuring admission control for quota and limitrange are modified to intercept
+		// pod updates.  Right now, they are not intercepting pod updates to preserve support for kubectl patch
+		// see https://github.com/kubernetes/kubernetes/issues/18272 for history
 		container.Image = oldPod.Spec.Containers[ix].Image
 		newContainers = append(newContainers, container)
 	}

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -54,9 +54,18 @@ type limitRanger struct {
 
 // Admit admits resources into cluster that do not violate any defined LimitRange in the namespace
 func (l *limitRanger) Admit(a admission.Attributes) (err error) {
-
 	// Ignore all calls to subresources
 	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	// NOTE:
+	// Right now, this operation ignores update operations for the pod resource type.
+	// At this time, we do not allow a pod's resource requirements to change dynamically.
+	// In the future, if we allow updating a pod's resource requirements post creation, we need to coordinate
+	// that change with how admission control works today to ensure that we do not break kubectl patch.
+	// see: https://github.com/kubernetes/kubernetes/issues/18272 for history
+	if a.GetOperation() == admission.Update && a.GetResource() == api.Resource("pods") {
 		return nil
 	}
 

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -443,8 +443,8 @@ func TestLimitRangerIgnoresSubresource(t *testing.T) {
 
 	indexer.Add(&limitRange)
 	err := handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "", admission.Update, nil))
-	if err == nil {
-		t.Errorf("Expected an error since the pod did not specify resource limits in its update call")
+	if err != nil {
+		t.Errorf("Did not expect an error since the pod is ignored on update because resource limits are ignored.")
 	}
 
 	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "status", admission.Update, nil))

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -167,9 +167,13 @@ func (q *quota) Admit(a admission.Attributes) (err error) {
 // Return true if the usage must be recorded prior to admitting the new resource
 // Return an error if the operation should not pass admission control
 func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, client client.Interface) (bool, error) {
-	// on update, the only resource that can modify the value of a quota is pods
-	// so if your not a pod, we exit quickly
-	if a.GetOperation() == admission.Update && a.GetResource() != api.Resource("pods") {
+	// NOTE:
+	// Right now, this operation ignores update operations for any resource type.
+	// At this time, we do not allow a pod's resource requirements to change dynamically.
+	// In the future, if we allow updating a pod's resource requirements post creation, we need to coordinate
+	// that change with how admission control works today to ensure that we do not break kubectl patch.
+	// see: https://github.com/kubernetes/kubernetes/issues/18272 for history
+	if a.GetOperation() == admission.Update {
 		return false, nil
 	}
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/18272

At the moment, `ResourceQuota` and `LimitRanger` do not need to handle pod resource requirements updates because they are immutable post-creation.

We will need to visit a richer solution pattern if/when we look to support updating resource requirements on updates via server-side "defaulters".

I will have to cherry-pick this to 1.1 if we think it should be back-ported.  I am not sure how common patching a single pod is in practice versus the pod template in a replication controller or job.

/cc @erictune @deads2k @lavalamp 
