### PR TITLE
Godeps: bump go-oidc to fix the race in tests.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -247,23 +247,23 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/http",
-			"Rev": "ee7cb1fb480df22f7d8c4c90199e438e454ca3b6"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/jose",
-			"Rev": "ee7cb1fb480df22f7d8c4c90199e438e454ca3b6"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/key",
-			"Rev": "ee7cb1fb480df22f7d8c4c90199e438e454ca3b6"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/oauth2",
-			"Rev": "ee7cb1fb480df22f7d8c4c90199e438e454ca3b6"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/oidc",
-			"Rev": "ee7cb1fb480df22f7d8c4c90199e438e454ca3b6"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-semver/semver",

--- a/Godeps/_workspace/src/github.com/coreos/go-oidc/jose/claims.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-oidc/jose/claims.go
@@ -26,6 +26,32 @@ func (c Claims) StringClaim(name string) (string, bool, error) {
 	return v, true, nil
 }
 
+func (c Claims) StringsClaim(name string) ([]string, bool, error) {
+	cl, ok := c[name]
+	if !ok {
+		return nil, false, nil
+	}
+
+	if v, ok := cl.([]string); ok {
+		return v, true, nil
+	}
+
+	// When unmarshaled, []string will become []interface{}.
+	if v, ok := cl.([]interface{}); ok {
+		var ret []string
+		for _, vv := range v {
+			str, ok := vv.(string)
+			if !ok {
+				return nil, false, fmt.Errorf("unable to parse claim as string array: %v", name)
+			}
+			ret = append(ret, str)
+		}
+		return ret, true, nil
+	}
+
+	return nil, false, fmt.Errorf("unable to parse claim as string array: %v", name)
+}
+
 func (c Claims) Int64Claim(name string) (int64, bool, error) {
 	cl, ok := c[name]
 	if !ok {

--- a/Godeps/_workspace/src/github.com/coreos/go-oidc/jose/jwt.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-oidc/jose/jwt.go
@@ -1,8 +1,6 @@
 package jose
 
-import (
-	"strings"
-)
+import "strings"
 
 type JWT JWS
 
@@ -63,13 +61,13 @@ func (j *JWT) Encode() string {
 	return strings.Join([]string{d, s}, ".")
 }
 
-func NewSignedJWT(claims map[string]interface{}, s Signer) (*JWT, error) {
+func NewSignedJWT(claims Claims, s Signer) (*JWT, error) {
 	header := JOSEHeader{
 		HeaderKeyAlgorithm: s.Alg(),
 		HeaderKeyID:        s.ID(),
 	}
 
-	jwt, err := NewJWT(header, Claims(claims))
+	jwt, err := NewJWT(header, claims)
 	if err != nil {
 		return nil, err
 	}

--- a/Godeps/_workspace/src/github.com/coreos/go-oidc/key/key.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-oidc/key/key.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"encoding/json"
 	"math/big"
 	"time"
 
@@ -16,6 +17,19 @@ func NewPublicKey(jwk jose.JWK) *PublicKey {
 
 type PublicKey struct {
 	jwk jose.JWK
+}
+
+func (k *PublicKey) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.jwk)
+}
+
+func (k *PublicKey) UnmarshalJSON(data []byte) error {
+	var jwk jose.JWK
+	if err := json.Unmarshal(data, &jwk); err != nil {
+		return err
+	}
+	k.jwk = jwk
+	return nil
 }
 
 func (k *PublicKey) ID() string {

--- a/Godeps/_workspace/src/github.com/coreos/go-oidc/oauth2/error.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-oidc/oauth2/error.go
@@ -1,10 +1,5 @@
 package oauth2
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
 const (
 	ErrorAccessDenied            = "access_denied"
 	ErrorInvalidClient           = "invalid_client"
@@ -17,23 +12,18 @@ const (
 )
 
 type Error struct {
-	Type  string `json:"error"`
-	State string `json:"state,omitempty"`
+	Type        string `json:"error"`
+	Description string `json:"error_description,omitempty"`
+	State       string `json:"state,omitempty"`
 }
 
 func (e *Error) Error() string {
+	if e.Description != "" {
+		return e.Type + ": " + e.Description
+	}
 	return e.Type
 }
 
 func NewError(typ string) *Error {
 	return &Error{Type: typ}
-}
-
-func unmarshalError(b []byte) error {
-	var oerr Error
-	err := json.Unmarshal(b, &oerr)
-	if err != nil {
-		return fmt.Errorf("unrecognized error: %s", string(b))
-	}
-	return &oerr
 }

--- a/Godeps/_workspace/src/github.com/coreos/go-oidc/oidc/provider.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-oidc/oidc/provider.go
@@ -25,6 +25,9 @@ const (
 	discoveryConfigPath = "/.well-known/openid-configuration"
 )
 
+// internally configurable for tests
+var minimumProviderConfigSyncInterval = MinimumProviderConfigSyncInterval
+
 type ProviderConfig struct {
 	Issuer                            string    `json:"issuer"`
 	AuthEndpoint                      string    `json:"authorization_endpoint"`
@@ -172,8 +175,8 @@ func nextSyncAfter(exp time.Time, clock clockwork.Clock) time.Duration {
 	t := exp.Sub(clock.Now()) / 2
 	if t > MaximumProviderConfigSyncInterval {
 		t = MaximumProviderConfigSyncInterval
-	} else if t < MinimumProviderConfigSyncInterval {
-		t = MinimumProviderConfigSyncInterval
+	} else if t < minimumProviderConfigSyncInterval {
+		t = minimumProviderConfigSyncInterval
 	}
 
 	return t

--- a/Godeps/_workspace/src/github.com/coreos/go-oidc/oidc/util.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-oidc/oidc/util.go
@@ -53,7 +53,7 @@ func CookieTokenExtractor(cookieName string) RequestTokenExtractor {
 	}
 }
 
-func NewClaims(iss, sub, aud string, iat, exp time.Time) jose.Claims {
+func NewClaims(iss, sub string, aud interface{}, iat, exp time.Time) jose.Claims {
 	return jose.Claims{
 		// required
 		"iss": iss,

--- a/plugin/pkg/auth/authenticator/token/oidc/oidc_test.go
+++ b/plugin/pkg/auth/authenticator/token/oidc/oidc_test.go
@@ -350,7 +350,7 @@ func TestOIDCAuthentication(t *testing.T) {
 			op.generateGoodToken(t, srv.URL, "client-foo", "client-bar", "sub", "user-foo"),
 			nil,
 			false,
-			"oidc: JWT claims invalid: invalid claim value: 'aud'",
+			"oidc: JWT claims invalid: invalid claims, 'aud' claim and 'client_id' do not match",
 		},
 		{
 			// Invalid issuer.


### PR DESCRIPTION
Bump the go-oidc version as https://github.com/coreos/go-oidc/pull/27 has landed.

@liggitt How can I also verify the race in kubernetes is also fixed? Or can you help me on this?

related to https://github.com/kubernetes/kubernetes/pull/13838
