### PR TITLE
Hide common codec methods under helpers

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -422,7 +422,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 				if err != nil {
 					t.Errorf("Could not get codec for %s: %s", expectedType, err)
 				}
-				if err := codec.DecodeInto(data, expectedType); err != nil {
+				if err := runtime.DecodeInto(codec, data, expectedType); err != nil {
 					t.Errorf("%s did not decode correctly: %v\n%s", path, err, string(data))
 					return
 				}

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -153,7 +153,7 @@ func AddToNodeAddresses(addresses *[]NodeAddress, addAddresses ...NodeAddress) {
 }
 
 func HashObject(obj runtime.Object, codec runtime.Codec) (string, error) {
-	data, err := codec.Encode(obj)
+	data, err := runtime.Encode(codec, obj)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -67,13 +67,13 @@ func roundTrip(t *testing.T, codec runtime.Codec, item runtime.Object) {
 	t.Logf("fully qualified kind for %v is %v with codec %v", reflect.TypeOf(item), gvk, codec)
 
 	name := reflect.TypeOf(item).Elem().Name()
-	data, err := codec.Encode(item)
+	data, err := runtime.Encode(codec, item)
 	if err != nil {
 		t.Errorf("%v: %v (%s)", name, err, printer.Sprintf("%#v", item))
 		return
 	}
 
-	obj2, err := codec.Decode(data)
+	obj2, err := runtime.Decode(codec, data)
 	if err != nil {
 		t.Errorf("0: %v: %v\nCodec: %v\nData: %s\nSource: %#v", name, err, codec, string(data), printer.Sprintf("%#v", item))
 		return
@@ -84,7 +84,7 @@ func roundTrip(t *testing.T, codec runtime.Codec, item runtime.Object) {
 	}
 
 	obj3 := reflect.New(reflect.TypeOf(item).Elem()).Interface().(runtime.Object)
-	err = codec.DecodeInto(data, obj3)
+	err = runtime.DecodeInto(codec, data, obj3)
 	if err != nil {
 		t.Errorf("2: %v: %v", name, err)
 		return
@@ -307,7 +307,7 @@ func BenchmarkDecodeCodec(b *testing.B) {
 	width := len(items)
 	encoded := make([][]byte, width)
 	for i := range items {
-		data, err := codec.Encode(&items[i])
+		data, err := runtime.Encode(codec, &items[i])
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -316,7 +316,7 @@ func BenchmarkDecodeCodec(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := codec.Decode(encoded[i%width]); err != nil {
+		if _, err := runtime.Decode(codec, encoded[i%width]); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -329,7 +329,7 @@ func BenchmarkDecodeIntoCodec(b *testing.B) {
 	width := len(items)
 	encoded := make([][]byte, width)
 	for i := range items {
-		data, err := codec.Encode(&items[i])
+		data, err := runtime.Encode(codec, &items[i])
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -339,7 +339,7 @@ func BenchmarkDecodeIntoCodec(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		obj := v1.Pod{}
-		if err := codec.DecodeInto(encoded[i%width], &obj); err != nil {
+		if err := runtime.DecodeInto(codec, encoded[i%width], &obj); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -353,7 +353,7 @@ func BenchmarkDecodeIntoJSON(b *testing.B) {
 	width := len(items)
 	encoded := make([][]byte, width)
 	for i := range items {
-		data, err := codec.Encode(&items[i])
+		data, err := runtime.Encode(codec, &items[i])
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -377,7 +377,7 @@ func BenchmarkDecodeIntoJSONCodecGen(b *testing.B) {
 	width := len(items)
 	encoded := make([][]byte, width)
 	for i := range items {
-		data, err := kcodec.Encode(&items[i])
+		data, err := runtime.Encode(kcodec, &items[i])
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/api/testing/compat/compatibility_tester.go
+++ b/pkg/api/testing/compat/compatibility_tester.go
@@ -49,7 +49,7 @@ func TestCompatibility(
 
 	// Decode
 	codec := runtime.CodecFor(api.Scheme, version)
-	obj, err := codec.Decode(input)
+	obj, err := runtime.Decode(codec, input)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestCompatibility(
 	}
 
 	// Encode
-	output, err := codec.Encode(obj)
+	output, err := runtime.Encode(codec, obj)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -275,7 +275,7 @@ func TestSetDefaultJob(t *testing.T) {
 }
 
 func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
-	data, err := Codec.Encode(obj)
+	data, err := runtime.Encode(Codec, obj)
 	if err != nil {
 		t.Errorf("%v\n %#v", err, obj)
 		return nil

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -406,7 +406,7 @@ func writeJSON(statusCode int, codec runtime.Codec, object runtime.Object, w htt
 
 func prettyJSON(codec runtime.Codec, object runtime.Object, w http.ResponseWriter) {
 	formatted := &bytes.Buffer{}
-	output, err := codec.Encode(object)
+	output, err := runtime.Encode(codec, object)
 	if err != nil {
 		errorJSONFatal(err, codec, w)
 	}
@@ -431,7 +431,7 @@ func errorJSONFatal(err error, codec runtime.Codec, w http.ResponseWriter) int {
 	util.HandleError(fmt.Errorf("apiserver was unable to write a JSON response: %v", err))
 	status := errToAPIStatus(err)
 	code := int(status.Code)
-	output, err := codec.Encode(status)
+	output, err := runtime.Encode(codec, status)
 	if err != nil {
 		w.WriteHeader(code)
 		fmt.Fprintf(w, "%s: %s", status.Reason, status.Message)

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -276,11 +276,11 @@ func handleInternal(storage map[string]rest.Storage, admissionControl admission.
 
 func TestSimpleSetupRight(t *testing.T) {
 	s := &apiservertesting.Simple{ObjectMeta: api.ObjectMeta{Name: "aName"}}
-	wire, err := codec.Encode(s)
+	wire, err := runtime.Encode(codec, s)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s2, err := codec.Decode(wire)
+	s2, err := runtime.Decode(codec, wire)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,11 +291,11 @@ func TestSimpleSetupRight(t *testing.T) {
 
 func TestSimpleOptionsSetupRight(t *testing.T) {
 	s := &apiservertesting.SimpleGetOptions{}
-	wire, err := codec.Encode(s)
+	wire, err := runtime.Encode(codec, s)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s2, err := codec.Decode(wire)
+	s2, err := runtime.Decode(codec, wire)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -618,7 +618,7 @@ func extractBody(response *http.Response, object runtime.Object) (string, error)
 	if err != nil {
 		return string(body), err
 	}
-	err = codec.DecodeInto(body, object)
+	err = runtime.DecodeInto(codec, body, object)
 	return string(body), err
 }
 
@@ -1514,7 +1514,7 @@ func TestConnectResponderObject(t *testing.T) {
 	if connectStorage.receivedID != itemID {
 		t.Errorf("Unexpected item id. Expected: %s. Actual: %s.", itemID, connectStorage.receivedID)
 	}
-	obj, err := codec.Decode(body)
+	obj, err := runtime.Decode(codec, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1555,7 +1555,7 @@ func TestConnectResponderError(t *testing.T) {
 	if connectStorage.receivedID != itemID {
 		t.Errorf("Unexpected item id. Expected: %s. Actual: %s.", itemID, connectStorage.receivedID)
 	}
-	obj, err := codec.Decode(body)
+	obj, err := runtime.Decode(codec, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1725,7 +1725,7 @@ func TestDeleteWithOptions(t *testing.T) {
 	item := &api.DeleteOptions{
 		GracePeriodSeconds: &grace,
 	}
-	body, err := codec.Encode(item)
+	body, err := runtime.Encode(codec, item)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1789,7 +1789,7 @@ func TestLegacyDeleteIgnoresOptions(t *testing.T) {
 	defer server.Close()
 
 	item := api.NewDeleteOptions(300)
-	body, err := codec.Encode(item)
+	body, err := runtime.Encode(codec, item)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1942,7 +1942,7 @@ func TestUpdate(t *testing.T) {
 		},
 		Other: "bar",
 	}
-	body, err := codec.Encode(item)
+	body, err := runtime.Encode(codec, item)
 	if err != nil {
 		// The following cases will fail, so die now
 		t.Fatalf("unexpected error: %v", err)
@@ -1979,7 +1979,7 @@ func TestUpdateInvokesAdmissionControl(t *testing.T) {
 		},
 		Other: "bar",
 	}
-	body, err := codec.Encode(item)
+	body, err := runtime.Encode(codec, item)
 	if err != nil {
 		// The following cases will fail, so die now
 		t.Fatalf("unexpected error: %v", err)
@@ -2008,7 +2008,7 @@ func TestUpdateRequiresMatchingName(t *testing.T) {
 	item := &apiservertesting.Simple{
 		Other: "bar",
 	}
-	body, err := codec.Encode(item)
+	body, err := runtime.Encode(codec, item)
 	if err != nil {
 		// The following cases will fail, so die now
 		t.Fatalf("unexpected error: %v", err)
@@ -2040,7 +2040,7 @@ func TestUpdateAllowsMissingNamespace(t *testing.T) {
 		},
 		Other: "bar",
 	}
-	body, err := codec.Encode(item)
+	body, err := runtime.Encode(codec, item)
 	if err != nil {
 		// The following cases will fail, so die now
 		t.Fatalf("unexpected error: %v", err)
@@ -2078,7 +2078,7 @@ func TestUpdateAllowsMismatchedNamespaceOnError(t *testing.T) {
 		},
 		Other: "bar",
 	}
-	body, err := codec.Encode(item)
+	body, err := runtime.Encode(codec, item)
 	if err != nil {
 		// The following cases will fail, so die now
 		t.Fatalf("unexpected error: %v", err)
@@ -2115,7 +2115,7 @@ func TestUpdatePreventsMismatchedNamespace(t *testing.T) {
 		},
 		Other: "bar",
 	}
-	body, err := codec.Encode(item)
+	body, err := runtime.Encode(codec, item)
 	if err != nil {
 		// The following cases will fail, so die now
 		t.Fatalf("unexpected error: %v", err)
@@ -2150,7 +2150,7 @@ func TestUpdateMissing(t *testing.T) {
 		},
 		Other: "bar",
 	}
-	body, err := codec.Encode(item)
+	body, err := runtime.Encode(codec, item)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2179,7 +2179,7 @@ func TestCreateNotFound(t *testing.T) {
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{Other: "foo"}
-	data, err := codec.Encode(simple)
+	data, err := runtime.Encode(codec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2205,7 +2205,7 @@ func TestCreateChecksDecode(t *testing.T) {
 	client := http.Client{}
 
 	simple := &api.Pod{}
-	data, err := codec.Encode(simple)
+	data, err := runtime.Encode(codec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2395,7 +2395,7 @@ func TestCreateWithName(t *testing.T) {
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{Other: "foo"}
-	data, err := codec.Encode(simple)
+	data, err := runtime.Encode(codec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2422,7 +2422,7 @@ func TestUpdateChecksDecode(t *testing.T) {
 	client := http.Client{}
 
 	simple := &api.Pod{}
-	data, err := codec.Encode(simple)
+	data, err := runtime.Encode(codec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2498,7 +2498,7 @@ func TestCreate(t *testing.T) {
 	simple := &apiservertesting.Simple{
 		Other: "bar",
 	}
-	data, err := codec.Encode(simple)
+	data, err := runtime.Encode(codec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2557,7 +2557,7 @@ func TestCreateInNamespace(t *testing.T) {
 	simple := &apiservertesting.Simple{
 		Other: "bar",
 	}
-	data, err := codec.Encode(simple)
+	data, err := runtime.Encode(codec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2616,7 +2616,7 @@ func TestCreateInvokesAdmissionControl(t *testing.T) {
 	simple := &apiservertesting.Simple{
 		Other: "bar",
 	}
-	data, err := codec.Encode(simple)
+	data, err := runtime.Encode(codec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2744,7 +2744,7 @@ func TestCreateTimeout(t *testing.T) {
 	defer server.Close()
 
 	simple := &apiservertesting.Simple{Other: "foo"}
-	data, err := codec.Encode(simple)
+	data, err := runtime.Encode(codec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2836,7 +2836,7 @@ func TestCreateChecksAPIVersion(t *testing.T) {
 
 	simple := &apiservertesting.Simple{}
 	//using newCodec and send the request to testVersion URL shall cause a discrepancy in apiVersion
-	data, err := newCodec.Encode(simple)
+	data, err := runtime.Encode(newCodec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2866,7 +2866,7 @@ func TestCreateDefaultsAPIVersion(t *testing.T) {
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{}
-	data, err := codec.Encode(simple)
+	data, err := runtime.Encode(codec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2901,7 +2901,7 @@ func TestUpdateChecksAPIVersion(t *testing.T) {
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{ObjectMeta: api.ObjectMeta{Name: "bar"}}
-	data, err := newCodec.Encode(simple)
+	data, err := runtime.Encode(newCodec, simple)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -483,7 +483,7 @@ func patchResource(ctx api.Context, timeout time.Duration, versionedObj runtime.
 		return nil, err
 	}
 
-	originalObjJS, err := codec.Encode(original)
+	originalObjJS, err := runtime.Encode(codec, original)
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +493,7 @@ func patchResource(ctx api.Context, timeout time.Duration, versionedObj runtime.
 	}
 
 	objToUpdate := patcher.New()
-	if err := codec.DecodeInto(originalPatchedObjJS, objToUpdate); err != nil {
+	if err := runtime.DecodeInto(codec, originalPatchedObjJS, objToUpdate); err != nil {
 		return nil, err
 	}
 	if err := checkName(objToUpdate, name, namespace, namer); err != nil {
@@ -517,7 +517,7 @@ func patchResource(ctx api.Context, timeout time.Duration, versionedObj runtime.
 			if err != nil {
 				return nil, err
 			}
-			currentObjectJS, err := codec.Encode(currentObject)
+			currentObjectJS, err := runtime.Encode(codec, currentObject)
 			if err != nil {
 				return nil, err
 			}
@@ -551,7 +551,7 @@ func patchResource(ctx api.Context, timeout time.Duration, versionedObj runtime.
 			if err != nil {
 				return nil, err
 			}
-			if err := codec.DecodeInto(newlyPatchedObjJS, objToUpdate); err != nil {
+			if err := runtime.DecodeInto(codec, newlyPatchedObjJS, objToUpdate); err != nil {
 				return nil, err
 			}
 

--- a/pkg/apiserver/resthandler_test.go
+++ b/pkg/apiserver/resthandler_test.go
@@ -176,12 +176,12 @@ func (tc *patchTestCase) Run(t *testing.T) {
 		}
 		t.Logf("Working with patchType %v", patchType)
 
-		originalObjJS, err := codec.Encode(tc.startingPod)
+		originalObjJS, err := runtime.Encode(codec, tc.startingPod)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 			return
 		}
-		changedJS, err := codec.Encode(tc.changedPod)
+		changedJS, err := runtime.Encode(codec, tc.changedPod)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 			return
@@ -231,12 +231,12 @@ func (tc *patchTestCase) Run(t *testing.T) {
 		resultPod := resultObj.(*api.Pod)
 
 		// roundtrip to get defaulting
-		expectedJS, err := codec.Encode(tc.expectedPod)
+		expectedJS, err := runtime.Encode(codec, tc.expectedPod)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 			return
 		}
-		expectedObj, err := codec.Decode(expectedJS)
+		expectedObj, err := runtime.Decode(codec, expectedJS)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 			return

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -82,7 +82,7 @@ func TestWatchWebsocket(t *testing.T) {
 		if got.Type != action {
 			t.Errorf("Unexpected type: %v", got.Type)
 		}
-		gotObj, err := codec.Decode(got.Object)
+		gotObj, err := runtime.Decode(codec, got.Object)
 		if err != nil {
 			t.Fatalf("Decode error: %v", err)
 		}
@@ -146,7 +146,7 @@ func TestWatchHTTP(t *testing.T) {
 			t.Errorf("%d: Unexpected type: %v", i, got.Type)
 		}
 		t.Logf("obj: %v", string(got.Object))
-		gotObj, err := codec.Decode(got.Object)
+		gotObj, err := runtime.Decode(codec, got.Object)
 		if err != nil {
 			t.Fatalf("Decode error: %v", err)
 		}

--- a/pkg/client/unversioned/testclient/fixture.go
+++ b/pkg/client/unversioned/testclient/fixture.go
@@ -114,7 +114,7 @@ func AddObjectsFromPath(path string, o ObjectRetriever, decoder runtime.Decoder)
 	if err != nil {
 		return err
 	}
-	obj, err := decoder.Decode(data)
+	obj, err := runtime.Decode(decoder, data)
 	if err != nil {
 		return err
 	}

--- a/pkg/conversion/unversioned_test.go
+++ b/pkg/conversion/unversioned_test.go
@@ -40,7 +40,7 @@ func TestV1EncodeDecodeStatus(t *testing.T) {
 
 	v1Codec := testapi.Default.Codec()
 
-	encoded, err := v1Codec.Encode(status)
+	encoded, err := runtime.Encode(v1Codec, status)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestV1EncodeDecodeStatus(t *testing.T) {
 	if typeMeta.APIVersion != "v1" {
 		t.Errorf("APIVersion is not set to \"v1\". Got %v", string(encoded))
 	}
-	decoded, err := v1Codec.Decode(encoded)
+	decoded, err := runtime.Decode(v1Codec, encoded)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestExperimentalEncodeDecodeStatus(t *testing.T) {
 	// moves experimental from v1 to v1beta1 got merged.
 	// expCodec := testapi.Extensions.Codec()
 	expCodec := runtime.CodecFor(api.Scheme, "extensions/v1beta1")
-	encoded, err := expCodec.Encode(status)
+	encoded, err := runtime.Encode(expCodec, status)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestExperimentalEncodeDecodeStatus(t *testing.T) {
 	if typeMeta.APIVersion != "" {
 		t.Errorf("APIVersion is not set to \"\". Got %s", encoded)
 	}
-	decoded, err := expCodec.Decode(encoded)
+	decoded, err := runtime.Decode(expCodec, encoded)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -474,7 +474,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 		t.Errorf("unexpected print to default printer")
 	}
 
-	out, err := codec.Decode(buf.Bytes())
+	out, err := runtime.Decode(codec, buf.Bytes())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -31,6 +31,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
@@ -278,7 +279,7 @@ func TestGenerateService(t *testing.T) {
 					}
 					defer req.Body.Close()
 					svc := &api.Service{}
-					if err := codec.DecodeInto(data, svc); err != nil {
+					if err := runtime.DecodeInto(codec, data, svc); err != nil {
 						t.Errorf("unexpected error: %v", err)
 						t.FailNow()
 					}

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -1099,7 +1099,7 @@ func readOrDie(t *testing.T, req *http.Request, codec runtime.Codec) runtime.Obj
 		t.Errorf("Error reading: %v", err)
 		t.FailNow()
 	}
-	obj, err := codec.Decode(data)
+	obj, err := runtime.Decode(codec, data)
 	if err != nil {
 		t.Errorf("error decoding: %v", err)
 		t.FailNow()

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -158,7 +158,7 @@ func (t *thirdPartyResourceDataCodec) Decode(data []byte) (runtime.Object, error
 
 func (t *thirdPartyResourceDataCodec) DecodeToVersion(data []byte, gv unversioned.GroupVersion) (runtime.Object, error) {
 	// TODO: this is hacky, there must be a better way...
-	obj, err := t.Decode(data)
+	obj, err := runtime.Decode(t, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/thirdpartyresourcedata/codec_test.go
+++ b/pkg/registry/thirdpartyresourcedata/codec_test.go
@@ -92,7 +92,7 @@ func TestCodec(t *testing.T) {
 			t.Errorf("[%s] unexpected error: %v", test.name, err)
 			continue
 		}
-		obj, err := codec.Decode(data)
+		obj, err := runtime.Decode(&codec, data)
 		if err != nil && !test.expectErr {
 			t.Errorf("[%s] unexpected error: %v", test.name, err)
 			continue
@@ -120,7 +120,7 @@ func TestCodec(t *testing.T) {
 			t.Errorf("[%s]\nexpected\n%v\nsaw\n%v\n", test.name, test.obj, &output)
 		}
 
-		data, err = codec.Encode(rsrcObj)
+		data, err = runtime.Encode(&codec, rsrcObj)
 		if err != nil {
 			t.Errorf("[%s] unexpected error: %v", test.name, err)
 		}

--- a/pkg/runtime/codec.go
+++ b/pkg/runtime/codec.go
@@ -22,6 +22,24 @@ import (
 	"k8s.io/kubernetes/pkg/util/yaml"
 )
 
+// Encode is a convenience wrapper for encoding to a []byte from an Encoder
+// TODO: these are transitional interfaces to reduce refactor cost as Codec is altered.
+func Encode(e Encoder, obj Object) ([]byte, error) {
+	return e.Encode(obj)
+}
+
+// Decode is a convenience wrapper for decoding data into an Object.
+// TODO: these are transitional interfaces to reduce refactor cost as Codec is altered.
+func Decode(d Decoder, data []byte) (Object, error) {
+	return d.Decode(data)
+}
+
+// DecodeInto performs a Decode into the provided object.
+// TODO: these are transitional interfaces to reduce refactor cost as Codec is altered.
+func DecodeInto(d Decoder, data []byte, into Object) error {
+	return d.DecodeInto(data, into)
+}
+
 // CodecFor returns a Codec that invokes Encode with the provided version.
 func CodecFor(codec ObjectCodec, version string) Codec {
 	return &codecWrapper{codec, version}
@@ -62,7 +80,7 @@ func (c yamlCodec) DecodeInto(data []byte, obj Object) error {
 
 // EncodeOrDie is a version of Encode which will panic instead of returning an error. For tests.
 func EncodeOrDie(codec Codec, obj Object) string {
-	bytes, err := codec.Encode(obj)
+	bytes, err := Encode(codec, obj)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/runtime/embedded_test.go
+++ b/pkg/runtime/embedded_test.go
@@ -126,7 +126,7 @@ func TestArrayOfRuntimeObject(t *testing.T) {
 	}
 	t.Logf("exact wire is: %s", string(obj.Items[0].RawJSON))
 
-	decoded, err := s.Decode(wire)
+	decoded, err := runtime.Decode(s, wire)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestEmbeddedObject(t *testing.T) {
 
 	t.Logf("Wire format is:\n%v\n", string(wire))
 
-	decoded, err := s.Decode(wire)
+	decoded, err := runtime.Decode(s, wire)
 	if err != nil {
 		t.Fatalf("Unexpected decode error %v", err)
 	}

--- a/pkg/runtime/helper.go
+++ b/pkg/runtime/helper.go
@@ -66,7 +66,7 @@ func DecodeList(objects []Object, decoders ...ObjectDecoder) []error {
 				if !decoder.Recognizes(gv.WithKind(t.Kind)) {
 					continue
 				}
-				obj, err := decoder.Decode(t.RawJSON)
+				obj, err := Decode(decoder, t.RawJSON)
 				if err != nil {
 					errs = append(errs, err)
 					break

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -31,11 +31,13 @@ type Codec interface {
 
 // Decoder defines methods for deserializing API objects into a given type
 type Decoder interface {
+	// TODO: change the signature of this method
 	Decode(data []byte) (Object, error)
-	// TODO: Remove this method?
+	// DEPRECATED: This method is being removed
 	DecodeToVersion(data []byte, groupVersion unversioned.GroupVersion) (Object, error)
+	// DEPRECATED: This method is being removed
 	DecodeInto(data []byte, obj Object) error
-	// TODO: Remove this method?
+	// DEPRECATED: This method is being removed
 	DecodeIntoWithSpecifiedVersionKind(data []byte, obj Object, groupVersionKind unversioned.GroupVersionKind) error
 
 	DecodeParametersInto(parameters url.Values, obj Object) error
@@ -43,6 +45,7 @@ type Decoder interface {
 
 // Encoder defines methods for serializing API objects into bytes
 type Encoder interface {
+	// DEPRECATED: This method is being removed
 	Encode(obj Object) (data []byte, err error)
 	EncodeToStream(obj Object, stream io.Writer) error
 

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -130,7 +130,7 @@ func (self *Scheme) rawExtensionToEmbeddedObject(in *RawExtension, out *Embedded
 		return err
 	}
 
-	err = scheme.DecodeInto(in.RawJSON, inObj)
+	err = DecodeInto(scheme, in.RawJSON, inObj)
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -95,9 +95,9 @@ func TestScheme(t *testing.T) {
 	// Test Encode, Decode, DecodeInto, and DecodeToVersion
 	obj := runtime.Object(simple)
 	data, err := scheme.EncodeToVersion(obj, externalGV.String())
-	obj2, err2 := scheme.Decode(data)
+	obj2, err2 := runtime.Decode(scheme, data)
 	obj3 := &InternalSimple{}
-	err3 := scheme.DecodeInto(data, obj3)
+	err3 := runtime.DecodeInto(scheme, data, obj3)
 	obj4, err4 := scheme.DecodeToVersion(data, externalGV)
 	if err != nil || err2 != nil || err3 != nil || err4 != nil {
 		t.Fatalf("Failure: '%v' '%v' '%v' '%v'", err, err2, err3, err4)
@@ -154,11 +154,11 @@ func TestInvalidObjectValueKind(t *testing.T) {
 func TestBadJSONRejection(t *testing.T) {
 	scheme := runtime.NewScheme()
 	badJSONMissingKind := []byte(`{ }`)
-	if _, err := scheme.Decode(badJSONMissingKind); err == nil {
+	if _, err := runtime.Decode(scheme, badJSONMissingKind); err == nil {
 		t.Errorf("Did not reject despite lack of kind field: %s", badJSONMissingKind)
 	}
 	badJSONUnknownType := []byte(`{"kind": "bar"}`)
-	if _, err1 := scheme.Decode(badJSONUnknownType); err1 == nil {
+	if _, err1 := runtime.Decode(scheme, badJSONUnknownType); err1 == nil {
 		t.Errorf("Did not reject despite use of unknown type: %s", badJSONUnknownType)
 	}
 	/*badJSONKindMismatch := []byte(`{"kind": "Pod"}`)
@@ -224,7 +224,7 @@ func TestExternalToInternalMapping(t *testing.T) {
 	}
 
 	for _, item := range table {
-		gotDecoded, err := scheme.Decode([]byte(item.encoded))
+		gotDecoded, err := runtime.Decode(scheme, []byte(item.encoded))
 		if err != nil {
 			t.Errorf("unexpected error '%v' (%v)", err, item.encoded)
 		} else if e, a := item.obj, gotDecoded; !reflect.DeepEqual(e, a) {
@@ -282,7 +282,7 @@ func TestExtensionMapping(t *testing.T) {
 			t.Errorf("expected\n%#v\ngot\n%#v\n", e, a)
 		}
 
-		gotDecoded, err := scheme.Decode([]byte(item.encoded))
+		gotDecoded, err := runtime.Decode(scheme, []byte(item.encoded))
 		if err != nil {
 			t.Errorf("unexpected error '%v' (%v)", err, item.encoded)
 		} else if e, a := item.obj, gotDecoded; !reflect.DeepEqual(e, a) {
@@ -311,8 +311,8 @@ func TestEncode(t *testing.T) {
 		TestString: "I'm the same",
 	}
 	obj := runtime.Object(test)
-	data, err := codec.Encode(obj)
-	obj2, err2 := codec.Decode(data)
+	data, err := runtime.Encode(codec, obj)
+	obj2, err2 := runtime.Decode(codec, data)
 	if err != nil || err2 != nil {
 		t.Fatalf("Failure: '%v' '%v'", err, err2)
 	}

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -43,7 +43,7 @@ func (unstructuredJSONScheme) Recognizes(gvk unversioned.GroupVersionKind) bool 
 
 func (s unstructuredJSONScheme) Decode(data []byte) (Object, error) {
 	unstruct := &Unstructured{}
-	if err := s.DecodeInto(data, unstruct); err != nil {
+	if err := DecodeInto(s, data, unstruct); err != nil {
 		return nil, err
 	}
 	return unstruct, nil

--- a/pkg/watch/json/types.go
+++ b/pkg/watch/json/types.go
@@ -45,7 +45,7 @@ func Object(codec runtime.Codec, event *watch.Event) (interface{}, error) {
 	if !ok {
 		return nil, fmt.Errorf("the event object cannot be safely converted to JSON: %v", reflect.TypeOf(event.Object).Name())
 	}
-	data, err := codec.Encode(obj)
+	data, err := runtime.Encode(codec, obj)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The pending codec -> conversion split changes the signature of
Encode and Decode to be more complicated. Create a stub helper
with the exact semantics of today and do the simple mechanical
refactor here to reduce the cost of that change.

Extracted from #17922
