### PR TITLE
kube-addons: Use python container if python is not found on the machine.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -819,6 +819,16 @@ function kube::release::write_addon_docker_images_for_server() {
       ) &
     done
 
+    if [[ ! -z "${BUILD_PYTHON_IMAGE:-}" ]]; then
+      (
+        kube::log::status "Building Docker python image"
+        
+        local img_name=python:2.7-slim-pyyaml
+        docker build -t "${img_name}" "${KUBE_ROOT}/cluster/addons/python-image"
+        docker save "${img_name}" > "${1}/${img_name}.tar"
+      ) &
+    fi
+
     kube::util::wait-for-jobs || { kube::log::error "unable to pull or write addon image"; return 1; }
     kube::log::status "Addon images done"
   )

--- a/cluster/addons/README.md
+++ b/cluster/addons/README.md
@@ -58,6 +58,8 @@ of:
      pods.
   1. Note that this cannot happen for Services as their version is always empty.
 
+Note that in order to run the updator script, python is required on the machine.
+For OS distros that don't have python installed, a python container will be used.
 
 
 

--- a/cluster/addons/python-image/Dockerfile
+++ b/cluster/addons/python-image/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:2.7-slim
+
+RUN pip install pyyaml

--- a/cluster/addons/python-image/README.md
+++ b/cluster/addons/python-image/README.md
@@ -1,0 +1,6 @@
+# Python image
+
+The python image here is used by OS distros that don't have python installed to
+run python scripts to parse the yaml files in the addon updator script.
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/python-image/README.md?pixel)]()

--- a/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
@@ -98,7 +98,7 @@ function log() {
 function get-object-kind-from-file() {
     # prints to stdout, so log cannot be used
     #WARNING: only yaml is supported
-    cat $1 | python -c '''
+    cat $1 | ${PYTHON} -c '''
 try:
         import pipes,sys,yaml
         y = yaml.load(sys.stdin)
@@ -120,7 +120,7 @@ function get-object-nsname-from-file() {
     # prints to stdout, so log cannot be used
     #WARNING: only yaml is supported
     #addons that do not specify a namespace are assumed to be in "default".
-    cat $1 | python -c '''
+    cat $1 | ${PYTHON} -c '''
 try:
         import pipes,sys,yaml
         y = yaml.load(sys.stdin)


### PR DESCRIPTION
Also add a Dockerfile to build a python image that has pyyaml.

Second try for #17241 
