### PR TITLE
specify advertise-address for api-server

### DIFF
--- a/cluster/centos/master/scripts/apiserver.sh
+++ b/cluster/centos/master/scripts/apiserver.sh
@@ -31,14 +31,18 @@ KUBE_LOG_LEVEL="--v=4"
 # comma separated. Mutually exclusive with -etcd-config
 KUBE_ETCD_SERVERS="--etcd-servers=${ETCD_SERVERS}"
 
-# --address=127.0.0.1: DEPRECATED: see --insecure-bind-address instead
-KUBE_API_ADDRESS="--address=${MASTER_ADDRESS}"
+# --insecure-bind-address=127.0.0.1: The IP address on which to serve the --insecure-port.
+KUBE_API_ADDRESS="--insecure-bind-address=${MASTER_ADDRESS}"
 
-# --port=8080: DEPRECATED: see --insecure-port instead
-KUBE_API_PORT="--port=8080"
+# --insecure-port=8080: The port on which to serve unsecured, unauthenticated access.
+KUBE_API_PORT="--insecure-port=8080"
 
 # --kubelet-port=10250: Kubelet port
 NODE_PORT="--kubelet-port=10250"
+
+# --advertise-address=<nil>: The IP address on which to advertise 
+# the apiserver to members of the cluster.
+KUBE_ADVERTISE_ADDR="--advertise-address=${MASTER_ADDRESS}"
 
 # --allow-privileged=false: If true, allow privileged containers.
 KUBE_ALLOW_PRIV="--allow-privileged=false"
@@ -75,7 +79,8 @@ KUBE_APISERVER_OPTS="   \${KUBE_LOGTOSTDERR}         \\
                         \${KUBE_ETCD_SERVERS}        \\
                         \${KUBE_API_ADDRESS}         \\
                         \${KUBE_API_PORT}            \\
-                        \${NODE_PORT}              \\
+                        \${NODE_PORT}                \\
+                        \${KUBE_ADVERTISE_ADDR}      \\
                         \${KUBE_ALLOW_PRIV}          \\
                         \${KUBE_SERVICE_ADDRESSES}   \\
                         \${KUBE_ADMISSION_CONTROL}   \\

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -203,6 +203,7 @@ KUBE_APISERVER_OPTS="\
  --service-cluster-ip-range=${1}\
  --admission-control=${2}\
  --service-node-port-range=${3}\
+ --advertise-address=${4}\
  --client-ca-file=/srv/kubernetes/ca.crt\
  --tls-cert-file=/srv/kubernetes/server.cert\
  --tls-private-key-file=/srv/kubernetes/server.key"
@@ -232,14 +233,12 @@ EOF
 function create-kubelet-opts() {
   cat <<EOF > ~/kube/default/kubelet
 KUBELET_OPTS="\
- --address=0.0.0.0\
- --port=10250 \
  --hostname-override=${1} \
  --api-servers=http://${2}:8080 \
  --logtostderr=true \
  --config=/etc/kubernetes/manifests \
- --cluster-dns=$3 \
- --cluster-domain=$4"
+ --cluster-dns=${3} \
+ --cluster-domain=${4}"
 EOF
 
 }
@@ -383,7 +382,8 @@ function provision-master() {
     create-kube-apiserver-opts \
       '${SERVICE_CLUSTER_IP_RANGE}' \
       '${ADMISSION_CONTROL}' \
-      '${SERVICE_NODE_PORT_RANGE}'
+      '${SERVICE_NODE_PORT_RANGE}' \
+      '${MASTER_IP}'
     create-kube-controller-manager-opts '${NODE_IPS}'
     create-kube-scheduler-opts
     create-flanneld-opts '127.0.0.1' '${MASTER_IP}'
@@ -487,7 +487,8 @@ function provision-masterandnode() {
     create-kube-apiserver-opts \
       '${SERVICE_CLUSTER_IP_RANGE}' \
       '${ADMISSION_CONTROL}' \
-      '${SERVICE_NODE_PORT_RANGE}'
+      '${SERVICE_NODE_PORT_RANGE}' \
+      '${MASTER_IP}'
     create-kube-controller-manager-opts '${NODE_IPS}'
     create-kube-scheduler-opts
     create-kubelet-opts \


### PR DESCRIPTION
- Fix #17013
  Specify `--advertise-address` to get rid of default interface when it comes to multi-nic. 
  It's not an ubuntu-specific issue, and at least apply to bare-metal centos to my best knowledge.
- deprecate out-dated param for centos scripts

/cc @thockin @MikeSpreitzer 
/cc centos maintainer @coolsvap
