### PR TITLE
Close web socket watches correctly

### DIFF
--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -88,6 +88,7 @@ type WatchServer struct {
 
 // HandleWS implements a websocket handler.
 func (w *WatchServer) HandleWS(ws *websocket.Conn) {
+	defer ws.Close()
 	done := make(chan struct{})
 	go func() {
 		var unused interface{}


### PR DESCRIPTION
The websocket library will close the underlying net connection, but it is up to the handler function to call Close() on the websocket connection, sending the final frame.

We were already doing this for websocket-based log streaming and exec. This adds it to websocket-based watches.
