### PR TITLE
add a label to namespaces created by e2e framework

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -180,5 +180,6 @@ func TestE2E(t *testing.T) {
 	if *reportDir != "" {
 		r = append(r, reporters.NewJUnitReporter(path.Join(*reportDir, fmt.Sprintf("junit_%02d.xml", config.GinkgoConfig.ParallelNode))))
 	}
+	glog.Infof("Starting e2e run; %q", runId)
 	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Kubernetes e2e suite", r)
 }

--- a/test/e2e/example_cluster_dns.go
+++ b/test/e2e/example_cluster_dns.go
@@ -76,7 +76,7 @@ var _ = Describe("[Example] ClusterDns", func() {
 		namespaces := []*api.Namespace{nil, nil}
 		for i := range namespaces {
 			var err error
-			namespaces[i], err = createTestingNS(fmt.Sprintf("dnsexample%d", i), c)
+			namespaces[i], err = createTestingNS(fmt.Sprintf("dnsexample%d", i), c, nil)
 			if testContext.DeleteNamespace {
 				if namespaces[i] != nil {
 					defer deleteNS(c, namespaces[i].Name, 5*time.Minute /* namespace deletion timeout */)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -75,7 +75,9 @@ func (f *Framework) beforeEach() {
 	f.Client = c
 
 	By("Building a namespace api object")
-	namespace, err := createTestingNS(f.BaseName, f.Client)
+	namespace, err := createTestingNS(f.BaseName, f.Client, map[string]string{
+		"e2e-framework": f.BaseName,
+	})
 	Expect(err).NotTo(HaveOccurred())
 
 	f.Namespace = namespace

--- a/test/e2e/namespace.go
+++ b/test/e2e/namespace.go
@@ -40,7 +40,7 @@ func extinguish(c *client.Client, totalNS int, maxAllowedAfterDel int, maxSecond
 		go func(n int) {
 			defer wg.Done()
 			defer GinkgoRecover()
-			_, err = createTestingNS(fmt.Sprintf("nslifetest-%v", n), c)
+			_, err = createTestingNS(fmt.Sprintf("nslifetest-%v", n), c, nil)
 			Expect(err).NotTo(HaveOccurred())
 		}(n)
 	}

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -778,7 +778,7 @@ var _ = Describe("Services", func() {
 		ns1 := f.Namespace.Name
 
 		By("Building a second namespace api object")
-		namespacePtr, err := createTestingNS("services", c)
+		namespacePtr, err := createTestingNS("services", c, nil)
 		Expect(err).NotTo(HaveOccurred())
 		ns2 := namespacePtr.Name
 		extraNamespaces = append(extraNamespaces, ns2)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -119,6 +119,9 @@ type CloudConfig struct {
 	Provider cloudprovider.Interface
 }
 
+// unique identifier of the e2e run
+var runId = util.NewUUID()
+
 type TestContextType struct {
 	KubeConfig            string
 	KubeContext           string
@@ -554,11 +557,17 @@ func waitForPersistentVolumePhase(phase api.PersistentVolumePhase, c *client.Cli
 
 // createTestingNS should be used by every test, note that we append a common prefix to the provided test name.
 // Please see NewFramework instead of using this directly.
-func createTestingNS(baseName string, c *client.Client) (*api.Namespace, error) {
+func createTestingNS(baseName string, c *client.Client, labels map[string]string) (*api.Namespace, error) {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["e2e-run"] = string(runId)
+
 	namespaceObj := &api.Namespace{
 		ObjectMeta: api.ObjectMeta{
 			GenerateName: fmt.Sprintf("e2e-tests-%v-", baseName),
 			Namespace:    "",
+			Labels:       labels,
 		},
 		Status: api.NamespaceStatus{},
 	}


### PR DESCRIPTION
makes cleanup easire when using --delete-namespace=false

k delete ns -l e2e-framework

cc @gmarek 
