### PR TITLE
Allow node IP to be passed as optional config for kubelet

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -158,6 +158,7 @@ type KubeletServer struct {
 	// Pull images one at a time.
 	SerializeImagePulls        bool
 	ExperimentalFlannelOverlay bool
+	NodeIP                     net.IP
 }
 
 // bootstrapping interface for kubelet, targets the initialization protocol
@@ -349,6 +350,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", s.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")
 	fs.BoolVar(&s.SerializeImagePulls, "serialize-image-pulls", s.SerializeImagePulls, "Pull images one at a time. We recommend *not* changing the default value on nodes that run docker daemon with version < 1.9 or an Aufs storage backend. Issue #10959 has more details. [default=true]")
 	fs.BoolVar(&s.ExperimentalFlannelOverlay, "experimental-flannel-overlay", s.ExperimentalFlannelOverlay, "Experimental support for starting the kubelet with the default overlay network (flannel). Assumes flanneld is already running in client mode. [default=false]")
+	fs.IPVar(&s.NodeIP, "node-ip", s.NodeIP, "IP address of the node. If set, kubelet will use this IP address for the node")
 }
 
 // UnsecuredKubeletConfig returns a KubeletConfig suitable for being run, or an error if the server setup
@@ -488,6 +490,7 @@ func (s *KubeletServer) UnsecuredKubeletConfig() (*KubeletConfig, error) {
 		VolumePlugins:                  ProbeVolumePlugins(s.VolumePluginDir),
 
 		ExperimentalFlannelOverlay: s.ExperimentalFlannelOverlay,
+		NodeIP: s.NodeIP,
 	}, nil
 }
 
@@ -964,6 +967,7 @@ type KubeletConfig struct {
 	VolumePlugins                  []volume.VolumePlugin
 
 	ExperimentalFlannelOverlay bool
+	NodeIP                     net.IP
 }
 
 func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.PodConfig, err error) {
@@ -1047,6 +1051,7 @@ func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.SerializeImagePulls,
 		kc.ContainerManager,
 		kc.ExperimentalFlannelOverlay,
+		kc.NodeIP,
 	)
 
 	if err != nil {

--- a/docs/admin/kubelet.md
+++ b/docs/admin/kubelet.md
@@ -113,6 +113,7 @@ kubelet
       --minimum-container-ttl-duration=1m0s: Minimum age for a finished container before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'
       --network-plugin="": <Warning: Alpha feature> The name of the network plugin to be invoked for various events in kubelet/pod lifecycle
       --network-plugin-dir="/usr/libexec/kubernetes/kubelet-plugins/net/exec/": <Warning: Alpha feature> The full path of the directory in which to search for network plugins
+      --node-ip=<nil>: IP address of the node. If set, kubelet will use this IP address for the node
       --node-label=[]: add labels when registering the node in the cluster, the flag can be used multiple times (key=value)
       --node-labels-file="": the path to a yaml or json file containing a series of key pair labels to apply on node registration
       --node-status-update-frequency=10s: Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller. Default: 10s

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -221,6 +221,7 @@ namespace-sync-period
 network-plugin
 network-plugin-dir
 node-instance-group
+node-ip
 node-monitor-grace-period
 node-monitor-period
 node-label


### PR DESCRIPTION
In case of multiple IPs on the node, this will allow admin to
specify desired IP to be used for the node.

fixes: https://github.com/kubernetes/kubernetes/issues/17704
