### PR TITLE
Treat first-seen, non-pending pods as updates

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -229,10 +229,18 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 				// this is a no-op
 				continue
 			}
-			// this is an add
 			recordFirstSeenTime(ref)
 			pods[name] = ref
-			addPods = append(addPods, ref)
+			// If a pod is not found in the cache, and it's also not in the
+			// pending phase, it implies that kubelet may have restarted.
+			// Treat this pod as update so that kubelet wouldn't reject the
+			// pod in the admission process.
+			if ref.Status.Phase != api.PodPending {
+				updatePods = append(updatePods, ref)
+			} else {
+				// this is an add
+				addPods = append(addPods, ref)
+			}
 		}
 
 	case kubetypes.REMOVE:
@@ -275,7 +283,16 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 			}
 			recordFirstSeenTime(ref)
 			pods[name] = ref
-			addPods = append(addPods, ref)
+			// If a pod is not found in the cache, and it's also not in the
+			// pending phase, it implies that kubelet may have restarted.
+			// Treat this pod as update so that kubelet wouldn't reject the
+			// pod in the admission process.
+			if ref.Status.Phase != api.PodPending {
+				updatePods = append(updatePods, ref)
+			} else {
+				// this is an add
+				addPods = append(addPods, ref)
+			}
 		}
 
 		for name, existing := range oldPods {

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -71,6 +71,9 @@ func CreateValidPod(name, namespace string) *api.Pod {
 				},
 			},
 		},
+		Status: api.PodStatus{
+			Phase: api.PodPending,
+		},
 	}
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2240,11 +2240,6 @@ func (kl *Kubelet) isOutOfDisk() bool {
 	if err == nil && !withinBounds {
 		outOfRootDisk = true
 	}
-	// Kubelet would indicate all pods as newly created on the first run after restart.
-	// We ignore the first disk check to ensure that running pods are not killed.
-	// Disk manager will only declare out of disk problems if unfreeze has been called.
-	kl.diskSpaceManager.Unfreeze()
-
 	return outOfDockerDisk || outOfRootDisk
 }
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2482,7 +2482,6 @@ func updateDiskSpacePolicy(kubelet *Kubelet, mockCadvisor *cadvisor.Mock, rootCa
 	if err != nil {
 		return err
 	}
-	diskSpaceManager.Unfreeze()
 	kubelet.diskSpaceManager = diskSpaceManager
 	return nil
 }
@@ -3612,6 +3611,15 @@ func TestRegisterExistingNodeWithApiserver(t *testing.T) {
 		DockerVersion:      "1.5.0",
 	}
 	mockCadvisor.On("VersionInfo").Return(versionInfo, nil)
+	mockCadvisor.On("DockerImagesFsInfo").Return(cadvisorapiv2.FsInfo{
+		Usage:     400 * mb,
+		Capacity:  1000 * mb,
+		Available: 600 * mb,
+	}, nil)
+	mockCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{
+		Usage:    9 * mb,
+		Capacity: 10 * mb,
+	}, nil)
 
 	done := make(chan struct{})
 	go func() {

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
+	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
@@ -36,6 +37,15 @@ import (
 func TestRunOnce(t *testing.T) {
 	cadvisor := &cadvisor.Mock{}
 	cadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
+	cadvisor.On("DockerImagesFsInfo").Return(cadvisorapiv2.FsInfo{
+		Usage:     400 * mb,
+		Capacity:  1000 * mb,
+		Available: 600 * mb,
+	}, nil)
+	cadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{
+		Usage:    9 * mb,
+		Capacity: 10 * mb,
+	}, nil)
 	podManager := kubepod.NewBasicPodManager(kubepod.NewFakeMirrorClient())
 	diskSpaceManager, _ := newDiskSpaceManager(cadvisor, DiskSpacePolicy{})
 	fakeRuntime := &kubecontainer.FakeRuntime{}


### PR DESCRIPTION
Kubelet doesn't peform checkpointing and loses all its internal states after
restarts. It'd then mistaken pods from the api server as new pods and attempt
to go through the admission process. This may result in pods being rejected
even though they are running on the node (e.g., out of disk situation). This
change adds a condition to check whether the pod was seen before and categorize
such pods as updates. The change also removes freeze/unfreeze mechanism used to
work around such cases, since it is no longer needed and it stopped working
correctly ever since we switched to incremental updates.

/cc @kubernetes/goog-node 
