### PR TITLE
remove `newPod.Status = oldPod.Status` in validation.go

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1207,7 +1207,6 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) validation.ErrorList {
 		allErrs = append(allErrs, validation.NewInvalidError(specPath, "contents not printed here, please refer to the \"details\"", "may not update fields other than container.image"))
 	}
 
-	newPod.Status = oldPod.Status
 	return allErrs
 }
 


### PR DESCRIPTION
remove `newPod.Status = oldPod.Status` in validation.go, which has been done in podStrategy:
https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/pod/strategy.go#L63-L67
