### PR TITLE
Correct typo for two parameters in mesos scheduler.

### DIFF
--- a/contrib/mesos/pkg/scheduler/config/config.go
+++ b/contrib/mesos/pkg/scheduler/config/config.go
@@ -56,8 +56,8 @@ type Config struct {
 	UpdatesBacklog                     int             `gcfg:"updates-backlog"`
 	FrameworkIdRefreshInterval         WrappedDuration `gcfg:"framework-id-refresh-interval"`
 	InitialImplicitReconciliationDelay WrappedDuration `gcfg:"initial-implicit-reconciliation-delay"`
-	ExplicitReconciliationMaxBackoff   WrappedDuration `gcfg:"explicit-reconciliantion-max-backoff"`
-	ExplicitReconciliationAbortTimeout WrappedDuration `gcfg:"explicit-reconciliantion-abort-timeout"`
+	ExplicitReconciliationMaxBackoff   WrappedDuration `gcfg:"explicit-reconciliation-max-backoff"`
+	ExplicitReconciliationAbortTimeout WrappedDuration `gcfg:"explicit-reconciliation-abort-timeout"`
 	InitialPodBackoff                  WrappedDuration `gcfg:"initial-pod-backoff"`
 	MaxPodBackoff                      WrappedDuration `gcfg:"max-pod-backoff"`
 	HttpHandlerTimeout                 WrappedDuration `gcfg:"http-handler-timeout"`

--- a/contrib/mesos/pkg/scheduler/config/config_test.go
+++ b/contrib/mesos/pkg/scheduler/config/config_test.go
@@ -67,8 +67,8 @@ func TestConfig_Read(t *testing.T) {
 	updates-backlog=42
 	framework-id-refresh-interval=42s
 	initial-implicit-reconciliation-delay=42s
-	explicit-reconciliantion-max-backoff=42s
-	explicit-reconciliantion-abort-timeout=42s
+	explicit-reconciliation-max-backoff=42s
+	explicit-reconciliation-abort-timeout=42s
 	initial-pod-backoff=42s
 	max-pod-backoff=42s
 	http-handler-timeout=42s


### PR DESCRIPTION
xref #18491 
