### PR TITLE
Add quiet mode to gcloud calls from upgrade e2e tests

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -83,7 +83,8 @@ func masterUpgradeGKE(v string) error {
 		"upgrade",
 		testContext.CloudConfig.Cluster,
 		"--master",
-		fmt.Sprintf("--cluster-version=%s", v))
+		fmt.Sprintf("--cluster-version=%s", v),
+		"--quiet")
 	return err
 }
 
@@ -141,7 +142,8 @@ func nodeUpgradeGKE(v string) error {
 		"clusters",
 		"upgrade",
 		testContext.CloudConfig.Cluster,
-		fmt.Sprintf("--cluster-version=%s", v))
+		fmt.Sprintf("--cluster-version=%s", v),
+		"--quiet")
 	return err
 }
 
@@ -393,6 +395,9 @@ func retryCmd(command string, args ...string) (string, string, error) {
 
 // runCmd runs cmd using args and returns its stdout and stderr. It also outputs
 // cmd's stdout and stderr to their respective OS streams.
+//
+// TODO(ihmccreery) This function should either be moved into util.go or
+// removed; other e2e's use bare exe.Command.
 func runCmd(command string, args ...string) (string, string, error) {
 	Logf("Running %s %v", command, args)
 	var bout, berr bytes.Buffer


### PR DESCRIPTION
We're rolling out user prompts prior to upgrades, so we need to add `--quiet` to the `gcloud` calls.
