### PR TITLE
[AWS] Wrong assignment of `KUBE_MASTER_IP` with Elastic IP

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -934,8 +934,13 @@ function start-master() {
       wait-for-instance-state ${master_id} "running"
 
       KUBE_MASTER=${MASTER_NAME}
-      KUBE_MASTER_IP=$(assign-elastic-ip $ip $master_id)
-      echo -e " ${color_green}[master running @${KUBE_MASTER_IP}]${color_norm}"
+      echo -e " ${color_green}[master running @${ip}]${color_norm}"
+
+      local attach_message
+      attach_message=$(assign-elastic-ip $ip $master_id)
+      # Get master ip again after attachment.
+      KUBE_MASTER_IP=$(get_instance_public_ip $master_id)
+      echo ${attach_message}
 
       # This is a race between instance start and volume attachment.  There appears to be no way to start an AWS instance with a volume attached.
       # To work around this, we wait for volume to be ready in setup-master-pd.sh


### PR DESCRIPTION
Currently when using a custom elastic IP, the ENV var `KUBE_MASTER_IP` gets
the output of `$(assign-elastic-ip $ip $master_id)` assigned.
See https://github.com/kubernetes/kubernetes/blob/master/cluster/aws/util.sh#L937

This is wrong since the command returns a string:
`Attaching IP 99.999.999.999 to instance i-9999999`

This patch fixes the assignment by calling `get_instance_public_ip` again.
