### PR TITLE
Fix workspace not empty on gce tests.

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -1142,7 +1142,7 @@ if [[ "${E2E_UP,,}" == "true" || "${JENKINS_FORCE_GET_TARS:-}" =~ ^[yY]$ ]]; the
         # Otherwise, we want a completely empty directory.
         if [[ "${JENKINS_FORCE_GET_TARS:-}" =~ ^[yY]$ ]]; then
             rm -rf kubernetes*
-        elif [[ $(find . | wc -l) != 1 ]]; then
+        elif [[ $(find . -not -path './.config*' | wc -l) != 1 ]]; then
             echo $PWD not empty, bailing!
             find .
             exit 1


### PR DESCRIPTION
We added a gcloud command earlier in e2e.sh which creates a .config
folder in the workspace. Ignore it.
