### PR TITLE
set default value of MaxUnavailable  in kubectl rolling-update as 1

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -330,7 +330,7 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 		Interval:       interval,
 		Timeout:        timeout,
 		CleanupPolicy:  updateCleanupPolicy,
-		MaxUnavailable: intstr.FromInt(0),
+		MaxUnavailable: intstr.FromInt(1),
 		MaxSurge:       intstr.FromInt(1),
 	}
 	if rollback {


### PR DESCRIPTION
This PR helps to fix https://github.com/kubernetes/kubernetes/issues/18463
