### PR TITLE
Hpa tolerance config fix

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -320,7 +320,7 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 			go podautoscaler.NewHorizontalController(hpaClient.Core(), hpaClient.Extensions(), hpaClient, metricsClient, s.HorizontalPodAutoscalerSyncPeriod.Duration).
 				Run(wait.NeverStop)
 			// TODO parameterize tolerance/downscale/upscale options.
-			tolerance := 1.0
+			tolerance := .1
 			downScale := time.Duration(5) * time.Second
 			upScale := time.Duration(3) * time.Second
 			go podautoscaler.NewHorizontalController(hpaClient, hpaClient, hpaClient, metricsClient, tolerance, downScale, upScale), s.HorizontalPodAutoscalerSyncPeriod.Duration)

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -319,6 +319,12 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 			)
 			go podautoscaler.NewHorizontalController(hpaClient.Core(), hpaClient.Extensions(), hpaClient, metricsClient, s.HorizontalPodAutoscalerSyncPeriod.Duration).
 				Run(wait.NeverStop)
+			// TODO parameterize tolerance/downscale/upscale options.
+			tolerance := 1.0
+			downScale := time.Duration(5) * time.Second
+			upScale := time.Duration(3) * time.Second
+			go podautoscaler.NewHorizontalController(hpaClient, hpaClient, hpaClient, metricsClient, tolerance, downScale, upScale), s.HorizontalPodAutoscalerSyncPeriod.Duration)
+				Run(s.HorizontalPodAutoscalerSyncPeriod)
 			time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))
 		}
 

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"math"
 	"testing"
 	"time"
 
@@ -38,9 +39,14 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 
-	heapster "k8s.io/heapster/api/v1/types"
-
+	glog "github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
+	heapster "k8s.io/heapster/api/v1/types"
+)
+
+// unit tests need tolerance awareness to calibrate.
+const (
+	tolerance = .1
 )
 
 func (w fakeResponseWrapper) DoRaw() ([]byte, error) {
@@ -374,6 +380,7 @@ func (tc *testCase) verifyResults(t *testing.T) {
 func (tc *testCase) runTest(t *testing.T) {
 	testClient := tc.prepareTestClient(t)
 	metricsClient := metrics.NewHeapsterMetricsClient(testClient, metrics.DefaultHeapsterNamespace, metrics.DefaultHeapsterScheme, metrics.DefaultHeapsterService, metrics.DefaultHeapsterPort)
+<<<<<<< daf6be1a6656514211343847b7745bc7a6d5b3d3
 
 	broadcaster := record.NewBroadcasterForTests(0)
 	broadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{Interface: testClient.Core().Events("")})
@@ -395,6 +402,11 @@ func (tc *testCase) runTest(t *testing.T) {
 	go hpaController.Run(stop)
 
 	tc.Lock()
+=======
+	hpaController := NewHorizontalController(testClient, testClient.Extensions(), testClient.Extensions(), metricsClient, tolerance, time.Second, time.Second)
+	err := hpaController.reconcileAutoscalers()
+	assert.Equal(t, nil, err)
+>>>>>>> Revert "Merge pull request #18630 from kubernetes/revert-18315-hpa-tolerance-config"
 	if tc.verifyEvents {
 		tc.Unlock()
 		// We need to wait for events to be broadcasted (sleep for longer than record.sleepDuration).
@@ -746,4 +758,64 @@ func TestEventNotCreated(t *testing.T) {
 	tc.runTest(t)
 }
 
-// TODO: add more tests
+// TestComputedToleranceAlgImplementation is a regression test which
+// back-calculates a minimal percentage for downscaling based on a small percentage
+// increase in pod utilization which is calibrated against the tolerance value.
+func TestComputedToleranceAlgImplementation(t *testing.T) {
+
+	startPods := 10
+	// 150 mCPU per pod.
+	totalUsedCPUOfAllPods := uint64(startPods * 150)
+	// Each pod starts out asking for 2X what is really needed.
+	// This means we will have a 50% ratio of used/requested
+	totalRequestedCPUOfAllPods := 2 * totalUsedCPUOfAllPods
+	requestedToUsed := float64(totalRequestedCPUOfAllPods / totalUsedCPUOfAllPods)
+	// Spread the amount we ask over 10 pods.  We can add some jitter later in reportedLevels.
+	perPodRequested := int(totalRequestedCPUOfAllPods) / startPods
+
+	// Force a minimal scaling event by satisfying  (tolerance < 1 - resourcesUsedRatio).
+	target := math.Abs(1/(requestedToUsed*(1-tolerance))) + .01
+	finalCpuPercentTarget := int(target * 100)
+	resourcesUsedRatio := float64(totalUsedCPUOfAllPods) / float64(float64(totalRequestedCPUOfAllPods)*target)
+	// the autoscaler will compare this vs. tolearnce.  Lets calculate the usageRatio, which will be
+	// compared w tolerance.
+	usageRatioToleranceValue := float64(1 - resourcesUsedRatio)
+	// i.e. .60 * 20 -> scaled down expectation.
+	finalPods := math.Ceil(resourcesUsedRatio * float64(startPods))
+
+	glog.Infof("To breach tolerance %f we will create a utilization ratio difference of %f", tolerance, usageRatioToleranceValue)
+	tc := testCase{
+		minReplicas:     0,
+		maxReplicas:     1000,
+		initialReplicas: startPods,
+		desiredReplicas: int(finalPods),
+		CPUTarget:       finalCpuPercentTarget,
+		reportedLevels: []uint64{
+			totalUsedCPUOfAllPods / 10,
+			totalUsedCPUOfAllPods / 10,
+			totalUsedCPUOfAllPods / 10,
+			totalUsedCPUOfAllPods / 10,
+			totalUsedCPUOfAllPods / 10,
+			totalUsedCPUOfAllPods / 10,
+			totalUsedCPUOfAllPods / 10,
+			totalUsedCPUOfAllPods / 10,
+			totalUsedCPUOfAllPods / 10,
+			totalUsedCPUOfAllPods / 10,
+		},
+		reportedCPURequests: []resource.Quantity{
+			resource.MustParse(fmt.Sprint(perPodRequested+100) + "m"),
+			resource.MustParse(fmt.Sprint(perPodRequested-100) + "m"),
+			resource.MustParse(fmt.Sprint(perPodRequested+10) + "m"),
+			resource.MustParse(fmt.Sprint(perPodRequested-10) + "m"),
+			resource.MustParse(fmt.Sprint(perPodRequested+2) + "m"),
+			resource.MustParse(fmt.Sprint(perPodRequested-2) + "m"),
+			resource.MustParse(fmt.Sprint(perPodRequested+1) + "m"),
+			resource.MustParse(fmt.Sprint(perPodRequested-1) + "m"),
+			resource.MustParse(fmt.Sprint(perPodRequested) + "m"),
+			resource.MustParse(fmt.Sprint(perPodRequested) + "m"),
+		},
+	}
+	tc.runTest(t)
+}
+
+// TODO: add more tests, e.g., enforcement of upscal/downscale window.


### PR DESCRIPTION
This fixes an off by -order of magnitude- error in the previous HPA tolerance tests.
Thanks @wojtek-t for noting the regression. 
I think woj or @jszczepkowski , can review as he knows this test very well.

Since the HPAs dont run in CI, I've run this manually on GCE, looks good to me. 

If folks would like to  test before merge, its easy:

`cluster/kube-up.sh ; hack/build-go.sh ; _output/local/go/bin/e2e.test --kubeconfig=~/.kube/config --provider="local" --ginkgo.v=true --minStartupPods=1 --ginkgo.focus="Should scale from 5 pods"`

The tests now pass, since the tolerance is small enough that the autoscaler will act : 

```
• [SLOW TEST:1184.141 seconds]
Horizontal pod autoscaling (scale resource: CPU) [Skipped]
/Users/jayunit100/Development/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/horizontal_pod_autoscaling.go:60
  [Autoscaling] ReplicationController
  /Users/jayunit100/Development/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/horizontal_pod_autoscaling.go:59
    Should scale from 5 pods to 3 pods and from 3 to 1
    /Users/jayunit100/Development/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/horizontal_pod_autoscaling.go:58
```
