### PR TITLE
HPA Multitest which uses scaleUp and scaleDown for 2 generations.

### DIFF
--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -236,17 +236,18 @@ func (rc *ResourceConsumer) GetReplicas() int {
 	return 0
 }
 
-func (rc *ResourceConsumer) WaitForReplicas(desiredReplicas int) {
+func (rc *ResourceConsumer) WaitForReplicas(desiredReplicas int) bool {
 	timeout := 10 * time.Minute
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(20 * time.Second) {
 		if desiredReplicas == rc.GetReplicas() {
 			Logf("%s: current replicas number is equal to desired replicas number: %d", rc.kind, desiredReplicas)
-			return
+			return true
 		} else {
 			Logf("%s: current replicas number %d waiting to be %d", rc.kind, rc.GetReplicas(), desiredReplicas)
 		}
 	}
-	Failf("timeout waiting %v for pods size to be %d", timeout, desiredReplicas)
+	Logf("Timeout expired.  The desiredReplica count was never reached.")
+	return false
 }
 
 func (rc *ResourceConsumer) EnsureDesiredReplicas(desiredReplicas int, timeout time.Duration) {

--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -32,29 +33,44 @@ const (
 )
 
 var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Skipped]", func() {
-	var rc *ResourceConsumer
-	f := NewFramework("horizontal-pod-autoscaling")
 
 	titleUp := "Should scale from 1 pod to 3 pods and from 3 to 5"
 	titleDown := "Should scale from 5 pods to 3 pods and from 3 to 1"
+	titleMult := "Should HPA scale in parallel"
 
 	Describe("Deployment", func() {
+		f1 := NewFramework("horizontal-pod-autoscaling-deploy")
 		// CPU tests via deployments
 		It(titleUp, func() {
-			scaleUp("deployment", kindDeployment, rc, f)
+			if !scaleUp("deployment", kindDeployment, f1) {
+				Failf("Deployment: Scale up failed.")
+			}
 		})
 		It(titleDown, func() {
-			scaleDown("deployment", kindDeployment, rc, f)
+			if !scaleDown("deployment", kindDeployment, f1) {
+				Failf("Deployment: Scale down failed.")
+			}
+		})
+		It(titleMult+"(deployments)", func() {
+			scaleMultitest("deployment", kindDeployment, f1)
 		})
 	})
 
 	Describe("[Autoscaling] ReplicationController", func() {
+		f := NewFramework("horizontal-pod-autoscaling-rc")
 		// CPU tests via replication controllers
 		It(titleUp, func() {
-			scaleUp("rc", kindRC, rc, f)
+			if !scaleUp("rc", kindRC, f) {
+				Failf("RC: Scale up failed.")
+			}
 		})
 		It(titleDown, func() {
-			scaleDown("rc", kindRC, rc, f)
+			if !scaleDown("rc", kindRC, f) {
+				Failf("RC: Scale down failed.")
+			}
+		})
+		It(titleMult+"(replication controllers)", func() {
+			scaleMultitest("rc", kindDeployment, f)
 		})
 	})
 })
@@ -79,17 +95,83 @@ type HPAScaleTest struct {
 // The first state change is due to the CPU being consumed initially, which HPA responds to by changing pod counts.
 // The second state change is due to the CPU burst parameter, which HPA again responds to.
 // TODO The use of 3 states is arbitrary, we could eventually make this test handle "n" states once this test stabilizes.
-func (scaleTest *HPAScaleTest) run(name, kind string, rc *ResourceConsumer, f *Framework) {
-	rc = NewDynamicResourceConsumer(name, kind, scaleTest.initPods, scaleTest.cpuStart, 0, scaleTest.maxCPU, 100, f)
+func (scaleTest *HPAScaleTest) run(name, kind string, f *Framework) bool {
+	rc := NewDynamicResourceConsumer(name, kind, scaleTest.initPods, scaleTest.cpuStart, 0, scaleTest.maxCPU, 100, f)
 	defer rc.CleanUp()
 	createCPUHorizontalPodAutoscaler(rc, scaleTest.idealCPU, scaleTest.minPods, scaleTest.maxPods)
-	rc.WaitForReplicas(scaleTest.firstScale)
+	passed := rc.WaitForReplicas(scaleTest.firstScale)
+	if !passed {
+		Logf("first scale: timeout waiting for pods size to be %d", scaleTest.secondScale)
+		return false
+	}
+	// Apparently this is failing, because deleted.  logging time to see why.
 	rc.EnsureDesiredReplicas(scaleTest.firstScale, scaleTest.firstScaleStasis)
 	rc.ConsumeCPU(scaleTest.cpuBurst)
-	rc.WaitForReplicas(scaleTest.secondScale)
+	passed = rc.WaitForReplicas(scaleTest.secondScale)
+	if !passed {
+		Logf("second scale: timeout waiting for pods size to be %d", scaleTest.secondScale)
+		return false
+	}
+	return true
 }
 
-func scaleUp(name, kind string, rc *ResourceConsumer, f *Framework) {
+// Tests that multiple HPAs work properly, in parallel.
+// Right now, we only test 2 generations.
+func scaleMultitest(name, kind string, f *Framework) {
+	testResults := [2]bool{}
+	testDone := [2]bool{}
+	Logf("start %v", testResults)
+
+	// Important: make sure exactly len(testResults) go func's are created,
+	// and that each one writes to a unique element of the tests array.
+	for i := 0; i < len(testResults); i += 2 {
+		go func(ii int) {
+			defer GinkgoRecover()
+			testResults[ii] = scaleUp(fmt.Sprint(name, "up", ii), kind, f)
+			testDone[ii] = true
+		}(i)
+		go func(ii int) {
+			defer GinkgoRecover()
+			testResults[ii] = scaleDown(fmt.Sprint(name, "down", ii), kind, f)
+			testDone[ii] = true
+		}(i + 1)
+	}
+
+	// remainingTests is just a helper function for determining if all tests are completed.
+	remainingTests := func() int {
+		count := 0
+		for i := 0; i < len(testDone); i++ {
+			if !testDone[i] {
+				count++
+			}
+		}
+		return count
+	}
+
+	// here we will wait for all goroutines to complete.
+	for i := remainingTests(); i > 0; i = remainingTests() {
+		Logf("Remaining tests: %v", i)
+		time.Sleep(time.Duration(10) * time.Second)
+	}
+
+	Logf("All tests done.  computing result...")
+	allTestsPassed := true
+	for i := 0; i < len(testResults); i++ {
+		if testResults[i] == false {
+			Logf("Test %v failed !!!", i)
+			allTestsPassed = false
+		} else {
+			Logf("Test %v passed.", i)
+		}
+	}
+	if !allTestsPassed {
+		Failf("Some of the HPA parallel scaling tests failed... See logs above.")
+	} else {
+		Logf("All HPA scaling events for this test ( %v %v ) passed.", name, kind)
+	}
+}
+
+func scaleUp(name, kind string, f *Framework) bool {
 	scaleTest := &HPAScaleTest{
 		initPods:         1,
 		cpuStart:         250,
@@ -102,10 +184,10 @@ func scaleUp(name, kind string, rc *ResourceConsumer, f *Framework) {
 		cpuBurst:         700,
 		secondScale:      5,
 	}
-	scaleTest.run(name, kind, rc, f)
+	return scaleTest.run(name, kind, f)
 }
 
-func scaleDown(name, kind string, rc *ResourceConsumer, f *Framework) {
+func scaleDown(name, kind string, f *Framework) bool {
 	scaleTest := &HPAScaleTest{
 		initPods:         5,
 		cpuStart:         400,
@@ -118,7 +200,7 @@ func scaleDown(name, kind string, rc *ResourceConsumer, f *Framework) {
 		cpuBurst:         100,
 		secondScale:      1,
 	}
-	scaleTest.run(name, kind, rc, f)
+	return scaleTest.run(name, kind, f)
 }
 
 func createCPUHorizontalPodAutoscaler(rc *ResourceConsumer, cpu, minReplicas, maxRepl int) {


### PR DESCRIPTION
This implements a parallel test for 2 generations using existing `scaleUp` and `scaleDown` tests.  
It also modifies the scaleUp and scaleDown tests so that they can be composed.   

Probably ideal for @jszczepkowski or @wojtek-t  to review.
- First off it makes the scaleUp and scaleDown tests so that they are usable by other tests.
- Secondly, it leverages them for a 2-generation parallel HPA test.
