### PR TITLE
Replace stop with delete command in e2e test

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -775,7 +775,7 @@ var _ = Describe("Kubectl client", func() {
 		})
 
 		AfterEach(func() {
-			runKubectlOrDie("stop", "rc", rcName, nsFlag)
+			runKubectlOrDie("delete", "rc", rcName, nsFlag)
 		})
 
 		It("should create an rc from an image [Conformance]", func() {
@@ -818,7 +818,7 @@ var _ = Describe("Kubectl client", func() {
 		})
 
 		AfterEach(func() {
-			runKubectlOrDie("stop", "jobs", jobName, nsFlag)
+			runKubectlOrDie("delete", "jobs", jobName, nsFlag)
 		})
 
 		It("should create a job from an image when restart is OnFailure [Conformance]", func() {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1016,7 +1016,7 @@ func cleanup(filePath string, ns string, selectors ...string) {
 	if ns != "" {
 		nsArg = fmt.Sprintf("--namespace=%s", ns)
 	}
-	runKubectlOrDie("stop", "--grace-period=0", "-f", filePath, nsArg)
+	runKubectlOrDie("delete", "--grace-period=0", "-f", filePath, nsArg)
 
 	for _, selector := range selectors {
 		resources := runKubectlOrDie("get", "rc,svc", "-l", selector, "--no-headers", nsArg)


### PR DESCRIPTION
Stop command is marked as deprecated, we shouldn't use it.
