### PR TITLE
Autoscaling e2e tests: bumped resource consumer to version beta2.

### DIFF
--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -38,7 +38,7 @@ const (
 	timeoutRC                       = 120 * time.Second
 	startServiceTimeout             = time.Minute
 	startServiceInterval            = 5 * time.Second
-	resourceConsumerImage           = "gcr.io/google_containers/resource_consumer:beta"
+	resourceConsumerImage           = "gcr.io/google_containers/resource_consumer:beta2"
 	rcIsNil                         = "ERROR: replicationController = nil"
 	deploymentIsNil                 = "ERROR: deployment = nil"
 	invalidKind                     = "ERROR: invalid workload kind for resource consumer"

--- a/test/images/resource-consumer/Makefile
+++ b/test/images/resource-consumer/Makefile
@@ -1,4 +1,4 @@
-TAG = beta
+TAG = beta2
 PREFIX = gcr.io/google_containers
 
 all: clean consumer


### PR DESCRIPTION
Autoscaling e2e tests: bumped resource consumer to version beta2.
