### PR TITLE
Source control all master-branch GCE Jenkins jobs.

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -454,6 +454,7 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-flaky"}
     : ${PROJECT:="k8s-jkns-e2e-gce-flaky"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${E2E_DOWN:="true"}
     ;;
 
   # Runs slow tests on GCE, sequentially.

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -1,12 +1,12 @@
 - job-template:
     name: 'kubernetes-e2e-{suffix}'
-    description: 'Run E2E tests on GCE using the latest successful build. Test owner: Build Cop.'
+    description: '{description} Test owner: {test-owner}.'
     logrotate:
         daysToKeep: 7
     builders:
         - shell: |
             curl -fsS -o upload-to-gcs.sh --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" && source upload-to-gcs.sh; rm -f upload-to-gcs.sh
-            curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e.sh" | bash -
+            curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/{branch}/hack/jenkins/e2e.sh" | bash -
     properties:
         - mail-watcher
     publishers:
@@ -17,14 +17,14 @@
         - junit-publisher
     triggers:
         - reverse:
-            jobs: kubernetes-build
+            jobs: '{trigger-job}'
             result: success
         - timed: 'H/30 * * * *'
     wrappers:
         - ansicolor:
             colormap: xterm
         - timeout:
-            timeout: 150
+            timeout: '{timeout}'
             abort: true
             fail: true
         - timestamps
@@ -32,7 +32,33 @@
 
 - project:
     name: kubernetes-e2e
+    trigger-job: 'kubernetes-build'
+    test-owner: 'Build Cop'
+    branch: 'master'
     suffix:
-        - 'gce'
+        - 'gce':
+            description: 'Run E2E tests on GCE using the latest successful build.'
+            timeout: 150
+        - 'gce-autoscaling':
+            description: 'Run autoscaling E2E tests on GCE using the latest successful build.'
+            timeout: 210
+        - 'gce-flaky':
+            description: 'Run E2E tests on GCE using the latest successful build. Limit to known-flaky tests.'
+            timeout: 180
+        - 'gce-parallel':
+            description: 'Run E2E tests using Ginkgo''s parallel test runner on GCE using the latest successful build.'
+            timeout: 120
+        - 'gce-parallel-flaky':
+            description: 'Run E2E tests using Ginkgo''s parallel test runner on GCE using the latest successful build. Limit to known-flaky tests.'
+            timeout: 90
+        - 'gce-reboot':
+            description: 'Run E2E reboot tests on GCE using the latest successful build. The reboot tests are currently flaky and causing other tests to fail, so we quarantine them into this project and dedicated test cluster.'
+            timeout: 90
+        - 'gce-scalability':
+            description: 'Run scalability E2E tests on GCE using the latest successful build.'
+            timeout: 210
+        - 'gce-slow':
+            description: 'Run slow E2E tests on GCE using the latest successful build.'
+            timeout: 270
     jobs:
         - 'kubernetes-e2e-{suffix}'


### PR DESCRIPTION
I left out the trusty jobs as well as examples. I backed up all of the jobs this will replace. Before adding jobs from non-master releases, I'll have to repeat the GCE_SERVICE_ACCOUNT stuff on those branches.
#18122
