### PR TITLE
Don't restrict kube2sky to build only on amd64

### DIFF
--- a/cluster/addons/dns/kube2sky/Makefile
+++ b/cluster/addons/dns/kube2sky/Makefile
@@ -10,7 +10,7 @@ PREFIX = gcr.io/google_containers
 all: container
 
 kube2sky: kube2sky.go
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo --ldflags '-w' ./kube2sky.go
+	GOOS=linux CGO_ENABLED=0 godep go build -a -installsuffix cgo --ldflags '-w' ./kube2sky.go
 
 container: kube2sky
 	docker build -t $(PREFIX)/kube2sky:$(TAG) .


### PR DESCRIPTION
Part of: #17981

@thockin @ArtfulCoder @vishh (some contributors to this file)
@brendandburns 
Just a small change.
Make it easier to build for ARM.

I could also make this `Makefile` more like [hyperkube Makefile](https://github.com/kubernetes/kubernetes/blob/master/cluster/images/hyperkube/Makefile) is now.
`gcr.io/google_containers/kube2sky` => `gcr.io/google_containers/kube2sky-amd64` and `gcr.io/google_containers/kube2sky-arm`
If we do that, we have to choose base image instead of `busybox`. Personally I use `scratch`

But that may wait to next PR.
