### PR TITLE
enforce node quorum to prevent es split brain problem

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch.yml
+++ b/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch.yml
@@ -4,4 +4,5 @@ node.data: ${NODE_DATA}
 transport.tcp.port: ${TRANSPORT_PORT}
 http.port: ${HTTP_PORT}
 discovery.zen.ping.multicast.enabled: false
+discovery.zen.minimum_master_nodes: 2
 path.data: /data

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: fluentd-elasticsearch
   namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
 spec:
   containers:
   - name: fluentd-elasticsearch

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: fluentd-cloud-logging
   namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
 spec:
   containers:
   - name: fluentd-cloud-logging

--- a/docs/getting-started-guides/logging.md
+++ b/docs/getting-started-guides/logging.md
@@ -166,6 +166,8 @@ kind: Pod
 metadata:
   name: fluentd-cloud-logging
   namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
 spec:
   containers:
   - name: fluentd-cloud-logging

--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -47,8 +47,9 @@ var _ = Describe("Cluster level logging using Elasticsearch", func() {
 })
 
 const (
-	esKey   = "k8s-app"
-	esValue = "elasticsearch-logging"
+	k8sAppKey    = "k8s-app"
+	esValue      = "elasticsearch-logging"
+	fluentdValue = "fluentd-logging"
 )
 
 func bodyToJSON(body []byte) (map[string]interface{}, error) {
@@ -58,6 +59,15 @@ func bodyToJSON(body []byte) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("failed to unmarshal Elasticsearch response: %v", err)
 	}
 	return r, nil
+}
+
+func nodeInNodeList(nodeName string, nodeList *api.NodeList) bool {
+	for _, node := range nodeList.Items {
+		if nodeName == node.Name {
+			return true
+		}
+	}
+	return false
 }
 
 // ClusterLevelLoggingWithElasticsearch is an end to end test for cluster level logging.
@@ -84,7 +94,7 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 
 	// Wait for the Elasticsearch pods to enter the running state.
 	By("Checking to make sure the Elasticsearch pods are running")
-	label := labels.SelectorFromSet(labels.Set(map[string]string{esKey: esValue}))
+	label := labels.SelectorFromSet(labels.Set(map[string]string{k8sAppKey: esValue}))
 	options := unversioned.ListOptions{LabelSelector: unversioned.LabelSelector{label}}
 	pods, err := f.Client.Pods(api.NamespaceSystem).List(options)
 	Expect(err).NotTo(HaveOccurred())
@@ -153,13 +163,14 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 			Resource("services").
 			Name("elasticsearch-logging").
 			Suffix("_cluster/health").
-			Param("health", "pretty").
+			Param("level", "indices").
 			DoRaw()
 		if err != nil {
 			continue
 		}
 		health, err := bodyToJSON(body)
 		if err != nil {
+			Logf("Bad json response from elasticsearch: %v", err)
 			continue
 		}
 		statusIntf, ok := health["status"]
@@ -169,7 +180,7 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 		}
 		status := statusIntf.(string)
 		if status != "green" && status != "yellow" {
-			Logf("Cluster health has bad status: %s", status)
+			Logf("Cluster health has bad status: %v", health)
 			continue
 		}
 		if err == nil && ok {
@@ -202,6 +213,33 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 		Failf("Less than two nodes were found Ready: %d", len(nodes.Items))
 	}
 	Logf("Found %d healthy nodes.", len(nodes.Items))
+
+	// Wait for the Fluentd pods to enter the running state.
+	By("Checking to make sure the Fluentd pod are running on each healthy node")
+	label = labels.SelectorFromSet(labels.Set(map[string]string{k8sAppKey: fluentdValue}))
+	options = unversioned.ListOptions{LabelSelector: unversioned.LabelSelector{label}}
+	pods, err = f.Client.Pods(api.NamespaceSystem).List(options)
+	Expect(err).NotTo(HaveOccurred())
+	for _, pod := range pods.Items {
+		if nodeInNodeList(pod.Spec.NodeName, nodes) {
+			err = waitForPodRunningInNamespace(f.Client, pod.Name, api.NamespaceSystem)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	// Check if each healthy node has fluentd running on it
+	for _, node := range nodes.Items {
+		exists := false
+		for _, pod := range pods.Items {
+			if pod.Spec.NodeName == node.Name {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			Failf("Node %v does not have fluentd pod running on it.", node.Name)
+		}
+	}
 
 	// Create a unique root name for the resources in this test to permit
 	// parallel executions of this test.
@@ -269,7 +307,7 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 	for start := time.Now(); time.Since(start) < ingestionTimeout; time.Sleep(10 * time.Second) {
 
 		// Debugging code to report the status of the elasticsearch logging endpoints.
-		selector := labels.Set{esKey: esValue}.AsSelector()
+		selector := labels.Set{k8sAppKey: esValue}.AsSelector()
 		options := unversioned.ListOptions{LabelSelector: unversioned.LabelSelector{selector}}
 		esPods, err := f.Client.Pods(api.NamespaceSystem).List(options)
 		if err != nil {
@@ -387,6 +425,13 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 	for n := range missingPerNode {
 		if missingPerNode[n] > 0 {
 			Logf("Node %d is missing %d logs", n, missingPerNode[n])
+			opts := &api.PodLogOptions{}
+			body, err = f.Client.Pods(ns).GetLogs(podNames[n], opts).DoRaw()
+			if err != nil {
+				Logf("Cannot get logs from pod %v", podNames[n])
+				continue
+			}
+			Logf("Pod %s has the following logs: %s", podNames[n], body)
 		}
 	}
 	Failf("Failed to find all %d log lines", expected)


### PR DESCRIPTION
Problem description and fix:
http://blog.trifork.com/2013/10/24/how-to-avoid-the-split-brain-problem-in-elasticsearch/
