### PR TITLE
Add jobs and ingresses to valid resources for kubectl get

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -127,6 +127,8 @@ __custom_func() {
    * quota
    * horizontalpodautoscalers (aka 'hpa')
    * serviceaccounts
+   * jobs
+   * ingresses
 `
 )
 


### PR DESCRIPTION
Adds a couple missing resources into the help for `kubectl get`

@deads2k @derekwaynecarr 
