### PR TITLE
enforce node quorum to prevent es split brain problem

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - image: gcr.io/google_containers/elasticsearch:1.7
+      - image: gcr.io/google_containers/elasticsearch:1.8
         name: elasticsearch-logging         
         resources:
           limits:

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -2,7 +2,7 @@
 
 # The current value of the tag to be used for building and
 # pushing an image to gcr.io
-TAG = 1.7
+TAG = 1.8
 
 build:	elasticsearch_logging_discovery
 	docker build -t gcr.io/google_containers/elasticsearch:$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch.yml
+++ b/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch.yml
@@ -4,4 +4,5 @@ node.data: ${NODE_DATA}
 transport.tcp.port: ${TRANSPORT_PORT}
 http.port: ${HTTP_PORT}
 discovery.zen.ping.multicast.enabled: false
+discovery.zen.minimum_master_nodes: 2
 path.data: /data


### PR DESCRIPTION
ES split brain problem and fixes:
http://blog.trifork.com/2013/10/24/how-to-avoid-the-split-brain-problem-in-elasticsearch/

ref: #17873 
