### PR TITLE
Client-gen output

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -29,6 +29,7 @@ import (
 type genClientForType struct {
 	generator.DefaultGen
 	outputPackage string
+	group         string
 	typeToMatch   *types.Type
 	imports       *generator.ImportTracker
 }
@@ -54,6 +55,7 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		"type":             t,
 		"package":          pkg,
 		"Package":          namer.IC(pkg),
+		"Group":            namer.IC(g.group),
 		"watchInterface":   c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/watch", Name: "Interface"}),
 		"apiDeleteOptions": c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "DeleteOptions"}),
 		"unvListOptions":   c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api/unversioned", Name: "ListOptions"}),
@@ -97,13 +99,13 @@ type $.type|public$Interface interface {
 var structTemplate = `
 // $.type|privatePlural$ implements $.type|public$Interface
 type $.type|privatePlural$ struct {
-	client *$.Package$Client
+	client *$.Group$Client
 	ns     string
 }
 `
 var newStructTemplate = `
 // new$.type|publicPlural$ returns a $.type|publicPlural$
-func new$.type|publicPlural$(c *$.Package$Client, namespace string) *$.type|privatePlural$ {
+func new$.type|publicPlural$(c *$.Group$Client, namespace string) *$.type|privatePlural$ {
 	return &$.type|privatePlural${
 		client: c,
 		ns:     namespace,

--- a/cmd/libs/go2idl/client-gen/main.go
+++ b/cmd/libs/go2idl/client-gen/main.go
@@ -56,7 +56,7 @@ func main() {
 			"k8s.io/kubernetes/pkg/api/latest",
 		}
 		// We may change the output path later.
-		arguments.OutputPackagePath = "k8s.io/kubernetes/pkg/client/clientset/unversioned"
+		arguments.OutputPackagePath = "k8s.io/kubernetes/pkg/client/typed/generated"
 	}
 
 	if err := arguments.Execute(

--- a/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/v1/types.go
+++ b/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/v1/types.go
@@ -22,6 +22,7 @@ import (
 )
 
 // +genclient=true
+
 type TestType struct {
 	unversioned.TypeMeta `json:",inline"`
 	api.ObjectMeta       `json:"metadata,omitempty"`

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/doc.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/doc.go
@@ -14,23 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testgroup
-
-import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-)
-
-// +genclient=true
-
-type TestType struct {
-	unversioned.TypeMeta `json:",inline"`
-	api.ObjectMeta       `json:"metadata,omitempty"`
-}
-
-type TestTypeList struct {
-	unversioned.TypeMeta `json:",inline"`
-	unversioned.ListMeta `json:"metadata,omitempty"`
-
-	Items []TestType `json:"items"`
-}
+// Package unversioned has the automatically generated clients for unversioned resources.
+package unversioned

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testType.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testType.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testoutput
+package unversioned
 
 import (
 	testgroup "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testdata/apis/testgroup"

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testgroup_client.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testgroup_client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testoutput
+package unversioned
 
 import (
 	"fmt"
@@ -35,10 +35,10 @@ func (c *TestgroupClient) TestTypes(namespace string) TestTypeInterface {
 	return newTestTypes(c, namespace)
 }
 
-// NewTestgroup creates a new TestgroupClient for the given config.
-func NewTestgroup(c *unversioned.Config) (*TestgroupClient, error) {
+// NewForConfig creates a new TestgroupClient for the given config.
+func NewForConfig(c *unversioned.Config) (*TestgroupClient, error) {
 	config := *c
-	if err := setTestgroupDefaults(&config); err != nil {
+	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
 	client, err := unversioned.RESTClientFor(&config)
@@ -48,17 +48,22 @@ func NewTestgroup(c *unversioned.Config) (*TestgroupClient, error) {
 	return &TestgroupClient{client}, nil
 }
 
-// NewTestgroupOrDie creates a new TestgroupClient for the given config and
+// NewForConfigOrDie creates a new TestgroupClient for the given config and
 // panics if there is an error in the config.
-func NewTestgroupOrDie(c *unversioned.Config) *TestgroupClient {
-	client, err := NewTestgroup(c)
+func NewForConfigOrDie(c *unversioned.Config) *TestgroupClient {
+	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
 	}
 	return client
 }
 
-func setTestgroupDefaults(config *unversioned.Config) error {
+// New creates a new TestgroupClient for the given RESTClient.
+func New(c *unversioned.RESTClient) *TestgroupClient {
+	return &TestgroupClient{c}
+}
+
+func setConfigDefaults(config *unversioned.Config) error {
 	// if testgroup group is not registered, return an error
 	g, err := latest.Group("testgroup")
 	if err != nil {

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testgroup_test.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testgroup_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testoutput_test
+package unversioned_test
 
 import (
 	"net/http"
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testdata/apis/testgroup"
 	_ "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/install"
-	. "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testoutput"
+	. "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/testapi"
@@ -53,7 +53,7 @@ type DecoratedSimpleClient struct {
 func (c *DecoratedSimpleClient) Setup(t *testing.T) *DecoratedSimpleClient {
 	c.simpleClient.Setup(t)
 	url := c.simpleClient.ServerURL()
-	c.TestgroupClient = NewTestgroupOrDie(&client.Config{
+	c.TestgroupClient = NewForConfigOrDie(&client.Config{
 		Host: url,
 	})
 	return c

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -254,6 +254,8 @@ type PersistentVolumeClaimVolumeSource struct {
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
+// +genclient=true
+
 type PersistentVolume struct {
 	unversioned.TypeMeta `json:",inline"`
 	ObjectMeta           `json:"metadata,omitempty"`
@@ -309,6 +311,8 @@ type PersistentVolumeList struct {
 	unversioned.ListMeta `json:"metadata,omitempty"`
 	Items                []PersistentVolume `json:"items"`
 }
+
+// +genclient=true
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaim struct {
@@ -1113,6 +1117,8 @@ type PodStatusResult struct {
 	Status PodStatus `json:"status,omitempty"`
 }
 
+// +genclient=true
+
 // Pod is a collection of containers, used as either input (create, update) or as output (list, get).
 type Pod struct {
 	unversioned.TypeMeta `json:",inline"`
@@ -1134,6 +1140,8 @@ type PodTemplateSpec struct {
 	// Spec defines the behavior of a pod.
 	Spec PodSpec `json:"spec,omitempty"`
 }
+
+// +genclient=true
 
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplate struct {
@@ -1182,6 +1190,8 @@ type ReplicationControllerStatus struct {
 	// ObservedGeneration is the most recent generation observed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
+
+// +genclient=true
 
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationController struct {
@@ -1332,6 +1342,8 @@ type ServicePort struct {
 	NodePort int `json:"nodePort"`
 }
 
+// +genclient=true
+
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
 // (for example 3306) that the proxy listens on, and the selector that determines which pods
 // will answer requests sent through the proxy.
@@ -1345,6 +1357,8 @@ type Service struct {
 	// Status represents the current status of a service.
 	Status ServiceStatus `json:"status,omitempty"`
 }
+
+// +genclient=true
 
 // ServiceAccount binds together:
 // * a name, understood by users, and perhaps by peripheral systems, for an identity
@@ -1370,6 +1384,8 @@ type ServiceAccountList struct {
 
 	Items []ServiceAccount `json:"items"`
 }
+
+// +genclient=true
 
 // Endpoints is a collection of endpoints that implement the actual service.  Example:
 //   Name: "mysvc",
@@ -1578,6 +1594,8 @@ const (
 // ResourceList is a set of (resource name, quantity) pairs.
 type ResourceList map[ResourceName]resource.Quantity
 
+// +genclient=true
+
 // Node is a worker node in Kubernetes
 // The name of the node according to etcd is in ObjectMeta.Name.
 type Node struct {
@@ -1627,6 +1645,8 @@ const (
 	// NamespaceTerminating means the namespace is undergoing graceful termination
 	NamespaceTerminating NamespacePhase = "Terminating"
 )
+
+// +genclient=true
 
 // A namespace provides a scope for Names.
 // Use of multiple namespaces is optional
@@ -1816,6 +1836,8 @@ const (
 	EventTypeWarning string = "Warning"
 )
 
+// +genclient=true
+
 // Event is a report of an event somewhere in the cluster.
 // TODO: Decide whether to store these separately or with the object they apply to.
 type Event struct {
@@ -1899,6 +1921,8 @@ type LimitRangeSpec struct {
 	Limits []LimitRangeItem `json:"limits"`
 }
 
+// +genclient=true
+
 // LimitRange sets resource usage limits for each kind of resource in a Namespace
 type LimitRange struct {
 	unversioned.TypeMeta `json:",inline"`
@@ -1947,6 +1971,8 @@ type ResourceQuotaStatus struct {
 	Used ResourceList `json:"used,omitempty"`
 }
 
+// +genclient=true
+
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuota struct {
 	unversioned.TypeMeta `json:",inline"`
@@ -1967,6 +1993,8 @@ type ResourceQuotaList struct {
 	// Items is a list of ResourceQuota objects
 	Items []ResourceQuota `json:"items"`
 }
+
+// +genclient=true
 
 // Secret holds secret data of a certain type.  The total bytes of the values in
 // the Data field must be less than MaxSecretSize bytes.
@@ -2101,6 +2129,8 @@ type ComponentCondition struct {
 	Message string                 `json:"message,omitempty"`
 	Error   string                 `json:"error,omitempty"`
 }
+
+// +genclient=true
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatus struct {

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -119,6 +119,8 @@ type HorizontalPodAutoscalerStatus struct {
 	CurrentCPUUtilizationPercentage *int `json:"currentCPUUtilizationPercentage,omitempty"`
 }
 
+// +genclient=true
+
 // configuration of a horizontal pod autoscaler.
 type HorizontalPodAutoscaler struct {
 	unversioned.TypeMeta `json:",inline"`
@@ -139,6 +141,8 @@ type HorizontalPodAutoscalerList struct {
 	// list of horizontal pod autoscaler objects.
 	Items []HorizontalPodAutoscaler `json:"items"`
 }
+
+// +genclient=true
 
 // A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource
 // types to the API.  It consists of one or more Versions of the api.
@@ -184,6 +188,8 @@ type ThirdPartyResourceData struct {
 	// Data is the raw JSON data for this data.
 	Data []byte `json:"name,omitempty"`
 }
+
+// +genclient=true
 
 type Deployment struct {
 	unversioned.TypeMeta `json:",inline"`
@@ -331,6 +337,8 @@ type DaemonSetStatus struct {
 	DesiredNumberScheduled int `json:"desiredNumberScheduled"`
 }
 
+// +genclient=true
+
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSet struct {
 	unversioned.TypeMeta `json:",inline"`
@@ -369,6 +377,8 @@ type ThirdPartyResourceDataList struct {
 	// Items is a list of third party objects
 	Items []ThirdPartyResourceData `json:"items"`
 }
+
+// +genclient=true
 
 // Job represents the configuration of a single job.
 type Job struct {
@@ -467,6 +477,8 @@ type JobCondition struct {
 	// Human readable message indicating details about last transition.
 	Message string `json:"message,omitempty"`
 }
+
+// +genclient=true
 
 // Ingress is a collection of rules that allow inbound connections to reach the
 // endpoints defined by a backend. An Ingress can be configured to give services

--- a/pkg/client/typed/generated/extensions/unversioned/daemonSet.go
+++ b/pkg/client/typed/generated/extensions/unversioned/daemonSet.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// DaemonSetNamespacer has methods to work with DaemonSet resources in a namespace
+type DaemonSetNamespacer interface {
+	DaemonSets(namespace string) DaemonSetInterface
+}
+
+// DaemonSetInterface has methods to work with DaemonSet resources.
+type DaemonSetInterface interface {
+	Create(*extensions.DaemonSet) (*extensions.DaemonSet, error)
+	Update(*extensions.DaemonSet) (*extensions.DaemonSet, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*extensions.DaemonSet, error)
+	List(opts unversioned.ListOptions) (*extensions.DaemonSetList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// daemonSets implements DaemonSetInterface
+type daemonSets struct {
+	client *ExtensionsClient
+	ns     string
+}
+
+// newDaemonSets returns a DaemonSets
+func newDaemonSets(c *ExtensionsClient, namespace string) *daemonSets {
+	return &daemonSets{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
+func (c *daemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
+	result = &extensions.DaemonSet{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("daemonSets").
+		Body(daemonSet).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a daemonSet and updates it. Returns the server's representation of the daemonSet, and an error, if there is any.
+func (c *daemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
+	result = &extensions.DaemonSet{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("daemonSets").
+		Name(daemonSet.Name).
+		Body(daemonSet).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the daemonSet and deletes it. Returns an error if one occurs.
+func (c *daemonSets) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("daemonSets").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("daemonSets").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
+func (c *daemonSets) Get(name string) (result *extensions.DaemonSet, err error) {
+	result = &extensions.DaemonSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonSets").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
+func (c *daemonSets) List(opts unversioned.ListOptions) (result *extensions.DaemonSetList, err error) {
+	result = &extensions.DaemonSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonSets").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested daemonSets.
+func (c *daemonSets) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("daemonSets").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/extensions/unversioned/deployment.go
+++ b/pkg/client/typed/generated/extensions/unversioned/deployment.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// DeploymentNamespacer has methods to work with Deployment resources in a namespace
+type DeploymentNamespacer interface {
+	Deployments(namespace string) DeploymentInterface
+}
+
+// DeploymentInterface has methods to work with Deployment resources.
+type DeploymentInterface interface {
+	Create(*extensions.Deployment) (*extensions.Deployment, error)
+	Update(*extensions.Deployment) (*extensions.Deployment, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*extensions.Deployment, error)
+	List(opts unversioned.ListOptions) (*extensions.DeploymentList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// deployments implements DeploymentInterface
+type deployments struct {
+	client *ExtensionsClient
+	ns     string
+}
+
+// newDeployments returns a Deployments
+func newDeployments(c *ExtensionsClient, namespace string) *deployments {
+	return &deployments{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
+func (c *deployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
+	result = &extensions.Deployment{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("deployments").
+		Body(deployment).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
+func (c *deployments) Update(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
+	result = &extensions.Deployment{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(deployment.Name).
+		Body(deployment).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the deployment and deletes it. Returns an error if one occurs.
+func (c *deployments) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
+func (c *deployments) Get(name string) (result *extensions.Deployment, err error) {
+	result = &extensions.Deployment{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) List(opts unversioned.ListOptions) (result *extensions.DeploymentList, err error) {
+	result = &extensions.DeploymentList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *deployments) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/extensions/unversioned/doc.go
+++ b/pkg/client/typed/generated/extensions/unversioned/doc.go
@@ -15,4 +15,4 @@ limitations under the License.
 */
 
 // Package unversioned has the automatically generated clients for unversioned resources.
-package testoutput
+package unversioned

--- a/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
+++ b/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+	latest "k8s.io/kubernetes/pkg/api/latest"
+	unversioned "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type ExtensionsInterface interface {
+	DaemonSetNamespacer
+	DeploymentNamespacer
+	HorizontalPodAutoscalerNamespacer
+	IngressNamespacer
+	JobNamespacer
+	ThirdPartyResourceNamespacer
+}
+
+// ExtensionsClient is used to interact with features provided by the Extensions group.
+type ExtensionsClient struct {
+	*unversioned.RESTClient
+}
+
+func (c *ExtensionsClient) DaemonSets(namespace string) DaemonSetInterface {
+	return newDaemonSets(c, namespace)
+}
+
+func (c *ExtensionsClient) Deployments(namespace string) DeploymentInterface {
+	return newDeployments(c, namespace)
+}
+
+func (c *ExtensionsClient) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface {
+	return newHorizontalPodAutoscalers(c, namespace)
+}
+
+func (c *ExtensionsClient) Ingresses(namespace string) IngressInterface {
+	return newIngresses(c, namespace)
+}
+
+func (c *ExtensionsClient) Jobs(namespace string) JobInterface {
+	return newJobs(c, namespace)
+}
+
+func (c *ExtensionsClient) ThirdPartyResources(namespace string) ThirdPartyResourceInterface {
+	return newThirdPartyResources(c, namespace)
+}
+
+// NewForConfig creates a new ExtensionsClient for the given config.
+func NewForConfig(c *unversioned.Config) (*ExtensionsClient, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := unversioned.RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return &ExtensionsClient{client}, nil
+}
+
+// NewForConfigOrDie creates a new ExtensionsClient for the given config and
+// panics if there is an error in the config.
+func NewForConfigOrDie(c *unversioned.Config) *ExtensionsClient {
+	client, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// New creates a new ExtensionsClient for the given RESTClient.
+func New(c *unversioned.RESTClient) *ExtensionsClient {
+	return &ExtensionsClient{c}
+}
+
+func setConfigDefaults(config *unversioned.Config) error {
+	// if extensions group is not registered, return an error
+	g, err := latest.Group("extensions")
+	if err != nil {
+		return err
+	}
+	config.Prefix = "/apis"
+	if config.UserAgent == "" {
+		config.UserAgent = unversioned.DefaultKubernetesUserAgent()
+	}
+	// TODO: Unconditionally set the config.Version, until we fix the config.
+	//if config.Version == "" {
+	copyGroupVersion := g.GroupVersion
+	config.GroupVersion = &copyGroupVersion
+	//}
+
+	versionInterfaces, err := g.InterfacesFor(*config.GroupVersion)
+	if err != nil {
+		return fmt.Errorf("Extensions API version '%s' is not recognized (valid values: %s)",
+			config.GroupVersion, g.GroupVersions)
+	}
+	config.Codec = versionInterfaces.Codec
+	if config.QPS == 0 {
+		config.QPS = 5
+	}
+	if config.Burst == 0 {
+		config.Burst = 10
+	}
+	return nil
+}

--- a/pkg/client/typed/generated/extensions/unversioned/horizontalPodAutoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/horizontalPodAutoscaler.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// HorizontalPodAutoscalerNamespacer has methods to work with HorizontalPodAutoscaler resources in a namespace
+type HorizontalPodAutoscalerNamespacer interface {
+	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface
+}
+
+// HorizontalPodAutoscalerInterface has methods to work with HorizontalPodAutoscaler resources.
+type HorizontalPodAutoscalerInterface interface {
+	Create(*extensions.HorizontalPodAutoscaler) (*extensions.HorizontalPodAutoscaler, error)
+	Update(*extensions.HorizontalPodAutoscaler) (*extensions.HorizontalPodAutoscaler, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*extensions.HorizontalPodAutoscaler, error)
+	List(opts unversioned.ListOptions) (*extensions.HorizontalPodAutoscalerList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
+type horizontalPodAutoscalers struct {
+	client *ExtensionsClient
+	ns     string
+}
+
+// newHorizontalPodAutoscalers returns a HorizontalPodAutoscalers
+func newHorizontalPodAutoscalers(c *ExtensionsClient, namespace string) *horizontalPodAutoscalers {
+	return &horizontalPodAutoscalers{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
+func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
+	result = &extensions.HorizontalPodAutoscaler{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("horizontalPodAutoscalers").
+		Body(horizontalPodAutoscaler).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a horizontalPodAutoscaler and updates it. Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
+func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
+	result = &extensions.HorizontalPodAutoscaler{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("horizontalPodAutoscalers").
+		Name(horizontalPodAutoscaler.Name).
+		Body(horizontalPodAutoscaler).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the horizontalPodAutoscaler and deletes it. Returns an error if one occurs.
+func (c *horizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("horizontalPodAutoscalers").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
+func (c *horizontalPodAutoscalers) Get(name string) (result *extensions.HorizontalPodAutoscaler, err error) {
+	result = &extensions.HorizontalPodAutoscaler{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalPodAutoscalers").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) List(opts unversioned.ListOptions) (result *extensions.HorizontalPodAutoscalerList, err error) {
+	result = &extensions.HorizontalPodAutoscalerList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalPodAutoscalers").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
+func (c *horizontalPodAutoscalers) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("horizontalPodAutoscalers").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/extensions/unversioned/ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/ingress.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// IngressNamespacer has methods to work with Ingress resources in a namespace
+type IngressNamespacer interface {
+	Ingresses(namespace string) IngressInterface
+}
+
+// IngressInterface has methods to work with Ingress resources.
+type IngressInterface interface {
+	Create(*extensions.Ingress) (*extensions.Ingress, error)
+	Update(*extensions.Ingress) (*extensions.Ingress, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*extensions.Ingress, error)
+	List(opts unversioned.ListOptions) (*extensions.IngressList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// ingresses implements IngressInterface
+type ingresses struct {
+	client *ExtensionsClient
+	ns     string
+}
+
+// newIngresses returns a Ingresses
+func newIngresses(c *ExtensionsClient, namespace string) *ingresses {
+	return &ingresses{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
+func (c *ingresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+	result = &extensions.Ingress{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("ingresses").
+		Body(ingress).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a ingress and updates it. Returns the server's representation of the ingress, and an error, if there is any.
+func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+	result = &extensions.Ingress{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(ingress.Name).
+		Body(ingress).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the ingress and deletes it. Returns an error if one occurs.
+func (c *ingresses) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("ingresses").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
+func (c *ingresses) Get(name string) (result *extensions.Ingress, err error) {
+	result = &extensions.Ingress{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
+func (c *ingresses) List(opts unversioned.ListOptions) (result *extensions.IngressList, err error) {
+	result = &extensions.IngressList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested ingresses.
+func (c *ingresses) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/extensions/unversioned/job.go
+++ b/pkg/client/typed/generated/extensions/unversioned/job.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// JobNamespacer has methods to work with Job resources in a namespace
+type JobNamespacer interface {
+	Jobs(namespace string) JobInterface
+}
+
+// JobInterface has methods to work with Job resources.
+type JobInterface interface {
+	Create(*extensions.Job) (*extensions.Job, error)
+	Update(*extensions.Job) (*extensions.Job, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*extensions.Job, error)
+	List(opts unversioned.ListOptions) (*extensions.JobList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// jobs implements JobInterface
+type jobs struct {
+	client *ExtensionsClient
+	ns     string
+}
+
+// newJobs returns a Jobs
+func newJobs(c *ExtensionsClient, namespace string) *jobs {
+	return &jobs{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
+func (c *jobs) Create(job *extensions.Job) (result *extensions.Job, err error) {
+	result = &extensions.Job{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("jobs").
+		Body(job).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a job and updates it. Returns the server's representation of the job, and an error, if there is any.
+func (c *jobs) Update(job *extensions.Job) (result *extensions.Job, err error) {
+	result = &extensions.Job{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(job.Name).
+		Body(job).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the job and deletes it. Returns an error if one occurs.
+func (c *jobs) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("jobs").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
+func (c *jobs) Get(name string) (result *extensions.Job, err error) {
+	result = &extensions.Job{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Jobs that match those selectors.
+func (c *jobs) List(opts unversioned.ListOptions) (result *extensions.JobList, err error) {
+	result = &extensions.JobList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested jobs.
+func (c *jobs) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/extensions/unversioned/thirdPartyResource.go
+++ b/pkg/client/typed/generated/extensions/unversioned/thirdPartyResource.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// ThirdPartyResourceNamespacer has methods to work with ThirdPartyResource resources in a namespace
+type ThirdPartyResourceNamespacer interface {
+	ThirdPartyResources(namespace string) ThirdPartyResourceInterface
+}
+
+// ThirdPartyResourceInterface has methods to work with ThirdPartyResource resources.
+type ThirdPartyResourceInterface interface {
+	Create(*extensions.ThirdPartyResource) (*extensions.ThirdPartyResource, error)
+	Update(*extensions.ThirdPartyResource) (*extensions.ThirdPartyResource, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*extensions.ThirdPartyResource, error)
+	List(opts unversioned.ListOptions) (*extensions.ThirdPartyResourceList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// thirdPartyResources implements ThirdPartyResourceInterface
+type thirdPartyResources struct {
+	client *ExtensionsClient
+	ns     string
+}
+
+// newThirdPartyResources returns a ThirdPartyResources
+func newThirdPartyResources(c *ExtensionsClient, namespace string) *thirdPartyResources {
+	return &thirdPartyResources{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a thirdPartyResource and creates it.  Returns the server's representation of the thirdPartyResource, and an error, if there is any.
+func (c *thirdPartyResources) Create(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
+	result = &extensions.ThirdPartyResource{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("thirdPartyResources").
+		Body(thirdPartyResource).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a thirdPartyResource and updates it. Returns the server's representation of the thirdPartyResource, and an error, if there is any.
+func (c *thirdPartyResources) Update(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
+	result = &extensions.ThirdPartyResource{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("thirdPartyResources").
+		Name(thirdPartyResource.Name).
+		Body(thirdPartyResource).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the thirdPartyResource and deletes it. Returns an error if one occurs.
+func (c *thirdPartyResources) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("thirdPartyResources").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("thirdPartyResources").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the thirdPartyResource, and returns the corresponding thirdPartyResource object, and an error if there is any.
+func (c *thirdPartyResources) Get(name string) (result *extensions.ThirdPartyResource, err error) {
+	result = &extensions.ThirdPartyResource{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("thirdPartyResources").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ThirdPartyResources that match those selectors.
+func (c *thirdPartyResources) List(opts unversioned.ListOptions) (result *extensions.ThirdPartyResourceList, err error) {
+	result = &extensions.ThirdPartyResourceList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("thirdPartyResources").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested thirdPartyResources.
+func (c *thirdPartyResources) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("thirdPartyResources").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/componentStatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/componentStatus.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// ComponentStatusNamespacer has methods to work with ComponentStatus resources in a namespace
+type ComponentStatusNamespacer interface {
+	ComponentStatus(namespace string) ComponentStatusInterface
+}
+
+// ComponentStatusInterface has methods to work with ComponentStatus resources.
+type ComponentStatusInterface interface {
+	Create(*api.ComponentStatus) (*api.ComponentStatus, error)
+	Update(*api.ComponentStatus) (*api.ComponentStatus, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.ComponentStatus, error)
+	List(opts unversioned.ListOptions) (*api.ComponentStatusList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// componentStatus implements ComponentStatusInterface
+type componentStatus struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newComponentStatus returns a ComponentStatus
+func newComponentStatus(c *LegacyClient, namespace string) *componentStatus {
+	return &componentStatus{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a componentStatus and creates it.  Returns the server's representation of the componentStatus, and an error, if there is any.
+func (c *componentStatus) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+	result = &api.ComponentStatus{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("componentStatus").
+		Body(componentStatus).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a componentStatus and updates it. Returns the server's representation of the componentStatus, and an error, if there is any.
+func (c *componentStatus) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+	result = &api.ComponentStatus{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("componentStatus").
+		Name(componentStatus.Name).
+		Body(componentStatus).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the componentStatus and deletes it. Returns an error if one occurs.
+func (c *componentStatus) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("componentStatus").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("componentStatus").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the componentStatus, and returns the corresponding componentStatus object, and an error if there is any.
+func (c *componentStatus) Get(name string) (result *api.ComponentStatus, err error) {
+	result = &api.ComponentStatus{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("componentStatus").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ComponentStatus that match those selectors.
+func (c *componentStatus) List(opts unversioned.ListOptions) (result *api.ComponentStatusList, err error) {
+	result = &api.ComponentStatusList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("componentStatus").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested componentStatus.
+func (c *componentStatus) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("componentStatus").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/doc.go
+++ b/pkg/client/typed/generated/legacy/unversioned/doc.go
@@ -14,23 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testgroup
-
-import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-)
-
-// +genclient=true
-
-type TestType struct {
-	unversioned.TypeMeta `json:",inline"`
-	api.ObjectMeta       `json:"metadata,omitempty"`
-}
-
-type TestTypeList struct {
-	unversioned.TypeMeta `json:",inline"`
-	unversioned.ListMeta `json:"metadata,omitempty"`
-
-	Items []TestType `json:"items"`
-}
+// Package unversioned has the automatically generated clients for unversioned resources.
+package unversioned

--- a/pkg/client/typed/generated/legacy/unversioned/endpoints.go
+++ b/pkg/client/typed/generated/legacy/unversioned/endpoints.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// EndpointsNamespacer has methods to work with Endpoints resources in a namespace
+type EndpointsNamespacer interface {
+	Endpoints(namespace string) EndpointsInterface
+}
+
+// EndpointsInterface has methods to work with Endpoints resources.
+type EndpointsInterface interface {
+	Create(*api.Endpoints) (*api.Endpoints, error)
+	Update(*api.Endpoints) (*api.Endpoints, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.Endpoints, error)
+	List(opts unversioned.ListOptions) (*api.EndpointsList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// endpoints implements EndpointsInterface
+type endpoints struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newEndpoints returns a Endpoints
+func newEndpoints(c *LegacyClient, namespace string) *endpoints {
+	return &endpoints{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a endpoints and creates it.  Returns the server's representation of the endpoints, and an error, if there is any.
+func (c *endpoints) Create(endpoints *api.Endpoints) (result *api.Endpoints, err error) {
+	result = &api.Endpoints{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("endpoints").
+		Body(endpoints).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a endpoints and updates it. Returns the server's representation of the endpoints, and an error, if there is any.
+func (c *endpoints) Update(endpoints *api.Endpoints) (result *api.Endpoints, err error) {
+	result = &api.Endpoints{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("endpoints").
+		Name(endpoints.Name).
+		Body(endpoints).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the endpoints and deletes it. Returns an error if one occurs.
+func (c *endpoints) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("endpoints").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("endpoints").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the endpoints, and returns the corresponding endpoints object, and an error if there is any.
+func (c *endpoints) Get(name string) (result *api.Endpoints, err error) {
+	result = &api.Endpoints{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("endpoints").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Endpoints that match those selectors.
+func (c *endpoints) List(opts unversioned.ListOptions) (result *api.EndpointsList, err error) {
+	result = &api.EndpointsList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("endpoints").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested endpoints.
+func (c *endpoints) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("endpoints").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/event.go
+++ b/pkg/client/typed/generated/legacy/unversioned/event.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// EventNamespacer has methods to work with Event resources in a namespace
+type EventNamespacer interface {
+	Events(namespace string) EventInterface
+}
+
+// EventInterface has methods to work with Event resources.
+type EventInterface interface {
+	Create(*api.Event) (*api.Event, error)
+	Update(*api.Event) (*api.Event, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.Event, error)
+	List(opts unversioned.ListOptions) (*api.EventList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// events implements EventInterface
+type events struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newEvents returns a Events
+func newEvents(c *LegacyClient, namespace string) *events {
+	return &events{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+func (c *events) Create(event *api.Event) (result *api.Event, err error) {
+	result = &api.Event{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("events").
+		Body(event).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+func (c *events) Update(event *api.Event) (result *api.Event, err error) {
+	result = &api.Event{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("events").
+		Name(event.Name).
+		Body(event).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the event and deletes it. Returns an error if one occurs.
+func (c *events) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("events").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("events").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
+func (c *events) Get(name string) (result *api.Event, err error) {
+	result = &api.Event{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Events that match those selectors.
+func (c *events) List(opts unversioned.ListOptions) (result *api.EventList, err error) {
+	result = &api.EventList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested events.
+func (c *events) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/legacy_client.go
+++ b/pkg/client/typed/generated/legacy/unversioned/legacy_client.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+	latest "k8s.io/kubernetes/pkg/api/latest"
+	unversioned "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type LegacyInterface interface {
+	ComponentStatusNamespacer
+	EndpointsNamespacer
+	EventNamespacer
+	LimitRangeNamespacer
+	NamespaceNamespacer
+	NodeNamespacer
+	PersistentVolumeNamespacer
+	PersistentVolumeClaimNamespacer
+	PodNamespacer
+	PodTemplateNamespacer
+	ReplicationControllerNamespacer
+	ResourceQuotaNamespacer
+	SecretNamespacer
+	ServiceNamespacer
+	ServiceAccountNamespacer
+}
+
+// LegacyClient is used to interact with features provided by the Legacy group.
+type LegacyClient struct {
+	*unversioned.RESTClient
+}
+
+func (c *LegacyClient) ComponentStatus(namespace string) ComponentStatusInterface {
+	return newComponentStatus(c, namespace)
+}
+
+func (c *LegacyClient) Endpoints(namespace string) EndpointsInterface {
+	return newEndpoints(c, namespace)
+}
+
+func (c *LegacyClient) Events(namespace string) EventInterface {
+	return newEvents(c, namespace)
+}
+
+func (c *LegacyClient) LimitRanges(namespace string) LimitRangeInterface {
+	return newLimitRanges(c, namespace)
+}
+
+func (c *LegacyClient) Namespaces(namespace string) NamespaceInterface {
+	return newNamespaces(c, namespace)
+}
+
+func (c *LegacyClient) Nodes(namespace string) NodeInterface {
+	return newNodes(c, namespace)
+}
+
+func (c *LegacyClient) PersistentVolumes(namespace string) PersistentVolumeInterface {
+	return newPersistentVolumes(c, namespace)
+}
+
+func (c *LegacyClient) PersistentVolumeClaims(namespace string) PersistentVolumeClaimInterface {
+	return newPersistentVolumeClaims(c, namespace)
+}
+
+func (c *LegacyClient) Pods(namespace string) PodInterface {
+	return newPods(c, namespace)
+}
+
+func (c *LegacyClient) PodTemplates(namespace string) PodTemplateInterface {
+	return newPodTemplates(c, namespace)
+}
+
+func (c *LegacyClient) ReplicationControllers(namespace string) ReplicationControllerInterface {
+	return newReplicationControllers(c, namespace)
+}
+
+func (c *LegacyClient) ResourceQuotas(namespace string) ResourceQuotaInterface {
+	return newResourceQuotas(c, namespace)
+}
+
+func (c *LegacyClient) Secrets(namespace string) SecretInterface {
+	return newSecrets(c, namespace)
+}
+
+func (c *LegacyClient) Services(namespace string) ServiceInterface {
+	return newServices(c, namespace)
+}
+
+func (c *LegacyClient) ServiceAccounts(namespace string) ServiceAccountInterface {
+	return newServiceAccounts(c, namespace)
+}
+
+// NewForConfig creates a new LegacyClient for the given config.
+func NewForConfig(c *unversioned.Config) (*LegacyClient, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := unversioned.RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return &LegacyClient{client}, nil
+}
+
+// NewForConfigOrDie creates a new LegacyClient for the given config and
+// panics if there is an error in the config.
+func NewForConfigOrDie(c *unversioned.Config) *LegacyClient {
+	client, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// New creates a new LegacyClient for the given RESTClient.
+func New(c *unversioned.RESTClient) *LegacyClient {
+	return &LegacyClient{c}
+}
+
+func setConfigDefaults(config *unversioned.Config) error {
+	// if legacy group is not registered, return an error
+	g, err := latest.Group("")
+	if err != nil {
+		return err
+	}
+	config.Prefix = "/api"
+	if config.UserAgent == "" {
+		config.UserAgent = unversioned.DefaultKubernetesUserAgent()
+	}
+	// TODO: Unconditionally set the config.Version, until we fix the config.
+	//if config.Version == "" {
+	copyGroupVersion := g.GroupVersion
+	config.GroupVersion = &copyGroupVersion
+	//}
+
+	versionInterfaces, err := g.InterfacesFor(*config.GroupVersion)
+	if err != nil {
+		return fmt.Errorf("Legacy API version '%s' is not recognized (valid values: %s)",
+			config.GroupVersion, g.GroupVersions)
+	}
+	config.Codec = versionInterfaces.Codec
+	if config.QPS == 0 {
+		config.QPS = 5
+	}
+	if config.Burst == 0 {
+		config.Burst = 10
+	}
+	return nil
+}

--- a/pkg/client/typed/generated/legacy/unversioned/limitRange.go
+++ b/pkg/client/typed/generated/legacy/unversioned/limitRange.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// LimitRangeNamespacer has methods to work with LimitRange resources in a namespace
+type LimitRangeNamespacer interface {
+	LimitRanges(namespace string) LimitRangeInterface
+}
+
+// LimitRangeInterface has methods to work with LimitRange resources.
+type LimitRangeInterface interface {
+	Create(*api.LimitRange) (*api.LimitRange, error)
+	Update(*api.LimitRange) (*api.LimitRange, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.LimitRange, error)
+	List(opts unversioned.ListOptions) (*api.LimitRangeList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// limitRanges implements LimitRangeInterface
+type limitRanges struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newLimitRanges returns a LimitRanges
+func newLimitRanges(c *LegacyClient, namespace string) *limitRanges {
+	return &limitRanges{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a limitRange and creates it.  Returns the server's representation of the limitRange, and an error, if there is any.
+func (c *limitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
+	result = &api.LimitRange{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("limitRanges").
+		Body(limitRange).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a limitRange and updates it. Returns the server's representation of the limitRange, and an error, if there is any.
+func (c *limitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
+	result = &api.LimitRange{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("limitRanges").
+		Name(limitRange.Name).
+		Body(limitRange).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the limitRange and deletes it. Returns an error if one occurs.
+func (c *limitRanges) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("limitRanges").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("limitRanges").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the limitRange, and returns the corresponding limitRange object, and an error if there is any.
+func (c *limitRanges) Get(name string) (result *api.LimitRange, err error) {
+	result = &api.LimitRange{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("limitRanges").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of LimitRanges that match those selectors.
+func (c *limitRanges) List(opts unversioned.ListOptions) (result *api.LimitRangeList, err error) {
+	result = &api.LimitRangeList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("limitRanges").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested limitRanges.
+func (c *limitRanges) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("limitRanges").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/namespace.go
+++ b/pkg/client/typed/generated/legacy/unversioned/namespace.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// NamespaceNamespacer has methods to work with Namespace resources in a namespace
+type NamespaceNamespacer interface {
+	Namespaces(namespace string) NamespaceInterface
+}
+
+// NamespaceInterface has methods to work with Namespace resources.
+type NamespaceInterface interface {
+	Create(*api.Namespace) (*api.Namespace, error)
+	Update(*api.Namespace) (*api.Namespace, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.Namespace, error)
+	List(opts unversioned.ListOptions) (*api.NamespaceList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// namespaces implements NamespaceInterface
+type namespaces struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newNamespaces returns a Namespaces
+func newNamespaces(c *LegacyClient, namespace string) *namespaces {
+	return &namespaces{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
+func (c *namespaces) Create(namespace *api.Namespace) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("namespaces").
+		Body(namespace).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a namespace and updates it. Returns the server's representation of the namespace, and an error, if there is any.
+func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("namespaces").
+		Name(namespace.Name).
+		Body(namespace).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the namespace and deletes it. Returns an error if one occurs.
+func (c *namespaces) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("namespaces").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("namespaces").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
+func (c *namespaces) Get(name string) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("namespaces").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
+func (c *namespaces) List(opts unversioned.ListOptions) (result *api.NamespaceList, err error) {
+	result = &api.NamespaceList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("namespaces").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested namespaces.
+func (c *namespaces) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("namespaces").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/node.go
+++ b/pkg/client/typed/generated/legacy/unversioned/node.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// NodeNamespacer has methods to work with Node resources in a namespace
+type NodeNamespacer interface {
+	Nodes(namespace string) NodeInterface
+}
+
+// NodeInterface has methods to work with Node resources.
+type NodeInterface interface {
+	Create(*api.Node) (*api.Node, error)
+	Update(*api.Node) (*api.Node, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.Node, error)
+	List(opts unversioned.ListOptions) (*api.NodeList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// nodes implements NodeInterface
+type nodes struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newNodes returns a Nodes
+func newNodes(c *LegacyClient, namespace string) *nodes {
+	return &nodes{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a node and creates it.  Returns the server's representation of the node, and an error, if there is any.
+func (c *nodes) Create(node *api.Node) (result *api.Node, err error) {
+	result = &api.Node{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("nodes").
+		Body(node).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a node and updates it. Returns the server's representation of the node, and an error, if there is any.
+func (c *nodes) Update(node *api.Node) (result *api.Node, err error) {
+	result = &api.Node{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("nodes").
+		Name(node.Name).
+		Body(node).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the node and deletes it. Returns an error if one occurs.
+func (c *nodes) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("nodes").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("nodes").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the node, and returns the corresponding node object, and an error if there is any.
+func (c *nodes) Get(name string) (result *api.Node, err error) {
+	result = &api.Node{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("nodes").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Nodes that match those selectors.
+func (c *nodes) List(opts unversioned.ListOptions) (result *api.NodeList, err error) {
+	result = &api.NodeList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("nodes").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested nodes.
+func (c *nodes) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("nodes").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/persistentVolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentVolume.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// PersistentVolumeNamespacer has methods to work with PersistentVolume resources in a namespace
+type PersistentVolumeNamespacer interface {
+	PersistentVolumes(namespace string) PersistentVolumeInterface
+}
+
+// PersistentVolumeInterface has methods to work with PersistentVolume resources.
+type PersistentVolumeInterface interface {
+	Create(*api.PersistentVolume) (*api.PersistentVolume, error)
+	Update(*api.PersistentVolume) (*api.PersistentVolume, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.PersistentVolume, error)
+	List(opts unversioned.ListOptions) (*api.PersistentVolumeList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// persistentVolumes implements PersistentVolumeInterface
+type persistentVolumes struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newPersistentVolumes returns a PersistentVolumes
+func newPersistentVolumes(c *LegacyClient, namespace string) *persistentVolumes {
+	return &persistentVolumes{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a persistentVolume and creates it.  Returns the server's representation of the persistentVolume, and an error, if there is any.
+func (c *persistentVolumes) Create(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("persistentVolumes").
+		Body(persistentVolume).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a persistentVolume and updates it. Returns the server's representation of the persistentVolume, and an error, if there is any.
+func (c *persistentVolumes) Update(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("persistentVolumes").
+		Name(persistentVolume.Name).
+		Body(persistentVolume).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the persistentVolume and deletes it. Returns an error if one occurs.
+func (c *persistentVolumes) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("persistentVolumes").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("persistentVolumes").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the persistentVolume, and returns the corresponding persistentVolume object, and an error if there is any.
+func (c *persistentVolumes) Get(name string) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentVolumes").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PersistentVolumes that match those selectors.
+func (c *persistentVolumes) List(opts unversioned.ListOptions) (result *api.PersistentVolumeList, err error) {
+	result = &api.PersistentVolumeList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentVolumes").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumes.
+func (c *persistentVolumes) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("persistentVolumes").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/persistentVolumeClaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentVolumeClaim.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// PersistentVolumeClaimNamespacer has methods to work with PersistentVolumeClaim resources in a namespace
+type PersistentVolumeClaimNamespacer interface {
+	PersistentVolumeClaims(namespace string) PersistentVolumeClaimInterface
+}
+
+// PersistentVolumeClaimInterface has methods to work with PersistentVolumeClaim resources.
+type PersistentVolumeClaimInterface interface {
+	Create(*api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
+	Update(*api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.PersistentVolumeClaim, error)
+	List(opts unversioned.ListOptions) (*api.PersistentVolumeClaimList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// persistentVolumeClaims implements PersistentVolumeClaimInterface
+type persistentVolumeClaims struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newPersistentVolumeClaims returns a PersistentVolumeClaims
+func newPersistentVolumeClaims(c *LegacyClient, namespace string) *persistentVolumeClaims {
+	return &persistentVolumeClaims{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
+func (c *persistentVolumeClaims) Create(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("persistentVolumeClaims").
+		Body(persistentVolumeClaim).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a persistentVolumeClaim and updates it. Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
+func (c *persistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("persistentVolumeClaims").
+		Name(persistentVolumeClaim.Name).
+		Body(persistentVolumeClaim).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the persistentVolumeClaim and deletes it. Returns an error if one occurs.
+func (c *persistentVolumeClaims) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("persistentVolumeClaims").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("persistentVolumeClaims").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the persistentVolumeClaim, and returns the corresponding persistentVolumeClaim object, and an error if there is any.
+func (c *persistentVolumeClaims) Get(name string) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentVolumeClaims").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
+func (c *persistentVolumeClaims) List(opts unversioned.ListOptions) (result *api.PersistentVolumeClaimList, err error) {
+	result = &api.PersistentVolumeClaimList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentVolumeClaims").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
+func (c *persistentVolumeClaims) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("persistentVolumeClaims").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/pod.go
+++ b/pkg/client/typed/generated/legacy/unversioned/pod.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// PodNamespacer has methods to work with Pod resources in a namespace
+type PodNamespacer interface {
+	Pods(namespace string) PodInterface
+}
+
+// PodInterface has methods to work with Pod resources.
+type PodInterface interface {
+	Create(*api.Pod) (*api.Pod, error)
+	Update(*api.Pod) (*api.Pod, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.Pod, error)
+	List(opts unversioned.ListOptions) (*api.PodList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// pods implements PodInterface
+type pods struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newPods returns a Pods
+func newPods(c *LegacyClient, namespace string) *pods {
+	return &pods{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
+func (c *pods) Create(pod *api.Pod) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("pods").
+		Body(pod).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
+func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("pods").
+		Name(pod.Name).
+		Body(pod).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the pod and deletes it. Returns an error if one occurs.
+func (c *pods) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("pods").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("pods").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the pod, and returns the corresponding pod object, and an error if there is any.
+func (c *pods) Get(name string) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("pods").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Pods that match those selectors.
+func (c *pods) List(opts unversioned.ListOptions) (result *api.PodList, err error) {
+	result = &api.PodList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("pods").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested pods.
+func (c *pods) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("pods").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/podTemplate.go
+++ b/pkg/client/typed/generated/legacy/unversioned/podTemplate.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// PodTemplateNamespacer has methods to work with PodTemplate resources in a namespace
+type PodTemplateNamespacer interface {
+	PodTemplates(namespace string) PodTemplateInterface
+}
+
+// PodTemplateInterface has methods to work with PodTemplate resources.
+type PodTemplateInterface interface {
+	Create(*api.PodTemplate) (*api.PodTemplate, error)
+	Update(*api.PodTemplate) (*api.PodTemplate, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.PodTemplate, error)
+	List(opts unversioned.ListOptions) (*api.PodTemplateList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// podTemplates implements PodTemplateInterface
+type podTemplates struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newPodTemplates returns a PodTemplates
+func newPodTemplates(c *LegacyClient, namespace string) *podTemplates {
+	return &podTemplates{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a podTemplate and creates it.  Returns the server's representation of the podTemplate, and an error, if there is any.
+func (c *podTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("podTemplates").
+		Body(podTemplate).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a podTemplate and updates it. Returns the server's representation of the podTemplate, and an error, if there is any.
+func (c *podTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("podTemplates").
+		Name(podTemplate.Name).
+		Body(podTemplate).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the podTemplate and deletes it. Returns an error if one occurs.
+func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("podTemplates").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the podTemplate, and returns the corresponding podTemplate object, and an error if there is any.
+func (c *podTemplates) Get(name string) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podTemplates").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PodTemplates that match those selectors.
+func (c *podTemplates) List(opts unversioned.ListOptions) (result *api.PodTemplateList, err error) {
+	result = &api.PodTemplateList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podTemplates").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podTemplates.
+func (c *podTemplates) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("podTemplates").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/replicationController.go
+++ b/pkg/client/typed/generated/legacy/unversioned/replicationController.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// ReplicationControllerNamespacer has methods to work with ReplicationController resources in a namespace
+type ReplicationControllerNamespacer interface {
+	ReplicationControllers(namespace string) ReplicationControllerInterface
+}
+
+// ReplicationControllerInterface has methods to work with ReplicationController resources.
+type ReplicationControllerInterface interface {
+	Create(*api.ReplicationController) (*api.ReplicationController, error)
+	Update(*api.ReplicationController) (*api.ReplicationController, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.ReplicationController, error)
+	List(opts unversioned.ListOptions) (*api.ReplicationControllerList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// replicationControllers implements ReplicationControllerInterface
+type replicationControllers struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newReplicationControllers returns a ReplicationControllers
+func newReplicationControllers(c *LegacyClient, namespace string) *replicationControllers {
+	return &replicationControllers{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a replicationController and creates it.  Returns the server's representation of the replicationController, and an error, if there is any.
+func (c *replicationControllers) Create(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("replicationControllers").
+		Body(replicationController).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a replicationController and updates it. Returns the server's representation of the replicationController, and an error, if there is any.
+func (c *replicationControllers) Update(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("replicationControllers").
+		Name(replicationController.Name).
+		Body(replicationController).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the replicationController and deletes it. Returns an error if one occurs.
+func (c *replicationControllers) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("replicationControllers").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("replicationControllers").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the replicationController, and returns the corresponding replicationController object, and an error if there is any.
+func (c *replicationControllers) Get(name string) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicationControllers").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ReplicationControllers that match those selectors.
+func (c *replicationControllers) List(opts unversioned.ListOptions) (result *api.ReplicationControllerList, err error) {
+	result = &api.ReplicationControllerList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicationControllers").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested replicationControllers.
+func (c *replicationControllers) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("replicationControllers").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/resourceQuota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/resourceQuota.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// ResourceQuotaNamespacer has methods to work with ResourceQuota resources in a namespace
+type ResourceQuotaNamespacer interface {
+	ResourceQuotas(namespace string) ResourceQuotaInterface
+}
+
+// ResourceQuotaInterface has methods to work with ResourceQuota resources.
+type ResourceQuotaInterface interface {
+	Create(*api.ResourceQuota) (*api.ResourceQuota, error)
+	Update(*api.ResourceQuota) (*api.ResourceQuota, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.ResourceQuota, error)
+	List(opts unversioned.ListOptions) (*api.ResourceQuotaList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// resourceQuotas implements ResourceQuotaInterface
+type resourceQuotas struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newResourceQuotas returns a ResourceQuotas
+func newResourceQuotas(c *LegacyClient, namespace string) *resourceQuotas {
+	return &resourceQuotas{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a resourceQuota and creates it.  Returns the server's representation of the resourceQuota, and an error, if there is any.
+func (c *resourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("resourceQuotas").
+		Body(resourceQuota).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a resourceQuota and updates it. Returns the server's representation of the resourceQuota, and an error, if there is any.
+func (c *resourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("resourceQuotas").
+		Name(resourceQuota.Name).
+		Body(resourceQuota).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the resourceQuota and deletes it. Returns an error if one occurs.
+func (c *resourceQuotas) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("resourceQuotas").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("resourceQuotas").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the resourceQuota, and returns the corresponding resourceQuota object, and an error if there is any.
+func (c *resourceQuotas) Get(name string) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("resourceQuotas").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ResourceQuotas that match those selectors.
+func (c *resourceQuotas) List(opts unversioned.ListOptions) (result *api.ResourceQuotaList, err error) {
+	result = &api.ResourceQuotaList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("resourceQuotas").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested resourceQuotas.
+func (c *resourceQuotas) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("resourceQuotas").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/secret.go
+++ b/pkg/client/typed/generated/legacy/unversioned/secret.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// SecretNamespacer has methods to work with Secret resources in a namespace
+type SecretNamespacer interface {
+	Secrets(namespace string) SecretInterface
+}
+
+// SecretInterface has methods to work with Secret resources.
+type SecretInterface interface {
+	Create(*api.Secret) (*api.Secret, error)
+	Update(*api.Secret) (*api.Secret, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.Secret, error)
+	List(opts unversioned.ListOptions) (*api.SecretList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// secrets implements SecretInterface
+type secrets struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newSecrets returns a Secrets
+func newSecrets(c *LegacyClient, namespace string) *secrets {
+	return &secrets{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
+func (c *secrets) Create(secret *api.Secret) (result *api.Secret, err error) {
+	result = &api.Secret{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("secrets").
+		Body(secret).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a secret and updates it. Returns the server's representation of the secret, and an error, if there is any.
+func (c *secrets) Update(secret *api.Secret) (result *api.Secret, err error) {
+	result = &api.Secret{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("secrets").
+		Name(secret.Name).
+		Body(secret).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the secret and deletes it. Returns an error if one occurs.
+func (c *secrets) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("secrets").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("secrets").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
+func (c *secrets) Get(name string) (result *api.Secret, err error) {
+	result = &api.Secret{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Secrets that match those selectors.
+func (c *secrets) List(opts unversioned.ListOptions) (result *api.SecretList, err error) {
+	result = &api.SecretList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested secrets.
+func (c *secrets) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/service.go
+++ b/pkg/client/typed/generated/legacy/unversioned/service.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// ServiceNamespacer has methods to work with Service resources in a namespace
+type ServiceNamespacer interface {
+	Services(namespace string) ServiceInterface
+}
+
+// ServiceInterface has methods to work with Service resources.
+type ServiceInterface interface {
+	Create(*api.Service) (*api.Service, error)
+	Update(*api.Service) (*api.Service, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.Service, error)
+	List(opts unversioned.ListOptions) (*api.ServiceList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// services implements ServiceInterface
+type services struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newServices returns a Services
+func newServices(c *LegacyClient, namespace string) *services {
+	return &services{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
+func (c *services) Create(service *api.Service) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("services").
+		Body(service).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a service and updates it. Returns the server's representation of the service, and an error, if there is any.
+func (c *services) Update(service *api.Service) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("services").
+		Name(service.Name).
+		Body(service).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the service and deletes it. Returns an error if one occurs.
+func (c *services) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("services").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
+func (c *services) Get(name string) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Services that match those selectors.
+func (c *services) List(opts unversioned.ListOptions) (result *api.ServiceList, err error) {
+	result = &api.ServiceList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested services.
+func (c *services) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/serviceAccount.go
+++ b/pkg/client/typed/generated/legacy/unversioned/serviceAccount.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// ServiceAccountNamespacer has methods to work with ServiceAccount resources in a namespace
+type ServiceAccountNamespacer interface {
+	ServiceAccounts(namespace string) ServiceAccountInterface
+}
+
+// ServiceAccountInterface has methods to work with ServiceAccount resources.
+type ServiceAccountInterface interface {
+	Create(*api.ServiceAccount) (*api.ServiceAccount, error)
+	Update(*api.ServiceAccount) (*api.ServiceAccount, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Get(name string) (*api.ServiceAccount, error)
+	List(opts unversioned.ListOptions) (*api.ServiceAccountList, error)
+	Watch(opts unversioned.ListOptions) (watch.Interface, error)
+}
+
+// serviceAccounts implements ServiceAccountInterface
+type serviceAccounts struct {
+	client *LegacyClient
+	ns     string
+}
+
+// newServiceAccounts returns a ServiceAccounts
+func newServiceAccounts(c *LegacyClient, namespace string) *serviceAccounts {
+	return &serviceAccounts{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a serviceAccount and creates it.  Returns the server's representation of the serviceAccount, and an error, if there is any.
+func (c *serviceAccounts) Create(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
+	result = &api.ServiceAccount{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("serviceAccounts").
+		Body(serviceAccount).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a serviceAccount and updates it. Returns the server's representation of the serviceAccount, and an error, if there is any.
+func (c *serviceAccounts) Update(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
+	result = &api.ServiceAccount{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("serviceAccounts").
+		Name(serviceAccount.Name).
+		Body(serviceAccount).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the serviceAccount and deletes it. Returns an error if one occurs.
+func (c *serviceAccounts) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("serviceAccounts").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("serviceAccounts").
+		Name(name).
+		Body(body).
+		Do().
+		Error()
+}
+
+// Get takes name of the serviceAccount, and returns the corresponding serviceAccount object, and an error if there is any.
+func (c *serviceAccounts) Get(name string) (result *api.ServiceAccount, err error) {
+	result = &api.ServiceAccount{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("serviceAccounts").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ServiceAccounts that match those selectors.
+func (c *serviceAccounts) List(opts unversioned.ListOptions) (result *api.ServiceAccountList, err error) {
+	result = &api.ServiceAccountList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("serviceAccounts").
+		VersionedParams(&opts, api.Scheme).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested serviceAccounts.
+func (c *serviceAccounts) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("serviceAccounts").
+		VersionedParams(&opts, api.Scheme).
+		Watch()
+}


### PR DESCRIPTION
This PR 1. changes the output directory of the client-gen according to the client package [proposal](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/client-package-structure.md#package-structure); 2. generates the output.

I plan to make a follow-up PR that adds the uncommon methods of client (e.g. `func (c *pods) GetLogs(...)`, another PR to add the [clientset](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/client-package-structure.md#high-level-client-sets), and a final PR to replace `pkg/client/unversioned`.

First commit is #18231.
Commit "add OrderTypes() to Orderer" is #18687.
Commits "change output directory", "make the types ordered", and "output" are the important ones.

cc @krousey @wojtek-t 
