### PR TITLE
Backport smoke/conformance test harness changes to release-1.1 from master

### DIFF
--- a/cluster/test-conformance.sh
+++ b/cluster/test-conformance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 The Kubernetes Authors All rights reserved.
+# Copyright 2015 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Smoke Tests a running Kubernetes cluster.
+# Conformance Tests a running Kubernetes cluster.
 # Validates that the cluster was deployed, is accessible, and at least
-# satisfies minimal functional requirements.
-# Emphasis on speed and being non-destructive over thoroughness.
+# satisfies end-to-end tests marked as being a part of the conformance suite.
+# Emphasis on broad coverage and being non-destructive over thoroughness.
 
 set -o errexit
 set -o nounset
@@ -27,6 +27,4 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 TEST_ARGS="$@"
 
-SMOKE_TEST_FOCUS_REGEX="Guestbook.application"
-
-exec "${KUBE_ROOT}/cluster/test-e2e.sh" -ginkgo.focus="${SMOKE_TEST_FOCUS_REGEX}" ${TEST_ARGS}
+exec "${KUBE_ROOT}/hack/conformance-test.sh" ${TEST_ARGS}

--- a/contrib/mesos/ci/build-release.sh
+++ b/contrib/mesos/ci/build-release.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cleans output files/images and builds a full release from scratch
+#
+# Prerequisite:
+# ./cluster/mesos/docker/test/build.sh
+#
+# Example Usage:
+# ./contrib/mesos/ci/build-release.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+
+"${KUBE_ROOT}/contrib/mesos/ci/run.sh" make clean
+
+export KUBERNETES_CONTRIB=mesos
+export KUBE_RELEASE_RUN_TESTS="${KUBE_RELEASE_RUN_TESTS:-N}"
+export KUBE_SKIP_CONFIRMATIONS=Y
+
+"${KUBE_ROOT}/build/release.sh"

--- a/contrib/mesos/ci/build.sh
+++ b/contrib/mesos/ci/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cleans output files/images and builds linux binaries from scratch
+#
+# Prerequisite:
+# ./cluster/mesos/docker/test/build.sh
+#
+# Example Usage:
+# ./contrib/mesos/ci/build.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+TEST_ARGS="$@"
+
+KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+
+export KUBERNETES_CONTRIB=mesos
+
+"${KUBE_ROOT}/contrib/mesos/ci/run.sh" make clean all ${TEST_ARGS}

--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploys a test cluster, runs the specified command, and destroys the test cluster.
+# Runs all commands inside the mesosphere/kubernetes-mesos-test docker image (built on demand).
+# Uses the mesos/docker cluster provider.
+#
+# Prerequisite:
+# ./cluster/mesos/docker/test/build.sh
+#
+# Example Usage:
+# ./contrib/mesos/ci/run-with-cluster.sh ./cluster/test-smoke.sh -v=2
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+RUN_CMD="$@"
+[ -z "${RUN_CMD:-}" ] && echo "No command supplied" && exit 1
+
+KUBERNETES_PROVIDER="mesos/docker"
+
+MESOS_DOCKER_WORK_DIR="${MESOS_DOCKER_WORK_DIR:-${HOME}/tmp/kubernetes}"
+
+KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+
+# Clean (test artifacts)
+echo "Cleaning work dir"
+echo "${MESOS_DOCKER_WORK_DIR}"
+rm -rf "${MESOS_DOCKER_WORK_DIR}"
+mkdir -p "${MESOS_DOCKER_WORK_DIR}"
+
+echo "Detecting docker client"
+# Mount docker client binary to avoid client/compose/daemon version conflicts
+if [ -n "${DOCKER_MACHINE_NAME:-}" ] && which docker-machine; then
+  # On a Mac with docker-machine, use the binary in the VM, not the host binary
+  DOCKER_BIN_PATH="$(docker-machine ssh "${DOCKER_MACHINE_NAME}" which docker)"
+else
+  DOCKER_BIN_PATH="$(which docker)"
+fi
+echo "${DOCKER_BIN_PATH}"
+
+# Clean (k8s output & images), Build, Kube-Up, Test, Kube-Down
+cd "${KUBE_ROOT}"
+exec docker run \
+  --rm \
+  -v "${KUBE_ROOT}:/go/src/github.com/GoogleCloudPlatform/kubernetes" \
+  -v "/var/run/docker.sock:/var/run/docker.sock" \
+  -v "${DOCKER_BIN_PATH}:/usr/bin/docker" \
+  -v "${MESOS_DOCKER_WORK_DIR}/auth:${MESOS_DOCKER_WORK_DIR}/auth" \
+  -v "${MESOS_DOCKER_WORK_DIR}/log:${MESOS_DOCKER_WORK_DIR}/log" \
+  -v "${MESOS_DOCKER_WORK_DIR}/mesosslave1/mesos:${MESOS_DOCKER_WORK_DIR}/mesosslave1/mesos" \
+  -v "${MESOS_DOCKER_WORK_DIR}/mesosslave2/mesos:${MESOS_DOCKER_WORK_DIR}/mesosslave2/mesos" \
+  -v "${MESOS_DOCKER_WORK_DIR}/overlay:${MESOS_DOCKER_WORK_DIR}/overlay" \
+  -v "${MESOS_DOCKER_WORK_DIR}/reports:${MESOS_DOCKER_WORK_DIR}/reports" \
+  -e "MESOS_DOCKER_WORK_DIR=${MESOS_DOCKER_WORK_DIR}" \
+  -e "MESOS_DOCKER_IMAGE_DIR=/var/tmp/kubernetes" \
+  -e "MESOS_DOCKER_OVERLAY_DIR=${MESOS_DOCKER_WORK_DIR}/overlay" \
+  -e "KUBERNETES_CONTRIB=mesos" \
+  -e "KUBERNETES_PROVIDER=mesos/docker" \
+  -e "USER=root" \
+  -e "E2E_REPORT_DIR=${MESOS_DOCKER_WORK_DIR}/reports" \
+  -t $(tty &>/dev/null && echo "-i") \
+  mesosphere/kubernetes-mesos-test \
+  -ceux "\
+    make clean all && \
+    trap 'timeout 5m ./cluster/kube-down.sh' EXIT && \
+    ./cluster/kube-down.sh && \
+    ./cluster/kube-up.sh && \
+    trap \"test \\\$? != 0 && export MESOS_DOCKER_DUMP_LOGS=true; cd \${PWD} && timeout 5m ./cluster/kube-down.sh\" EXIT && \
+    ${RUN_CMD}
+  "

--- a/contrib/mesos/ci/run.sh
+++ b/contrib/mesos/ci/run.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the specified command in the test container (mesosphere/kubernetes-mesos-test).
+#
+# Prerequisite:
+# ./cluster/mesos/docker/test/build.sh
+#
+# Example Usage:
+# ./contrib/mesos/ci/run.sh make test
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+RUN_CMD="$@"
+[ -z "${RUN_CMD:-}" ] && echo "No command supplied" && exit 1
+
+KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+
+echo "Detecting docker client"
+# Mount docker client binary to avoid client/compose/daemon version conflicts
+if [ -n "${DOCKER_MACHINE_NAME:-}" ] && which docker-machine; then
+  # On a Mac with docker-machine, use the binary in the VM, not the host binary
+  DOCKER_BIN_PATH="$(docker-machine ssh "${DOCKER_MACHINE_NAME}" which docker)"
+else
+  DOCKER_BIN_PATH="$(which docker)"
+fi
+echo "${DOCKER_BIN_PATH}"
+
+# Clean (k8s output & images) & Build
+cd "${KUBE_ROOT}"
+exec docker run \
+  --rm \
+  -v "${KUBE_ROOT}:/go/src/github.com/GoogleCloudPlatform/kubernetes" \
+  -v "/var/run/docker.sock:/var/run/docker.sock" \
+  -v "${DOCKER_BIN_PATH}:/usr/bin/docker" \
+  -e "KUBERNETES_CONTRIB=mesos" \
+  -e "USER=root" \
+  -t $(tty &>/dev/null && echo "-i") \
+  mesosphere/kubernetes-mesos-test \
+  -ceux "${RUN_CMD}"

--- a/contrib/mesos/ci/test-conformance.sh
+++ b/contrib/mesos/ci/test-conformance.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploys a test cluster, runs the conformance tests, and destroys the test cluster.
+#
+# Prerequisite:
+# ./cluster/mesos/docker/test/build.sh
+#
+# Example Usage:
+# ./contrib/mesos/ci/test-conformance.sh -v=2
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+TEST_ARGS="$@"
+
+KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+
+TEST_CMD="KUBECONFIG=~/.kube/config hack/conformance-test.sh"
+if [ -n "${CONFORMANCE_BRANCH}" ]; then
+	# create a CONFORMANCE_BRANCH clone in a subdirectory
+	TEST_CMD="
+git fetch https://github.com/kubernetes/kubernetes --tags -q ${CONFORMANCE_BRANCH} &&
+git branch -f ${CONFORMANCE_BRANCH} FETCH_HEAD &&
+git clone -s -b ${CONFORMANCE_BRANCH} . conformance &&
+cd conformance && make all && ${TEST_CMD}"
+fi
+
+"${KUBE_ROOT}/contrib/mesos/ci/run-with-cluster.sh" ${TEST_CMD} ${TEST_ARGS}

--- a/contrib/mesos/ci/test-e2e.sh
+++ b/contrib/mesos/ci/test-e2e.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploys a test cluster, runs the e2e tests, and destroys the test cluster.
+#
+# Prerequisite:
+# ./cluster/mesos/docker/test/build.sh
+#
+# Example Usage:
+# ./contrib/mesos/ci/test-e2e.sh -v=2
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+TEST_ARGS="$@"
+
+KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+
+"${KUBE_ROOT}/contrib/mesos/ci/run-with-cluster.sh" ./cluster/test-e2e.sh ${TEST_ARGS}

--- a/contrib/mesos/ci/test-integration.sh
+++ b/contrib/mesos/ci/test-integration.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cleans & runs the integration tests in the test container (mesosphere/kubernetes-mesos-test).
+#
+# Prerequisite:
+# ./cluster/mesos/docker/test/build.sh
+#
+# Example Usage:
+# ./contrib/mesos/ci/test-integration.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+TEST_ARGS="$@"
+
+KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+
+"${KUBE_ROOT}/contrib/mesos/ci/run.sh" make clean test_integration ${TEST_ARGS}

--- a/contrib/mesos/ci/test-smoke.sh
+++ b/contrib/mesos/ci/test-smoke.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploys a test cluster, runs the smoke tests, and destroys the test cluster.
+#
+# Prerequisite:
+# ./cluster/mesos/docker/test/build.sh
+#
+# Example Usage:
+# ./contrib/mesos/ci/test-smoke.sh -v=2
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+TEST_ARGS="$@"
+
+KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+
+"${KUBE_ROOT}/contrib/mesos/ci/run-with-cluster.sh" ./cluster/test-smoke.sh ${TEST_ARGS}

--- a/contrib/mesos/ci/test-unit.sh
+++ b/contrib/mesos/ci/test-unit.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cleans & runs the unit tests in the test container (mesosphere/kubernetes-mesos-test).
+#
+# Prerequisite:
+# ./cluster/mesos/docker/test/build.sh
+#
+# Example Usage:
+# ./contrib/mesos/ci/test-unit.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+TEST_ARGS="$@"
+
+KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+
+"${KUBE_ROOT}/contrib/mesos/ci/run.sh" make clean test ${TEST_ARGS}

--- a/hack/conformance-test.sh
+++ b/hack/conformance-test.sh
@@ -61,6 +61,7 @@
 # a new column for conformance at that new version, and notify
 # community.
 
+TEST_ARGS="$@"
 
 : ${KUBECONFIG:?"Must set KUBECONFIG before running conformance test."}
 echo "Conformance test using current-context of ${KUBECONFIG}"
@@ -70,7 +71,7 @@ echo -n "Conformance test SHA:"
 HEAD_SHA=$(git rev-parse HEAD)
 echo $HEAD_SHA
 echo "Conformance test version tag(s):"
-git show-ref | grep $HEAD_SHA | grep refs/tags
+git tag --points-at $HEAD_SHA
 echo
 echo "Conformance test checking conformance with Kubernetes version 1.0"
 
@@ -83,5 +84,4 @@ echo "Conformance test checking conformance with Kubernetes version 1.0"
 
 declare -x KUBERNETES_CONFORMANCE_TEST="y"
 declare -x NUM_MINIONS=4
-hack/ginkgo-e2e.sh -ginkgo.focus='\[Conformance\]'
-exit $?
+exec hack/ginkgo-e2e.sh -ginkgo.focus='\[Conformance\]' -ginkgo.skip='\[Skipped\]' ${TEST_ARGS}


### PR DESCRIPTION
The following changes (hopefully) make it feasible to run release-1.1 branch conformance tests on master code in mesos environments. This should also fix mesos smoke tests on cherry-pick PRs to release-1.1.
- Backport contrib/mesos/ci to release-1.1 #17511 #17842 #17835
- Skip [Skipped] tests when testing for conformance #17180
- Add cluster/test-conformance.sh script #17997
- Support passing args to cluster/test-smoke.sh #15404
- Support annotated tags in conformance test version detection #17839

(This only affects smoke/conformance tests. So e2e tests are not required.)
