### PR TITLE
Add OrderTypes() to go2idl Orderer

### DIFF
--- a/cmd/libs/go2idl/generator/generator.go
+++ b/cmd/libs/go2idl/generator/generator.go
@@ -185,7 +185,7 @@ func NewContext(b *parser.Builder, nameSystems namer.NameSystems, canonicalOrder
 		c.Namers[name] = systemNamer
 		if name == canonicalOrderName {
 			orderer := namer.Orderer{systemNamer}
-			c.Order = orderer.Order(u)
+			c.Order = orderer.OrderUniverse(u)
 		}
 	}
 	return c, nil

--- a/cmd/libs/go2idl/namer/namer_test.go
+++ b/cmd/libs/go2idl/namer/namer_test.go
@@ -49,7 +49,7 @@ func TestNameStrategy(t *testing.T) {
 	u.Type(types.Name{Package: "", Name: "string"})
 
 	o := Orderer{NewPublicNamer(0)}
-	order := o.Order(u)
+	order := o.OrderUniverse(u)
 	orderedNames := make([]string, len(order))
 	for i, t := range order {
 		orderedNames[i] = o.Name(t)
@@ -60,7 +60,7 @@ func TestNameStrategy(t *testing.T) {
 	}
 
 	o = Orderer{NewRawNamer("my/package", nil)}
-	order = o.Order(u)
+	order = o.OrderUniverse(u)
 	orderedNames = make([]string, len(order))
 	for i, t := range order {
 		orderedNames[i] = o.Name(t)
@@ -72,7 +72,7 @@ func TestNameStrategy(t *testing.T) {
 	}
 
 	o = Orderer{NewRawNamer("foo/bar", nil)}
-	order = o.Order(u)
+	order = o.OrderUniverse(u)
 	orderedNames = make([]string, len(order))
 	for i, t := range order {
 		orderedNames[i] = o.Name(t)
@@ -84,7 +84,7 @@ func TestNameStrategy(t *testing.T) {
 	}
 
 	o = Orderer{NewPublicNamer(1)}
-	order = o.Order(u)
+	order = o.OrderUniverse(u)
 	orderedNames = make([]string, len(order))
 	for i, t := range order {
 		orderedNames[i] = o.Name(t)

--- a/cmd/libs/go2idl/namer/order.go
+++ b/cmd/libs/go2idl/namer/order.go
@@ -27,9 +27,9 @@ type Orderer struct {
 	Namer
 }
 
-// Order assigns a name to every type, and returns a list sorted by those
-// names.
-func (o *Orderer) Order(u types.Universe) []*types.Type {
+// OrderUniverse assigns a name to every type in the Universe, including Types,
+// Functions and Variables, and returns a list sorted by those names.
+func (o *Orderer) OrderUniverse(u types.Universe) []*types.Type {
 	list := tList{
 		namer: o.Namer,
 	}
@@ -43,6 +43,17 @@ func (o *Orderer) Order(u types.Universe) []*types.Type {
 		for _, v := range p.Variables {
 			list.types = append(list.types, v)
 		}
+	}
+	sort.Sort(list)
+	return list.types
+}
+
+// OrderTypes assigns a name to every type, and returns a list sorted by those
+// names.
+func (o *Orderer) OrderTypes(typeList []*types.Type) []*types.Type {
+	list := tList{
+		namer: o.Namer,
+		types: typeList,
 	}
 	sort.Sort(list)
 	return list.types

--- a/cmd/libs/go2idl/parser/parse_test.go
+++ b/cmd/libs/go2idl/parser/parse_test.go
@@ -39,7 +39,7 @@ func construct(t *testing.T, files map[string]string, testNamer namer.Namer) (*p
 		t.Fatal(err)
 	}
 	orderer := namer.Orderer{testNamer}
-	o := orderer.Order(u)
+	o := orderer.OrderUniverse(u)
 	return b, u, o
 }
 


### PR DESCRIPTION
Adding a useful helper function to the go2idl Orderer. It's used by the client-gen: https://github.com/kubernetes/kubernetes/pull/18685/files#diff-0d4c98e7fc9371538ef792fdef94f798R133

cc @krousey @wojtek-t 
