### PR TITLE
Teach kubelet about CNI bridge plugins

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -112,8 +112,8 @@ ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota
 # Optional: if set to true kube-up will automatically check for existing resources and clean them up.
 KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}
 
-# OpenContrail networking plugin specific settings
-NETWORK_PROVIDER="${NETWORK_PROVIDER:-none}" # opencontrail, flannel
+# Networking plugin specific settings.
+NETWORK_PROVIDER="${NETWORK_PROVIDER:-none}" # opencontrail, flannel, kubernetes
 OPENCONTRAIL_TAG="${OPENCONTRAIL_TAG:-R2.20}"
 OPENCONTRAIL_KUBERNETES_TAG="${OPENCONTRAIL_KUBERNETES_TAG:-master}"
 OPENCONTRAIL_PUBLIC_SUBNET="${OPENCONTRAIL_PUBLIC_SUBNET:-10.1.0.0/16}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -124,8 +124,8 @@ KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}
 # is only supported in trusty nodes.
 TEST_CLUSTER="${TEST_CLUSTER:-true}"
 
-# Networking plugin specific settings
-NETWORK_PROVIDER="${NETWORK_PROVIDER:-none}" # opencontrail,flannel, kubernetes
+# OpenContrail networking plugin specific settings
+NETWORK_PROVIDER="${NETWORK_PROVIDER:-none}" # opencontrail,flannel
 OPENCONTRAIL_TAG="${OPENCONTRAIL_TAG:-R2.20}"
 OPENCONTRAIL_KUBERNETES_TAG="${OPENCONTRAIL_KUBERNETES_TAG:-master}"
 OPENCONTRAIL_PUBLIC_SUBNET="${OPENCONTRAIL_PUBLIC_SUBNET:-10.1.0.0/16}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -124,8 +124,8 @@ KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}
 # is only supported in trusty nodes.
 TEST_CLUSTER="${TEST_CLUSTER:-true}"
 
-# OpenContrail networking plugin specific settings
-NETWORK_PROVIDER="${NETWORK_PROVIDER:-none}" # opencontrail,flannel
+# Networking plugin specific settings
+NETWORK_PROVIDER="${NETWORK_PROVIDER:-none}" # opencontrail,flannel, kubernetes
 OPENCONTRAIL_TAG="${OPENCONTRAIL_TAG:-R2.20}"
 OPENCONTRAIL_KUBERNETES_TAG="${OPENCONTRAIL_KUBERNETES_TAG:-master}"
 OPENCONTRAIL_PUBLIC_SUBNET="${OPENCONTRAIL_PUBLIC_SUBNET:-10.1.0.0/16}"

--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -3,5 +3,12 @@
 {% if pillar.get('e2e_storage_test_environment', '').lower() == 'true' -%}
 {% set e2e_opts = '-s devicemapper' -%}
 {% endif -%}
-DOCKER_OPTS="{{grains_opts}} {{e2e_opts}} --bridge=cbr0 --iptables=false --ip-masq=false --log-level=warn"
+{% set bridge_opts = "--bridge=cbr0" %}
+# If Kubernetes is responsible for networking a network plugin will get invoked
+# that sets up the container bridge (and manages restarting) docker, if at all
+# necessary.
+{% if pillar.get('network_provider', '').lower() == 'kubernetes' %}
+  {% set bridge_opts = "" %}
+{% endif -%}
+DOCKER_OPTS="{{grains_opts}} {{e2e_opts}} {{bridge_opts}} --iptables=false --ip-masq=false --log-level=warn"
 DOCKER_NOFILE=1000000

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -116,9 +116,13 @@
   {% set test_args=pillar['kubelet_test_args'] %}
 {% endif -%}
 
+{% set network_plugin_dir = "" -%}
 {% set network_plugin = "" -%}
 {% if pillar.get('network_provider', '').lower() == 'opencontrail' %}
   {% set network_plugin = "--network-plugin=opencontrail" %}
+{% elif pillar.get('network_provider', '').lower() == 'kubernetes' %}
+  {% set network_plugin_dir = "--network-plugin-dir=/etc/cni/net.d" -%}
+  {% set network_plugin = "--network-plugin=net.alpha.kubernetes.io/default" -%}
 {% endif -%}
 
 {% set kubelet_port = "" -%}
@@ -127,4 +131,4 @@
 {% endif -%}
 
 # test_args has to be kept at the end, so they'll overwrite any prior configuration
-DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} {{manifest_url}} --allow-privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}} {{ master_kubelet_args }} {{cpu_cfs_quota}} {{network_plugin}} {{kubelet_port}} {{experimental_flannel_overlay}} {{test_args}}"
+DAEMON_ARGS="{{daemon_args}} {{api_servers_with_port}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{config}} {{manifest_url}} --allow-privileged={{pillar['allow_privileged']}} {{pillar['log_level']}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}} {{configure_cbr0}} {{cgroup_root}} {{system_container}} {{pod_cidr}} {{ master_kubelet_args }} {{cpu_cfs_quota}} {{network_plugin}} {{network_plugin_dir}} {{kubelet_port}} {{experimental_flannel_overlay}} {{test_args}}"

--- a/cluster/saltbase/salt/network-plugins/init.sls
+++ b/cluster/saltbase/salt/network-plugins/init.sls
@@ -1,0 +1,31 @@
+# Install all network plugins under /opt/cni, note this must match one of the directories
+# the CNI plugin under kubelet/network/cni/ searches for.
+/opt/cni:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+
+# Network config for the one Kubernetes default network. Must match the
+# --network-plugin-dir flag given to the Kubelet.
+/etc/cni/net.d:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+
+# These are all available CNI network plugins.
+network-plugins-tar:
+  archive:
+    - extracted
+    - user: root
+    - name: /opt/cni
+    - makedirs: True
+    - source: https://storage.googleapis.com/kubernetes-release/network-plugins/cni-v0.1.0.tar.gz
+    - tar_options: v
+    - source_hash: md5=a21f366b13cd20da0809d9397f7890b5
+    - archive_format: tar
+    - if_missing: /opt/cni/bin
+

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -20,6 +20,7 @@ base:
     - cadvisor
     - kube-client-tools
     - kube-node-unpacker
+    - network-plugins
     - kubelet
 {% if pillar.get('network_provider', '').lower() == 'opencontrail' %}
     - opencontrail-networking-minion

--- a/docs/admin/network-plugins.md
+++ b/docs/admin/network-plugins.md
@@ -1,0 +1,121 @@
+<!-- BEGIN MUNGE: UNVERSIONED_WARNING -->
+
+<!-- BEGIN STRIP_FOR_RELEASE -->
+
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+
+<h2>PLEASE NOTE: This document applies to the HEAD of the source tree</h2>
+
+If you are using a released version of Kubernetes, you should
+refer to the docs that go with that version.
+
+<strong>
+The latest release of this document can be found
+[here](http://releases.k8s.io/release-1.1/docs/admin/network-plugins.md).
+
+Documentation for other releases can be found at
+[releases.k8s.io](http://releases.k8s.io).
+</strong>
+--
+
+<!-- END STRIP_FOR_RELEASE -->
+
+<!-- END MUNGE: UNVERSIONED_WARNING -->
+
+# Network Plugins
+
+__Disclaimer__: Network plugins are in alpha. Its contents will change rapidly.
+
+Network plugins in Kubernets come in 2 flavors:
+* Plain vanilla exec plugins - deprecated in favor of CNI plugins.
+* CNI plugins - adhere to the appc/CNI specification, designed for interoperability.
+
+## Installation
+
+The kubelet has a single default network plugin, and a default network common to the entire cluster. It probes for plugins when it starts up, remembers what it found, and executes the plugin at appropriate times in the pod lifecycle (this is true for docker, rkt manages its own CNI plugins). There are 2 Kubelet command line parameters to keep in mind when installing plugins:
+* network-plugin-dir: The directory the Kubelet probes for plugins. For exec plugins this directory must contain the plugin binaries as described below. For CNI plugins this directory can contain a networking .conf file.
+* network-plugin-name: Must match the name reported by the plugin object created by the Kubelet when it probes for plugins. For CNI plugins, this is simply "cni".
+
+### Exec
+
+Place plugins in network-plugin-dir/plugin-name/plugin-name, i.e if you have a bridge plugin and network-plugin-dir is /usr/lib/kubernetes, you'd place the bridge plugin in /usr/lib/kubernetes/bridge/bridge. See [this comment](../../pkg/kubelet/network/exec/exec.go) for more details.
+
+### CNI
+
+CNI plugins require 1 or more netwwork configuration files, and some executables that can fulfill the network configuration. The network configuration must match the CNI specification. To install a CNI plugin place the .conf file in network-plugin-dir and the binaries that fulfill the plugin in `/opt/cni/bin`.
+
+## Using the default Kubernetes network plugin
+
+To use the default Kubernetes network plugin:
+1. Specify a `--network-plugin-dir`: You *do not* need to place anything in this directory. It's the directory the Kubelet will write out any network.conf files it needs to, to fulfill the plugin it chooses.
+2. Specify `--network-plugin-name=net.alpha.kubernetes.io/default`, where kubernetes.io/default matches the [DefaultPluginName](). This instructs the Kubelet to write a net.conf, and execute a (CNI) plugin in `/opt/cni/bin` (configurable with a vendor directory).
+3. Set `--configure-cbr0`: This gives the Kubelet control of the container bridge. Depending on the network plugin that satisfies the default, it may or may not need this.
+
+To clarify, the difference between this mode and the "normal" CNI mode, is that the latter has the same specifications but --network-plugin-dir actually contains a net.conf, and --network-plugin-name cannot be `net.alpha.kubernetes.io/default`. If you specify `net.alpha.kubernets.io/default` AND put your own net.conf in `--network-plugin-dir`, you will end up with some undefined behaviour (currently, the kubelet will ignore your conf and write out its own).
+
+## Writing a network plugin
+
+This section is very much a work in progress.
+
+Each of the above plugin specifications has a Kubelet-shim, a small interface that sits between the Kubelet and the actual plugin. This shim must implment the methods of a [NetworkPlugin](../../pkg/kubelet/network/plugins.go).
+
+### How is the default Kubelet network plugin chosen?
+
+The Kubelet currently does the following dance:
+
+```
+if --network-name starts with net.alpha.kubernetes.io
+  kubelet.networkname = --network-name
+  --network-name=cni
+probe plugins using --network-name=cni
+  no net conf found, but that's ok
+  load shell CNI network plugin
+if node.podCIDR
+  write bridge netconf to --network-plugin-dir
+start creating pods
+```
+
+### At what points in the pod lifecycle are the plugins invoked?
+
+For each non-host networking pod the Kubelet does the following:
+
+```
+Create pause container
+   Invoke bridge plugin from /opt/cni/bin with netconf written by kubelet
+     Bridge plugin invokes host-local IPAM to allocate podCIDR
+Create other containers
+...
+
+Periodically
+  nsenter pause container and return ip
+  sync with apiserver podip on change
+...
+Delete pause container
+   Invoke bridge plugin from /opt/cni/bin with netconf written by kubelet
+     Bridge plugin invokes host-local IPAM to de-allocate podCIDR
+Delete other containers
+```
+
+### How to get more inforamtion from the runtime?
+
+After choosing a default plugin, the Kubelet invokes the network interface's `Init` method with a Kubernetes host interface capable of retrieving more information from both the container runtime and/or apiserver.
+
+## Limitations
+
+* Docker's and your network plugin's bridge name must be different. Docker will startup by default on docker0, the plugin's bridge name is in the netconf written by kubelet (hardcoded to "cbr0" for now).
+* Only the bridge plugin is currently supported, both `net.alpha.kubernetes.io/default` and `net.alpha.kubernetes.io/bridge` will end up using bridge.
+
+
+
+<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/admin/network-plugins.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/pkg/kubelet/container_bridge.go
+++ b/pkg/kubelet/container_bridge.go
@@ -18,28 +18,79 @@ package kubelet
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"regexp"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/util"
 )
 
-var cidrRegexp = regexp.MustCompile(`inet ([0-9a-fA-F.:]*/[0-9]*)`)
+var (
+	iptablesMasqCheck = []string{
+		"-t", "nat",
+		"-C", "POSTROUTING",
+		"!", "-d", "10.0.0.0/8",
+		"-m", "addrtype", "!", "--dst-type", "LOCAL",
+		"-j", "MASQUERADE",
+	}
+	iptablesMasqAppend = []string{
+		"-t", "nat",
+		"-A", "POSTROUTING",
+		"!", "-d", "10.0.0.0/8",
+		"-m", "addrtype", "!", "--dst-type", "LOCAL",
+		"-j", "MASQUERADE",
+	}
 
-func createCBR0(wantCIDR *net.IPNet) error {
-	// recreate cbr0 with wantCIDR
-	if err := exec.Command("brctl", "addbr", "cbr0").Run(); err != nil {
+	cidrRegexp = regexp.MustCompile(`inet ([0-9a-fA-F.:]*/[0-9]*)`)
+)
+
+// containerBridgeReconciler is used to setup basic node networking.
+type containerBridgeReconciler struct {
+	// execer will be used to exec commands.
+	execer
+	// name is the name of the container bridge, eg: cbr0
+	name string
+	// bridgeExistsFunc will be called to determine if bridge exists.
+	bridgeExistsFunc func(string) (bool, error)
+}
+
+// netContainerBridgeReconciler creates a containerBridgeReconciler.
+func newContainerBridgeReconciler(bridgeName string) *containerBridgeReconciler {
+	return &containerBridgeReconciler{
+		execer:           execerImpl{},
+		name:             bridgeName,
+		bridgeExistsFunc: brExists,
+	}
+}
+
+func (c *containerBridgeReconciler) reconcile(podCIDR string) error {
+	if podCIDR == "" {
+		glog.V(5).Infof("PodCIDR not set. Will not configure bridge %v.", c.name)
+		return nil
+	}
+	glog.V(5).Infof("PodCIDR is set to %q", podCIDR)
+	_, cidr, err := net.ParseCIDR(podCIDR)
+	if err != nil {
+		return err
+	}
+	// Set bridge interface address to first address in IPNet
+	cidr.IP.To4()[3] += 1
+	return c.ensure(cidr)
+}
+
+func (c *containerBridgeReconciler) create(wantCIDR *net.IPNet) error {
+	// recreate bridge with wantCIDR
+	if _, err := c.execCmd("brctl", "addbr", c.name); err != nil {
 		glog.Error(err)
 		return err
 	}
-	if err := exec.Command("ip", "addr", "add", wantCIDR.String(), "dev", "cbr0").Run(); err != nil {
+	if _, err := c.execCmd("ip", "addr", "add", wantCIDR.String(), "dev", c.name); err != nil {
 		glog.Error(err)
 		return err
 	}
-	if err := exec.Command("ip", "link", "set", "dev", "cbr0", "mtu", "1460", "up").Run(); err != nil {
+	if _, err := c.execCmd("ip", "link", "set", "dev", c.name, "mtu", "1460", "up"); err != nil {
 		glog.Error(err)
 		return err
 	}
@@ -47,98 +98,87 @@ func createCBR0(wantCIDR *net.IPNet) error {
 	// For now just log the error. The containerRuntime check will catch docker failures.
 	// TODO (dawnchen) figure out what we should do for rkt here.
 	if util.UsingSystemdInitSystem() {
-		if err := exec.Command("systemctl", "restart", "docker").Run(); err != nil {
+		if _, err := c.execCmd("systemctl", "restart", "docker"); err != nil {
 			glog.Error(err)
 		}
 	} else {
-		if err := exec.Command("service", "docker", "restart").Run(); err != nil {
+		if _, err := c.execCmd("service", "docker", "restart"); err != nil {
 			glog.Error(err)
 		}
 	}
-	glog.V(2).Info("Recreated cbr0 and restarted docker")
+	glog.V(2).Infof("Recreated bridge %v and restarted docker", c.name)
 	return nil
 }
 
-func ensureCbr0(wantCIDR *net.IPNet) error {
-	exists, err := cbr0Exists()
+func (c *containerBridgeReconciler) ensure(wantCIDR *net.IPNet) error {
+	exists, err := c.bridgeExistsFunc(c.name)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		glog.V(2).Infof("CBR0 doesn't exist, attempting to create it with range: %s", wantCIDR)
-		return createCBR0(wantCIDR)
+		glog.V(2).Infof("bridge %v doesn't exist, attempting to create it with range: %s", c.name, wantCIDR)
+		return c.create(wantCIDR)
 	}
-	if !cbr0CidrCorrect(wantCIDR) {
-		glog.V(2).Infof("Attempting to recreate cbr0 with address range: %s", wantCIDR)
+	if !c.checkCIDR(wantCIDR) {
+		glog.V(2).Infof("Attempting to recreate %v with address range: %s", c.name, wantCIDR)
 
-		// delete cbr0
-		if err := exec.Command("ip", "link", "set", "dev", "cbr0", "down").Run(); err != nil {
+		// delete bridge
+		if _, err := c.execCmd("ip", "link", "set", "dev", c.name, "down"); err != nil {
 			glog.Error(err)
 			return err
 		}
-		if err := exec.Command("brctl", "delbr", "cbr0").Run(); err != nil {
+		if _, err := c.execCmd("brctl", "delbr", c.name); err != nil {
 			glog.Error(err)
 			return err
 		}
-		return createCBR0(wantCIDR)
+		return c.create(wantCIDR)
 	}
 	return nil
 }
 
-// Check if cbr0 network interface is configured or not, and take action
+func (c *containerBridgeReconciler) checkCIDR(wantCIDR *net.IPNet) bool {
+	output, err := c.execCmd("ip", "addr", "show", c.name)
+	if err != nil {
+		return false
+	}
+	match := cidrRegexp.FindSubmatch([]byte(output))
+	if len(match) < 2 {
+		return false
+	}
+	bridgeIP, bridgeCIDR, err := net.ParseCIDR(string(match[1]))
+	if err != nil {
+		glog.Errorf("Couldn't parse CIDR: %q", match[1])
+		return false
+	}
+	bridgeCIDR.IP = bridgeIP
+
+	glog.V(5).Infof("Want bridge CIDR: %s, have bridge CIDR: %s", wantCIDR, bridgeCIDR)
+	return wantCIDR.IP.Equal(bridgeIP) && bytes.Equal(wantCIDR.Mask, bridgeCIDR.Mask)
+}
+
+// TODO(dawnchen): Using pkg/util/iptables
+func ensureIPTablesMasqRule(e execer) error {
+	// Check if the MASQUERADE rule exist or not
+	if _, err := e.execCmd("iptables", iptablesMasqCheck...); err == nil {
+		// The MASQUERADE rule exists
+		return nil
+	}
+	glog.Infof("MASQUERADE rule doesn't exist, recreate it")
+	if _, err := e.execCmd("iptables", iptablesMasqAppend...); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Check if bridge network interface is configured or not, and take action
 // when the configuration is missing on the node, and propagate the rest
 // error to kubelet to handle.
-func cbr0Exists() (bool, error) {
-	if _, err := os.Stat("/sys/class/net/cbr0"); err != nil {
+func brExists(bridgeName string) (bool, error) {
+	if _, err := os.Stat(fmt.Sprintf("/sys/class/net/%v", bridgeName)); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return false, err
 	}
 	return true, nil
-}
-
-func cbr0CidrCorrect(wantCIDR *net.IPNet) bool {
-	output, err := exec.Command("ip", "addr", "show", "cbr0").Output()
-	if err != nil {
-		return false
-	}
-	match := cidrRegexp.FindSubmatch(output)
-	if len(match) < 2 {
-		return false
-	}
-	cbr0IP, cbr0CIDR, err := net.ParseCIDR(string(match[1]))
-	if err != nil {
-		glog.Errorf("Couldn't parse CIDR: %q", match[1])
-		return false
-	}
-	cbr0CIDR.IP = cbr0IP
-
-	glog.V(5).Infof("Want cbr0 CIDR: %s, have cbr0 CIDR: %s", wantCIDR, cbr0CIDR)
-	return wantCIDR.IP.Equal(cbr0IP) && bytes.Equal(wantCIDR.Mask, cbr0CIDR.Mask)
-}
-
-// TODO(dawnchen): Using pkg/util/iptables
-func ensureIPTablesMasqRule() error {
-	// Check if the MASQUERADE rule exist or not
-	if err := exec.Command("iptables",
-		"-t", "nat",
-		"-C", "POSTROUTING",
-		"!", "-d", "10.0.0.0/8",
-		"-m", "addrtype", "!", "--dst-type", "LOCAL",
-		"-j", "MASQUERADE").Run(); err == nil {
-		// The MASQUERADE rule exists
-		return nil
-	}
-
-	glog.Infof("MASQUERADE rule doesn't exist, recreate it")
-	if err := exec.Command("iptables",
-		"-t", "nat",
-		"-A", "POSTROUTING",
-		"!", "-d", "10.0.0.0/8",
-		"-m", "addrtype", "!", "--dst-type", "LOCAL",
-		"-j", "MASQUERADE").Run(); err != nil {
-		return err
-	}
-	return nil
 }

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -318,7 +318,7 @@ func (dm *DockerManager) determineContainerIP(podNamespace, podName string, cont
 		result = container.NetworkSettings.IPAddress
 	}
 
-	if dm.networkPlugin.Name() != network.DefaultPluginName {
+	if dm.networkPlugin.Name() != network.NoOpPluginName {
 		netStatus, err := dm.networkPlugin.Status(podNamespace, podName, kubetypes.DockerID(container.ID))
 		if err != nil {
 			glog.Errorf("NetworkPlugin %s failed on the status hook for pod '%s' - %v", dm.networkPlugin.Name(), podName, err)

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -1572,7 +1572,14 @@ func (dm *DockerManager) createPodInfraContainer(pod *api.Pod) (kubetypes.Docker
 	netNamespace := ""
 	var ports []api.ContainerPort
 
-	if dm.networkPlugin.Name() == "cni" {
+	// CNI plugins run with net=none, unless they already have net=Host.
+	if dm.networkPlugin.Name() == network.CNIPluginName {
+		// TODO: This has deeper ramifications.
+		// 1. It will break host ports since we no longer get the docker
+		// userspace proxy, and we start docker with --iptables=false. We should
+		// forward the appropriate ports in the network plugin.
+		// 2. We should setup delegate /etc/hosts and resolvconf management
+		// to the plugin.
 		netNamespace = "none"
 	}
 
@@ -2007,6 +2014,18 @@ func getIPCMode(pod *api.Pod) string {
 		ipcMode = "host"
 	}
 	return ipcMode
+}
+
+// GetNetworkMode returns the network mode of the container, eg "host"
+// This method is used by network plugins to determine if a pod requires
+// additional setup. Pods running with host networking do not.
+func (dm *DockerManager) GetNetworkMode(containerID kubecontainer.ContainerID) (string, error) {
+	inspectResult, err := dm.client.InspectContainer(containerID.ID)
+	if err != nil {
+		glog.Errorf("Error inspecting container: '%v'", err)
+		return "", err
+	}
+	return inspectResult.HostConfig.NetworkMode, nil
 }
 
 // GetNetNs returns the network namespace path for the given container

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -4176,5 +4177,79 @@ func TestGetPodsToSync(t *testing.T) {
 
 	} else {
 		t.Errorf("expected %d pods to sync, got %d", 3, len(podsToSync))
+	}
+}
+
+// fakeExecer implements execer for testing.
+type fakeExecer struct {
+	Cmd    map[string][]string
+	Output map[string]string
+	Err    error
+}
+
+func (f *fakeExecer) execCmd(name string, args ...string) (string, error) {
+	f.Cmd[name] = args
+	r, _ := f.Output[name]
+	return r, f.Err
+}
+
+func TestSyncNetworkStatus(t *testing.T) {
+	testKubelet := newTestKubelet(t)
+	kubelet := testKubelet.kubelet
+	kubelet.configureCBR0 = true
+	kubelet.flannelExperimentalOverlay = false
+	kubelet.shaper = bandwidth.NewTCShaper("cbr0")
+	fe := &fakeExecer{
+		Cmd: map[string][]string{},
+		Err: fmt.Errorf("Error to test iptables appending."),
+	}
+	kubelet.cbr0 = &containerBridgeReconciler{fe, "cbr0", func(string) (bool, error) { return true, nil }}
+	currTime := time.Now()
+	kubelet.runtimeState.clock = &util.FakeClock{currTime}
+	kubelet.runtimeState.lastBaseRuntimeSync = currTime
+
+	// Test step1: MASQ rule
+	log.Printf("First sync should throw error")
+	kubelet.syncNetworkStatus()
+	if len(kubelet.runtimeState.errors()) == 0 {
+		t.Fatalf("Expected error since iptables rule failed")
+	}
+	executedCmd := fe.Cmd["iptables"]
+	if !reflect.DeepEqual(executedCmd, iptablesMasqAppend) {
+		t.Fatalf("Unexpected iptables rule: %v", executedCmd)
+	}
+	log.Printf("Clearing error")
+	fe.Err = nil
+	kubelet.syncNetworkStatus()
+	// We should not be appending rules continuously.
+	executedCmd = fe.Cmd["iptables"]
+	if !reflect.DeepEqual(executedCmd, iptablesMasqCheck) {
+		t.Fatalf("Unexpected iptables rule: %v", executedCmd)
+	}
+
+	// Test step2: podCIDR
+	// Sync network status should always return error before podCIDR is initialized
+	kubelet.syncNetworkStatus()
+	if len(kubelet.runtimeState.errors()) == 0 {
+		t.Fatalf("Expected error since iptables rule failed")
+	}
+	// The first sync after podCIDR should clear errors.
+	podCIDR := "10.240.1.0/24"
+	kubelet.runtimeState.setPodCIDR(podCIDR)
+	kubelet.syncNetworkStatus()
+	errors := kubelet.runtimeState.errors()
+	if len(errors) != 0 {
+		t.Fatalf("Did not expect errors, got %v", errors)
+	}
+
+	// Test step3: container bridge reconciliation
+	// TODO: better container bridge reconciliation and bw shaping tests
+	// deferred till we have network plugins.
+	kubelet.cbr0.bridgeExistsFunc = func(string) (bool, error) { return false, nil }
+	kubelet.syncNetworkStatus()
+	executedCmd = fe.Cmd["ip"]
+	bridgeUp := []string{"link", "set", "dev", "cbr0", "mtu", "1460", "up"}
+	if !reflect.DeepEqual(executedCmd, bridgeUp) {
+		t.Fatalf("Unexpected bridge creation command %v", executedCmd)
 	}
 }

--- a/pkg/kubelet/network/cni/cni_test.go
+++ b/pkg/kubelet/network/cni/cni_test.go
@@ -209,3 +209,21 @@ func TestCNIPlugin(t *testing.T) {
 		t.Errorf("Mismatch in expected output for setup hook. Expected '%s', got '%s'", expectedOutput, string(output))
 	}
 }
+
+func TestCNIAlwaysCreatesPlugin(t *testing.T) {
+	// Empty plugin directories
+	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
+	vendorName := fmt.Sprintf("test_vendor%d", rand.Intn(1000))
+	tmpDir := tmpDirOrDie()
+	defer tearDownPlugin(tmpDir)
+	// Probe will not find a net.conf but should create a "hollow" plugin anyway.
+	np := probeNetworkPluginsWithVendorCNIDirPrefix(path.Join(testNetworkConfigPath, pluginName), testVendorCNIDirPrefix)
+	// Hollow plugin should not get picked if Kubelet is passed a different --network-plugin-name, such as exec.
+	plug, err := network.InitNetworkPlugin(np, "cni", NewFakeHost(nil))
+	if err != nil {
+		t.Fatalf("Failed to select the desired plugin: %v", err)
+	}
+	if _, err := network.InitNetworkPlugin(np, "exec", NewFakeHost(nil)); err == nil {
+		t.Fatalf("Loaded plugin for unknown type")
+	}
+}

--- a/pkg/kubelet/network/cni/cni_test.go
+++ b/pkg/kubelet/network/cni/cni_test.go
@@ -213,13 +213,14 @@ func TestCNIPlugin(t *testing.T) {
 func TestCNIAlwaysCreatesPlugin(t *testing.T) {
 	// Empty plugin directories
 	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
-	vendorName := fmt.Sprintf("test_vendor%d", rand.Intn(1000))
 	tmpDir := tmpDirOrDie()
+	testNetworkConfigPath := path.Join(tmpDir, "plugins", "net", "cni")
+	testVendorCNIDirPrefix := tmpDir
 	defer tearDownPlugin(tmpDir)
 	// Probe will not find a net.conf but should create a "hollow" plugin anyway.
 	np := probeNetworkPluginsWithVendorCNIDirPrefix(path.Join(testNetworkConfigPath, pluginName), testVendorCNIDirPrefix)
 	// Hollow plugin should not get picked if Kubelet is passed a different --network-plugin-name, such as exec.
-	plug, err := network.InitNetworkPlugin(np, "cni", NewFakeHost(nil))
+	_, err := network.InitNetworkPlugin(np, "cni", NewFakeHost(nil))
 	if err != nil {
 		t.Fatalf("Failed to select the desired plugin: %v", err)
 	}

--- a/pkg/kubelet/network/exec/exec.go
+++ b/pkg/kubelet/network/exec/exec.go
@@ -177,3 +177,7 @@ func (plugin *execNetworkPlugin) Status(namespace string, name string, id kubety
 	errStr := fmt.Sprintf("Unknown version '%s' in network status for pod '%s'.", findVersion.APIVersion, name)
 	return nil, errors.New(errStr)
 }
+
+func (plugin *execNetworkPlugin) ReloadConf(ncw network.NetConfWriterTo) error {
+	return nil
+}

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -50,7 +50,12 @@ const (
 	// it always resolves to the CNI bridge plugin and host-local IPAM, but
 	// uses the podCIDR allocated by the Kubernetes master as the IPAM subnet.
 	KubeletDefaultPluginName = "default"
-	DefaultNetConfFile       = "kubernetes-network.conf"
+
+	DefaultNetConfFile = "kubernetes-network.conf"
+	// String used to detect docker host networking. Must match the value
+	// returned by docker inspect -f '{{.HostConfig.NetworkMode}}'.
+	// TODO: Re-use a value from the Kubernetes/kubelet/docker.
+	HostNetworking = "host"
 )
 
 // GetPluginType returns the string after the second '/' in the default

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -50,6 +50,7 @@ const (
 	// it always resolves to the CNI bridge plugin and host-local IPAM, but
 	// uses the podCIDR allocated by the Kubernetes master as the IPAM subnet.
 	KubeletDefaultPluginName = "default"
+	DefaultNetConfFile       = "kubernetes-network.conf"
 )
 
 // GetPluginType returns the string after the second '/' in the default

--- a/pkg/kubelet/network/plugins_test.go
+++ b/pkg/kubelet/network/plugins_test.go
@@ -29,7 +29,7 @@ func TestSelectDefaultPlugin(t *testing.T) {
 	if plug == nil {
 		t.Fatalf("Failed to select the default plugin.")
 	}
-	if plug.Name() != DefaultPluginName {
-		t.Errorf("Failed to select the default plugin. Expected %s. Got %s", DefaultPluginName, plug.Name())
+	if plug.Name() != NoOpPluginName {
+		t.Errorf("Failed to select the default plugin. Expected %s. Got %s", NoOpPluginName, plug.Name())
 	}
 }


### PR DESCRIPTION
This pr teaches the kubelet to write out a bridge plugin net.conf after the node controller has assigned it a podcidr. The goal is to teach the kubelet to pick a plugin based on 
--network-plugin=net.alph.kubernetes.io/plugin-type, by invoking a kubernetes meta-plugin and passing it plugin-type. 

Dependencies: https://github.com/kubernetes/kubernetes/pull/18682, https://github.com/kubernetes/kubernetes/pull/18672, https://github.com/appc/cni/issues/88
Ref https://github.com/kubernetes/kubernetes/issues/17795
