### PR TITLE
Fix 'kubectl logs' not working issue in k8sm

### DIFF
--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -215,6 +215,7 @@ func NewSchedulerServer() *SchedulerServer {
 		kubeletSyncFrequency: 10 * time.Second,
 		containPodResources:  true,
 		nodeRelistPeriod:     defaultNodeRelistPeriod,
+		enableProfiling:      true,
 	}
 	// cache this for later use. also useful in case the original binary gets deleted, e.g.
 	// during upgrades, development deployments, etc.


### PR DESCRIPTION
This is a follow up from #18681 to resolve an issue in k8sm where `kubectl logs` does not work (see also https://github.com/kubernetes/kubernetes/blob/master/contrib/mesos/docs/issues.md#kubectl). The root of the problem is k8sm scheduler uses `--profile` flag to set kubelet's `--enable-debugging-handlers` flag, and by default `--profile` is set to false, thus causing `--enable-debugging-handlers` to also be set to false (which normally is set to true in k8s-standalone mode). This will cause REST calls that are normally enabled on kubelet such as /containerLogs, /run, /exec, /attach, etc. to be disabled. 

When a user issues `kubectl logs`, the api server will eventually calls /containerLogs on the kubelet for the specified pod, but since /containerLogs is disabled in k8sm by default, this `kubectl logs` call will fail. The fix is to set `--profile` flag in k8sm to `true` so it is consistent with `--enable-debugging-handlers` flag being set to `true` in k8s. This helps the out-of-box UX of k8s and k8sm to be more similar.
