### PR TITLE
Use installed kubectl as fallback during kube-up

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -86,6 +86,7 @@ if [[ -z "${KUBECTL_PATH:-}" ]]; then
     "${KUBE_ROOT}/_output/dockerized/bin/${host_os}/${host_arch}/kubectl"
     "${KUBE_ROOT}/_output/local/bin/${host_os}/${host_arch}/kubectl"
     "${KUBE_ROOT}/platforms/${host_os}/${host_arch}/kubectl"
+    "/usr/local/bin/kubectl"
   )
   kubectl=$( (ls -t "${locations[@]}" 2>/dev/null || true) | head -1 )
 


### PR DESCRIPTION
If developer would not find the https://github.com/kubernetes/kubernetes/commit/e71798df3f13f95a1ee4b2773ba9f0315fff1145#diff-37c4a2353d5e56f6bf67be4085e3f735R82

and run setup cluster (for my case in AWS) the process would stop on setup kube/config.
This would safe some time.
