### PR TITLE
Revert "Remove use of legacy pods proxy path"

### DIFF
--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -132,9 +132,9 @@ func assertFilesExist(fileNames []string, fileDir string, pod *api.Pod, client *
 		failed = []string{}
 		for _, fileName := range fileNames {
 			if _, err := client.Get().
-				Namespace(pod.Namespace).
+				Prefix("proxy").
 				Resource("pods").
-				SubResource("proxy").
+				Namespace(pod.Namespace).
 				Name(pod.Name).
 				Suffix(fileDir, fileName).
 				Do().Raw(); err != nil {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -259,10 +259,10 @@ var _ = Describe("Kubectl client", func() {
 				Failf("unable to create streaming upload. Error: %s", err)
 			}
 			resp, err := c.Post().
+				Prefix("proxy").
 				Namespace(ns).
 				Name("netexec").
 				Resource("pods").
-				SubResource("proxy").
 				Suffix("upload").
 				SetHeader("Content-Type", postConfigBodyWriter.FormDataContentType()).
 				Body(pipeConfigReader).
@@ -286,10 +286,10 @@ var _ = Describe("Kubectl client", func() {
 			var uploadOutput NetexecOutput
 			// Upload the kubectl binary
 			resp, err = c.Post().
+				Prefix("proxy").
 				Namespace(ns).
 				Name("netexec").
 				Resource("pods").
-				SubResource("proxy").
 				Suffix("upload").
 				SetHeader("Content-Type", postBodyWriter.FormDataContentType()).
 				Body(pipeReader).
@@ -324,10 +324,10 @@ var _ = Describe("Kubectl client", func() {
 				shellCommand := fmt.Sprintf("%s=%s .%s --kubeconfig=%s --server=%s --namespace=%s exec nginx echo running in container", proxyVar, proxyAddr, uploadBinaryName, kubecConfigRemotePath, apiServer, ns)
 				// Execute kubectl on remote exec server.
 				netexecShellOutput, err := c.Post().
+					Prefix("proxy").
 					Namespace(ns).
 					Name("netexec").
 					Resource("pods").
-					SubResource("proxy").
 					Suffix("shell").
 					Param("shellCommand", shellCommand).
 					Do().Raw()
@@ -1126,9 +1126,9 @@ func getUDData(jpgExpected string, ns string) func(*client.Client, string) error
 	return func(c *client.Client, podID string) error {
 		Logf("validating pod %s", podID)
 		body, err := c.Get().
+			Prefix("proxy").
 			Namespace(ns).
 			Resource("pods").
-			SubResource("proxy").
 			Name(podID).
 			Suffix("data.json").
 			Do().

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -118,9 +118,8 @@ func testPreStop(c *client.Client, ns string) {
 	// Validate that the server received the web poke.
 	err = wait.Poll(time.Second*5, time.Second*60, func() (bool, error) {
 		if body, err := c.Get().
-			Namespace(ns).
+			Namespace(ns).Prefix("proxy").
 			Resource("pods").
-			SubResource("proxy").
 			Name(podDescr.Name).
 			Suffix("read").
 			DoRaw(); err != nil {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -891,9 +891,9 @@ func (r podResponseChecker) checkAllResponses() (done bool, err error) {
 			return false, fmt.Errorf("pod with UID %s is no longer a member of the replica set.  Must have been restarted for some reason.  Current replica set: %v", pod.UID, currentPods)
 		}
 		body, err := r.c.Get().
+			Prefix("proxy").
 			Namespace(r.ns).
 			Resource("pods").
-			SubResource("proxy").
 			Name(string(pod.Name)).
 			Do().
 			Raw()

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -227,8 +227,8 @@ func testVolumeClient(client *client.Client, config VolumeTestConfig, volume api
 	By("reading a web page from the client")
 	body, err := client.Get().
 		Namespace(config.namespace).
+		Prefix("proxy").
 		Resource("pods").
-		SubResource("proxy").
 		Name(clientPod.Name).
 		DoRaw()
 	expectNoError(err, "Cannot read web page: %v", err)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#17002.  This change caused backwards-incompatibility with old clusters, (subresource proxy via tunneling is known to be broken in 1.0, https://github.com/kubernetes/kubernetes/pull/15224#issuecomment-146769463).

Unless there's a good reason not to roll it back, I propose we do so (and if there is, I'll pursue #18720).  @smarterclayton?
