### PR TITLE
update kube2sky version

### DIFF
--- a/cluster/addons/dns/kube2sky/.gitignore
+++ b/cluster/addons/dns/kube2sky/.gitignore
@@ -1,0 +1,1 @@
+kube2sky

--- a/cluster/addons/dns/kube2sky/Changelog
+++ b/cluster/addons/dns/kube2sky/Changelog
@@ -1,3 +1,8 @@
+## Version 1.12 (Dec 15 2015 Abhishek Shah <abshah@google.com>)
+- Gave pods their own cache store. (034ecbd)
+- Allow pods to have dns. (717660a)
+
+
 ## Version 1.10 (Jun 19 2015 Tim Hockin <thockin@google.com>)
 - Fall back on service account tokens if no other auth is specified.
 

--- a/cluster/addons/dns/kube2sky/Makefile
+++ b/cluster/addons/dns/kube2sky/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: all kube2sky container push clean test
 
-TAG = 1.11
+TAG = 1.12
 PREFIX = gcr.io/google_containers
 
 all: container

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v9
+  name: kube-dns-v10
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v9
+    version: v10
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
     k8s-app: kube-dns
-    version: v9
+    version: v10
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v9
+        version: v10
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
@@ -40,7 +40,7 @@ spec:
         - name: etcd-storage
           mountPath: /var/etcd/data
       - name: kube2sky
-        image: gcr.io/google_containers/kube2sky:1.11
+        image: gcr.io/google_containers/kube2sky:1.12
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Picks up the following:
+- Gave pods their own cache store. (034ecbd)
+- Allow pods to have dns. (717660a)
