### PR TITLE
Revert "Use dogfood Cloud SDK and test endpoint by default for Jenkins GKE e2e tests (release-1.1)"

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -120,6 +120,11 @@ function configure_upgrade_step() {
         ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
         )"
 
+  if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
+    DOGFOOD_GCLOUD="true"
+    GKE_API_ENDPOINT="https://test-container.sandbox.googleapis.com/"
+  fi
+
   E2E_CLUSTER_NAME="$cluster_name"
   E2E_NETWORK="$cluster_name"
   PROJECT="$project"
@@ -257,8 +262,6 @@ if [[ ${JOB_NAME} =~ ^kubernetes-.*-gce ]]; then
 elif [[ ${JOB_NAME} =~ ^kubernetes-.*-gke ]]; then
   KUBERNETES_PROVIDER="gke"
   : ${E2E_ZONE:="us-central1-f"}
-  : ${CLOUDSDK_BUCKET:="gs://cloud-sdk-build/testing/staging"}
-  : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
 elif [[ ${JOB_NAME} =~ ^kubernetes-.*-aws ]]; then
   KUBERNETES_PROVIDER="aws"
   : ${E2E_MIN_STARTUP_PODS:="1"}
@@ -676,6 +679,7 @@ case ${JOB_NAME} in
     ;;
 
   kubernetes-e2e-gke-subnet)
+    : ${DOGFOOD_GCLOUD:="true"}
     : ${E2E_CLUSTER_NAME:="jkns-gke-subnet"}
     # auto-subnet manually created - if deleted, it will need to be recreated
     # gcloud alpha compute networks create auto-subnet --mode auto
@@ -692,8 +696,7 @@ case ${JOB_NAME} in
     ;;
 
   kubernetes-e2e-gke-prod)
-    : ${CLOUDSDK_BUCKET:=""}
-    : ${GKE_API_ENDPOINT:="https://container.googleapis.com/"}
+    : ${DOGFOOD_GCLOUD:="true"}
     : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-prod"}
     : ${E2E_NETWORK:="e2e-gke-prod"}
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
@@ -708,7 +711,7 @@ case ${JOB_NAME} in
     ;;
 
   kubernetes-e2e-gke-staging)
-    : ${CLOUDSDK_BUCKET:="gs://cloud-sdk-build/testing/rc"}
+    : ${DOGFOOD_GCLOUD:="true"}
     : ${GKE_API_ENDPOINT:="https://staging-container.sandbox.googleapis.com/"}
     : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-staging"}
     : ${E2E_NETWORK:="e2e-gke-staging"}
@@ -724,7 +727,9 @@ case ${JOB_NAME} in
     ;;
 
   kubernetes-e2e-gke-test)
+    : ${DOGFOOD_GCLOUD:="true"}
     : ${CLOUDSDK_BUCKET:="gs://cloud-sdk-build/testing/rc"}
+    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
     : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-test"}
     : ${E2E_NETWORK:="e2e-gke-test"}
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
@@ -739,6 +744,8 @@ case ${JOB_NAME} in
     ;;
 
   kubernetes-e2e-gke-1.1)
+    : ${DOGFOOD_GCLOUD:="true"}
+    : ${GKE_API_ENDPOINT:="https://test-container.sandbox.googleapis.com/"}
     : ${E2E_CLUSTER_NAME:="gke-release-1-1"}
     : ${E2E_NETWORK:="gke-release-1-1"}
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
@@ -871,6 +878,7 @@ export CLUSTER_NAME=${E2E_CLUSTER_NAME}
 export ZONE=${E2E_ZONE}
 export KUBE_GKE_NETWORK=${E2E_NETWORK}
 export E2E_SET_CLUSTER_API_VERSION=${E2E_SET_CLUSTER_API_VERSION:-}
+export DOGFOOD_GCLOUD=${DOGFOOD_GCLOUD:-}
 export CMD_GROUP=${CMD_GROUP:-}
 export MACHINE_TYPE=${MINION_SIZE:-}  # GKE scripts use MACHINE_TYPE for the node vm size
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#18547
