### PR TITLE
Run upload-to-gcs.sh as a post build script

### DIFF
--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -11,6 +11,7 @@
 - publisher:
     name: gcs-uploader
     publishers:
+        # Use the plugin for the build log, since it isn't available on Jenkins slaves.
         - google-cloud-storage:
             credentials-id: kubernetes-jenkins
             uploads:
@@ -19,6 +20,17 @@
                     storage-location: gs://kubernetes-jenkins/logs/$JOB_NAME/$BUILD_NUMBER
                     share-publicly: true
                     upload-for-failed-jobs: true
+        # Use our script for build artifacts, since it's more flexible.
+        - postbuildscript:
+            builders:
+                - shell: |
+                    if [[ -x ./hack/jenkins/upload-to-gcs.sh ]]; then
+                      ./hack/jenkins/upload-to-gcs.sh
+                    else
+                      curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" | bash -
+                    fi
+            script-only-if-succeeded: False
+            script-only-if-failed: False
 
 # Default log parser rules.
 - publisher:

--- a/hack/jenkins/job-configs/kubernetes-build.yaml
+++ b/hack/jenkins/job-configs/kubernetes-build.yaml
@@ -9,6 +9,8 @@
         - mail-watcher
     publishers:
         - claim-build
+        - gcs-uploader
+        - log-parser
         - email-ext:
             recipients: $DEFAULT_RECIPIENTS, cloud-kubernetes-team@google.com
             presend-script: $DEFAULT_PRESEND_SCRIPT
@@ -17,8 +19,6 @@
             send-to:
                 - culprits
                 - recipients
-        - gcs-uploader
-        - log-parser
     scm:
         - git:
             url: https://github.com/kubernetes/kubernetes

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -5,16 +5,15 @@
         daysToKeep: 7
     builders:
         - shell: |
-            curl -fsS -o upload-to-gcs.sh --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" && source upload-to-gcs.sh; rm -f upload-to-gcs.sh
             curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/{branch}/hack/jenkins/e2e.sh" | bash -
     properties:
         - mail-watcher
     publishers:
         - claim-build
-        - email-ext
+        - junit-publisher
         - gcs-uploader
         - log-parser
-        - junit-publisher
+        - email-ext
     triggers:
         - reverse:
             jobs: '{trigger-job}'


### PR DESCRIPTION
I've tested this by tweaking the configuration on `kubernetes-e2e-gce-parallel` and it seems to work.

I haven't tested the YAML yet.

Should fix the root cause of #18441, and it's less gross than the previous hack.
We should be able to revert #18715 after this is rolled out everywhere, too.

@kubernetes/goog-testing 
