### PR TITLE
add SecondClosestCommentLines to go2idl types.Type

### DIFF
--- a/cmd/libs/go2idl/parser/parse_test.go
+++ b/cmd/libs/go2idl/parser/parse_test.go
@@ -211,6 +211,47 @@ type Blah struct {
 	}
 }
 
+func TestParseSecondClosestCommentLines(t *testing.T) {
+	const fileName = "base/foo/proto/foo.go"
+	testCases := []struct {
+		testFile map[string]string
+		expected string
+	}{
+		{
+			map[string]string{fileName: `package foo
+// Blah's SecondClosestCommentLines.
+// Another line.
+
+// Blah is a test.
+// A test, I tell you.
+type Blah struct {
+	a int
+}
+`},
+			"Blah's SecondClosestCommentLines.\nAnother line.\n",
+		},
+		{
+			map[string]string{fileName: `package foo
+// Blah's SecondClosestCommentLines.
+// Another line.
+
+type Blah struct {
+	a int
+}
+`},
+			"Blah's SecondClosestCommentLines.\nAnother line.\n",
+		},
+	}
+	for _, test := range testCases {
+		_, u, o := construct(t, test.testFile, namer.NewPublicNamer(0))
+		t.Logf("%#v", o)
+		blahT := u.Type(types.Name{Package: "base/foo/proto", Name: "Blah"})
+		if e, a := test.expected, blahT.SecondClosestCommentLines; e != a {
+			t.Errorf("struct second closest comment wrong, wanted %v, got %v", e, a)
+		}
+	}
+}
+
 func TestTypeKindParse(t *testing.T) {
 	var testFiles = map[string]string{
 		"a/foo.go": "package a\ntype Test string\n",

--- a/cmd/libs/go2idl/types/types.go
+++ b/cmd/libs/go2idl/types/types.go
@@ -231,6 +231,23 @@ type Type struct {
 	// they will be recorded here.
 	CommentLines string
 
+	// If there are comment lines preceding the `CommentLines`, they will be
+	// recorded here. There are two cases:
+	// ---
+	// SecondClosestCommentLines
+	// a blank line
+	// CommentLines
+	// type definition
+	// ---
+	//
+	// or
+	// ---
+	// SecondClosestCommentLines
+	// a blank line
+	// type definition
+	// ---
+	SecondClosestCommentLines string
+
 	// If Kind == Struct
 	Members []Member
 


### PR DESCRIPTION
The go2idl's types.Type will record the second closest comment block of a type, e.g.,

```
// Second closest comment

// Immediate comment
// type X struct {...}
```

or 

```
// Second closest comment

// type X struct {...}
```

It's useful for users who need to add a filter tag in the comment without showing that tag in godoc. E.g., https://github.com/kubernetes/kubernetes/pull/18685/files#r47740652

ref #18685

@krousey @wojtek-t
