### PR TITLE
AWS: Fixed compacting script of cloud init for MacOS

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -895,8 +895,9 @@ function start-master() {
 
   # We're running right up against the 16KB limit
   # Remove all comment lines and then put back the bin/bash shebang
-  sed -i -e 's/^[[:blank:]]*#.*$//' -e '/^[[:blank:]]*$/d' "${KUBE_TEMP}/master-user-data"
-  sed -i '1i #! /bin/bash' "${KUBE_TEMP}/master-user-data"
+  cat "${KUBE_TEMP}/master-user-data" | sed -e 's/^[[:blank:]]*#.*$//' | sed -e '/^[[:blank:]]*$/d' > "${KUBE_TEMP}/master-user-data.tmp"
+  echo '#! /bin/bash' | cat - "${KUBE_TEMP}/master-user-data.tmp" > "${KUBE_TEMP}/master-user-data"
+  rm "${KUBE_TEMP}/master-user-data.tmp"
 
   echo "Starting Master"
   master_id=$($AWS_CMD run-instances \


### PR DESCRIPTION
In MacOS there is error during setup a new cluster:

```
$ KUBERNETES_PROVIDER=aws ./cluster/kube-up.sh
....
+ sed -i -e 's/^[[:blank:]]*#.*$//' -e '/^[[:blank:]]*$/d' /sometmpfile
sed: -e: No such file or directory
```

Because `sed` version of MacOS does not support modern features.

Environment:

```
$ uname -a
Darwin kakashka.local 15.2.0 Darwin Kernel Version 15.2.0: Fri Nov 13 19:56:56 PST 2015; root:xnu-3248.20.55~2/RELEASE_X86_64 x86_64
```
