### PR TITLE
AWS: Load cluster env during the validation

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -21,6 +21,11 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then
+    source "${KUBE_ROOT}/cluster/env.sh"
+fi
+
 source "${KUBE_ROOT}/cluster/kube-env.sh"
 source "${KUBE_ROOT}/cluster/kube-util.sh"
 


### PR DESCRIPTION
There is an issue when I specified all env in `cluster/env.sh`
And redefine `NUM_NODES`, than if it less than there is a loop.

```
NUM_NODES=1
Waiting for 4 ready nodes. 1 ready nodes, 1 registered. Retrying.
```
