### PR TITLE
Add version-guarding around calls to SubResource proxy in e2es

### DIFF
--- a/pkg/version/semver.go
+++ b/pkg/version/semver.go
@@ -44,7 +44,7 @@ func Parse(gitversion string) (semver.Version, error) {
 func MustParse(gitversion string) semver.Version {
 	v, err := Parse(gitversion)
 	if err != nil {
-		glog.Fatalf("failed to parse semver from giversion %q: %v", gitversion, err)
+		glog.Fatalf("failed to parse semver from gitversion %q: %v", gitversion, err)
 	}
 	return v
 }

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -117,13 +117,29 @@ func testPreStop(c *client.Client, ns string) {
 
 	// Validate that the server received the web poke.
 	err = wait.Poll(time.Second*5, time.Second*60, func() (bool, error) {
-		if body, err := c.Get().
-			Namespace(ns).
-			Resource("pods").
-			SubResource("proxy").
-			Name(podDescr.Name).
-			Suffix("read").
-			DoRaw(); err != nil {
+		subResourceProxyAvailable, err := serverVersionGTE(subResourceProxyVersion, c)
+		if err != nil {
+			return false, err
+		}
+		var body []byte
+		if subResourceProxyAvailable {
+			body, err = c.Get().
+				Namespace(ns).
+				Resource("pods").
+				SubResource("proxy").
+				Name(podDescr.Name).
+				Suffix("read").
+				DoRaw()
+		} else {
+			body, err = c.Get().
+				Prefix("proxy").
+				Namespace(ns).
+				Resource("pods").
+				Name(podDescr.Name).
+				Suffix("read").
+				DoRaw()
+		}
+		if err != nil {
 			By(fmt.Sprintf("Error validating prestop: %v", err))
 		} else {
 			Logf("Saw: %s", string(body))

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -52,8 +52,10 @@ import (
 	deploymentutil "k8s.io/kubernetes/pkg/util/deployment"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/watch"
 
+	"github.com/blang/semver"
 	"github.com/davecgh/go-spew/spew"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/websocket"
@@ -105,6 +107,14 @@ const (
 	serviceRespondingTimeout = 2 * time.Minute
 	endpointRegisterTimeout  = time.Minute
 )
+
+// SubResource proxy should have been functional in v1.0.0, but SubResource
+// proxy via tunneling is known to be broken in v1.0.  See
+// https://github.com/kubernetes/kubernetes/pull/15224#issuecomment-146769463
+//
+// TODO(ihmccreery): remove once we don't care about v1.0 anymore, (tentatively
+// in v1.3).
+var subResourceProxyVersion = version.MustParse("v1.1.0")
 
 type CloudConfig struct {
 	ProjectID         string
@@ -890,13 +900,28 @@ func (r podResponseChecker) checkAllResponses() (done bool, err error) {
 		if !isElementOf(pod.UID, currentPods) {
 			return false, fmt.Errorf("pod with UID %s is no longer a member of the replica set.  Must have been restarted for some reason.  Current replica set: %v", pod.UID, currentPods)
 		}
-		body, err := r.c.Get().
-			Namespace(r.ns).
-			Resource("pods").
-			SubResource("proxy").
-			Name(string(pod.Name)).
-			Do().
-			Raw()
+		subResourceProxyAvailable, err := serverVersionGTE(subResourceProxyVersion, r.c)
+		if err != nil {
+			return false, err
+		}
+		var body []byte
+		if subResourceProxyAvailable {
+			body, err = r.c.Get().
+				Namespace(r.ns).
+				Resource("pods").
+				SubResource("proxy").
+				Name(string(pod.Name)).
+				Do().
+				Raw()
+		} else {
+			body, err = r.c.Get().
+				Prefix("proxy").
+				Namespace(r.ns).
+				Resource("pods").
+				Name(string(pod.Name)).
+				Do().
+				Raw()
+		}
 		if err != nil {
 			Logf("Controller %s: Failed to GET from replica %d [%s]: %v:", r.controllerName, i+1, pod.Name, err)
 			continue
@@ -929,6 +954,22 @@ func (r podResponseChecker) checkAllResponses() (done bool, err error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// serverVersionGTE returns true if v is greater than or equal to the server
+// version.
+//
+// TODO(18726): This should be incorporated into client.VersionInterface.
+func serverVersionGTE(v semver.Version, c client.VersionInterface) (bool, error) {
+	serverVersion, err := c.ServerVersion()
+	if err != nil {
+		return false, fmt.Errorf("Unable to get server version: %v", err)
+	}
+	sv, err := version.Parse(serverVersion.GitVersion)
+	if err != nil {
+		return false, fmt.Errorf("Unable to parse server version %q: %v", serverVersion.GitVersion, err)
+	}
+	return sv.GTE(v), nil
 }
 
 func podsResponding(c *client.Client, ns, name string, wantName bool, pods *api.PodList) error {

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -225,12 +225,26 @@ func testVolumeClient(client *client.Client, config VolumeTestConfig, volume api
 	expectNoError(waitForPodRunningInNamespace(client, clientPod.Name, config.namespace))
 
 	By("reading a web page from the client")
-	body, err := client.Get().
-		Namespace(config.namespace).
-		Resource("pods").
-		SubResource("proxy").
-		Name(clientPod.Name).
-		DoRaw()
+	subResourceProxyAvailable, err := serverVersionGTE(subResourceProxyVersion, client)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	var body []byte
+	if subResourceProxyAvailable {
+		body, err = client.Get().
+			Namespace(config.namespace).
+			Resource("pods").
+			SubResource("proxy").
+			Name(clientPod.Name).
+			DoRaw()
+	} else {
+		body, err = client.Get().
+			Prefix("proxy").
+			Namespace(config.namespace).
+			Resource("pods").
+			Name(clientPod.Name).
+			DoRaw()
+	}
 	expectNoError(err, "Cannot read web page: %v", err)
 	Logf("body: %v", string(body))
 


### PR DESCRIPTION
Fixes #18660 and #18720; makes progress toward #18581.

This is a modification of #17002 that version-guards subresource proxy logic in the e2e tests.  We need this functionality to be backward-compatible with 1.0 in order to test upgrades from 1.0.  We can remove it once we don't care about v1.0 anymore, (tentatively in v1.3).

There's been discussion of adding a version-and-provider guard, since subresource proxies in 1.0 are only broken for ssh-tunnels, and GKE is the only provider (AFAIK) that uses them.  @liggitt?

cc @ixdy (reviewer of #17002) @brendandburns @cjcullen @liggitt.
