### PR TITLE
Add kubernetes-upgrade-gce job configs (1.1-master and current-stable) to release-1.1

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -123,6 +123,10 @@ function configure_upgrade_step() {
   if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
     DOGFOOD_GCLOUD="true"
     GKE_API_ENDPOINT="https://test-container.sandbox.googleapis.com/"
+  else
+    NUM_NODES=5
+    KUBE_ENABLE_DEPLOYMENTS=true
+    KUBE_ENABLE_DAEMONSETS=true
   fi
 
   E2E_CLUSTER_NAME="$cluster_name"
@@ -801,6 +805,24 @@ case ${JOB_NAME} in
     configure_upgrade_step 'ci/latest-1.1' 'configured-in-master' 'upgrade-gke-1-1-master' 'kubernetes-jenkins-gke-upgrade'
     ;;
 
+  # kubernetes-upgrade-gce-1.1-master
+  #
+  # Test upgrades from the latest release-1.1 build to the latest master build.
+  #
+  # Configurations for step2, step3, step5, and step7 live in master.
+
+  kubernetes-upgrade-gce-1.1-master-step1-deploy)
+    configure_upgrade_step 'ci/latest-1.1' 'configured-in-master' 'upgrade-gce-1-1-master' 'k8s-jkns-gce-upgrade'
+    ;;
+
+  kubernetes-upgrade-gce-1.1-master-step4-e2e-old)
+    configure_upgrade_step 'ci/latest-1.1' 'configured-in-master' 'upgrade-gce-1-1-master' 'k8s-jkns-gce-upgrade'
+    ;;
+
+  kubernetes-upgrade-gce-1.1-master-step6-e2e-old)
+    configure_upgrade_step 'ci/latest-1.1' 'configured-in-master' 'upgrade-gce-1-1-master' 'k8s-jkns-gce-upgrade'
+    ;;
+
   # kubernetes-upgrade-gke-1.0-current-release
   #
   # Test upgrades from the latest release-1.0 build to the latest current
@@ -822,6 +844,38 @@ case ${JOB_NAME} in
 
   kubernetes-upgrade-gke-1.0-current-release-step7-e2e-new)
     configure_upgrade_step 'configured-in-release-1.0' 'ci/latest-1.1' 'upgrade-gke-1-0-current-release' 'kubernetes-jenkins-gke-upgrade'
+    ;;
+
+  # kubernetes-upgrade-gce-stable-current-release
+  #
+  # Test upgrades from the stable build to the latest current release build.
+
+  kubernetes-upgrade-gce-stable-current-release-step1-deploy)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gce-stable-current-release' 'k8s-jkns-gce-upgrade'
+    ;;
+
+  kubernetes-upgrade-gce-stable-current-release-step2-kubectl-e2e-new)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gce-stable-current-release' 'k8s-jkns-gce-upgrade'
+    ;;
+
+  kubernetes-upgrade-gce-stable-current-release-step3-upgrade-master)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gce-stable-current-release' 'k8s-jkns-gce-upgrade'
+    ;;
+
+  kubernetes-upgrade-gce-stable-current-release-step4-e2e-old)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gce-stable-current-release' 'k8s-jkns-gce-upgrade'
+    ;;
+
+  kubernetes-upgrade-gce-stable-current-release-step5-upgrade-cluster)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gce-stable-current-release' 'k8s-jkns-gce-upgrade'
+    ;;
+
+  kubernetes-upgrade-gce-stable-current-release-step6-e2e-old)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gce-stable-current-release' 'k8s-jkns-gce-upgrade'
+    ;;
+
+  kubernetes-upgrade-gce-stable-current-release-step7-e2e-new)
+    configure_upgrade_step 'release/stable-1.1' 'ci/latest-1.1' 'upgrade-gce-stable-current-release' 'k8s-jkns-gce-upgrade'
     ;;
 
   # kubernetes-upgrade-gke-stable-current-release


### PR DESCRIPTION
Add `kubernetes-upgrade-gce-1.1-master` and `kubernetes-upgrade-gce-stable-current-release` jobs to e2e.sh.

xref #18792
