### PR TITLE
Fix nodeport service compat with default-deny fw

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -84,7 +84,8 @@ const (
 type Table string
 
 const (
-	TableNAT Table = "nat"
+	TableNAT    Table = "nat"
+	TableFilter Table = "filter"
 )
 
 type Chain string
@@ -93,6 +94,7 @@ const (
 	ChainPostrouting Chain = "POSTROUTING"
 	ChainPrerouting  Chain = "PREROUTING"
 	ChainOutput      Chain = "OUTPUT"
+	ChainInput       Chain = "INPUT"
 )
 
 const (

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -356,6 +356,9 @@ var _ = Describe("Services", func() {
 		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
 	})
 
+	// TODO: Run this test against the userspace proxy and nodes
+	// configured with a default deny firewall to validate that the
+	// proxy whitelists NodePort traffic.
 	It("should be able to create a functioning NodePort service", func() {
 		serviceName := "nodeportservice-test"
 		ns := f.Namespace.Name


### PR DESCRIPTION
This PR is a first pass at fixing #18802.  It adds explicit iptables rules allowing NodePort service traffic originating from outside a node to avoid the default-deny rules configured on non-cloud/vm deployments of fedora/centos/rhel.  

As per a conversation on #kubernetes-dev with @thockin, the goal was to:
- add a chain to the filter table 
- add rules to that chain per protocol that accepted traffic on the range of active proxy ports

I assumed that it was necessary to maintain availability of services when modifying the rule, and this implied adding a rule with an updated range before removing the rule with the previous range.  Since multiple iptables operations cannot be executed atomically, however, there exists the possibility that a new rule would be added and removal of the old rule would fail.  Subsequently removing an old rule is complicated by the current implementation for rule deletion, which requires the exact rule to target for deletion.  Since the rules in question include the port range for a given protocol at a point in time, attempting deletion of 'orphaned' rules would require keeping track of any protocol and port range pairs that were known to have been orphaned and repeatedly attempting their deletion.  I'm not sure this would be worth the trouble, though, and think the following alternatives would be preferable:
- implement chain-local orphan deletion.  When updating the rules, delete all rules in the chain that don't correspond to the current protocol/port-range pairs.  This approach adds some complexity in iptables manipulation for the sake of rule simplicity.
- add a rule per-service rather than using a rule per protocol with ranges.  This would be much simpler to implement, but would result in an additional rule per proxy port.

I've avoided adding unit tests for the new code just yet since the implementation is likely to change.  Ensuring e2ed coverage for the change will be complicated by the distro-specific nature of the problem, though existing tests will still detect regressions.
