### PR TITLE
Add documentation about multiple clusters on AWS

### DIFF
--- a/docs/design/aws_under_the_hood.md
+++ b/docs/design/aws_under_the_hood.md
@@ -58,6 +58,7 @@ you manually created or configured your cluster.
  * [Tagging](#tagging)
  * [AWS objects](#aws-objects)
  * [Manual infrastructure creation](#manual-infrastructure-creation)
+ * [Multiple clusters](#multiple-clusters)
  * [Instance boot](#instance-boot)
 
 ### Architecture overview
@@ -291,6 +292,16 @@ Currently there is no way to do the following with kube-up:
 If any of the above items apply to your situation, open an issue to request an
 enhancement to the kube-up script. You should provide a complete description of
 the use-case, including all the details around what you want to accomplish.
+
+### Multiple clusters
+
+To run multiple clusters, set a unique value of `KUBE_AWS_INSTANCE_PREFIX` for
+each cluster you create (e.g. `kubernetes-production` and `kubernetes-staging`).
+By default, a VPC will be created for each cluster, but `VPC_ID` can be used to
+reuse an existing VPC.
+
+For more information about running multiple clusters, see the related
+[admin documentation]([kube-up](../admin/multi-cluster.md).
 
 ### Instance boot
 


### PR DESCRIPTION
I didn't see any existing documentation about running multiple clusters on AWS, but let me know if I'm overlooking it. It took a bit of digging through the source to find how to do it, and I'm still not sure if `KUBE_AWS_INSTANCE_PREFIX` is the recommended approach, but I wanted to at least start the conversation re: making it easier to learn how to set up multiple clusters.

Also, let me know if `aws_under_the_hood.md` isn't the appropriate place for this. `multi-cluster.md` seemed a decent candidate, too, but it doesn't have any provider-specific documentation.
