### PR TITLE
Fix update/verify-codecgen.sh for OSX.

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -40,3 +40,16 @@ source "${KUBE_ROOT}/hack/lib/golang.sh"
 source "${KUBE_ROOT}/hack/lib/etcd.sh"
 
 KUBE_OUTPUT_HOSTBIN="${KUBE_OUTPUT_BINPATH}/$(kube::util::host_platform)"
+
+# emulates "readlink -f" which is not available on BSD (OS X).
+function readlinkdashf {
+  path=$1
+  # Follow links until there are no more links to follow.
+  while readlink "$path"; do
+    path="$(readlink $path)"
+  done 
+  # Convert to canonical path.
+  path=$(cd "$(dirname "${path}")" && pwd -P)
+  echo "$path"
+}
+

--- a/hack/update-codecgen.sh
+++ b/hack/update-codecgen.sh
@@ -53,8 +53,7 @@ result=""
 function depends {
   file=${generated_files[$1]//\.generated\.go/.go}
   deps=$(go list -f "{{.Deps}}" ${file} | tr "[" " " | tr "]" " ")
-  inputfile=${generated_files[$2]//\.generated\.go/.go}
-  fullpath=${generated_files[$2]//\.generated\.go/.go}
+  fullpath=$(readlinkdashf "${generated_files[$2]//\.generated\.go/.go}")
   candidate=$(dirname "${fullpath}")
   result=false
   for dep in ${deps}; do
@@ -102,7 +101,6 @@ godep go build -o "${CODECGEN}" github.com/ugorji/go/codec/codecgen
 for (( i=0; i < number; i++ )); do
   rm -f "${generated_files[${i}]}"
 done
-
 
 # Generate files in the dependency order.
 for current in "${index[@]}"; do

--- a/hack/verify-codecgen.sh
+++ b/hack/verify-codecgen.sh
@@ -54,7 +54,7 @@ result=""
 function depends {
   file=${generated_files[$1]//\.generated\.go/.go}
   deps=$(go list -f "{{.Deps}}" ${file} | tr "[" " " | tr "]" " ")
-  fullpath=$(readlink -f ${generated_files[$2]//\.generated\.go/.go})
+  fullpath=$(readlinkdashf "${generated_files[$2]//\.generated\.go/.go}")
   candidate=$(dirname "${fullpath}")
   result=false
   for dep in ${deps}; do


### PR DESCRIPTION
Implements `readlink -f` in shell since that does not work on OS X.
