### PR TITLE
Remove ~/repo before moving Cloud SDK components there

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -1306,6 +1306,7 @@ fi
 # at HEAD, release candidate.
 if [[ ! -z "${CLOUDSDK_BUCKET:-}" ]]; then
     gsutil -m cp -r "${CLOUDSDK_BUCKET}" ~
+    rm -rf ~/repo
     mv ~/$(basename "${CLOUDSDK_BUCKET}") ~/repo
     mkdir ~/cloudsdk
     tar zvxf ~/repo/google-cloud-sdk.tar.gz -C ~/cloudsdk


### PR DESCRIPTION
`~/repo` might have existed from a prior run, if we're doing jobs in sequence and not cleaning up in between.

Not sure if this is the right way to fix this problem; I'm open to suggestions.

Failure e.g. http://kubekins.dls.corp.google.com/view/Upgrade%20Test%20-%20GKE/job/kubernetes-upgrade-gke-1.0-master-step5-upgrade-cluster/21/console
