### PR TITLE
Remove ~/repo before moving Cloud SDK components there (on release-1.1)

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -1135,6 +1135,7 @@ fi
 # at HEAD, release candidate.
 if [[ ! -z "${CLOUDSDK_BUCKET:-}" ]]; then
     gsutil -m cp -r "${CLOUDSDK_BUCKET}" ~
+    rm -rf ~/repo
     mv ~/$(basename "${CLOUDSDK_BUCKET}") ~/repo
     mkdir ~/cloudsdk
     tar zvxf ~/repo/google-cloud-sdk.tar.gz -C ~/cloudsdk


### PR DESCRIPTION
Cherry pick of #18840 into release-1.1.
