### PR TITLE
external versions no longer need reordering

### DIFF
--- a/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/install/install.go
+++ b/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/install/install.go
@@ -65,18 +65,13 @@ func init() {
 }
 
 func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper {
-	worstToBestGroupVersions := []unversioned.GroupVersion{}
-	for i := len(externalVersions) - 1; i >= 0; i-- {
-		worstToBestGroupVersions = append(worstToBestGroupVersions, externalVersions[i])
-	}
-
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
 	rootScoped := sets.NewString()
 
 	ignoredKinds := sets.NewString()
 
-	return api.NewDefaultRESTMapper(worstToBestGroupVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
+	return api.NewDefaultRESTMapper(externalVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
 }
 
 // InterfacesFor returns the default Codec and ResourceVersioner for a given version

--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -90,11 +90,6 @@ func enableVersions(externalVersions []unversioned.GroupVersion) error {
 var userResources = []string{"rc", "svc", "pods", "pvc"}
 
 func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper {
-	worstToBestGroupVersions := []unversioned.GroupVersion{}
-	for i := len(externalVersions) - 1; i >= 0; i-- {
-		worstToBestGroupVersions = append(worstToBestGroupVersions, externalVersions[i])
-	}
-
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
 	rootScoped := sets.NewString(
@@ -117,7 +112,7 @@ func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper 
 		"ThirdPartyResourceData",
 		"ThirdPartyResourceList")
 
-	mapper := api.NewDefaultRESTMapper(worstToBestGroupVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
+	mapper := api.NewDefaultRESTMapper(externalVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
 	// setup aliases for groups of resources
 	mapper.AddResourceAlias("all", userResources...)
 

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -87,18 +87,13 @@ func enableVersions(externalVersions []unversioned.GroupVersion) error {
 }
 
 func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper {
-	worstToBestGroupVersions := []unversioned.GroupVersion{}
-	for i := len(externalVersions) - 1; i >= 0; i-- {
-		worstToBestGroupVersions = append(worstToBestGroupVersions, externalVersions[i])
-	}
-
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
 	rootScoped := sets.NewString()
 
 	ignoredKinds := sets.NewString()
 
-	return api.NewDefaultRESTMapper(worstToBestGroupVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
+	return api.NewDefaultRESTMapper(externalVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
 }
 
 // interfacesFor returns the default Codec and ResourceVersioner for a given version

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -87,18 +87,13 @@ func enableVersions(externalVersions []unversioned.GroupVersion) error {
 }
 
 func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper {
-	worstToBestGroupVersions := []unversioned.GroupVersion{}
-	for i := len(externalVersions) - 1; i >= 0; i-- {
-		worstToBestGroupVersions = append(worstToBestGroupVersions, externalVersions[i])
-	}
-
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
 	rootScoped := sets.NewString()
 
 	ignoredKinds := sets.NewString()
 
-	return api.NewDefaultRESTMapper(worstToBestGroupVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
+	return api.NewDefaultRESTMapper(externalVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
 }
 
 // interfacesFor returns the default Codec and ResourceVersioner for a given version

--- a/pkg/apis/metrics/install/install.go
+++ b/pkg/apis/metrics/install/install.go
@@ -87,18 +87,13 @@ func enableVersions(externalVersions []unversioned.GroupVersion) error {
 }
 
 func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper {
-	worstToBestGroupVersions := []unversioned.GroupVersion{}
-	for i := len(externalVersions) - 1; i >= 0; i-- {
-		worstToBestGroupVersions = append(worstToBestGroupVersions, externalVersions[i])
-	}
-
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
 	rootScoped := sets.NewString()
 
 	ignoredKinds := sets.NewString()
 
-	return api.NewDefaultRESTMapper(worstToBestGroupVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
+	return api.NewDefaultRESTMapper(externalVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
 }
 
 // interfacesFor returns the default Codec and ResourceVersioner for a given version


### PR DESCRIPTION
The `RESTMapper` used to required reversing the order of the `externalVersions` during creation because the priority of the `KindFor` matches was "last one wins". Now it uses the explicit priority chosen during creation, so the reversal is no longer needed.

Fixes https://github.com/kubernetes/kubernetes/issues/17372

@caesarxuchao @liggitt 
