### PR TITLE
Minimize log level for request backoffs

### DIFF
--- a/pkg/client/unversioned/restclient.go
+++ b/pkg/client/unversioned/restclient.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -94,12 +93,9 @@ func readExpBackoffConfig() BackoffManager {
 
 	backoffBaseInt, errBase := strconv.ParseInt(backoffBase, 10, 64)
 	backoffDurationInt, errDuration := strconv.ParseInt(backoffDuration, 10, 64)
-
 	if errBase != nil || errDuration != nil {
-		glog.V(2).Infof("Configuring no exponential backoff.")
 		return &NoBackoff{}
 	} else {
-		glog.V(2).Infof("Configuring exponential backoff as %v, %v", backoffBaseInt, backoffDurationInt)
 		return &URLBackoff{
 			Backoff: util.NewBackOff(
 				time.Duration(backoffBaseInt)*time.Second,


### PR DESCRIPTION
Fixes #18796 so that logs only will be created if running at high verbosity.
I can delete it if we really want... but the logs will trail off after startup either way...

```
while true; do cat /tmp/kube* | grep ackoff | wc -l
sleep 1 ; done
138
138
138
138
139
139
141
141
141
142
```
