### PR TITLE
Add a Jenkins job that updates gcloud components hourly

### DIFF
--- a/hack/jenkins/job-configs/jenkins-gcloud-update.yaml
+++ b/hack/jenkins/job-configs/jenkins-gcloud-update.yaml
@@ -1,0 +1,62 @@
+- job:
+    name: 'jenkins-gcloud-update'
+    description: 'Run gcloud components update. Test owner: spxtr.'
+    logrotate:
+        numToKeep: 200
+    builders:
+        - shell: |
+            # Once updates are removed elsewhere, remove the flock (#18846)
+            sudo chown jenkins:jenkins /var/run/lock/gcloud-components.lock
+            sudo chown -R jenkins:jenkins /usr/local/share/google
+            (
+              flock -x -w 60 9
+              gcloud components update
+              gcloud components update alpha
+              gcloud components update beta
+            ) 9> /var/run/lock/gcloud-components.lock
+
+- job:
+    name: 'jenkins-gcloud-update-all'
+    description: 'Update gcloud components on all nodes. Test owner: spxtr.'
+    logrotate:
+        numToKeep: 200
+    builders:
+        # Run jenkins-gcloud-update on all nodes.
+        - raw:
+            xml: |
+                <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@2.29">
+                    <configs>
+                        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+                            <configs class="empty-list"/>
+                            <configFactories>
+                                <org.jvnet.jenkins.plugins.nodelabelparameter.parameterizedtrigger.AllNodesBuildParameterFactory plugin="nodelabelparameter@1.7"/>
+                            </configFactories>
+                            <projects>jenkins-gcloud-update</projects>
+                            <condition>ALWAYS</condition>
+                            <triggerWithNoParameters>false</triggerWithNoParameters>
+                            <block>
+                                <buildStepFailureThreshold>
+                                    <name>FAILURE</name>
+                                    <ordinal>2</ordinal>
+                                    <color>RED</color>
+                                    <completeBuild>true</completeBuild>
+                                </buildStepFailureThreshold>
+                                <unstableThreshold>
+                                    <name>UNSTABLE</name>
+                                    <ordinal>1</ordinal>
+                                    <color>YELLOW</color>
+                                    <completeBuild>true</completeBuild>
+                                </unstableThreshold>
+                                <failureThreshold>
+                                    <name>FAILURE</name>
+                                    <ordinal>2</ordinal>
+                                    <color>RED</color>
+                                    <completeBuild>true</completeBuild>
+                                </failureThreshold>
+                            </block>
+                            <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+                        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+                    </configs>
+                </hudson.plugins.parameterizedtrigger.TriggerBuilder>
+    triggers:
+        - timed: '@daily'


### PR DESCRIPTION
Two jobs, actually, since there isn't a tidy way to make the same job trigger itself on multiple nodes. I tried playing around with conditional steps to do that, but it's a real hassle.

@ixdy: we'll need a copy on PR Jenkins, and we don't have JJB pointing there yet.

ref: #18846
