### PR TITLE
[minor] Explain the way e2e's are rigged into the build product through go te…

### DIFF
--- a/docs/devel/e2e-tests.md
+++ b/docs/devel/e2e-tests.md
@@ -55,6 +55,12 @@ The output for the end-2-end tests will be a single binary called `e2e.test` und
 
 `$ ./e2e.test --help`
 
+Implementation detail for test developers:  These tests are compiled using `go test -c`, and like any golang test, they end with an _test suffix.
+
+The build machinery of kuberentes declares the test target and `go test -c` is used to compile a binary from that test target's directory, and this binary is included as a kubernetes build artifact.  To learn more about this, read about the go test command.
+
+To see precisely how the e2e tests are compiled and built, see [the build script] (https://github.com/kubernetes/kubernetes/blob/master/hack/build-go.sh).
+
 ### Running the Tests
 
 For the purposes of brevity, we will look at a subset of the options, which are listed below:

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -62,6 +62,7 @@ readonly KUBE_CLIENT_BINARIES_WIN=("${KUBE_CLIENT_BINARIES[@]/%/.exe}")
 
 # The set of test targets that we are building for all platforms
 kube::golang::test_targets() {
+  # targets array: Note that for tests we append .test to signify different compilation strategy
   local targets=(
     cmd/integration
     cmd/gendocs


### PR DESCRIPTION
 I think its worth adding a comment since the test/e2e/test.e2e artifact is a non existent directory, took me a couple of hours to figure out why and how the e2e.test binary is manufactured.  Turns out that the go test logic builds a test package, and that our shell script signifies the build to compile anything with `.test` using the `go test` directive.  Updates @timothysc 's original doc as well as the hack script with a quick comment. 
