### PR TITLE
Add gke-ci and gke-ci-reboot to source control

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -238,7 +238,6 @@ E2E_OPT=${E2E_OPT:-""}
 # Set environment variables shared for all of the GCE Jenkins projects.
 if [[ ${JOB_NAME} =~ ^kubernetes-.*-gce ]]; then
   KUBERNETES_PROVIDER="gce"
-  : ${GCE_SERVICE_ACCOUNT:=$(gcloud auth list 2> /dev/null | grep active | cut -f3 -d' ')}
   : ${E2E_MIN_STARTUP_PODS:="1"}
   : ${E2E_ZONE:="us-central1-f"}
   : ${NUM_NODES_PARALLEL:="6"}  # Number of nodes required to run all of the tests in parallel
@@ -1102,7 +1101,7 @@ export KUBE_GCS_STAGING_PATH_SUFFIX=${KUBE_GCS_STAGING_PATH_SUFFIX:-}
 export KUBE_GCE_NODE_PROJECT=${KUBE_GCE_NODE_PROJECT:-}
 export KUBE_GCE_NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-}
 export KUBE_OS_DISTRIBUTION=${KUBE_OS_DISTRIBUTION:-}
-export GCE_SERVICE_ACCOUNT=${GCE_SERVICE_ACCOUNT:-}
+export GCE_SERVICE_ACCOUNT=$(gcloud auth list 2> /dev/null | grep active | cut -f3 -d' ')
 
 # GKE variables
 export CLUSTER_NAME=${E2E_CLUSTER_NAME}

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -60,5 +60,25 @@
         - 'gce-slow':
             description: 'Run slow E2E tests on GCE using the latest successful build.'
             timeout: 270
+        - 'gke-ci':
+            description: |
+                Run e2e tests using the following config:<br>
+                - provider: GKE<br>
+                - apiary: staging<br>
+                - borg job: test<br>
+                - client (kubectl): ci/latest.txt<br>
+                - cluster (k8s): ci/latest.txt<br>
+                - tests: ci/latest.txt
+            timeout: 300
+        - 'gke-ci-reboot:':
+            description: |
+                Run e2e tests using the following config:<br>
+                - provider: GKE<br>
+                - apiary: staging<br>
+                - borg job: test<br>
+                - client (kubectl): ci/latest.txt<br>
+                - cluster (k8s): ci/latest.txt<br>
+                - tests: ci/latest.txt
+            timeout: 120
     jobs:
         - 'kubernetes-e2e-{suffix}'


### PR DESCRIPTION
This is hopefully the last change to make to e2e.sh, so once this is in and tested I can make the changes to release-1.0 and release-1.1 branches and add the rest of the e2e tests.
#18122
