### PR TITLE
Undo unintentional changes to goidl testdata

### DIFF
--- a/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/types.generated.go
+++ b/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/types.generated.go
@@ -158,13 +158,7 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[2] {
 					yy10 := &x.ObjectMeta
-					yym11 := z.EncBinary()
-					_ = yym11
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy10) {
-					} else {
-						z.EncFallback(yy10)
-					}
+					yy10.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
@@ -173,14 +167,8 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy12 := &x.ObjectMeta
-					yym13 := z.EncBinary()
-					_ = yym13
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy12) {
-					} else {
-						z.EncFallback(yy12)
-					}
+					yy11 := &x.ObjectMeta
+					yy11.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -196,25 +184,25 @@ func (x *TestType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym14 := z.DecBinary()
-	_ = yym14
+	yym12 := z.DecBinary()
+	_ = yym12
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct15 := r.ContainerType()
-		if yyct15 == codecSelferValueTypeMap1234 {
-			yyl15 := r.ReadMapStart()
-			if yyl15 == 0 {
+		yyct13 := r.ContainerType()
+		if yyct13 == codecSelferValueTypeMap1234 {
+			yyl13 := r.ReadMapStart()
+			if yyl13 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl15, d)
+				x.codecDecodeSelfFromMap(yyl13, d)
 			}
-		} else if yyct15 == codecSelferValueTypeArray1234 {
-			yyl15 := r.ReadArrayStart()
-			if yyl15 == 0 {
+		} else if yyct13 == codecSelferValueTypeArray1234 {
+			yyl13 := r.ReadArrayStart()
+			if yyl13 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl15, d)
+				x.codecDecodeSelfFromArray(yyl13, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -226,12 +214,12 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys16Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys16Slc
-	var yyhl16 bool = l >= 0
-	for yyj16 := 0; ; yyj16++ {
-		if yyhl16 {
-			if yyj16 >= l {
+	var yys14Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys14Slc
+	var yyhl14 bool = l >= 0
+	for yyj14 := 0; ; yyj14++ {
+		if yyhl14 {
+			if yyj14 >= l {
 				break
 			}
 		} else {
@@ -240,10 +228,10 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys16Slc = r.DecodeBytes(yys16Slc, true, true)
-		yys16 := string(yys16Slc)
+		yys14Slc = r.DecodeBytes(yys14Slc, true, true)
+		yys14 := string(yys14Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys16 {
+		switch yys14 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -260,19 +248,13 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv19 := &x.ObjectMeta
-				yym20 := z.DecBinary()
-				_ = yym20
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv19) {
-				} else {
-					z.DecFallback(yyv19, false)
-				}
+				yyv17 := &x.ObjectMeta
+				yyv17.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys16)
-		} // end switch yys16
-	} // end for yyj16
+			z.DecStructFieldNotFound(-1, yys14)
+		} // end switch yys14
+	} // end for yyj14
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -280,16 +262,16 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj21 int
-	var yyb21 bool
-	var yyhl21 bool = l >= 0
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	var yyj18 int
+	var yyb18 bool
+	var yyhl18 bool = l >= 0
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb21 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb21 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -299,13 +281,13 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb21 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb21 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -315,13 +297,13 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb21 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb21 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -329,27 +311,21 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv24 := &x.ObjectMeta
-		yym25 := z.DecBinary()
-		_ = yym25
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv24) {
-		} else {
-			z.DecFallback(yyv24, false)
-		}
+		yyv21 := &x.ObjectMeta
+		yyv21.CodecDecodeSelf(d)
 	}
 	for {
-		yyj21++
-		if yyhl21 {
-			yyb21 = yyj21 > l
+		yyj18++
+		if yyhl18 {
+			yyb18 = yyj18 > l
 		} else {
-			yyb21 = r.CheckBreak()
+			yyb18 = r.CheckBreak()
 		}
-		if yyb21 {
+		if yyb18 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj21-1, "")
+		z.DecStructFieldNotFound(yyj18-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -361,118 +337,118 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym26 := z.EncBinary()
-		_ = yym26
+		yym22 := z.EncBinary()
+		_ = yym22
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep27 := !z.EncBinary()
-			yy2arr27 := z.EncBasicHandle().StructToArray
-			var yyq27 [4]bool
-			_, _, _ = yysep27, yyq27, yy2arr27
-			const yyr27 bool = false
-			yyq27[0] = x.Kind != ""
-			yyq27[1] = x.APIVersion != ""
-			yyq27[2] = true
-			var yynn27 int
-			if yyr27 || yy2arr27 {
+			yysep23 := !z.EncBinary()
+			yy2arr23 := z.EncBasicHandle().StructToArray
+			var yyq23 [4]bool
+			_, _, _ = yysep23, yyq23, yy2arr23
+			const yyr23 bool = false
+			yyq23[0] = x.Kind != ""
+			yyq23[1] = x.APIVersion != ""
+			yyq23[2] = true
+			var yynn23 int
+			if yyr23 || yy2arr23 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn27 = 1
-				for _, b := range yyq27 {
+				yynn23 = 1
+				for _, b := range yyq23 {
 					if b {
-						yynn27++
+						yynn23++
 					}
 				}
-				r.EncodeMapStart(yynn27)
-				yynn27 = 0
+				r.EncodeMapStart(yynn23)
+				yynn23 = 0
 			}
-			if yyr27 || yy2arr27 {
+			if yyr23 || yy2arr23 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq27[0] {
+				if yyq23[0] {
+					yym25 := z.EncBinary()
+					_ = yym25
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq23[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym26 := z.EncBinary()
+					_ = yym26
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr23 || yy2arr23 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq23[1] {
+					yym28 := z.EncBinary()
+					_ = yym28
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq23[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym29 := z.EncBinary()
 					_ = yym29
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq27[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym30 := z.EncBinary()
-					_ = yym30
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr27 || yy2arr27 {
+			if yyr23 || yy2arr23 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq27[1] {
+				if yyq23[2] {
+					yy31 := &x.ListMeta
 					yym32 := z.EncBinary()
 					_ = yym32
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy31) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq27[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym33 := z.EncBinary()
-					_ = yym33
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr27 || yy2arr27 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq27[2] {
-					yy35 := &x.ListMeta
-					yym36 := z.EncBinary()
-					_ = yym36
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy35) {
-					} else {
-						z.EncFallback(yy35)
+						z.EncFallback(yy31)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq27[2] {
+				if yyq23[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy37 := &x.ListMeta
-					yym38 := z.EncBinary()
-					_ = yym38
+					yy33 := &x.ListMeta
+					yym34 := z.EncBinary()
+					_ = yym34
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy37) {
+					} else if z.HasExtensions() && z.EncExt(yy33) {
 					} else {
-						z.EncFallback(yy37)
+						z.EncFallback(yy33)
 					}
 				}
 			}
-			if yyr27 || yy2arr27 {
+			if yyr23 || yy2arr23 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym40 := z.EncBinary()
-					_ = yym40
+					yym36 := z.EncBinary()
+					_ = yym36
 					if false {
 					} else {
 						h.encSliceTestType(([]TestType)(x.Items), e)
@@ -485,15 +461,15 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym41 := z.EncBinary()
-					_ = yym41
+					yym37 := z.EncBinary()
+					_ = yym37
 					if false {
 					} else {
 						h.encSliceTestType(([]TestType)(x.Items), e)
 					}
 				}
 			}
-			if yyr27 || yy2arr27 {
+			if yyr23 || yy2arr23 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -506,25 +482,25 @@ func (x *TestTypeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym42 := z.DecBinary()
-	_ = yym42
+	yym38 := z.DecBinary()
+	_ = yym38
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct43 := r.ContainerType()
-		if yyct43 == codecSelferValueTypeMap1234 {
-			yyl43 := r.ReadMapStart()
-			if yyl43 == 0 {
+		yyct39 := r.ContainerType()
+		if yyct39 == codecSelferValueTypeMap1234 {
+			yyl39 := r.ReadMapStart()
+			if yyl39 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl43, d)
+				x.codecDecodeSelfFromMap(yyl39, d)
 			}
-		} else if yyct43 == codecSelferValueTypeArray1234 {
-			yyl43 := r.ReadArrayStart()
-			if yyl43 == 0 {
+		} else if yyct39 == codecSelferValueTypeArray1234 {
+			yyl39 := r.ReadArrayStart()
+			if yyl39 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl43, d)
+				x.codecDecodeSelfFromArray(yyl39, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -536,12 +512,12 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys44Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys44Slc
-	var yyhl44 bool = l >= 0
-	for yyj44 := 0; ; yyj44++ {
-		if yyhl44 {
-			if yyj44 >= l {
+	var yys40Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys40Slc
+	var yyhl40 bool = l >= 0
+	for yyj40 := 0; ; yyj40++ {
+		if yyhl40 {
+			if yyj40 >= l {
 				break
 			}
 		} else {
@@ -550,10 +526,10 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys44Slc = r.DecodeBytes(yys44Slc, true, true)
-		yys44 := string(yys44Slc)
+		yys40Slc = r.DecodeBytes(yys40Slc, true, true)
+		yys40 := string(yys40Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys44 {
+		switch yys40 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -570,31 +546,31 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv47 := &x.ListMeta
-				yym48 := z.DecBinary()
-				_ = yym48
+				yyv43 := &x.ListMeta
+				yym44 := z.DecBinary()
+				_ = yym44
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv47) {
+				} else if z.HasExtensions() && z.DecExt(yyv43) {
 				} else {
-					z.DecFallback(yyv47, false)
+					z.DecFallback(yyv43, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv49 := &x.Items
-				yym50 := z.DecBinary()
-				_ = yym50
+				yyv45 := &x.Items
+				yym46 := z.DecBinary()
+				_ = yym46
 				if false {
 				} else {
-					h.decSliceTestType((*[]TestType)(yyv49), d)
+					h.decSliceTestType((*[]TestType)(yyv45), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys44)
-		} // end switch yys44
-	} // end for yyj44
+			z.DecStructFieldNotFound(-1, yys40)
+		} // end switch yys40
+	} // end for yyj40
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -602,16 +578,16 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj51 int
-	var yyb51 bool
-	var yyhl51 bool = l >= 0
-	yyj51++
-	if yyhl51 {
-		yyb51 = yyj51 > l
+	var yyj47 int
+	var yyb47 bool
+	var yyhl47 bool = l >= 0
+	yyj47++
+	if yyhl47 {
+		yyb47 = yyj47 > l
 	} else {
-		yyb51 = r.CheckBreak()
+		yyb47 = r.CheckBreak()
 	}
-	if yyb51 {
+	if yyb47 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -621,13 +597,13 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj51++
-	if yyhl51 {
-		yyb51 = yyj51 > l
+	yyj47++
+	if yyhl47 {
+		yyb47 = yyj47 > l
 	} else {
-		yyb51 = r.CheckBreak()
+		yyb47 = r.CheckBreak()
 	}
-	if yyb51 {
+	if yyb47 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -637,13 +613,13 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj51++
-	if yyhl51 {
-		yyb51 = yyj51 > l
+	yyj47++
+	if yyhl47 {
+		yyb47 = yyj47 > l
 	} else {
-		yyb51 = r.CheckBreak()
+		yyb47 = r.CheckBreak()
 	}
-	if yyb51 {
+	if yyb47 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -651,22 +627,22 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv54 := &x.ListMeta
-		yym55 := z.DecBinary()
-		_ = yym55
+		yyv50 := &x.ListMeta
+		yym51 := z.DecBinary()
+		_ = yym51
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv54) {
+		} else if z.HasExtensions() && z.DecExt(yyv50) {
 		} else {
-			z.DecFallback(yyv54, false)
+			z.DecFallback(yyv50, false)
 		}
 	}
-	yyj51++
-	if yyhl51 {
-		yyb51 = yyj51 > l
+	yyj47++
+	if yyhl47 {
+		yyb47 = yyj47 > l
 	} else {
-		yyb51 = r.CheckBreak()
+		yyb47 = r.CheckBreak()
 	}
-	if yyb51 {
+	if yyb47 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -674,26 +650,26 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv56 := &x.Items
-		yym57 := z.DecBinary()
-		_ = yym57
+		yyv52 := &x.Items
+		yym53 := z.DecBinary()
+		_ = yym53
 		if false {
 		} else {
-			h.decSliceTestType((*[]TestType)(yyv56), d)
+			h.decSliceTestType((*[]TestType)(yyv52), d)
 		}
 	}
 	for {
-		yyj51++
-		if yyhl51 {
-			yyb51 = yyj51 > l
+		yyj47++
+		if yyhl47 {
+			yyb47 = yyj47 > l
 		} else {
-			yyb51 = r.CheckBreak()
+			yyb47 = r.CheckBreak()
 		}
-		if yyb51 {
+		if yyb47 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj51-1, "")
+		z.DecStructFieldNotFound(yyj47-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -703,10 +679,10 @@ func (x codecSelfer1234) encSliceTestType(v []TestType, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv58 := range v {
+	for _, yyv54 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy59 := &yyv58
-		yy59.CodecEncodeSelf(e)
+		yy55 := &yyv54
+		yy55.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -716,83 +692,83 @@ func (x codecSelfer1234) decSliceTestType(v *[]TestType, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv60 := *v
-	yyh60, yyl60 := z.DecSliceHelperStart()
-	var yyc60 bool
-	if yyl60 == 0 {
-		if yyv60 == nil {
-			yyv60 = []TestType{}
-			yyc60 = true
-		} else if len(yyv60) != 0 {
-			yyv60 = yyv60[:0]
-			yyc60 = true
+	yyv56 := *v
+	yyh56, yyl56 := z.DecSliceHelperStart()
+	var yyc56 bool
+	if yyl56 == 0 {
+		if yyv56 == nil {
+			yyv56 = []TestType{}
+			yyc56 = true
+		} else if len(yyv56) != 0 {
+			yyv56 = yyv56[:0]
+			yyc56 = true
 		}
-	} else if yyl60 > 0 {
-		var yyrr60, yyrl60 int
-		var yyrt60 bool
-		if yyl60 > cap(yyv60) {
+	} else if yyl56 > 0 {
+		var yyrr56, yyrl56 int
+		var yyrt56 bool
+		if yyl56 > cap(yyv56) {
 
-			yyrg60 := len(yyv60) > 0
-			yyv260 := yyv60
-			yyrl60, yyrt60 = z.DecInferLen(yyl60, z.DecBasicHandle().MaxInitLen, 192)
-			if yyrt60 {
-				if yyrl60 <= cap(yyv60) {
-					yyv60 = yyv60[:yyrl60]
+			yyrg56 := len(yyv56) > 0
+			yyv256 := yyv56
+			yyrl56, yyrt56 = z.DecInferLen(yyl56, z.DecBasicHandle().MaxInitLen, 192)
+			if yyrt56 {
+				if yyrl56 <= cap(yyv56) {
+					yyv56 = yyv56[:yyrl56]
 				} else {
-					yyv60 = make([]TestType, yyrl60)
+					yyv56 = make([]TestType, yyrl56)
 				}
 			} else {
-				yyv60 = make([]TestType, yyrl60)
+				yyv56 = make([]TestType, yyrl56)
 			}
-			yyc60 = true
-			yyrr60 = len(yyv60)
-			if yyrg60 {
-				copy(yyv60, yyv260)
+			yyc56 = true
+			yyrr56 = len(yyv56)
+			if yyrg56 {
+				copy(yyv56, yyv256)
 			}
-		} else if yyl60 != len(yyv60) {
-			yyv60 = yyv60[:yyl60]
-			yyc60 = true
+		} else if yyl56 != len(yyv56) {
+			yyv56 = yyv56[:yyl56]
+			yyc56 = true
 		}
-		yyj60 := 0
-		for ; yyj60 < yyrr60; yyj60++ {
-			yyh60.ElemContainerState(yyj60)
+		yyj56 := 0
+		for ; yyj56 < yyrr56; yyj56++ {
+			yyh56.ElemContainerState(yyj56)
 			if r.TryDecodeAsNil() {
-				yyv60[yyj60] = TestType{}
+				yyv56[yyj56] = TestType{}
 			} else {
-				yyv61 := &yyv60[yyj60]
-				yyv61.CodecDecodeSelf(d)
+				yyv57 := &yyv56[yyj56]
+				yyv57.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt60 {
-			for ; yyj60 < yyl60; yyj60++ {
-				yyv60 = append(yyv60, TestType{})
-				yyh60.ElemContainerState(yyj60)
+		if yyrt56 {
+			for ; yyj56 < yyl56; yyj56++ {
+				yyv56 = append(yyv56, TestType{})
+				yyh56.ElemContainerState(yyj56)
 				if r.TryDecodeAsNil() {
-					yyv60[yyj60] = TestType{}
+					yyv56[yyj56] = TestType{}
 				} else {
-					yyv62 := &yyv60[yyj60]
-					yyv62.CodecDecodeSelf(d)
+					yyv58 := &yyv56[yyj56]
+					yyv58.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj60 := 0
-		for ; !r.CheckBreak(); yyj60++ {
+		yyj56 := 0
+		for ; !r.CheckBreak(); yyj56++ {
 
-			if yyj60 >= len(yyv60) {
-				yyv60 = append(yyv60, TestType{}) // var yyz60 TestType
-				yyc60 = true
+			if yyj56 >= len(yyv56) {
+				yyv56 = append(yyv56, TestType{}) // var yyz56 TestType
+				yyc56 = true
 			}
-			yyh60.ElemContainerState(yyj60)
-			if yyj60 < len(yyv60) {
+			yyh56.ElemContainerState(yyj56)
+			if yyj56 < len(yyv56) {
 				if r.TryDecodeAsNil() {
-					yyv60[yyj60] = TestType{}
+					yyv56[yyj56] = TestType{}
 				} else {
-					yyv63 := &yyv60[yyj60]
-					yyv63.CodecDecodeSelf(d)
+					yyv59 := &yyv56[yyj56]
+					yyv59.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -800,16 +776,16 @@ func (x codecSelfer1234) decSliceTestType(v *[]TestType, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj60 < len(yyv60) {
-			yyv60 = yyv60[:yyj60]
-			yyc60 = true
-		} else if yyj60 == 0 && yyv60 == nil {
-			yyv60 = []TestType{}
-			yyc60 = true
+		if yyj56 < len(yyv56) {
+			yyv56 = yyv56[:yyj56]
+			yyc56 = true
+		} else if yyj56 == 0 && yyv56 == nil {
+			yyv56 = []TestType{}
+			yyc56 = true
 		}
 	}
-	yyh60.End()
-	if yyc60 {
-		*v = yyv60
+	yyh56.End()
+	if yyc56 {
+		*v = yyv56
 	}
 }

--- a/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/v1/types.generated.go
+++ b/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/v1/types.generated.go
@@ -158,13 +158,7 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[2] {
 					yy10 := &x.ObjectMeta
-					yym11 := z.EncBinary()
-					_ = yym11
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy10) {
-					} else {
-						z.EncFallback(yy10)
-					}
+					yy10.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
@@ -173,14 +167,8 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy12 := &x.ObjectMeta
-					yym13 := z.EncBinary()
-					_ = yym13
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy12) {
-					} else {
-						z.EncFallback(yy12)
-					}
+					yy11 := &x.ObjectMeta
+					yy11.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -196,25 +184,25 @@ func (x *TestType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym14 := z.DecBinary()
-	_ = yym14
+	yym12 := z.DecBinary()
+	_ = yym12
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct15 := r.ContainerType()
-		if yyct15 == codecSelferValueTypeMap1234 {
-			yyl15 := r.ReadMapStart()
-			if yyl15 == 0 {
+		yyct13 := r.ContainerType()
+		if yyct13 == codecSelferValueTypeMap1234 {
+			yyl13 := r.ReadMapStart()
+			if yyl13 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl15, d)
+				x.codecDecodeSelfFromMap(yyl13, d)
 			}
-		} else if yyct15 == codecSelferValueTypeArray1234 {
-			yyl15 := r.ReadArrayStart()
-			if yyl15 == 0 {
+		} else if yyct13 == codecSelferValueTypeArray1234 {
+			yyl13 := r.ReadArrayStart()
+			if yyl13 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl15, d)
+				x.codecDecodeSelfFromArray(yyl13, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -226,12 +214,12 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys16Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys16Slc
-	var yyhl16 bool = l >= 0
-	for yyj16 := 0; ; yyj16++ {
-		if yyhl16 {
-			if yyj16 >= l {
+	var yys14Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys14Slc
+	var yyhl14 bool = l >= 0
+	for yyj14 := 0; ; yyj14++ {
+		if yyhl14 {
+			if yyj14 >= l {
 				break
 			}
 		} else {
@@ -240,10 +228,10 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys16Slc = r.DecodeBytes(yys16Slc, true, true)
-		yys16 := string(yys16Slc)
+		yys14Slc = r.DecodeBytes(yys14Slc, true, true)
+		yys14 := string(yys14Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys16 {
+		switch yys14 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -260,19 +248,13 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv19 := &x.ObjectMeta
-				yym20 := z.DecBinary()
-				_ = yym20
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv19) {
-				} else {
-					z.DecFallback(yyv19, false)
-				}
+				yyv17 := &x.ObjectMeta
+				yyv17.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys16)
-		} // end switch yys16
-	} // end for yyj16
+			z.DecStructFieldNotFound(-1, yys14)
+		} // end switch yys14
+	} // end for yyj14
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -280,16 +262,16 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj21 int
-	var yyb21 bool
-	var yyhl21 bool = l >= 0
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	var yyj18 int
+	var yyb18 bool
+	var yyhl18 bool = l >= 0
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb21 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb21 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -299,13 +281,13 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb21 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb21 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -315,13 +297,13 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb21 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb21 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -329,27 +311,21 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv24 := &x.ObjectMeta
-		yym25 := z.DecBinary()
-		_ = yym25
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv24) {
-		} else {
-			z.DecFallback(yyv24, false)
-		}
+		yyv21 := &x.ObjectMeta
+		yyv21.CodecDecodeSelf(d)
 	}
 	for {
-		yyj21++
-		if yyhl21 {
-			yyb21 = yyj21 > l
+		yyj18++
+		if yyhl18 {
+			yyb18 = yyj18 > l
 		} else {
-			yyb21 = r.CheckBreak()
+			yyb18 = r.CheckBreak()
 		}
-		if yyb21 {
+		if yyb18 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj21-1, "")
+		z.DecStructFieldNotFound(yyj18-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -361,118 +337,118 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym26 := z.EncBinary()
-		_ = yym26
+		yym22 := z.EncBinary()
+		_ = yym22
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep27 := !z.EncBinary()
-			yy2arr27 := z.EncBasicHandle().StructToArray
-			var yyq27 [4]bool
-			_, _, _ = yysep27, yyq27, yy2arr27
-			const yyr27 bool = false
-			yyq27[0] = x.Kind != ""
-			yyq27[1] = x.APIVersion != ""
-			yyq27[2] = true
-			var yynn27 int
-			if yyr27 || yy2arr27 {
+			yysep23 := !z.EncBinary()
+			yy2arr23 := z.EncBasicHandle().StructToArray
+			var yyq23 [4]bool
+			_, _, _ = yysep23, yyq23, yy2arr23
+			const yyr23 bool = false
+			yyq23[0] = x.Kind != ""
+			yyq23[1] = x.APIVersion != ""
+			yyq23[2] = true
+			var yynn23 int
+			if yyr23 || yy2arr23 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn27 = 1
-				for _, b := range yyq27 {
+				yynn23 = 1
+				for _, b := range yyq23 {
 					if b {
-						yynn27++
+						yynn23++
 					}
 				}
-				r.EncodeMapStart(yynn27)
-				yynn27 = 0
+				r.EncodeMapStart(yynn23)
+				yynn23 = 0
 			}
-			if yyr27 || yy2arr27 {
+			if yyr23 || yy2arr23 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq27[0] {
+				if yyq23[0] {
+					yym25 := z.EncBinary()
+					_ = yym25
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq23[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym26 := z.EncBinary()
+					_ = yym26
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr23 || yy2arr23 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq23[1] {
+					yym28 := z.EncBinary()
+					_ = yym28
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq23[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym29 := z.EncBinary()
 					_ = yym29
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq27[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym30 := z.EncBinary()
-					_ = yym30
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr27 || yy2arr27 {
+			if yyr23 || yy2arr23 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq27[1] {
+				if yyq23[2] {
+					yy31 := &x.ListMeta
 					yym32 := z.EncBinary()
 					_ = yym32
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy31) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq27[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym33 := z.EncBinary()
-					_ = yym33
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr27 || yy2arr27 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq27[2] {
-					yy35 := &x.ListMeta
-					yym36 := z.EncBinary()
-					_ = yym36
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy35) {
-					} else {
-						z.EncFallback(yy35)
+						z.EncFallback(yy31)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq27[2] {
+				if yyq23[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy37 := &x.ListMeta
-					yym38 := z.EncBinary()
-					_ = yym38
+					yy33 := &x.ListMeta
+					yym34 := z.EncBinary()
+					_ = yym34
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy37) {
+					} else if z.HasExtensions() && z.EncExt(yy33) {
 					} else {
-						z.EncFallback(yy37)
+						z.EncFallback(yy33)
 					}
 				}
 			}
-			if yyr27 || yy2arr27 {
+			if yyr23 || yy2arr23 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym40 := z.EncBinary()
-					_ = yym40
+					yym36 := z.EncBinary()
+					_ = yym36
 					if false {
 					} else {
 						h.encSliceTestType(([]TestType)(x.Items), e)
@@ -485,15 +461,15 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym41 := z.EncBinary()
-					_ = yym41
+					yym37 := z.EncBinary()
+					_ = yym37
 					if false {
 					} else {
 						h.encSliceTestType(([]TestType)(x.Items), e)
 					}
 				}
 			}
-			if yyr27 || yy2arr27 {
+			if yyr23 || yy2arr23 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -506,25 +482,25 @@ func (x *TestTypeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym42 := z.DecBinary()
-	_ = yym42
+	yym38 := z.DecBinary()
+	_ = yym38
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct43 := r.ContainerType()
-		if yyct43 == codecSelferValueTypeMap1234 {
-			yyl43 := r.ReadMapStart()
-			if yyl43 == 0 {
+		yyct39 := r.ContainerType()
+		if yyct39 == codecSelferValueTypeMap1234 {
+			yyl39 := r.ReadMapStart()
+			if yyl39 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl43, d)
+				x.codecDecodeSelfFromMap(yyl39, d)
 			}
-		} else if yyct43 == codecSelferValueTypeArray1234 {
-			yyl43 := r.ReadArrayStart()
-			if yyl43 == 0 {
+		} else if yyct39 == codecSelferValueTypeArray1234 {
+			yyl39 := r.ReadArrayStart()
+			if yyl39 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl43, d)
+				x.codecDecodeSelfFromArray(yyl39, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -536,12 +512,12 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys44Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys44Slc
-	var yyhl44 bool = l >= 0
-	for yyj44 := 0; ; yyj44++ {
-		if yyhl44 {
-			if yyj44 >= l {
+	var yys40Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys40Slc
+	var yyhl40 bool = l >= 0
+	for yyj40 := 0; ; yyj40++ {
+		if yyhl40 {
+			if yyj40 >= l {
 				break
 			}
 		} else {
@@ -550,10 +526,10 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys44Slc = r.DecodeBytes(yys44Slc, true, true)
-		yys44 := string(yys44Slc)
+		yys40Slc = r.DecodeBytes(yys40Slc, true, true)
+		yys40 := string(yys40Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys44 {
+		switch yys40 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -570,31 +546,31 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv47 := &x.ListMeta
-				yym48 := z.DecBinary()
-				_ = yym48
+				yyv43 := &x.ListMeta
+				yym44 := z.DecBinary()
+				_ = yym44
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv47) {
+				} else if z.HasExtensions() && z.DecExt(yyv43) {
 				} else {
-					z.DecFallback(yyv47, false)
+					z.DecFallback(yyv43, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv49 := &x.Items
-				yym50 := z.DecBinary()
-				_ = yym50
+				yyv45 := &x.Items
+				yym46 := z.DecBinary()
+				_ = yym46
 				if false {
 				} else {
-					h.decSliceTestType((*[]TestType)(yyv49), d)
+					h.decSliceTestType((*[]TestType)(yyv45), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys44)
-		} // end switch yys44
-	} // end for yyj44
+			z.DecStructFieldNotFound(-1, yys40)
+		} // end switch yys40
+	} // end for yyj40
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -602,16 +578,16 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj51 int
-	var yyb51 bool
-	var yyhl51 bool = l >= 0
-	yyj51++
-	if yyhl51 {
-		yyb51 = yyj51 > l
+	var yyj47 int
+	var yyb47 bool
+	var yyhl47 bool = l >= 0
+	yyj47++
+	if yyhl47 {
+		yyb47 = yyj47 > l
 	} else {
-		yyb51 = r.CheckBreak()
+		yyb47 = r.CheckBreak()
 	}
-	if yyb51 {
+	if yyb47 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -621,13 +597,13 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj51++
-	if yyhl51 {
-		yyb51 = yyj51 > l
+	yyj47++
+	if yyhl47 {
+		yyb47 = yyj47 > l
 	} else {
-		yyb51 = r.CheckBreak()
+		yyb47 = r.CheckBreak()
 	}
-	if yyb51 {
+	if yyb47 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -637,13 +613,13 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj51++
-	if yyhl51 {
-		yyb51 = yyj51 > l
+	yyj47++
+	if yyhl47 {
+		yyb47 = yyj47 > l
 	} else {
-		yyb51 = r.CheckBreak()
+		yyb47 = r.CheckBreak()
 	}
-	if yyb51 {
+	if yyb47 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -651,22 +627,22 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv54 := &x.ListMeta
-		yym55 := z.DecBinary()
-		_ = yym55
+		yyv50 := &x.ListMeta
+		yym51 := z.DecBinary()
+		_ = yym51
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv54) {
+		} else if z.HasExtensions() && z.DecExt(yyv50) {
 		} else {
-			z.DecFallback(yyv54, false)
+			z.DecFallback(yyv50, false)
 		}
 	}
-	yyj51++
-	if yyhl51 {
-		yyb51 = yyj51 > l
+	yyj47++
+	if yyhl47 {
+		yyb47 = yyj47 > l
 	} else {
-		yyb51 = r.CheckBreak()
+		yyb47 = r.CheckBreak()
 	}
-	if yyb51 {
+	if yyb47 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -674,26 +650,26 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv56 := &x.Items
-		yym57 := z.DecBinary()
-		_ = yym57
+		yyv52 := &x.Items
+		yym53 := z.DecBinary()
+		_ = yym53
 		if false {
 		} else {
-			h.decSliceTestType((*[]TestType)(yyv56), d)
+			h.decSliceTestType((*[]TestType)(yyv52), d)
 		}
 	}
 	for {
-		yyj51++
-		if yyhl51 {
-			yyb51 = yyj51 > l
+		yyj47++
+		if yyhl47 {
+			yyb47 = yyj47 > l
 		} else {
-			yyb51 = r.CheckBreak()
+			yyb47 = r.CheckBreak()
 		}
-		if yyb51 {
+		if yyb47 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj51-1, "")
+		z.DecStructFieldNotFound(yyj47-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -703,10 +679,10 @@ func (x codecSelfer1234) encSliceTestType(v []TestType, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv58 := range v {
+	for _, yyv54 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy59 := &yyv58
-		yy59.CodecEncodeSelf(e)
+		yy55 := &yyv54
+		yy55.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -716,83 +692,83 @@ func (x codecSelfer1234) decSliceTestType(v *[]TestType, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv60 := *v
-	yyh60, yyl60 := z.DecSliceHelperStart()
-	var yyc60 bool
-	if yyl60 == 0 {
-		if yyv60 == nil {
-			yyv60 = []TestType{}
-			yyc60 = true
-		} else if len(yyv60) != 0 {
-			yyv60 = yyv60[:0]
-			yyc60 = true
+	yyv56 := *v
+	yyh56, yyl56 := z.DecSliceHelperStart()
+	var yyc56 bool
+	if yyl56 == 0 {
+		if yyv56 == nil {
+			yyv56 = []TestType{}
+			yyc56 = true
+		} else if len(yyv56) != 0 {
+			yyv56 = yyv56[:0]
+			yyc56 = true
 		}
-	} else if yyl60 > 0 {
-		var yyrr60, yyrl60 int
-		var yyrt60 bool
-		if yyl60 > cap(yyv60) {
+	} else if yyl56 > 0 {
+		var yyrr56, yyrl56 int
+		var yyrt56 bool
+		if yyl56 > cap(yyv56) {
 
-			yyrg60 := len(yyv60) > 0
-			yyv260 := yyv60
-			yyrl60, yyrt60 = z.DecInferLen(yyl60, z.DecBasicHandle().MaxInitLen, 192)
-			if yyrt60 {
-				if yyrl60 <= cap(yyv60) {
-					yyv60 = yyv60[:yyrl60]
+			yyrg56 := len(yyv56) > 0
+			yyv256 := yyv56
+			yyrl56, yyrt56 = z.DecInferLen(yyl56, z.DecBasicHandle().MaxInitLen, 192)
+			if yyrt56 {
+				if yyrl56 <= cap(yyv56) {
+					yyv56 = yyv56[:yyrl56]
 				} else {
-					yyv60 = make([]TestType, yyrl60)
+					yyv56 = make([]TestType, yyrl56)
 				}
 			} else {
-				yyv60 = make([]TestType, yyrl60)
+				yyv56 = make([]TestType, yyrl56)
 			}
-			yyc60 = true
-			yyrr60 = len(yyv60)
-			if yyrg60 {
-				copy(yyv60, yyv260)
+			yyc56 = true
+			yyrr56 = len(yyv56)
+			if yyrg56 {
+				copy(yyv56, yyv256)
 			}
-		} else if yyl60 != len(yyv60) {
-			yyv60 = yyv60[:yyl60]
-			yyc60 = true
+		} else if yyl56 != len(yyv56) {
+			yyv56 = yyv56[:yyl56]
+			yyc56 = true
 		}
-		yyj60 := 0
-		for ; yyj60 < yyrr60; yyj60++ {
-			yyh60.ElemContainerState(yyj60)
+		yyj56 := 0
+		for ; yyj56 < yyrr56; yyj56++ {
+			yyh56.ElemContainerState(yyj56)
 			if r.TryDecodeAsNil() {
-				yyv60[yyj60] = TestType{}
+				yyv56[yyj56] = TestType{}
 			} else {
-				yyv61 := &yyv60[yyj60]
-				yyv61.CodecDecodeSelf(d)
+				yyv57 := &yyv56[yyj56]
+				yyv57.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt60 {
-			for ; yyj60 < yyl60; yyj60++ {
-				yyv60 = append(yyv60, TestType{})
-				yyh60.ElemContainerState(yyj60)
+		if yyrt56 {
+			for ; yyj56 < yyl56; yyj56++ {
+				yyv56 = append(yyv56, TestType{})
+				yyh56.ElemContainerState(yyj56)
 				if r.TryDecodeAsNil() {
-					yyv60[yyj60] = TestType{}
+					yyv56[yyj56] = TestType{}
 				} else {
-					yyv62 := &yyv60[yyj60]
-					yyv62.CodecDecodeSelf(d)
+					yyv58 := &yyv56[yyj56]
+					yyv58.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj60 := 0
-		for ; !r.CheckBreak(); yyj60++ {
+		yyj56 := 0
+		for ; !r.CheckBreak(); yyj56++ {
 
-			if yyj60 >= len(yyv60) {
-				yyv60 = append(yyv60, TestType{}) // var yyz60 TestType
-				yyc60 = true
+			if yyj56 >= len(yyv56) {
+				yyv56 = append(yyv56, TestType{}) // var yyz56 TestType
+				yyc56 = true
 			}
-			yyh60.ElemContainerState(yyj60)
-			if yyj60 < len(yyv60) {
+			yyh56.ElemContainerState(yyj56)
+			if yyj56 < len(yyv56) {
 				if r.TryDecodeAsNil() {
-					yyv60[yyj60] = TestType{}
+					yyv56[yyj56] = TestType{}
 				} else {
-					yyv63 := &yyv60[yyj60]
-					yyv63.CodecDecodeSelf(d)
+					yyv59 := &yyv56[yyj56]
+					yyv59.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -800,16 +776,16 @@ func (x codecSelfer1234) decSliceTestType(v *[]TestType, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj60 < len(yyv60) {
-			yyv60 = yyv60[:yyj60]
-			yyc60 = true
-		} else if yyj60 == 0 && yyv60 == nil {
-			yyv60 = []TestType{}
-			yyc60 = true
+		if yyj56 < len(yyv56) {
+			yyv56 = yyv56[:yyj56]
+			yyc56 = true
+		} else if yyj56 == 0 && yyv56 == nil {
+			yyv56 = []TestType{}
+			yyc56 = true
 		}
 	}
-	yyh60.End()
-	if yyc60 {
-		*v = yyv60
+	yyh56.End()
+	if yyc56 {
+		*v = yyv56
 	}
 }


### PR DESCRIPTION
Introduced by #17940 due to bug.  Bug fixed by #18860.
