### PR TITLE
Revert whitespace changes introduced by #17940.

### DIFF
--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -408,7 +408,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -470,7 +470,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -525,7 +525,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -566,7 +566,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -607,7 +607,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -655,7 +655,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -696,7 +696,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -744,7 +744,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -785,7 +785,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -847,7 +847,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -909,7 +909,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -964,7 +964,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -998,7 +998,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1032,7 +1032,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1087,7 +1087,7 @@ Examples:<br>
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1142,7 +1142,7 @@ Examples:<br>
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1176,7 +1176,7 @@ Examples:<br>
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1222,7 +1222,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1277,7 +1277,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1311,7 +1311,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1373,7 +1373,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1421,7 +1421,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1476,7 +1476,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1545,7 +1545,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1586,7 +1586,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1620,7 +1620,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1651,7 +1651,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1685,7 +1685,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1838,7 +1838,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1902,7 +1902,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -1936,7 +1936,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2061,7 +2061,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2102,7 +2102,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2136,7 +2136,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2202,7 +2202,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2243,7 +2243,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2298,7 +2298,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2332,7 +2332,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2372,7 +2372,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2420,7 +2420,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2485,7 +2485,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2540,7 +2540,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2581,7 +2581,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2615,7 +2615,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2656,7 +2656,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2711,7 +2711,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2759,7 +2759,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2821,7 +2821,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2872,7 +2872,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2906,7 +2906,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2947,7 +2947,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -2981,7 +2981,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3050,7 +3050,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3091,7 +3091,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3132,7 +3132,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3180,7 +3180,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3330,7 +3330,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3413,7 +3413,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3479,7 +3479,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3562,7 +3562,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3603,7 +3603,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3665,7 +3665,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3797,7 +3797,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3852,7 +3852,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3893,7 +3893,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3941,7 +3941,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -3989,7 +3989,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -4030,7 +4030,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -4085,7 +4085,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -4147,7 +4147,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -4209,7 +4209,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <col style="width:20%;">
 <col style="width:20%;">
 <col style="width:20%;">
-<col style="width:20%;">
+<col style="width:20%;"> 
 </colgroup>
 <thead>
 <tr>
@@ -4292,7 +4292,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2015-12-16 14:33:53 UTC
+Last updated 2015-12-17 23:51:47 UTC
 </div>
 </div>
 </body>


### PR DESCRIPTION
This whitespace difference is thought to be breaking
the build.

The differences in white space are hypothesized to happen
because trailing whitespace is chomped by some people's
editors but not others.

The trailing whitespace is enough of a difference to make
hack/verify-api-references-docs.sh think that the
docs are not different.
