### PR TITLE
ignore trailing whitespace and blankline when verify api reference docs

### DIFF
--- a/hack/verify-api-reference-docs.sh
+++ b/hack/verify-api-reference-docs.sh
@@ -35,7 +35,7 @@ TMP_ROOT="${KUBE_ROOT}/_tmp"
 
 echo "diffing ${API_REFERENCE_DOCS_ROOT} against freshly generated docs"
 ret=0
-diff -Naupr -I 'Last update' --exclude=*.md "${API_REFERENCE_DOCS_ROOT}" "${OUTPUT_DIR}" || ret=$?
+diff -NauprBZ -I 'Last update' --exclude=*.md "${API_REFERENCE_DOCS_ROOT}" "${OUTPUT_DIR}" || ret=$?
 rm -rf "${TMP_ROOT}"
 if [[ $ret -eq 0 ]]
 then


### PR DESCRIPTION
ref #18870

I tested locally and it worked.
