### PR TITLE
Allow parallelism > completions

### DIFF
--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -4025,7 +4025,7 @@
      "completions": {
       "type": "integer",
       "format": "int32",
-      "description": "Completions specifies the desired number of successfully finished pods the job should be run with. Defaults to 1. More info: http://releases.k8s.io/HEAD/docs/user-guide/jobs.md"
+      "description": "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job."
      },
      "activeDeadlineSeconds": {
       "type": "integer",

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -3633,7 +3633,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">completions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Completions specifies the desired number of successfully finished pods the job should be run with. Defaults to 1. More info: <a href="http://releases.k8s.io/HEAD/docs/user-guide/jobs.md">http://releases.k8s.io/HEAD/docs/user-guide/jobs.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4573,7 +4573,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-01-18 17:24:36 UTC
+Last updated 2016-01-19 18:09:13 UTC
 </div>
 </div>
 </body>

--- a/examples/job/work-queue-2/README.md
+++ b/examples/job/work-queue-2/README.md
@@ -185,6 +185,8 @@ using above links. Then build the image:
 $ docker build -t job-wq-2 .
 ```
 
+### Push the image
+
 For the [Docker Hub](https://hub.docker.com/), tag your app image with
 your username and push to the Hub with the below commands. Replace
 `<username>` with your Hub username.
@@ -193,6 +195,9 @@ your username and push to the Hub with the below commands. Replace
 docker tag job-wq-2 <username>/job-wq-2
 docker push <username>/job-wq-2
 ```
+
+You need to push to a public repository or [configure your cluster to be able to access
+your private repository](../../../docs/user-guide/images.md).
 
 If you are using [Google Container
 Registry](https://cloud.google.com/tools/container-registry/), tag
@@ -220,7 +225,6 @@ spec:
   selector:
     matchLabels:
       app: job-wq-2
-  completions: 1
   parallelism: 2
   template:
     metadata:
@@ -263,17 +267,19 @@ Now wait a bit, then check on the job.
 $ ./kubectl describe jobs/job-wq-2 
 Name:		job-wq-2
 Namespace:	default
-Image(s):	gcr.io/causal-jigsaw-637/job-wq-2
+Image(s):	gcr.io/exampleproject/job-wq-2
 Selector:	app in (job-wq-2)
 Parallelism:	2
-Completions:	1
+Completions:	Unset
+Start Time:	Mon, 11 Jan 2016 17:07:59 -0800
 Labels:		app=job-wq-2
-Pods Statuses:	0 Running / 1 Succeeded / 0 Failed
+Pods Statuses:	1 Running / 0 Succeeded / 0 Failed
 No volumes.
 Events:
-  FirstSeen	LastSeen	Count	From	SubobjectPath	Reason			Message
-  ─────────	────────	─────	────	─────────────	──────			───────
-  1m		1m		1	{job }			SuccessfulCreate	Created pod: job-wq-2-7r7b2
+  FirstSeen	LastSeen	Count	From			SubobjectPath	Type		Reason			Message
+  ---------	--------	-----	----			-------------	--------	------			-------
+  33s		33s		1	{job-controller }			Normal		SuccessfulCreate	Created pod: job-wq-2-lglf8
+
 
 $ kubectl logs pods/job-wq-2-7r7b2
 Worker with sessionID: bbd72d0a-9e5c-4dd6-abf6-416cc267991f

--- a/examples/job/work-queue-2/job.yaml
+++ b/examples/job/work-queue-2/job.yaml
@@ -6,7 +6,6 @@ spec:
   selector:
     matchLabels:
       app: job-wq-2
-  completions: 1
   parallelism: 2
   template:
     metadata:

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -481,7 +481,7 @@ type JobSpec struct {
 	Parallelism *int `json:"parallelism,omitempty"`
 
 	// Completions specifies the desired number of successfully finished pods the
-	// job should be run with. Defaults to 1.
+	// job should be run with.  When unset, any pod exiting signals the job to complete.
 	Completions *int `json:"completions,omitempty"`
 
 	// Optional duration in seconds relative to the startTime that the job may be active

--- a/pkg/apis/extensions/v1beta1/defaults.go
+++ b/pkg/apis/extensions/v1beta1/defaults.go
@@ -120,12 +120,17 @@ func addDefaultingFuncs(scheme *runtime.Scheme) {
 					obj.Labels = labels
 				}
 			}
-			if obj.Spec.Completions == nil {
-				completions := int32(1)
-				obj.Spec.Completions = &completions
+			// For a non-parallel job, you can leave both `.spec.completions` and
+			// `.spec.parallelism` unset.  When both are unset, both are defaulted to 1.
+			if obj.Spec.Completions == nil && obj.Spec.Parallelism == nil {
+				obj.Spec.Completions = new(int32)
+				*obj.Spec.Completions = 1
+				obj.Spec.Parallelism = new(int32)
+				*obj.Spec.Parallelism = 1
 			}
 			if obj.Spec.Parallelism == nil {
-				obj.Spec.Parallelism = obj.Spec.Completions
+				obj.Spec.Parallelism = new(int32)
+				*obj.Spec.Parallelism = 1
 			}
 		},
 		func(obj *HorizontalPodAutoscaler) {

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -302,7 +302,124 @@ func TestSetDefaultDeployment(t *testing.T) {
 	}
 }
 
-func TestSetDefaultJob(t *testing.T) {
+func TestSetDefaultJobParallelismAndCompletions(t *testing.T) {
+	tests := []struct {
+		original *Job
+		expected *Job
+	}{
+		// both unspecified -> sets both to 1
+		{
+			original: &Job{
+				Spec: JobSpec{},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(1),
+					Parallelism: newInt32(1),
+				},
+			},
+		},
+		// WQ: Parallelism explicitly 0 and completions unset -> no change
+		{
+			original: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(0),
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(0),
+				},
+			},
+		},
+		// WQ: Parallelism explicitly 2 and completions unset -> no change
+		{
+			original: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(2),
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Parallelism: newInt32(2),
+				},
+			},
+		},
+		// Completions explicitly 2 and parallelism unset -> parallelism is defaulted
+		{
+			original: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(2),
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(2),
+					Parallelism: newInt32(1),
+				},
+			},
+		},
+		// Both set -> no change
+		{
+			original: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(10),
+					Parallelism: newInt32(11),
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(10),
+					Parallelism: newInt32(11),
+				},
+			},
+		},
+		// Both set, flipped -> no change
+		{
+			original: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(11),
+					Parallelism: newInt32(10),
+				},
+			},
+			expected: &Job{
+				Spec: JobSpec{
+					Completions: newInt32(11),
+					Parallelism: newInt32(10),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		original := tc.original
+		expected := tc.expected
+		obj2 := roundTrip(t, runtime.Object(original))
+		got, ok := obj2.(*Job)
+		if !ok {
+			t.Errorf("unexpected object: %v", got)
+			t.FailNow()
+		}
+		if (got.Spec.Completions == nil) != (expected.Spec.Completions == nil) {
+			t.Errorf("got different *completions than expected: %v %v", got.Spec.Completions, expected.Spec.Completions)
+		}
+		if got.Spec.Completions != nil && expected.Spec.Completions != nil {
+			if *got.Spec.Completions != *expected.Spec.Completions {
+				t.Errorf("got different completions than expected: %d %d", *got.Spec.Completions, *expected.Spec.Completions)
+			}
+		}
+		if (got.Spec.Parallelism == nil) != (expected.Spec.Parallelism == nil) {
+			t.Errorf("got different *Parallelism than expected: %v %v", got.Spec.Parallelism, expected.Spec.Parallelism)
+		}
+		if got.Spec.Parallelism != nil && expected.Spec.Parallelism != nil {
+			if *got.Spec.Parallelism != *expected.Spec.Parallelism {
+				t.Errorf("got different parallelism than expected: %d %d", *got.Spec.Parallelism, *expected.Spec.Parallelism)
+			}
+		}
+	}
+}
+
+func TestSetDefaultJobSelector(t *testing.T) {
 	expected := &Job{
 		Spec: JobSpec{
 			Selector: &LabelSelector{
@@ -331,28 +448,6 @@ func TestSetDefaultJob(t *testing.T) {
 				},
 			},
 		},
-		// selector from template labels, completions set explicitly, parallelism - default
-		{
-			Spec: JobSpec{
-				Completions: newInt32(1),
-				Template: v1.PodTemplateSpec{
-					ObjectMeta: v1.ObjectMeta{
-						Labels: map[string]string{"job": "selector"},
-					},
-				},
-			},
-		},
-		// selector from template labels, completions - default, parallelism set explicitly
-		{
-			Spec: JobSpec{
-				Parallelism: newInt32(1),
-				Template: v1.PodTemplateSpec{
-					ObjectMeta: v1.ObjectMeta{
-						Labels: map[string]string{"job": "selector"},
-					},
-				},
-			},
-		},
 	}
 
 	for _, original := range tests {
@@ -361,12 +456,6 @@ func TestSetDefaultJob(t *testing.T) {
 		if !ok {
 			t.Errorf("unexpected object: %v", got)
 			t.FailNow()
-		}
-		if *got.Spec.Completions != *expected.Spec.Completions {
-			t.Errorf("got different completions than expected: %d %d", *got.Spec.Completions, *expected.Spec.Completions)
-		}
-		if *got.Spec.Parallelism != *expected.Spec.Parallelism {
-			t.Errorf("got different parallelism than expected: %d %d", *got.Spec.Parallelism, *expected.Spec.Parallelism)
 		}
 		if !reflect.DeepEqual(got.Spec.Selector, expected.Spec.Selector) {
 			t.Errorf("got different selectors %#v %#v", got.Spec.Selector, expected.Spec.Selector)

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -473,8 +473,10 @@ type JobSpec struct {
 	Parallelism *int32 `json:"parallelism,omitempty"`
 
 	// Completions specifies the desired number of successfully finished pods the
-	// job should be run with. Defaults to 1.
-	// More info: http://releases.k8s.io/HEAD/docs/user-guide/jobs.md
+	// job should be run with.  Setting to nil means that the success of any
+	// pod signals the success of all pods, and allows parallelism to have any positive
+	// value.  Setting to 1 means that parallelism is limited to 1 and the success of that
+	// pod signals the success of the job.
 	Completions *int32 `json:"completions,omitempty"`
 
 	// Optional duration in seconds relative to the startTime that the job may be active

--- a/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -381,7 +381,7 @@ func (JobList) SwaggerDoc() map[string]string {
 var map_JobSpec = map[string]string{
 	"":                      "JobSpec describes how the job execution will look like.",
 	"parallelism":           "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://releases.k8s.io/HEAD/docs/user-guide/jobs.md",
-	"completions":           "Completions specifies the desired number of successfully finished pods the job should be run with. Defaults to 1. More info: http://releases.k8s.io/HEAD/docs/user-guide/jobs.md",
+	"completions":           "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job.",
 	"activeDeadlineSeconds": "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
 	"selector":              "Selector is a label query over pods that should match the pod count. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors",
 	"template":              "Template is the object that describes the pod that will be created when executing a job. More info: http://releases.k8s.io/HEAD/docs/user-guide/jobs.md",

--- a/pkg/client/unversioned/conditions.go
+++ b/pkg/client/unversioned/conditions.go
@@ -115,9 +115,14 @@ func JobHasDesiredParallelism(c ExtensionsInterface, job *extensions.Job) wait.C
 		if job.Spec.Parallelism != nil && job.Status.Active == *job.Spec.Parallelism {
 			return true, nil
 		}
-		// otherwise count successful
-		progress := *job.Spec.Completions - job.Status.Active - job.Status.Succeeded
-		return progress == 0, nil
+		if job.Spec.Completions == nil {
+			// A job without specified completions needs to wait for Active to reach Parallelism.
+			return false, nil
+		} else {
+			// otherwise count successful
+			progress := *job.Spec.Completions - job.Status.Active - job.Status.Succeeded
+			return progress == 0, nil
+		}
 	}
 }
 

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -908,7 +908,11 @@ func describeJob(job *extensions.Job, events *api.EventList) (string, error) {
 		selector, _ := extensions.LabelSelectorAsSelector(job.Spec.Selector)
 		fmt.Fprintf(out, "Selector:\t%s\n", selector)
 		fmt.Fprintf(out, "Parallelism:\t%d\n", *job.Spec.Parallelism)
-		fmt.Fprintf(out, "Completions:\t%d\n", *job.Spec.Completions)
+		if job.Spec.Completions != nil {
+			fmt.Fprintf(out, "Completions:\t%d\n", *job.Spec.Completions)
+		} else {
+			fmt.Fprintf(out, "Completions:\tNot Set\n")
+		}
 		if job.Status.StartTime != nil {
 			fmt.Fprintf(out, "Start Time:\t%s\n", job.Status.StartTime.Time.Format(time.RFC1123Z))
 		}


### PR DESCRIPTION
This is a work in progress to change Job to support running "dynamic" jobs.  It allows completions to be unset.  When it is unset, parallelism can be scaled to any value.    See https://github.com/kubernetes/kubernetes/blob/master/examples/job/work-queue-1/README.md and https://github.com/kubernetes/kubernetes/blob/master/examples/job/work-queue-2/README.md for why you want this.
