### PR TITLE
Update validate-cluster.sh

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -40,9 +40,9 @@ while true; do
   # Suppress errors from kubectl output because during cluster bootstrapping
   # for clusters where the master node is registered, the apiserver will become
   # available and then get restarted as the kubelet configures the docker bridge.
-  nodes_status=$("${KUBE_ROOT}/cluster/kubectl.sh" get nodes -o template --template='{{range .items}}{{range .status.conditions}}{{if eq .type "Ready"}}{{.type}}:{{.status}},{{end}}{{end}}{{end}}' --api-version=v1) || true
-  found=$(echo "${nodes_status}" | tr "," "\n" | grep -c 'Ready:') || true
-  ready=$(echo "${nodes_status}" | tr "," "\n" | grep -c 'Ready:True') || true
+  nodes=$("${KUBE_ROOT}/cluster/kubectl.sh" get nodes) || true
+  found=$(($(echo "${nodes}" | wc -l) - 1)) || true
+  ready=$(echo "${nodes}" | grep -c "Ready") || true
 
   if (( "${found}" == "${EXPECTED_NUM_NODES}" )) && (( "${ready}" == "${EXPECTED_NUM_NODES}")); then
     break
@@ -50,8 +50,8 @@ while true; do
     echo -e "${color_red}Detected ${ready} ready nodes, found ${found} nodes out of expected ${EXPECTED_NUM_NODES}. Found more nodes than expected, your cluster may not behave correctly.${color_norm}"
     break
   else
-    # Set the timeout to ~10minutes (40 x 15 second) to avoid timeouts for 100-node clusters.
-    if (( attempt > 40 )); then
+    # Set the timeout to ~25minutes (100 x 15 second) to avoid timeouts for 1000-node clusters.
+    if (( attempt > 100 )); then
       echo -e "${color_red}Detected ${ready} ready nodes, found ${found} nodes out of expected ${EXPECTED_NUM_NODES}. Your cluster may not be working.${color_norm}"
       "${KUBE_ROOT}/cluster/kubectl.sh" get nodes
       exit 2


### PR DESCRIPTION
- don't do crazy unneeded -o template stuff
- increase a number of retries to 100, to avoid timeouts for 1000 node clusters.
