### PR TITLE
Fix bugs in cluster/get-kube-local.sh

### DIFF
--- a/cluster/get-kube-local.sh
+++ b/cluster/get-kube-local.sh
@@ -114,7 +114,7 @@ function get_latest_version_number {
 }
 
 latest_release=$(get_latest_version_number)
-release=${KUBE_VERSION:-latest_release}
+release=${KUBE_VERSION:-${latest_release}}
 
 uname=$(uname)
 if [[ "${uname}" == "Darwin" ]]; then
@@ -151,7 +151,7 @@ if [[ $(ls . | grep ^kubectl$ | wc -l) -lt 1 ]]; then
   if [[ $(which wget) ]]; then
     run "wget ${kubectl_url}"
   elif [[ $(which curl) ]]; then
-    run "curl -L ${kubectl_url}"
+    run "curl -OL ${kubectl_url}"
   else
     echo_red "Couldn't find curl or wget.  Bailing out."
     exit 1


### PR DESCRIPTION
- default the release to the value of latest_release instead of
  the string 'latest_release'
- use curl -O when retrieving kubectl to write output to disk instead
  of to the screen
