### PR TITLE
re-disable TestWatchEtcdError due to flake

### DIFF
--- a/pkg/storage/etcd/etcd_watcher_test.go
+++ b/pkg/storage/etcd/etcd_watcher_test.go
@@ -217,6 +217,7 @@ func TestWatchInterpretation_ResponseBadData(t *testing.T) {
 	}
 }
 
+/* re-Disabling due to flakes seen upstream #18914
 func TestWatchEtcdError(t *testing.T) {
 	codec := testapi.Default.Codec()
 	server := etcdtesting.NewEtcdTestClientServer(t)
@@ -232,7 +233,7 @@ func TestWatchEtcdError(t *testing.T) {
 		t.Fatalf("Unexpected non-error")
 	}
 	watching.Stop()
-}
+}*/
 
 func TestWatch(t *testing.T) {
 	codec := testapi.Default.Codec()


### PR DESCRIPTION
@ixdy @k8s-oncall
https://github.com/kubernetes/kubernetes/issues/18914
