### PR TITLE
Slice conversion requires destination package

### DIFF
--- a/pkg/runtime/conversion_generator.go
+++ b/pkg/runtime/conversion_generator.go
@@ -235,6 +235,8 @@ func (g *conversionGenerator) generateConversionsForMap(inType, outType reflect.
 func (g *conversionGenerator) generateConversionsForSlice(inType, outType reflect.Type) error {
 	inElem := inType.Elem()
 	outElem := outType.Elem()
+	// slice conversion requires the package for the destination type in order to instantiate the map
+	g.addImportByPath(outElem.PkgPath())
 	if err := g.generateConversionsBetween(inElem, outElem); err != nil {
 		return err
 	}


### PR DESCRIPTION
When we writeConversionForSlice, we use the outField type name to
instantiate the make(...) call (runtime.RawExtension).  Currently
runtime.RawExtension is shielded from exposing this bug because it
is hardcoded - the upcoming codec split exposes it. We need to record
import for the package path of the out slice conversion so that
when we write the conversion function the package is imported.
