### PR TITLE
Mark e2e tests that time out failed

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -25,7 +25,6 @@
             colormap: xterm
         - timeout:
             timeout: '{timeout}'
-            abort: true
             fail: true
         - timestamps
         - workspace-cleanup


### PR DESCRIPTION
Previously we were marking them failed, then marking them aborted, as seen [here](http://kubekins.dls.corp.google.com/job/kubernetes-e2e-gce-parallel/13058/).
