### PR TITLE
Revert part of #18860

### DIFF
--- a/hack/verify-codecgen.sh
+++ b/hack/verify-codecgen.sh
@@ -32,7 +32,6 @@ generated_files=($(
         -o -wholename './target' \
         -o -wholename '*/third_party/*' \
         -o -wholename '*/Godeps/*' \
-        -o -wholename '*/testdata/*' \
       \) -prune \
     \) -name '*.generated.go'))
 


### PR DESCRIPTION
Revert the part of #18860 which skipped running hack/verify-codecgen.sh on
testdata directories.  @caesarxuchao pointed out it is not necessary.
