### PR TITLE
fix bug: still mount the old path of dataset after migration

### DIFF
--- a/pkg/volume/flocker/plugin.go
+++ b/pkg/volume/flocker/plugin.go
@@ -199,14 +199,15 @@ func (b flockerBuilder) SetUpAt(dir string) error {
 		if err := b.updateDatasetPrimary(datasetID, primaryUUID); err != nil {
 			return err
 		}
+
+		newState, err := b.client.GetDatasetState(datasetID)
+		if err != nil {
+			return fmt.Errorf("The volume '%s' is not available in Flocker after migration.", dir)
+		}
+
+		b.flocker.path = newState.Path
 	}
 
-	newState, err := b.client.GetDatasetState(datasetID)
-	if err != nil {
-		return fmt.Errorf("The volume '%s' is not available in Flocker after migration.", dir)
-	}
-
-	b.flocker.path = newState.Path
 	volumeutil.SetReady(b.getMetaDir())
 	return nil
 }

--- a/pkg/volume/flocker/plugin.go
+++ b/pkg/volume/flocker/plugin.go
@@ -201,7 +201,12 @@ func (b flockerBuilder) SetUpAt(dir string) error {
 		}
 	}
 
-	b.flocker.path = s.Path
+	newState, err := b.client.GetDatasetState(datasetID)
+	if err != nil {
+		return fmt.Errorf("The volume '%s' is not available in Flocker after migration.", dir)
+	}
+
+	b.flocker.path = newState.Path
 	volumeutil.SetReady(b.getMetaDir())
 	return nil
 }


### PR DESCRIPTION
This pull request attempts to fix a bug in the current Flocker volume plugin, that is the plugin would still mount the path of old state of dataset after migration which has been changed.
