### PR TITLE
Remove redundant / complex client code

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -144,18 +144,11 @@ func (c *$.type|privatePlural$) Get(name string) (result *$.type|raw$, err error
 var deleteTemplate = `
 // Delete takes name of the $.type|private$ and deletes it. Returns an error if one occurs.
 func (c *$.type|privatePlural$) Delete(name string, options *$.apiDeleteOptions|raw$) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("$.type|privatePlural$").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("$.type|privatePlural$").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
@@ -164,23 +157,11 @@ func (c *$.type|privatePlural$) Delete(name string, options *$.apiDeleteOptions|
 var deleteCollectionTemplate = `
 // DeleteCollection deletes a collection of objects.
 func (c *$.type|privatePlural$) DeleteCollection(options *$.apiDeleteOptions|raw$, listOptions $.apiListOptions|raw$) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("$.type|privatePlural$").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("$.type|privatePlural$").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testType.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testType.go
@@ -79,18 +79,11 @@ func (c *testTypes) Update(testType *testgroup.TestType) (result *testgroup.Test
 
 // Delete takes name of the testType and deletes it. Returns an error if one occurs.
 func (c *testTypes) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("testTypes").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("testTypes").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/apis/extensions/v1beta1/register.go
+++ b/pkg/apis/extensions/v1beta1/register.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -60,6 +61,7 @@ func addKnownTypes() {
 		&ListOptions{},
 		&ConfigMap{},
 		&ConfigMapList{},
+		&v1.DeleteOptions{},
 	)
 }
 

--- a/pkg/apis/metrics/v1alpha1/register.go
+++ b/pkg/apis/metrics/v1alpha1/register.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -40,6 +41,7 @@ func addKnownTypes() {
 	api.Scheme.AddKnownTypes(SchemeGroupVersion,
 		&RawNode{},
 		&RawPod{},
+		&v1.DeleteOptions{},
 	)
 }
 

--- a/pkg/client/typed/generated/extensions/unversioned/daemonSet.go
+++ b/pkg/client/typed/generated/extensions/unversioned/daemonSet.go
@@ -79,41 +79,22 @@ func (c *daemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions
 
 // Delete takes name of the daemonSet and deletes it. Returns an error if one occurs.
 func (c *daemonSets) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("daemonSets").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("daemonSets").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *daemonSets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("daemonSets").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("daemonSets").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/extensions/unversioned/deployment.go
+++ b/pkg/client/typed/generated/extensions/unversioned/deployment.go
@@ -79,41 +79,22 @@ func (c *deployments) Update(deployment *extensions.Deployment) (result *extensi
 
 // Delete takes name of the deployment and deletes it. Returns an error if one occurs.
 func (c *deployments) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *deployments) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("deployments").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("deployments").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/extensions/unversioned/horizontalPodAutoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/horizontalPodAutoscaler.go
@@ -79,41 +79,22 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *extensions.Ho
 
 // Delete takes name of the horizontalPodAutoscaler and deletes it. Returns an error if one occurs.
 func (c *horizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("horizontalPodAutoscalers").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *horizontalPodAutoscalers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("horizontalPodAutoscalers").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("horizontalPodAutoscalers").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/extensions/unversioned/ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/ingress.go
@@ -79,41 +79,22 @@ func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingr
 
 // Delete takes name of the ingress and deletes it. Returns an error if one occurs.
 func (c *ingresses) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("ingresses").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("ingresses").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *ingresses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("ingresses").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("ingresses").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/extensions/unversioned/job.go
+++ b/pkg/client/typed/generated/extensions/unversioned/job.go
@@ -79,41 +79,22 @@ func (c *jobs) Update(job *extensions.Job) (result *extensions.Job, err error) {
 
 // Delete takes name of the job and deletes it. Returns an error if one occurs.
 func (c *jobs) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("jobs").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("jobs").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *jobs) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("jobs").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("jobs").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/extensions/unversioned/thirdPartyResource.go
+++ b/pkg/client/typed/generated/extensions/unversioned/thirdPartyResource.go
@@ -79,41 +79,22 @@ func (c *thirdPartyResources) Update(thirdPartyResource *extensions.ThirdPartyRe
 
 // Delete takes name of the thirdPartyResource and deletes it. Returns an error if one occurs.
 func (c *thirdPartyResources) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("thirdPartyResources").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("thirdPartyResources").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *thirdPartyResources) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("thirdPartyResources").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("thirdPartyResources").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/componentStatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/componentStatus.go
@@ -78,41 +78,22 @@ func (c *componentStatus) Update(componentStatus *api.ComponentStatus) (result *
 
 // Delete takes name of the componentStatus and deletes it. Returns an error if one occurs.
 func (c *componentStatus) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("componentStatus").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("componentStatus").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *componentStatus) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("componentStatus").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("componentStatus").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/endpoints.go
+++ b/pkg/client/typed/generated/legacy/unversioned/endpoints.go
@@ -78,41 +78,22 @@ func (c *endpoints) Update(endpoints *api.Endpoints) (result *api.Endpoints, err
 
 // Delete takes name of the endpoints and deletes it. Returns an error if one occurs.
 func (c *endpoints) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("endpoints").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("endpoints").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *endpoints) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("endpoints").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("endpoints").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/event.go
+++ b/pkg/client/typed/generated/legacy/unversioned/event.go
@@ -78,41 +78,22 @@ func (c *events) Update(event *api.Event) (result *api.Event, err error) {
 
 // Delete takes name of the event and deletes it. Returns an error if one occurs.
 func (c *events) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("events").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("events").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *events) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("events").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("events").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/limitRange.go
+++ b/pkg/client/typed/generated/legacy/unversioned/limitRange.go
@@ -78,41 +78,22 @@ func (c *limitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange
 
 // Delete takes name of the limitRange and deletes it. Returns an error if one occurs.
 func (c *limitRanges) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("limitRanges").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("limitRanges").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *limitRanges) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("limitRanges").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("limitRanges").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/namespace.go
+++ b/pkg/client/typed/generated/legacy/unversioned/namespace.go
@@ -78,41 +78,22 @@ func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, er
 
 // Delete takes name of the namespace and deletes it. Returns an error if one occurs.
 func (c *namespaces) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("namespaces").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("namespaces").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *namespaces) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("namespaces").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("namespaces").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/node.go
+++ b/pkg/client/typed/generated/legacy/unversioned/node.go
@@ -78,41 +78,22 @@ func (c *nodes) Update(node *api.Node) (result *api.Node, err error) {
 
 // Delete takes name of the node and deletes it. Returns an error if one occurs.
 func (c *nodes) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("nodes").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("nodes").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *nodes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("nodes").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("nodes").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/persistentVolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentVolume.go
@@ -78,41 +78,22 @@ func (c *persistentVolumes) Update(persistentVolume *api.PersistentVolume) (resu
 
 // Delete takes name of the persistentVolume and deletes it. Returns an error if one occurs.
 func (c *persistentVolumes) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("persistentVolumes").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("persistentVolumes").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *persistentVolumes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("persistentVolumes").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("persistentVolumes").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/persistentVolumeClaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentVolumeClaim.go
@@ -78,41 +78,22 @@ func (c *persistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVol
 
 // Delete takes name of the persistentVolumeClaim and deletes it. Returns an error if one occurs.
 func (c *persistentVolumeClaims) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("persistentVolumeClaims").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("persistentVolumeClaims").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *persistentVolumeClaims) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("persistentVolumeClaims").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("persistentVolumeClaims").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/pod.go
+++ b/pkg/client/typed/generated/legacy/unversioned/pod.go
@@ -78,41 +78,22 @@ func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
 
 // Delete takes name of the pod and deletes it. Returns an error if one occurs.
 func (c *pods) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("pods").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("pods").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *pods) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("pods").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("pods").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/podTemplate.go
+++ b/pkg/client/typed/generated/legacy/unversioned/podTemplate.go
@@ -78,41 +78,22 @@ func (c *podTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemp
 
 // Delete takes name of the podTemplate and deletes it. Returns an error if one occurs.
 func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("podTemplates").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *podTemplates) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("podTemplates").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("podTemplates").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/replicationController.go
+++ b/pkg/client/typed/generated/legacy/unversioned/replicationController.go
@@ -78,41 +78,22 @@ func (c *replicationControllers) Update(replicationController *api.ReplicationCo
 
 // Delete takes name of the replicationController and deletes it. Returns an error if one occurs.
 func (c *replicationControllers) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("replicationControllers").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("replicationControllers").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *replicationControllers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("replicationControllers").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("replicationControllers").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/resourceQuota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/resourceQuota.go
@@ -78,41 +78,22 @@ func (c *resourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.R
 
 // Delete takes name of the resourceQuota and deletes it. Returns an error if one occurs.
 func (c *resourceQuotas) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("resourceQuotas").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("resourceQuotas").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *resourceQuotas) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("resourceQuotas").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("resourceQuotas").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/secret.go
+++ b/pkg/client/typed/generated/legacy/unversioned/secret.go
@@ -78,41 +78,22 @@ func (c *secrets) Update(secret *api.Secret) (result *api.Secret, err error) {
 
 // Delete takes name of the secret and deletes it. Returns an error if one occurs.
 func (c *secrets) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("secrets").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("secrets").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *secrets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("secrets").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("secrets").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/service.go
+++ b/pkg/client/typed/generated/legacy/unversioned/service.go
@@ -78,41 +78,22 @@ func (c *services) Update(service *api.Service) (result *api.Service, err error)
 
 // Delete takes name of the service and deletes it. Returns an error if one occurs.
 func (c *services) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("services").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("services").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *services) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("services").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("services").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/serviceAccount.go
+++ b/pkg/client/typed/generated/legacy/unversioned/serviceAccount.go
@@ -78,41 +78,22 @@ func (c *serviceAccounts) Update(serviceAccount *api.ServiceAccount) (result *ap
 
 // Delete takes name of the serviceAccount and deletes it. Returns an error if one occurs.
 func (c *serviceAccounts) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("serviceAccounts").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("serviceAccounts").
 		Name(name).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *serviceAccounts) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	if options == nil {
-		return c.client.Delete().
-			NamespaceIfScoped(c.ns, len(c.ns) > 0).
-			Resource("serviceAccounts").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return c.client.Delete().
 		NamespaceIfScoped(c.ns, len(c.ns) > 0).
 		Resource("serviceAccounts").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/unversioned/deployment.go
+++ b/pkg/client/unversioned/deployment.go
@@ -68,14 +68,7 @@ func (c *deployments) Get(name string) (result *extensions.Deployment, err error
 
 // Delete takes name of the deployment and deletes it. Returns an error if one occurs.
 func (c *deployments) Delete(name string, options *api.DeleteOptions) error {
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
-	return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Body(body).Do().Error()
+	return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Body(options).Do().Error()
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.

--- a/pkg/client/unversioned/events.go
+++ b/pkg/client/unversioned/events.go
@@ -187,24 +187,11 @@ func (e *events) Delete(name string) error {
 
 // DeleteCollection deletes a collection of objects.
 func (e *events) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	// TODO: to make this reusable in other client libraries
-	if options == nil {
-		return e.client.Delete().
-			NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
-			Resource("events").
-			VersionedParams(&listOptions, api.Scheme).
-			Do().
-			Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, e.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
 	return e.client.Delete().
 		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
 		Resource("events").
 		VersionedParams(&listOptions, api.Scheme).
-		Body(body).
+		Body(options).
 		Do().
 		Error()
 }

--- a/pkg/client/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/unversioned/horizontalpodautoscaler.go
@@ -68,15 +68,7 @@ func (c *horizontalPodAutoscalers) Get(name string) (result *extensions.Horizont
 
 // Delete takes the name of the horizontalPodAutoscaler and deletes it.  Returns an error if one occurs.
 func (c *horizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
-	// TODO: to make this reusable in other client libraries
-	if options == nil {
-		return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion().String())
-	if err != nil {
-		return err
-	}
-	return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Body(body).Do().Error()
+	return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Body(options).Do().Error()
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if it occurs.

--- a/pkg/client/unversioned/ingress.go
+++ b/pkg/client/unversioned/ingress.go
@@ -79,15 +79,7 @@ func (c *ingress) Update(ingress *extensions.Ingress) (result *extensions.Ingres
 
 // Delete deletes a ingress, returns error if one occurs.
 func (c *ingress) Delete(name string, options *api.DeleteOptions) (err error) {
-	if options == nil {
-		return c.r.Delete().Namespace(c.ns).Resource("ingresses").Name(name).Do().Error()
-	}
-
-	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion().String())
-	if err != nil {
-		return err
-	}
-	return c.r.Delete().Namespace(c.ns).Resource("ingresses").Name(name).Body(body).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource("ingresses").Name(name).Body(options).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested ingress.

--- a/pkg/client/unversioned/jobs.go
+++ b/pkg/client/unversioned/jobs.go
@@ -18,7 +18,6 @@ package unversioned
 
 import (
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -83,15 +82,7 @@ func (c *jobs) Update(job *extensions.Job) (result *extensions.Job, err error) {
 
 // Delete deletes a job, returns error if one occurs.
 func (c *jobs) Delete(name string, options *api.DeleteOptions) (err error) {
-	if options == nil {
-		return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Do().Error()
-	}
-
-	body, err := api.Scheme.EncodeToVersion(options, latest.GroupOrDie(api.GroupName).GroupVersion.String())
-	if err != nil {
-		return err
-	}
-	return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Body(body).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Body(options).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested jobs.

--- a/pkg/client/unversioned/pod_templates.go
+++ b/pkg/client/unversioned/pod_templates.go
@@ -66,15 +66,7 @@ func (c *podTemplates) Get(name string) (result *api.PodTemplate, err error) {
 
 // Delete takes the name of the podTemplate, and returns an error if one occurs
 func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
-	// TODO: to make this reusable in other client libraries
-	if options == nil {
-		return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion().String())
-	if err != nil {
-		return err
-	}
-	return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Body(body).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Body(options).Do().Error()
 }
 
 // Create takes the representation of a podTemplate.  Returns the server's representation of the podTemplate, and an error, if it occurs.

--- a/pkg/client/unversioned/pods.go
+++ b/pkg/client/unversioned/pods.go
@@ -69,15 +69,7 @@ func (c *pods) Get(name string) (result *api.Pod, err error) {
 
 // Delete takes the name of the pod, and returns an error if one occurs
 func (c *pods) Delete(name string, options *api.DeleteOptions) error {
-	// TODO: to make this reusable in other client libraries
-	if options == nil {
-		return c.r.Delete().Namespace(c.ns).Resource("pods").Name(name).Do().Error()
-	}
-	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion().String())
-	if err != nil {
-		return err
-	}
-	return c.r.Delete().Namespace(c.ns).Resource("pods").Name(name).Body(body).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource("pods").Name(name).Body(options).Do().Error()
 }
 
 // Create takes the representation of a pod.  Returns the server's representation of the pod, and an error, if it occurs.


### PR DESCRIPTION
The generation of DeleteOptions should be handled by the request
in the codec, not by client wrapper code.
