### PR TITLE
Document lowercase filenames

### DIFF
--- a/docs/devel/coding-conventions.md
+++ b/docs/devel/coding-conventions.md
@@ -68,6 +68,7 @@ Directory and file conventions
   - Avoid package sprawl. Find an appropriate subdirectory for new packages. (See [#4851](http://issues.k8s.io/4851) for discussion.)
     - Libraries with no more appropriate home belong in new package subdirectories of pkg/util
   - Avoid general utility packages. Packages called "util" are suspect. Instead, derive a name that describes your desired function. For example, the utility functions dealing with waiting for operations are in the "wait" package and include functionality like Poll. So the full name is wait.Poll
+  - All filenames should be lowercase
   - Go source files and directories use underscores, not dashes
     - Package directories should generally avoid using separators as much as possible (when packages are multiple words, they usually should be in nested subdirectories).
   - Document directories and filenames should use dashes rather than underscores


### PR DESCRIPTION
Triggered by #18939 - we did not have documentation in place

@kubernetes/goog-csi as a standin for general code health
