### PR TITLE
httplog is not a CloseNotifier

### DIFF
--- a/pkg/httplog/log.go
+++ b/pkg/httplog/log.go
@@ -200,6 +200,11 @@ func (rl *respLogger) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return rl.w.(http.Hijacker).Hijack()
 }
 
+// CloseNotify implements http.CloseNotifier
+func (rl *respLogger) CloseNotify() <-chan bool {
+	return rl.w.(http.CloseNotifier).CloseNotify()
+}
+
 func (rl *respLogger) recordStatus(status int) {
 	rl.status = status
 	rl.statusRecorded = true

--- a/test/integration/master_test.go
+++ b/test/integration/master_test.go
@@ -37,3 +37,17 @@ func TestExperimentalPrefix(t *testing.T) {
 		t.Fatalf("got status %v instead of 200 OK", resp.StatusCode)
 	}
 }
+
+func TestWatchSucceedsWithoutArgs(t *testing.T) {
+	_, s := framework.RunAMaster(t)
+	defer s.Close()
+
+	resp, err := http.Get(s.URL + "/api/v1/namespaces?watch=1")
+	if err != nil {
+		t.Fatalf("unexpected error getting experimental prefix: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %v instead of 200 OK", resp.StatusCode)
+	}
+	resp.Body.Close()
+}


### PR DESCRIPTION
We wrap TimeoutHandler with RecoverPanics, but httplog does not
implement http.CloseNotifier, which causes a naive watch from curl
against the insecure port to fail.

For now, implement CloseNotifier (but we should consider removing
httplog now that we have other tools in the stack to manage it).

I couldn't recreate this with framework.RunAMaster, but recreation
is:

```
$ etcd &
$ kube-apiserver --service-cluster-ip-range=172.30.0.0/16 --etcd-servers=http://127.0.0.1:4001
$ curl http://localhost:8080/api/v1/namespaces?watch=1
404 page not found
> I1221 02:59:10.945154    3321 <autogenerated>:1] unable to get CloseNotifier
```

What confuses me is why this doesn't happen in normal use...
