### PR TITLE
Update mesos.md

### DIFF
--- a/docs/getting-started-guides/mesos.md
+++ b/docs/getting-started-guides/mesos.md
@@ -165,12 +165,6 @@ disown -a
 
 #### Validate KM Services
 
-Add the appropriate binary folder to your `PATH` to access kubectl:
-
-```bash
-export PATH=<path/to/kubernetes-directory>/platforms/linux/amd64:$PATH
-```
-
 Interact with the kubernetes-mesos framework via `kubectl`:
 
 ```console


### PR DESCRIPTION
There is no "`<path/to/kubernetes-directory>/platforms/linux/amd64`" folder, and `kubectl` command is also in `<path/to/kubernetes-directory>/_output/local/go/bin` folder.
