### PR TITLE
Add PV.Name to volume tags.

### DIFF
--- a/pkg/controller/persistentvolume/types.go
+++ b/pkg/controller/persistentvolume/types.go
@@ -32,10 +32,13 @@ const (
 	qosProvisioningKey = "volume.alpha.kubernetes.io/storage-class"
 	// Name of a tag attached to a real volume in cloud (e.g. AWS EBS or GCE PD)
 	// with namespace of a persistent volume claim used to create this volume.
-	cloudVolumeCreatedForNamespaceTag = "kubernetes.io/created-for/pvc/namespace"
+	cloudVolumeCreatedForClaimNamespaceTag = "kubernetes.io/created-for/pvc/namespace"
 	// Name of a tag attached to a real volume in cloud (e.g. AWS EBS or GCE PD)
 	// with name of a persistent volume claim used to create this volume.
-	cloudVolumeCreatedForNameTag = "kubernetes.io/created-for/pvc/name"
+	cloudVolumeCreatedForClaimNameTag = "kubernetes.io/created-for/pvc/name"
+	// Name of a tag attached to a real volume in cloud (e.g. AWS EBS or GCE PD)
+	// with name of appropriate Kubernetes persistent volume .
+	cloudVolumeCreatedForVolumeNameTag = "kubernetes.io/created-for/pv/name"
 )
 
 // persistentVolumeOrderedIndex is a cache.Store that keeps persistent volumes indexed by AccessModes and ordered by storage capacity.

--- a/pkg/volume/testing.go
+++ b/pkg/volume/testing.go
@@ -119,9 +119,10 @@ func ProbeVolumePlugins(config VolumeConfig) []VolumePlugin {
 // Use as:
 //   volume.RegisterPlugin(&FakePlugin{"fake-name"})
 type FakeVolumePlugin struct {
-	PluginName string
-	Host       VolumeHost
-	Config     VolumeConfig
+	PluginName             string
+	Host                   VolumeHost
+	Config                 VolumeConfig
+	LastProvisionerOptions VolumeOptions
 }
 
 var _ VolumePlugin = &FakeVolumePlugin{}
@@ -160,6 +161,7 @@ func (plugin *FakeVolumePlugin) NewDeleter(spec *Spec) (Deleter, error) {
 }
 
 func (plugin *FakeVolumePlugin) NewProvisioner(options VolumeOptions) (Provisioner, error) {
+	plugin.LastProvisionerOptions = options
 	return &FakeProvisioner{options, plugin.Host}, nil
 }
 

--- a/test/integration/persistent_volumes_test.go
+++ b/test/integration/persistent_volumes_test.go
@@ -50,7 +50,7 @@ func TestPersistentVolumeRecycler(t *testing.T) {
 	testClient := client.NewOrDie(&client.Config{Host: s.URL, GroupVersion: testapi.Default.GroupVersion()})
 	host := volume.NewFakeVolumeHost("/tmp/fake", nil, nil)
 
-	plugins := []volume.VolumePlugin{&volume.FakeVolumePlugin{"plugin-name", host, volume.VolumeConfig{}}}
+	plugins := []volume.VolumePlugin{&volume.FakeVolumePlugin{"plugin-name", host, volume.VolumeConfig{}, volume.VolumeOptions{}}}
 	cloud := &fake_cloud.FakeCloud{}
 
 	binder := persistentvolumecontroller.NewPersistentVolumeClaimBinder(binderClient, 10*time.Second)


### PR DESCRIPTION
We add claim.Name and claim.Namespace as tags to AWS EBS / GCE PD / OpenStack
Cinder volumes created by Kubernetes. To easily match Kubernetes volumes and
cloud volumes, let's add also PV.Name.

This allows easier matching between Kubernetes and real cloud volumes.
