### PR TITLE
Tag OpenStack Cinder volumes created by Kubernetes.

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -1025,7 +1025,7 @@ func (os *OpenStack) getVolume(diskName string) (volumes.Volume, error) {
 }
 
 // Create a volume of given size (in GiB)
-func (os *OpenStack) CreateVolume(size int) (volumeName string, err error) {
+func (os *OpenStack) CreateVolume(size int, tags *map[string]string) (volumeName string, err error) {
 
 	sClient, err := openstack.NewBlockStorageV1(os.provider, gophercloud.EndpointOpts{
 		Region: os.region,
@@ -1037,6 +1037,9 @@ func (os *OpenStack) CreateVolume(size int) (volumeName string, err error) {
 	}
 
 	opts := volumes.CreateOpts{Size: size}
+	if tags != nil {
+		opts.Metadata = *tags
+	}
 	vol, err := volumes.Create(sClient, opts).Extract()
 	if err != nil {
 		glog.Errorf("Failed to create a %d GB volume: %v", size, err)

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -210,7 +210,10 @@ func TestVolumes(t *testing.T) {
 		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}
 
-	vol, err := os.CreateVolume(1)
+	tags := map[string]string{
+		"test": "value",
+	}
+	vol, err := os.CreateVolume(1, &tags)
 	if err != nil {
 		t.Fatalf("Cannot create a new Cinder volume: %v", err)
 	}

--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -153,7 +153,7 @@ func (util *CinderDiskUtil) CreateVolume(c *cinderVolumeProvisioner) (volumeID s
 	volSizeBytes := c.options.Capacity.Value()
 	// Cinder works with gigabytes, convert to GiB with rounding up
 	volSizeGB := int(volume.RoundUpSize(volSizeBytes, 1024*1024*1024))
-	name, err := cloud.CreateVolume(volSizeGB)
+	name, err := cloud.CreateVolume(volSizeGB, c.options.CloudTags)
 	if err != nil {
 		glog.V(2).Infof("Error creating cinder volume: %v", err)
 		return "", 0, err


### PR DESCRIPTION
This synchronizes Cinder with AWS EBS code, where we already tag volumes with
claim.Namespace and claim.Name (and pv.Name, as suggested in separate PR).
