### PR TITLE
MESOS: contrib/mesos/kubelet: don't disable debug handler by default

### DIFF
--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -409,7 +409,6 @@ func (s *SchedulerServer) prepareExecutorInfo(hks hyperkube.Interface) (*mesos.E
 	ci.Arguments = append(ci.Arguments, fmt.Sprintf("--cadvisor-port=%v", s.kubeletCadvisorPort))
 	ci.Arguments = append(ci.Arguments, fmt.Sprintf("--sync-frequency=%v", s.kubeletSyncFrequency))
 	ci.Arguments = append(ci.Arguments, fmt.Sprintf("--contain-pod-resources=%t", s.containPodResources))
-	ci.Arguments = append(ci.Arguments, fmt.Sprintf("--enable-debugging-handlers=%t", s.enableProfiling))
 
 	if s.authPath != "" {
 		//TODO(jdef) should probably support non-local files, e.g. hdfs:///some/config/file


### PR DESCRIPTION
Accidentally the debug handlers of the kubelet (e.g. used for kubectl-logs) were disabled by disabling profiling in the Mesos scheduler. This PR removes the `--enable-debugging-handler` from the kubelet/executor command line, leading to the original upstream default behaviour (= enabled) again.

Compare with https://github.com/kubernetes/kubernetes/pull/18966 to make the setting configurable.
