### PR TITLE
MESOS: make kubelet debugging handlers configurable

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -158,6 +158,7 @@ kubelet-certificate-authority
 kubelet-client-certificate
 kubelet-client-key
 kubelet-docker-endpoint
+kubelet-enable-debugging-handlers
 kubelet-host-network-sources
 kubelet-https
 kubelet-network-plugin


### PR DESCRIPTION
This PR adds a `--kubelet-enable-debugging-handlers` flag to the Mesos scheduler, defaulting to true.
