### PR TITLE
Set logtostderr to false by default

### DIFF
--- a/pkg/util/logs.go
+++ b/pkg/util/logs.go
@@ -29,7 +29,7 @@ var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum
 
 // TODO(thockin): This is temporary until we agree on log dirs and put those into each cmd.
 func init() {
-	flag.Set("logtostderr", "true")
+	flag.Set("logtostderr", "false")
 }
 
 // GlogWriter serves as a bridge between the standard log package and the glog package.


### PR DESCRIPTION
Ref #14216

@thockin - can we disable it now?

cc @spiffxp @kubernetes/sig-scalability @wojtek-t @fgrzadkowski 
