### PR TITLE
Remove colon from gke-ci-reboot job name (typo)

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -68,7 +68,7 @@
                 - cluster (k8s): ci/latest.txt<br>
                 - tests: ci/latest.txt
             timeout: 300
-        - 'gke-ci-reboot:':
+        - 'gke-ci-reboot':
             description: |
                 Run e2e tests using the following config:<br>
                 - provider: GKE<br>


### PR DESCRIPTION
It's valid YAML but Jenkins won't allow it.
