### PR TITLE
Improve the code in pkg/controller/job/controller.go

### DIFF
--- a/pkg/util/workqueue/queue.go
+++ b/pkg/util/workqueue/queue.go
@@ -113,6 +113,17 @@ func (q *Type) Get() (item interface{}, shutdown bool) {
 	return item, false
 }
 
+// Get the head of the queue
+func (q *Type) Peek() interface{} {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	if len(q.queue) == 0 {
+		return nil
+	}
+	item := q.queue[0]
+	return item
+}
+
 // Done marks item as done processing, and if it has been marked as dirty again
 // while it was being processed, it will be re-added to the queue for
 // re-processing.


### PR DESCRIPTION
Everytime we have a pod creationg, update or deletion, we will enqueue the
controller that manages it and update its expections. And this queue consumed
at the worker().

In my commit, we check if the controller is already in this queue. If it is not,
enqueue it. If it is and it is not at the head of this queue, abort inserting since
it will do replicated job. If it is in the head of this queue, still need insert it.
At the head of this queue means this item may be consuming right now, the update
may not work in this consuming. We still need to enqueue it. Also, I add a new func
Head() in workqueue obj which will return the head of this queue.
