### PR TITLE
remove '.ha' suffix from examples/high-availability vagrant hostnames

### DIFF
--- a/examples/high-availability/Vagrantfile
+++ b/examples/high-availability/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "kube0" do |kube0|
     kube0.vm.box = fedora
-    kube0.vm.hostname = "kube0.ha"
+    kube0.vm.hostname = "kube0"
     kube0.vm.synced_folder ".", "/vagrant"
     kube0.vm.network :private_network, ip: "192.168.4.100"
     kube0.vm.provision "shell", path:script
@@ -29,7 +29,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "kube1" do |kube1|
     kube1.vm.box = fedora
-    kube1.vm.hostname = "kube1.ha"
+    kube1.vm.hostname = "kube1"
     kube1.vm.synced_folder ".", "/vagrant"
     kube1.vm.network :private_network, ip: "192.168.4.101"
     kube1.vm.provision "shell", path:script
@@ -37,7 +37,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "kube2" do |kube2|
     kube2.vm.box = fedora
-    kube2.vm.hostname = "kube2.ha"
+    kube2.vm.hostname = "kube2"
     kube2.vm.network :private_network, ip: "192.168.4.102"
     kube2.vm.synced_folder ".", "/vagrant"
     kube2.vm.provision "shell", path:script

--- a/examples/high-availability/etc_kubernetes_kubelet
+++ b/examples/high-availability/etc_kubernetes_kubelet
@@ -12,7 +12,7 @@ KUBELET_ADDRESS=""
 # KUBELET_HOSTNAME="--hostname-override=0.0.0."
 
 # location of the api-server
-KUBELET_API_SERVER="--api-servers=http://0.0.0.0:8080,kube1.ha:8080,kube0.ha:8080 "
+KUBELET_API_SERVER="--api-servers=http://0.0.0.0:8080,kube1:8080,kube0:8080 "
 # --cert-dir="/var/run/kubernetes": The directory where the TLS certs are located (by default /var/run/kubernetes). If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.
 # --tls-cert-file="": File containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). If --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory passed to --cert-dir.
 #  --tls-private-key-file="": File containing x509 private key matching --tls-cert-file.

--- a/examples/high-availability/etcd.manifest
+++ b/examples/high-availability/etcd.manifest
@@ -13,7 +13,7 @@
 	      "--initial-advertise-peer-urls",  "http://NODE_IP:2380",
 	      "--listen-peer-urls",     	"http://NODE_IP:2380",
 	      "--advertise-client-urls",    	"http://NODE_IP:2379",
-	      "-initial-cluster", "kube0.ha=http://192.168.4.100:2380",
+	      "-initial-cluster", "kube0=http://192.168.4.100:2380",
 	      "--listen-client-urls",   	"http://127.0.0.1:2379,http://NODE_IP:2379",
           "--data-dir","/var/etcd/data"
     ],

--- a/examples/high-availability/kube-apiserver.manifest
+++ b/examples/high-availability/kube-apiserver.manifest
@@ -14,7 +14,7 @@
     "command": [
                  "/bin/sh",
                  "-c",
-                 "/usr/local/bin/kube-apiserver --address=0.0.0.0 --etcd-servers=http://kube0.ha:2379 --service-cluster-ip-range=10.0.0.0/16 --v=4 --allow-privileged=True 1>>/var/log/kube-apiserver.log 2>&1"
+                 "/usr/local/bin/kube-apiserver --address=0.0.0.0 --etcd-servers=http://kube0:2379 --service-cluster-ip-range=10.0.0.0/16 --v=4 --allow-privileged=True 1>>/var/log/kube-apiserver.log 2>&1"
                ],
     "livenessProbe": {
       "httpGet": {

--- a/examples/high-availability/provision-flannel.sh
+++ b/examples/high-availability/provision-flannel.sh
@@ -22,11 +22,11 @@ function setup_flannel {
     yum install -y flannel
 
     ### Write this k/v to etcd.  Flannel will grab it to setup its networking.
-    curl --silent -s -L http://kube0.ha:2379/v2/keys/coreos.com/network/config -XPUT -d value='{"Network": "172.31.255.0/24", "SubnetLen": 27, "Backend": {"Type": "vxlan"}}'
+    curl --silent -s -L http://kube0:2379/v2/keys/coreos.com/network/config -XPUT -d value='{"Network": "172.31.255.0/24", "SubnetLen": 27, "Backend": {"Type": "vxlan"}}'
 
 ### Write flannel etcd file
 cat >> /etc/sysconfig/flanneld << EOF
-FLANNEL_ETCD="http://kube0.ha:2379"
+FLANNEL_ETCD="http://kube0:2379"
 FLANNEL_ETCD_KEY="/coreos.com/network"
 FLANNEL_OPTIONS="--iface=eth1"
 EOF

--- a/examples/high-availability/provision.sh
+++ b/examples/high-availability/provision.sh
@@ -68,7 +68,7 @@ function test_etcd {
     ( journalctl -u kubelet | grep -A 20 -B 20 Fail || echo "no failure in logs")
     echo "----------- END DEBUG OF KUBELET ----------------------------"
 
-    ( curl http://kube0.ha:2379 > /tmp/curl_output || echo "failed etcd!!!" )
+    ( curl http://kube0:2379 > /tmp/curl_output || echo "failed etcd!!!" )
     if [ -s /tmp/curl_output ]; then
          echo "etcd success"
     else
@@ -136,7 +136,7 @@ function poll {
 function install_components {
     ### etcd node - this node only runs etcd in a kubelet, no flannel.
     ### we dont want circular dependency of docker -> flannel -> etcd -> docker
-    if [ "`hostname`" == "kube0.ha" ]; then
+    if [ "`hostname`" == "kube0" ]; then
             write_etcd_manifest
             start_kubelet
 
@@ -153,7 +153,7 @@ function install_components {
         /vagrant/provision-flannel.sh
 
         echo "Now pulling down flannel nodes. "
-        curl -L http://kube0.ha:2379/v2/keys/coreos.com/network/subnets | python -mjson.tool
+        curl -L http://kube0:2379/v2/keys/coreos.com/network/subnets | python -mjson.tool
 
         echo " Inspect the above lines carefully ^."
         ### All nodes run api server
@@ -173,7 +173,7 @@ initialize
 install_components
 iptables -F
 
-if [ "`hostname`" == "kube2.ha" ]; then
+if [ "`hostname`" == "kube2" ]; then
     poll
     k8petstore
 fi


### PR DESCRIPTION
Vagrant (at least in version 1.8) seems to unreliably set the hostname
of the virtual machine during provisioning. Many steps in provision.sh
fail because the VM's hostname is expected to be "kube0.ha" but at 
the point where provision.sh checks if it should install or test etcd the
hostname is just "kube0".

To simplify, remove the ".ha" suffix so that the hostname matches the
basic VM name in the Vagrantfile.
