### PR TITLE
Increase scheduler QPS

### DIFF
--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -69,8 +69,8 @@ func NewSchedulerServer() *SchedulerServer {
 		AlgorithmProvider: factory.DefaultProvider,
 		BindPodsQPS:       50.0,
 		BindPodsBurst:     100,
-		KubeAPIQPS:        50.0,
-		KubeAPIBurst:      100,
+		KubeAPIQPS:        100.0,
+		KubeAPIBurst:      200,
 		SchedulerName:     api.DefaultSchedulerName,
 	}
 	return &s


### PR DESCRIPTION
Since we have BindPodQPS set to 50, this requires 100QPS, so increasing QPS limit to match the BindPodQPS limit.
