### PR TITLE
Revert "Enable logs generation rate checking in scalability tests"

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -576,8 +576,7 @@ case ${JOB_NAME} in
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-scalability"}
     : ${E2E_NETWORK:="e2e-scalability"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Performance\] \
-        --gather-resource-usage=true \
-        --gather-logs-sizes=true"}
+        --gather-resource-usage=true"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-scalability"}
     : ${PROJECT:="kubernetes-jenkins"}
     # Override GCE defaults.


### PR DESCRIPTION
Reverts kubernetes/kubernetes#18998

It caused scalability test failure:
http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-scalability/3578
