### PR TITLE
Update cluster-monitoring addon

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/grafana-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-service.yaml
@@ -3,16 +3,15 @@ kind: Service
 metadata:
   name: monitoring-grafana
   namespace: kube-system
-  labels: 
+  labels:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Grafana"
 spec:
   # On production clusters, consider setting up auth for grafana, and
   # exposing Grafana either using a LoadBalancer or a public IP.
   # type: LoadBalancer
-  ports: 
+  ports:
     - port: 80
       targetPort: 3000
-  selector: 
+  selector:
     k8s-app: influxGrafana
-

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -6,26 +6,26 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v10
+  name: heapster-v11
   namespace: kube-system
   labels:
     k8s-app: heapster
-    version: v10
+    version: v11
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: heapster
-    version: v10
+    version: v11
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v10
+        version: v11
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.2
+        - image: gcr.io/google_containers/heapster:v0.19.1
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-service.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Heapster"
-spec: 
-  ports: 
+spec:
+  ports:
     - port: 80
       targetPort: 8082
-  selector: 
+  selector:
     k8s-app: heapster

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -1,36 +1,36 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: monitoring-influxdb-grafana-v2
+  name: monitoring-influxdb-grafana-v3
   namespace: kube-system
-  labels: 
+  labels:
     k8s-app: influxGrafana
-    version: v2
+    version: v3
     kubernetes.io/cluster-service: "true"
-spec: 
+spec:
   replicas: 1
-  selector: 
+  selector:
     k8s-app: influxGrafana
-    version: v2
-  template: 
-    metadata: 
-      labels: 
+    version: v3
+  template:
+    metadata:
+      labels:
         k8s-app: influxGrafana
-        version: v2
+        version: v3
         kubernetes.io/cluster-service: "true"
-    spec: 
-      containers: 
-        - image: gcr.io/google_containers/heapster_influxdb:v0.4
+    spec:
+      containers:
+        - image: gcr.io/google_containers/heapster_influxdb:v0.6
           name: influxdb
           resources:
             # keep request = limit to keep this container in guaranteed class
             limits:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 1000m
+              memory: 600Mi
             requests:
-              cpu: 100m
-              memory: 200Mi
-          ports: 
+              cpu: 1000m
+              memory: 600Mi
+          ports:
             - containerPort: 8083
               hostPort: 8083
             - containerPort: 8086
@@ -38,7 +38,7 @@ spec:
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data
-        - image: gcr.io/google_containers/heapster_grafana:v2.1.1
+        - image: gcr.io/google_containers/heapster_grafana:v2.5.0
           name: grafana
           env:
           resources:
@@ -68,11 +68,8 @@ spec:
           volumeMounts:
           - name: grafana-persistent-storage
             mountPath: /var
-              
       volumes:
       - name: influxdb-persistent-storage
         emptyDir: {}
       - name: grafana-persistent-storage
         emptyDir: {}
-
-

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -25,11 +25,11 @@ spec:
           resources:
             # keep request = limit to keep this container in guaranteed class
             limits:
-              cpu: 1000m
-              memory: 600Mi
+              cpu: 100m
+              memory: 200Mi
             requests:
-              cpu: 1000m
-              memory: 600Mi
+              cpu: 100m
+              memory: 200Mi
           ports:
             - containerPort: 8083
               hostPort: 8083

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-service.yaml
@@ -3,17 +3,16 @@ kind: Service
 metadata:
   name: monitoring-influxdb
   namespace: kube-system
-  labels: 
+  labels:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "InfluxDB"
-spec: 
-  ports: 
+spec:
+  ports:
     - name: http
       port: 8083
       targetPort: 8083
     - name: api
       port: 8086
       targetPort: 8086
-  selector: 
+  selector:
     k8s-app: influxGrafana
-


### PR DESCRIPTION
This is a proposal to update to cluster-monitoring add-on.

Updated components:
- heapster v0.19.1
- influxdb v0.9.6
- grafana v2.5.0

---

Motivation: the current version of the monitoring add-on...
- is quite outdated compared to the current state of the [heapster project](https://github.com/kubernetes/heapster/releases)
- uses a version of InfluxDB with known performance issues (high CPU usage)
- uses a version of InfluxDB which misses important features (tag values)
- does not include any CPU metrics.

Heapster v0.19.1 has proven to work very reliably for me in 2 very active clusters over the past week, therefore I'm suggesting to update in the kubernetes repo.

This PR currently includes updates only for the InfluxDB flavor. I will update the other ones if this proposal is accepted.
