### PR TITLE
fix flake in deployment unit test

### DIFF
--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -365,6 +365,7 @@ func newFixture(t *testing.T) *fixture {
 func (f *fixture) run(deploymentName string) {
 	f.client = testclient.NewSimpleFake(f.objects)
 	c := NewDeploymentController(f.client, controller.NoResyncPeriodFunc)
+	c.eventRecorder = &record.FakeRecorder{}
 	c.rcStoreSynced = alwaysReady
 	c.podStoreSynced = alwaysReady
 	for _, d := range f.dStore {


### PR DESCRIPTION
Becase the recorder sends events async, we very rarely saw an extra action against the client that we weren't anticipating. Just ignore event recording in this test.

https://github.com/kubernetes/kubernetes/blob/master/pkg/client/record/event.go#L259-L262

Fixes #19003

cc @gmarek @wojtek-t @nikhiljindal 
